### PR TITLE
Add tetrahedron gizmos

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -6,7 +6,7 @@ use std::f32::consts::TAU;
 use bevy_color::Color;
 use bevy_math::primitives::{
     BoxedPolyline3d, Capsule3d, Cone, ConicalFrustum, Cuboid, Cylinder, Line3d, Plane3d,
-    Polyline3d, Primitive3d, Segment3d, Sphere, Torus,
+    Polyline3d, Primitive3d, Segment3d, Sphere, Tetrahedron, Torus,
 };
 use bevy_math::{Dir3, Quat, Vec3};
 
@@ -939,5 +939,33 @@ impl<T: GizmoConfigGroup> Drop for Torus3dBuilder<'_, '_, '_, T> {
                     .short_arc_3d_between(center, from, to, *color)
                     .segments(*minor_segments);
             });
+    }
+}
+
+// tetrahedron
+
+impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Tetrahedron> for Gizmos<'w, 's, T> {
+    type Output<'a> = () where Self: 'a;
+
+    fn primitive_3d(
+        &mut self,
+        primitive: Tetrahedron,
+        position: Vec3,
+        rotation: Quat,
+        color: Color,
+    ) -> Self::Output<'_> {
+        if !self.enabled {
+            return;
+        }
+
+        let [a, b, c, d] = primitive
+            .vertices
+            .map(rotate_then_translate_3d(rotation, position));
+
+        let lines = [(a, b), (a, c), (a, d), (b, c), (b, d), (c, d)];
+
+        for (a, b) in lines.into_iter() {
+            self.line(a, b, color);
+        }
     }
 }

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -954,7 +954,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Tetrahedron> for Gizmos<'w, '
         primitive: Tetrahedron,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         if !self.enabled {
             return;
@@ -966,6 +966,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Tetrahedron> for Gizmos<'w, '
 
         let lines = [(a, b), (a, c), (a, d), (b, c), (b, d), (c, d)];
 
+        let color = color.into();
         for (a, b) in lines.into_iter() {
             self.line(a, b, color);
         }


### PR DESCRIPTION
# Objective

- Adds tetrahedron gizmos, suggestion of #9400

## Solution

- Implement tetrahedron gizmos as a `gizmos.primitive_3d`

## Additional info

Here is a short video of the default tetrahedron :)

https://github.com/bevyengine/bevy/assets/62256001/a6f31b6f-78bc-4dc2-8f46-2ebd04ed8a0e


