### PR TITLE
add comment about coordinate system

### DIFF
--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -122,7 +122,7 @@ fn create_cube_mesh() -> Mesh {
     Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD)
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_POSITION,
-        // Each array is an [x, y, z] coordinate in local space.
+        // Each array is an [x, y, z] coordinate in local space. Bevy uses a right-handed Y-up coordinate system.
         // Meshes always rotate around their local [0, 0, 0] when a rotation is applied to their Transform.
         // By centering our mesh around the origin, rotating the mesh preserves its center of mass.
         vec![


### PR DESCRIPTION
# Objective

When learning about creating meshes in bevy using this example I couldn't tell which coordinate system bevy uses, which caused confusion and having to look it up else where.

## Solution

Add a comment that says what coordinate system bevy uses.
