### PR TITLE
Use `impl Into<Color>` for `gizmos.primitive_3d(...)`

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -29,7 +29,7 @@ pub trait GizmoPrimitive3d<P: Primitive3d> {
         primitive: P,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_>;
 }
 
@@ -43,7 +43,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Dir3> for Gizmos<'w, 's, T> {
         primitive: Dir3,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         self.arrow(position, position + (rotation * *primitive), color);
     }
@@ -85,14 +85,14 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Sphere> for Gizmos<'w, 's, T>
         primitive: Sphere,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         SphereBuilder {
             gizmos: self,
             radius: primitive.radius,
             position,
             rotation,
-            color,
+            color: color.into(),
             segments: DEFAULT_NUMBER_SEGMENTS,
         }
     }
@@ -184,14 +184,14 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Plane3d> for Gizmos<'w, 's, T
         primitive: Plane3d,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         Plane3dBuilder {
             gizmos: self,
             normal: primitive.normal,
             rotation,
             position,
-            color,
+            color: color.into(),
             axis_count: 4,
             segment_count: 3,
             segment_length: 0.25,
@@ -251,12 +251,13 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Line3d> for Gizmos<'w, 's, T>
         primitive: Line3d,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         if !self.enabled {
             return;
         }
 
+        let color = color.into();
         let direction = rotation * *primitive.direction;
         self.arrow(position, position + direction, color);
 
@@ -278,7 +279,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Segment3d> for Gizmos<'w, 's,
         primitive: Segment3d,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         if !self.enabled {
             return;
@@ -303,7 +304,7 @@ impl<'w, 's, const N: usize, T: GizmoConfigGroup> GizmoPrimitive3d<Polyline3d<N>
         primitive: Polyline3d<N>,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         if !self.enabled {
             return;
@@ -328,7 +329,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<BoxedPolyline3d> for Gizmos<'
         primitive: BoxedPolyline3d,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         if !self.enabled {
             return;
@@ -355,7 +356,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cuboid> for Gizmos<'w, 's, T>
         primitive: Cuboid,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         if !self.enabled {
             return;
@@ -390,6 +391,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cuboid> for Gizmos<'w, 's, T>
         // lines connecting upper and lower rectangles of the cuboid
         let connections = vertices.into_iter().zip(vertices.into_iter().skip(4));
 
+        let color = color.into();
         upper
             .chain(lower)
             .chain(connections)
@@ -439,7 +441,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cylinder> for Gizmos<'w, 's, 
         primitive: Cylinder,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         Cylinder3dBuilder {
             gizmos: self,
@@ -447,7 +449,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cylinder> for Gizmos<'w, 's, 
             half_height: primitive.half_height,
             position,
             rotation,
-            color,
+            color: color.into(),
             segments: DEFAULT_NUMBER_SEGMENTS,
         }
     }
@@ -536,7 +538,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Capsule3d> for Gizmos<'w, 's,
         primitive: Capsule3d,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         Capsule3dBuilder {
             gizmos: self,
@@ -544,7 +546,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Capsule3d> for Gizmos<'w, 's,
             half_length: primitive.half_length,
             position,
             rotation,
-            color,
+            color: color.into(),
             segments: DEFAULT_NUMBER_SEGMENTS,
         }
     }
@@ -651,7 +653,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cone> for Gizmos<'w, 's, T> {
         primitive: Cone,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         Cone3dBuilder {
             gizmos: self,
@@ -659,7 +661,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cone> for Gizmos<'w, 's, T> {
             height: primitive.height,
             position,
             rotation,
-            color,
+            color: color.into(),
             base_segments: DEFAULT_NUMBER_SEGMENTS,
             height_segments: DEFAULT_NUMBER_SEGMENTS,
         }
@@ -749,7 +751,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<ConicalFrustum> for Gizmos<'w
         primitive: ConicalFrustum,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         ConicalFrustum3dBuilder {
             gizmos: self,
@@ -758,7 +760,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<ConicalFrustum> for Gizmos<'w
             height: primitive.height,
             position,
             rotation,
-            color,
+            color: color.into(),
             segments: DEFAULT_NUMBER_SEGMENTS,
         }
     }
@@ -861,7 +863,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Torus> for Gizmos<'w, 's, T> 
         primitive: Torus,
         position: Vec3,
         rotation: Quat,
-        color: Color,
+        color: impl Into<Color>,
     ) -> Self::Output<'_> {
         Torus3dBuilder {
             gizmos: self,
@@ -869,7 +871,7 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Torus> for Gizmos<'w, 's, T> 
             major_radius: primitive.major_radius,
             position,
             rotation,
-            color,
+            color: color.into(),
             minor_segments: DEFAULT_NUMBER_SEGMENTS,
             major_segments: DEFAULT_NUMBER_SEGMENTS,
         }


### PR DESCRIPTION
# Objective

- All gizmos APIs besides `gizmos.primitive_3d` use `impl Into<Color>` as their type for `color`.  

## Solution

- This PR changes `primitive_3d()` to use `impl Into<Color>` aswell.
