### PR TITLE
Remove unused `ImePreedit` component from `text_input` example

### DIFF
--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -123,9 +123,6 @@ struct Bubble {
     timer: Timer,
 }
 
-#[derive(Component)]
-struct ImePreedit;
-
 fn bubbling_text(
     mut commands: Commands,
     mut bubbles: Query<(Entity, &mut Transform, &mut Bubble)>,


### PR DESCRIPTION
# Objective

- The `ImePreedit` component from [`text_input`](https://github.com/bevyengine/bevy/blob/50699ecf76800e5b1b31bd9b6845b30e4ede5e32/examples/input/text_input.rs#L126-L127) appears to be unused.
  - This was found by running `cargo check --workspace --examples`, originally as part of #12817.

## Solution

- Remove it :)
