### PR TITLE
Use a slotmap for render assets storage

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -40,7 +40,6 @@ pub const CORE_3D_DEPTH_FORMAT: TextureFormat = TextureFormat::Depth32Float;
 
 use std::ops::Range;
 
-use bevy_asset::AssetId;
 use bevy_color::LinearRgba;
 pub use camera_3d::*;
 pub use main_opaque_pass_3d_node::*;
@@ -52,8 +51,8 @@ use bevy_math::FloatOrd;
 use bevy_render::{
     camera::{Camera, ExtractedCamera},
     extract_component::ExtractComponentPlugin,
-    mesh::Mesh,
     prelude::Msaa,
+    render_asset::RenderAssetKey,
     render_graph::{EmptyNode, RenderGraphApp, ViewNodeRunner},
     render_phase::{
         sort_phase_system, BinnedPhaseItem, BinnedRenderPhase, CachedRenderPipelinePhaseItem,
@@ -64,7 +63,7 @@ use bevy_render::{
         Texture, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages, TextureView,
     },
     renderer::RenderDevice,
-    texture::{BevyDefault, ColorAttachment, Image, TextureCache},
+    texture::{BevyDefault, ColorAttachment, TextureCache},
     view::{ExtractedView, ViewDepthTexture, ViewTarget},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -196,7 +195,7 @@ pub struct Opaque3dBinKey {
     pub draw_function: DrawFunctionId,
 
     /// The mesh.
-    pub asset_id: AssetId<Mesh>,
+    pub mesh_asset_key: RenderAssetKey,
 
     /// The ID of a bind group specific to the material.
     ///
@@ -204,7 +203,7 @@ pub struct Opaque3dBinKey {
     pub material_bind_group_id: Option<BindGroupId>,
 
     /// The lightmap, if present.
-    pub lightmap_image: Option<AssetId<Image>>,
+    pub lightmap_image: Option<RenderAssetKey>,
 }
 
 impl PhaseItem for Opaque3d {

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -29,11 +29,10 @@ pub mod node;
 
 use std::ops::Range;
 
-use bevy_asset::AssetId;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
-    mesh::Mesh,
+    render_asset::RenderAssetKey,
     render_phase::{BinnedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem},
     render_resource::{BindGroupId, CachedRenderPipelineId, Extent3d, TextureFormat, TextureView},
     texture::ColorAttachment,
@@ -133,7 +132,7 @@ pub struct OpaqueNoLightmap3dBinKey {
     pub draw_function: DrawFunctionId,
 
     /// The ID of the mesh.
-    pub asset_id: AssetId<Mesh>,
+    pub mesh_asset_key: RenderAssetKey,
 
     /// The ID of a bind group specific to the material.
     ///

--- a/crates/bevy_pbr/src/light_probe/environment_map.rs
+++ b/crates/bevy_pbr/src/light_probe/environment_map.rs
@@ -330,13 +330,13 @@ impl<'a> RenderViewEnvironmentMapBindGroupEntries<'a> {
 }
 
 impl LightProbeComponent for EnvironmentMapLight {
-    type AssetId = EnvironmentMapIds;
+    type AssetKey = EnvironmentMapIds;
 
     // Information needed to render with the environment map attached to the
     // view.
     type ViewLightProbeInfo = EnvironmentMapViewLightProbeInfo;
 
-    fn id(&self, image_assets: &RenderAssets<GpuImage>) -> Option<Self::AssetId> {
+    fn key(&self, image_assets: &RenderAssets<GpuImage>) -> Option<Self::AssetKey> {
         if let (Some(diffuse), Some(specular)) = (
             image_assets.get_key(&self.diffuse_map),
             image_assets.get_key(&self.specular_map),

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
@@ -316,13 +316,13 @@ pub(crate) fn get_bind_group_layout_entries(
 }
 
 impl LightProbeComponent for IrradianceVolume {
-    type AssetId = RenderAssetKey;
+    type AssetKey = RenderAssetKey;
 
     // Irradiance volumes can't be attached to the view, so we store nothing
     // here.
     type ViewLightProbeInfo = ();
 
-    fn id(&self, image_assets: &RenderAssets<GpuImage>) -> Option<Self::AssetId> {
+    fn key(&self, image_assets: &RenderAssets<GpuImage>) -> Option<Self::AssetKey> {
         image_assets.get_key(&self.voxels)
     }
 

--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -125,9 +125,10 @@ pub struct RenderLightmaps {
 impl SetRenderAssetKey for RenderLightmaps {
     #[inline]
     fn set_asset_key(&mut self, entity: Entity, key: RenderAssetKey) {
-        self.render_lightmaps
-            .get_mut(&entity)
-            .map(|render_lightmap| render_lightmap.image = key);
+        let Some(render_lightmap) = self.render_lightmaps.get_mut(&entity) else {
+            return;
+        };
+        render_lightmap.image = key;
     }
 }
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -476,10 +476,10 @@ impl<P: PhaseItem, M: Material, const I: usize> RenderCommand<P> for SetMaterial
         let materials = materials.into_inner();
         let material_instances = material_instances.into_inner();
 
-        let Some(&material_asset_id) = material_instances.get(&item.entity()) else {
+        let Some(&material_asset_key) = material_instances.get(&item.entity()) else {
             return RenderCommandResult::Failure;
         };
-        let Some(material) = materials.get_with_key(material_asset_id) else {
+        let Some(material) = materials.get_with_key(material_asset_key) else {
             return RenderCommandResult::Failure;
         };
         pass.set_bind_group(I, &material.bind_group, &[]);
@@ -698,7 +698,7 @@ pub fn queue_material_meshes<M: Material>(
 
         let rangefinder = view.rangefinder3d();
         for visible_entity in visible_entities.iter::<WithMesh>() {
-            let Some(&material_asset_id) = render_material_instances.get(visible_entity) else {
+            let Some(&material_asset_key) = render_material_instances.get(visible_entity) else {
                 continue;
             };
             let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*visible_entity)
@@ -708,7 +708,7 @@ pub fn queue_material_meshes<M: Material>(
             let Some(mesh) = render_meshes.get_with_key(mesh_instance.mesh_asset_key) else {
                 continue;
             };
-            let Some(material) = render_materials.get_with_key(material_asset_id) else {
+            let Some(material) = render_materials.get_with_key(material_asset_key) else {
                 continue;
             };
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -506,7 +506,10 @@ impl<M: Material> Default for RenderMaterialInstances<M> {
 impl<M: Material> SetRenderAssetKey for RenderMaterialInstances<M> {
     #[inline]
     fn set_asset_key(&mut self, entity: Entity, key: RenderAssetKey) {
-        self.get_mut(&entity).map(|asset_key| *asset_key = key);
+        let Some(asset_key) = self.get_mut(&entity) else {
+            return;
+        };
+        *asset_key = key;
     }
 }
 

--- a/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
@@ -139,8 +139,8 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
 
         view_key |= MeshPipelineKey::from_primitive_topology(PrimitiveTopology::TriangleList);
 
-        for material_id in render_material_instances.values() {
-            let Some(material) = render_materials.get(*material_id) else {
+        for &material_key in render_material_instances.values() {
+            let Some(material) = render_materials.get_with_key(material_key) else {
                 continue;
             };
 
@@ -199,7 +199,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
                 }),
             };
 
-            let material_id = gpu_scene.get_material_id(material_id.untyped());
+            let material_id = gpu_scene.get_material_id(material_key);
 
             let pipeline_id = *cache.entry(view_key).or_insert_with(|| {
                 pipeline_cache.queue_render_pipeline(pipeline_descriptor.clone())
@@ -264,8 +264,8 @@ pub fn prepare_material_meshlet_meshes_prepass<M: Material>(
 
         view_key |= MeshPipelineKey::from_primitive_topology(PrimitiveTopology::TriangleList);
 
-        for material_id in render_material_instances.values() {
-            let Some(material) = render_materials.get(*material_id) else {
+        for &material_key in render_material_instances.values() {
+            let Some(material) = render_materials.get_with_key(material_key) else {
                 continue;
             };
 
@@ -351,7 +351,7 @@ pub fn prepare_material_meshlet_meshes_prepass<M: Material>(
                 }),
             };
 
-            let material_id = gpu_scene.get_material_id(material_id.untyped());
+            let material_id = gpu_scene.get_material_id(material_key);
 
             let pipeline_id = *cache.entry(view_key).or_insert_with(|| {
                 pipeline_cache.queue_render_pipeline(pipeline_descriptor.clone())

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -776,14 +776,14 @@ pub fn queue_prepass_material_meshes<M: Material>(
         }
 
         for visible_entity in visible_entities.iter::<WithMesh>() {
-            let Some(&material_asset_id) = render_material_instances.get(visible_entity) else {
+            let Some(&material_asset_key) = render_material_instances.get(visible_entity) else {
                 continue;
             };
             let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*visible_entity)
             else {
                 continue;
             };
-            let Some(material) = render_materials.get_with_key(material_asset_id) else {
+            let Some(material) = render_materials.get_with_key(material_asset_key) else {
                 continue;
             };
             let Some(mesh) = render_meshes.get_with_key(mesh_instance.mesh_asset_key) else {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -776,17 +776,17 @@ pub fn queue_prepass_material_meshes<M: Material>(
         }
 
         for visible_entity in visible_entities.iter::<WithMesh>() {
-            let Some(material_asset_id) = render_material_instances.get(visible_entity) else {
+            let Some(&material_asset_id) = render_material_instances.get(visible_entity) else {
                 continue;
             };
             let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*visible_entity)
             else {
                 continue;
             };
-            let Some(material) = render_materials.get(*material_asset_id) else {
+            let Some(material) = render_materials.get_with_key(material_asset_id) else {
                 continue;
             };
-            let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
+            let Some(mesh) = render_meshes.get_with_key(mesh_instance.mesh_asset_key) else {
                 continue;
             };
 
@@ -859,7 +859,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                             OpaqueNoLightmap3dBinKey {
                                 draw_function: opaque_draw_deferred,
                                 pipeline: pipeline_id,
-                                asset_id: mesh_instance.mesh_asset_id,
+                                mesh_asset_key: mesh_instance.mesh_asset_key,
                                 material_bind_group_id: material.get_bind_group_id().0,
                             },
                             *visible_entity,
@@ -870,7 +870,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                             OpaqueNoLightmap3dBinKey {
                                 draw_function: opaque_draw_prepass,
                                 pipeline: pipeline_id,
-                                asset_id: mesh_instance.mesh_asset_id,
+                                mesh_asset_key: mesh_instance.mesh_asset_key,
                                 material_bind_group_id: material.get_bind_group_id().0,
                             },
                             *visible_entity,
@@ -884,7 +884,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                         let bin_key = OpaqueNoLightmap3dBinKey {
                             pipeline: pipeline_id,
                             draw_function: alpha_mask_draw_deferred,
-                            asset_id: mesh_instance.mesh_asset_id,
+                            mesh_asset_key: mesh_instance.mesh_asset_key,
                             material_bind_group_id: material.get_bind_group_id().0,
                         };
                         alpha_mask_deferred_phase.as_mut().unwrap().add(
@@ -896,7 +896,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                         let bin_key = OpaqueNoLightmap3dBinKey {
                             pipeline: pipeline_id,
                             draw_function: alpha_mask_draw_prepass,
-                            asset_id: mesh_instance.mesh_asset_id,
+                            mesh_asset_key: mesh_instance.mesh_asset_key,
                             material_bind_group_id: material.get_bind_group_id().0,
                         };
                         alpha_mask_phase.add(

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1663,10 +1663,10 @@ pub fn queue_shadows<M: Material>(
                 {
                     continue;
                 }
-                let Some(&material_asset_id) = render_material_instances.get(&entity) else {
+                let Some(&material_asset_key) = render_material_instances.get(&entity) else {
                     continue;
                 };
-                let Some(material) = render_materials.get_with_key(material_asset_id) else {
+                let Some(material) = render_materials.get_with_key(material_asset_key) else {
                     continue;
                 };
                 let Some(mesh) = render_meshes.get_with_key(mesh_instance.mesh_asset_key) else {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1,9 +1,8 @@
-use bevy_asset::AssetId;
 use bevy_core_pipeline::core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT};
 use bevy_ecs::prelude::*;
 use bevy_ecs::{entity::EntityHashMap, system::lifetimeless::Read};
 use bevy_math::{Mat4, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
-use bevy_render::mesh::Mesh;
+use bevy_render::render_asset::RenderAssetKey;
 use bevy_render::{
     camera::Camera,
     diagnostic::RecordDiagnostics,
@@ -1664,13 +1663,13 @@ pub fn queue_shadows<M: Material>(
                 {
                     continue;
                 }
-                let Some(material_asset_id) = render_material_instances.get(&entity) else {
+                let Some(&material_asset_id) = render_material_instances.get(&entity) else {
                     continue;
                 };
-                let Some(material) = render_materials.get(*material_asset_id) else {
+                let Some(material) = render_materials.get_with_key(material_asset_id) else {
                     continue;
                 };
-                let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
+                let Some(mesh) = render_meshes.get_with_key(mesh_instance.mesh_asset_key) else {
                     continue;
                 };
 
@@ -1720,7 +1719,7 @@ pub fn queue_shadows<M: Material>(
                     ShadowBinKey {
                         draw_function: draw_shadow_mesh,
                         pipeline: pipeline_id,
-                        asset_id: mesh_instance.mesh_asset_id,
+                        mesh_asset_key: mesh_instance.mesh_asset_key,
                     },
                     entity,
                     mesh_instance.should_batch(),
@@ -1746,7 +1745,7 @@ pub struct ShadowBinKey {
     pub draw_function: DrawFunctionId,
 
     /// The mesh.
-    pub asset_id: AssetId<Mesh>,
+    pub mesh_asset_key: RenderAssetKey,
 }
 
 impl PhaseItem for Shadow {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -527,10 +527,10 @@ impl SetRenderAssetKey for RenderMeshInstances {
     fn set_asset_key(&mut self, entity: Entity, key: RenderAssetKey) {
         match *self {
             RenderMeshInstances::CpuBuilding(ref mut instances) => {
-                instances.set_mesh_asset_key(entity, key)
+                instances.set_mesh_asset_key(entity, key);
             }
             RenderMeshInstances::GpuBuilding(ref mut instances) => {
-                instances.set_mesh_asset_key(entity, key)
+                instances.set_mesh_asset_key(entity, key);
             }
         }
     }
@@ -552,9 +552,10 @@ impl RenderMeshInstancesTable for RenderMeshInstancesCpu {
     }
 
     fn set_mesh_asset_key(&mut self, entity: Entity, key: RenderAssetKey) {
-        self.get_mut(&entity).map(|instance| {
-            instance.shared.mesh_asset_key = key;
-        });
+        let Some(instance) = self.get_mut(&entity) else {
+            return;
+        };
+        instance.shared.mesh_asset_key = key;
     }
 
     fn render_mesh_queue_data(&self, entity: Entity) -> Option<RenderMeshQueueData> {
@@ -572,9 +573,10 @@ impl RenderMeshInstancesTable for RenderMeshInstancesGpu {
     }
 
     fn set_mesh_asset_key(&mut self, entity: Entity, key: RenderAssetKey) {
-        self.get_mut(&entity).map(|instance| {
-            instance.shared.mesh_asset_key = key;
-        });
+        let Some(instance) = self.get_mut(&entity) else {
+            return;
+        };
+        instance.shared.mesh_asset_key = key;
     }
 
     /// Constructs [`RenderMeshQueueData`] for the given entity, if it has a
@@ -701,7 +703,7 @@ pub fn extract_meshes_for_cpu_building(
             pending_mesh_assets
                 .entry(asset_id)
                 .or_default()
-                .extend(entities.drain(..));
+                .append(&mut entities);
         }
     }
 }
@@ -711,6 +713,7 @@ pub fn extract_meshes_for_cpu_building(
 ///
 /// This is the variant of the system that runs when we're using GPU
 /// [`MeshUniform`] building.
+#[allow(clippy::too_many_arguments)]
 pub fn extract_meshes_for_gpu_building(
     mut render_mesh_instances: ResMut<RenderMeshInstances>,
     mut batched_instance_buffers: ResMut<
@@ -800,7 +803,7 @@ pub fn extract_meshes_for_gpu_building(
             pending_mesh_assets
                 .entry(asset_id)
                 .or_default()
-                .extend(entities.drain(..));
+                .append(&mut entities);
         }
     }
 }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -247,7 +247,7 @@ impl<A: RenderAsset> RenderAssets<A> {
     pub fn iter(&self) -> impl Iterator<Item = (AssetId<A::SourceAsset>, &A)> {
         self.id_to_key.iter().filter_map(|(&id, &key)| {
             self.get_with_key(key)
-                .and_then(|prepared_asset| Some((id, prepared_asset)))
+                .map(|prepared_asset| (id, prepared_asset))
         })
     }
 }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -176,6 +176,11 @@ impl<A: RenderAsset> Default for ExtractedAssets<A> {
 }
 
 new_key_type! {
+    /// A [`SlotMap`] key for lookups into [`RenderAssets`] instead of [`AssetId`].
+    ///
+    /// This is a generational index using two [`u32`]s which is more compact
+    /// than [`AssetId`] and brings significant performance benefits due to
+    /// better cache hit rates in hot loops.
     pub struct RenderAssetKey;
 }
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -35,7 +35,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
-use bevy_utils::{slotmap::Key, tracing::error};
+use bevy_utils::tracing::error;
 use std::hash::Hash;
 use std::marker::PhantomData;
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -413,7 +413,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
             let Some(material2d) = render_materials.get(*material_asset_id) else {
                 continue;
             };
-            let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
+            let Some(mesh) = render_meshes.get_with_key(mesh_instance.mesh_asset_key) else {
                 continue;
             };
             let mesh_key =

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -215,8 +215,10 @@ pub struct RenderMesh2dInstances(EntityHashMap<RenderMesh2dInstance>);
 impl SetRenderAssetKey for RenderMesh2dInstances {
     #[inline]
     fn set_asset_key(&mut self, entity: Entity, key: RenderAssetKey) {
-        self.get_mut(&entity)
-            .map(|instance| instance.mesh_asset_key = key);
+        let Some(instance) = self.get_mut(&entity) else {
+            return;
+        };
+        instance.mesh_asset_key = key;
     }
 }
 
@@ -280,7 +282,7 @@ pub fn extract_mesh2d(
             pending_mesh_assets
                 .entry(asset_id)
                 .or_default()
-                .extend(entities.drain(..));
+                .append(&mut entities);
         }
     }
 }

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -18,6 +18,7 @@ web-time = { version = "0.2" }
 hashbrown = { version = "0.14", features = ["serde"] }
 bevy_utils_proc_macros = { version = "0.14.0-dev", path = "macros" }
 thread_local = "1.0"
+slotmap = "1.0"
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -32,6 +32,7 @@ pub use cow_arc::*;
 pub use default::default;
 pub use hashbrown;
 pub use parallel_queue::*;
+pub use slotmap;
 pub use tracing;
 pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -130,7 +130,7 @@ fn queue_custom(
             let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(entity) else {
                 continue;
             };
-            let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
+            let Some(mesh) = meshes.get_with_key(mesh_instance.mesh_asset_key) else {
                 continue;
             };
             let key =
@@ -249,7 +249,10 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
         else {
             return RenderCommandResult::Failure;
         };
-        let Some(gpu_mesh) = meshes.into_inner().get(mesh_instance.mesh_asset_id) else {
+        let Some(gpu_mesh) = meshes
+            .into_inner()
+            .get_with_key(mesh_instance.mesh_asset_key)
+        else {
             return RenderCommandResult::Failure;
         };
         let Some(instance_buffer) = instance_buffer else {


### PR DESCRIPTION
# Objective

- Optimise material mesh entity rendering code paths
- Prepare for 'draw stream' rendering which needs to pack render commands into a `Vec<u32>`

## Solution

- AssetId is quite large due to supporting a UUID variant and the type is used in very hot loops for batching and rendering. In rendering, we don't need the UUID. We can use a smaller id to refer to the prepared render asset.
- Use a slotmap as the backing store for `RenderAssets`
- Maintain a map from `AssetId<A: RenderAsset>` to slotmap key inside `RenderAssets` and use it to look up keys for known render assets at extraction time
- Add a `UpdatePendingRenderAssetKeyPlugin` to help with updating asset keys on instance data for assets that were loaded during the current frame, to avoid a 1-frame lag.

## Benchmarks

On an M1 Max, running `cargo run --release --example bevymark -- --benchmark --waves 160 --per-wave 1000 --mode mesh2d`. Yellow is main, red is this PR:

<img width="804" alt="Screenshot 2024-04-18 at 12 20 21" src="https://github.com/bevyengine/bevy/assets/302146/893c24aa-29a6-48dc-9107-ff76f8a6d96e">

A 6.3% reduction in median frame time.

Main:
<img width="1165" alt="Screenshot 2024-04-18 at 12 20 54" src="https://github.com/bevyengine/bevy/assets/302146/4aaec06d-d660-44ec-b972-7dafefe0994c">

PR:
<img width="1160" alt="Screenshot 2024-04-18 at 12 21 19" src="https://github.com/bevyengine/bevy/assets/302146/10eec853-ee77-4719-aa07-647a8994e9bc">

Noteworthy spans:
```
92.16ms -> 86.00ms : main_pass_2d
19.20ms -> 17.72mz : batch_and_prepare_sorted_render_phase
 6.07ms ->  4.34ms : queue_material2d_meshes
 0.95ms ->  1.71ms : extract_material_meshes_2d
```

---

## Changelog

- Added: `RenderAssetKey` slotmap key type to be used with `RenderAssets`
- Added: `get_key`, `get_with_key`, and `get_with_key_mut` methods to `RenderAssets` to use slotmap keys.
- Added: `UpdatePendingRenderAssetKeyPlugin` to help with updating asset keys on instance data for assets that were loaded during the current frame, to avoid a 1-frame lag.
- Changed: Use slotmap for internal storage for `RenderAssets` for improved performance due to the smaller asset reference data size of slotmap keys compared to `AssetId`
