### PR TITLE
Add Disabled marker

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -37,7 +37,7 @@ pub struct TypeRegistrationPlugin;
 
 impl Plugin for TypeRegistrationPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Name>();
+        app.register_type::<Name>().register_type::<Disabled>();
     }
 }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -45,7 +45,9 @@ pub mod prelude {
         component::Component,
         entity::{Entity, EntityMapper},
         event::{Event, EventReader, EventWriter, Events},
-        query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
+        query::{
+            Added, AnyOf, Changed, Disabled, Has, Or, QueryBuilder, QueryState, With, Without,
+        },
         removal_detection::RemovedComponents,
         schedule::{
             apply_deferred, apply_state_transition, common_conditions::*, Condition,
@@ -69,7 +71,7 @@ mod tests {
         change_detection::Ref,
         component::{Component, ComponentId},
         entity::Entity,
-        query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
+        query::{Added, Changed, Disabled, FilteredAccess, QueryFilter, With, Without},
         system::Resource,
         world::{EntityRef, Mut, World},
     };
@@ -1379,6 +1381,7 @@ mod tests {
     #[test]
     fn filtered_query_access() {
         let mut world = World::new();
+        let disabled_id = world.init_component::<Disabled>();
         let query = world.query_filtered::<&mut A, Changed<B>>();
 
         let mut expected = FilteredAccess::<ComponentId>::default();
@@ -1386,6 +1389,7 @@ mod tests {
         let b_id = world.components.get_id(TypeId::of::<B>()).unwrap();
         expected.add_write(a_id);
         expected.add_read(b_id);
+        expected.and_without(disabled_id);
         assert!(
             query.component_access.eq(&expected),
             "ComponentId access from query fetch and query filter should be combined"

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -23,7 +23,7 @@ pub enum QueryEntityError {
 
 /// An error that occurs when evaluating a [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState) as a single expected result via
 /// [`get_single`](crate::system::Query::get_single) or [`get_single_mut`](crate::system::Query::get_single_mut).
-#[derive(Debug, Error)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum QuerySingleError {
     /// No entity fits the query.
     #[error("No entities fit the query {0}")]

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -23,8 +23,48 @@ pub use world_query::*;
 
 use crate as bevy_ecs;
 
-/// A marker component that excludes an entity from queries that don't specifically request them.
-#[derive(bevy_ecs_macros::Component)]
+/// A special marker component to disable an entity.
+///
+/// Disabled entities do not show up in most queries, unless the query mentions Disabled.
+///
+/// ## Example
+///
+/// ```rust
+/// # use bevy_ecs::prelude::*;
+/// # let mut world = World::new();
+/// #
+/// // This entity is enabled, since all entities are enabled by default
+/// let entity_a = world.spawn_empty().id();
+///
+/// // We disable this entity using a helper method
+/// let entity_b = world.spawn_empty().id();
+/// world.disable(entity_b);
+///
+/// // It can also be inserted like other component
+/// let entity_c = world.spawn(Disabled).id();
+///
+/// // This query does not mention Disabled, so disabled entities are hidden
+/// let mut query = world.query::<Entity>();
+/// assert_eq!(1, query.iter(&world).count());
+/// assert_eq!(Ok(entity_a), query.get_single(&world));
+///
+/// // If our query mentions Disabled, we can find disabled entities like normal
+/// // Here we query for only the disabled entities
+/// let mut query = world.query_filtered::<(), With<Disabled>>();
+/// assert!(query.get(&world, entity_a).is_err());
+/// assert!(query.get_many(&world, [entity_b, entity_c]).is_ok());
+///
+/// // It also works as part of the query data
+/// let mut query = world.query::<Has<Disabled>>();
+/// assert_eq!(Ok([false, true, true]), query.get_many(&world, [entity_a, entity_b, entity_c]));
+///
+/// // If we exclude Disabled, it functions the same as the default behavior
+/// let mut query = world.query_filtered::<Entity, Without<Disabled>>();
+/// assert_eq!(1, query.iter(&world).count());
+/// assert_eq!(Ok(entity_a), query.get_single(&world));
+/// ```
+#[derive(bevy_ecs_macros::Component, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct Disabled;
 
 /// A debug checked version of [`Option::unwrap_unchecked`]. Will panic in

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -21,6 +21,12 @@ pub use par_iter::*;
 pub use state::*;
 pub use world_query::*;
 
+use crate as bevy_ecs;
+
+/// A marker component that excludes an entity from queries that don't specifically request them.
+#[derive(bevy_ecs_macros::Component)]
+pub struct Disabled;
+
 /// A debug checked version of [`Option::unwrap_unchecked`]. Will panic in
 /// debug modes if unwrapping a `None` or `Err` value in debug mode, but is
 /// equivalent to `Option::unwrap_unchecked` or `Result::unwrap_unchecked`

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -151,6 +151,7 @@ fn contains_disabled(
     disabled_id: ComponentId,
 ) -> bool {
     component_access.access().has_read(disabled_id)
+        || component_access.access().has_archetypal(disabled_id)
         || component_access.filter_sets.iter().any(|f| {
             f.with.contains(disabled_id.index()) || f.without.contains(disabled_id.index())
         })
@@ -2061,8 +2062,7 @@ mod tests {
         let mut query = QueryState::<(Entity, Option<&Disabled>)>::new(&mut world);
         assert_eq!(3, query.iter(&world).count());
 
-        // TODO: This case is not handled correctly yet, since Has<T> does not register component access
-        // let mut query = QueryState::<(Entity, Has<Disabled>)>::new(&mut world);
-        // assert_eq!(3, query.iter(&world).count());
+        let mut query = QueryState::<(Entity, Has<Disabled>)>::new(&mut world);
+        assert_eq!(3, query.iter(&world).count());
     }
 }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -933,6 +933,16 @@ impl EntityCommands<'_> {
         self.add(despawn);
     }
 
+    /// Enable this entity, removing the [`bevy_ecs::prelude::Disabled`] marker if it's present
+    pub fn enable(&mut self) {
+        self.add(enable);
+    }
+
+    /// Disable this entity, adding the [`bevy_ecs::prelude::Disabled`] marker to the entity
+    pub fn disable(&mut self) {
+        self.add(disable);
+    }
+
     /// Pushes an [`EntityCommand`] to the queue, which will get executed for the current [`Entity`].
     ///
     /// # Examples
@@ -1082,6 +1092,14 @@ where
 /// if you're using `bevy_hierarchy`), which may leave the world in an invalid state.
 fn despawn(entity: Entity, world: &mut World) {
     world.despawn(entity);
+}
+
+fn enable(entity: Entity, world: &mut World) {
+    world.enable(entity);
+}
+
+fn disable(entity: Entity, world: &mut World) {
+    world.disable(entity);
 }
 
 /// An [`EntityCommand`] that adds the components in a [`Bundle`] to an entity.

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -933,12 +933,12 @@ impl EntityCommands<'_> {
         self.add(despawn);
     }
 
-    /// Enable this entity, removing the [`bevy_ecs::prelude::Disabled`] marker if it's present
+    /// Enable this entity, see [`Disabled`](crate::prelude::Disabled) for more information.
     pub fn enable(&mut self) {
         self.add(enable);
     }
 
-    /// Disable this entity, adding the [`bevy_ecs::prelude::Disabled`] marker to the entity
+    /// Disable this entity, see [`Disabled`](crate::prelude::Disabled) for more information.
     pub fn disable(&mut self) {
         self.add(disable);
     }
@@ -1001,6 +1001,10 @@ impl EntityCommands<'_> {
     /// }
     /// # bevy_ecs::system::assert_is_system(remove_combat_stats_system);
     /// ```
+    ///
+    /// # Disabled
+    ///
+    /// Calling retain does not remove the [`Disabled`](crate::prelude::Disabled) marker even if it is present.
     pub fn retain<T>(&mut self) -> &mut Self
     where
         T: Bundle,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2608,18 +2608,10 @@ mod tests {
 
         let disabled_id = world.init_component::<Disabled>();
         world.entity_mut(ent).retain::<Marker<1>>();
-        assert!(world
-            .entity(ent)
-            .archetype()
-            .components()
-            .any(|c| c == disabled_id));
+        assert!(world.entity(ent).contains_id(disabled_id));
 
         world.entity_mut(ent).retain::<()>();
-        assert!(world
-            .entity(ent)
-            .archetype()
-            .components()
-            .any(|c| c == disabled_id))
+        assert!(world.entity(ent).contains_id(disabled_id));
     }
 
     // Test removing some components with `retain`, including components not on the entity.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1271,12 +1271,12 @@ impl<'w> EntityWorldMut<'w> {
         self.entity
     }
 
-    /// Enables the current entity, removing the [`Disabled`] marker.
+    /// Enables the current entity, see [`Disabled`] for more information.
     pub fn enable(&mut self) {
         self.remove::<Disabled>();
     }
 
-    /// Disables the current entity, adding the [`Disabled`] marker.
+    /// Disables the current entity, see [`Disabled`] for more information.
     pub fn disable(&mut self) {
         self.insert(Disabled);
     }
@@ -2595,7 +2595,7 @@ mod tests {
         assert_eq!(world.entity(ent).archetype().components().next(), None);
     }
 
-    // Test that calling retain retains [`Disabled`].
+    // Test that calling retain retains `Disabled`.
     #[test]
     fn retain_disabled() {
         #[derive(Component)]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -939,7 +939,7 @@ impl World {
         }
     }
 
-    /// Enables the given `entity`, if it exists and was [`crate::prelude::Disabled`].
+    /// Enables the given `entity`, if it exists and was [`Disabled`](crate::prelude::Disabled).
     /// Returns `true` if the `entity` is now enabled and `false` if the `entity` does not exist.
     #[inline]
     pub fn enable(&mut self, entity: Entity) -> bool {
@@ -952,7 +952,7 @@ impl World {
         }
     }
 
-    /// Disabled the given `entity`, if it exists and didn't have [`crate::prelude::Disabled`] yet.
+    /// Disables the given `entity`, if it exists and didn't have [`Disabled`](crate::prelude::Disabled) yet.
     /// Returns `true` if the `entity` is now disabled and `false` if the `entity` does not exist.
     #[inline]
     pub fn disable(&mut self, entity: Entity) -> bool {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -939,6 +939,32 @@ impl World {
         }
     }
 
+    /// Enables the given `entity`, if it exists and was [`crate::prelude::Disabled`].
+    /// Returns `true` if the `entity` is now enabled and `false` if the `entity` does not exist.
+    #[inline]
+    pub fn enable(&mut self, entity: Entity) -> bool {
+        if let Some(mut entity) = self.get_entity_mut(entity) {
+            entity.enable();
+            true
+        } else {
+            warn!("error[B0003]: Could not enable entity {:?} because it doesn't exist in this World.", entity);
+            false
+        }
+    }
+
+    /// Disabled the given `entity`, if it exists and didn't have [`crate::prelude::Disabled`] yet.
+    /// Returns `true` if the `entity` is now disabled and `false` if the `entity` does not exist.
+    #[inline]
+    pub fn disable(&mut self, entity: Entity) -> bool {
+        if let Some(mut entity) = self.get_entity_mut(entity) {
+            entity.disable();
+            true
+        } else {
+            warn!("error[B0003]: Could not disable entity {:?} because it doesn't exist in this World.", entity);
+            false
+        }
+    }
+
     /// Clears the internal component tracker state.
     ///
     /// The world maintains some internal state about changed and removed components. This state

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -135,15 +135,236 @@ impl<'w> DespawnRecursiveExt for EntityWorldMut<'w> {
     }
 }
 
+/// Disables the given entity and all its children recursively
+#[derive(Debug)]
+pub struct DisableRecursive {
+    /// Target entity
+    pub entity: Entity,
+}
+
+/// Disables the given entity's children recursively
+#[derive(Debug)]
+pub struct DisableChildrenRecursive {
+    /// Target entity
+    pub entity: Entity,
+}
+
+/// Function for disabling an entity and all its children
+pub fn disable_with_children_recursive(world: &mut World, entity: Entity) {
+    disable_children_recursive(world, entity);
+
+    if !world.disable(entity) {
+        debug!("Failed to disable entity {:?}", entity);
+    }
+}
+
+fn disable_children_recursive(world: &mut World, entity: Entity) {
+    if let Some(children) = world.entity(entity).get::<Children>() {
+        for e in children.0.clone() {
+            disable_with_children_recursive(world, e);
+        }
+    }
+}
+
+impl Command for DisableRecursive {
+    fn apply(self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "command",
+            name = "DisableRecursive",
+            entity = bevy_utils::tracing::field::debug(self.entity)
+        )
+        .entered();
+        disable_with_children_recursive(world, self.entity);
+    }
+}
+
+impl Command for DisableChildrenRecursive {
+    fn apply(self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "command",
+            name = "DisableChildrenRecursive",
+            entity = bevy_utils::tracing::field::debug(self.entity)
+        )
+        .entered();
+        disable_children_recursive(world, self.entity);
+    }
+}
+
+/// Trait that holds functions for disabling recursively down the hierarchy
+pub trait DisableRecursiveExt {
+    /// Disables the provided entity alongside all descendants.
+    fn disable_recursive(self);
+
+    /// Disables all descendants of the given entity.
+    fn disable_descendants(&mut self) -> &mut Self;
+}
+
+impl DisableRecursiveExt for EntityCommands<'_> {
+    fn disable_recursive(mut self) {
+        let entity = self.id();
+        self.commands().add(DisableRecursive { entity });
+    }
+
+    fn disable_descendants(&mut self) -> &mut Self {
+        let entity = self.id();
+        self.commands().add(DisableChildrenRecursive { entity });
+        self
+    }
+}
+
+impl<'w> DisableRecursiveExt for EntityWorldMut<'w> {
+    fn disable_recursive(self) {
+        let entity = self.id();
+
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "disable_recursive",
+            entity = bevy_utils::tracing::field::debug(entity)
+        )
+        .entered();
+
+        disable_with_children_recursive(self.into_world_mut(), entity);
+    }
+
+    fn disable_descendants(&mut self) -> &mut Self {
+        let entity = self.id();
+
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "disable_descendants",
+            entity = bevy_utils::tracing::field::debug(entity)
+        )
+        .entered();
+
+        self.world_scope(|world| {
+            disable_children_recursive(world, entity);
+        });
+        self
+    }
+}
+
+/// Enables the given entity and all its children recursively
+#[derive(Debug)]
+pub struct EnableRecursive {
+    /// Target entity
+    pub entity: Entity,
+}
+
+/// Enables the given entity's children recursively
+#[derive(Debug)]
+pub struct EnableChildrenRecursive {
+    /// Target entity
+    pub entity: Entity,
+}
+
+/// Function for enabling an entity and all its children
+pub fn enable_with_children_recursive(world: &mut World, entity: Entity) {
+    enable_children_recursive(world, entity);
+
+    if !world.enable(entity) {
+        debug!("Failed to enable entity {:?}", entity);
+    }
+}
+
+fn enable_children_recursive(world: &mut World, entity: Entity) {
+    if let Some(children) = world.entity(entity).get::<Children>() {
+        for e in children.0.clone() {
+            enable_with_children_recursive(world, e);
+        }
+    }
+}
+
+impl Command for EnableRecursive {
+    fn apply(self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "command",
+            name = "EnableRecursive",
+            entity = bevy_utils::tracing::field::debug(self.entity)
+        )
+        .entered();
+        enable_with_children_recursive(world, self.entity);
+    }
+}
+
+impl Command for EnableChildrenRecursive {
+    fn apply(self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "command",
+            name = "EnableChildrenRecursive",
+            entity = bevy_utils::tracing::field::debug(self.entity)
+        )
+        .entered();
+        enable_children_recursive(world, self.entity);
+    }
+}
+
+/// Trait that holds functions for enabling recursively down the hierarchy
+pub trait EnableRecursiveExt {
+    /// Enables the provided entity alongside all descendants.
+    fn enable_recursive(self);
+
+    /// Enables all descendants of the given entity.
+    fn enable_descendants(&mut self) -> &mut Self;
+}
+
+impl EnableRecursiveExt for EntityCommands<'_> {
+    fn enable_recursive(mut self) {
+        let entity = self.id();
+        self.commands().add(EnableRecursive { entity });
+    }
+
+    fn enable_descendants(&mut self) -> &mut Self {
+        let entity = self.id();
+        self.commands().add(EnableChildrenRecursive { entity });
+        self
+    }
+}
+
+impl<'w> EnableRecursiveExt for EntityWorldMut<'w> {
+    fn enable_recursive(self) {
+        let entity = self.id();
+
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "enable_recursive",
+            entity = bevy_utils::tracing::field::debug(entity)
+        )
+        .entered();
+
+        enable_with_children_recursive(self.into_world_mut(), entity);
+    }
+
+    fn enable_descendants(&mut self) -> &mut Self {
+        let entity = self.id();
+
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!(
+            "enable_descendants",
+            entity = bevy_utils::tracing::field::debug(entity)
+        )
+        .entered();
+
+        self.world_scope(|world| {
+            enable_children_recursive(world, entity);
+        });
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bevy_ecs::{
         component::Component,
+        query::Disabled,
         system::Commands,
         world::{CommandQueue, World},
     };
 
-    use super::DespawnRecursiveExt;
+    use super::{DespawnRecursiveExt, DisableRecursiveExt, EnableRecursiveExt};
     use crate::{child_builder::BuildChildren, components::Children};
 
     #[derive(Component, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Debug)]
@@ -247,6 +468,37 @@ mod tests {
         assert!(world.entity(parent).get::<Children>().is_none());
         // The child should be despawned.
         assert!(world.get_entity(child).is_none());
+    }
+
+    #[test]
+    fn disable_enable_recursive() {
+        let mut world = World::default();
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+
+        let grandchild = commands.spawn_empty().id();
+        let child = commands.spawn_empty().add_child(grandchild).id();
+        let parent = commands.spawn_empty().add_child(child).id();
+
+        commands.entity(child).add_child(grandchild);
+        commands.entity(parent).add_child(child);
+        commands.entity(parent).disable_recursive();
+
+        queue.apply(&mut world);
+
+        // All entities should be disabled
+        assert!(world.entity(parent).contains::<Disabled>());
+        assert!(world.entity(child).contains::<Disabled>());
+        assert!(world.entity(grandchild).contains::<Disabled>());
+
+        let mut commands = Commands::new(&mut queue, &world);
+        commands.entity(child).enable_recursive();
+        queue.apply(&mut world);
+
+        // Only child and grandchild should be enabled again
+        assert!(world.entity(parent).contains::<Disabled>());
+        assert!(!world.entity(child).contains::<Disabled>());
+        assert!(!world.entity(grandchild).contains::<Disabled>());
     }
 
     #[test]


### PR DESCRIPTION
# Objective

- Add the ability to disable entities. See #11090

## Solution

- Implement functionality to disable and enable entities (using the Disabled marker component)
- Skip the Disabled component in `retain`
- Add a way to disable entities recursively

---

## Changelog

- Add `Disabled` marker component, which hides an entity queries that don't specifically request them

## Migration Guide

- Entities can get disabled, causing them to "disappear" from queries without being removed and thus triggering things like `RemovedComponents`, some systems might need to be adjusted to account for this.