### PR TITLE
Fix Clippy lints on WASM

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -141,7 +141,7 @@ impl Plugin for ScheduleRunnerPlugin {
                         let g = f.clone();
 
                         let c = move || {
-                            let mut app = Rc::get_mut(&mut rc).unwrap();
+                            let app = Rc::get_mut(&mut rc).unwrap();
                             let delay = tick(app, wait);
                             if let Ok(delay) = delay {
                                 set_timeout(f.borrow().as_ref().unwrap(), delay.unwrap_or(asap));

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -143,11 +143,8 @@ impl Plugin for ScheduleRunnerPlugin {
                         let c = move || {
                             let mut app = Rc::get_mut(&mut rc).unwrap();
                             let delay = tick(&mut app, wait);
-                            match delay {
-                                Ok(delay) => {
-                                    set_timeout(f.borrow().as_ref().unwrap(), delay.unwrap_or(asap))
-                                }
-                                Err(_) => {}
+                            if let Ok(delay) = delay {
+                                set_timeout(f.borrow().as_ref().unwrap(), delay.unwrap_or(asap));
                             }
                         };
                         *g.borrow_mut() = Some(Closure::wrap(Box::new(c) as Box<dyn FnMut()>));

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -142,7 +142,7 @@ impl Plugin for ScheduleRunnerPlugin {
 
                         let c = move || {
                             let mut app = Rc::get_mut(&mut rc).unwrap();
-                            let delay = tick(&mut app, wait);
+                            let delay = tick(app, wait);
                             if let Ok(delay) = delay {
                                 set_timeout(f.borrow().as_ref().unwrap(), delay.unwrap_or(asap));
                             }

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -37,7 +37,7 @@ impl HttpWasmAssetReader {
     }
 }
 
-fn js_value_to_err<'a>(context: &'a str) -> impl FnOnce(JsValue) -> std::io::Error + 'a {
+fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> std::io::Error + '_ {
     move |value| {
         let message = match JSON::stringify(&value) {
             Ok(js_str) => format!("Failed to {context}: {js_str}"),

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -81,7 +81,7 @@ impl HttpWasmAssetReader {
                 Ok(reader)
             }
             404 => Err(AssetReaderError::NotFound(path)),
-            status => Err(AssetReaderError::HttpError(status as u16)),
+            status => Err(AssetReaderError::HttpError(status)),
         }
     }
 }

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -94,7 +94,7 @@ impl AssetReader for HttpWasmAssetReader {
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
         let meta_path = get_meta_path(&self.root_path.join(path));
-        Ok(self.fetch_bytes(meta_path).await?)
+        self.fetch_bytes(meta_path).await
     }
 
     async fn read_directory<'a>(

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -37,7 +37,7 @@ struct Position { x: f32, y: f32 }
 
 ### Worlds
 
-Entities, Components, and Resources are stored in a `World`. Worlds, much like Rust std collections like HashSet and Vec, expose operations to insert, read, write, and remove the data they store.
+Entities, Components, and Resources are stored in a `World`. Worlds, much like `std::collections`'s `HashSet` and `Vec`, expose operations to insert, read, write, and remove the data they store.
 
 ```rust
 use bevy_ecs::world::World;

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -79,7 +79,7 @@ impl ScreenshotManager {
 
                     #[cfg(target_arch = "wasm32")]
                     {
-                        match (|| {
+                        let save_screenshot = || {
                             use image::EncodableLayout;
                             use wasm_bindgen::{JsCast, JsValue};
 
@@ -107,7 +107,9 @@ impl ScreenshotManager {
                             html_element.click();
                             web_sys::Url::revoke_object_url(&url)?;
                             Ok::<(), JsValue>(())
-                        })() {
+                        };
+
+                        match (save_screenshot)() {
                             Ok(_) => info!("Screenshot saved to {}", path.display()),
                             Err(e) => error!("Cannot save screenshot, error: {e:?}"),
                         };

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -106,10 +106,12 @@ impl TaskPool {
         T: Send + 'static,
     {
         let executor = &async_executor::LocalExecutor::new();
+        // TODO: Safety comment
         let executor: &'env async_executor::LocalExecutor<'env> =
             unsafe { mem::transmute(executor) };
 
         let results: RefCell<Vec<Rc<RefCell<Option<T>>>>> = RefCell::new(Vec::new());
+        // TODO: Safety comment
         let results: &'env RefCell<Vec<Rc<RefCell<Option<T>>>>> =
             unsafe { mem::transmute(&results) };
 
@@ -120,6 +122,7 @@ impl TaskPool {
             env: PhantomData,
         };
 
+        // TODO: Safety comment
         let scope_ref: &'env mut Scope<'_, 'env, T> = unsafe { mem::transmute(&mut scope) };
 
         f(scope_ref);

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -105,13 +105,21 @@ impl TaskPool {
         F: for<'scope> FnOnce(&'env mut Scope<'scope, 'env, T>),
         T: Send + 'static,
     {
+        // SAFETY: This safety comment applies to all references transmuted to 'env.
+        // Any futures spawned with these references need to return before this function completes.
+        // This is guaranteed because we drive all the futures spawned onto the Scope
+        // to completion in this function. However, rust has no way of knowing this so we
+        // transmute the lifetimes to 'env here to appease the compiler as it is unable to validate safety.
+        // Any usages of the references passed into `Scope` must be accessed through
+        // the transmuted reference for the rest of this function.
+
         let executor = &async_executor::LocalExecutor::new();
-        // TODO: Safety comment
+        // SAFETY: As above, all futures must complete in this function so we can change the lifetime
         let executor: &'env async_executor::LocalExecutor<'env> =
             unsafe { mem::transmute(executor) };
 
         let results: RefCell<Vec<Rc<RefCell<Option<T>>>>> = RefCell::new(Vec::new());
-        // TODO: Safety comment
+        // SAFETY: As above, all futures must complete in this function so we can change the lifetime
         let results: &'env RefCell<Vec<Rc<RefCell<Option<T>>>>> =
             unsafe { mem::transmute(&results) };
 
@@ -122,7 +130,7 @@ impl TaskPool {
             env: PhantomData,
         };
 
-        // TODO: Safety comment
+        // SAFETY: As above, all futures must complete in this function so we can change the lifetime
         let scope_ref: &'env mut Scope<'_, 'env, T> = unsafe { mem::transmute(&mut scope) };
 
         f(scope_ref);

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::{cell::RefCell, future::Future, marker::PhantomData, mem, rc::Rc};
 
 thread_local! {
-    static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = async_executor::LocalExecutor::new();
+    static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = const { async_executor::LocalExecutor::new() };
 }
 
 /// Used to create a [`TaskPool`].

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -1,3 +1,3 @@
 # Bevy Transform
 
-This crate is largely a 1:1 port from [legion_transform](https://github.com/AThilenius/legion_transform) (ecs: legion, math: nalgebra) to bevy (ecs: bevy_ecs, math: glam)
+This crate is largely a 1:1 port from [legion_transform](https://github.com/AThilenius/legion_transform) (ecs: `legion`, math: `nalgebra`) to bevy (ecs: `bevy_ecs`, math: `glam`)

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -1,3 +1,3 @@
 # Bevy Transform
 
-This crate is largely a 1:1 port from [legion_transform](https://github.com/AThilenius/legion_transform) (ecs: `legion`, math: `nalgebra`) to bevy (ecs: `bevy_ecs`, math: `glam`)
+This crate contains types and functions associated with the `Transform` component.

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -293,7 +293,7 @@ pub(crate) fn changed_windows(
 
         #[cfg(target_arch = "wasm32")]
         if window.canvas != cache.window.canvas {
-            window.canvas = cache.window.canvas.clone();
+            window.canvas.clone_from(&cache.window.canvas);
             warn!(
                 "Bevy currently doesn't support modifying the window canvas after initialization."
             );

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -191,7 +191,7 @@ impl WinitWindows {
                 let window = web_sys::window().unwrap();
                 let document = window.document().unwrap();
                 let canvas = document
-                    .query_selector(&selector)
+                    .query_selector(selector)
                     .expect("Cannot query for canvas element.");
                 if let Some(canvas) = canvas {
                     let canvas = canvas.dyn_into::<web_sys::HtmlCanvasElement>().ok();


### PR DESCRIPTION
# Objective

- Fixes #13024.

## Solution

- Run `cargo clippy --target wasm32-unknown-unknown` until there are no more errors.
  - I recommend reviewing one commit at a time :)

---

## Changelog

- Fixed Clippy lints for `wasm32-unknown-unknown` target.
- Updated `bevy_transform`'s `README.md`.
