### PR TITLE
Fix some nightly Clippy lints

### DIFF
--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -78,6 +78,12 @@ impl BatchingStrategy {
     }
 }
 
+impl Default for BatchingStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A parallel iterator over query results of a [`Query`](crate::system::Query).
 ///
 /// This struct is created by the [`Query::par_iter`](crate::system::Query::par_iter) and

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -696,7 +696,7 @@ impl ScheduleState {
         // if our NodeId list hasn't been populated, copy it over from the
         // schedule
         if self.node_ids.len() != schedule.systems_len() {
-            self.node_ids = schedule.executable().system_ids.clone();
+            self.node_ids.clone_from(&schedule.executable().system_ids);
         }
 
         // Now that we have the schedule, apply any pending system behavior

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -481,7 +481,7 @@ pub struct WorldChildBuilder<'w> {
 impl<'w> WorldChildBuilder<'w> {
     /// Spawns an entity with the given bundle and inserts it into the parent entity's [`Children`].
     /// Also adds [`Parent`] component to the created entity.
-    pub fn spawn(&mut self, bundle: impl Bundle + Send + Sync + 'static) -> EntityWorldMut<'_> {
+    pub fn spawn(&mut self, bundle: impl Bundle) -> EntityWorldMut<'_> {
         let entity = self.world.spawn((bundle, Parent(self.parent))).id();
         push_child_unchecked(self.world, self.parent, entity);
         push_events(

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1059,7 +1059,7 @@ impl Reflect for Cow<'static, str> {
     fn apply(&mut self, value: &dyn Reflect) {
         let value = value.as_any();
         if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
+            self.clone_from(value);
         } else {
             panic!("Value is not a {}.", Self::type_path());
         }
@@ -1548,7 +1548,7 @@ impl Reflect for Cow<'static, Path> {
     fn apply(&mut self, value: &dyn Reflect) {
         let value = value.as_any();
         if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
+            self.clone_from(value);
         } else {
             panic!("Value is not a {}.", Self::type_path());
         }

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -110,6 +110,12 @@ impl<T: TypedProperty> NonGenericTypeCell<T> {
     }
 }
 
+impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A container for [`TypedProperty`] over generic types, allowing instances to be stored statically.
 ///
 /// This is specifically meant for use with generic types. If your type isn't generic,
@@ -242,6 +248,12 @@ impl<T: TypedProperty> GenericTypeCell<T> {
                 Box::leak(Box::new(value))
             })
             .get()
+    }
+}
+
+impl<T: TypedProperty> Default for GenericTypeCell<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -123,14 +123,14 @@ impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
 
 /// This system prepares all components of the corresponding component type.
 /// They are transformed into uniforms and stored in the [`ComponentUniforms`] resource.
-fn prepare_uniform_components<C: Component>(
+fn prepare_uniform_components<C>(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut component_uniforms: ResMut<ComponentUniforms<C>>,
     components: Query<(Entity, &C)>,
 ) where
-    C: ShaderType + WriteInto + Clone,
+    C: Component + ShaderType + WriteInto + Clone,
 {
     let components_iter = components.iter();
     let count = components_iter.len();


### PR DESCRIPTION
# Objective

- I daily drive nightly Rust when developing Bevy, so I notice when new warnings are raised by `cargo check` and Clippy.
- `cargo +nightly clippy` raises a few of these new warnings.

## Solution

- Fix most warnings from `cargo +nightly clippy`
  - I skipped the docs-related warnings because some were covered by #12692.
  - Use `Clone::clone_from` in applicable scenarios, which can sometimes avoid an extra allocation.
  - Implement `Default` for structs that have a `pub const fn new() -> Self` method.
  - Fix an occurrence where generic constraints were defined in both `<C: Trait>` and `where C: Trait`.
  - Removed generic constraints that were implied by the `Bundle` trait.

---

## Changelog

- `BatchingStrategy`, `NonGenericTypeCell`, and `GenericTypeCell` now implement `Default`.
