### PR TITLE
Add missing Default impl to ExtendedMaterial.

### DIFF
--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -128,6 +128,20 @@ pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
     pub extension: E,
 }
 
+
+impl<B, E> Default for ExtendedMaterial<B, E>
+    where
+        B: Material + Default,
+        E: MaterialExtension + Default,
+{
+    fn default() -> Self {
+        Self {
+            base: B::default(),
+            extension: E::default(),
+        }
+    }
+}
+
 // We don't use the `TypePath` derive here due to a bug where `#[reflect(type_path = false)]`
 // causes the `TypePath` derive to not generate an implementation.
 impl_type_path!((in bevy_pbr::extended_material) ExtendedMaterial<B: Material, E: MaterialExtension>);

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -128,11 +128,10 @@ pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
     pub extension: E,
 }
 
-
 impl<B, E> Default for ExtendedMaterial<B, E>
-    where
-        B: Material + Default,
-        E: MaterialExtension + Default,
+where
+    B: Material + Default,
+    E: MaterialExtension + Default,
 {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
# Objective

When trying to be generic over `Material + Default`, the lack of a `Default` impl for `ExtendedMaterial`, even when both of its components implement `Default`, is problematic. I think was probably just overlooked.

## Solution

Impl `Default` if the material and extension both impl `Default`.

---

## Changelog

## Migration Guide

