### PR TITLE
Disable RAY_QUERY and RAY_TRACING_ACCELERATION_STRUCTURE by default

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -209,6 +209,15 @@ pub async fn initialize_renderer(
             // integrated GPUs.
             features -= wgpu::Features::MAPPABLE_PRIMARY_BUFFERS;
         }
+
+        // RAY_QUERY and RAY_TRACING_ACCELERATION STRUCTURE will sometimes cause DeviceLost failures on platforms
+        // that report them as supported:
+        // <https://github.com/gfx-rs/wgpu/issues/5488>
+        // WGPU also currently doesn't actually support these features yet, so we should disable
+        // them until they are safe to enable.
+        features -= wgpu::Features::RAY_QUERY;
+        features -= wgpu::Features::RAY_TRACING_ACCELERATION_STRUCTURE;
+
         limits = adapter.limits();
     }
 


### PR DESCRIPTION
# Objective

See https://github.com/gfx-rs/wgpu/issues/5488 for context and rationale.

## Solution

- Disables `wgpu::Features::RAY_QUERY` and `wgpu::Features::RAY_TRACING_ACCELERATION_STRUCTURE` by default. They must be explicitly opted into now.

---

## Changelog

- Disables `wgpu::Features::RAY_QUERY` and `wgpu::Features::RAY_TRACING_ACCELERATION_STRUCTURE` by default. They must be explicitly opted into now.

## Migration Guide

- If you need  `wgpu::Features::RAY_QUERY` or `wgpu::Features::RAY_TRACING_ACCELERATION_STRUCTURE`, enable them explicitly using `WgpuSettings::features`
