### PR TITLE
Deprecate `ReceivedCharacter`

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -172,7 +172,10 @@ pub struct CursorLeft {
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[deprecated = "Use `KeyboardInput` instead."]
+#[deprecated(
+    since = "0.14.0",
+    note = "Use `KeyboardInput` instead."
+)]
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::path::PathBuf;
 
 use bevy_ecs::entity::Entity;
@@ -171,6 +172,7 @@ pub struct CursorLeft {
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
+#[deprecated = "Use `KeyboardInput` instead."]
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -172,10 +172,7 @@ pub struct CursorLeft {
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[deprecated(
-    since = "0.14.0",
-    note = "Use `KeyboardInput` instead."
-)]
+#[deprecated(since = "0.14.0", note = "Use `KeyboardInput` instead.")]
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -28,6 +28,7 @@ pub use window::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
+    #[allow(deprecated)]
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, Ime, MonitorSelection,

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
@@ -29,6 +28,7 @@ pub use window::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
+    #[allow(deprecated)]
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, Ime, MonitorSelection,
@@ -86,6 +86,7 @@ pub struct WindowPlugin {
 impl Plugin for WindowPlugin {
     fn build(&self, app: &mut App) {
         // User convenience events
+        #[allow(deprecated)]
         app.add_event::<WindowResized>()
             .add_event::<WindowCreated>()
             .add_event::<WindowClosed>()
@@ -133,6 +134,7 @@ impl Plugin for WindowPlugin {
         }
 
         // Register event types
+        #[allow(deprecated)]
         app.register_type::<WindowResized>()
             .register_type::<RequestRedraw>()
             .register_type::<WindowCreated>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
@@ -28,7 +29,6 @@ pub use window::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
-    #[allow(deprecated)]
     #[doc(hidden)]
     pub use crate::{
         CursorEntered, CursorIcon, CursorLeft, CursorMoved, FileDragAndDrop, Ime, MonitorSelection,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -41,6 +41,7 @@ use bevy_math::{ivec2, DVec2, Vec2};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
 use bevy_utils::tracing::{error, trace, warn};
+#[allow(deprecated)]
 use bevy_window::{
     exit_on_all_closed, ApplicationLifetime, CursorEntered, CursorLeft, CursorMoved,
     FileDragAndDrop, Ime, ReceivedCharacter, RequestRedraw, Window,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
@@ -41,7 +42,6 @@ use bevy_math::{ivec2, DVec2, Vec2};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
 use bevy_utils::tracing::{error, trace, warn};
-#[allow(deprecated)]
 use bevy_window::{
     exit_on_all_closed, ApplicationLifetime, CursorEntered, CursorLeft, CursorMoved,
     FileDragAndDrop, Ime, ReceivedCharacter, RequestRedraw, Window,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![doc(
@@ -42,6 +41,7 @@ use bevy_math::{ivec2, DVec2, Vec2};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
 use bevy_utils::tracing::{error, trace, warn};
+#[allow(deprecated)]
 use bevy_window::{
     exit_on_all_closed, ApplicationLifetime, CursorEntered, CursorLeft, CursorMoved,
     FileDragAndDrop, Ime, ReceivedCharacter, RequestRedraw, Window,
@@ -463,6 +463,7 @@ fn handle_winit_event(
                     if event.state.is_pressed() {
                         if let Some(char) = &event.text {
                             let char = char.clone();
+                            #[allow(deprecated)]
                             winit_events.send(ReceivedCharacter { window, char });
                         }
                     }

--- a/crates/bevy_winit/src/winit_event.rs
+++ b/crates/bevy_winit/src/winit_event.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 #![allow(missing_docs)]
 
 use bevy_app::App;
@@ -11,7 +12,6 @@ use bevy_input::{
 use bevy_reflect::Reflect;
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
-#[allow(deprecated)]
 use bevy_window::{
     ApplicationLifetime, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime,
     ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested,

--- a/crates/bevy_winit/src/winit_event.rs
+++ b/crates/bevy_winit/src/winit_event.rs
@@ -11,6 +11,7 @@ use bevy_input::{
 use bevy_reflect::Reflect;
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+#[allow(deprecated)]
 use bevy_window::{
     ApplicationLifetime, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime,
     ReceivedCharacter, RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested,

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -1,6 +1,9 @@
 //! Prints out all chars as they are inputted.
 
-use bevy::prelude::*;
+use bevy::{
+    input::keyboard::{Key, KeyboardInput},
+    prelude::*,
+};
 
 fn main() {
     App::new()
@@ -10,8 +13,10 @@ fn main() {
 }
 
 /// This system prints out all char events as they come in
-fn print_char_event_system(mut char_input_events: EventReader<ReceivedCharacter>) {
+fn print_char_event_system(mut char_input_events: EventReader<KeyboardInput>) {
     for event in char_input_events.read() {
-        info!("{:?}: '{}'", event, event.char);
+        if let Key::Character(character) = &event.logical_key {
+            info!("{:?}: '{}'", event, character);
+        }
     }
 }

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -1,7 +1,10 @@
 //! Prints out all chars as they are inputted.
 
 use bevy::{
-    input::keyboard::{Key, KeyboardInput},
+    input::{
+        keyboard::{Key, KeyboardInput},
+        ButtonState,
+    },
     prelude::*,
 };
 
@@ -15,6 +18,10 @@ fn main() {
 /// This system prints out all char events as they come in
 fn print_char_event_system(mut char_input_events: EventReader<KeyboardInput>) {
     for event in char_input_events.read() {
+        // Only check for characters when the key is pressed
+        if event.state == ButtonState::Released {
+            continue;
+        }
         if let Key::Character(character) = &event.logical_key {
             info!("{:?}: '{}'", event, character);
         }

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -204,9 +204,7 @@ fn listen_keyboard_input_events(
                 edit_text.single_mut().sections[0].value.pop();
             }
             Key::Character(character) => {
-                edit_text.single_mut().sections[0]
-                    .value
-                    .push_str(&character);
+                edit_text.single_mut().sections[0].value.push_str(character);
             }
             _ => continue,
         }


### PR DESCRIPTION
# Objective

- Partially resolves #12639.

## Solution

- Deprecate `ReceivedCharacter`.
- Replace `ReceivedCharacter` with `KeyboardInput` in the relevant examples.

## Migration Guide

- `ReceivedCharacter` is now deprecated, use `KeyboardInput` instead.

- Before:
  ```rust
  fn listen_characters(events: EventReader<ReceivedCharacter>) {
    for event in events.read() {
      info!("{}", event.char);
    }
  }
  ```
  
  After:
  ```rust
  fn listen_characters(events: EventReader<KeyboardInput>) {
    for event in events.read() {
      // Only check for characters when the key is pressed.
      if event.state == ButtonState::Released {
        continue;
      }
      // Note that some keys such as `Space` and `Tab` won't be detected as before.
      // Instead, check for them with `Key::Space` and `Key::Tab`.
      if let Key::Character(character) = &event.logical_key {
        info!("{}", character);
      }
    }
  }
  ```