### PR TITLE
Manipulate non-send resources with `Commands`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -540,9 +540,9 @@ impl<'w, 's> Commands<'w, 's> {
     /// # }
     /// # bevy_ecs::system::assert_is_system(insert_my_non_send);
     /// ```
-    /// 
+    ///
     /// Note that the value must be constructed inside of the closure. Moving it will fail to compile:
-    /// 
+    ///
     /// ```compile_fail,E0277
     /// # use bevy_ecs::prelude::*;
     /// #
@@ -550,7 +550,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// #
     /// # fn insert_my_non_send(mut commands: Commands) {
     /// let my_non_send = MyNonSend(std::ptr::null());
-    /// 
+    ///
     /// commands.insert_non_send_resource(move || {
     ///     my_non_send
     /// });

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -500,27 +500,20 @@ impl<'w, 's> Commands<'w, 's> {
     /// # Example
     ///
     /// ```
-    /// # use bevy::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     /// #
-    /// struct MyNonSend(*const u8);
-    ///
-    /// impl Default for MyNonSend {
-    ///     fn default() -> Self {
-    ///         MyNonSend(std::ptr::null())
-    ///     }
-    /// }
-    ///
-    /// fn create_my_non_send(mut commands: Commands) {
-    ///     commands.init_non_send_resource::<MyNonSend>();
-    /// }
+    /// # struct MyNonSend(*const u8);
     /// #
-    /// # App::new()
-    /// #     .add_systems(Startup, (create_my_non_send, check).chain())
-    /// #     .run();
-    /// #
-    /// # fn check(my_non_send: NonSend<MyNonSend>) {
-    /// #     assert!(my_non_send.0.is_null());
+    /// # impl Default for MyNonSend {
+    /// #     fn default() -> Self {
+    /// #         MyNonSend(std::ptr::null())
+    /// #     }
     /// # }
+    /// #
+    /// # fn init_my_non_send(mut commands: Commands) {
+    /// commands.init_non_send_resource::<MyNonSend>();
+    /// # }
+    /// # bevy_ecs::system::assert_is_system(init_my_non_send);
     /// ```
     pub fn init_non_send_resource<R: FromWorld + 'static>(&mut self) {
         self.queue.push(init_non_send_resource::<R>);
@@ -536,24 +529,16 @@ impl<'w, 's> Commands<'w, 's> {
     /// # Example
     ///
     /// ```
-    /// # use bevy::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     /// #
-    /// struct MyNonSend(*const u8);
-    ///
-    /// fn create_my_non_send(mut commands: Commands) {
-    ///     // Note that this is a closure:
-    ///     commands.insert_non_send_resource(|| {
-    ///         MyNonSend(std::ptr::null())
-    ///     });
-    /// }
+    /// # struct MyNonSend(*const u8);
     /// #
-    /// # App::new()
-    /// #     .add_systems(Startup, (create_my_non_send, check).chain())
-    /// #     .run();
-    /// #
-    /// # fn check(my_non_send: NonSend<MyNonSend>) {
-    /// #     assert!(my_non_send.0.is_null());
+    /// # fn insert_my_non_send(mut commands: Commands) {
+    /// commands.insert_non_send_resource(|| {
+    ///     MyNonSend(std::ptr::null())
+    /// });
     /// # }
+    /// # bevy_ecs::system::assert_is_system(insert_my_non_send);
     /// ```
     pub fn insert_non_send_resource<F, R>(&mut self, func: F)
     where
@@ -568,22 +553,14 @@ impl<'w, 's> Commands<'w, 's> {
     /// See [`World::remove_non_send_resource`] for more details.
     ///
     /// ```
-    /// # use bevy::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     /// #
-    /// struct MyNonSend(*const u8);
-    ///
-    /// fn remove_my_non_send(mut commands: Commands) {
-    ///     commands.remove_non_send_resource::<MyNonSend>();
-    /// }
+    /// # struct MyNonSend(*const u8);
     /// #
-    /// # App::new()
-    /// #     .insert_non_send_resource(MyNonSend(std::ptr::null()))
-    /// #     .add_systems(Startup, (remove_my_non_send, check).chain())
-    /// #     .run();
-    /// #
-    /// # fn check(my_non_send: Option<NonSend<MyNonSend>>) {
-    /// #     assert!(my_non_send.is_none());
+    /// # fn remove_my_non_send(mut commands: Commands) {
+    /// commands.remove_non_send_resource::<MyNonSend>();
     /// # }
+    /// # bevy_ecs::system::assert_is_system(remove_my_non_send);
     /// ```
     pub fn remove_non_send_resource<R: 'static>(&mut self) {
         self.queue.push(remove_non_send_resource::<R>);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1122,16 +1122,16 @@ fn init_resource<R: Resource + FromWorld>(world: &mut World) {
     world.init_resource::<R>();
 }
 
-/// A [`Command`] that removes the [resource](Resource) `R` from the world.
-fn remove_resource<R: Resource>(world: &mut World) {
-    world.remove_resource::<R>();
-}
-
 /// A [`Command`] that inserts a [`Resource`] into the world.
 fn insert_resource<R: Resource>(resource: R) -> impl Command {
     move |world: &mut World| {
         world.insert_resource(resource);
     }
+}
+
+/// A [`Command`] that removes the [resource](Resource) `R` from the world.
+fn remove_resource<R: Resource>(world: &mut World) {
+    world.remove_resource::<R>();
 }
 
 /// [`EntityCommand`] to log the components of a given entity. See [`EntityCommands::log_components`].

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -18,6 +18,7 @@ bitflags! {
         const EXAMPLE_CHECK = 0b10000000;
         const COMPILE_CHECK = 0b100000000;
         const CFG_CHECK = 0b1000000000;
+        const TEST_CHECK = 0b10000000000;
     }
 }
 
@@ -56,13 +57,18 @@ fn main() {
         ("doc", Check::DOC_TEST | Check::DOC_CHECK),
         (
             "compile",
-            Check::COMPILE_FAIL | Check::BENCH_CHECK | Check::EXAMPLE_CHECK | Check::COMPILE_CHECK,
+            Check::COMPILE_FAIL
+                | Check::BENCH_CHECK
+                | Check::EXAMPLE_CHECK
+                | Check::COMPILE_CHECK
+                | Check::TEST_CHECK,
         ),
         ("format", Check::FORMAT),
         ("clippy", Check::CLIPPY),
         ("compile-fail", Check::COMPILE_FAIL),
         ("bench-check", Check::BENCH_CHECK),
         ("example-check", Check::EXAMPLE_CHECK),
+        ("test-check", Check::TEST_CHECK),
         ("cfg-check", Check::CFG_CHECK),
         ("doc-check", Check::DOC_CHECK),
         ("doc-test", Check::DOC_TEST),
@@ -310,6 +316,24 @@ fn main() {
                 failure_message: "Please fix failing cfg checks in output above.",
                 subdir: None,
                 env_vars: vec![("RUSTFLAGS", "-D warnings")],
+            }],
+        );
+    }
+
+    if checks.contains(Check::TEST_CHECK) {
+        let mut args = vec!["--workspace", "--examples"];
+
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--keep-going");
+        }
+
+        test_suite.insert(
+            Check::TEST_CHECK,
+            vec![CITest {
+                command: cmd!(sh, "cargo check {args...}"),
+                failure_message: "Please fix compiler examples for tests in output above.",
+                subdir: None,
+                env_vars: Vec::new(),
             }],
         );
     }


### PR DESCRIPTION
# Objective

- While it is possible to manipulate `Resources` using `Commands`, it is not possible to do the same for non-send resources (`NonSend`).
  - Please see #12795 for full justification and additional discussion.
- Closes #12795.
- Incompatible with #9122. I'd prefer that get merged instead of this one, but... uhhh...  <img width="152" alt="image" src="https://github.com/bevyengine/bevy/assets/59022059/91785d76-cd54-482d-9459-be19c373f67a">

## Solution

- Implements `init_non_send_resource`, `insert_non_send_resource`, and `remove_non_send_resource` methods for `Commands`.
  - Since `Commands` is accessible across threads, `insert_non_send_resource`'s implementation takes a closure that creates the non-send resource on the main thread, instead of straight-up taking the value. This can be a bit confusing, so please check my documentation closely to make sure I explained it well!
- I additionally moved `remove_resource` in 13e0f175f73d877ff5a09411fd994cd6a8509f72, which is why the diff looks weird. I recommend looking at 314391cbd8abd0f80cb5dda60d52e89dc19287ce for the actual new content.

---

## Changelog

- Added methods for manipulating non-send resources in `Commands`.

## Migration Guide

_This PR is not actually a breaking change, but I feel a migration guide is useful. Comment if you think I should remove it. :)_

It is now possible to insert and remove non-send resources using `Commands`. If you have any systems that take `&mut World` like this:

```rust
fn insert_non_send(world: &mut World) {
    world.insert_non_send_resource(MyNonSend::new());
}
```

You can replace it with the following, which may yield performance improvements:

```rust
fn insert_non_send(mut commands: Commands) {
    commands.insert_non_send_resource(|| {
        MyNonSend::new()
    });
}
```

This also applies to the methods `init_non_send_resource` and `remove_non_send_resource`. Note that `Commands::insert_non_send_resource` takes a closure, not `MyNonSend` directly. This closure's returned value will be inserted, after it is run on the main thread.

Be warned that **this may change the order of inserting your resource!** `Commands` works by delaying work until `apply_deferred` is called. If you depend on a resource being inserted / removed within a schedule, using `Commands` will break your code.