### PR TITLE
Normalize warning messages with Nvidia drivers

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -341,7 +341,7 @@ pub fn prepare_windows(
                 Err(wgpu::SurfaceError::Outdated) if is_nvidia() => {
                     warn_once!(
                         "Couldn't get swap chain texture. This often happens with \
-                        the Nvidia 550 driver. It can be safely ignored."
+                        the NVIDIA drivers on Linux. It can be safely ignored."
                     );
                 }
                 Err(wgpu::SurfaceError::Outdated) => {


### PR DESCRIPTION
# Objective
There are currently 2 different warning messages that are logged when resizing on Linux with Nvidia drivers (introduced in https://github.com/bevyengine/bevy/commit/70c69cdd51311e4f2be6f4ee245ff5ab89c1fc24).
Fixes #12830

## Solution
Generalize both to say:
```Couldn't get swap chain texture. This often happens with the NVIDIA drivers on Linux. It can be safely ignored.```