### PR TITLE
Implement clone for most bundles.

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -252,6 +252,15 @@ where
     pub settings: PlaybackSettings,
 }
 
+impl<T: Asset + Decodable> Clone for AudioSourceBundle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+            settings: self.settings,
+        }
+    }
+}
+
 impl<T: Decodable + Asset> Default for AudioSourceBundle<T> {
     fn default() -> Self {
         Self {

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -18,7 +18,7 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 #[reflect(Component)]
 pub struct Camera2d;
 
-#[derive(Bundle)]
+#[derive(Bundle, Clone)]
 pub struct Camera2dBundle {
     pub camera: Camera,
     pub camera_render_graph: CameraRenderGraph,

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -133,7 +133,7 @@ pub enum ScreenSpaceTransmissionQuality {
     Ultra,
 }
 
-#[derive(Bundle)]
+#[derive(Bundle, Clone)]
 pub struct Camera3dBundle {
     pub camera: Camera,
     pub camera_render_graph: CameraRenderGraph,

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -44,16 +44,16 @@ pub const NORMAL_PREPASS_FORMAT: TextureFormat = TextureFormat::Rgb10a2Unorm;
 pub const MOTION_VECTOR_PREPASS_FORMAT: TextureFormat = TextureFormat::Rg16Float;
 
 /// If added to a [`crate::prelude::Camera3d`] then depth values will be copied to a separate texture available to the main pass.
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Default, Reflect, Clone)]
 pub struct DepthPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then vertex world normals will be copied to a separate texture available to the main pass.
 /// Normals will have normal map textures already applied.
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Default, Reflect, Clone)]
 pub struct NormalPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then screen space motion vectors will be copied to a separate texture available to the main pass.
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Default, Reflect, Clone)]
 pub struct MotionVectorPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then deferred materials will be rendered to the deferred gbuffer texture and will be available to subsequent passes.

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -85,7 +85,7 @@ impl Plugin for TemporalAntiAliasPlugin {
 }
 
 /// Bundle to apply temporal anti-aliasing.
-#[derive(Bundle, Default)]
+#[derive(Bundle, Default, Clone)]
 pub struct TemporalAntiAliasBundle {
     pub settings: TemporalAntiAliasSettings,
     pub jitter: TemporalJitter,

--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -79,7 +79,7 @@ pub struct CascadesVisibleEntities {
 }
 
 /// A component bundle for [`PointLight`] entities.
-#[derive(Debug, Bundle, Default)]
+#[derive(Debug, Bundle, Default, Clone)]
 pub struct PointLightBundle {
     pub point_light: PointLight,
     pub cubemap_visible_entities: CubemapVisibleEntities,
@@ -95,7 +95,7 @@ pub struct PointLightBundle {
 }
 
 /// A component bundle for spot light entities
-#[derive(Debug, Bundle, Default)]
+#[derive(Debug, Bundle, Default, Clone)]
 pub struct SpotLightBundle {
     pub spot_light: SpotLight,
     pub visible_entities: VisibleEntities,
@@ -111,7 +111,7 @@ pub struct SpotLightBundle {
 }
 
 /// A component bundle for [`DirectionalLight`] entities.
-#[derive(Debug, Bundle, Default)]
+#[derive(Debug, Bundle, Default, Clone)]
 pub struct DirectionalLightBundle {
     pub directional_light: DirectionalLight,
     pub frusta: CascadesFrusta,

--- a/crates/bevy_pbr/src/light_probe/environment_map.rs
+++ b/crates/bevy_pbr/src/light_probe/environment_map.rs
@@ -116,7 +116,7 @@ pub struct EnvironmentMapIds {
 /// A reflection probe is a type of environment map that specifies the light
 /// surrounding a region in space. For more information, see
 /// [`crate::environment_map`].
-#[derive(Bundle)]
+#[derive(Bundle, Clone)]
 pub struct ReflectionProbeBundle {
     /// Contains a transform that specifies the position of this reflection probe in space.
     pub spatial: SpatialBundle,

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -127,7 +127,7 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
 }
 
 /// Bundle to apply screen space ambient occlusion.
-#[derive(Bundle, Default)]
+#[derive(Bundle, Default, Clone)]
 pub struct ScreenSpaceAmbientOcclusionBundle {
     pub settings: ScreenSpaceAmbientOcclusionSettings,
     pub depth_prepass: DepthPrepass,

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -318,7 +318,7 @@ impl CubemapFrusta {
     }
 }
 
-#[derive(Component, Debug, Default, Reflect)]
+#[derive(Component, Debug, Default, Reflect, Clone)]
 #[reflect(Component, Default)]
 pub struct CascadesFrusta {
     #[reflect(ignore)]

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -22,7 +22,7 @@ pub struct SceneInstance(pub(crate) InstanceId);
 ///
 /// The scene from `scene` will be spawned as a child of the entity with this component.
 /// Once it's spawned, the entity will have a [`SceneInstance`] component.
-#[derive(Default, Bundle)]
+#[derive(Default, Bundle, Clone)]
 pub struct SceneBundle {
     /// Handle to the scene to spawn.
     pub scene: Handle<Scene>,
@@ -46,7 +46,7 @@ pub struct SceneBundle {
 ///
 /// The dynamic scene from `scene` will be spawn as a child of the entity with this component.
 /// Once it's spawned, the entity will have a [`SceneInstance`] component.
-#[derive(Default, Bundle)]
+#[derive(Default, Bundle, Clone)]
 pub struct DynamicSceneBundle {
     /// Handle to the scene to spawn.
     pub scene: Handle<DynamicScene>,


### PR DESCRIPTION
# Objective

Closes #12985.

## Solution

- Derive clone for most types with bundle in their name.
- Bundle types missing clone:
    - [`TextBundle`](https://docs.rs/bevy/latest/bevy/prelude/struct.TextBundle.html) (Contains [`ContentSize`](https://docs.rs/bevy/latest/bevy/ui/struct.ContentSize.html) which can't be cloned because it itself contains a `Option<MeasureFunc>` where [`MeasureFunc`](https://docs.rs/taffy/0.3.18/taffy/node/enum.MeasureFunc.html) isn't clone)
    - [`ImageBundle`](https://docs.rs/bevy/latest/bevy/prelude/struct.ImageBundle.html) (Same as `TextBundle`)
    - [`AtlasImageBundle`](https://docs.rs/bevy/latest/bevy/prelude/struct.AtlasImageBundle.html) (Will be deprecated in 0.14 there's no point)