### PR TITLE
Add previous_view_uniforms.inverse_view

### DIFF
--- a/crates/bevy_pbr/src/meshlet/material_draw_nodes.rs
+++ b/crates/bevy_pbr/src/meshlet/material_draw_nodes.rs
@@ -149,7 +149,7 @@ impl ViewNode for MeshletPrepassNode {
             camera,
             view_prepass_textures,
             view_uniform_offset,
-            previous_view_projection_uniform_offset,
+            previous_view_uniform_offset,
             meshlet_view_materials,
             meshlet_view_bind_groups,
             meshlet_view_resources,
@@ -209,15 +209,13 @@ impl ViewNode for MeshletPrepassNode {
             render_pass.set_camera_viewport(viewport);
         }
 
-        if let Some(previous_view_projection_uniform_offset) =
-            previous_view_projection_uniform_offset
-        {
+        if let Some(previous_view_uniform_offset) = previous_view_uniform_offset {
             render_pass.set_bind_group(
                 0,
                 prepass_view_bind_group.motion_vectors.as_ref().unwrap(),
                 &[
                     view_uniform_offset.offset,
-                    previous_view_projection_uniform_offset.offset,
+                    previous_view_uniform_offset.offset,
                 ],
             );
         } else {
@@ -272,7 +270,7 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
             camera,
             view_prepass_textures,
             view_uniform_offset,
-            previous_view_projection_uniform_offset,
+            previous_view_uniform_offset,
             meshlet_view_materials,
             meshlet_view_bind_groups,
             meshlet_view_resources,
@@ -337,15 +335,13 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
             render_pass.set_camera_viewport(viewport);
         }
 
-        if let Some(previous_view_projection_uniform_offset) =
-            previous_view_projection_uniform_offset
-        {
+        if let Some(previous_view_uniform_offset) = previous_view_uniform_offset {
             render_pass.set_bind_group(
                 0,
                 prepass_view_bind_group.motion_vectors.as_ref().unwrap(),
                 &[
                     view_uniform_offset.offset,
-                    previous_view_projection_uniform_offset.offset,
+                    previous_view_uniform_offset.offset,
                 ],
             );
         } else {

--- a/crates/bevy_pbr/src/meshlet/material_draw_nodes.rs
+++ b/crates/bevy_pbr/src/meshlet/material_draw_nodes.rs
@@ -7,8 +7,8 @@ use super::{
     MeshletGpuScene,
 };
 use crate::{
-    MeshViewBindGroup, PrepassViewBindGroup, PreviousViewProjectionUniformOffset,
-    ViewFogUniformOffset, ViewLightProbesUniformOffset, ViewLightsUniformOffset,
+    MeshViewBindGroup, PrepassViewBindGroup, PreviousViewUniformOffset, ViewFogUniformOffset,
+    ViewLightProbesUniformOffset, ViewLightsUniformOffset,
 };
 use bevy_core_pipeline::prepass::ViewPrepassTextures;
 use bevy_ecs::{query::QueryItem, world::World};
@@ -135,7 +135,7 @@ impl ViewNode for MeshletPrepassNode {
         &'static ExtractedCamera,
         &'static ViewPrepassTextures,
         &'static ViewUniformOffset,
-        Option<&'static PreviousViewProjectionUniformOffset>,
+        Option<&'static PreviousViewUniformOffset>,
         &'static MeshletViewMaterialsPrepass,
         &'static MeshletViewBindGroups,
         &'static MeshletViewResources,
@@ -256,7 +256,7 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
         &'static ExtractedCamera,
         &'static ViewPrepassTextures,
         &'static ViewUniformOffset,
-        Option<&'static PreviousViewProjectionUniformOffset>,
+        Option<&'static PreviousViewUniformOffset>,
         &'static MeshletViewMaterialsDeferredGBufferPrepass,
         &'static MeshletViewBindGroups,
         &'static MeshletViewResources,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wgsl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wgsl
@@ -22,7 +22,7 @@
 #ifdef PREPASS_FRAGMENT
 #ifdef MOTION_VECTOR_PREPASS
 #import bevy_pbr::{
-    prepass_bindings::previous_view_proj,
+    prepass_bindings::previous_view_uniforms,
     pbr_prepass_functions::calculate_motion_vector,
 }
 #endif
@@ -153,9 +153,9 @@ fn resolve_vertex_output(frag_coord: vec4<f32>) -> VertexOutput {
     let previous_world_position_1 = mesh_position_local_to_world(previous_model, vec4(vertex_1.position, 1.0));
     let previous_world_position_2 = mesh_position_local_to_world(previous_model, vec4(vertex_2.position, 1.0));
     let previous_world_position_3 = mesh_position_local_to_world(previous_model, vec4(vertex_3.position, 1.0));
-    let previous_clip_position_1 = previous_view_proj * vec4(previous_world_position_1.xyz, 1.0);
-    let previous_clip_position_2 = previous_view_proj * vec4(previous_world_position_2.xyz, 1.0);
-    let previous_clip_position_3 = previous_view_proj * vec4(previous_world_position_3.xyz, 1.0);
+    let previous_clip_position_1 = previous_view_uniforms.view_proj * vec4(previous_world_position_1.xyz, 1.0);
+    let previous_clip_position_2 = previous_view_uniforms.view_proj * vec4(previous_world_position_2.xyz, 1.0);
+    let previous_clip_position_3 = previous_view_uniforms.view_proj * vec4(previous_world_position_3.xyz, 1.0);
     let previous_partial_derivatives = compute_partial_derivatives(
         array(previous_clip_position_1, previous_clip_position_2, previous_clip_position_3),
         frag_coord_ndc,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -648,8 +648,8 @@ pub fn prepare_previous_view_uniforms(
         return;
     };
 
-    for (entity, camera, maybe_previous_view_proj) in views_iter {
-        let view_projection = match maybe_previous_view_proj {
+    for (entity, camera, maybe_previous_view_uniforms) in views_iter {
+        let view_projection = match maybe_previous_view_uniforms {
             Some(previous_view) => previous_view.clone(),
             None => {
                 let inverse_view = camera.transform.compute_matrix().inverse();
@@ -677,7 +677,7 @@ pub fn prepare_prepass_view_bind_group<M: Material>(
     prepass_pipeline: Res<PrepassPipeline<M>>,
     view_uniforms: Res<ViewUniforms>,
     globals_buffer: Res<GlobalsBuffer>,
-    previous_view_proj_uniforms: Res<PreviousViewProjectionUniforms>,
+    previous_view_uniforms: Res<PreviousViewProjectionUniforms>,
     mut prepass_view_bind_group: ResMut<PrepassViewBindGroup>,
 ) {
     if let (Some(view_binding), Some(globals_binding)) = (
@@ -690,14 +690,14 @@ pub fn prepare_prepass_view_bind_group<M: Material>(
             &BindGroupEntries::sequential((view_binding.clone(), globals_binding.clone())),
         ));
 
-        if let Some(previous_view_proj_binding) = previous_view_proj_uniforms.uniforms.binding() {
+        if let Some(previous_view_uniforms_binding) = previous_view_uniforms.uniforms.binding() {
             prepass_view_bind_group.motion_vectors = Some(render_device.create_bind_group(
                 "prepass_view_motion_vectors_bind_group",
                 &prepass_pipeline.view_layout_motion_vectors,
                 &BindGroupEntries::sequential((
                     view_binding,
                     globals_binding,
-                    previous_view_proj_binding,
+                    previous_view_uniforms_binding,
                 )),
             ));
         }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -627,7 +627,7 @@ pub struct PreviousViewProjectionUniforms {
 }
 
 #[derive(Component)]
-pub struct PreviousViewProjectionUniformOffset {
+pub struct PreviousViewUniformOffset {
     pub offset: u32,
 }
 
@@ -660,11 +660,9 @@ pub fn prepare_previous_view_uniforms(
             }
         };
 
-        commands
-            .entity(entity)
-            .insert(PreviousViewProjectionUniformOffset {
-                offset: writer.write(&view_projection),
-            });
+        commands.entity(entity).insert(PreviousViewUniformOffset {
+            offset: writer.write(&view_projection),
+        });
     }
 }
 
@@ -924,16 +922,16 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetPrepassViewBindGroup<
     type Param = SRes<PrepassViewBindGroup>;
     type ViewQuery = (
         Read<ViewUniformOffset>,
-        Option<Read<PreviousViewProjectionUniformOffset>>,
+        Option<Read<PreviousViewUniformOffset>>,
     );
     type ItemQuery = ();
 
     #[inline]
     fn render<'w>(
         _item: &P,
-        (view_uniform_offset, previous_view_projection_uniform_offset): (
+        (view_uniform_offset, previous_view_uniform_offset): (
             &'_ ViewUniformOffset,
-            Option<&'_ PreviousViewProjectionUniformOffset>,
+            Option<&'_ PreviousViewUniformOffset>,
         ),
         _entity: Option<()>,
         prepass_view_bind_group: SystemParamItem<'w, '_, Self::Param>,
@@ -941,15 +939,13 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetPrepassViewBindGroup<
     ) -> RenderCommandResult {
         let prepass_view_bind_group = prepass_view_bind_group.into_inner();
 
-        if let Some(previous_view_projection_uniform_offset) =
-            previous_view_projection_uniform_offset
-        {
+        if let Some(previous_view_uniform_offset) = previous_view_uniform_offset {
             pass.set_bind_group(
                 I,
                 prepass_view_bind_group.motion_vectors.as_ref().unwrap(),
                 &[
                     view_uniform_offset.offset,
-                    previous_view_projection_uniform_offset.offset,
+                    previous_view_uniform_offset.offset,
                 ],
             );
         } else {

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -4,7 +4,7 @@
     prepass_io::{Vertex, VertexOutput, FragmentOutput},
     skinning,
     morph,
-    mesh_view_bindings::{view, previous_view_proj},
+    mesh_view_bindings::view,
 }
 
 #ifdef DEFERRED_PREPASS
@@ -127,7 +127,7 @@ fn fragment(in: VertexOutput) -> FragmentOutput {
 #ifdef MOTION_VECTOR_PREPASS
     let clip_position_t = view.unjittered_view_proj * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
-    let previous_clip_position_t = prepass_bindings::previous_view_proj * in.previous_world_position;
+    let previous_clip_position_t = prepass_bindings::previous_view_uniforms.view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;
     // These motion vectors are used as offsets to UV positions and are stored
     // in the range -1,1 to allow offsetting from the one corner to the

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -1,7 +1,12 @@
 #define_import_path bevy_pbr::prepass_bindings
 
+struct PreviousViewUniforms {
+    inverse_view: mat4x4<f32>,
+    view_proj:  mat4x4<f32>,
+}
+
 #ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(2) var<uniform> previous_view_proj: mat4x4<f32>;
+@group(0) @binding(2) var<uniform> previous_view_uniforms: PreviousViewUniforms;
 #endif // MOTION_VECTOR_PREPASS
 
 // Material bindings will be in @group(2)

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -2,7 +2,7 @@
 
 struct PreviousViewUniforms {
     inverse_view: mat4x4<f32>,
-    view_proj:  mat4x4<f32>,
+    view_proj: mat4x4<f32>,
 }
 
 #ifdef MOTION_VECTOR_PREPASS

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -2,7 +2,7 @@
 
 #import bevy_pbr::{
     prepass_io::VertexOutput,
-    prepass_bindings::previous_view_proj,
+    prepass_bindings::previous_view_uniforms,
     mesh_view_bindings::view,
     pbr_bindings,
     pbr_types,
@@ -47,7 +47,7 @@ fn prepass_alpha_discard(in: VertexOutput) {
 fn calculate_motion_vector(world_position: vec4<f32>, previous_world_position: vec4<f32>) -> vec2<f32> {
     let clip_position_t = view.unjittered_view_proj * world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
-    let previous_clip_position_t = previous_view_proj * previous_world_position;
+    let previous_clip_position_t = previous_view_uniforms.view_proj * previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;
     // These motion vectors are used as offsets to UV positions and are stored
     // in the range -1,1 to allow offsetting from the one corner to the


### PR DESCRIPTION
# Objective
- Upload previous frame's inverse_view matrix to the GPU for use with  https://github.com/bevyengine/bevy/pull/12898.

---

## Changelog
- Added `prepass_bindings::previous_view_uniforms.inverse_view`.
- Renamed `prepass_bindings::previous_view_proj` to `prepass_bindings::previous_view_uniforms.view_proj`.
- Renamed `PreviousViewProjectionUniformOffset` to `PreviousViewUniformOffset`.
- Renamed `PreviousViewProjection` to `PreviousViewData`.

## Migration Guide
- Renamed `prepass_bindings::previous_view_proj` to `prepass_bindings::previous_view_uniforms.view_proj`.
- Renamed `PreviousViewProjectionUniformOffset` to `PreviousViewUniformOffset`.
- Renamed `PreviousViewProjection` to `PreviousViewData`.