### PR TITLE
Bump crate-ci/typos from 1.19.0 to 1.20.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.19.0
+        uses: crate-ci/typos@v1.20.4
       - name: Typos info
         if: failure()
         run: |

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -147,7 +147,7 @@ fn calculate_view(
         // Orthographic view vector
         V = normalize(vec3<f32>(view_bindings::view.view_proj[0].z, view_bindings::view.view_proj[1].z, view_bindings::view.view_proj[2].z));
     } else {
-        // Only valid for a perpective projection
+        // Only valid for a perspective projection
         V = normalize(view_bindings::view.world_position.xyz - world_position.xyz);
     }
     return V;

--- a/typos.toml
+++ b/typos.toml
@@ -11,7 +11,9 @@ extend-exclude = [
 
 # Match Whole Word - Case Sensitive
 [default.extend-identifiers]
+iy = "iy"   # Variable name used in bevy_gizmos. Probably stands for "y-axis index", as it's being used in loops.
 ser = "ser" # ron::ser - Serializer
+SME = "SME" # Subject Matter Expert
 Sur = "Sur" # macOS Big Sur - South
 
 # Match Inside a Word - Case Insensitive
@@ -23,6 +25,7 @@ TOI = "TOI" # Time of impact
 extend-ignore-identifiers-re = [
   "NDK",        # NDK - Native  Development Kit
   "inventario", # Inventory in Portuguese
+  "PNG",        # PNG - Portable Network Graphics file format
   # Used in bevy_mikktspace
   "iFO",
   "vOt",


### PR DESCRIPTION
# Objective

- Adopting https://github.com/bevyengine/bevy/pull/12903.

## Solution

- Bump crate-ci/typos from 1.19.0 to 1.20.4.
- Fixed a typo in `crates/bevy_pbr/src/render/pbr_functions.wgsl` file.
- Added "PNG", "iy" and "SME" as exceptions to prevent false positives.