### PR TITLE
UI: pass the untransformed node size to the shader

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -1141,7 +1141,7 @@ pub fn prepare_uinodes(
                             flags: flags | shader_flags::CORNERS[i],
                             radius: extracted_uinode.border_radius,
                             border: extracted_uinode.border,
-                            size: transformed_rect_size.xy().into(),
+                            size: rect_size.xy().into(),
                         });
                     }
 


### PR DESCRIPTION
# Objective

- #12500 broke rotating ui nodes, see examples `pbr` (missing "metallic" label) or `overflow_debug` (bottom right box is empty)

## Solution

- Pass the untransformed node size to the shader
