### PR TITLE
[bevy_ui/layout] Replace unwrap, expect, and panic with Result

### DIFF
--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -13,22 +13,31 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
     let taffy_to_entity: HashMap<Node, Entity> = ui_surface
         .entity_to_taffy
         .iter()
-        .map(|(entity, node)| (*node, *entity))
-        .collect();
-    for (&entity, roots) in &ui_surface.camera_roots {
-        let mut out = String::new();
-        for root in roots {
+        .map(|(&ui_entity, &taffy_node)| (taffy_node, ui_entity))
+        .collect::<HashMap<Node, Entity>>();
+    for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes.iter() {
+        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity}");
+        for &root_node_entity in root_node_set.iter() {
+            let Some(implicit_viewport_node) = ui_surface
+                .root_node_data
+                .get(&root_node_entity)
+                .map(|rnd| rnd.implicit_viewport_node)
+                else {
+                    continue;
+                };
+            let mut out = String::new();
             print_node(
                 ui_surface,
                 &taffy_to_entity,
-                entity,
-                root.implicit_viewport_node,
+                camera_entity,
+                implicit_viewport_node,
                 false,
                 String::new(),
                 &mut out,
             );
+
+            bevy_utils::tracing::info!("{out}");
         }
-        bevy_utils::tracing::info!("Layout tree for camera entity: {entity:?}\n{out}");
     }
 }
 

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -1,4 +1,4 @@
-use crate::UiSurface;
+use crate::layout::ui_surface::UiSurface;
 use bevy_ecs::prelude::Entity;
 use bevy_utils::HashMap;
 use std::fmt::Write;

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -22,9 +22,9 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
                 .root_node_data
                 .get(&root_node_entity)
                 .map(|rnd| rnd.implicit_viewport_node)
-                else {
-                    continue;
-                };
+            else {
+                continue;
+            };
             let mut out = String::new();
             print_node(
                 ui_surface,

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -1,9 +1,12 @@
-use crate::layout::ui_surface::UiSurface;
-use bevy_ecs::prelude::Entity;
-use bevy_utils::HashMap;
 use std::fmt::Write;
+
 use taffy::prelude::Node;
 use taffy::tree::LayoutTree;
+
+use bevy_ecs::prelude::Entity;
+use bevy_utils::HashMap;
+
+use crate::layout::ui_surface::UiSurface;
 
 /// Prints a debug representation of the computed layout of the UI layout tree for each window.
 pub fn print_ui_layout_tree(ui_surface: &UiSurface) {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,8 +1,8 @@
-mod convert;
-pub mod debug;
-pub(crate) mod ui_surface;
+use std::fmt;
 
-use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
+use taffy::{Taffy, tree::LayoutTree};
+use thiserror::Error;
+
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     entity::{Entity, EntityHashMap},
@@ -16,13 +16,16 @@ use bevy_hierarchy::{Children, Parent};
 use bevy_math::{UVec2, Vec2};
 use bevy_render::camera::{Camera, NormalizedRenderTarget};
 use bevy_transform::components::Transform;
-use bevy_utils::tracing::warn;
 use bevy_utils::{default, HashMap, HashSet};
+use bevy_utils::tracing::warn;
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
-use std::fmt;
-use taffy::{Taffy, tree::LayoutTree};
-use thiserror::Error;
 use ui_surface::UiSurface;
+
+use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
+
+mod convert;
+pub mod debug;
+pub(crate) mod ui_surface;
 
 pub struct LayoutContext {
     pub scale_factor: f32,
@@ -323,12 +326,8 @@ fn round_layout_coords(value: Vec2) -> Vec2 {
 
 #[cfg(test)]
 mod tests {
-    use crate::layout::round_layout_coords;
-    use crate::prelude::*;
-    use crate::ui_layout_system;
-    use crate::update::update_target_camera_system;
-    use crate::ContentSize;
-    use crate::layout::ui_surface::UiSurface;
+    use taffy::tree::LayoutTree;
+
     use bevy_asset::AssetEvent;
     use bevy_asset::Assets;
     use bevy_core_pipeline::core_2d::Camera2dBundle;
@@ -348,15 +347,21 @@ mod tests {
     use bevy_render::prelude::Camera;
     use bevy_render::texture::Image;
     use bevy_transform::prelude::{GlobalTransform, Transform};
-    use bevy_utils::prelude::default;
     use bevy_utils::HashMap;
+    use bevy_utils::prelude::default;
     use bevy_window::PrimaryWindow;
     use bevy_window::Window;
     use bevy_window::WindowCreated;
     use bevy_window::WindowResized;
     use bevy_window::WindowResolution;
     use bevy_window::WindowScaleFactorChanged;
-    use taffy::tree::LayoutTree;
+
+    use crate::ContentSize;
+    use crate::layout::round_layout_coords;
+    use crate::layout::ui_surface::UiSurface;
+    use crate::prelude::*;
+    use crate::ui_layout_system;
+    use crate::update::update_target_camera_system;
 
     #[test]
     fn round_layout_coords_must_round_ties_up() {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     entity::Entity,
     event::EventReader,
-    query::{With, Without},
+    query::{Added, With, Without},
     removal_detection::RemovedComponents,
     system::{Query, Res, ResMut, SystemParam},
     world::Ref,
@@ -73,6 +73,7 @@ pub fn ui_layout_system(
     style_query: Query<(Entity, Ref<Style>, Option<&TargetCamera>), With<Node>>,
     mut measure_query: Query<(Entity, &mut ContentSize)>,
     children_query: Query<(Entity, Ref<Children>), With<Node>>,
+    demoted_root_node_query: Query<(Entity, Ref<Parent>), (With<Node>, Added<Parent>)>,
     just_children_query: Query<&Children>,
     mut removed_components: UiLayoutSystemRemovedComponentParam,
     mut node_transform_query: Query<(&mut Node, &mut Transform)>,
@@ -167,6 +168,12 @@ pub fn ui_layout_system(
     for (entity, mut content_size) in &mut measure_query {
         if let Some(measure_func) = content_size.measure_func.take() {
             ui_surface.try_update_measure(entity, measure_func);
+        }
+    }
+    // When a root node is added as a child to another ui node
+    for (entity, parent) in &demoted_root_node_query {
+        if parent.is_added() {
+            ui_surface.demote_ui_node(&entity, &parent.get());
         }
     }
 
@@ -337,7 +344,10 @@ mod tests {
     use bevy_ecs::schedule::Schedule;
     use bevy_ecs::system::RunSystemOnce;
     use bevy_ecs::world::World;
-    use bevy_hierarchy::{despawn_with_children_recursive, BuildWorldChildren, Children, Parent};
+    use bevy_hierarchy::{
+        despawn_with_children_recursive, BuildChildren, BuildWorldChildren, Children,
+        DespawnRecursiveExt, Parent,
+    };
     use bevy_math::{vec2, Rect, UVec2, Vec2};
     use bevy_render::camera::ManualTextureViews;
     use bevy_render::camera::OrthographicProjection;
@@ -540,6 +550,37 @@ mod tests {
         assert_eq!(ui_surface.entity_to_taffy.len(), 1);
         assert!(ui_surface.root_node_data.contains_key(&ui_entity));
         assert_eq!(ui_surface.root_node_data.len(), 1);
+    }
+
+    #[test]
+    /// test to make sure the ui updates when root nodes become children of other nodes during runtime
+    fn ui_demotion_from_root_to_child() {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+
+        let ui_entity1 = world.spawn(NodeBundle::default()).id();
+        let ui_entity2 = world.spawn(NodeBundle::default()).id();
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity1));
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity2));
+        assert_eq!(ui_surface.taffy.total_node_count(), 4);
+
+        world.commands().entity(ui_entity1).add_child(ui_entity2);
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity1));
+        assert!(!ui_surface.root_node_data.contains_key(&ui_entity2));
+        assert_eq!(ui_surface.taffy.total_node_count(), 3);
+        let taffy_parent = ui_surface.entity_to_taffy.get(&ui_entity1).unwrap();
+        let taffy_child = ui_surface.entity_to_taffy.get(&ui_entity2).unwrap();
+        assert_eq!(
+            ui_surface.taffy.parent(*taffy_child).unwrap(),
+            *taffy_parent
+        );
     }
 
     #[test]

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,6 +1,6 @@
 mod convert;
 pub mod debug;
-mod ui_surface;
+pub(crate) mod ui_surface;
 
 use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
 use bevy_ecs::{

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -507,9 +507,7 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface
-            .camera_root_nodes
-            .contains_key(&camera_entity));
+        assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
         assert_eq!(ui_surface.camera_root_nodes.len(), 1);
 
         world.despawn(ui_entity);
@@ -519,9 +517,7 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(!ui_surface
-            .camera_root_nodes
-            .contains_key(&camera_entity));
+        assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
         assert!(ui_surface.camera_root_nodes.is_empty());
     }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -13,8 +13,8 @@ use bevy_hierarchy::{Children, Parent};
 use bevy_math::{UVec2, Vec2};
 use bevy_render::camera::{Camera, NormalizedRenderTarget};
 use bevy_transform::components::Transform;
-use bevy_utils::{HashMap, HashSet};
 use bevy_utils::tracing::warn;
+use bevy_utils::{HashMap, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 use ui_surface::UiSurface;
 
@@ -337,15 +337,15 @@ mod tests {
     use bevy_ecs::schedule::Schedule;
     use bevy_ecs::system::RunSystemOnce;
     use bevy_ecs::world::World;
-    use bevy_hierarchy::{BuildWorldChildren, Children, despawn_with_children_recursive, Parent};
-    use bevy_math::{Rect, UVec2, vec2, Vec2};
+    use bevy_hierarchy::{despawn_with_children_recursive, BuildWorldChildren, Children, Parent};
+    use bevy_math::{vec2, Rect, UVec2, Vec2};
     use bevy_render::camera::ManualTextureViews;
     use bevy_render::camera::OrthographicProjection;
     use bevy_render::prelude::Camera;
     use bevy_render::texture::Image;
     use bevy_transform::prelude::{GlobalTransform, Transform};
-    use bevy_utils::HashMap;
     use bevy_utils::prelude::default;
+    use bevy_utils::HashMap;
     use bevy_window::PrimaryWindow;
     use bevy_window::Window;
     use bevy_window::WindowCreated;
@@ -353,12 +353,12 @@ mod tests {
     use bevy_window::WindowResolution;
     use bevy_window::WindowScaleFactorChanged;
 
-    use crate::ContentSize;
     use crate::layout::round_layout_coords;
     use crate::layout::ui_surface::UiSurface;
     use crate::prelude::*;
     use crate::ui_layout_system;
     use crate::update::update_target_camera_system;
+    use crate::ContentSize;
 
     #[test]
     fn round_layout_coords_must_round_ties_up() {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -516,6 +516,7 @@ mod tests {
         assert_eq!(ui_surface.entity_to_taffy.len(), 1);
         assert!(!ui_surface.root_node_data.contains_key(&ui_entity));
         assert!(ui_surface.root_node_data.is_empty());
+        assert_eq!(ui_surface.taffy.total_node_count(), 1);
     }
 
     #[test]
@@ -533,6 +534,7 @@ mod tests {
         assert!(ui_surface.entity_to_taffy.is_empty());
         assert!(!ui_surface.root_node_data.contains_key(&ui_entity));
         assert!(ui_surface.root_node_data.is_empty());
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
     }
 
     #[test]
@@ -550,6 +552,7 @@ mod tests {
         assert_eq!(ui_surface.entity_to_taffy.len(), 1);
         assert!(ui_surface.root_node_data.contains_key(&ui_entity));
         assert_eq!(ui_surface.root_node_data.len(), 1);
+        assert_eq!(ui_surface.taffy.total_node_count(), 2);
     }
 
     #[test]
@@ -678,6 +681,7 @@ mod tests {
 
         // `ui_node` is removed, attempting to retrieve a style for `ui_node` panics
         let _ = ui_surface.taffy.style(ui_node);
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
     }
 
     #[test]
@@ -780,6 +784,7 @@ mod tests {
         // all nodes should have been deleted
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface.entity_to_taffy.is_empty());
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
     }
 
     /// regression test for >=0.13.1 root node layouts

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -200,7 +200,7 @@ pub fn ui_layout_system(
     for (camera_id, camera) in &camera_layout_info {
         let inverse_target_scale_factor = camera.scale_factor.recip();
 
-        ui_surface.compute_camera_layout(*camera_id, camera.size);
+        ui_surface.compute_camera_layout(camera_id, camera.size);
         for root in &camera.root_nodes {
             update_uinode_geometry_recursive(
                 *root,
@@ -494,7 +494,7 @@ mod tests {
 
         // no UI entities in world, none in UiSurface
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.camera_entity_to_taffy.is_empty());
+        assert!(ui_surface.camera_root_nodes.is_empty());
 
         // respawn camera
         let camera_entity = world.spawn(Camera2dBundle::default()).id();
@@ -508,9 +508,9 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface
-            .camera_entity_to_taffy
+            .camera_root_nodes
             .contains_key(&camera_entity));
-        assert_eq!(ui_surface.camera_entity_to_taffy.len(), 1);
+        assert_eq!(ui_surface.camera_root_nodes.len(), 1);
 
         world.despawn(ui_entity);
         world.despawn(camera_entity);
@@ -520,9 +520,9 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
         assert!(!ui_surface
-            .camera_entity_to_taffy
+            .camera_root_nodes
             .contains_key(&camera_entity));
-        assert!(ui_surface.camera_entity_to_taffy.is_empty());
+        assert!(ui_surface.camera_root_nodes.is_empty());
     }
 
     #[test]

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,5 +1,6 @@
 mod convert;
 pub mod debug;
+mod ui_surface;
 
 use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
 use bevy_ecs::{
@@ -19,8 +20,9 @@ use bevy_utils::tracing::warn;
 use bevy_utils::{default, HashMap, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 use std::fmt;
-use taffy::{tree::LayoutTree, Taffy};
+use taffy::{Taffy, tree::LayoutTree};
 use thiserror::Error;
+use ui_surface::UiSurface;
 
 pub struct LayoutContext {
     pub scale_factor: f32,
@@ -37,218 +39,6 @@ impl LayoutContext {
             physical_size,
             min_size: physical_size.x.min(physical_size.y),
             max_size: physical_size.x.max(physical_size.y),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RootNodePair {
-    // The implicit "viewport" node created by Bevy
-    implicit_viewport_node: taffy::node::Node,
-    // The root (parentless) node specified by the user
-    user_root_node: taffy::node::Node,
-}
-
-#[derive(Resource)]
-pub struct UiSurface {
-    entity_to_taffy: EntityHashMap<taffy::node::Node>,
-    camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::node::Node>>,
-    camera_roots: EntityHashMap<Vec<RootNodePair>>,
-    taffy: Taffy,
-}
-
-fn _assert_send_sync_ui_surface_impl_safe() {
-    fn _assert_send_sync<T: Send + Sync>() {}
-    _assert_send_sync::<EntityHashMap<taffy::node::Node>>();
-    _assert_send_sync::<Taffy>();
-    _assert_send_sync::<UiSurface>();
-}
-
-impl fmt::Debug for UiSurface {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("UiSurface")
-            .field("entity_to_taffy", &self.entity_to_taffy)
-            .field("camera_roots", &self.camera_roots)
-            .finish()
-    }
-}
-
-impl Default for UiSurface {
-    fn default() -> Self {
-        let mut taffy = Taffy::new();
-        taffy.disable_rounding();
-        Self {
-            entity_to_taffy: Default::default(),
-            camera_entity_to_taffy: Default::default(),
-            camera_roots: Default::default(),
-            taffy,
-        }
-    }
-}
-
-impl UiSurface {
-    /// Retrieves the Taffy node associated with the given UI node entity and updates its style.
-    /// If no associated Taffy node exists a new Taffy node is inserted into the Taffy layout.
-    pub fn upsert_node(&mut self, entity: Entity, style: &Style, context: &LayoutContext) {
-        let mut added = false;
-        let taffy = &mut self.taffy;
-        let taffy_node = self.entity_to_taffy.entry(entity).or_insert_with(|| {
-            added = true;
-            taffy.new_leaf(convert::from_style(context, style)).unwrap()
-        });
-
-        if !added {
-            self.taffy
-                .set_style(*taffy_node, convert::from_style(context, style))
-                .unwrap();
-        }
-    }
-
-    /// Update the `MeasureFunc` of the taffy node corresponding to the given [`Entity`] if the node exists.
-    pub fn try_update_measure(
-        &mut self,
-        entity: Entity,
-        measure_func: taffy::node::MeasureFunc,
-    ) -> Option<()> {
-        let taffy_node = self.entity_to_taffy.get(&entity)?;
-
-        self.taffy.set_measure(*taffy_node, Some(measure_func)).ok()
-    }
-
-    /// Update the children of the taffy node corresponding to the given [`Entity`].
-    pub fn update_children(&mut self, entity: Entity, children: &Children) {
-        let mut taffy_children = Vec::with_capacity(children.len());
-        for child in children {
-            if let Some(taffy_node) = self.entity_to_taffy.get(child) {
-                taffy_children.push(*taffy_node);
-            } else {
-                warn!(
-                    "Unstyled child in a UI entity hierarchy. You are using an entity \
-without UI components as a child of an entity with UI components, results may be unexpected."
-                );
-            }
-        }
-
-        let taffy_node = self.entity_to_taffy.get(&entity).unwrap();
-        self.taffy
-            .set_children(*taffy_node, &taffy_children)
-            .unwrap();
-    }
-
-    /// Removes children from the entity's taffy node if it exists. Does nothing otherwise.
-    pub fn try_remove_children(&mut self, entity: Entity) {
-        if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            self.taffy.set_children(*taffy_node, &[]).unwrap();
-        }
-    }
-
-    /// Removes the measure from the entity's taffy node if it exists. Does nothing otherwise.
-    pub fn try_remove_measure(&mut self, entity: Entity) {
-        if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            self.taffy.set_measure(*taffy_node, None).unwrap();
-        }
-    }
-
-    /// Set the ui node entities without a [`Parent`] as children to the root node in the taffy layout.
-    pub fn set_camera_children(
-        &mut self,
-        camera_id: Entity,
-        children: impl Iterator<Item = Entity>,
-    ) {
-        let viewport_style = taffy::style::Style {
-            display: taffy::style::Display::Grid,
-            // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
-            // So this is setting width:100% and height:100%
-            size: taffy::geometry::Size {
-                width: taffy::style::Dimension::Percent(1.0),
-                height: taffy::style::Dimension::Percent(1.0),
-            },
-            align_items: Some(taffy::style::AlignItems::Start),
-            justify_items: Some(taffy::style::JustifyItems::Start),
-            ..default()
-        };
-
-        let camera_root_node_map = self.camera_entity_to_taffy.entry(camera_id).or_default();
-        let existing_roots = self.camera_roots.entry(camera_id).or_default();
-        let mut new_roots = Vec::new();
-        for entity in children {
-            let node = *self.entity_to_taffy.get(&entity).unwrap();
-            let root_node = existing_roots
-                .iter()
-                .find(|n| n.user_root_node == node)
-                .cloned()
-                .unwrap_or_else(|| {
-                    if let Some(previous_parent) = self.taffy.parent(node) {
-                        // remove the root node from the previous implicit node's children
-                        self.taffy.remove_child(previous_parent, node).unwrap();
-                    }
-
-                    let viewport_node = *camera_root_node_map
-                        .entry(entity)
-                        .or_insert_with(|| self.taffy.new_leaf(viewport_style.clone()).unwrap());
-                    self.taffy.add_child(viewport_node, node).unwrap();
-
-                    RootNodePair {
-                        implicit_viewport_node: viewport_node,
-                        user_root_node: node,
-                    }
-                });
-            new_roots.push(root_node);
-        }
-
-        self.camera_roots.insert(camera_id, new_roots);
-    }
-
-    /// Compute the layout for each window entity's corresponding root node in the layout.
-    pub fn compute_camera_layout(&mut self, camera: Entity, render_target_resolution: UVec2) {
-        let Some(camera_root_nodes) = self.camera_roots.get(&camera) else {
-            return;
-        };
-
-        let available_space = taffy::geometry::Size {
-            width: taffy::style::AvailableSpace::Definite(render_target_resolution.x as f32),
-            height: taffy::style::AvailableSpace::Definite(render_target_resolution.y as f32),
-        };
-        for root_nodes in camera_root_nodes {
-            self.taffy
-                .compute_layout(root_nodes.implicit_viewport_node, available_space)
-                .unwrap();
-        }
-    }
-
-    /// Removes each camera entity from the internal map and then removes their associated node from taffy
-    pub fn remove_camera_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
-        for entity in entities {
-            if let Some(camera_root_node_map) = self.camera_entity_to_taffy.remove(&entity) {
-                for (_, node) in camera_root_node_map.iter() {
-                    self.taffy.remove(*node).unwrap();
-                }
-            }
-        }
-    }
-
-    /// Removes each entity from the internal map and then removes their associated node from taffy
-    pub fn remove_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
-        for entity in entities {
-            if let Some(node) = self.entity_to_taffy.remove(&entity) {
-                self.taffy.remove(node).unwrap();
-            }
-        }
-    }
-
-    /// Get the layout geometry for the taffy node corresponding to the ui node [`Entity`].
-    /// Does not compute the layout geometry, `compute_window_layouts` should be run before using this function.
-    pub fn get_layout(&self, entity: Entity) -> Result<&taffy::layout::Layout, LayoutError> {
-        if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            self.taffy
-                .layout(*taffy_node)
-                .map_err(LayoutError::TaffyError)
-        } else {
-            warn!(
-                "Styled child in a non-UI entity hierarchy. You are using an entity \
-with UI components as a child of an entity without UI components, results may be unexpected."
-            );
-            Err(LayoutError::InvalidHierarchy)
         }
     }
 }
@@ -538,7 +328,7 @@ mod tests {
     use crate::ui_layout_system;
     use crate::update::update_target_camera_system;
     use crate::ContentSize;
-    use crate::UiSurface;
+    use crate::layout::ui_surface::UiSurface;
     use bevy_asset::AssetEvent;
     use bevy_asset::Assets;
     use bevy_core_pipeline::core_2d::Camera2dBundle;
@@ -551,8 +341,8 @@ mod tests {
     use bevy_ecs::schedule::Schedule;
     use bevy_ecs::system::RunSystemOnce;
     use bevy_ecs::world::World;
-    use bevy_hierarchy::{despawn_with_children_recursive, BuildWorldChildren, Children, Parent};
-    use bevy_math::{vec2, Rect, UVec2, Vec2};
+    use bevy_hierarchy::{BuildWorldChildren, Children, despawn_with_children_recursive, Parent};
+    use bevy_math::{Rect, UVec2, vec2, Vec2};
     use bevy_render::camera::ManualTextureViews;
     use bevy_render::camera::OrthographicProjection;
     use bevy_render::prelude::Camera;

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -584,6 +584,33 @@ mod tests {
     }
 
     #[test]
+    fn ui_promotion_from_child_to_root() {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+
+        let ui_entity1 = world.spawn(NodeBundle::default()).id();
+        let ui_entity2 = world.spawn(NodeBundle::default()).id();
+        world.commands().entity(ui_entity1).add_child(ui_entity2);
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity1));
+        assert!(!ui_surface.root_node_data.contains_key(&ui_entity2));
+        assert_eq!(ui_surface.taffy.total_node_count(), 3);
+
+        world.commands().entity(ui_entity2).remove_parent();
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity1));
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity2));
+        assert_eq!(ui_surface.taffy.total_node_count(), 4);
+        let taffy_child = ui_surface.entity_to_taffy.get(&ui_entity2).unwrap();
+        assert_eq!(ui_surface.taffy.parent(*taffy_child), None);
+    }
+
+    #[test]
     fn ui_surface_tracks_camera_entities() {
         let (mut world, mut ui_schedule) = setup_ui_test_world();
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,22 +1,19 @@
-use std::fmt;
-
-use taffy::{Taffy, tree::LayoutTree};
 use thiserror::Error;
 
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
-    entity::{Entity, EntityHashMap},
+    entity::Entity,
     event::EventReader,
     query::{With, Without},
     removal_detection::RemovedComponents,
-    system::{Query, Res, ResMut, Resource, SystemParam},
+    system::{Query, Res, ResMut, SystemParam},
     world::Ref,
 };
 use bevy_hierarchy::{Children, Parent};
 use bevy_math::{UVec2, Vec2};
 use bevy_render::camera::{Camera, NormalizedRenderTarget};
 use bevy_transform::components::Transform;
-use bevy_utils::{default, HashMap, HashSet};
+use bevy_utils::{HashMap, HashSet};
 use bevy_utils::tracing::warn;
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 use ui_surface::UiSurface;

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -430,7 +430,7 @@ mod tests {
         assert_eq!(ui_surface.taffy.total_node_count(), 0);
     }
 
-    const DUMMY_LAYOUT_CONTEXT: LayoutContext = LayoutContext {
+    const TEST_LAYOUT_CONTEXT: LayoutContext = LayoutContext {
         scale_factor: 1.0,
         physical_size: Vec2::ONE,
         min_size: 0.0,
@@ -461,14 +461,14 @@ mod tests {
         let style = Style::default();
 
         // standard upsert
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         // should be inserted into taffy
         assert_eq!(ui_surface.taffy.total_node_count(), 1);
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
 
         // test duplicate insert 1
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         // node count should not have increased
         assert_eq!(ui_surface.taffy.total_node_count(), 1);
@@ -483,7 +483,7 @@ mod tests {
         assert!(ui_surface.has_valid_root_node_data(&root_node_entity));
 
         // test duplicate insert 2
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         // node count should not have increased
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
@@ -499,7 +499,7 @@ mod tests {
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         // assign root node to camera
         ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
@@ -537,7 +537,7 @@ mod tests {
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
 
@@ -570,7 +570,7 @@ mod tests {
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
         let mut content_size = ContentSize::default();
         content_size.set(FixedMeasure { size: Vec2::ONE });
         let measure_func = content_size.measure_func.take().unwrap();
@@ -586,8 +586,8 @@ mod tests {
         let child_entity = Entity::from_raw(2);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
-        ui_surface.upsert_node(child_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         ui_surface.update_children(root_node_entity, &[child_entity]);
 
@@ -604,8 +604,8 @@ mod tests {
         let child_entity = Entity::from_raw(2);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
-        ui_surface.upsert_node(child_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         let root_taffy_node = *ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
         let child_taffy = *ui_surface.entity_to_taffy.get(&child_entity).unwrap();
@@ -722,7 +722,7 @@ mod tests {
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
 
         ui_surface.compute_camera_layout(&camera_entity, UVec2::new(800, 600));
 
@@ -738,8 +738,8 @@ mod tests {
         let child_entity = Entity::from_raw(2);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
-        ui_surface.upsert_node(child_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT);
         ui_surface.update_children(root_node_entity, &[child_entity]);
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
         

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -5,7 +5,6 @@ use taffy::Taffy;
 
 use bevy_ecs::entity::{Entity, EntityHashMap};
 use bevy_ecs::prelude::Resource;
-use bevy_hierarchy::Children;
 use bevy_math::UVec2;
 use bevy_utils::default;
 use bevy_utils::tracing::warn;
@@ -91,7 +90,7 @@ impl UiSurface {
     }
 
     /// Update the children of the taffy node corresponding to the given [`Entity`].
-    pub fn update_children(&mut self, entity: Entity, children: &Children) {
+    pub fn update_children(&mut self, entity: Entity, children: &[Entity]) {
         let mut taffy_children = Vec::with_capacity(children.len());
         for child in children {
             if let Some(taffy_node) = self.entity_to_taffy.get(child) {

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -110,12 +110,8 @@ impl UiSurface {
     /// Disassociates the root node from the assigned camera (if any) and removes the viewport node from taffy
     /// Removes entry in root_node_data
     pub(super) fn remove_root_node_viewport(&mut self, root_node_entity: &Entity) {
-        if let Some(mut removed) = self.root_node_data.remove(root_node_entity) {
-            if let Some(camera_entity) = removed.camera_entity.take() {
-                if let Some(root_node_entities) = self.camera_root_nodes.get_mut(&camera_entity) {
-                    root_node_entities.remove(root_node_entity);
-                }
-            }
+        self.mark_root_node_as_orphaned(root_node_entity);
+        if let Some(removed) = self.root_node_data.remove(root_node_entity) {
             self.taffy.remove(removed.implicit_viewport_node).unwrap();
         }
     }
@@ -319,14 +315,7 @@ without UI components as a child of an entity with UI components, results may be
         }
 
         for orphan in removed_children.iter() {
-            if let Some(root_node_data) = self.root_node_data.get_mut(orphan) {
-                // mark as orphan
-                if let Some(camera_entity) = root_node_data.camera_entity.take() {
-                    if let Some(children_set) = self.camera_root_nodes.get_mut(&camera_entity) {
-                        children_set.remove(orphan);
-                    }
-                }
-            }
+            self.mark_root_node_as_orphaned(orphan);
         }
     }
 

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -1,0 +1,223 @@
+use bevy_ecs::entity::{Entity, EntityHashMap};
+use bevy_ecs::prelude::Resource;
+use taffy::Taffy;
+use bevy_hierarchy::{Children, Parent};
+use bevy_math::UVec2;
+use bevy_utils::default;
+use bevy_utils::tracing::warn;
+use std::fmt;
+use taffy::prelude::LayoutTree;
+use crate::{LayoutContext, LayoutError, Style};
+use crate::layout::convert;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RootNodePair {
+    // The implicit "viewport" node created by Bevy
+    implicit_viewport_node: taffy::node::Node,
+    // The root (parentless) node specified by the user
+    user_root_node: taffy::node::Node,
+}
+
+#[derive(Resource)]
+pub struct UiSurface {
+    entity_to_taffy: EntityHashMap<taffy::node::Node>,
+    camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::node::Node>>,
+    camera_roots: EntityHashMap<Vec<RootNodePair>>,
+    taffy: Taffy,
+}
+
+fn _assert_send_sync_ui_surface_impl_safe() {
+    fn _assert_send_sync<T: Send + Sync>() {}
+    _assert_send_sync::<EntityHashMap<taffy::node::Node>>();
+    _assert_send_sync::<Taffy>();
+    _assert_send_sync::<UiSurface>();
+}
+
+impl fmt::Debug for UiSurface {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("UiSurface")
+            .field("entity_to_taffy", &self.entity_to_taffy)
+            .field("camera_roots", &self.camera_roots)
+            .finish()
+    }
+}
+
+impl Default for UiSurface {
+    fn default() -> Self {
+        let mut taffy = Taffy::new();
+        taffy.disable_rounding();
+        Self {
+            entity_to_taffy: Default::default(),
+            camera_entity_to_taffy: Default::default(),
+            camera_roots: Default::default(),
+            taffy,
+        }
+    }
+}
+
+impl UiSurface {
+    /// Retrieves the Taffy node associated with the given UI node entity and updates its style.
+    /// If no associated Taffy node exists a new Taffy node is inserted into the Taffy layout.
+    pub fn upsert_node(&mut self, entity: Entity, style: &Style, context: &LayoutContext) {
+        let mut added = false;
+        let taffy = &mut self.taffy;
+        let taffy_node = self.entity_to_taffy.entry(entity).or_insert_with(|| {
+            added = true;
+            taffy.new_leaf(convert::from_style(context, style)).unwrap()
+        });
+
+        if !added {
+            self.taffy
+                .set_style(*taffy_node, convert::from_style(context, style))
+                .unwrap();
+        }
+    }
+
+    /// Update the `MeasureFunc` of the taffy node corresponding to the given [`Entity`] if the node exists.
+    pub fn try_update_measure(
+        &mut self,
+        entity: Entity,
+        measure_func: taffy::node::MeasureFunc,
+    ) -> Option<()> {
+        let taffy_node = self.entity_to_taffy.get(&entity)?;
+
+        self.taffy.set_measure(*taffy_node, Some(measure_func)).ok()
+    }
+
+    /// Update the children of the taffy node corresponding to the given [`Entity`].
+    pub fn update_children(&mut self, entity: Entity, children: &Children) {
+        let mut taffy_children = Vec::with_capacity(children.len());
+        for child in children {
+            if let Some(taffy_node) = self.entity_to_taffy.get(child) {
+                taffy_children.push(*taffy_node);
+            } else {
+                warn!(
+                    "Unstyled child in a UI entity hierarchy. You are using an entity \
+without UI components as a child of an entity with UI components, results may be unexpected."
+                );
+            }
+        }
+
+        let taffy_node = self.entity_to_taffy.get(&entity).unwrap();
+        self.taffy
+            .set_children(*taffy_node, &taffy_children)
+            .unwrap();
+    }
+
+    /// Removes children from the entity's taffy node if it exists. Does nothing otherwise.
+    pub fn try_remove_children(&mut self, entity: Entity) {
+        if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
+            self.taffy.set_children(*taffy_node, &[]).unwrap();
+        }
+    }
+
+    /// Removes the measure from the entity's taffy node if it exists. Does nothing otherwise.
+    pub fn try_remove_measure(&mut self, entity: Entity) {
+        if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
+            self.taffy.set_measure(*taffy_node, None).unwrap();
+        }
+    }
+
+    /// Set the ui node entities without a [`Parent`] as children to the root node in the taffy layout.
+    pub fn set_camera_children(
+        &mut self,
+        camera_id: Entity,
+        children: impl Iterator<Item = Entity>,
+    ) {
+        let viewport_style = taffy::style::Style {
+            display: taffy::style::Display::Grid,
+            // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
+            // So this is setting width:100% and height:100%
+            size: taffy::geometry::Size {
+                width: taffy::style::Dimension::Percent(1.0),
+                height: taffy::style::Dimension::Percent(1.0),
+            },
+            align_items: Some(taffy::style::AlignItems::Start),
+            justify_items: Some(taffy::style::JustifyItems::Start),
+            ..default()
+        };
+
+        let camera_root_node_map = self.camera_entity_to_taffy.entry(camera_id).or_default();
+        let existing_roots = self.camera_roots.entry(camera_id).or_default();
+        let mut new_roots = Vec::new();
+        for entity in children {
+            let node = *self.entity_to_taffy.get(&entity).unwrap();
+            let root_node = existing_roots
+                .iter()
+                .find(|n| n.user_root_node == node)
+                .cloned()
+                .unwrap_or_else(|| {
+                    if let Some(previous_parent) = self.taffy.parent(node) {
+                        // remove the root node from the previous implicit node's children
+                        self.taffy.remove_child(previous_parent, node).unwrap();
+                    }
+
+                    let viewport_node = *camera_root_node_map
+                        .entry(entity)
+                        .or_insert_with(|| self.taffy.new_leaf(viewport_style.clone()).unwrap());
+                    self.taffy.add_child(viewport_node, node).unwrap();
+
+                    RootNodePair {
+                        implicit_viewport_node: viewport_node,
+                        user_root_node: node,
+                    }
+                });
+            new_roots.push(root_node);
+        }
+
+        self.camera_roots.insert(camera_id, new_roots);
+    }
+
+    /// Compute the layout for each window entity's corresponding root node in the layout.
+    pub fn compute_camera_layout(&mut self, camera: Entity, render_target_resolution: UVec2) {
+        let Some(camera_root_nodes) = self.camera_roots.get(&camera) else {
+            return;
+        };
+
+        let available_space = taffy::geometry::Size {
+            width: taffy::style::AvailableSpace::Definite(render_target_resolution.x as f32),
+            height: taffy::style::AvailableSpace::Definite(render_target_resolution.y as f32),
+        };
+        for root_nodes in camera_root_nodes {
+            self.taffy
+                .compute_layout(root_nodes.implicit_viewport_node, available_space)
+                .unwrap();
+        }
+    }
+
+    /// Removes each camera entity from the internal map and then removes their associated node from taffy
+    pub fn remove_camera_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+        for entity in entities {
+            if let Some(camera_root_node_map) = self.camera_entity_to_taffy.remove(&entity) {
+                for (_, node) in camera_root_node_map.iter() {
+                    self.taffy.remove(*node).unwrap();
+                }
+            }
+        }
+    }
+
+    /// Removes each entity from the internal map and then removes their associated node from taffy
+    pub fn remove_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+        for entity in entities {
+            if let Some(node) = self.entity_to_taffy.remove(&entity) {
+                self.taffy.remove(node).unwrap();
+            }
+        }
+    }
+
+    /// Get the layout geometry for the taffy node corresponding to the ui node [`Entity`].
+    /// Does not compute the layout geometry, `compute_window_layouts` should be run before using this function.
+    pub fn get_layout(&self, entity: Entity) -> Result<&taffy::layout::Layout, LayoutError> {
+        if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
+            self.taffy
+                .layout(*taffy_node)
+                .map_err(LayoutError::TaffyError)
+        } else {
+            warn!(
+                "Styled child in a non-UI entity hierarchy. You are using an entity \
+with UI components as a child of an entity without UI components, results may be unexpected."
+            );
+            Err(LayoutError::InvalidHierarchy)
+        }
+    }
+}

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -171,10 +171,12 @@ impl UiSurface {
         // if it's not added we want to re-assign the parent we cleared above
         if !added {
             let Some(root_node_data) = self.root_node_data.get(target_entity) else {
-              unreachable!("impossible");
+                unreachable!("impossible");
             };
             let taffy_node = self.entity_to_taffy.get(target_entity).unwrap();
-            self.taffy.add_child(root_node_data.implicit_viewport_node, *taffy_node).unwrap();
+            self.taffy
+                .add_child(root_node_data.implicit_viewport_node, *taffy_node)
+                .unwrap();
         }
     }
 
@@ -746,13 +748,19 @@ mod tests {
         ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
         assert_eq!(ui_surface.taffy.total_node_count(), 3);
 
-
         ui_surface.promote_ui_node(&child_entity, &camera_entity);
         assert_eq!(ui_surface.taffy.total_node_count(), 4);
-        assert_eq!(ui_surface.get_associated_camera_entity(child_entity), Some(camera_entity));
+        assert_eq!(
+            ui_surface.get_associated_camera_entity(child_entity),
+            Some(camera_entity)
+        );
 
         let root_node_entity_taffy = ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
         let child_entity_taffy = ui_surface.entity_to_taffy.get(&child_entity).unwrap();
-        assert!(!ui_surface.taffy.children(*root_node_entity_taffy).unwrap().contains(child_entity_taffy));
+        assert!(!ui_surface
+            .taffy
+            .children(*root_node_entity_taffy)
+            .unwrap()
+            .contains(child_entity_taffy));
     }
 }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -122,10 +122,6 @@ impl UiSurface {
         if let Some(taffy_node) = self.entity_to_taffy.remove(ui_node_entity) {
             self.taffy.remove(taffy_node).unwrap();
         }
-        // remove root node entry if this is a root node
-        if self.root_node_data.contains_key(ui_node_entity) {
-            self.remove_root_node_viewport(ui_node_entity);
-        }
     }
 
     /// Demotes root node to a child node of the specified parent

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -108,7 +108,7 @@ impl UiSurface {
     }
 
     /// Disassociates the root node from the assigned camera (if any) and removes the viewport node from taffy
-    /// Removes entry in root_node_data
+    /// Removes entry in `root_node_data`
     pub(super) fn remove_root_node_viewport(&mut self, root_node_entity: &Entity) {
         self.mark_root_node_as_orphaned(root_node_entity);
         if let Some(removed) = self.root_node_data.remove(root_node_entity) {
@@ -116,7 +116,7 @@ impl UiSurface {
         }
     }
 
-    /// Removes the ui node from the taffy tree, and if it's a root node it also calls remove_root_node_viewport
+    /// Removes the ui node from the taffy tree, and if it's a root node it also calls `remove_root_node_viewport`
     pub(super) fn remove_ui_node(&mut self, ui_node_entity: &Entity) {
         self.remove_root_node_viewport(ui_node_entity);
         if let Some(taffy_node) = self.entity_to_taffy.remove(ui_node_entity) {
@@ -128,6 +128,7 @@ impl UiSurface {
         }
     }
 
+    /// Demotes root node to a child node of the specified parent
     pub(super) fn demote_ui_node(&mut self, target_entity: &Entity, parent_entity: &Entity) {
         // remove camera association
         self.mark_root_node_as_orphaned(target_entity);
@@ -142,6 +143,7 @@ impl UiSurface {
         }
     }
 
+    /// Converts ui node to root node
     pub(super) fn promote_ui_node(&mut self, target_entity: &Entity) {
         self.root_node_data
             .entry(*target_entity)
@@ -203,10 +205,15 @@ without UI components as a child of an entity with UI components, results may be
         }
     }
 
+    /// Removes camera association to root node
+    /// Shorthand for calling `replace_camera_association(root_node_entity, None)`
     fn mark_root_node_as_orphaned(&mut self, root_node_entity: &Entity) {
         self.replace_camera_association(*root_node_entity, None);
     }
 
+    /// `Some(camera_entity)` - Updates camera association to root node
+    /// `None` - Removes camera association to root node
+    /// Does not check to see if they are the same before performing operations
     fn replace_camera_association(
         &mut self,
         root_node_entity: Entity,
@@ -232,6 +239,7 @@ without UI components as a child of an entity with UI components, results may be
         }
     }
 
+    /// Creates or updates a root node
     fn create_or_update_root_node_data(
         &mut self,
         root_node_entity: &Entity,
@@ -244,7 +252,8 @@ without UI components as a child of an entity with UI components, results may be
         let mut added = false;
 
         // creates mutable borrow on self that lives as long as the result
-        let _ = self.root_node_data
+        let _ = self
+            .root_node_data
             .entry(ui_root_node_entity)
             .or_insert_with(|| {
                 added = true;
@@ -314,7 +323,7 @@ without UI components as a child of an entity with UI components, results may be
         }
     }
 
-    // Compute the layout for each window entity's corresponding root node in the layout.
+    /// Compute the layout for each window entity's corresponding root node in the layout.
     pub fn compute_camera_layout(
         &mut self,
         camera_entity: &Entity,

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -5,7 +5,7 @@ use taffy::Taffy;
 
 use bevy_ecs::entity::{Entity, EntityHashMap};
 use bevy_ecs::prelude::Resource;
-use bevy_hierarchy::{Children, Parent};
+use bevy_hierarchy::Children;
 use bevy_math::UVec2;
 use bevy_utils::default;
 use bevy_utils::tracing::warn;

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -126,7 +126,7 @@ without UI components as a child of an entity with UI components, results may be
     /// Set the ui node entities without a [`Parent`] as children to the root node in the taffy layout.
     pub fn set_camera_children(
         &mut self,
-        camera_id: Entity,
+        camera_entity: Entity,
         children: impl Iterator<Item = Entity>,
     ) {
         let viewport_style = taffy::style::Style {
@@ -142,8 +142,8 @@ without UI components as a child of an entity with UI components, results may be
             ..default()
         };
 
-        let camera_root_node_map = self.camera_entity_to_taffy.entry(camera_id).or_default();
-        let existing_roots = self.camera_roots.entry(camera_id).or_default();
+        let camera_root_node_map = self.camera_entity_to_taffy.entry(camera_entity).or_default();
+        let existing_roots = self.camera_roots.entry(camera_entity).or_default();
         let mut new_roots = Vec::new();
         for entity in children {
             let node = *self.entity_to_taffy.get(&entity).unwrap();
@@ -170,7 +170,7 @@ without UI components as a child of an entity with UI components, results may be
             new_roots.push(root_node);
         }
 
-        self.camera_roots.insert(camera_id, new_roots);
+        self.camera_roots.insert(camera_entity, new_roots);
     }
 
     /// Compute the layout for each window entity's corresponding root node in the layout.

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -32,6 +32,8 @@ pub struct UiSurface {
 fn _assert_send_sync_ui_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
     _assert_send_sync::<EntityHashMap<taffy::node::Node>>();
+    _assert_send_sync::<EntityHashMap<EntityHashMap<taffy::node::Node>>>();
+    _assert_send_sync::<EntityHashMap<Vec<RootNodePair>>>();
     _assert_send_sync::<Taffy>();
     _assert_send_sync::<UiSurface>();
 }
@@ -40,6 +42,7 @@ impl fmt::Debug for UiSurface {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("UiSurface")
             .field("entity_to_taffy", &self.entity_to_taffy)
+            .field("camera_entity_to_taffy", &self.camera_entity_to_taffy)
             .field("camera_roots", &self.camera_roots)
             .finish()
     }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -13,6 +13,7 @@ use crate::layout::convert;
 use crate::{LayoutContext, LayoutError, Style};
 
 #[inline(always)]
+/// Style used for `implicit_viewport_node`
 fn default_viewport_style() -> taffy::style::Style {
     taffy::style::Style {
         display: taffy::style::Display::Grid,
@@ -29,17 +30,43 @@ fn default_viewport_style() -> taffy::style::Style {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Stores reference data to quickly identify:
+/// - Its associated camera
+/// - Its parent `implicit_viewport_node` taffy node
 pub struct RootNodeData {
+    /// Associated camera `Entity`
+    ///
+    /// inferred by components: `TargetCamera`, `IsDefaultUiCamera`
+    ///
+    /// "Orphans" are root nodes not assigned to a camera.
+    /// Root nodes might temporarily enter an orphan state as they transition between cameras
+    /// The reason for this is to prevent us from prematurely recreating taffy nodes
+    /// and allowing for the entities to be cleaned up when they are requested to be removed by the ECS
     pub(super) camera_entity: Option<Entity>,
-    // The implicit "viewport" node created by Bevy
+    /// The implicit "viewport" node created by Bevy
+    ///
+    /// This forces the root nodes to behave independently to other root nodes.
+    /// Just as if they were set to `PositionType::Absolute`
+    ///
+    /// This must be manually removed on `Entity` despawn
+    /// or else it will survive in the taffy tree with no references
     pub(super) implicit_viewport_node: taffy::node::Node,
 }
 
 #[derive(Resource)]
+/// Manages state and hierarchy for ui entities
 pub struct UiSurface {
+    /// Maps `Entity` to its corresponding taffy node
+    ///
+    /// Maintains an entry for each root ui node (parentless), and any of its children
+    ///
+    /// (does not include the `implicit_viewport_node`)
     pub(super) entity_to_taffy: EntityHashMap<taffy::node::Node>,
+    /// Maps root ui node (parentless) `Entity` to its corresponding `RootNodeData`
     pub(super) root_node_data: EntityHashMap<RootNodeData>,
+    /// Maps camera `Entity` to an associated `EntityHashSet` of root nodes (parentless)
     pub(super) camera_root_nodes: EntityHashMap<EntityHashSet>,
+    /// Manages the UI Node Tree
     pub(super) taffy: Taffy,
 }
 
@@ -98,7 +125,7 @@ impl UiSurface {
     }
 
     /// Disassociates the camera from all of its assigned root nodes and removes their viewport nodes
-    /// Removes entry in camera_root_nodes
+    /// Removes entry in `camera_root_nodes`
     pub(super) fn remove_camera(&mut self, camera_entity: &Entity) {
         if let Some(root_node_entities) = self.camera_root_nodes.remove(camera_entity) {
             for root_node_entity in root_node_entities {
@@ -231,6 +258,7 @@ without UI components as a child of an entity with UI components, results may be
         self.replace_camera_association(*root_node_entity, None);
     }
 
+    /// Reassigns or removes a root node's associated camera entity
     /// `Some(camera_entity)` - Updates camera association to root node
     /// `None` - Removes camera association to root node
     /// Does not check to see if they are the same before performing operations

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -144,10 +144,21 @@ impl UiSurface {
     }
 
     /// Converts ui node to root node
-    pub(super) fn promote_ui_node(&mut self, target_entity: &Entity) {
+    /// Should only be used for testing - does not set `TargetCamera`
+    #[cfg(test)]
+    pub(super) fn promote_ui_node(&mut self, target_entity: &Entity, camera_entity: &Entity) {
+        let taffy_node = self.entity_to_taffy.get(target_entity).unwrap();
+        
+        // clear the parent - new_with_children doesn't seem to notify the old parent its children have changed
+        if let Some(parent) = self.taffy.parent(*taffy_node) {
+            self.taffy.remove_child(parent, *taffy_node).unwrap();
+        }
+        
+        let mut added = false;        
         self.root_node_data
             .entry(*target_entity)
             .or_insert_with(|| {
+                added = true;
                 let user_root_node = *self.entity_to_taffy.get(target_entity).unwrap();
                 let implicit_viewport_node = self
                     .taffy
@@ -158,6 +169,17 @@ impl UiSurface {
                     implicit_viewport_node,
                 }
             });
+        
+        self.replace_camera_association(*target_entity, Some(*camera_entity));
+        
+        // if it's not added we want to re-assign the parent we cleared above
+        if !added {
+            let Some(root_node_data) = self.root_node_data.get(target_entity) else {
+              unreachable!("impossible");  
+            };
+            let taffy_node = self.entity_to_taffy.get(target_entity).unwrap();
+            self.taffy.add_child(root_node_data.implicit_viewport_node, *taffy_node).unwrap();
+        }
     }
 
     /// Update the `MeasureFunc` of the taffy node corresponding to the given [`Entity`] if the node exists.
@@ -710,5 +732,31 @@ mod tests {
 
         let taffy_node = ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
         assert!(ui_surface.taffy.layout(*taffy_node).is_ok());
+    }
+    
+    #[test]
+    fn test_promotion() {
+        let mut ui_surface = UiSurface::default();
+        let camera_entity = Entity::from_raw(0);
+        let root_node_entity = Entity::from_raw(1);
+        let child_entity = Entity::from_raw(2);
+        let style = Style::default();
+
+        ui_surface.upsert_node(root_node_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(child_entity, &style, &DUMMY_LAYOUT_CONTEXT);
+        ui_surface.update_children(root_node_entity, &[child_entity]);
+        assert_eq!(ui_surface.taffy.total_node_count(), 2);
+        
+        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
+        assert_eq!(ui_surface.taffy.total_node_count(), 3);
+        
+        
+        ui_surface.promote_ui_node(&child_entity, &camera_entity);
+        assert_eq!(ui_surface.taffy.total_node_count(), 4);
+        assert_eq!(ui_surface.get_associated_camera_entity(child_entity), Some(camera_entity));
+        
+        let root_node_entity_taffy = ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
+        let child_entity_taffy = ui_surface.entity_to_taffy.get(&child_entity).unwrap();
+        assert!(!ui_surface.taffy.children(*root_node_entity_taffy).unwrap().contains(child_entity_taffy));
     }
 }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -11,19 +11,19 @@ use crate::{LayoutContext, LayoutError, Style};
 use crate::layout::convert;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct RootNodePair {
+pub struct RootNodePair {
     // The implicit "viewport" node created by Bevy
-    implicit_viewport_node: taffy::node::Node,
+    pub(super) implicit_viewport_node: taffy::node::Node,
     // The root (parentless) node specified by the user
-    user_root_node: taffy::node::Node,
+    pub(super) user_root_node: taffy::node::Node,
 }
 
 #[derive(Resource)]
 pub struct UiSurface {
-    entity_to_taffy: EntityHashMap<taffy::node::Node>,
-    camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::node::Node>>,
-    camera_roots: EntityHashMap<Vec<RootNodePair>>,
-    taffy: Taffy,
+    pub(super) entity_to_taffy: EntityHashMap<taffy::node::Node>,
+    pub(super) camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::node::Node>>,
+    pub(super) camera_roots: EntityHashMap<Vec<RootNodePair>>,
+    pub(super) taffy: Taffy,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -358,9 +358,11 @@ without UI components as a child of an entity with UI components, results may be
                 height: taffy::style::AvailableSpace::Definite(render_target_resolution.y as f32),
             };
 
-            let Some(root_node_data) = self.root_node_data.get(&root_node_entity) else {
-                continue;
-            };
+            let root_node_data = self
+                .root_node_data
+                .get(&root_node_entity)
+                .expect("root_node_data missing");
+
             if root_node_data.camera_entity.is_none() {
                 panic!("internal map out of sync");
             }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -12,6 +12,22 @@ use bevy_utils::tracing::warn;
 use crate::layout::convert;
 use crate::{LayoutContext, LayoutError, Style};
 
+#[inline(always)]
+fn default_viewport_style() -> taffy::style::Style {
+    taffy::style::Style {
+        display: taffy::style::Display::Grid,
+        // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
+        // So this is setting width:100% and height:100%
+        size: taffy::geometry::Size {
+            width: taffy::style::Dimension::Percent(1.0),
+            height: taffy::style::Dimension::Percent(1.0),
+        },
+        align_items: Some(taffy::style::AlignItems::Start),
+        justify_items: Some(taffy::style::JustifyItems::Start),
+        ..default()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootNodeData {
     // The implicit "viewport" node created by Bevy
@@ -129,19 +145,6 @@ without UI components as a child of an entity with UI components, results may be
         camera_entity: Entity,
         children: impl Iterator<Item = Entity>,
     ) {
-        let viewport_style = taffy::style::Style {
-            display: taffy::style::Display::Grid,
-            // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
-            // So this is setting width:100% and height:100%
-            size: taffy::geometry::Size {
-                width: taffy::style::Dimension::Percent(1.0),
-                height: taffy::style::Dimension::Percent(1.0),
-            },
-            align_items: Some(taffy::style::AlignItems::Start),
-            justify_items: Some(taffy::style::JustifyItems::Start),
-            ..default()
-        };
-
         let camera_root_node_map = self.camera_entity_to_taffy.entry(camera_entity).or_default();
         let existing_roots = self.camera_roots.entry(camera_entity).or_default();
         let mut new_roots = Vec::new();
@@ -159,7 +162,7 @@ without UI components as a child of an entity with UI components, results may be
 
                     let viewport_node = *camera_root_node_map
                         .entry(entity)
-                        .or_insert_with(|| self.taffy.new_leaf(viewport_style.clone()).unwrap());
+                        .or_insert_with(|| self.taffy.new_leaf(default_viewport_style()).unwrap());
                     self.taffy.add_child(viewport_node, node).unwrap();
 
                     RootNodeData {

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -32,6 +32,7 @@ fn default_viewport_style() -> taffy::style::Style {
 pub struct RootNodeData {
     // The implicit "viewport" node created by Bevy
     pub(super) implicit_viewport_node: taffy::node::Node,
+    #[deprecated]
     // The root (parentless) node specified by the user
     pub(super) user_root_node: taffy::node::Node,
 }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -2,15 +2,46 @@ use std::fmt;
 
 use taffy::prelude::LayoutTree;
 use taffy::Taffy;
+use thiserror::Error;
 
 use bevy_ecs::entity::{Entity, EntityHashMap, EntityHashSet};
 use bevy_ecs::prelude::Resource;
 use bevy_math::UVec2;
 use bevy_utils::default;
+use bevy_utils::hashbrown::hash_map::Entry;
 use bevy_utils::tracing::warn;
 
 use crate::layout::convert;
 use crate::{LayoutContext, LayoutError, Style};
+
+#[derive(Debug, Error)]
+/// Error wrapper for most actions performed in `UiSurface`
+pub enum UiSurfaceError {
+    #[error("Invalid state: {0}")]
+    /// Used whenever a creating function encounters a situation where the internal maps are not returning expected results.
+    /// Otherwise, where appropriate `EntityNotFound` or `TaffyError` are likely used.
+    InvalidState(&'static str),
+    #[error("Entity not found in internal map: {0}")]
+    /// Used for when an entity is not found in a map.
+    /// But only when it's not explicitly expected to exist by the function creating the error.
+    /// Otherwise, `InvalidState` is used.
+    EntityNotFound(Entity),
+    #[error("Taffy error: {0}")]
+    /// Simple wrapper for `TaffyError`.
+    TaffyError(#[from] taffy::error::TaffyError),
+    #[error("Iteration error {0:?}")]
+    /// Used in loops that attempt to continue despite encountering an error.
+    IterationError(Vec<UiSurfaceError>),
+    #[error("Error processing {0:?}")]
+    /// Wrapper error usually used in conjunction with `IterationError`.
+    /// Boxed tuple associates `Entity` to the error that was encountered when processing.
+    ///
+    // (boxed to allow self referencing)
+    ProcessingEntityError(Box<(Entity, UiSurfaceError)>),
+    #[error("Unreachable")]
+    /// Code paths that are deemed unreachable but avoid `unreachable!` to allow caller to handle and proceed
+    Unreachable,
+}
 
 #[inline(always)]
 /// Style used for `implicit_viewport_node`
@@ -105,106 +136,124 @@ impl Default for UiSurface {
 impl UiSurface {
     /// Retrieves the Taffy node associated with the given UI node entity and updates its style.
     /// If no associated Taffy node exists a new Taffy node is inserted into the Taffy layout.
-    pub fn upsert_node(&mut self, ui_node_entity: Entity, style: &Style, context: &LayoutContext) {
-        let mut added = false;
-        let taffy_node = *self
-            .entity_to_taffy
-            .entry(ui_node_entity)
-            .or_insert_with(|| {
-                added = true;
-                self.taffy
-                    .new_leaf(convert::from_style(context, style))
-                    .unwrap()
-            });
+    pub fn upsert_node(
+        &mut self,
+        ui_node_entity: Entity,
+        style: &Style,
+        context: &LayoutContext,
+    ) -> Result<(), UiSurfaceError> {
+        let taffy_style = convert::from_style(context, style);
 
-        if !added {
-            self.taffy
-                .set_style(taffy_node, convert::from_style(context, style))
-                .unwrap();
+        match self.entity_to_taffy.entry(ui_node_entity) {
+            Entry::Occupied(entry) => {
+                self.taffy.set_style(*entry.get(), taffy_style)?;
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(self.taffy.new_leaf(taffy_style)?);
+            }
         }
+
+        Ok(())
     }
 
     /// Disassociates the camera from all of its assigned root nodes and removes their viewport nodes
     /// Removes entry in `camera_root_nodes`
-    pub(super) fn remove_camera(&mut self, camera_entity: &Entity) {
+    pub(super) fn remove_camera(&mut self, camera_entity: &Entity) -> Result<(), UiSurfaceError> {
         if let Some(root_node_entities) = self.camera_root_nodes.remove(camera_entity) {
             for root_node_entity in root_node_entities {
-                self.remove_root_node_viewport(&root_node_entity);
+                self.remove_root_node_viewport(&root_node_entity)?;
             }
         };
+
+        Ok(())
     }
 
     /// Disassociates the root node from the assigned camera (if any) and removes the viewport node from taffy
     /// Removes entry in `root_node_data`
-    pub(super) fn remove_root_node_viewport(&mut self, root_node_entity: &Entity) {
-        self.mark_root_node_as_orphaned(root_node_entity);
+    pub(super) fn remove_root_node_viewport(
+        &mut self,
+        root_node_entity: &Entity,
+    ) -> Result<(), UiSurfaceError> {
+        self.mark_root_node_as_orphaned(root_node_entity)?;
         if let Some(removed) = self.root_node_data.remove(root_node_entity) {
-            self.taffy.remove(removed.implicit_viewport_node).unwrap();
+            self.taffy.remove(removed.implicit_viewport_node)?;
         }
+
+        Ok(())
     }
 
     /// Removes the ui node from the taffy tree, and if it's a root node it also calls `remove_root_node_viewport`
-    pub(super) fn remove_ui_node(&mut self, ui_node_entity: &Entity) {
-        self.remove_root_node_viewport(ui_node_entity);
+    pub(super) fn remove_ui_node(&mut self, ui_node_entity: &Entity) -> Result<(), UiSurfaceError> {
+        self.remove_root_node_viewport(ui_node_entity)?;
         if let Some(taffy_node) = self.entity_to_taffy.remove(ui_node_entity) {
-            self.taffy.remove(taffy_node).unwrap();
+            self.taffy.remove(taffy_node)?;
         }
+
+        Ok(())
     }
 
     /// Demotes root node to a child node of the specified parent
-    pub(super) fn demote_ui_node(&mut self, target_entity: &Entity, parent_entity: &Entity) {
+    pub(super) fn demote_ui_node(
+        &mut self,
+        target_entity: &Entity,
+        parent_entity: &Entity,
+    ) -> Result<(), UiSurfaceError> {
         // remove camera association
-        self.mark_root_node_as_orphaned(target_entity);
+        self.mark_root_node_as_orphaned(target_entity)?;
 
         if let Some(root_node_data) = self.root_node_data.remove(target_entity) {
-            self.taffy
-                .remove(root_node_data.implicit_viewport_node)
-                .unwrap();
-            let parent_taffy = self.entity_to_taffy.get(parent_entity).unwrap();
-            let child_taffy = self.entity_to_taffy.get(target_entity).unwrap();
-            self.taffy.add_child(*parent_taffy, *child_taffy).unwrap();
+            self.taffy.remove(root_node_data.implicit_viewport_node)?;
+            let parent_taffy =
+                self.entity_to_taffy
+                    .get(parent_entity)
+                    .ok_or(UiSurfaceError::InvalidState(
+                        "entity missing in entity_to_taffy",
+                    ))?;
+            let child_taffy =
+                self.entity_to_taffy
+                    .get(target_entity)
+                    .ok_or(UiSurfaceError::InvalidState(
+                        "entity missing in entity_to_taffy",
+                    ))?;
+            self.taffy.add_child(*parent_taffy, *child_taffy)?;
         }
+        Ok(())
     }
 
     #[cfg(test)]
     /// Converts ui node to root node
     /// Should only be used for testing - does not set `TargetCamera`
-    pub(super) fn promote_ui_node(&mut self, target_entity: &Entity, camera_entity: &Entity) {
-        let taffy_node = self.entity_to_taffy.get(target_entity).unwrap();
+    pub(super) fn promote_ui_node(
+        &mut self,
+        target_entity: &Entity,
+        camera_entity: &Entity,
+    ) -> Result<(), UiSurfaceError> {
+        match self.root_node_data.entry(*target_entity) {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(entry) => {
+                let user_root_node = *self.entity_to_taffy.get(target_entity).ok_or(
+                    UiSurfaceError::InvalidState("entity missing in entity_to_taffy"),
+                )?;
 
-        // clear the parent - new_with_children doesn't seem to notify the old parent its children have changed
-        if let Some(parent) = self.taffy.parent(*taffy_node) {
-            self.taffy.remove_child(parent, *taffy_node).unwrap();
-        }
+                // clear the parent - new_with_children doesn't seem to notify the old parent its children have changed
+                if let Some(parent) = self.taffy.parent(user_root_node) {
+                    self.taffy.remove_child(parent, user_root_node)?;
+                }
 
-        let mut added = false;
-        self.root_node_data
-            .entry(*target_entity)
-            .or_insert_with(|| {
-                added = true;
-                let user_root_node = *self.entity_to_taffy.get(target_entity).unwrap();
                 let implicit_viewport_node = self
                     .taffy
-                    .new_with_children(default_viewport_style(), &[user_root_node])
-                    .unwrap();
-                RootNodeData {
+                    .new_with_children(default_viewport_style(), &[user_root_node])?;
+
+                entry.insert(RootNodeData {
                     camera_entity: None,
                     implicit_viewport_node,
-                }
-            });
-
-        self.replace_camera_association(*target_entity, Some(*camera_entity));
-
-        // if it's not added we want to re-assign the parent we cleared above
-        if !added {
-            let Some(root_node_data) = self.root_node_data.get(target_entity) else {
-                unreachable!();
-            };
-            let taffy_node = self.entity_to_taffy.get(target_entity).unwrap();
-            self.taffy
-                .add_child(root_node_data.implicit_viewport_node, *taffy_node)
-                .unwrap();
+                });
+            }
         }
+
+        self.replace_camera_association(*target_entity, Some(*camera_entity))?;
+
+        Ok(())
     }
 
     /// Update the `MeasureFunc` of the taffy node corresponding to the given [`Entity`] if the node exists.
@@ -212,15 +261,27 @@ impl UiSurface {
         &mut self,
         entity: Entity,
         measure_func: taffy::node::MeasureFunc,
-    ) -> Option<()> {
-        let taffy_node = self.entity_to_taffy.get(&entity)?;
+    ) -> Result<(), UiSurfaceError> {
+        let taffy_node = self
+            .entity_to_taffy
+            .get(&entity)
+            .ok_or(UiSurfaceError::EntityNotFound(entity))?;
 
-        self.taffy.set_measure(*taffy_node, Some(measure_func)).ok()
+        self.taffy
+            .set_measure(*taffy_node, Some(measure_func))
+            .map_err(UiSurfaceError::TaffyError)?;
+
+        Ok(())
     }
 
     /// Update the children of the taffy node corresponding to the given [`Entity`].
-    pub fn update_children(&mut self, entity: Entity, children: &[Entity]) {
+    pub fn update_children(
+        &mut self,
+        entity: Entity,
+        children: &[Entity],
+    ) -> Result<(), UiSurfaceError> {
         let mut taffy_children = Vec::with_capacity(children.len());
+
         for child in children {
             if let Some(taffy_node) = self.entity_to_taffy.get(child) {
                 taffy_children.push(*taffy_node);
@@ -232,30 +293,45 @@ without UI components as a child of an entity with UI components, results may be
             }
         }
 
-        let taffy_node = self.entity_to_taffy.get(&entity).unwrap();
-        self.taffy
-            .set_children(*taffy_node, &taffy_children)
-            .unwrap();
+        let taffy_node = self
+            .entity_to_taffy
+            .get(&entity)
+            .ok_or(UiSurfaceError::InvalidState(
+                "entity missing in entity_to_taffy",
+            ))?;
+
+        self.taffy.set_children(*taffy_node, &taffy_children)?;
+
+        Ok(())
     }
 
     /// Removes children from the entity's taffy node if it exists. Does nothing otherwise.
-    pub fn try_remove_children(&mut self, entity: Entity) {
+    pub fn try_remove_children(&mut self, entity: Entity) -> Result<(), UiSurfaceError> {
         if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            self.taffy.set_children(*taffy_node, &[]).unwrap();
+            self.taffy.set_children(*taffy_node, &[])?;
         }
+
+        Ok(())
     }
 
     /// Removes the measure from the entity's taffy node if it exists. Does nothing otherwise.
-    pub fn try_remove_measure(&mut self, entity: Entity) {
+    pub fn try_remove_measure(&mut self, entity: Entity) -> Result<(), UiSurfaceError> {
         if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            self.taffy.set_measure(*taffy_node, None).unwrap();
+            self.taffy.set_measure(*taffy_node, None)?;
         }
+
+        Ok(())
     }
 
     /// Removes camera association to root node
     /// Shorthand for calling `replace_camera_association(root_node_entity, None)`
-    fn mark_root_node_as_orphaned(&mut self, root_node_entity: &Entity) {
-        self.replace_camera_association(*root_node_entity, None);
+    fn mark_root_node_as_orphaned(
+        &mut self,
+        root_node_entity: &Entity,
+    ) -> Result<(), UiSurfaceError> {
+        self.replace_camera_association(*root_node_entity, None)?;
+
+        Ok(())
     }
 
     /// Reassigns or removes a root node's associated camera entity
@@ -266,7 +342,7 @@ without UI components as a child of an entity with UI components, results may be
         &mut self,
         root_node_entity: Entity,
         new_camera_entity_option: Option<Entity>,
-    ) {
+    ) -> Result<(), UiSurfaceError> {
         if let Some(root_node_data) = self.root_node_data.get_mut(&root_node_entity) {
             // Clear existing camera association, if any
             if let Some(old_camera_entity) = root_node_data.camera_entity.take() {
@@ -285,6 +361,8 @@ without UI components as a child of an entity with UI components, results may be
                     .insert(root_node_entity);
             }
         }
+
+        Ok(())
     }
 
     /// Creates or updates a root node
@@ -292,44 +370,40 @@ without UI components as a child of an entity with UI components, results may be
         &mut self,
         root_node_entity: &Entity,
         camera_entity: &Entity,
-    ) -> &mut RootNodeData {
-        let user_root_node = *self.entity_to_taffy.get(root_node_entity).expect("create_or_update_root_node_data called before ui_root_node_entity was added to taffy tree or was previously removed");
-        let ui_root_node_entity = *root_node_entity;
+    ) -> Result<&RootNodeData, UiSurfaceError> {
+        let user_root_node = *self.entity_to_taffy
+            .get(root_node_entity)
+            .ok_or(UiSurfaceError::InvalidState("create_or_update_root_node_data called before ui_root_node_entity was added to taffy tree or was previously removed"))?;
+        let root_node_entity = *root_node_entity;
         let camera_entity = *camera_entity;
 
-        let mut added = false;
-
         // creates mutable borrow on self that lives as long as the result
-        let _ = self
-            .root_node_data
-            .entry(ui_root_node_entity)
-            .or_insert_with(|| {
-                added = true;
-
+        match self.root_node_data.entry(root_node_entity) {
+            Entry::Occupied(_) => {
+                self.replace_camera_association(root_node_entity, Some(camera_entity))?;
+            }
+            Entry::Vacant(entry) => {
                 self.camera_root_nodes
                     .entry(camera_entity)
                     .or_default()
-                    .insert(ui_root_node_entity);
+                    .insert(root_node_entity);
 
-                let implicit_viewport_node = self.taffy.new_leaf(default_viewport_style()).unwrap();
+                let implicit_viewport_node = self.taffy.new_leaf(default_viewport_style())?;
 
                 self.taffy
-                    .add_child(implicit_viewport_node, user_root_node)
-                    .unwrap();
+                    .add_child(implicit_viewport_node, user_root_node)?;
 
-                RootNodeData {
+                entry.insert(RootNodeData {
                     camera_entity: Some(camera_entity),
                     implicit_viewport_node,
-                }
-            });
+                });
+            }
+        };
 
-        if !added {
-            self.replace_camera_association(ui_root_node_entity, Some(camera_entity));
-        }
-
-        self.root_node_data
-            .get_mut(root_node_entity)
-            .unwrap_or_else(|| unreachable!())
+        Ok(self
+            .root_node_data
+            .get_mut(&root_node_entity)
+            .ok_or(UiSurfaceError::Unreachable)?)
     }
 
     /// Set the ui node entities without a [`Parent`] as children to the root node in the taffy layout.
@@ -337,38 +411,63 @@ without UI components as a child of an entity with UI components, results may be
         &mut self,
         camera_entity: Entity,
         children: impl Iterator<Item = Entity>,
-    ) {
+    ) -> Result<(), UiSurfaceError> {
         let removed_children = self.camera_root_nodes.entry(camera_entity).or_default();
         let mut removed_children = removed_children.clone();
 
-        for ui_entity in children {
-            // creates mutable borrow on self that lives as long as the result
-            let _ = self.create_or_update_root_node_data(&ui_entity, &camera_entity);
+        let mut update =
+            |camera_entity: Entity, child_entity: Entity| -> Result<(), UiSurfaceError> {
+                // creates mutable borrow on self that lives as long as the result
+                let _ = self.create_or_update_root_node_data(&child_entity, &camera_entity)?;
 
-            // drop the mutable borrow on self by re-fetching
-            let root_node_data = self
-                .root_node_data
-                .get(&ui_entity)
-                .unwrap_or_else(|| unreachable!());
+                // drop the mutable borrow on self by re-fetching
+                let root_node_data = self
+                    .root_node_data
+                    .get(&child_entity)
+                    .ok_or(UiSurfaceError::Unreachable)?;
 
-            // fix taffy relationships
-            {
-                let taffy_node = *self.entity_to_taffy.get(&ui_entity).unwrap();
-                if let Some(parent) = self.taffy.parent(taffy_node) {
-                    self.taffy.remove_child(parent, taffy_node).unwrap();
+                // fix taffy relationships
+                {
+                    let taffy_node = *self
+                        .entity_to_taffy
+                        .get(&child_entity)
+                        .ok_or(UiSurfaceError::Unreachable)?;
+
+                    if let Some(parent) = self.taffy.parent(taffy_node) {
+                        self.taffy.remove_child(parent, taffy_node)?;
+                    }
+
+                    self.taffy
+                        .add_child(root_node_data.implicit_viewport_node, taffy_node)?;
                 }
 
-                self.taffy
-                    .add_child(root_node_data.implicit_viewport_node, taffy_node)
-                    .unwrap();
+                Ok(())
+            };
+
+        let mut errors = vec![];
+
+        for ui_entity in children {
+            match update(camera_entity, ui_entity) {
+                Ok(_) => {}
+                Err(err) => {
+                    errors.push(UiSurfaceError::ProcessingEntityError(Box::new((
+                        ui_entity, err,
+                    ))));
+                }
             }
 
             removed_children.remove(&ui_entity);
         }
 
         for orphan in removed_children.iter() {
-            self.mark_root_node_as_orphaned(orphan);
+            self.mark_root_node_as_orphaned(orphan)?;
         }
+
+        if !errors.is_empty() {
+            return Err(UiSurfaceError::IterationError(errors));
+        }
+
+        Ok(())
     }
 
     /// Compute the layout for each window entity's corresponding root node in the layout.
@@ -376,47 +475,106 @@ without UI components as a child of an entity with UI components, results may be
         &mut self,
         camera_entity: &Entity,
         render_target_resolution: UVec2,
-    ) {
-        let Some(root_nodes) = self.camera_root_nodes.get(camera_entity) else {
-            return;
-        };
-        for &root_node_entity in root_nodes.iter() {
+    ) -> Result<(), UiSurfaceError> {
+        let root_nodes = self
+            .camera_root_nodes
+            .get(camera_entity)
+            .ok_or(UiSurfaceError::EntityNotFound(*camera_entity))?;
+
+        let mut update = |root_node_entity: Entity| -> Result<(), UiSurfaceError> {
             let available_space = taffy::geometry::Size {
                 width: taffy::style::AvailableSpace::Definite(render_target_resolution.x as f32),
                 height: taffy::style::AvailableSpace::Definite(render_target_resolution.y as f32),
             };
 
-            let root_node_data = self
-                .root_node_data
-                .get(&root_node_entity)
-                .expect("root_node_data missing");
+            let root_node_data =
+                self.root_node_data
+                    .get(&root_node_entity)
+                    .ok_or(UiSurfaceError::InvalidState(
+                        "root_node_data missing entity",
+                    ))?;
 
             if root_node_data.camera_entity.is_none() {
-                panic!("internal map out of sync");
+                return Err(UiSurfaceError::InvalidState(
+                    "root node not associated with any camera",
+                ));
             }
 
             self.taffy
-                .compute_layout(root_node_data.implicit_viewport_node, available_space)
-                .unwrap();
+                .compute_layout(root_node_data.implicit_viewport_node, available_space)?;
+
+            Ok(())
+        };
+
+        let mut errors = vec![];
+
+        for &root_node_entity in root_nodes.iter() {
+            match update(root_node_entity) {
+                Ok(_) => {}
+                Err(err) => {
+                    errors.push(UiSurfaceError::ProcessingEntityError(Box::new((
+                        root_node_entity,
+                        err,
+                    ))));
+                }
+            }
         }
+
+        if !errors.is_empty() {
+            return Err(UiSurfaceError::IterationError(errors));
+        }
+
+        Ok(())
     }
 
     /// Removes specified camera entities by disassociating them from their associated `implicit_viewport_node`
     /// in the internal map, and subsequently removes the `implicit_viewport_node`
     /// from the `taffy` layout engine for each.
-    pub fn remove_camera_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+    pub fn remove_camera_entities(
+        &mut self,
+        entities: impl IntoIterator<Item = Entity>,
+    ) -> Result<(), UiSurfaceError> {
+        let mut errors = vec![];
+
         for entity in entities {
-            self.remove_camera(&entity);
+            let res = self.remove_camera(&entity);
+            if let Err(err) = res {
+                errors.push(UiSurfaceError::ProcessingEntityError(Box::new((
+                    entity, err,
+                ))));
+            }
         }
+
+        if !errors.is_empty() {
+            return Err(UiSurfaceError::IterationError(errors));
+        }
+
+        Ok(())
     }
 
     /// Removes the specified entities from the internal map while
     /// removing their `implicit_viewport_node` from taffy,
     /// and then subsequently removes their entry from `entity_to_taffy` and associated node from taffy
-    pub fn remove_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+    pub fn remove_entities(
+        &mut self,
+        entities: impl IntoIterator<Item = Entity>,
+    ) -> Result<(), UiSurfaceError> {
+        let mut errors = vec![];
+
         for entity in entities {
-            self.remove_ui_node(&entity);
+            let res = self.remove_ui_node(&entity);
+            if let Err(err) = res {
+                errors.push(UiSurfaceError::ProcessingEntityError(Box::new((
+                    entity, err,
+                ))));
+            }
         }
+
+        if !errors.is_empty() {
+            return Err(UiSurfaceError::IterationError(errors));
+        }
+
+        Ok(())
     }
 
     /// Get the layout geometry for the taffy node corresponding to the ui node [`Entity`].
@@ -486,27 +644,27 @@ mod tests {
     }
 
     #[test]
-    fn test_upsert() {
+    fn test_upsert() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let camera_entity = Entity::from_raw(0);
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
         // standard upsert
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
         // should be inserted into taffy
         assert_eq!(ui_surface.taffy.total_node_count(), 1);
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
 
         // test duplicate insert 1
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
         // node count should not have increased
         assert_eq!(ui_surface.taffy.total_node_count(), 1);
 
         // assign root node to camera
-        ui_surface.set_camera_children(camera_entity, vec![root_node_entity].into_iter());
+        ui_surface.set_camera_children(camera_entity, vec![root_node_entity].into_iter())?;
 
         // each root node will create 2 taffy nodes
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
@@ -515,39 +673,41 @@ mod tests {
         assert!(ui_surface.has_valid_root_node_data(&root_node_entity));
 
         // test duplicate insert 2
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
         // node count should not have increased
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
 
         // root node data should be unaffected
         assert!(ui_surface.has_valid_root_node_data(&root_node_entity));
+
+        Ok(())
     }
 
     #[test]
-    fn test_remove_camera_entities() {
+    fn test_remove_camera_entities() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let camera_entity = Entity::from_raw(0);
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
         // assign root node to camera
-        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
+        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter())?;
 
         assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
         assert!(ui_surface.root_node_data.contains_key(&root_node_entity));
         let _root_node_data = ui_surface
             .get_root_node_data(root_node_entity)
-            .expect("expected root node data");
+            .ok_or(UiSurfaceError::InvalidState(""))?;
         assert!(ui_surface
             .camera_root_nodes
             .get(&camera_entity)
-            .unwrap()
+            .ok_or(UiSurfaceError::InvalidState(""))?
             .contains(&root_node_entity));
 
-        ui_surface.remove_camera_entities([camera_entity]);
+        ui_surface.remove_camera_entities([camera_entity])?;
 
         // should not affect `entity_to_taffy`
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
@@ -560,101 +720,121 @@ mod tests {
         // root node data should be removed
         let root_node_data = ui_surface.get_root_node_data(root_node_entity);
         assert_eq!(root_node_data, None);
+
+        Ok(())
     }
 
     #[test]
-    fn test_remove_entities() {
+    fn test_remove_entities() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let camera_entity = Entity::from_raw(0);
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
-        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
+        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter())?;
 
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
         assert!(ui_surface
             .camera_root_nodes
             .get(&camera_entity)
-            .unwrap()
+            .ok_or(UiSurfaceError::InvalidState(""))?
             .contains(&root_node_entity));
-        let _root_node_data = ui_surface.get_root_node_data(root_node_entity).unwrap();
+        let _root_node_data = ui_surface
+            .get_root_node_data(root_node_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
 
-        ui_surface.remove_entities([root_node_entity]);
+        ui_surface.remove_entities([root_node_entity])?;
         assert!(!ui_surface.entity_to_taffy.contains_key(&root_node_entity));
 
         assert!(!ui_surface
             .camera_root_nodes
             .get(&camera_entity)
-            .unwrap()
+            .ok_or(UiSurfaceError::InvalidState(""))?
             .contains(&root_node_entity));
         assert!(ui_surface
             .camera_root_nodes
             .get(&camera_entity)
-            .unwrap()
+            .ok_or(UiSurfaceError::InvalidState(""))?
             .is_empty());
+
+        Ok(())
     }
 
     #[test]
-    fn test_try_update_measure() {
+    fn test_try_update_measure() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
         let mut content_size = ContentSize::default();
         content_size.set(FixedMeasure { size: Vec2::ONE });
-        let measure_func = content_size.measure_func.take().unwrap();
-        assert!(ui_surface
-            .try_update_measure(root_node_entity, measure_func)
-            .is_some());
+        let measure_func = content_size
+            .measure_func
+            .take()
+            .ok_or(UiSurfaceError::InvalidState(""))?;
+        ui_surface.try_update_measure(root_node_entity, measure_func)?;
+
+        Ok(())
     }
 
     #[test]
-    fn test_update_children() {
+    fn test_update_children() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let root_node_entity = Entity::from_raw(1);
         let child_entity = Entity::from_raw(2);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
-        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
+        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
-        ui_surface.update_children(root_node_entity, &[child_entity]);
+        ui_surface.update_children(root_node_entity, &[child_entity])?;
 
-        let parent_node = *ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
-        let child_node = *ui_surface.entity_to_taffy.get(&child_entity).unwrap();
+        let parent_node = *ui_surface
+            .entity_to_taffy
+            .get(&root_node_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
+        let child_node = *ui_surface
+            .entity_to_taffy
+            .get(&child_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
         assert_eq!(ui_surface.taffy.parent(child_node), Some(parent_node));
+
+        Ok(())
     }
 
     #[test]
-    fn test_set_camera_children() {
+    fn test_set_camera_children() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let camera_entity = Entity::from_raw(0);
         let root_node_entity = Entity::from_raw(1);
         let child_entity = Entity::from_raw(2);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
-        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
+        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
-        let root_taffy_node = *ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
-        let child_taffy = *ui_surface.entity_to_taffy.get(&child_entity).unwrap();
+        let root_taffy_node = *ui_surface
+            .entity_to_taffy
+            .get(&root_node_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
+        let child_taffy = *ui_surface
+            .entity_to_taffy
+            .get(&child_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
 
         // set up the relationship manually
-        ui_surface
-            .taffy
-            .add_child(root_taffy_node, child_taffy)
-            .unwrap();
+        ui_surface.taffy.add_child(root_taffy_node, child_taffy)?;
 
-        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
+        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter())?;
 
         assert!(
             ui_surface
                 .camera_root_nodes
                 .get(&camera_entity)
-                .unwrap()
+                .ok_or(UiSurfaceError::InvalidState(""))?
                 .contains(&root_node_entity),
             "root node not associated with camera"
         );
@@ -662,35 +842,35 @@ mod tests {
             !ui_surface
                 .camera_root_nodes
                 .get(&camera_entity)
-                .unwrap()
+                .ok_or(UiSurfaceError::InvalidState(""))?
                 .contains(&child_entity),
             "child of root node should not be associated with camera"
         );
 
         let _root_node_data = ui_surface
             .get_root_node_data(root_node_entity)
-            .expect("expected root node data");
+            .ok_or(UiSurfaceError::InvalidState(""))?;
 
         assert_eq!(ui_surface.taffy.parent(child_taffy), Some(root_taffy_node));
-        let root_taffy_children = ui_surface.taffy.children(root_taffy_node).unwrap();
+        let root_taffy_children = ui_surface.taffy.children(root_taffy_node)?;
         assert!(
             root_taffy_children.contains(&child_taffy),
             "root node is not a parent of child node"
         );
         assert_eq!(
-            ui_surface.taffy.child_count(root_taffy_node).unwrap(),
+            ui_surface.taffy.child_count(root_taffy_node)?,
             1,
             "expected root node child count to be 1"
         );
 
         // clear camera's root nodes
-        ui_surface.set_camera_children(camera_entity, Vec::<Entity>::new().into_iter());
+        ui_surface.set_camera_children(camera_entity, Vec::<Entity>::new().into_iter())?;
 
         assert!(
             !ui_surface
                 .camera_root_nodes
                 .get(&camera_entity)
-                .unwrap()
+                .ok_or(UiSurfaceError::InvalidState(""))?
                 .contains(&root_node_entity),
             "root node should have been unassociated with camera"
         );
@@ -698,30 +878,30 @@ mod tests {
             !ui_surface
                 .camera_root_nodes
                 .get(&camera_entity)
-                .unwrap()
+                .ok_or(UiSurfaceError::InvalidState(""))?
                 .contains(&child_entity),
             "child of root node should not be associated with camera"
         );
 
-        let root_taffy_children = ui_surface.taffy.children(root_taffy_node).unwrap();
+        let root_taffy_children = ui_surface.taffy.children(root_taffy_node)?;
         assert!(
             root_taffy_children.contains(&child_taffy),
             "root node is not a parent of child node"
         );
         assert_eq!(
-            ui_surface.taffy.child_count(root_taffy_node).unwrap(),
+            ui_surface.taffy.child_count(root_taffy_node)?,
             1,
             "expected root node child count to be 1"
         );
 
         // re-associate root node with camera
-        ui_surface.set_camera_children(camera_entity, vec![root_node_entity].into_iter());
+        ui_surface.set_camera_children(camera_entity, vec![root_node_entity].into_iter())?;
 
         assert!(
             ui_surface
                 .camera_root_nodes
                 .get(&camera_entity)
-                .unwrap()
+                .ok_or(UiSurfaceError::InvalidState(""))?
                 .contains(&root_node_entity),
             "root node should have been re-associated with camera"
         );
@@ -729,68 +909,87 @@ mod tests {
             !ui_surface
                 .camera_root_nodes
                 .get(&camera_entity)
-                .unwrap()
+                .ok_or(UiSurfaceError::InvalidState(""))?
                 .contains(&child_entity),
             "child of root node should not be associated with camera"
         );
 
-        let child_taffy = ui_surface.entity_to_taffy.get(&child_entity).unwrap();
-        let root_taffy_children = ui_surface.taffy.children(root_taffy_node).unwrap();
+        let child_taffy = ui_surface
+            .entity_to_taffy
+            .get(&child_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
+        let root_taffy_children = ui_surface.taffy.children(root_taffy_node)?;
         assert!(
             root_taffy_children.contains(child_taffy),
             "root node is not a parent of child node"
         );
         assert_eq!(
-            ui_surface.taffy.child_count(root_taffy_node).unwrap(),
+            ui_surface.taffy.child_count(root_taffy_node)?,
             1,
             "expected root node child count to be 1"
         );
+
+        Ok(())
     }
 
     #[test]
-    fn test_compute_camera_layout() {
+    fn test_compute_camera_layout() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let camera_entity = Entity::from_raw(0);
         let root_node_entity = Entity::from_raw(1);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
 
-        ui_surface.compute_camera_layout(&camera_entity, UVec2::new(800, 600));
+        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter())?;
 
-        let taffy_node = ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
-        assert!(ui_surface.taffy.layout(*taffy_node).is_ok());
+        ui_surface.compute_camera_layout(&camera_entity, UVec2::new(800, 600))?;
+
+        let taffy_node = ui_surface
+            .entity_to_taffy
+            .get(&root_node_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
+        ui_surface.taffy.layout(*taffy_node)?;
+
+        Ok(())
     }
 
     #[test]
-    fn test_promotion() {
+    fn test_promotion() -> Result<(), UiSurfaceError> {
         let mut ui_surface = UiSurface::default();
         let camera_entity = Entity::from_raw(0);
         let root_node_entity = Entity::from_raw(1);
         let child_entity = Entity::from_raw(2);
         let style = Style::default();
 
-        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT);
-        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT);
-        ui_surface.update_children(root_node_entity, &[child_entity]);
+        ui_surface.upsert_node(root_node_entity, &style, &TEST_LAYOUT_CONTEXT)?;
+        ui_surface.upsert_node(child_entity, &style, &TEST_LAYOUT_CONTEXT)?;
+        ui_surface.update_children(root_node_entity, &[child_entity])?;
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
 
-        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
+        ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter())?;
         assert_eq!(ui_surface.taffy.total_node_count(), 3);
 
-        ui_surface.promote_ui_node(&child_entity, &camera_entity);
+        ui_surface.promote_ui_node(&child_entity, &camera_entity)?;
         assert_eq!(ui_surface.taffy.total_node_count(), 4);
         assert_eq!(
             ui_surface.get_associated_camera_entity(child_entity),
             Some(camera_entity)
         );
 
-        let root_node_entity_taffy = ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
-        let child_entity_taffy = ui_surface.entity_to_taffy.get(&child_entity).unwrap();
+        let root_node_entity_taffy = ui_surface
+            .entity_to_taffy
+            .get(&root_node_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
+        let child_entity_taffy = ui_surface
+            .entity_to_taffy
+            .get(&child_entity)
+            .ok_or(UiSurfaceError::InvalidState(""))?;
         assert!(!ui_surface
             .taffy
-            .children(*root_node_entity_taffy)
-            .unwrap()
+            .children(*root_node_entity_taffy)?
             .contains(child_entity_taffy));
+
+        Ok(())
     }
 }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -78,12 +78,7 @@ impl Default for UiSurface {
 impl UiSurface {
     /// Retrieves the Taffy node associated with the given UI node entity and updates its style.
     /// If no associated Taffy node exists a new Taffy node is inserted into the Taffy layout.
-    pub fn upsert_node(
-        &mut self,
-        ui_node_entity: Entity,
-        style: &Style,
-        context: &LayoutContext,
-    ) {
+    pub fn upsert_node(&mut self, ui_node_entity: Entity, style: &Style, context: &LayoutContext) {
         let mut added = false;
         let taffy_node = *self
             .entity_to_taffy
@@ -121,9 +116,7 @@ impl UiSurface {
                     root_node_entities.remove(root_node_entity);
                 }
             }
-            self.taffy
-                .remove(removed.implicit_viewport_node)
-                .unwrap();
+            self.taffy.remove(removed.implicit_viewport_node).unwrap();
         }
     }
 
@@ -151,9 +144,7 @@ impl UiSurface {
                 .unwrap();
             let parent_taffy = self.entity_to_taffy.get(parent_entity).unwrap();
             let child_taffy = self.entity_to_taffy.get(target_entity).unwrap();
-            self.taffy
-                .add_child(*parent_taffy, *child_taffy)
-                .unwrap();
+            self.taffy.add_child(*parent_taffy, *child_taffy).unwrap();
         }
     }
 
@@ -311,16 +302,11 @@ without UI components as a child of an entity with UI components, results may be
             {
                 let taffy_node = *self.entity_to_taffy.get(&ui_entity).unwrap();
                 if let Some(parent) = self.taffy.parent(taffy_node) {
-                    self.taffy
-                        .remove_child(parent, taffy_node)
-                        .unwrap();
+                    self.taffy.remove_child(parent, taffy_node).unwrap();
                 }
 
                 self.taffy
-                    .add_child(
-                        root_node_data.implicit_viewport_node,
-                        taffy_node,
-                    )
+                    .add_child(root_node_data.implicit_viewport_node, taffy_node)
                     .unwrap();
             }
 
@@ -367,10 +353,7 @@ without UI components as a child of an entity with UI components, results may be
             }
 
             self.taffy
-                .compute_layout(
-                    root_node_data.implicit_viewport_node,
-                    available_space,
-                )
+                .compute_layout(root_node_data.implicit_viewport_node, available_space)
                 .unwrap();
         }
     }
@@ -510,12 +493,8 @@ mod tests {
         // assign root node to camera
         ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
 
-        assert!(ui_surface
-            .camera_root_nodes
-            .contains_key(&camera_entity));
-        assert!(ui_surface
-            .root_node_data
-            .contains_key(&root_node_entity));
+        assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
+        assert!(ui_surface.root_node_data.contains_key(&root_node_entity));
         let _root_node_data = ui_surface
             .get_root_node_data(root_node_entity)
             .expect("expected root node data");
@@ -531,10 +510,8 @@ mod tests {
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
 
         // `camera_roots` and `camera_entity_to_taffy` should no longer contain entries for `camera_entity`
-        assert!(!ui_surface
-            .camera_root_nodes
-            .contains_key(&camera_entity));
-        
+        assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
+
         assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
 
         // root node data should be removed
@@ -559,9 +536,7 @@ mod tests {
             .get(&camera_entity)
             .unwrap()
             .contains(&root_node_entity));
-        let _root_node_data = ui_surface
-            .get_root_node_data(root_node_entity)
-            .unwrap();
+        let _root_node_data = ui_surface.get_root_node_data(root_node_entity).unwrap();
 
         ui_surface.remove_entities([root_node_entity]);
         assert!(!ui_surface.entity_to_taffy.contains_key(&root_node_entity));

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -10,8 +10,8 @@ use bevy_math::UVec2;
 use bevy_utils::default;
 use bevy_utils::tracing::warn;
 
-use crate::{LayoutContext, LayoutError, Style};
 use crate::layout::convert;
+use crate::{LayoutContext, LayoutError, Style};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootNodePair {

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -1,12 +1,15 @@
+use std::fmt;
+
+use taffy::prelude::LayoutTree;
+use taffy::Taffy;
+
 use bevy_ecs::entity::{Entity, EntityHashMap};
 use bevy_ecs::prelude::Resource;
-use taffy::Taffy;
 use bevy_hierarchy::{Children, Parent};
 use bevy_math::UVec2;
 use bevy_utils::default;
 use bevy_utils::tracing::warn;
-use std::fmt;
-use taffy::prelude::LayoutTree;
+
 use crate::{LayoutContext, LayoutError, Style};
 use crate::layout::convert;
 

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -198,7 +198,7 @@ impl UiSurface {
         // if it's not added we want to re-assign the parent we cleared above
         if !added {
             let Some(root_node_data) = self.root_node_data.get(target_entity) else {
-                unreachable!("impossible");
+                unreachable!();
             };
             let taffy_node = self.entity_to_taffy.get(target_entity).unwrap();
             self.taffy
@@ -329,7 +329,7 @@ without UI components as a child of an entity with UI components, results may be
 
         self.root_node_data
             .get_mut(root_node_entity)
-            .unwrap_or_else(|| unreachable!("impossible"))
+            .unwrap_or_else(|| unreachable!())
     }
 
     /// Set the ui node entities without a [`Parent`] as children to the root node in the taffy layout.
@@ -349,7 +349,7 @@ without UI components as a child of an entity with UI components, results may be
             let root_node_data = self
                 .root_node_data
                 .get(&ui_entity)
-                .unwrap_or_else(|| unreachable!("impossible"));
+                .unwrap_or_else(|| unreachable!());
 
             // fix taffy relationships
             {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -42,8 +42,8 @@ use widget::UiImageSize;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        geometry::*, Interaction, node_bundles::*, ui_material::*, ui_node::*, UiMaterialPlugin,
-        UiScale, widget::Button, widget::Label,
+        geometry::*, node_bundles::*, ui_material::*, ui_node::*, widget::Button, widget::Label,
+        Interaction, UiMaterialPlugin, UiScale,
     };
     // `bevy_sprite` re-exports for texture slicing
     #[doc(hidden)]

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -42,8 +42,8 @@ use widget::UiImageSize;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        geometry::*, node_bundles::*, ui_material::*, ui_node::*, widget::Button, widget::Label,
-        Interaction, UiMaterialPlugin, UiScale,
+        geometry::*, Interaction, node_bundles::*, ui_material::*, ui_node::*, UiMaterialPlugin,
+        UiScale, widget::Button, widget::Label,
     };
     // `bevy_sprite` re-exports for texture slicing
     #[doc(hidden)]
@@ -55,6 +55,7 @@ use bevy_ecs::prelude::*;
 use bevy_input::InputSystem;
 use bevy_render::RenderApp;
 use bevy_transform::TransformSystem;
+use layout::ui_surface::UiSurface;
 use stack::ui_stack_system;
 pub use stack::UiStack;
 use update::{update_clipping_system, update_target_camera_system};


### PR DESCRIPTION
This is 5 of 5 iterative PR's that affect bevy_ui/layout

- [x] Blocked by https://github.com/bevyengine/bevy/pull/12801
- [x] Blocked by https://github.com/bevyengine/bevy/pull/12802
- [x] Blocked by https://github.com/bevyengine/bevy/pull/12803
- [ ] ~~Blocked by https://github.com/bevyengine/bevy/pull/12804~~ https://github.com/bevyengine/bevy/pull/16362

[Diff to parent PR](https://github.com/StrikeForceZero/bevy/compare/dev/bevy_ui/ui_surface_update_mappings..dev/bevy_ui/remove_unwrap)

This is a very ambitious attempt to add error handling to `UiSurface` and the `ui_layout_system` (WIP) instead of panicking

---

# Objective

- Replace `unwrap`, `expect`, `panic!`, with `Result`
  - https://github.com/bevyengine/bevy/issues/12660

## Solution

- Replaces all instances `unwrap`, `expect`, `panic!`, with `Result`
- Adds `UiSurfaceError`

---

## Changelog


## Migration Guide

TBD - probably should be saved for 0.14