### PR TITLE
Fix UV coords in `generate_custom_mesh` example

### DIFF
--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -166,7 +166,7 @@ fn create_cube_mesh() -> Mesh {
         Mesh::ATTRIBUTE_UV_0,
         vec![
             // Assigning the UV coords for the top side.
-            [0.0, 0.2], [0.0, 0.0], [1.0, 0.0], [1.0, 0.25],
+            [0.0, 0.2], [0.0, 0.0], [1.0, 0.0], [1.0, 0.2],
             // Assigning the UV coords for the bottom side.
             [0.0, 0.45], [0.0, 0.25], [1.0, 0.25], [1.0, 0.45],
             // Assigning the UV coords for the right side.


### PR DESCRIPTION
# Objective
Fix the last coordinate  of the top side in the `generate_custom_mesh` example.
Fixes #12822

## Images
Added a yellow square to the texture to demonstrate as suggested in [the issue](https://github.com/bevyengine/bevy/issues/12822).

<details>
  <summary>Texture:</summary>
  <img src="https://github.com/bevyengine/bevy/assets/70668395/c605e916-bb02-4247-bf24-2f033c650419" />
</details>

<details>
  <summary>Before:</summary>
  <img src="https://github.com/bevyengine/bevy/assets/70668395/e67b592b-8001-42e3-a6ce-7d62ad59bf81" />
</details>

<details>
  <summary>After:</summary>
  <img src="https://github.com/bevyengine/bevy/assets/70668395/e9194784-ee4a-4848-87c2-0eb54e05236c" />
</details>

## Solution
Change the coordinate from 0.25 to 0.2.