### PR TITLE
Document Camera coordinate space

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -15,8 +15,8 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the "main 3d render graph".
-/// The camera coordinate space is right handed y-up.
-/// This means "forward" is -Z, with +X being "right".
+/// The camera coordinate space is right-handed x-right, y-up, z-back.
+/// This means "forward" is -Z.
 #[derive(Component, Reflect, Clone, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
 #[reflect(Component)]

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -135,8 +135,8 @@ pub enum ScreenSpaceTransmissionQuality {
     Ultra,
 }
 
-/// The camera coordinate space is right handed y-up.
-/// This means "forward" is -Z, with +X being "right".
+/// The camera coordinate space is right-handed x-right, y-up, z-back.
+/// This means "forward" is -Z.
 #[derive(Bundle, Clone)]
 pub struct Camera3dBundle {
     pub camera: Camera,

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -15,6 +15,8 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the "main 3d render graph".
+/// The camera coordinate space is right handed y-up.
+/// This means "forward" is -Z, with +X being "right".
 #[derive(Component, Reflect, Clone, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
 #[reflect(Component)]
@@ -133,6 +135,8 @@ pub enum ScreenSpaceTransmissionQuality {
     Ultra,
 }
 
+/// The camera coordinate space is right handed y-up.
+/// This means "forward" is -Z, with +X being "right".
 #[derive(Bundle, Clone)]
 pub struct Camera3dBundle {
     pub camera: Camera,


### PR DESCRIPTION
# Objective

Missing docs

## Solution

Add docs paraphrased from the Cart's mouth: https://discord.com/channels/691052431525675048/691052431974465548/1172305792154738759
> It follows the natural "results" of right handed y-up. The default camera will face "forward" in -Z, with +X being "right". The RH y-up setup is reasonably common. Thats why I asked for existing examples.I think we should appeal to the masses here / see how other RH Y-up 3D packages / engines handle this

