### PR TITLE
Remove unused nightly toolchain environmental variable

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
   build-for-iOS:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
   test:


### PR DESCRIPTION
# Objective

- Many of our CI workflows contain a `NIGHTLY_TOOLCHAIN` environmental variable.
- This specifies which nightly to use. If there is a bug in one of the nightlies, we can pin the toolchain to be an earlier version.
- Both the daily and weekly workflows do not use the nightly compiler, but still have a `NIGHTLY_TOOLCHAIN` variable.

## Solution

- Delete the unused variable.