### PR TITLE
Fix panic in bevy_ui layout

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -129,7 +129,10 @@ without UI components as a child of an entity with UI components, results may be
             }
         }
 
-        let taffy_node = self.entity_to_taffy.get(&entity).unwrap();
+        let Some(taffy_node) = self.entity_to_taffy.get(&entity) else {
+            warn!("Missing taffy node for entity when calling update_children.");
+            return;
+        };
         self.taffy
             .set_children(*taffy_node, &taffy_children)
             .unwrap();


### PR DESCRIPTION
# Objective

I encountered a panic in bevy_ui on this line, which calls `unwrap`. It happened while I was despawning UI nodes, but I only saw it once and have been unable to reproduce it.

Related to #12660.

## Solution

Remove `unwrap` and replace with `let ... else` and a warning.