### PR TITLE
fail when an example doesn't set doc-scrape-examples

### DIFF
--- a/tools/build-templated-pages/src/examples.rs
+++ b/tools/build-templated-pages/src/examples.rs
@@ -58,6 +58,9 @@ fn parse_examples(panic_on_missing: bool) -> Vec<Example> {
             if panic_on_missing && metadatas.get(&technical_name).is_none() {
                 panic!("Missing metadata for example {technical_name}");
             }
+            if panic_on_missing && val.get("doc-scrape-examples").is_none() {
+                panic!("Example {technical_name} is missing doc-scrape-examples");
+            }
 
             if metadatas
                 .get(&technical_name)


### PR DESCRIPTION
# Objective

- Ensure that all examples are scrapped for doc

## Solution

- Panic in the example tool when an example doesn't specify `doc-scrape-examples`
- If an example must not be scrapped, it can set the value to false
