### PR TITLE
Remove stepping from default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ default = [
   "default_font",
   "webgl2",
   "sysinfo_plugin",
-  "bevy_debug_stepping",
 ]
 
 # Force dynamic linking, which improves iterative compile times
@@ -1685,6 +1684,7 @@ wasm = false
 name = "system_stepping"
 path = "examples/ecs/system_stepping.rs"
 doc-scrape-examples = true
+required-features = ["bevy_debug_stepping"]
 
 [package.metadata.example.system_stepping]
 name = "System Stepping"

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 [features]
 trace = []
 bevy_debug_stepping = []
-default = ["bevy_reflect", "bevy_debug_stepping"]
+default = ["bevy_reflect"]
 bevy_reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect"]
 
 [dependencies]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines", "data-structures"]
 trace = []
 multi-threaded = ["bevy_tasks/multi-threaded"]
 bevy_debug_stepping = []
-default = ["bevy_reflect", "bevy_debug_stepping"]
+default = ["bevy_reflect"]
 
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.14.0-dev" }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -18,7 +18,6 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_audio|Provides audio functionality|
 |bevy_color|Provides shared color types and operations|
 |bevy_core_pipeline|Provides cameras and other basic render pipeline features|
-|bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
 |bevy_gilrs|Adds gamepad support|
 |bevy_gizmos|Adds support for rendering gizmos|
 |bevy_gltf|[glTF](https://www.khronos.org/gltf/) support|
@@ -50,6 +49,7 @@ The default feature set enables most of the expected features of a game engine, 
 |async-io|Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.|
 |basis-universal|Basis Universal compressed texture support|
 |bevy_ci_testing|Enable systems that allow for automated testing on CI|
+|bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
 |bevy_dev_tools|Provides a collection of developer tools|
 |bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading))|
 |bmp|BMP image format support|

--- a/examples/README.md
+++ b/examples/README.md
@@ -262,7 +262,7 @@ Example | Description
 [System Closure](../examples/ecs/system_closure.rs) | Show how to use closures as systems, and how to configure `Local` variables by capturing external state
 [System Parameter](../examples/ecs/system_param.rs) | Illustrates creating custom system parameters with `SystemParam`
 [System Piping](../examples/ecs/system_piping.rs) | Pipe the output of one system into a second, allowing you to handle any errors gracefully
-[System Stepping](../examples/ecs/system_stepping.rs) | Demonstrate stepping through systems in order of execution
+[System Stepping](../examples/ecs/system_stepping.rs) | Demonstrate stepping through systems in order of execution. Requires enabling the `bevy_debug_stepping` feature.
 
 ## Games
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -269,7 +269,7 @@ Example | Description
 Example | Description
 --- | ---
 [Alien Cake Addict](../examples/games/alien_cake_addict.rs) | Eat the cakes. Eat them all. An example 3D game
-[Breakout](../examples/games/breakout.rs) | An implementation of the classic game "Breakout"
+[Breakout](../examples/games/breakout.rs) | An implementation of the classic game "Breakout". Demonstrates Bevy's stepping capabilities if compiled with the `bevy_debug_stepping` feature.
 [Contributors](../examples/games/contributors.rs) | Displays each contributor as a bouncy bevy-ball!
 [Desk Toy](../examples/games/desk_toy.rs) | Bevy logo as a desk toy using transparent windows! Now with Googly Eyes!
 [Game Menu](../examples/games/game_menu.rs) | A simple game menu

--- a/examples/ecs/system_stepping.rs
+++ b/examples/ecs/system_stepping.rs
@@ -1,4 +1,6 @@
 //! Demonstrate stepping through systems in order of execution.
+//!
+//! To run this example, you must enable the `bevy_debug_stepping` feature.
 
 use bevy::{ecs::schedule::Stepping, log::LogPlugin, prelude::*};
 

--- a/examples/games/stepping.rs
+++ b/examples/games/stepping.rs
@@ -32,6 +32,10 @@ impl SteppingPlugin {
 
 impl Plugin for SteppingPlugin {
     fn build(&self, app: &mut App) {
+        if cfg!(not(feature = "bevy_debug_stepping")) {
+            info!("Bevy was compiled without the bevy_debug_stepping feature. Run with `--features=bevy_debug_stepping` to enable.");
+            return;
+        }
         // create and insert our debug schedule into the main schedule order.
         // We need an independent schedule so we have access to all other
         // schedules through the `Stepping` resource


### PR DESCRIPTION
# Objective

Fix #11931 

## Solution

- Make stepping a non-default feature
- Adjust documentation and examples
  - In particular, make the breakout example not show the stepping prompt if compiled without the feature (shows a log message instead)

---

## Changelog

- Removed `bevy_debug_stepping` from default features

## Migration Guide

The system-by-system stepping feature is now disabled by default; to use it, enable the `bevy_debug_stepping` feature explicitly:

```toml
[dependencies]
bevy = { version = "0.14", features = ["bevy_debug_stepping"] }
```

Code using [`Stepping`](https://docs.rs/bevy/latest/bevy/ecs/schedule/struct.Stepping.html) will still compile with the feature disabled, but will print a runtime error message to the console if the application attempts to enable stepping.