### PR TITLE
Move `close_on_esc` to `bevy_dev_tools`

### DIFF
--- a/crates/bevy_dev_tools/src/close_on_esc.rs
+++ b/crates/bevy_dev_tools/src/close_on_esc.rs
@@ -1,0 +1,32 @@
+use bevy_ecs::prelude::*;
+use bevy_input::{keyboard::KeyCode, ButtonInput};
+use bevy_window::Window;
+
+/// Close the focused window whenever the escape key (<kbd>Esc</kbd>) is pressed
+///
+/// This is useful for examples or prototyping.
+///
+/// # Example
+///
+/// ```no_run
+/// # use bevy_app::prelude::*;
+/// # use bevy_dev_tools::close_on_esc;
+/// #
+/// App::new()
+///     .add_systems(Update, close_on_esc);
+/// ```
+pub fn close_on_esc(
+    mut commands: Commands,
+    focused_windows: Query<(Entity, &Window)>,
+    input: Res<ButtonInput<KeyCode>>,
+) {
+    for (window, focus) in focused_windows.iter() {
+        if !focus.focused {
+            continue;
+        }
+
+        if input.just_pressed(KeyCode::Escape) {
+            commands.entity(window).despawn();
+        }
+    }
+}

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -12,10 +12,15 @@ use bevy_app::prelude::*;
 
 #[cfg(feature = "bevy_ci_testing")]
 pub mod ci_testing;
+
 pub mod fps_overlay;
 
 #[cfg(feature = "bevy_ui_debug")]
 pub mod ui_debug_overlay;
+
+mod close_on_esc;
+
+pub use crate::close_on_esc::close_on_esc;
 
 /// Enables developer tools in an [`App`]. This plugin is added automatically with `bevy_dev_tools`
 /// feature.

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -23,6 +23,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
 ] }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 # Used for close_on_esc
+# TODO: remove this
 bevy_input = { path = "../bevy_input", version = "0.14.0-dev" }
 
 # other

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -20,11 +20,9 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "glam",
+  "smol_str",
 ] }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
-# Used for close_on_esc
-# TODO: remove this
-bevy_input = { path = "../bevy_input", version = "0.14.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -117,13 +117,12 @@ pub struct WindowDestroyed {
 /// The event is sent only if the cursor is over one of the application's windows.
 /// It is the translated version of [`WindowEvent::CursorMoved`] from the `winit` crate with the addition of `delta`.
 ///
-/// Not to be confused with the [`MouseMotion`] event from `bevy_input`.
+/// Not to be confused with the `MouseMotion` event from `bevy_input`.
 ///
 /// Because the range of data is limited by the window area and it may have been transformed by the OS to implement certain effects like acceleration,
 /// you should not use it for non-cursor-like behaviour such as 3D camera control. Please see [`MouseMotion`] instead.
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
-/// [`MouseMotion`]: bevy_input::mouse::MouseMotion
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -120,7 +120,7 @@ pub struct WindowDestroyed {
 /// Not to be confused with the `MouseMotion` event from `bevy_input`.
 ///
 /// Because the range of data is limited by the window area and it may have been transformed by the OS to implement certain effects like acceleration,
-/// you should not use it for non-cursor-like behaviour such as 3D camera control. Please see [`MouseMotion`] instead.
+/// you should not use it for non-cursor-like behaviour such as 3D camera control. Please see `MouseMotion` instead.
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -2,7 +2,6 @@ use crate::{PrimaryWindow, Window, WindowCloseRequested};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
-use bevy_input::{keyboard::KeyCode, ButtonInput};
 
 /// Exit the application when there are no open windows.
 ///

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -45,22 +45,3 @@ pub fn close_when_requested(mut commands: Commands, mut closed: EventReader<Wind
         commands.entity(event.window).despawn();
     }
 }
-
-/// Close the focused window whenever the escape key (<kbd>Esc</kbd>) is pressed
-///
-/// This is useful for examples or prototyping.
-pub fn close_on_esc(
-    mut commands: Commands,
-    focused_windows: Query<(Entity, &Window)>,
-    input: Res<ButtonInput<KeyCode>>,
-) {
-    for (window, focus) in focused_windows.iter() {
-        if !focus.focused {
-            continue;
-        }
-
-        if input.just_pressed(KeyCode::Escape) {
-            commands.entity(window).despawn();
-        }
-    }
-}

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -227,7 +227,7 @@ pub struct Window {
     ///
     /// If enabled, the window will receive [`Ime`](crate::Ime) events instead of
     /// [`ReceivedCharacter`](crate::ReceivedCharacter) or
-    /// [`KeyboardInput`](bevy_input::keyboard::KeyboardInput).
+    /// `KeyboardInput` from `bevy_input`.
     ///
     /// IME should be enabled during text input, but not when you expect to get the exact key pressed.
     ///

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -17,7 +17,6 @@ fn main() {
                 rotate_to_player_system,
             ),
         )
-        .add_systems(Update, bevy::window::close_on_esc)
         .run();
 }
 

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use bevy::{prelude::*, render::render_resource::TextureFormat, window::close_on_esc};
+use bevy::{prelude::*, render::render_resource::TextureFormat};
 
 fn main() {
     App::new()
@@ -19,7 +19,6 @@ fn main() {
                 update_parallax_depth_scale,
                 update_parallax_layers,
                 switch_method,
-                close_on_esc,
             ),
         )
         .run();

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -42,7 +42,7 @@ fn main() {
         .add_systems(OnEnter(GameState::GameOver), display_score)
         .add_systems(
             Update,
-            (gameover_keyboard.run_if(in_state(GameState::GameOver)),),
+            gameover_keyboard.run_if(in_state(GameState::GameOver)),
         )
         .add_systems(OnExit(GameState::GameOver), teardown)
         .run();

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -42,10 +42,7 @@ fn main() {
         .add_systems(OnEnter(GameState::GameOver), display_score)
         .add_systems(
             Update,
-            (
-                gameover_keyboard.run_if(in_state(GameState::GameOver)),
-                bevy::window::close_on_esc,
-            ),
+            (gameover_keyboard.run_if(in_state(GameState::GameOver)),),
         )
         .add_systems(OnExit(GameState::GameOver), teardown)
         .run();

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -75,7 +75,7 @@ fn main() {
                 // `chain`ing systems together runs them in order
                 .chain(),
         )
-        .add_systems(Update, (update_scoreboard, bevy::window::close_on_esc))
+        .add_systems(Update, update_scoreboard)
         .run();
 }
 

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -7,7 +7,6 @@ fn main() {
         // By default, a primary window gets spawned by `WindowPlugin`, contained in `DefaultPlugins`
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup_scene)
-        .add_systems(Update, bevy::window::close_on_esc)
         .run();
 }
 

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -36,14 +36,7 @@ fn main() {
         })
         .insert_resource(ContractingY)
         .add_systems(Startup, (setup_3d, setup_2d))
-        .add_systems(
-            Update,
-            (
-                change_window_size,
-                sync_dimensions,
-                bevy::window::close_on_esc,
-            ),
-        )
+        .add_systems(Update, (change_window_size, sync_dimensions))
         .run();
 }
 


### PR DESCRIPTION
# Objective

- As @james7132 said [on Discord](https://discord.com/channels/691052431525675048/692572690833473578/1224626740773523536), the `close_on_esc` system is forcing `bevy_window` to depend on `bevy_input`.
- `close_on_esc` is not likely to be used in production, so it arguably does not have a place in `bevy_window`.

## Solution

- As suggested by @afonsolage, move `close_on_esc` into `bevy_dev_tools`.
  - Add an example to the documentation too.
- Remove `bevy_window`'s dependency on `bevy_input`.
  - Add `bevy_reflect`'s `smol_str` feature to `bevy_window` because it was implicitly depended upon with `bevy_input` before it was removed.
- Remove any usage of `close_on_esc` from the examples.
  - `bevy_dev_tools` is not enabled by default. I personally find it frustrating to run examples with additional features, so I opted to remove it entirely.
  - This is up for discussion if you have an alternate solution.

---

## Changelog

- Moved `bevy_window::close_on_esc` to `bevy_dev_tools::close_on_esc`.
- Removed usage of `bevy_dev_tools::close_on_esc` from all examples.

## Migration Guide

`bevy_window::close_on_esc` has been moved to `bevy_dev_tools::close_on_esc`. You will first need to enable `bevy_dev_tools` as a feature in your `Cargo.toml`:

```toml
[dependencies]
bevy = { version = "0.14", features = ["bevy_dev_tools"] }
```

Finally, modify any imports to use `bevy_dev_tools` instead:

```rust
// Old:
// use bevy::window::close_on_esc;

// New:
use bevy::dev_tools::close_on_esc;

App::new()
    .add_systems(Update, close_on_esc)
    // ...
    .run();
```