### PR TITLE
Add `RemovedComponentEvents::iter`

### DIFF
--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -83,6 +83,11 @@ impl RemovedComponentEvents {
         }
     }
 
+    /// Returns iterator over components and their entity events.
+    pub fn iter(&self) -> impl Iterator<Item = (&ComponentId, &Events<RemovedComponentEntity>)> {
+        self.event_sets.iter()
+    }
+
     /// Gets the event storage for a given component.
     pub fn get(
         &self,

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -83,7 +83,7 @@ impl RemovedComponentEvents {
         }
     }
 
-    /// Returns iterator over components and their entity events.
+    /// Returns an iterator over components and their entity events.
     pub fn iter(&self) -> impl Iterator<Item = (&ComponentId, &Events<RemovedComponentEntity>)> {
         self.event_sets.iter()
     }


### PR DESCRIPTION
# Objective

Sometimes it's useful to iterate over removed entities. For example, in my library [bevy_replicon](https://github.com/projectharmonia/bevy_replicon) I need it to iterate over all removals to replicate them over the network.

Right now we do lookups, but it would be more convenient and faster to just iterate over all removals.

## Solution

Add `RemovedComponentEvents::iter`.

---

## Changelog

### Added

- `RemovedComponentEvents::iter` to iterate over all removed components.