### PR TITLE
impl `Reflect` for `EntityHashSet`

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -103,7 +103,6 @@ impl_reflect_value!(
 impl_reflect_value!(::std::collections::BTreeSet<T: Ord + Eq + Clone + Send + Sync>());
 impl_reflect_value!(::std::collections::HashSet<T: Hash + Eq + Clone + Send + Sync, S: TypePath + Clone + Send + Sync>());
 impl_reflect_value!(::bevy_utils::HashSet<T: Hash + Eq + Clone + Send + Sync>());
-impl_reflect_value!(::bevy_utils::EntityHashSet<T: Hash + Eq + Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::Range<T: Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::RangeInclusive<T: Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::RangeFrom<T: Clone + Send + Sync>());
@@ -1880,10 +1879,5 @@ mod tests {
         let expected = "Hello, World!";
         let output = <&'static str as FromReflect>::from_reflect(&expected).unwrap();
         assert_eq!(expected, output);
-    }
-
-    #[test]
-    fn entity_hashset_impls_reflect() {
-        let _: &dyn Reflect = &bevy_utils::EntityHashSet::<()>::default();
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -103,6 +103,7 @@ impl_reflect_value!(
 impl_reflect_value!(::std::collections::BTreeSet<T: Ord + Eq + Clone + Send + Sync>());
 impl_reflect_value!(::std::collections::HashSet<T: Hash + Eq + Clone + Send + Sync, S: TypePath + Clone + Send + Sync>());
 impl_reflect_value!(::bevy_utils::HashSet<T: Hash + Eq + Clone + Send + Sync>());
+impl_reflect_value!(::bevy_utils::EntityHashSet<T: Hash + Eq + Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::Range<T: Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::RangeInclusive<T: Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::RangeFrom<T: Clone + Send + Sync>());
@@ -1879,5 +1880,10 @@ mod tests {
         let expected = "Hello, World!";
         let output = <&'static str as FromReflect>::from_reflect(&expected).unwrap();
         assert_eq!(expected, output);
+    }
+
+    #[test]
+    fn entity_hashset_impls_reflect() {
+        let _: &dyn Reflect = &bevy_utils::EntityHashSet::<()>::default();
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -102,7 +102,7 @@ impl_reflect_value!(
 );
 impl_reflect_value!(::std::collections::BTreeSet<T: Ord + Eq + Clone + Send + Sync>());
 impl_reflect_value!(::std::collections::HashSet<T: Hash + Eq + Clone + Send + Sync, S: TypePath + Clone + Send + Sync>());
-impl_reflect_value!(::bevy_utils::HashSet<T: Hash + Eq + Clone + Send + Sync>());
+impl_reflect_value!(::bevy_utils::hashbrown::HashSet<T: Hash + Eq + Clone + Send + Sync, S: TypePath + Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::Range<T: Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::RangeInclusive<T: Clone + Send + Sync>());
 impl_reflect_value!(::core::ops::RangeFrom<T: Clone + Send + Sync>());
@@ -219,6 +219,10 @@ impl_reflect_value!(::std::ffi::OsString(
 #[cfg(not(any(unix, windows)))]
 impl_reflect_value!(::std::ffi::OsString(Debug, Hash, PartialEq));
 impl_reflect_value!(::alloc::collections::BinaryHeap<T: Clone>);
+
+impl_type_path!(::bevy_utils::NoOpHash);
+impl_type_path!(::bevy_utils::EntityHash);
+impl_type_path!(::bevy_utils::FixedState);
 
 macro_rules! impl_reflect_for_veclike {
     ($ty:path, $insert:expr, $remove:expr, $push:expr, $pop:expr, $sub:ty) => {
@@ -629,7 +633,6 @@ impl_type_path!(::std::collections::HashMap<K, V, S>);
 
 impl_reflect_for_hashmap!(bevy_utils::hashbrown::HashMap<K, V, S>);
 impl_type_path!(::bevy_utils::hashbrown::hash_map::DefaultHashBuilder);
-impl_type_path!(::bevy_utils::NoOpHash);
 impl_type_path!(::bevy_utils::hashbrown::HashMap<K, V, S>);
 
 impl<K, V> Map for ::std::collections::BTreeMap<K, V>


### PR DESCRIPTION
`EntityHashSet` doesn't seem to implement `Reflect` which seems weird! Especially since `EntityHashMap` implements `Reflect`.

This PR just added an extra `impl_reflect_value!` for `EntityHashSet` and this seems to do the trick.

I left out doing the same for `StableHashSet` since it's marked as deprecated.

---

I'm really wondering what was the issue here. If anyone can explain why `EntityHashSet` can't use the `Reflect` impl of `bevy_utils::HashSet` similar to how it's the case with the `...HashMap`s I'd be interested!