### PR TITLE
Cleanup extract_meshes

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
     query::ROQueryItem,
     system::{lifetimeless::*, SystemParamItem, SystemState},
 };
-use bevy_math::{Affine3, Rect, UVec2, Vec3, Vec4};
+use bevy_math::{vec3, Affine3, Rect, UVec2, Vec3, Vec4};
 use bevy_render::{
     batching::{
         gpu_preprocessing, no_gpu_preprocessing, GetBatchData, GetFullBatchData,
@@ -741,8 +741,12 @@ pub fn extract_meshes_for_gpu_building(
     render_mesh_instances.clear();
     for queue in render_mesh_instance_queues.iter_mut() {
         for ((entity, shared), mesh_uniform) in queue.drain(..) {
-            let buffer_index = current_input_buffer.push(u);
-            let translation = mesh_uniform.transform.row(3).xyz();
+            let buffer_index = current_input_buffer.push(mesh_uniform);
+            let translation = vec3(
+                mesh_uniform.transform[0].w,
+                mesh_uniform.transform[1].w,
+                mesh_uniform.transform[2].w,
+            );
             render_mesh_instances.insert_unique_unchecked(
                 entity,
                 RenderMeshInstanceGpu {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -644,7 +644,7 @@ pub fn extract_meshes_for_gpu_building(
         gpu_preprocessing::BatchedInstanceBuffers<MeshUniform, MeshInputUniform>,
     >,
     mut render_mesh_instance_queues: Local<
-        Parallel<Vec<((Entity, RenderMeshInstanceShared), MeshInputUniform)>>,
+        Parallel<Vec<(Entity, RenderMeshInstanceShared, MeshInputUniform)>>,
     >,
     meshes_query: Extract<
         Query<(
@@ -725,7 +725,8 @@ pub fn extract_meshes_for_gpu_building(
 
             render_mesh_instance_queues.scope(|queue| {
                 queue.push((
-                    (entity, shared),
+                    entity,
+                    shared,
                     MeshInputUniform {
                         flags: mesh_flags.bits(),
                         lightmap_uv_rect,
@@ -740,7 +741,7 @@ pub fn extract_meshes_for_gpu_building(
     // Build the [`RenderMeshInstance`]s and [`MeshInputUniform`]s.
     render_mesh_instances.clear();
     for queue in render_mesh_instance_queues.iter_mut() {
-        for ((entity, shared), mesh_uniform) in queue.drain(..) {
+        for (entity, shared, mesh_uniform) in queue.drain(..) {
             let buffer_index = current_input_buffer.push(mesh_uniform);
             let translation = vec3(
                 mesh_uniform.transform[0].w,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -740,13 +740,13 @@ pub fn extract_meshes_for_gpu_building(
     // Build the [`RenderMeshInstance`]s and [`MeshInputUniform`]s.
     render_mesh_instances.clear();
     for queue in render_mesh_instance_queues.iter_mut() {
-        for ((e, s), u) in queue.drain(..) {
+        for ((entity, shared), mesh_uniform) in queue.drain(..) {
             let buffer_index = current_input_buffer.push(u);
-            let translation = Vec3::new(u.transform[0].w, u.transform[1].w, u.transform[2].w);
+            let translation = mesh_uniform.transform.row(3).xyz();
             render_mesh_instances.insert_unique_unchecked(
-                e,
+                entity,
                 RenderMeshInstanceGpu {
-                    shared: s,
+                    shared,
                     translation,
                     current_uniform_index: NonMaxU32::new(buffer_index as u32).unwrap_or_default(),
                 },


### PR DESCRIPTION
# Objective

- clean up extract_mesh_(gpu/cpu)_building

## Solution

- gpu_building no need to hold  `prev_render_mesh_instances`
- using `insert_unique_unchecked` instead of simple insert as we know all entities are unique
- direcly get `previous_input_index ` in par_loop 


## Performance
this should also bring a slight performance win.

cargo run --release --example many_cubes --features bevy/trace_tracy -- --no-frustum-culling     
`extract_meshes_for_gpu_building`

![image](https://github.com/bevyengine/bevy/assets/45868716/a5425e8a-258b-482d-afda-170363ee6479)


