### PR TITLE
Cleanup the multithreaded executor

### DIFF
--- a/crates/bevy_utils/src/syncunsafecell.rs
+++ b/crates/bevy_utils/src/syncunsafecell.rs
@@ -101,12 +101,14 @@ impl<T> SyncUnsafeCell<[T]> {
     /// assert_eq!(slice_cell.len(), 3);
     /// ```
     pub fn as_slice_of_cells(&self) -> &[SyncUnsafeCell<T>] {
+        let self_ptr: *const SyncUnsafeCell<[T]> = ptr::from_ref(self);
+        let slice_ptr = self_ptr as *const [SyncUnsafeCell<T>];
         // SAFETY: `UnsafeCell<T>` and `SyncUnsafeCell<T>` have #[repr(transparent)]
         // therefore:
         // - `SyncUnsafeCell<T>` has the same layout as `T`
         // - `SyncUnsafeCell<[T]>` has the same layout as `[T]`
         // - `SyncUnsafeCell<[T]>` has the same layout as `[SyncUnsafeCell<T>]`
-        unsafe { &*(ptr::from_ref(self) as *const [SyncUnsafeCell<T>]) }
+        unsafe { &*slice_ptr }
     }
 }
 


### PR DESCRIPTION
# Objective
Improve the code quality of the multithreaded executor.

## Solution
 * Remove some unused variables.
 * Use `Mutex::get_mut` where applicable instead of locking.
 * Use a `startup_systems` FixedBitset to pre-compute the starting systems instead of building it bit-by-bit on startup.
 * Instead of using `FixedBitset::clear` and `FixedBitset::union_with`, use `FixedBitset::clone_from` instead, which does only a single copy and will not allocate if the target bitset has a large enough allocation.
 * Replace the `Mutex` around `Conditions` with `SyncUnsafeCell`, and add a `Context::try_lock` that forces it to be synchronized fetched alongside the executor lock.

This might produce minimal performance gains, but the focus here is on the code quality improvements.