### PR TITLE
Enable `clippy::ref_as_ptr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ semicolon_if_nothing_returned = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"
-#TODO(rust 1.77): enable `ref_as_ptr`
-# ref_as_ptr = "warn"
+ref_as_ptr = "warn"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -45,7 +45,7 @@
     unsafe_code
 )]
 
-use std::ptr::null_mut;
+use std::ptr::{self, null_mut};
 
 use glam::Vec3;
 
@@ -830,7 +830,7 @@ unsafe fn Build4RuleGroups(
                 let mut neigh_indexR: i32 = 0;
                 let vert_index: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
                 let ref mut fresh2 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
-                *fresh2 = &mut *pGroups.offset(iNrActiveGroups as isize) as *mut SGroup;
+                *fresh2 = ptr::from_mut(&mut *pGroups.offset(iNrActiveGroups as isize));
                 (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize])
                     .iVertexRepresentative = vert_index;
                 (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).bOrientPreservering =
@@ -838,7 +838,7 @@ unsafe fn Build4RuleGroups(
                 (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).iNrFaces = 0i32;
                 let ref mut fresh3 =
                     (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).pFaceIndices;
-                *fresh3 = &mut *piGroupTrianglesBuffer.offset(iOffset as isize) as *mut i32;
+                *fresh3 = ptr::from_mut(&mut *piGroupTrianglesBuffer.offset(iOffset as isize));
                 iNrActiveGroups += 1;
                 AddTriToGroup((*pTriInfos.offset(f as isize)).AssignedGroup[i as usize], f);
                 bOrPre = if (*pTriInfos.offset(f as isize)).iFlag & 8i32 != 0i32 {

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -2,7 +2,8 @@
     unsafe_op_in_unsafe_fn,
     clippy::all,
     clippy::undocumented_unsafe_blocks,
-    clippy::ptr_cast_constness
+    clippy::ptr_cast_constness,
+    clippy::ref_as_ptr
 )]
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -2,8 +2,7 @@
     unsafe_op_in_unsafe_fn,
     clippy::all,
     clippy::undocumented_unsafe_blocks,
-    clippy::ptr_cast_constness,
-    clippy::ref_as_ptr
+    clippy::ptr_cast_constness
 )]
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -80,6 +80,8 @@ impl Eq for MeshVertexBufferLayoutRef {}
 
 impl Hash for MeshVertexBufferLayoutRef {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        (&*self.0 as *const MeshVertexBufferLayout as usize).hash(state);
+        // Hash the address of the underlying data, so two layouts that share the same
+        // `MeshVertexBufferLayout` will have the same hash.
+        (Arc::as_ptr(&self.0) as usize).hash(state);
     }
 }


### PR DESCRIPTION
# Objective

- [`clippy::ref_as_ptr`](https://rust-lang.github.io/rust-clippy/master/index.html#/ref_as_ptr) prevents you from directly casting references to pointers, requiring you to use `std::ptr::from_ref` instead. This prevents you from accidentally converting an immutable reference into a mutable pointer (`&x as *mut T`).
- Follow up to #11818, now that our [`rust-version` is 1.77](https://github.com/bevyengine/bevy/blob/11817f4ba4cca8e956c50f6d919e38f601ecc5cf/Cargo.toml#L14).

## Solution

- Enable lint and fix all warnings.
