### PR TITLE
Fix strings not interpolating in weely ci run

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -90,7 +90,7 @@ jobs:
             --jq '.[0].number')
           if [[ -n $previous_issue_number ]]; then
             gh issue comment $previous_issue_number \
-              --body "Weekly pipeline still fails: $FAILED_RUN" 
+              --body "Weekly pipeline still fails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" 
           else
             gh issue create \
               --title "$TITLE" \
@@ -102,7 +102,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: Main branch fails to compile on Rust beta.
           LABELS: C-Bug,S-Needs-Triage
-          FAILED_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BODY: | 
             ## Weekly CI run has failed.
-            [The offending run.]($FAILED_RUN)
+            [The offending run.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
# Objective

Fix invalid links in weekly CI workflow.

## Solution

Replace env vars with direct evaluation.
