### PR TITLE
Added method to get waiting pipelines IDs from pipeline cache.

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -494,12 +494,16 @@ pub struct PipelineCache {
 }
 
 impl PipelineCache {
+    /// Returns an iterator over the pipelines in the pipeline cache.
     pub fn pipelines(&self) -> impl Iterator<Item = &CachedPipeline> {
         self.pipelines.iter()
     }
 
-    pub fn waiting_pipelines(&self) -> impl Iterator<Item = &CachedPipelineId> {
-        self.waiting_pipelines.iter()
+    /// Returns a vector of all currently waiting pipelines IDs.
+    pub fn waiting_pipelines(&self) -> Vec<CachedPipelineId> {
+        let mut waiting_pipelines_vec: Vec<CachedPipelineId> = Vec::new();
+        self.waiting_pipelines.iter().for_each(|id| waiting_pipelines_vec.push(*id));
+        waiting_pipelines_vec
     }
 
     /// Create a new pipeline cache associated with the given render device.

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -499,7 +499,7 @@ impl PipelineCache {
         self.pipelines.iter()
     }
 
-    /// Returns a vector of all currently waiting pipelines IDs.
+    /// Returns a iterator of the IDs of all currently waiting pipelines.
     pub fn waiting_pipelines(&self) -> impl Iterator<Item = CachedPipelineId> {
         self.waiting_pipelines.iter().copied()
     }

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -500,7 +500,7 @@ impl PipelineCache {
     }
 
     /// Returns a iterator of the IDs of all currently waiting pipelines.
-    pub fn waiting_pipelines(&self) -> impl Iterator<Item = CachedPipelineId> {
+    pub fn waiting_pipelines(&self) -> impl Iterator<Item = CachedPipelineId> + '_ {
         self.waiting_pipelines.iter().copied()
     }
 

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -500,12 +500,8 @@ impl PipelineCache {
     }
 
     /// Returns a vector of all currently waiting pipelines IDs.
-    pub fn waiting_pipelines(&self) -> Vec<CachedPipelineId> {
-        let mut waiting_pipelines_vec: Vec<CachedPipelineId> = Vec::new();
-        self.waiting_pipelines
-            .iter()
-            .for_each(|id| waiting_pipelines_vec.push(*id));
-        waiting_pipelines_vec
+    pub fn waiting_pipelines(&self) -> impl Iterator<Item = CachedPipelineId> {
+        self.waiting_pipelines.iter().copied()
     }
 
     /// Create a new pipeline cache associated with the given render device.

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -498,6 +498,10 @@ impl PipelineCache {
         self.pipelines.iter()
     }
 
+    pub fn waiting_pipelines(&self) -> impl Iterator<Item = &CachedPipelineId> {
+        self.waiting_pipelines.iter()
+    }
+
     /// Create a new pipeline cache associated with the given render device.
     pub fn new(
         device: RenderDevice,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -502,7 +502,9 @@ impl PipelineCache {
     /// Returns a vector of all currently waiting pipelines IDs.
     pub fn waiting_pipelines(&self) -> Vec<CachedPipelineId> {
         let mut waiting_pipelines_vec: Vec<CachedPipelineId> = Vec::new();
-        self.waiting_pipelines.iter().for_each(|id| waiting_pipelines_vec.push(*id));
+        self.waiting_pipelines
+            .iter()
+            .for_each(|id| waiting_pipelines_vec.push(*id));
         waiting_pipelines_vec
     }
 


### PR DESCRIPTION
# Objective
- Add a way to easily get currently waiting pipelines IDs.

## Solution
- Added a method to get waiting pipelines `CachedPipelineId`.
