### PR TITLE
Fix crates not building individually

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -13,7 +13,7 @@ bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
 ] }
-bytemuck = "1"
+bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
 wgpu-types = { version = "0.19", default-features = false, optional = true }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -30,7 +30,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.14.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }
-bevy_ui = { path = "../bevy_ui", version = "0.14.0-dev" }
+bevy_ui = { path = "../bevy_ui", version = "0.14.0-dev", features = ["bevy_text"] }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.14.0-dev" }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -30,7 +30,9 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.14.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }
-bevy_ui = { path = "../bevy_ui", version = "0.14.0-dev", features = ["bevy_text"] }
+bevy_ui = { path = "../bevy_ui", version = "0.14.0-dev", features = [
+  "bevy_text",
+] }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.14.0-dev" }

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -38,8 +38,10 @@ pub mod circles;
 pub mod config;
 pub mod gizmos;
 pub mod grid;
-pub mod light;
 pub mod primitives;
+
+#[cfg(feature = "bevy_pbr")]
+pub mod light;
 
 #[cfg(feature = "bevy_sprite")]
 mod pipeline_2d;
@@ -56,10 +58,12 @@ pub mod prelude {
             GizmoLineJoint, GizmoLineStyle,
         },
         gizmos::Gizmos,
-        light::{LightGizmoColor, LightGizmoConfigGroup, ShowLightGizmo},
         primitives::{dim2::GizmoPrimitive2d, dim3::GizmoPrimitive3d},
         AppGizmoBuilder,
     };
+
+    #[cfg(feature = "bevy_pbr")]
+    pub use crate::light::{LightGizmoColor, LightGizmoConfigGroup, ShowLightGizmo};
 }
 
 use aabb::AabbGizmoPlugin;
@@ -96,6 +100,7 @@ use config::{
     GizmoMeshConfig,
 };
 use gizmos::GizmoStorage;
+#[cfg(feature = "bevy_pbr")]
 use light::LightGizmoPlugin;
 use std::{any::TypeId, mem};
 
@@ -131,8 +136,10 @@ impl Plugin for GizmoPlugin {
             .init_resource::<LineGizmoHandles>()
             // We insert the Resource GizmoConfigStore into the world implicitly here if it does not exist.
             .init_gizmo_group::<DefaultGizmoConfigGroup>()
-            .add_plugins(AabbGizmoPlugin)
-            .add_plugins(LightGizmoPlugin);
+            .add_plugins(AabbGizmoPlugin);
+
+        #[cfg(feature = "bevy_pbr")]
+        app.add_plugins(LightGizmoPlugin);
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1,4 +1,5 @@
 use crate::{vertex_attributes::convert_attribute, Gltf, GltfExtras, GltfNode};
+#[cfg(feature = "bevy_animation")]
 use bevy_animation::{AnimationTarget, AnimationTargetId};
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, AsyncReadExt, Handle, LoadContext, ReadAssetBytesError,
@@ -44,7 +45,8 @@ use gltf::{
     Material, Node, Primitive, Semantic,
 };
 use serde::{Deserialize, Serialize};
-use smallvec::{smallvec, SmallVec};
+#[cfg(feature = "bevy_animation")]
+use smallvec::SmallVec;
 use std::io::Error;
 use std::{
     collections::VecDeque,
@@ -1032,7 +1034,7 @@ fn load_node(
         // This is an animation root. Make a new animation context.
         animation_context = Some(AnimationContext {
             root: node.id(),
-            path: smallvec![],
+            path: SmallVec::new(),
         });
     }
 


### PR DESCRIPTION
# Objective

- `cargo check --workspace` appears to merge features and dependencies together, so it does not catch some issues where dependencies are not properly feature-gated.
  - The issues **are** caught, though, by running `cd $crate && cargo check`.

## Solution

- Manually check each crate for issues.

```shell
# Script used
for i in crates/bevy_* do
    pushd $i
    cargo check
    popd
done
```

- `bevy_color` had an issue where it used `#[derive(Pod, Zeroable)]` without using `bytemuck`'s `derive` feature.
- The `FpsOverlayPlugin` in `bevy_dev_tools` uses `bevy_ui`'s `bevy_text` integration without properly enabling `bevy_text` as a feature.
- `bevy_gizmos`'s `light` module was not properly feature-gated behind `bevy_pbr`.
  - ~~Lights appear to only be implemented in `bevy_pbr` and not `bevy_sprite`, so I think this is the right call. Can I get a confirmation by a gizmos person?~~ Confirmed :)
- `bevy_gltf` imported `SmallVec`, but only used it if `bevy_animation` was enabled.
  - There was another issue, but it was more challenging to solve than the `smallvec` one. Run `cargo check -p bevy_gltf` and it will raise an issue about `animation_roots`.

<details>
  <summary><code>bevy_gltf</code> errors</summary>

```shell
error[E0425]: cannot find value `animation_roots` in this scope
   --> crates/bevy_gltf/src/loader.rs:608:26
    |
608 |                         &animation_roots,
    |                          ^^^^^^^^^^^^^^^ not found in this scope

warning: variable does not need to be mutable
    --> crates/bevy_gltf/src/loader.rs:1015:5
     |
1015 |     mut animation_context: Option<AnimationContext>,
     |     ----^^^^^^^^^^^^^^^^^
     |     |
     |     help: remove this `mut`
     |
     = note: `#[warn(unused_mut)]` on by default

For more information about this error, try `rustc --explain E0425`.
warning: `bevy_gltf` (lib) generated 1 warning
error: could not compile `bevy_gltf` (lib) due to 1 previous error; 1 warning emitted
```

</details> 

---

## Changelog

- Fixed `bevy_color`, `bevy_dev_tools`, and `bevy_gizmos` so they can now compile by themselves.