### PR TITLE
Run `CheckVisibility` after all the other visibility system sets have…

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -259,7 +259,18 @@ impl Plugin for VisibilityPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         use VisibilitySystems::*;
 
-        app.add_systems(
+        app.configure_sets(
+            PostUpdate,
+            (
+                CalculateBounds,
+                UpdateOrthographicFrusta,
+                UpdatePerspectiveFrusta,
+                UpdateProjectionFrusta,
+                VisibilityPropagate,
+            )
+                .before(CheckVisibility),
+        )
+        .add_systems(
             PostUpdate,
             (
                 calculate_bounds.in_set(CalculateBounds),
@@ -287,11 +298,6 @@ impl Plugin for VisibilityPlugin {
                 (visibility_propagate_system, reset_view_visibility).in_set(VisibilityPropagate),
                 check_visibility::<WithMesh>
                     .in_set(CheckVisibility)
-                    .after(CalculateBounds)
-                    .after(UpdateOrthographicFrusta)
-                    .after(UpdatePerspectiveFrusta)
-                    .after(UpdateProjectionFrusta)
-                    .after(VisibilityPropagate)
                     .after(TransformSystem::TransformPropagate),
             ),
         );


### PR DESCRIPTION
… run

# Objective

Make visibility system ordering explicit. Fixes #12953.

## Solution

Specify `CheckVisibility` happens after all other `VisibilitySystems` sets have happened.
