### PR TITLE
Fix 2D BatchedInstanceBuffer clear

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -126,7 +126,7 @@ where
 }
 
 /// A system that runs early in extraction and clears out all the
-/// [`gpu_preprocessing::BatchedInstanceBuffers`] for the frame.
+/// [`BatchedInstanceBuffers`] for the frame.
 ///
 /// We have to run this during extraction because, if GPU preprocessing is in
 /// use, the extraction phase will write to the mesh input uniform buffers
@@ -146,7 +146,7 @@ pub fn clear_batched_gpu_instance_buffers<GFBD>(
 /// A system that removes GPU preprocessing work item buffers that correspond to
 /// deleted [`ViewTarget`]s.
 ///
-/// This is a separate system from [`super::clear_batched_instance_buffers`]
+/// This is a separate system from [`clear_batched_gpu_instance_buffers`]
 /// because [`ViewTarget`]s aren't created until after the extraction phase is
 /// completed.
 pub fn delete_old_work_item_buffers<GFBD>(

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -125,6 +125,24 @@ where
     }
 }
 
+/// A system that runs early in extraction and clears out all the
+/// [`gpu_preprocessing::BatchedInstanceBuffers`] for the frame.
+///
+/// We have to run this during extraction because, if GPU preprocessing is in
+/// use, the extraction phase will write to the mesh input uniform buffers
+/// directly, so the buffers need to be cleared before then.
+pub fn clear_batched_gpu_instance_buffers<GFBD>(
+    gpu_batched_instance_buffers: Option<
+        ResMut<BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>>,
+    >,
+) where
+    GFBD: GetFullBatchData,
+{
+    if let Some(mut gpu_batched_instance_buffers) = gpu_batched_instance_buffers {
+        gpu_batched_instance_buffers.clear();
+    }
+}
+
 /// A system that removes GPU preprocessing work item buffers that correspond to
 /// deleted [`ViewTarget`]s.
 ///

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    system::{Query, ResMut, SystemParam, SystemParamItem},
+    system::{Query, SystemParam, SystemParamItem},
 };
 use bytemuck::Pod;
 use nonmax::NonMaxU32;
@@ -133,30 +133,6 @@ pub trait GetFullBatchData: GetBatchData {
         param: &SystemParamItem<Self::Param>,
         query_item: Entity,
     ) -> Option<NonMaxU32>;
-}
-
-/// A system that runs early in extraction and clears out all the
-/// [`gpu_preprocessing::BatchedInstanceBuffers`] for the frame.
-///
-/// We have to run this during extraction because, if GPU preprocessing is in
-/// use, the extraction phase will write to the mesh input uniform buffers
-/// directly, so the buffers need to be cleared before then.
-pub fn clear_batched_instance_buffers<GFBD>(
-    cpu_batched_instance_buffer: Option<
-        ResMut<no_gpu_preprocessing::BatchedInstanceBuffer<GFBD::BufferData>>,
-    >,
-    gpu_batched_instance_buffers: Option<
-        ResMut<gpu_preprocessing::BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>>,
-    >,
-) where
-    GFBD: GetFullBatchData,
-{
-    if let Some(mut cpu_batched_instance_buffer) = cpu_batched_instance_buffer {
-        cpu_batched_instance_buffer.clear();
-    }
-    if let Some(mut gpu_batched_instance_buffers) = gpu_batched_instance_buffers {
-        gpu_batched_instance_buffers.clear();
-    }
 }
 
 /// Sorts a render phase that uses bins.

--- a/crates/bevy_render/src/batching/no_gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/no_gpu_preprocessing.rs
@@ -43,6 +43,19 @@ where
     }
 }
 
+/// A system that clears out the [`BatchedInstanceBuffer`] for the frame.
+///
+/// This needs to run before the CPU batched instance buffers are used.
+pub fn clear_batched_cpu_instance_buffers<GBD>(
+    cpu_batched_instance_buffer: Option<ResMut<BatchedInstanceBuffer<GBD::BufferData>>>,
+) where
+    GBD: GetBatchData,
+{
+    if let Some(mut cpu_batched_instance_buffer) = cpu_batched_instance_buffer {
+        cpu_batched_instance_buffer.clear();
+    }
+}
+
 /// Batch the items in a sorted render phase, when GPU instance buffer building
 /// isn't in use. This means comparing metadata needed to draw each phase item
 /// and trying to combine the draws into a batch.

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -12,7 +12,8 @@ use bevy_ecs::{
 use bevy_math::{Affine3, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::batching::no_gpu_preprocessing::{
-    batch_and_prepare_sorted_render_phase, write_batched_instance_buffer, BatchedInstanceBuffer,
+    self, batch_and_prepare_sorted_render_phase, write_batched_instance_buffer,
+    BatchedInstanceBuffer,
 };
 use bevy_render::mesh::{GpuMesh, MeshVertexBufferLayoutRef};
 use bevy_render::{
@@ -107,6 +108,9 @@ impl Plugin for Mesh2dRenderPlugin {
                             .in_set(RenderSet::PrepareResourcesFlush),
                         prepare_mesh2d_bind_group.in_set(RenderSet::PrepareBindGroups),
                         prepare_mesh2d_view_bind_groups.in_set(RenderSet::PrepareBindGroups),
+                        no_gpu_preprocessing::clear_batched_cpu_instance_buffers::<Mesh2dPipeline>
+                            .in_set(RenderSet::Cleanup)
+                            .after(RenderSet::Render),
                     ),
                 );
         }


### PR DESCRIPTION
# Objective

- `cargo run --release --example bevymark -- --benchmark --waves 160 --per-wave 1000 --mode mesh2d` runs slower and slower over time due to `no_gpu_preprocessing::write_batched_instance_buffer<bevy_sprite::mesh2d::mesh::Mesh2dPipeline>` taking longer and longer because the `BatchedInstanceBuffer` is not cleared

## Solution

- Split the `clear_batched_instance_buffers` system into CPU and GPU versions
- Use the CPU version for 2D meshes