### PR TITLE
Make `AppExit` more specific about exit reason.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ semicolon_if_nothing_returned = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"
-#ref_as_ptr = "warn"
+ref_as_ptr = "warn"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ semicolon_if_nothing_returned = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"
-ref_as_ptr = "warn"
+#ref_as_ptr = "warn"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -180,7 +180,7 @@ impl App {
     /// ```
     /// # use bevy_app::prelude::*;
     /// #
-    /// fn my_runner(mut app: App) {
+    /// fn my_runner(mut app: App) -> AppExit {
     ///     loop {
     ///         println!("In main loop");
     ///         app.update();
@@ -911,7 +911,7 @@ mod tests {
         system::Commands,
     };
 
-    use crate::{App, Plugin};
+    use crate::{App, AppExit, Plugin};
 
     struct PluginA;
     impl Plugin for PluginA {
@@ -1112,19 +1112,21 @@ mod tests {
     /// fix: <https://github.com/bevyengine/bevy/pull/10389>
     #[test]
     fn regression_test_10385() {
-        use super::{Res, Resource};
+        use super::{Res, Resource, AppExit};
         use crate::PreUpdate;
 
         #[derive(Resource)]
         struct MyState {}
 
-        fn my_runner(mut app: App) {
+        fn my_runner(mut app: App) -> AppExit {
             let my_state = MyState {};
             app.world_mut().insert_resource(my_state);
 
             for _ in 0..5 {
                 app.update();
             }
+
+            AppExit::Success
         }
 
         fn my_system(_: Res<MyState>) {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -889,7 +889,7 @@ pub enum AppExit {
     /// [`App`] exited without any problems.
     #[default]
     Success,
-    /// [`App`] experienced unhandleable error.
+    /// The [`App`] experienced an unhandleable error.
     Error,
 }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1112,7 +1112,7 @@ mod tests {
     /// fix: <https://github.com/bevyengine/bevy/pull/10389>
     #[test]
     fn regression_test_10385() {
-        use super::{Res, Resource, AppExit};
+        use super::{AppExit, Res, Resource};
         use crate::PreUpdate;
 
         #[derive(Resource)]

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -187,6 +187,9 @@ impl App {
     ///     loop {
     ///         println!("In main loop");
     ///         app.update();
+    ///         if let Some(exit) = app.should_exit() {
+    ///             return exit;
+    ///         }
     ///     }
     /// }
     ///

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -28,7 +28,7 @@ pub use sub_app::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        app::App,
+        app::{App, AppExit},
         main_schedule::{
             First, FixedFirst, FixedLast, FixedPostUpdate, FixedPreUpdate, FixedUpdate, Last, Main,
             PostStartup, PostUpdate, PreStartup, PreUpdate, SpawnScene, Startup, StateTransition,

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -84,7 +84,21 @@ impl Plugin for ScheduleRunnerPlugin {
 
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
             match run_mode {
-                RunMode::Once => app.update(),
+                RunMode::Once => {
+                    app.update();
+
+                    let mut exit_code_reader = ManualEventReader::default();
+                    if let Some(app_exit_events) = app.world().get_resource::<Events<AppExit>>() {
+                        if exit_code_reader
+                            .read(app_exit_events)
+                            .any(|exit| *exit == AppExit::Error)
+                        {
+                            return AppExit::Error;
+                        }
+                    }
+
+                    AppExit::Success
+                }
                 RunMode::Loop { wait } => {
                     let mut tick = move |app: &mut App,
                                          wait: Option<Duration>|
@@ -93,11 +107,9 @@ impl Plugin for ScheduleRunnerPlugin {
 
                         app.update();
 
-                        if let Some(app_exit_events) =
-                            app.world_mut().get_resource_mut::<Events<AppExit>>()
+                        if let Some(app_exit_events) = app.world().get_resource::<Events<AppExit>>()
                         {
-                            if let Some(exit) = app_exit_event_reader.read(&app_exit_events).last()
-                            {
+                            if let Some(exit) = app_exit_event_reader.read(app_exit_events).last() {
                                 return Err(exit.clone());
                             }
                         }
@@ -116,40 +128,54 @@ impl Plugin for ScheduleRunnerPlugin {
 
                     #[cfg(not(target_arch = "wasm32"))]
                     {
-                        while let Ok(delay) = tick(&mut app, wait) {
-                            if let Some(delay) = delay {
-                                std::thread::sleep(delay);
+                        loop {
+                            match tick(&mut app, wait) {
+                                Ok(Some(delay)) => std::thread::sleep(delay),
+                                Ok(None) => continue,
+                                Err(exit) => return exit,
                             }
                         }
                     }
 
                     #[cfg(target_arch = "wasm32")]
                     {
-                        fn set_timeout(f: &Closure<dyn FnMut()>, dur: Duration) {
+                        fn set_timeout(callback: &Closure<dyn FnMut()>, dur: Duration) {
                             web_sys::window()
                                 .unwrap()
                                 .set_timeout_with_callback_and_timeout_and_arguments_0(
-                                    f.as_ref().unchecked_ref(),
+                                    callback.as_ref().unchecked_ref(),
                                     dur.as_millis() as i32,
                                 )
                                 .expect("Should register `setTimeout`.");
                         }
                         let asap = Duration::from_millis(1);
 
-                        let mut rc = Rc::new(app);
-                        let f = Rc::new(RefCell::new(None));
-                        let g = f.clone();
+                        let exit = Rc::new(RefCell::new(AppExit::Success));
+                        let closure_exit = exit.clone();
 
-                        let c = move || {
-                            let app = Rc::get_mut(&mut rc).unwrap();
+                        let mut app = Rc::new(app);
+                        let moved_tick_closure = Rc::new(RefCell::new(None));
+                        let base_tick_closure = moved_tick_closure.clone();
+
+                        let tick_app = move || {
+                            let mut app = Rc::get_mut(&mut app).unwrap();
                             let delay = tick(app, wait);
-                            if let Ok(delay) = delay {
-                                set_timeout(f.borrow().as_ref().unwrap(), delay.unwrap_or(asap));
+                            match delay {
+                                Ok(delay) => set_timeout(
+                                    moved_tick_closure.borrow().as_ref().unwrap(),
+                                    delay.unwrap_or(asap),
+                                ),
+                                Err(code) => {
+                                    closure_exit.replace(code);
+                                }
                             }
                         };
-                        *g.borrow_mut() = Some(Closure::wrap(Box::new(c) as Box<dyn FnMut()>));
-                        set_timeout(g.borrow().as_ref().unwrap(), asap);
-                    };
+                        *base_tick_closure.borrow_mut() =
+                            Some(Closure::wrap(Box::new(tick_app) as Box<dyn FnMut()>));
+                        set_timeout(base_tick_closure.borrow().as_ref().unwrap(), asap);
+
+                        exit.take()
+                    }
                 }
             }
         });

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -149,7 +149,7 @@ impl Plugin for ScheduleRunnerPlugin {
                         let base_tick_closure = moved_tick_closure.clone();
 
                         let tick_app = move || {
-                            let mut app = Rc::get_mut(&mut app).unwrap();
+                            let app = Rc::get_mut(&mut app).unwrap();
                             let delay = tick(app, wait);
                             match delay {
                                 Ok(delay) => set_timeout(

--- a/crates/bevy_dev_tools/src/ci_testing.rs
+++ b/crates/bevy_dev_tools/src/ci_testing.rs
@@ -37,7 +37,7 @@ fn ci_testing_exit_after(
 ) {
     if let Some(exit_after) = ci_testing_config.exit_after {
         if *current_frame > exit_after {
-            app_exit_events.send(AppExit);
+            app_exit_events.send(AppExit::Success);
             info!("Exiting after {} frames. Test successful!", exit_after);
         }
     }

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -193,7 +193,7 @@ fn renderer_extract(app_world: &mut World, _world: &mut World) {
                 render_channels.send_blocking(render_app);
             } else {
                 // Renderer thread panicked
-                world.send_event(AppExit::Error);
+                world.send_event(AppExit::error());
             }
         });
     });

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -193,7 +193,7 @@ fn renderer_extract(app_world: &mut World, _world: &mut World) {
                 render_channels.send_blocking(render_app);
             } else {
                 // Renderer thread panicked
-                world.send_event(AppExit);
+                world.send_event(AppExit::Error);
             }
         });
     });

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -13,7 +13,7 @@ use bevy_ecs::prelude::*;
 pub fn exit_on_all_closed(mut app_exit_events: EventWriter<AppExit>, windows: Query<&Window>) {
     if windows.is_empty() {
         bevy_utils::tracing::info!("No windows are open, exiting");
-        app_exit_events.send(AppExit);
+        app_exit_events.send(AppExit::Success);
     }
 }
 
@@ -28,7 +28,7 @@ pub fn exit_on_primary_closed(
 ) {
     if windows.is_empty() {
         bevy_utils::tracing::info!("Primary window was closed, exiting");
-        app_exit_events.send(AppExit);
+        app_exit_events.send(AppExit::Success);
     }
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -19,6 +19,8 @@ mod winit_config;
 pub mod winit_event;
 mod winit_windows;
 
+use std::sync::{Arc, Mutex};
+
 use approx::relative_eq;
 use bevy_a11y::AccessibilityRequested;
 use bevy_utils::Instant;
@@ -263,7 +265,7 @@ type UserEvent = RequestRedraw;
 ///
 /// Overriding the app's [runner](bevy_app::App::runner) while using `WinitPlugin` will bypass the
 /// `EventLoop`.
-pub fn winit_runner(mut app: App) {
+pub fn winit_runner(mut app: App) -> AppExit {
     if app.plugins_state() == PluginsState::Ready {
         app.finish();
         app.cleanup();
@@ -278,6 +280,9 @@ pub fn winit_runner(mut app: App) {
         .insert_non_send_resource(event_loop.create_proxy());
 
     let mut runner_state = WinitAppRunnerState::default();
+
+    let mut exit_status = Arc::new(Mutex::new(AppExit::Success));
+    let handle_exit_status = exit_status.clone();
 
     // prepare structures to access data in the world
     let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
@@ -298,6 +303,8 @@ pub fn winit_runner(mut app: App) {
     let mut winit_events = Vec::default();
     // set up the event loop
     let event_handler = move |event, event_loop: &EventLoopWindowTarget<UserEvent>| {
+        let mut exit_status = handle_exit_status.lock().unwrap();
+
         handle_winit_event(
             &mut app,
             &mut app_exit_event_reader,
@@ -307,6 +314,7 @@ pub fn winit_runner(mut app: App) {
             &mut focused_windows_state,
             &mut redraw_event_reader,
             &mut winit_events,
+            &mut exit_status,
             event,
             event_loop,
         );
@@ -317,6 +325,12 @@ pub fn winit_runner(mut app: App) {
     if let Err(err) = event_loop.run(event_handler) {
         error!("winit event loop returned an error: {err}");
     }
+
+    // We should be the only ones holding this `Arc` since the event loop exiting cleanly
+    // should drop the event handler. if this is not the case something funky is happening.
+    Arc::get_mut(&mut exit_status)
+        .map(|mutex| mutex.get_mut().unwrap().clone())
+        .unwrap_or(AppExit::Error)
 }
 
 #[allow(clippy::too_many_arguments /* TODO: probs can reduce # of args */)]
@@ -334,6 +348,7 @@ fn handle_winit_event(
     focused_windows_state: &mut SystemState<(Res<WinitSettings>, Query<&Window>)>,
     redraw_event_reader: &mut ManualEventReader<RequestRedraw>,
     winit_events: &mut Vec<WinitEvent>,
+    exit_status: &mut AppExit,
     event: Event<UserEvent>,
     event_loop: &EventLoopWindowTarget<UserEvent>,
 ) {
@@ -351,7 +366,12 @@ fn handle_winit_event(
         runner_state.redraw_requested = true;
 
         if let Some(app_exit_events) = app.world().get_resource::<Events<AppExit>>() {
-            if app_exit_event_reader.read(app_exit_events).last().is_some() {
+            let mut exit_events = app_exit_event_reader.read(app_exit_events);
+            if exit_events.len() != 0 {
+                *exit_status = exit_events
+                    .find(|exit| **exit == AppExit::Error)
+                    .cloned()
+                    .unwrap_or(AppExit::Success);
                 event_loop.exit();
                 return;
             }
@@ -411,6 +431,7 @@ fn handle_winit_event(
                         app_exit_event_reader,
                         redraw_event_reader,
                         winit_events,
+                        exit_status,
                     );
                     if runner_state.active != ActiveState::Suspended {
                         event_loop.set_control_flow(ControlFlow::Poll);
@@ -638,6 +659,7 @@ fn handle_winit_event(
                         app_exit_event_reader,
                         redraw_event_reader,
                         winit_events,
+                        exit_status,
                     );
                 }
                 _ => {}
@@ -738,6 +760,7 @@ fn run_app_update_if_should(
     app_exit_event_reader: &mut ManualEventReader<AppExit>,
     redraw_event_reader: &mut ManualEventReader<RequestRedraw>,
     winit_events: &mut Vec<WinitEvent>,
+    exit_status: &mut AppExit,
 ) {
     runner_state.reset_on_update();
 
@@ -798,8 +821,14 @@ fn run_app_update_if_should(
         }
 
         if let Some(app_exit_events) = app.world().get_resource::<Events<AppExit>>() {
-            if app_exit_event_reader.read(app_exit_events).last().is_some() {
+            let mut exit_events = app_exit_event_reader.read(app_exit_events);
+            if exit_events.len() != 0 {
+                *exit_status = exit_events
+                    .find(|exit| **exit == AppExit::Error)
+                    .cloned()
+                    .unwrap_or(AppExit::Success);
                 event_loop.exit();
+                return;
             }
         }
     }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -366,7 +366,7 @@ fn handle_winit_event(
         }
         runner_state.redraw_requested = true;
 
-        // BEFORE_MERGE(Brezak): Consider replacing after discussion and before pr.
+        // TODO: Replace with `App::should_exit()`
         if let Some(app_exit_events) = app.world().get_resource::<Events<AppExit>>() {
             let mut exit_events = app_exit_event_reader.read(app_exit_events);
             if exit_events.len() != 0 {
@@ -822,7 +822,7 @@ fn run_app_update_if_should(
             }
         }
 
-        // BEFORE_MERGE(Brezak): Consider replacing after discussion and before pr.
+        // TODO: Replace with `App::should_exit()`
         if let Some(app_exit_events) = app.world().get_resource::<Events<AppExit>>() {
             let mut exit_events = app_exit_event_reader.read(app_exit_events);
             if exit_events.len() != 0 {

--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -1,13 +1,13 @@
 //! This example demonstrates you can create a custom runner (to update an app manually). It reads
 //! lines from stdin and prints them from within the ecs.
 
-use bevy::prelude::*;
+use bevy::{app::AppExit, prelude::*};
 use std::io;
 
 #[derive(Resource)]
 struct Input(String);
 
-fn my_runner(mut app: App) {
+fn my_runner(mut app: App) -> AppExit {
     println!("Type stuff into the console");
     for line in io::stdin().lines() {
         {
@@ -16,6 +16,8 @@ fn my_runner(mut app: App) {
         }
         app.update();
     }
+
+    AppExit::Success
 }
 
 fn print_system(input: Res<Input>) {

--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -15,6 +15,10 @@ fn my_runner(mut app: App) -> AppExit {
             input.0 = line.unwrap();
         }
         app.update();
+
+        if let Some(exit) = app.should_exit() {
+            return exit;
+        }
     }
 
     AppExit::Success
@@ -24,10 +28,17 @@ fn print_system(input: Res<Input>) {
     println!("You typed: {}", input.0);
 }
 
-fn main() {
+fn exit_system(input: Res<Input>, mut exit_event: EventWriter<AppExit>) {
+    if input.0 == "exit" {
+        exit_event.send(AppExit::Success);
+    }
+}
+
+// AppExit implements `Termination` so we can return it from main.
+fn main() -> AppExit {
     App::new()
         .insert_resource(Input(String::new()))
         .set_runner(my_runner)
-        .add_systems(Update, print_system)
-        .run();
+        .add_systems(Update, (print_system, exit_system))
+        .run()
 }

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -130,10 +130,10 @@ fn game_over_system(
 ) {
     if let Some(ref player) = game_state.winning_player {
         println!("{player} won the game!");
-        app_exit_events.send(AppExit);
+        app_exit_events.send(AppExit::Success);
     } else if game_state.current_round == game_rules.max_rounds {
         println!("Ran out of rounds. Nobody wins!");
-        app_exit_events.send(AppExit);
+        app_exit_events.send(AppExit::Success);
     }
 }
 

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -334,7 +334,7 @@ fn quit(
         .distance(cursor_world_pos)
         < BEVY_LOGO_RADIUS
     {
-        app_exit.send(AppExit);
+        app_exit.send(AppExit::Success);
     }
 }
 

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -789,7 +789,7 @@ mod menu {
             if *interaction == Interaction::Pressed {
                 match menu_button_action {
                     MenuButtonAction::Quit => {
-                        app_exit_events.send(AppExit);
+                        app_exit_events.send(AppExit::Success);
                     }
                     MenuButtonAction::Play => {
                         game_state.set(GameState::Game);

--- a/examples/time/time.rs
+++ b/examples/time/time.rs
@@ -1,5 +1,6 @@
 //! An example that illustrates how Time is handled in ECS.
 
+use bevy::app::AppExit;
 use bevy::prelude::*;
 
 use std::io::{self, BufRead};
@@ -30,7 +31,7 @@ fn help() {
     println!("  u: Unpause");
 }
 
-fn runner(mut app: App) {
+fn runner(mut app: App) -> AppExit {
     banner();
     help();
     let stdin = io::stdin();
@@ -78,6 +79,8 @@ fn runner(mut app: App) {
             }
         }
     }
+
+    AppExit::Success
 }
 
 fn print_real_time(time: Res<Time<Real>>) {


### PR DESCRIPTION
# Objective

Closes #13017.

## Solution

- Make `AppExit` a enum with a `Success` and `Error` variant.
- Make `App::run()` return a `AppExit` if it ever returns.
- Make app runners return a `AppExit` to signal if they encountered a error.

---

## Changelog

### Added

- [`App::should_exit`](https://example.org/)
- [`AppExit`](https://docs.rs/bevy/latest/bevy/app/struct.AppExit.html) to the `bevy` and `bevy_app` preludes,

### Changed

- [`AppExit`](https://docs.rs/bevy/latest/bevy/app/struct.AppExit.html) is now a enum with 2 variants (`Success` and `Error`).
- The app's [runner function](https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.set_runner) now has to return a `AppExit`.
- [`App::run()`](https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.run) now also returns the `AppExit` produced by the runner function.


## Migration Guide

- Replace all usages of [`AppExit`](https://docs.rs/bevy/latest/bevy/app/struct.AppExit.html) with `AppExit::Success` or `AppExit::Failure`.
- Any custom app runners now need to return a `AppExit`. We suggest you return a `AppExit::Error` if any `AppExit` raised was a Error. You can use the new [`App::should_exit`](https://example.org/) method.
- If not exiting from `main` any other way. You should return the `AppExit` from `App::run()` so the app correctly returns a error code if anything fails e.g.
```rust
fn main() -> AppExit {
    App::new()
        //Your setup here...
        .run()
}
```