### PR TITLE
Fix wrong dependency in weekly ci

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -48,7 +48,7 @@ jobs:
   check-compiles:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: ci
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@beta


### PR DESCRIPTION
# Objective

Weekly Ci fails with a `Invalid workflow error`

## Solution

Make `check-compiles` depend on a job that actually exists.