### PR TITLE
ButtonInput docs - performance cost adjustment

### DIFF
--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -41,9 +41,9 @@ use bevy_ecs::schedule::State;
 ///
 /// | **[`ButtonInput`] operations**          | **Computational complexity** |
 /// |-----------------------------------|------------------------------------|
-/// | [`ButtonInput::any_just_pressed`]       | *O*(m*n)                     |
-/// | [`ButtonInput::any_just_released`]      | *O*(m*n)                     |
-/// | [`ButtonInput::any_pressed`]            | *O*(m*n)                     |
+/// | [`ButtonInput::any_just_pressed`]       | *O*(m)~                      |
+/// | [`ButtonInput::any_just_released`]      | *O*(m)~                      |
+/// | [`ButtonInput::any_pressed`]            | *O*(m)~                      |
 /// | [`ButtonInput::get_just_pressed`]       | *O*(n)                       |
 /// | [`ButtonInput::get_just_released`]      | *O*(n)                       |
 /// | [`ButtonInput::get_pressed`]            | *O*(n)                       |


### PR DESCRIPTION
Adjusted the documentation to better describe the performance cost of `ButtonInput::any_just_pressed|any_just_released|any_pressed`.

Each function iterates the full input, but each check is expected constant cost. It was described previously as a full input check, and a full internal list iteration, which I believe is incorrect.
