### PR TITLE
Fix extensionless image loading panic

### DIFF
--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -92,13 +92,14 @@ impl AssetLoader for ImageLoader {
         load_context: &'a mut LoadContext,
     ) -> bevy_utils::BoxedFuture<'a, Result<Image, Self::Error>> {
         Box::pin(async move {
-            // use the file extension for the image type
-            let ext = load_context.path().extension().unwrap().to_str().unwrap();
-
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
             let image_type = match settings.format {
-                ImageFormatSetting::FromExtension => ImageType::Extension(ext),
+                ImageFormatSetting::FromExtension => {
+                    // use the file extension for the image type
+                    let ext = load_context.path().extension().unwrap().to_str().unwrap();
+                    ImageType::Extension(ext)
+                }
                 ImageFormatSetting::Format(format) => ImageType::Format(format),
             };
             Ok(Image::from_buffer(


### PR DESCRIPTION
# Objective

Avoid panic when using path without extension, but providing format in the asset meta.

## Solution

Reorganize the code.

## Changelog

Fix extensionless image loading panic.
