### PR TITLE
Added `ButtonInput` docs usage example

### DIFF
--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -70,8 +70,10 @@ use bevy_ecs::schedule::State;
 /// ## Examples
 ///
 /// Reading and checking against the current set of pressed buttons:
-/// ```
-/// use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+/// ```no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
+/// # use bevy_ecs::{prelude::{IntoSystemConfigs, Res, Resource, resource_changed}, schedule::Condition};
+/// # use bevy_input::{ButtonInput, prelude::{GamepadButton, KeyCode, MouseButton}};
 ///
 /// fn main() {
 ///     App::new()
@@ -87,17 +89,6 @@ use bevy_ecs::schedule::State;
 ///         .add_systems(
 ///             Update,
 ///             print_keyboard.run_if(resource_changed::<ButtonInput<KeyCode>>),
-///         )
-///         .add_systems(
-///             Update,
-///             something_used.run_if(
-///                 input_just_pressed(KeyCode::KeyE)
-///                     .or_else(input_just_pressed(KeyCode::KeyE))
-///                     .or_else(input_just_pressed(GamepadButton::new(
-///                         Gamepad::new(0),
-///                         GamepadButtonType::West,
-///                     ))),
-///             ),
 ///         )
 ///         .run();
 /// }
@@ -122,11 +113,34 @@ use bevy_ecs::schedule::State;
 ///         println!("keyboard: {:?}", keyboard.get_pressed().collect::<Vec<_>>());
 ///     }
 /// }
+/// ```
+///
+/// Generic handling of a form of use-key:
+/// ```no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
+/// # use bevy_ecs::{prelude::IntoSystemConfigs, schedule::Condition};
+/// # use bevy_input::{ButtonInput, common_conditions::{input_just_pressed}, prelude::{GamepadButton, Gamepad, GamepadButtonType, KeyCode}};
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             something_used.run_if(
+///                 input_just_pressed(KeyCode::KeyE)
+///                     .or_else(input_just_pressed(KeyCode::KeyE))
+///                     .or_else(input_just_pressed(GamepadButton::new(
+///                         Gamepad::new(0),
+///                         GamepadButtonType::West,
+///                     ))),
+///             ),
+///         )
+///         .run();
+/// }
 ///
 /// fn something_used() {
 ///     println!("Generic use-ish button pressed.");
 /// }
-///
 /// ```
 ///
 /// ## Note

--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -67,6 +67,68 @@ use bevy_ecs::schedule::State;
 ///
 /// `ButtonInput<GamepadButton>` is independent of window focus.
 ///
+/// ## Examples
+/// 
+/// Reading and checking against the current set of pressed buttons:
+/// ```
+/// use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             print_gamepad.run_if(resource_changed::<ButtonInput<GamepadButton>>),
+///         )
+///         .add_systems(
+///             Update,
+///             print_mouse.run_if(resource_changed::<ButtonInput<MouseButton>>),
+///         )
+///         .add_systems(
+///             Update,
+///             print_keyboard.run_if(resource_changed::<ButtonInput<KeyCode>>),
+///         )
+///         .add_systems(
+///             Update,
+///             something_used.run_if(
+///                 input_just_pressed(KeyCode::KeyE)
+///                     .or_else(input_just_pressed(KeyCode::KeyE))
+///                     .or_else(input_just_pressed(GamepadButton::new(
+///                         Gamepad::new(0),
+///                         GamepadButtonType::West,
+///                     ))),
+///             ),
+///         )
+///         .run();
+/// }
+///
+/// fn print_gamepad(gamepad: Res<ButtonInput<GamepadButton>>) {
+///     println!("Gamepad: {:?}", gamepad.get_pressed().collect::<Vec<_>>());
+/// }
+///
+/// fn print_mouse(mouse: Res<ButtonInput<MouseButton>>) {
+///     println!("Mouse: {:?}", mouse.get_pressed().collect::<Vec<_>>());
+/// }
+///
+/// fn print_keyboard(keyboard: Res<ButtonInput<KeyCode>>) {
+///     if keyboard.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight])
+///         && keyboard.any_pressed([KeyCode::AltLeft, KeyCode::AltRight])
+///         && keyboard.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight])
+///         && keyboard.any_pressed([KeyCode::SuperLeft, KeyCode::SuperRight])
+///         && keyboard.pressed(KeyCode::KeyL)
+///     {
+///         println!("In Windows this opens linked-in.");
+///     } else {
+///         println!("keyboard: {:?}", keyboard.get_pressed().collect::<Vec<_>>());
+///     }
+/// }
+///
+/// fn something_used() {
+///     println!("Generic use-ish button pressed.");
+/// }
+///
+/// ```
+///
 /// ## Note
 ///
 /// When adding this resource for a new input type, you should:

--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -68,7 +68,7 @@ use bevy_ecs::schedule::State;
 /// `ButtonInput<GamepadButton>` is independent of window focus.
 ///
 /// ## Examples
-/// 
+///
 /// Reading and checking against the current set of pressed buttons:
 /// ```
 /// use bevy::{input::common_conditions::input_just_pressed, prelude::*};

--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -108,14 +108,14 @@ use bevy_ecs::schedule::State;
 ///         && keyboard.any_pressed([KeyCode::SuperLeft, KeyCode::SuperRight])
 ///         && keyboard.pressed(KeyCode::KeyL)
 ///     {
-///         println!("In Windows this opens linked-in.");
+///         println!("On Windows this opens LinkedIn.");
 ///     } else {
 ///         println!("keyboard: {:?}", keyboard.get_pressed().collect::<Vec<_>>());
 ///     }
 /// }
 /// ```
 ///
-/// Generic handling of a form of use-key:
+/// Accepting input from multiple devices:
 /// ```no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
 /// # use bevy_ecs::{prelude::IntoSystemConfigs, schedule::Condition};
@@ -128,7 +128,6 @@ use bevy_ecs::schedule::State;
 ///             Update,
 ///             something_used.run_if(
 ///                 input_just_pressed(KeyCode::KeyE)
-///                     .or_else(input_just_pressed(KeyCode::KeyE))
 ///                     .or_else(input_just_pressed(GamepadButton::new(
 ///                         Gamepad::new(0),
 ///                         GamepadButtonType::West,


### PR DESCRIPTION
# Objective

Fixes #12470

This adds a examples for `ButtonInput` with `KeyCode`, `MouseButton`, and `GamepadButton`.

It also includes an example of checking a multi-key combination, and checking multiple keys to mean roughly the same thing.
