### PR TITLE
Remove unnecessary branch in query iteration

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -785,7 +785,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 // SAFETY: set_table was called prior.
                 // `current_row` is a table row in range of the current table, because if it was not, then the above would have been executed.
                 let entity = unsafe { self.table_entities.get_unchecked(self.current_row) };
-                let row = TableRow::from_usize(self.current_row);
+                let row = TableRow::from_u32(self.current_row as u32);
                 if !F::filter_fetch(&mut self.filter, *entity, row) {
                     self.current_row += 1;
                     continue;

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -785,7 +785,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 // SAFETY: set_table was called prior.
                 // `current_row` is a table row in range of the current table, because if it was not, then the above would have been executed.
                 let entity = unsafe { self.table_entities.get_unchecked(self.current_row) };
-                let row = TableRow::from_u32(self.current_row as u32);
+                let row = TableRow::from_usize(self.current_row);
                 if !F::filter_fetch(&mut self.filter, *entity, row) {
                     self.current_row += 1;
                     continue;

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -56,7 +56,7 @@ impl TableId {
     /// Will panic if the provided value does not fit within a [`u32`].
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
-        assert!(index as u32 as usize == index);
+        debug_assert!(index as u32 as usize == index);
         Self(index as u32)
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -116,7 +116,7 @@ impl TableRow {
     /// Will panic if the provided value does not fit within a [`u32`].
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
-        assert!(index as u32 as usize == index);
+        debug_assert!(index as u32 as usize == index);
         Self(index as u32)
     }
 


### PR DESCRIPTION
# Objective

- Since #10811,Bevy uses `assert `in the hot path of iteration. The `for_each `method has an assert in the outer loop to help the compiler remove unnecessary branching in the internal loop.
- However , ` for` style iterations do not receive the same treatment. it still have a branch check in the internal loop, which could potentially hurt performance.

## Solution

- use `TableRow::from_u32 ` instead of ` TableRow::from_usize` to avoid unnecessary branch.

Before

![image](https://github.com/bevyengine/bevy/assets/45868716/f6d2a1ac-2129-48ff-97bf-d86713ddeaaf)



After ----------------------------------------------------------------------------

![image](https://github.com/bevyengine/bevy/assets/45868716/bfe5a9ee-ba6c-4a80-85b0-1c6d43adfe8c)


