### PR TITLE
Remove unecessary lint `#[allow(...)]`

### DIFF
--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -58,8 +58,6 @@ impl Default for WinitSettings {
     }
 }
 
-// Rustdoc mistakenly believes `App` is already in scope.
-#[allow(rustdoc::redundant_explicit_links)]
 /// Determines how frequently an [`App`](bevy_app::App) should update.
 ///
 /// **Note:** This setting is independent of VSync. VSync is controlled by a window's


### PR DESCRIPTION
# Objective

- https://github.com/rust-lang/rust/pull/123905 has been merged, so the workaround introduced in #12913 is no longer necessary.
- Closes #12968

## Solution

- Remove unecessary `allow` attribute
  - This is currently blocked until Rust beta updates.
  - Last tested with `rustc 1.78.0-beta.7 (6fd191292 2024-04-12)`.