### PR TITLE
Instrument asset loading and processing.

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -16,6 +16,7 @@ embedded_watcher = ["file_watcher"]
 multi-threaded = ["bevy_tasks/multi-threaded"]
 asset_processor = []
 watch = []
+trace = []
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -5,6 +5,11 @@ use crate::{
 use async_broadcast::RecvError;
 use bevy_tasks::IoTaskPool;
 use bevy_utils::tracing::{error, warn};
+#[cfg(feature = "trace")]
+use bevy_utils::{
+    tracing::{info_span, instrument::Instrument},
+    ConditionalSendFuture,
+};
 use bevy_utils::{HashMap, TypeIdMap};
 use std::{any::TypeId, sync::Arc};
 use thiserror::Error;
@@ -30,6 +35,8 @@ impl AssetLoaders {
         let loader_asset_type = TypeId::of::<L::Asset>();
         let loader_asset_type_name = std::any::type_name::<L::Asset>();
 
+        #[cfg(feature = "trace")]
+        let loader = InstrumentedAssetLoader(loader);
         let loader = Arc::new(loader);
 
         let (loader_index, is_new) =
@@ -41,7 +48,7 @@ impl AssetLoaders {
 
         if is_new {
             let mut duplicate_extensions = Vec::new();
-            for extension in loader.extensions() {
+            for extension in AssetLoader::extensions(&*loader) {
                 let list = self
                     .extension_to_loaders
                     .entry((*extension).into())
@@ -289,6 +296,34 @@ impl MaybeAssetLoader {
             MaybeAssetLoader::Ready(loader) => Ok(loader),
             MaybeAssetLoader::Pending { mut receiver, .. } => Ok(receiver.recv().await?),
         }
+    }
+}
+
+#[cfg(feature = "trace")]
+struct InstrumentedAssetLoader<T>(T);
+
+#[cfg(feature = "trace")]
+impl<T: AssetLoader> AssetLoader for InstrumentedAssetLoader<T> {
+    type Asset = T::Asset;
+    type Settings = T::Settings;
+    type Error = T::Error;
+
+    fn load<'a>(
+        &'a self,
+        reader: &'a mut crate::io::Reader,
+        settings: &'a Self::Settings,
+        load_context: &'a mut crate::LoadContext,
+    ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
+        let span = info_span!(
+            "asset loading",
+            loader = std::any::type_name::<T>(),
+            asset = load_context.asset_path().to_string(),
+        );
+        self.0.load(reader, settings, load_context).instrument(span)
+    }
+
+    fn extensions(&self) -> &[&str] {
+        self.0.extensions()
     }
 }
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["game-engines", "graphics", "gui", "rendering"]
 [features]
 trace = [
   "bevy_app/trace",
+  "bevy_asset?/trace",
   "bevy_core_pipeline?/trace",
   "bevy_ecs/trace",
   "bevy_log/trace",


### PR DESCRIPTION
# Objective

As described in #12467, Bevy does not have any spans for any of the tasks scheduled onto the IO and async compute task pools.  

## Solution

Instrument all asset loads and asset processing.  Since this change is restricted to asset tasks, it does not completely solve #12467, but it does mean we can record the asset path in the trace.  

![image](https://github.com/bevyengine/bevy/assets/8494645/59faee63-1f69-40af-bf47-312c4d67d1e2)

---

## Changelog

Tracing will now include spans for asset loading and asset processing.  
