### PR TITLE
Fix example game of life

### DIFF
--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,4 +1,6 @@
-@group(0) @binding(0) var texture: texture_storage_2d<r32float, read_write>;
+@group(0) @binding(0) var input: texture_storage_2d<r32float, read>;
+
+@group(0) @binding(1) var output: texture_storage_2d<r32float, write>;
 
 fn hash(value: u32) -> u32 {
     var state = value;
@@ -23,11 +25,11 @@ fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_wo
     let alive = randomNumber > 0.9;
     let color = vec4<f32>(f32(alive));
 
-    textureStore(texture, location, color);
+    textureStore(output, location, color);
 }
 
 fn is_alive(location: vec2<i32>, offset_x: i32, offset_y: i32) -> i32 {
-    let value: vec4<f32> = textureLoad(texture, location + vec2<i32>(offset_x, offset_y));
+    let value: vec4<f32> = textureLoad(input, location + vec2<i32>(offset_x, offset_y));
     return i32(value.x);
 }
 
@@ -59,7 +61,5 @@ fn update(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
     }
     let color = vec4<f32>(f32(alive));
 
-    storageBarrier();
-
-    textureStore(texture, location, color);
+    textureStore(output, location, color);
 }

--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -19,7 +19,7 @@ fn randomFloat(value: u32) -> f32 {
 fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
     let location = vec2<i32>(i32(invocation_id.x), i32(invocation_id.y));
 
-    let randomNumber = randomFloat(invocation_id.y * num_workgroups.x + invocation_id.x);
+    let randomNumber = randomFloat(invocation_id.y << 16u | invocation_id.x);
     let alive = randomNumber > 0.9;
     let color = vec4<f32>(f32(alive));
 

--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,3 +1,7 @@
+// The shader reads the previous frame's state from the `input` texture, and writes the new state of
+// each pixel to the `output` texture. The textures are flipped each step to progress the
+// simulation.
+
 @group(0) @binding(0) var input: texture_storage_2d<r32float, read>;
 
 @group(0) @binding(1) var output: texture_storage_2d<r32float, write>;

--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,6 +1,8 @@
 // The shader reads the previous frame's state from the `input` texture, and writes the new state of
 // each pixel to the `output` texture. The textures are flipped each step to progress the
 // simulation.
+// Two textures are needed for the game of life as each pixel of step N depends on the state of its
+// neighbors at step N-1.
 
 @group(0) @binding(0) var input: texture_storage_2d<r32float, read>;
 

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -43,6 +43,7 @@ fn main() {
             GameOfLifeComputePlugin,
         ))
         .add_systems(Startup, setup)
+        .add_systems(Update, switch_textures)
         .run();
 }
 
@@ -63,7 +64,6 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     let image0 = images.add(image.clone());
     let image1 = images.add(image);
 
-    // Note that we only display one of the textures to the user.
     commands.spawn(SpriteBundle {
         sprite: Sprite {
             custom_size: Some(Vec2::new(SIZE.0 as f32, SIZE.1 as f32)),
@@ -82,6 +82,16 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
         texture_a: image0,
         texture_b: image1,
     });
+}
+
+// Switch texture to display every frame to show the one that was written to most recently.
+fn switch_textures(images: Res<GameOfLifeImages>, mut displayed: Query<&mut Handle<Image>>) {
+    let mut displayed = displayed.single_mut();
+    if *displayed == images.texture_a {
+        *displayed = images.texture_b.clone_weak();
+    } else {
+        *displayed = images.texture_a.clone_weak();
+    }
 }
 
 struct GameOfLifeComputePlugin;

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -177,10 +177,7 @@ fn prepare_bind_group(
     let bind_group_0 = render_device.create_bind_group(
         None,
         &pipeline.texture_bind_group_layout,
-        &BindGroupEntries::sequential((
-            BindingResource::TextureView(&view_a.texture_view),
-            BindingResource::TextureView(&view_b.texture_view),
-        )),
+        &BindGroupEntries::sequential((&view_a.texture_view, &view_b.texture_view)),
     );
     let bind_group_1 = render_device.create_bind_group(
         None,

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -197,7 +197,16 @@ struct GameOfLifePipeline {
 impl FromWorld for GameOfLifePipeline {
     fn from_world(world: &mut World) -> Self {
         let render_device = world.resource::<RenderDevice>();
-        let texture_bind_group_layout = GameOfLifeImages::bind_group_layout(render_device);
+        let texture_bind_group_layout = render_device.create_bind_group_layout(
+            "GameOfLifeImages",
+            &BindGroupLayoutEntries::sequential(
+                ShaderStages::COMPUTE,
+                (
+                    texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::ReadOnly),
+                    texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::WriteOnly),
+                ),
+            ),
+        );
         let shader = world.load_asset("shaders/game_of_life.wgsl");
         let pipeline_cache = world.resource::<PipelineCache>();
         let init_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -185,10 +185,7 @@ fn prepare_bind_group(
     let bind_group_1 = render_device.create_bind_group(
         None,
         &pipeline.texture_bind_group_layout,
-        &BindGroupEntries::sequential((
-            BindingResource::TextureView(&view_b.texture_view),
-            BindingResource::TextureView(&view_a.texture_view),
-        )),
+        &BindGroupEntries::sequential((&view_b.texture_view, &view_a.texture_view)),
     );
     commands.insert_resource(GameOfLifeImageBindGroups([bind_group_0, bind_group_1]));
 }

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -17,21 +17,29 @@ use bevy::{
 };
 use std::borrow::Cow;
 
-const SIZE: (u32, u32) = (1280, 720);
+const DISPLAY_FACTOR: u32 = 4;
+const SIZE: (u32, u32) = (1280 / DISPLAY_FACTOR, 720 / DISPLAY_FACTOR);
 const WORKGROUP_SIZE: u32 = 8;
 
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    // uncomment for unthrottled FPS
-                    // present_mode: bevy::window::PresentMode::AutoNoVsync,
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        resolution: (
+                            (SIZE.0 * DISPLAY_FACTOR) as f32,
+                            (SIZE.1 * DISPLAY_FACTOR) as f32,
+                        )
+                            .into(),
+                        // uncomment for unthrottled FPS
+                        // present_mode: bevy::window::PresentMode::AutoNoVsync,
+                        ..default()
+                    }),
                     ..default()
-                }),
-                ..default()
-            }),
+                })
+                .set(ImagePlugin::default_nearest()),
             GameOfLifeComputePlugin,
         ))
         .add_systems(Startup, setup)
@@ -62,6 +70,10 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
             ..default()
         },
         texture: image0.clone(),
+        transform: Transform {
+            scale: Vec3::splat(DISPLAY_FACTOR as f32),
+            ..default()
+        },
         ..default()
     });
     commands.spawn(Camera2dBundle::default());

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -155,26 +155,10 @@ impl AsBindGroup for GameOfLifeImages {
         Self: Sized,
     {
         vec![
-            BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::COMPUTE,
-                ty: BindingType::StorageTexture {
-                    access: StorageTextureAccess::ReadOnly,
-                    format: TextureFormat::R32Float,
-                    view_dimension: TextureViewDimension::D2,
-                },
-                count: None,
-            },
-            BindGroupLayoutEntry {
-                binding: 1,
-                visibility: ShaderStages::COMPUTE,
-                ty: BindingType::StorageTexture {
-                    access: StorageTextureAccess::WriteOnly,
-                    format: TextureFormat::R32Float,
-                    view_dimension: TextureViewDimension::D2,
-                },
-                count: None,
-            },
+            texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::ReadOnly)
+                .build(0, ShaderStages::COMPUTE),
+            texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::WriteOnly)
+                .build(1, ShaderStages::COMPUTE),
         ]
     }
 }

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -126,42 +126,6 @@ struct GameOfLifeImages {
     texture_b: Handle<Image>,
 }
 
-// Manual implementation of AsBindGroup instead of the derive
-// The two textures have the same role and will be swapped in the bind group
-// In the layout, one is `ReadOnly`, the other is `WriteOnly`
-impl AsBindGroup for GameOfLifeImages {
-    type Data = ();
-
-    fn label() -> Option<&'static str> {
-        Some("GameOfLifeImages")
-    }
-
-    fn unprepared_bind_group(
-        &self,
-        _layout: &BindGroupLayout,
-        _render_device: &RenderDevice,
-        _images: &RenderAssets<Image>,
-        _fallback_image: &bevy::render::texture::FallbackImage,
-    ) -> Result<UnpreparedBindGroup<Self::Data>, AsBindGroupError> {
-        Ok(UnpreparedBindGroup {
-            bindings: vec![],
-            data: (),
-        })
-    }
-
-    fn bind_group_layout_entries(_render_device: &RenderDevice) -> Vec<BindGroupLayoutEntry>
-    where
-        Self: Sized,
-    {
-        vec![
-            texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::ReadOnly)
-                .build(0, ShaderStages::COMPUTE),
-            texture_storage_2d(TextureFormat::R32Float, StorageTextureAccess::WriteOnly)
-                .build(1, ShaderStages::COMPUTE),
-        ]
-    }
-}
-
 #[derive(Resource)]
 struct GameOfLifeImageBindGroups([BindGroup; 2]);
 

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -7,10 +7,9 @@ use bevy::{
     prelude::*,
     render::{
         extract_resource::{ExtractResource, ExtractResourcePlugin},
-        render_asset::RenderAssetUsages,
-        render_asset::RenderAssets,
+        render_asset::{RenderAssetUsages, RenderAssets},
         render_graph::{self, RenderGraph, RenderLabel},
-        render_resource::*,
+        render_resource::{binding_types::texture_storage_2d, *},
         renderer::{RenderContext, RenderDevice},
         Render, RenderApp, RenderSet,
     },

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -69,10 +69,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
             ..default()
         },
         texture: image0.clone(),
-        transform: Transform {
-            scale: Vec3::splat(DISPLAY_FACTOR as f32),
-            ..default()
-        },
+        transform: Transform::from_scale(Vec3::splat(DISPLAY_FACTOR as f32)),
         ..default()
     });
     commands.spawn(Camera2dBundle::default());


### PR DESCRIPTION
# Objective

- Example `compute_shader_game_of_life` is random and not following the rules of the game of life: at each steps, it randomly reads some pixel of the current step and some of the previous step instead of only from the previous step
- Fixes #9353 

## Solution

- Adopted from #9678 
- Added a switch of the texture displayed every frame otherwise the game of life looks wrong
- Added a way to display the texture bigger so that I could manually check everything was right
