### PR TITLE
Relax BufferVec's type constraints

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = { version = "1", optional = true }
 bitflags = "2.3"
 fixedbitset = "0.5"
 # direct dependency required for derive macro
-bytemuck = { version = "1", features = ["derive"] }
+bytemuck = { version = "1", features = ["derive", "must_cast"] }
 radsort = "0.1"
 smallvec = "1.6"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/bevy_pbr/src/meshlet/gpu_scene.rs
+++ b/crates/bevy_pbr/src/meshlet/gpu_scene.rs
@@ -174,7 +174,7 @@ pub fn queue_material_meshlet_meshes<M: Material>(
 }
 
 // TODO: Try using Queue::write_buffer_with() in queue_meshlet_mesh_upload() to reduce copies
-fn upload_storage_buffer<T: ShaderSize + bytemuck::Pod>(
+fn upload_storage_buffer<T: ShaderSize + bytemuck::NoUninit>(
     buffer: &mut StorageBuffer<Vec<T>>,
     render_device: &RenderDevice,
     render_queue: &RenderQueue,

--- a/crates/bevy_pbr/src/meshlet/gpu_scene.rs
+++ b/crates/bevy_pbr/src/meshlet/gpu_scene.rs
@@ -187,7 +187,7 @@ fn upload_storage_buffer<T: ShaderSize + bytemuck::NoUninit>(
 
     if capacity >= size {
         let inner = inner.unwrap();
-        let bytes = bytemuck::cast_slice(buffer.get().as_slice());
+        let bytes = bytemuck::must_cast_slice(buffer.get().as_slice());
         render_queue.write_buffer(inner, 0, bytes);
     } else {
         buffer.write_buffer(render_device, render_queue);

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -11,7 +11,7 @@ use bevy_render::{
     view::ViewVisibility,
     Extract,
 };
-use bytemuck::Pod;
+use bytemuck::NoUninit;
 
 #[derive(Component)]
 pub struct MorphIndex {
@@ -54,7 +54,7 @@ const fn can_align(step: usize, target: usize) -> bool {
 const WGPU_MIN_ALIGN: usize = 256;
 
 /// Align a [`BufferVec`] to `N` bytes by padding the end with `T::default()` values.
-fn add_to_alignment<T: Pod + Default>(buffer: &mut BufferVec<T>) {
+fn add_to_alignment<T: NoUninit + Default>(buffer: &mut BufferVec<T>) {
     let n = WGPU_MIN_ALIGN;
     let t_size = mem::size_of::<T>();
     if !can_align(n, t_size) {

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -80,7 +80,7 @@ wgpu = { version = "0.19.3", default-features = false, features = [
 naga = { version = "0.19", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }
 bitflags = { version = "2.3", features = ["serde"] }
-bytemuck = { version = "1.5", features = ["derive"] }
+bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
 downcast-rs = "1.2.0"
 thread_local = "1.1"
 thiserror = "1.0"


### PR DESCRIPTION
# Objective
Since BufferVec was first introduced, `bytemuck` has added additional traits with fewer restrictions than `Pod`. Within BufferVec, we only rely on the constraints of `bytemuck::cast_slice` to a `u8` slice, which now only requires `T: NoUninit` which is a strict superset of `Pod` types.

## Solution
Change out the `Pod` generic type constraint with `NoUninit`. Also taking the opportunity to substitute `cast_slice` with `must_cast_slice`, which avoids a runtime panic in place of a compile time failure if `T` cannot be used.

---

## Changelog
Changed: `BufferVec` now supports working with types containing `NoUninit` but not `Pod` members.
Changed: `BufferVec` will now fail to compile if used with a type that cannot be safely read from. Most notably, this includes ZSTs, which would previously always panic at runtime.