### PR TITLE
Add `Cascades` to the type registry, fixing lights in glTF.

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -269,6 +269,7 @@ impl Plugin for PbrPlugin {
         app.register_asset_reflect::<StandardMaterial>()
             .register_type::<AmbientLight>()
             .register_type::<CascadeShadowConfig>()
+            .register_type::<Cascades>()
             .register_type::<CascadesVisibleEntities>()
             .register_type::<ClusterConfig>()
             .register_type::<CubemapVisibleEntities>()


### PR DESCRIPTION
glTF files that contain lights currently panic when loaded into Bevy, because Bevy tries to reflect on `Cascades`, which accidentally wasn't registered.