### PR TITLE
Add archetypal to Access Debug impl

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -74,6 +74,7 @@ impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
             .field("writes", &FormattedBitSet::<T>::new(&self.writes))
             .field("reads_all", &self.reads_all)
             .field("writes_all", &self.writes_all)
+            .field("archetypal", &FormattedBitSet::<T>::new(&self.archetypal))
             .finish()
     }
 }


### PR DESCRIPTION
# Objective

- The `archetypal` field in `Access` doesn't get printed in debug output

## Solution

- Add the field to the impl