### PR TITLE
Fix beta CI

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -37,7 +37,7 @@ pub struct TaskPoolBuilder {
     /// If set, we'll use the given stack size rather than the system default
     stack_size: Option<usize>,
     /// Allows customizing the name of the threads - helpful for debugging. If set, threads will
-    /// be named <thread_name> (<thread_index>), i.e. "MyThreadPool (2)"
+    /// be named `<thread_name> (<thread_index>)`, i.e. `"MyThreadPool (2)"`.
     thread_name: Option<String>,
 
     on_thread_spawn: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
@@ -106,14 +106,10 @@ impl TaskPoolBuilder {
 /// will still execute a task, even if it is dropped.
 #[derive(Debug)]
 pub struct TaskPool {
-    /// The executor for the pool
-    ///
-    /// This has to be separate from TaskPoolInner because we have to create an `Arc<Executor>` to
-    /// pass into the worker threads, and we must create the worker threads before we can create
-    /// the `Vec<Task<T>>` contained within `TaskPoolInner`
+    /// The executor for the pool.
     executor: Arc<async_executor::Executor<'static>>,
 
-    /// Inner state of the pool
+    // The inner state of the pool.
     threads: Vec<JoinHandle<()>>,
     shutdown_tx: async_channel::Sender<()>,
 }

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -58,6 +58,8 @@ impl Default for WinitSettings {
     }
 }
 
+// Rustdoc mistakenly believes `App` is already in scope.
+#[allow(rustdoc::redundant_explicit_links)]
 /// Determines how frequently an [`App`](bevy_app::App) should update.
 ///
 /// **Note:** This setting is independent of VSync. VSync is controlled by a window's


### PR DESCRIPTION
# Objective

- Fixes #12905.

## Solution

- Use proper code `` tags for `TaskPoolBuilder::thread_name`.
- Remove leftover documentation in `TaskPool` referencing the deleted `TaskPoolInner` struct.
  - It may be possible to rephrase this, but I do not know enough about the task pool to write something. (cc @james7132 who made the change removing `TaskPoolInner`.)
- Ignore a buggy rustdoc lint that thinks `App` is already in scope for `UpdateMode` doc. (Extracted from #12692.)