### PR TITLE
fix find_current_keyframe panic

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -128,7 +128,7 @@ impl VariableCurve {
             .binary_search_by(|probe| probe.partial_cmp(&seek_time).unwrap());
 
         // Subtract one for zero indexing!
-        let last_keyframe = self.keyframes.len() - 1;
+        let last_keyframe = self.keyframe_timestamps.len() - 1;
 
         // We want to find the index of the keyframe before the current time
         // If the keyframe is past the second-to-last keyframe, the animation cannot be interpolated.


### PR DESCRIPTION
# Objective

i downloaded a random model from sketchfab (https://sketchfab.com/3d-models/dragon-glass-fe00cb0ecaca4e4595874b70de7e116b) to fiddle with bevy and encountered a panic when attempted to play animations:
```
thread 'Compute Task Pool (3)' panicked at /home/username/code/bevy/crates/bevy_animation/src/lib.rs:848:58:
index out of bounds: the len is 40 but the index is 40
```

"Animation / Animated Fox" (https://github.com/bevyengine/bevy/blob/5caf085dacf74bf553a0428a5eb7f4574a9bb99c/examples/animation/animated_fox.rs) example can be used for reproduction. to reproduce download a model from sketchfab (link above) and load it instead of loading fox.glb, keep only `dragon_glass.glb#Animation0` and remove `1` and `2` -> run and wait 1-2 seconds for crash to happen.

## Solution

correct keyframe indexing, i guess
