### PR TITLE
Fix a copy-paste typo doc

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -99,7 +99,7 @@ pub trait AssetReader: Send + Sync + 'static {
         &'a self,
         path: &'a Path,
     ) -> impl ConditionalSendFuture<Output = Result<Box<PathStream>, AssetReaderError>>;
-    /// Returns an iterator of directory entry names at the provided path.
+    /// Returns true if the provided path points to a directory.
     fn is_directory<'a>(
         &'a self,
         path: &'a Path,


### PR DESCRIPTION
trivial, new doc copied from https://github.com/bevyengine/bevy/blob/main/crates/bevy_asset/src/io/mod.rs#L138
