### PR TITLE
Don't examine every entity when extracting `SpriteSource`s.

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -214,7 +214,7 @@ pub fn calculate_bounds_2d(
 impl ExtractComponent for SpriteSource {
     type QueryData = ();
 
-    type QueryFilter = ();
+    type QueryFilter = With<SpriteSource>;
 
     type Out = SpriteSource;
 


### PR DESCRIPTION
`ExtractComponentPlugin` doesn't check to make sure the component is actually present unless it's in the `QueryFilter`. This meant we placed it everywhere. This regressed performance on many examples, such as `many_cubes`.

Fixes #12956.