### PR TITLE
flush ButtonInput<KeyCode> cache when Bevy window loses focus

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -105,6 +105,20 @@ pub struct KeyboardInput {
     pub window: Entity,
 }
 
+/// Gets generated from `bevy_winit::winit_runner`
+///
+/// Used for clearing all cached states to avoid having 'stuck' key presses
+/// when, for example, switching between windows with 'Alt-Tab' or using any other
+/// OS specific key combination that leads to Bevy window losing focus and not receiving any
+/// input events
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct KeyboardFocusLost;
+
 /// Updates the [`ButtonInput<KeyCode>`] resource with the latest [`KeyboardInput`] events.
 ///
 /// ## Differences
@@ -114,6 +128,7 @@ pub struct KeyboardInput {
 pub fn keyboard_input_system(
     mut key_input: ResMut<ButtonInput<KeyCode>>,
     mut keyboard_input_events: EventReader<KeyboardInput>,
+    mut focus_events: EventReader<KeyboardFocusLost>,
 ) {
     // Avoid clearing if it's not empty to ensure change detection is not triggered.
     key_input.bypass_change_detection().clear();
@@ -125,6 +140,12 @@ pub fn keyboard_input_system(
             ButtonState::Pressed => key_input.press(*key_code),
             ButtonState::Released => key_input.release(*key_code),
         }
+    }
+
+    // Release all cached input to avoid having stuck input when switching between windows in os
+    if !focus_events.is_empty() {
+        key_input.release_all();
+        focus_events.clear();
     }
 }
 

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -41,7 +41,7 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
-use keyboard::{keyboard_input_system, KeyCode, KeyboardInput};
+use keyboard::{keyboard_input_system, KeyCode, KeyboardFocusLost, KeyboardInput};
 use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use touch::{touch_screen_input_system, TouchInput, Touches};
 use touchpad::{TouchpadMagnify, TouchpadRotate};
@@ -69,6 +69,7 @@ impl Plugin for InputPlugin {
         app
             // keyboard
             .add_event::<KeyboardInput>()
+            .add_event::<KeyboardFocusLost>()
             .init_resource::<ButtonInput<KeyCode>>()
             .add_systems(PreUpdate, keyboard_input_system.in_set(InputSystem))
             // mouse

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -34,6 +34,7 @@ use bevy_ecs::event::ManualEventReader;
 use bevy_ecs::prelude::*;
 use bevy_ecs::system::SystemState;
 use bevy_input::{
+    keyboard::KeyboardFocusLost,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touchpad::{TouchpadMagnify, TouchpadRotate},
 };
@@ -583,6 +584,9 @@ fn handle_winit_event(
                 WindowEvent::Focused(focused) => {
                     win.focused = focused;
                     winit_events.send(WindowFocused { window, focused });
+                    if !focused {
+                        winit_events.send(KeyboardFocusLost);
+                    }
                 }
                 WindowEvent::Occluded(occluded) => {
                     winit_events.send(WindowOccluded { window, occluded });

--- a/crates/bevy_winit/src/winit_event.rs
+++ b/crates/bevy_winit/src/winit_event.rs
@@ -5,6 +5,7 @@ use bevy_ecs::prelude::*;
 use bevy_input::keyboard::KeyboardInput;
 use bevy_input::touch::TouchInput;
 use bevy_input::{
+    keyboard::KeyboardFocusLost,
     mouse::{MouseButtonInput, MouseMotion, MouseWheel},
     touchpad::{TouchpadMagnify, TouchpadRotate},
 };
@@ -61,6 +62,7 @@ pub enum WinitEvent {
     TouchInput(TouchInput),
 
     KeyboardInput(KeyboardInput),
+    KeyboardFocusLost(KeyboardFocusLost),
 }
 
 impl From<ApplicationLifetime> for WinitEvent {
@@ -188,6 +190,11 @@ impl From<KeyboardInput> for WinitEvent {
         Self::KeyboardInput(e)
     }
 }
+impl From<KeyboardFocusLost> for WinitEvent {
+    fn from(e: KeyboardFocusLost) -> Self {
+        Self::KeyboardFocusLost(e)
+    }
+}
 
 /// Forwards buffered [`WinitEvent`] events to the app.
 pub(crate) fn forward_winit_events(buffered_events: &mut Vec<WinitEvent>, app: &mut App) {
@@ -269,6 +276,9 @@ pub(crate) fn forward_winit_events(buffered_events: &mut Vec<WinitEvent>, app: &
                 app.world_mut().send_event(e);
             }
             WinitEvent::KeyboardInput(e) => {
+                app.world_mut().send_event(e);
+            }
+            WinitEvent::KeyboardFocusLost(e) => {
                 app.world_mut().send_event(e);
             }
         }


### PR DESCRIPTION
# Objective

This helps avoiding stuck key presses after switching from and back to Bevy window. Key press event gets stuck because window loses focus before receiving a key release event thus we end up with false positive in ButtonInput<KeyCode>.

## Solution

I saw two ways to fix this: 
1. add bevy_window as dependency and read WindowFocus events
2. add a KeyboardFocusLost event specifically for this. 

I chose the latter because adding another dependency felt wrong, but if that is more preferable changing this pr won't be a problem. Also if someone sees another way please let me know.

---

To test the bug use this small modification over examples/keyboard_input.rs:
(it will work only if you have Alt-Tab combination for switching between windows in your OS, otherwise change AltLeft accordingly)
```
//! Demonstrates handling a key press/release.

use bevy::{prelude::*, input::keyboard::KeyboardInput};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Update, keyboard_input_system)
        .run();
}

/// This system prints 'Alt' key state
fn keyboard_input_system(keyboard_input: Res<ButtonInput<KeyCode>>, mut keyboard_input_events: EventReader<KeyboardInput>) {
    for event in keyboard_input_events.read() {
        info!("{:?}", event);
    }

    if keyboard_input.pressed(KeyCode::AltLeft) {
        info!("'Alt' currently pressed");
    }

    if keyboard_input.just_pressed(KeyCode::AltLeft) {
        info!("'Alt' just pressed");
    }
    if keyboard_input.just_released(KeyCode::AltLeft) {
        info!("'Alt' just released");
    }
}

```

Here i made a quick video with demo of the fix: https://youtu.be/qTvUCk4IHvo
In first part i press Alt and Alt+Tab to switch back and forth from example app, logs will indicate that too. In second part I applied fix and you'll see that Alt will no longer be pressed when window gets unfocused

## Migration Guide

`WinitEvent` has a new enum variant: `WinitEvent::KeyboardFocusLost`.
