### PR TITLE
Load and convert RGB8 dds textures

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1491,19 +1491,20 @@ pub enum DataFormat {
     Rg,
 }
 
+/// Texture data need to be transcoded from this format for use with `wgpu`.
 #[derive(Clone, Copy, Debug)]
 pub enum TranscodeFormat {
     Etc1s,
     Uastc(DataFormat),
-    // Has to be transcoded to R8Unorm for use with `wgpu`
+    // Has to be transcoded to R8Unorm for use with `wgpu`.
     R8UnormSrgb,
-    // Has to be transcoded to R8G8Unorm for use with `wgpu`
+    // Has to be transcoded to R8G8Unorm for use with `wgpu`.
     Rg8UnormSrgb,
-    // Has to be transcoded to Rgba8 for use with `wgpu`
+    // Has to be transcoded to Rgba8 for use with `wgpu`.
     Rgb8,
 }
 
-/// An error that occurs when accessing specific pixels in a texture
+/// An error that occurs when accessing specific pixels in a texture.
 #[derive(Error, Debug)]
 pub enum TextureAccessError {
     #[error("out of bounds (x: {x}, y: {y}, z: {z})")]
@@ -1514,25 +1515,34 @@ pub enum TextureAccessError {
     WrongDimension,
 }
 
-/// An error that occurs when loading a texture
+/// An error that occurs when loading a texture.
 #[derive(Error, Debug)]
 pub enum TextureError {
+    /// Image MIME type is invalid.
     #[error("invalid image mime type: {0}")]
     InvalidImageMimeType(String),
+    /// Image extension is invalid.
     #[error("invalid image extension: {0}")]
     InvalidImageExtension(String),
+    /// Failed to load an image.
     #[error("failed to load an image: {0}")]
     ImageError(#[from] image::ImageError),
+    /// Texture format isn't supported.
     #[error("unsupported texture format: {0}")]
     UnsupportedTextureFormat(String),
+    /// Supercompression isn't supported.
     #[error("supercompression not supported: {0}")]
     SuperCompressionNotSupported(String),
-    #[error("failed to load an image: {0}")]
+    /// Failed to decompress an image.
+    #[error("failed to decompress an image: {0}")]
     SuperDecompressionError(String),
+    /// Invalid data.
     #[error("invalid data: {0}")]
     InvalidData(String),
+    /// Transcode error.
     #[error("transcode error: {0}")]
     TranscodeError(String),
+    /// Format requires transcoding.
     #[error("format requires transcoding: {0:?}")]
     FormatRequiresTranscodingError(TranscodeFormat),
     /// Only cubemaps with six faces are supported.


### PR DESCRIPTION
# Objective

- Closes #12944.

## Solution

- Load `R8G8B8` textures by transcoding to an rgba format since `wgpu` does not support texture formats with 3 channels.
- Switch to erroring out instead of panicking on an invalid dds file.

---

## Changelog

### Added

- DDS Textures  with the `R8G8B8` format are now supported. They require an additional conversion step, so using `R8G8B8A8` or a similar format is preferable for texture loading performance.
