### PR TITLE
Fix AABB projection for meshlet occlusion culling

### DIFF
--- a/crates/bevy_pbr/src/meshlet/cull_meshlets.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_meshlets.wgsl
@@ -9,7 +9,7 @@
     get_meshlet_previous_occlusion,
 }
 #ifdef MESHLET_SECOND_CULLING_PASS
-#import bevy_pbr::meshlet_bindings::depth_pyramid
+#import bevy_pbr::meshlet_bindings::{depth_pyramid, aabb_uv_to_viewport}
 #endif
 #import bevy_render::maths::affine3_to_square
 
@@ -55,10 +55,8 @@ fn cull_meshlets(@builtin(global_invocation_id) cluster_id: vec3<u32>) {
         let bounding_sphere_center_view_space = (view.inverse_view * vec4(bounding_sphere_center.xyz, 1.0)).xyz;
         let aabb = project_view_space_sphere_to_screen_space_aabb(bounding_sphere_center_view_space, bounding_sphere_radius);
 
-        // Halve the AABB size because the first depth mip resampling pass cut the full screen resolution into a power of two conservatively
-        let depth_pyramid_size_mip_0 = vec2<f32>(textureDimensions(depth_pyramid, 0)) * 0.5;
-        let width = (aabb.z - aabb.x) * depth_pyramid_size_mip_0.x;
-        let height = (aabb.w - aabb.y) * depth_pyramid_size_mip_0.y;
+        let width = (aabb.z - aabb.x) * aabb_uv_to_viewport.x;
+        let height = (aabb.w - aabb.y) * aabb_uv_to_viewport.y;
         let depth_level = max(0, i32(ceil(log2(max(width, height))))); // TODO: Naga doesn't like this being a u32
         let depth_pyramid_size = vec2<f32>(textureDimensions(depth_pyramid, depth_level));
         let aabb_top_left = vec2<u32>(aabb.xy * depth_pyramid_size);

--- a/crates/bevy_pbr/src/meshlet/gpu_scene.rs
+++ b/crates/bevy_pbr/src/meshlet/gpu_scene.rs
@@ -352,7 +352,7 @@ pub fn prepare_meshlet_per_frame_resources(
             });
 
         let depth_size = Extent3d {
-            // If not a power of 2, round down to the nearest power of 2 to ensure depth is conservative
+            // Round down to the nearest power of 2 to ensure depth is conservative
             width: previous_power_of_2(view.viewport.z),
             height: previous_power_of_2(view.viewport.w),
             depth_or_array_layers: 1,

--- a/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
@@ -134,8 +134,6 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
             view_key |= MeshPipelineKey::SCREEN_SPACE_AMBIENT_OCCLUSION;
         }
 
-        // TODO: Lightmaps
-
         view_key |= MeshPipelineKey::from_primitive_topology(PrimitiveTopology::TriangleList);
 
         for material_id in render_material_instances.values() {

--- a/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
@@ -55,6 +55,7 @@ struct DrawIndirectArgs {
 @group(0) @binding(7) var<storage, read> meshlet_previous_occlusion: array<u32>; // 1 bit per cluster (instance of a meshlet), packed as a bitmask
 @group(0) @binding(8) var<uniform> view: View;
 @group(0) @binding(9) var depth_pyramid: texture_2d<f32>; // Generated from the first raster pass (unused in the first pass but still bound)
+var<push_constant> aabb_uv_to_viewport: vec2<f32>; // Multiplier to convert UV-space AABB to view-space (unused in the first pass but still bound)
 
 fn should_cull_instance(instance_id: u32) -> bool {
     let bit_offset = instance_id % 32u;

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -75,6 +75,8 @@ use bevy_ecs::{
 use bevy_render::{
     render_graph::{RenderGraphApp, ViewNodeRunner},
     render_resource::{Shader, TextureUsages},
+    renderer::RenderDevice,
+    settings::WgpuFeatures,
     view::{prepare_view_targets, InheritedVisibility, Msaa, ViewVisibility, Visibility},
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -167,6 +169,15 @@ impl Plugin for MeshletPlugin {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
+
+        if !render_app
+            .world()
+            .resource::<RenderDevice>()
+            .features()
+            .contains(WgpuFeatures::PUSH_CONSTANTS)
+        {
+            return;
+        }
 
         render_app
             .add_render_graph_node::<MeshletVisibilityBufferRasterPassNode>(

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -104,7 +104,7 @@ const MESHLET_MESH_MATERIAL_SHADER_HANDLE: Handle<Shader> =
 ///
 /// This plugin is not compatible with [`Msaa`], and adding this plugin will disable it.
 ///
-/// This plugin does not work on the WebGL2 backend.
+/// This plugin does not work on WASM.
 ///
 /// ![A render of the Stanford dragon as a `MeshletMesh`](https://raw.githubusercontent.com/bevyengine/bevy/meshlet/crates/bevy_pbr/src/meshlet/meshlet_preview.png)
 pub struct MeshletPlugin;

--- a/crates/bevy_pbr/src/meshlet/pipelines.rs
+++ b/crates/bevy_pbr/src/meshlet/pipelines.rs
@@ -46,7 +46,10 @@ impl FromWorld for MeshletPipelines {
             cull_first: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
                 label: Some("meshlet_culling_first_pipeline".into()),
                 layout: vec![cull_layout.clone()],
-                push_constant_ranges: vec![],
+                push_constant_ranges: vec![PushConstantRange {
+                    stages: ShaderStages::COMPUTE,
+                    range: 0..8,
+                }],
                 shader: MESHLET_CULLING_SHADER_HANDLE,
                 shader_defs: vec!["MESHLET_CULLING_PASS".into()],
                 entry_point: "cull_meshlets".into(),
@@ -55,7 +58,10 @@ impl FromWorld for MeshletPipelines {
             cull_second: pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
                 label: Some("meshlet_culling_second_pipeline".into()),
                 layout: vec![cull_layout],
-                push_constant_ranges: vec![],
+                push_constant_ranges: vec![PushConstantRange {
+                    stages: ShaderStages::COMPUTE,
+                    range: 0..8,
+                }],
                 shader: MESHLET_CULLING_SHADER_HANDLE,
                 shader_defs: vec![
                     "MESHLET_CULLING_PASS".into(),

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_raster_node.rs
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_raster_node.rs
@@ -471,7 +471,7 @@ fn copy_material_depth_pass(
 /// Meshlet AABBs are calculated against the original view, and need to be scaled to match the depth pyramid.
 ///
 /// Calculates the depth pyramid size scaled by how much the first depth mip resampling cut the view depth resolution by.
-/// E.g. view_depth = 200, depth_pyramid = 100, aabb_uv_to_viewport = 100 * (100 / 200) = 50
+/// E.g. `view_depth = 200, depth_pyramid = 100, aabb_uv_to_viewport = 100 * (100 / 200) = 50`.
 fn calculate_aabb_uv_to_viewport(
     meshlet_view_resources: &MeshletViewResources,
     view_depth_size: Extent3d,


### PR DESCRIPTION
The previous code was incorrect for non-power-of-2 view sizes, as e.g. `view_size = 70 -> depth_pyramid_size = 64`, and `64 / 70 != 0.5`.