### PR TITLE
Fix beta lints

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,12 +1,12 @@
 doc-valid-idents = [
-    "GilRs",
-    "glTF",
-    "MacOS",
-    "NVidia",
-    "OpenXR",
-    "sRGB",
-    "VSync",
-    "WebGL2",
-    "WebGPU",
-    ".."
+  "GilRs",
+  "glTF",
+  "MacOS",
+  "NVidia",
+  "OpenXR",
+  "sRGB",
+  "VSync",
+  "WebGL2",
+  "WebGPU",
+  "..",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,6 +3,7 @@ doc-valid-idents = [
     "glTF",
     "MacOS",
     "NVidia",
+    "OpenXR",
     "sRGB",
     "VSync",
     "WebGL2",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,11 @@
-doc-valid-idents = ["GilRs", "glTF", "sRGB", "VSync", "WebGL2", "WebGPU", ".."]
+doc-valid-idents = [
+    "GilRs",
+    "glTF",
+    "MacOS",
+    "NVidia",
+    "sRGB",
+    "VSync",
+    "WebGL2",
+    "WebGPU",
+    ".."
+]

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -51,7 +51,7 @@ pub(crate) struct AssetIndexAllocator {
     /// A monotonically increasing index.
     next_index: AtomicU32,
     recycled_queue_sender: Sender<AssetIndex>,
-    /// This receives every recycled AssetIndex. It serves as a buffer/queue to store indices ready for reuse.
+    /// This receives every recycled [`AssetIndex`]. It serves as a buffer/queue to store indices ready for reuse.
     recycled_queue_receiver: Receiver<AssetIndex>,
     recycled_sender: Sender<AssetIndex>,
     recycled_receiver: Receiver<AssetIndex>,

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -71,7 +71,7 @@ pub enum AssetAction<LoaderSettings, ProcessSettings> {
 pub struct ProcessedInfo {
     /// A hash of the asset bytes and the asset .meta data
     pub hash: AssetHash,
-    /// A hash of the asset bytes, the asset .meta data, and the `full_hash` of every process_dependency
+    /// A hash of the asset bytes, the asset .meta data, and the `full_hash` of every `process_dependency`
     pub full_hash: AssetHash,
     /// Information about the "process dependencies" used to process this asset.
     pub process_dependencies: Vec<ProcessDependencyInfo>,

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -1058,7 +1058,7 @@ pub(crate) struct ProcessorAssetInfo {
     /// _This lock must be locked whenever a read or write to processed assets occurs_
     /// There are scenarios where processed assets (and their metadata) are being read and written in multiple places at once:
     /// * when the processor is running in parallel with an app
-    /// * when processing assets in parallel, the processor might read an asset's process_dependencies when processing new versions of those dependencies
+    /// * when processing assets in parallel, the processor might read an asset's `process_dependencies` when processing new versions of those dependencies
     ///     * this second scenario almost certainly isn't possible with the current implementation, but its worth protecting against
     /// This lock defends against those scenarios by ensuring readers don't read while processed files are being written. And it ensures
     /// Because this lock is shared across meta and asset bytes, readers can ensure they don't read "old" versions of metadata with "new" asset data.
@@ -1101,7 +1101,7 @@ pub struct ProcessorAssetInfos {
     /// The "current" in memory view of the asset space. During processing, if path does not exist in this, it should
     /// be considered non-existent.
     /// NOTE: YOU MUST USE `Self::get_or_insert` or `Self::insert` TO ADD ITEMS TO THIS COLLECTION TO ENSURE
-    /// non_existent_dependants DATA IS CONSUMED
+    /// `non_existent_dependants` DATA IS CONSUMED
     infos: HashMap<AssetPath<'static>, ProcessorAssetInfo>,
     /// Dependants for assets that don't exist. This exists to track "dangling" asset references due to deleted / missing files.
     /// If the dependant asset is added, it can "resolve" these dependencies and re-compute those assets.

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -35,7 +35,7 @@ pub(crate) struct AssetInfo {
     /// [`LoadedAsset`]: crate::loader::LoadedAsset
     loader_dependencies: HashMap<AssetPath<'static>, AssetHash>,
     /// The number of handle drops to skip for this asset.
-    /// See usage (and comments) in get_or_create_path_handle for context.
+    /// See usage (and comments) in `get_or_create_path_handle` for context.
     handle_drops_to_skip: usize,
 }
 

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -9,7 +9,7 @@ pub struct TaskPoolThreadAssignmentPolicy {
     pub min_threads: usize,
     /// Under no circumstance use more than this many threads for this pool
     pub max_threads: usize,
-    /// Target using this percentage of total cores, clamped by min_threads and max_threads. It is
+    /// Target using this percentage of total cores, clamped by `min_threads` and `max_threads`. It is
     /// permitted to use 1.0 to try to use all remaining threads
     pub percent: f32,
 }
@@ -34,11 +34,11 @@ impl TaskPoolThreadAssignmentPolicy {
 /// set up [`TaskPoolPlugin`](super::TaskPoolPlugin)
 #[derive(Clone, Debug)]
 pub struct TaskPoolOptions {
-    /// If the number of physical cores is less than min_total_threads, force using
-    /// min_total_threads
+    /// If the number of physical cores is less than `min_total_threads`, force using
+    /// `min_total_threads`
     pub min_total_threads: usize,
-    /// If the number of physical cores is greater than max_total_threads, force using
-    /// max_total_threads
+    /// If the number of physical cores is greater than `max_total_threads`, force using
+    /// `max_total_threads`
     pub max_total_threads: usize,
 
     /// Used to determine number of IO threads to allocate

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -149,7 +149,7 @@ pub enum Tonemapping {
     AgX,
     /// By Tomasz Stachowiak
     /// Has little hue shifting in the darks and mids, but lots in the brights. Brights desaturate across the spectrum.
-    /// Is sort of between Reinhard and ReinhardLuminance. Conceptually similar to reinhard-jodie.
+    /// Is sort of between Reinhard and `ReinhardLuminance`. Conceptually similar to reinhard-jodie.
     /// Designed as a compromise if you want e.g. decent skin tones in low light, but can't afford to re-do your
     /// VFX to look good without hue shifting.
     SomewhatBoringDisplayTransform,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1060,10 +1060,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::nonminimal_bool)] // This is intentionally testing `lt` and `ge` as separate functions.
     fn entity_comparison() {
-        // This is intentionally testing `lt` and `ge` as separate functions.
-        #![allow(clippy::nonminimal_bool)]
-
         assert_eq!(
             Entity::from_raw_and_generation(123, NonZeroU32::new(456).unwrap()),
             Entity::from_raw_and_generation(123, NonZeroU32::new(456).unwrap())

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -172,7 +172,7 @@ struct EventInstance<E: Event> {
 #[derive(Debug, Resource)]
 pub struct Events<E: Event> {
     /// Holds the oldest still active events.
-    /// Note that a.start_event_count + a.len() should always === events_b.start_event_count.
+    /// Note that `a.start_event_count + a.len()` should always be equal to `events_b.start_event_count`.
     events_a: EventSequence<E>,
     /// Holds the newer events.
     events_b: EventSequence<E>,

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -209,10 +209,8 @@ mod tests {
 
     #[rustfmt::skip]
     #[test]
+    #[allow(clippy::nonminimal_bool)] // This is intentionally testing `lt` and `ge` as separate functions.
     fn id_comparison() {
-        // This is intentionally testing `lt` and `ge` as separate functions.
-        #![allow(clippy::nonminimal_bool)]
-
         assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() == Identifier::new(123, 456, IdKind::Entity).unwrap());
         assert!(Identifier::new(123, 456, IdKind::Placeholder).unwrap() == Identifier::new(123, 456, IdKind::Placeholder).unwrap());
         assert!(Identifier::new(123, 789, IdKind::Entity).unwrap() != Identifier::new(123, 456, IdKind::Entity).unwrap());

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1448,7 +1448,7 @@ impl ScheduleGraph {
 
 /// Values returned by [`ScheduleGraph::process_configs`]
 struct ProcessConfigsResult {
-    /// All nodes contained inside this process_configs call's [`NodeConfigs`] hierarchy,
+    /// All nodes contained inside this `process_configs` call's [`NodeConfigs`] hierarchy,
     /// if `ancestor_chained` is true
     nodes: Vec<NodeId>,
     /// True if and only if all nodes are "densely chained", meaning that all nested nodes

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -58,7 +58,7 @@ enum SystemBehavior {
 // schedule_order index, and schedule start point
 #[derive(Debug, Default, Clone, Copy)]
 struct Cursor {
-    /// index within Stepping.schedule_order
+    /// index within `Stepping::schedule_order`
     pub schedule: usize,
     /// index within the schedule's system list
     pub system: usize,
@@ -606,11 +606,11 @@ struct ScheduleState {
     /// per-system [`SystemBehavior`]
     behaviors: HashMap<NodeId, SystemBehavior>,
 
-    /// order of NodeIds in the schedule
+    /// order of [`NodeId`]s in the schedule
     ///
-    /// This is a cached copy of SystemExecutable.system_ids. We need it
-    /// available here to be accessed by Stepping::cursor() so we can return
-    /// NodeIds to the caller.
+    /// This is a cached copy of `SystemExecutable::system_ids`. We need it
+    /// available here to be accessed by [`Stepping::cursor()`] so we can return
+    /// [`NodeId`]s to the caller.
     node_ids: Vec<NodeId>,
 
     /// changes to system behavior that should be applied the next time

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -713,7 +713,10 @@ mod tests {
         let mut q = world.query::<&Zst>();
         for zst in q.iter(&world) {
             // Ensure that the references returned are properly aligned.
-            assert_eq!(std::ptr::from_ref::<Zst>(zst) as usize % mem::align_of::<Zst>(), 0);
+            assert_eq!(
+                std::ptr::from_ref::<Zst>(zst) as usize % mem::align_of::<Zst>(),
+                0
+            );
             count += 1;
         }
 

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -713,7 +713,7 @@ mod tests {
         let mut q = world.query::<&Zst>();
         for zst in q.iter(&world) {
             // Ensure that the references returned are properly aligned.
-            assert_eq!(zst as *const Zst as usize % mem::align_of::<Zst>(), 0);
+            assert_eq!(std::ptr::from_ref::<Zst>(zst) as usize % mem::align_of::<Zst>(), 0);
             count += 1;
         }
 

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -183,6 +183,7 @@ pub enum NativeKeyCode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
+#[allow(clippy::doc_markdown)] // Clippy doesn't like our use of <kbd>.
 #[repr(u32)]
 pub enum KeyCode {
     /// This variant is used when the key cannot be translated to any other variant.
@@ -191,7 +192,7 @@ pub enum KeyCode {
     /// key-press and key-release events by hashing the [`KeyCode`]. It is also possible to use
     /// this for keybinds for non-standard keys, but such keybinds are tied to a given platform.
     Unidentified(NativeKeyCode),
-    /// <kbd>`</kbd> on a US keyboard. This is also called a backtick or grave.
+    /// <kbd>\`</kbd> on a US keyboard. This is also called a backtick or grave.
     /// This is the <kbd>半角</kbd>/<kbd>全角</kbd>/<kbd>漢字</kbd>
     /// (hankaku/zenkaku/kanji) key on Japanese keyboards
     Backquote,
@@ -700,6 +701,7 @@ pub enum NativeKey {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
+#[allow(clippy::doc_markdown)] // Clippy doesn't like our use of <kbd>.
 pub enum Key {
     /// A key string that corresponds to the character typed by the user, taking into account the
     /// user’s current locale setting, and any system-level keyboard mapping overrides that are in

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -13,202 +13,202 @@ pub mod prelude;
 mod default_plugins;
 pub use default_plugins::*;
 
+/// Integrate with platform accessibility APIs.
 pub mod a11y {
-    //! Integrate with platform accessibility APIs.
     pub use bevy_a11y::*;
 }
 
+/// Build bevy apps, create plugins, and read events.
 pub mod app {
-    //! Build bevy apps, create plugins, and read events.
     pub use bevy_app::*;
 }
 
+/// Load and store assets and resources for Apps.
 #[cfg(feature = "bevy_asset")]
 pub mod asset {
-    //! Load and store assets and resources for Apps.
     pub use bevy_asset::*;
 }
 
+/// Contains core plugins.
 pub mod core {
-    //! Contains core plugins.
     pub use bevy_core::*;
 }
 
+/// Shared color types and operations.
 #[cfg(feature = "bevy_color")]
 pub mod color {
-    //! Shared color types and operations.
     pub use bevy_color::*;
 }
 
+/// Useful diagnostic plugins and types for bevy apps.
 pub mod diagnostic {
-    //! Useful diagnostic plugins and types for bevy apps.
     pub use bevy_diagnostic::*;
 }
 
+/// Bevy's entity-component-system.
 pub mod ecs {
-    //! Bevy's entity-component-system.
     pub use bevy_ecs::*;
 }
 
+/// Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
 pub mod input {
-    //! Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
     pub use bevy_input::*;
 }
 
+/// Logging capabilities
 pub mod log {
-    //! Logging capabilities
     pub use bevy_log::*;
 }
 
+/// Math types (Vec3, Mat4, Quat, etc) and helpers.
 pub mod math {
-    //! Math types (Vec3, Mat4, Quat, etc) and helpers.
     pub use bevy_math::*;
 }
 
+/// Utilities for working with untyped pointers in a more safe way.
 pub mod ptr {
-    //! Utilities for working with untyped pointers in a more safe way.
     pub use bevy_ptr::*;
 }
 
+/// Type reflection used for dynamically interacting with rust types.
 pub mod reflect {
-    //! Type reflection used for dynamically interacting with rust types.
     pub use bevy_reflect::*;
 }
 
+/// Save/load collections of entities and components to/from file.
 #[cfg(feature = "bevy_scene")]
 pub mod scene {
-    //! Save/load collections of entities and components to/from file.
     pub use bevy_scene::*;
 }
 
+/// Pools for async, IO, and compute tasks.
 pub mod tasks {
-    //! Pools for async, IO, and compute tasks.
     pub use bevy_tasks::*;
 }
 
+/// Contains time utilities.
 pub mod time {
-    //! Contains time utilities.
     pub use bevy_time::*;
 }
 
+/// Entity hierarchies and property inheritance
 pub mod hierarchy {
-    //! Entity hierarchies and property inheritance
     pub use bevy_hierarchy::*;
 }
 
+/// Local and global transforms (e.g. translation, scale, rotation).
 pub mod transform {
-    //! Local and global transforms (e.g. translation, scale, rotation).
     pub use bevy_transform::*;
 }
 
+/// Various miscellaneous utilities for easing development
 pub mod utils {
-    //! Various miscellaneous utilities for easing development
     pub use bevy_utils::*;
 }
 
+/// Configuration, creation, and management of one or more windows.
 pub mod window {
-    //! Configuration, creation, and management of one or more windows.
     pub use bevy_window::*;
 }
 
+/// Provides types and plugins for animations.
 #[cfg(feature = "bevy_animation")]
 pub mod animation {
-    //! Provides types and plugins for animations.
     pub use bevy_animation::*;
 }
 
+/// Provides types and plugins for audio playback.
 #[cfg(feature = "bevy_audio")]
 pub mod audio {
-    //! Provides types and plugins for audio playback.
     pub use bevy_audio::*;
 }
 
+/// Core render pipeline.
 #[cfg(feature = "bevy_core_pipeline")]
 pub mod core_pipeline {
-    //! Core render pipeline.
     pub use bevy_core_pipeline::*;
 }
 
+/// Bevy interface with `GilRs` - "Game Input Library for Rust" - to handle gamepad inputs.
 #[cfg(feature = "bevy_gilrs")]
 pub mod gilrs {
-    //! Bevy interface with `GilRs` - "Game Input Library for Rust" - to handle gamepad inputs.
     pub use bevy_gilrs::*;
 }
 
+/// Support for GLTF file loading.
 #[cfg(feature = "bevy_gltf")]
 pub mod gltf {
-    //! Support for GLTF file loading.
     pub use bevy_gltf::*;
 }
 
+/// Physically based rendering.
 #[cfg(feature = "bevy_pbr")]
 pub mod pbr {
-    //! Physically based rendering.
     pub use bevy_pbr::*;
 }
 
+/// Cameras, meshes, textures, shaders, and pipelines.
+/// Use [`RenderDevice::features`](renderer::RenderDevice::features),
+/// [`RenderDevice::limits`](renderer::RenderDevice::limits), and the
+/// [`RenderAdapterInfo`](renderer::RenderAdapterInfo) resource to
+/// get runtime information about the actual adapter, backend, features, and limits.
 #[cfg(feature = "bevy_render")]
 pub mod render {
-    //! Cameras, meshes, textures, shaders, and pipelines.
-    //! Use [`RenderDevice::features`](renderer::RenderDevice::features),
-    //! [`RenderDevice::limits`](renderer::RenderDevice::limits), and the
-    //! [`RenderAdapterInfo`](renderer::RenderAdapterInfo) resource to
-    //! get runtime information about the actual adapter, backend, features, and limits.
     pub use bevy_render::*;
 }
 
+/// Items for sprites, rects, texture atlases, etc.
 #[cfg(feature = "bevy_sprite")]
 pub mod sprite {
-    //! Items for sprites, rects, texture atlases, etc.
     pub use bevy_sprite::*;
 }
 
+/// Text drawing, styling, and font assets.
 #[cfg(feature = "bevy_text")]
 pub mod text {
-    //! Text drawing, styling, and font assets.
     pub use bevy_text::*;
 }
 
+/// User interface components and widgets.
 #[cfg(feature = "bevy_ui")]
 pub mod ui {
-    //! User interface components and widgets.
     pub use bevy_ui::*;
 }
 
+/// Window creation, configuration, and handling
 #[cfg(feature = "bevy_winit")]
 pub mod winit {
-    //! Window creation, configuration, and handling
     pub use bevy_winit::*;
 }
 
+/// Immediate mode drawing api for visual debugging.
+///
+/// # Example
+/// ```
+/// # use bevy_gizmos::prelude::*;
+/// # use bevy_render::prelude::*;
+/// # use bevy_math::prelude::*;
+/// # use bevy_color::palettes::basic::GREEN;
+/// fn system(mut gizmos: Gizmos) {
+///     gizmos.line(Vec3::ZERO, Vec3::X, GREEN);
+/// }
+/// # bevy_ecs::system::assert_is_system(system);
+/// ```
+///
+/// See the documentation on [`Gizmos`](gizmos::Gizmos) for more examples.
 #[cfg(feature = "bevy_gizmos")]
 pub mod gizmos {
-    //! Immediate mode drawing api for visual debugging.
-    //!
-    //! # Example
-    //! ```
-    //! # use bevy_gizmos::prelude::*;
-    //! # use bevy_render::prelude::*;
-    //! # use bevy_math::prelude::*;
-    //! # use bevy_color::palettes::basic::GREEN;
-    //! fn system(mut gizmos: Gizmos) {
-    //!     gizmos.line(Vec3::ZERO, Vec3::X, GREEN);
-    //! }
-    //! # bevy_ecs::system::assert_is_system(system);
-    //! ```
-    //!
-    //! See the documentation on [`Gizmos`](gizmos::Gizmos) for more examples.
     pub use bevy_gizmos::*;
 }
 
+/// Dynamic linking of plugins
 #[cfg(feature = "bevy_dynamic_plugin")]
 pub mod dynamic_plugin {
-    //! Dynamic linking of plugins
     pub use bevy_dynamic_plugin::*;
 }
 
+/// Collection of developer tools
 #[cfg(feature = "bevy_dev_tools")]
 pub mod dev_tools {
-    //! Collection of developer tools
     pub use bevy_dev_tools::*;
 }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -130,7 +130,7 @@ const MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE: Handle<Shader> =
 
 /// Sets up the entire PBR infrastructure of bevy.
 pub struct PbrPlugin {
-    /// Controls if the prepass is enabled for the StandardMaterial.
+    /// Controls if the prepass is enabled for the [`StandardMaterial`].
     /// For more information about what a prepass is, see the [`bevy_core_pipeline::prepass`] docs.
     pub prepass_enabled: bool,
     /// Controls if [`DeferredPbrLightingPlugin`] is added.

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -814,7 +814,7 @@ pub enum OpaqueRendererMethod {
 /// Common [`Material`] properties, calculated for a specific material instance.
 pub struct MaterialProperties {
     /// Is this material should be rendered by the deferred renderer when.
-    /// AlphaMode::Opaque or AlphaMode::Mask
+    /// [`AlphaMode::Opaque`] or [`AlphaMode::Mask`]
     pub render_method: OpaqueRendererMethod,
     /// The [`AlphaMode`] of this material.
     pub alpha_mode: AlphaMode,

--- a/crates/bevy_pbr/src/meshlet/gpu_scene.rs
+++ b/crates/bevy_pbr/src/meshlet/gpu_scene.rs
@@ -619,11 +619,11 @@ pub struct MeshletGpuScene {
     next_material_id: u32,
     material_id_lookup: HashMap<UntypedAssetId, u32>,
     material_ids_present_in_scene: HashSet<u32>,
-    /// Per-instance Entity, RenderLayers, and NotShadowCaster
+    /// Per-instance [`Entity`], [`RenderLayers`], and [`NotShadowCaster`]
     instances: Vec<(Entity, RenderLayers, bool)>,
     /// Per-instance transforms, model matrices, and render flags
     instance_uniforms: StorageBuffer<Vec<MeshUniform>>,
-    /// Per-view per-instance visibility bit. Used for RenderLayer and NotShadowCaster support.
+    /// Per-view per-instance visibility bit. Used for [`RenderLayers`] and [`NotShadowCaster`] support.
     view_instance_visibility: EntityHashMap<StorageBuffer<Vec<u32>>>,
     instance_material_ids: StorageBuffer<Vec<u32>>,
     thread_instance_ids: StorageBuffer<Vec<u32>>,

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -483,7 +483,7 @@ pub struct StandardMaterial {
     /// PBR deferred lighting pass. Ignored in the case of forward materials.
     pub deferred_lighting_pass_id: u8,
 
-    /// The transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is identity.
+    /// The transform applied to the UVs corresponding to `ATTRIBUTE_UV_0` on the mesh before sampling. Default is identity.
     pub uv_transform: Affine2,
 }
 
@@ -669,7 +669,7 @@ pub struct StandardMaterialUniform {
     pub emissive: Vec4,
     /// Color white light takes after travelling through the attenuation distance underneath the material surface
     pub attenuation_color: Vec4,
-    /// The transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is identity.
+    /// The transform applied to the UVs corresponding to `ATTRIBUTE_UV_0` on the mesh before sampling. Default is identity.
     pub uv_transform: Mat3,
     /// Linear perceptual roughness, clamped to [0.089, 1.0] in the shader
     /// Defaults to minimum of 0.089

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -582,7 +582,7 @@ mod tests {
         assert_eq!(key, &1usize);
         assert_eq!(value, &mut values[2].to_owned());
 
-        *value = values[0].to_owned();
+        value.clone_from(&values[0].to_owned());
 
         assert_eq!(
             map.get(&1usize as &dyn Reflect)

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -40,7 +40,7 @@ struct BatchMeta<T: PartialEq> {
     /// buffers and layouts, shaders and their specializations, bind group
     /// layouts, etc.
     pipeline_id: CachedRenderPipelineId,
-    /// The draw function id defines the RenderCommands that are called to
+    /// The draw function id defines the `RenderCommands` that are called to
     /// set the pipeline and bindings, and make the draw command
     draw_function_id: DrawFunctionId,
     dynamic_offset: Option<NonMaxU32>,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -482,7 +482,7 @@ pub enum CameraOutputMode {
     /// Render Target's "intermediate" textures, which a camera with a higher order should write to the render target
     /// using [`CameraOutputMode::Write`]. The "skip" mode can easily prevent render results from being displayed, or cause
     /// them to be lost. Only use this if you know what you are doing!
-    /// In camera setups with multiple active cameras rendering to the same RenderTarget, the Skip mode can be used to remove
+    /// In camera setups with multiple active cameras rendering to the same [`RenderTarget`], the Skip mode can be used to remove
     /// unnecessary / redundant writes to the final output texture, removing unnecessary render passes.
     Skip,
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -124,7 +124,7 @@ pub enum RenderSet {
     Prepare,
     /// A sub-set within [`Prepare`](RenderSet::Prepare) for initializing buffers, textures and uniforms for use in bind groups.
     PrepareResources,
-    /// Flush buffers after [`PrepareResources`](RenderSet::PrepareResources), but before ['PrepareBindGroups'](RenderSet::PrepareBindGroups).
+    /// Flush buffers after [`PrepareResources`](RenderSet::PrepareResources), but before [`PrepareBindGroups`](RenderSet::PrepareBindGroups).
     PrepareResourcesFlush,
     /// A sub-set within [`Prepare`](RenderSet::Prepare) for constructing bind groups, or other data that relies on render resources prepared in [`PrepareResources`](RenderSet::PrepareResources).
     PrepareBindGroups,

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -122,8 +122,8 @@ pub struct Mesh {
     primitive_topology: PrimitiveTopology,
     /// `std::collections::BTreeMap` with all defined vertex attributes (Positions, Normals, ...)
     /// for this mesh. Attribute ids to attribute values.
-    /// Uses a BTreeMap because, unlike HashMap, it has a defined iteration order,
-    /// which allows easy stable VertexBuffers (i.e. same buffer order)
+    /// Uses a [`BTreeMap`] because, unlike `HashMap`, it has a defined iteration order,
+    /// which allows easy stable `VertexBuffers` (i.e. same buffer order)
     #[reflect(ignore)]
     attributes: BTreeMap<MeshVertexAttributeId, MeshAttributeData>,
     indices: Option<Indices>,

--- a/crates/bevy_render/src/render_graph/context.rs
+++ b/crates/bevy_render/src/render_graph/context.rs
@@ -30,10 +30,10 @@ pub struct RenderGraphContext<'a> {
     inputs: &'a [SlotValue],
     outputs: &'a mut [Option<SlotValue>],
     run_sub_graphs: Vec<RunSubGraph>,
-    /// The view_entity associated with the render graph being executed
-    /// This is optional because you aren't required to have a view_entity for a node.
+    /// The `view_entity` associated with the render graph being executed
+    /// This is optional because you aren't required to have a `view_entity` for a node.
     /// For example, compute shader nodes don't have one.
-    /// It should always be set when the RenderGraph is running on a View.
+    /// It should always be set when the [`RenderGraph`] is running on a View.
     view_entity: Option<Entity>,
 }
 

--- a/crates/bevy_render/src/render_graph/edge.rs
+++ b/crates/bevy_render/src/render_graph/edge.rs
@@ -19,7 +19,7 @@ use super::InternedRenderLabel;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Edge {
     /// An edge describing to ordering of both nodes (`output_node` before `input_node`)
-    /// and connecting the output slot at the `output_index` of the output_node
+    /// and connecting the output slot at the `output_index` of the `output_node`
     /// with the slot at the `input_index` of the `input_node`.
     SlotEdge {
         input_node: InternedRenderLabel,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -279,7 +279,7 @@ pub struct ImageSamplerDescriptor {
     pub compare: Option<ImageCompareFunction>,
     /// Must be at least 1. If this is not 1, all filter modes must be linear.
     pub anisotropy_clamp: u16,
-    /// Border color to use when `address_mode`` is [`ImageAddressMode::ClampToBorder`].
+    /// Border color to use when `address_mode` is [`ImageAddressMode::ClampToBorder`].
     pub border_color: Option<ImageSamplerBorderColor>,
 }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -92,8 +92,7 @@ pub enum SceneSpawnError {
         and registering the type using `app.register_type::<T>()`"
     )]
     UnregisteredType {
-        /// The [type name] for the unregistered type.
-        /// [type name]: std::any::type_name
+        /// The [type name](std::any::type_name) for the unregistered type.
         std_type_name: String,
     },
     /// Scene contains an unregistered type which has a `TypePath`.

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -296,7 +296,7 @@ pub struct ExtractedSprite {
     pub flip_x: bool,
     pub flip_y: bool,
     pub anchor: Vec2,
-    /// For cases where additional ExtractedSprites are created during extraction, this stores the
+    /// For cases where additional [`ExtractedSprites`] are created during extraction, this stores the
     /// entity that caused that creation for use in determining visibility.
     pub original_entity: Option<Entity>,
 }

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -12,7 +12,7 @@ pub enum FontLoaderError {
     /// An [IO](std::io) Error
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    /// An [InvalidFont](ab_glyph::InvalidFont) Error
+    /// An [`InvalidFont`](ab_glyph::InvalidFont) Error
     #[error(transparent)]
     FontInvalid(#[from] ab_glyph::InvalidFont),
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -14,7 +14,7 @@ pub struct Text {
     /// The text's internal alignment.
     /// Should not affect its position within a container.
     pub justify: JustifyText,
-    /// How the text should linebreak when running out of the bounds determined by max_size
+    /// How the text should linebreak when running out of the bounds determined by `max_size`
     pub linebreak_behavior: BreakLineOn,
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -925,11 +925,11 @@ pub enum MonitorSelection {
 #[reflect(Debug, PartialEq, Hash)]
 #[doc(alias = "vsync")]
 pub enum PresentMode {
-    /// Chooses FifoRelaxed -> Fifo based on availability.
+    /// Chooses [`FifoRelaxed`](Self::FifoRelaxed) -> [`Fifo`](Self::Fifo) based on availability.
     ///
     /// Because of the fallback behavior, it is supported everywhere.
     AutoVsync = 0, // NOTE: The explicit ordinal values mirror wgpu.
-    /// Chooses Immediate -> Mailbox -> Fifo (on web) based on availability.
+    /// Chooses [`Immediate`](Self::Immediate) -> [`Mailbox`](Self::Mailbox) -> [`Fifo`](Self::Fifo) (on web) based on availability.
     ///
     /// Because of the fallback behavior, it is supported everywhere.
     AutoNoVsync = 1,
@@ -942,7 +942,7 @@ pub enum PresentMode {
     ///
     /// No tearing will be observed.
     ///
-    /// Calls to get_current_texture will block until there is a spot in the queue.
+    /// Calls to `get_current_texture` will block until there is a spot in the queue.
     ///
     /// Supported on all platforms.
     ///
@@ -959,7 +959,7 @@ pub enum PresentMode {
     ///
     /// Tearing will be observed if frames last more than one vblank as the front buffer.
     ///
-    /// Calls to get_current_texture will block until there is a spot in the queue.
+    /// Calls to `get_current_texture` will block until there is a spot in the queue.
     ///
     /// Supported on AMD on Vulkan.
     ///

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -5,7 +5,6 @@ use bevy::{
         embedded_asset,
         io::{Reader, Writer},
         processor::LoadTransformAndSave,
-        ron,
         saver::{AssetSaver, SavedAsset},
         transformer::{AssetTransformer, TransformedAsset},
         AssetLoader, AsyncReadExt, AsyncWriteExt, LoadContext,

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -376,7 +376,7 @@ fn update_text(
     let new_text = format!("{text}", text = primitive_state.get());
     header.iter_mut().for_each(|mut header_text| {
         if let Some(kind) = header_text.sections.get_mut(1) {
-            kind.value = new_text.clone();
+            kind.value.clone_from(&new_text);
         };
     });
 }


### PR DESCRIPTION
# Objective

- Fixes #12976

## Solution

This one is a doozy.

- Run `cargo +beta clippy --workspace --all-targets --all-features` and fix all issues
- This includes:
  - Moving inner attributes to be outer attributes, when the item in question has both inner and outer attributes
  - Use `ptr::from_ref` in more scenarios
  - Extend the valid idents list used by `clippy:doc_markdown` with more names
  - Use `Clone::clone_from` when possible
  - Remove redundant `ron` import
  - Add backticks to **so many** identifiers and items
    - I'm sorry whoever has to review this

---

## Changelog

- Added links to more identifiers in documentation.