### PR TITLE
Allow `AssetServer::load` to acquire a guard item.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -357,6 +357,7 @@ futures-lite = "2.0.1"
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
 thiserror = "1.0"
+event-listener = "5.3.0"
 
 [[example]]
 name = "hello_world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1402,6 +1402,7 @@ description = "Demonstrates how to process and load custom assets"
 category = "Assets"
 wasm = false
 
+
 [[example]]
 name = "repeated_texture"
 path = "examples/asset/repeated_texture.rs"
@@ -1410,6 +1411,18 @@ doc-scrape-examples = true
 [package.metadata.example.repeated_texture]
 name = "Repeated texture configuration"
 description = "How to configure the texture to repeat instead of the default clamp to edges"
+category = "Assets"
+wasm = true
+
+# Assets
+[[example]]
+name = "multi_asset_sync"
+path = "examples/asset/multi_asset_sync.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.multi_asset_sync]
+name = "Mult-asset synchronization"
+description = "Demonstrates how to wait for multiple assets to be loaded."
 category = "Assets"
 wasm = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1403,7 +1403,6 @@ description = "Demonstrates how to process and load custom assets"
 category = "Assets"
 wasm = false
 
-
 [[example]]
 name = "repeated_texture"
 path = "examples/asset/repeated_texture.rs"

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -117,7 +117,7 @@ impl<'ctx, 'builder> NestedLoader<'ctx, 'builder> {
         let handle = if self.load_context.should_load_dependencies {
             self.load_context
                 .asset_server
-                .load_with_meta_transform(path, self.meta_transform)
+                .load_with_meta_transform(path, self.meta_transform, ())
         } else {
             self.load_context
                 .asset_server

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -345,7 +345,7 @@ impl AssetServer {
                     if let Err(err) = server.load_internal(owned_handle, path, false, None).await {
                         error!("{}", err);
                     }
-                    drop(acquires)
+                    drop(acquires);
                 })
                 .detach();
         }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -317,7 +317,11 @@ impl AssetServer {
         settings: impl Fn(&mut S) + Send + Sync + 'static,
         acquires: H,
     ) -> Handle<A> {
-        self.load_with_meta_transform(path, Some(loader_settings_meta_transform(settings)), acquires)
+        self.load_with_meta_transform(
+            path,
+            Some(loader_settings_meta_transform(settings)),
+            acquires,
+        )
     }
 
     fn load_with_meta_transform<'a, A: Asset, H: Send + Sync + 'static>(

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -323,7 +323,7 @@ impl AssetServer {
         self.load_with_meta_transform(path, Some(loader_settings_meta_transform(settings)), guard)
     }
 
-    fn load_with_meta_transform<'a, A: Asset, G: Send + Sync + 'static>(
+    pub(crate) fn load_with_meta_transform<'a, A: Asset, G: Send + Sync + 'static>(
         &self,
         path: impl Into<AssetPath<'a>>,
         meta_transform: Option<MetaTransform>,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -281,6 +281,8 @@ impl AssetServer {
     ///
     /// The guard item should notify the caller in its [`Drop`] implementation. See example `multi_asset_sync`.
     /// Synchronously this can be a [`Arc<AtomicU32>`] that decrements its counter, asynchronously this can be a `Barrier`.
+    /// This function only guarantees the asset referenced by the [`Handle`] is loaded. If your asset is separated into
+    /// multiple files, sub-assets referenced by the main asset might still be loading, depend on the implementation of the [`AssetLoader`].
     ///
     /// Additionally, you can check the asset's load state by reading [`AssetEvent`] events, calling [`AssetServer::load_state`], or checking
     /// the [`Assets`] storage to see if the [`Asset`] exists yet.
@@ -309,6 +311,9 @@ impl AssetServer {
 
     /// Begins loading an [`Asset`] of type `A` stored at `path` while holding a guard item.
     /// The guard item is dropped when either the asset is loaded or loading has failed.
+    ///
+    /// This function only guarantees the asset referenced by the [`Handle`] is loaded. If your asset is separated into
+    /// multiple files, sub-assets referenced by the main asset might still be loading, depend on the implementation of the [`AssetLoader`].
     ///
     /// The given `settings` function will override the asset's
     /// [`AssetLoader`] settings. The type `S` _must_ match the configured [`AssetLoader::Settings`] or `settings` changes

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -281,7 +281,7 @@ impl AssetServer {
     ///
     /// The guard item should notify the caller in its [`Drop`] implementation. See example `multi_asset_sync`.
     /// Synchronously this can be a [`Arc<AtomicU32>`] that decrements its counter, asynchronously this can be a `Barrier`.
-    /// 
+    ///
     /// Additionally, you can check the asset's load state by reading [`AssetEvent`] events, calling [`AssetServer::load_state`], or checking
     /// the [`Assets`] storage to see if the [`Asset`] exists yet.
     ///
@@ -320,11 +320,7 @@ impl AssetServer {
         settings: impl Fn(&mut S) + Send + Sync + 'static,
         guard: G,
     ) -> Handle<A> {
-        self.load_with_meta_transform(
-            path,
-            Some(loader_settings_meta_transform(settings)),
-            guard,
-        )
+        self.load_with_meta_transform(path, Some(loader_settings_meta_transform(settings)), guard)
     }
 
     fn load_with_meta_transform<'a, A: Asset, G: Send + Sync + 'static>(

--- a/examples/README.md
+++ b/examples/README.md
@@ -214,6 +214,7 @@ Example | Description
 [Embedded Asset](../examples/asset/embedded_asset.rs) | Embed an asset in the application binary and load it
 [Extra asset source](../examples/asset/extra_source.rs) | Load an asset from a non-standard asset source
 [Hot Reloading of Assets](../examples/asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk
+[Mult-asset synchronization](../examples/asset/multi_asset_sync.rs) | Demonstrates how to wait for multiple assets to be loaded.
 [Repeated texture configuration](../examples/asset/repeated_texture.rs) | How to configure the texture to repeat instead of the default clamp to edges
 
 ## Async Tasks

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -210,6 +210,7 @@ fn wait_on_load(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // If our barrier isn't ready, return early and wait another cycle
     if barrier.map(|b| b.is_ready()) != Some(true) {
         return;
     };

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -1,4 +1,4 @@
-//! This example illustrates various ways to load assets.
+//! This example illustrates how to wait for multiple assets to be loaded.
 
 use std::{
     f32::consts::PI,

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -268,7 +268,7 @@ fn wait_on_load(
 // This showcases how to wait for assets asynchronously.
 fn get_async_loading_state(
     state: Res<AsyncLoadingState>,
-    mut change_state: ResMut<NextState<LoadingState>>,
+    mut next_loading_state: ResMut<NextState<LoadingState>>,
     mut text: Query<&mut Text, With<LoadingText>>,
 ) {
     // Load the value written by the `Future`.
@@ -276,7 +276,7 @@ fn get_async_loading_state(
 
     // If loaded, change the state.
     if is_loaded {
-        change_state.set(LoadingState::Loaded);
+        next_loading_state.set(LoadingState::Loaded);
         if let Ok(mut text) = text.get_single_mut() {
             "Loaded!".clone_into(&mut text.sections[0].value);
         }

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -38,11 +38,8 @@ pub struct AssetBarrierInner {
     wakers: Mutex<Vec<Waker>>,
 }
 
-/// This is required to support both sync and async.
-///
-/// For sync only the easiest implementation is
-/// [`Arc<()>`] and use [`Arc::strong_count`] for completion.
-/// [`Arc<Atomic*>`] is a more robust alternative.
+/// Future for [`AssetBarrier`] completion.
+#[must_use = "`Future`s do nothing unless polled."]
 #[derive(Debug, Resource, Deref)]
 pub struct AssetBarrierFuture(Arc<AssetBarrierInner>);
 
@@ -138,6 +135,7 @@ fn setup(
     let loading_state = Arc::new(Mutex::new("Loading..".to_owned()));
     commands.insert_resource(AsyncLoadingState(loading_state.clone()));
 
+    // await the `AssetBarrierFuture`.
     AsyncComputeTaskPool::get()
         .spawn(async move {
             future.await;
@@ -229,7 +227,7 @@ fn wait_on_load(
     for i in 0..10 {
         for j in 0..10 {
             let index = i * 10 + j;
-            let position = Vec3::new(i as f32 - 5.0, 0.0, j as f32 - 5.0) * 1.0;
+            let position = Vec3::new(i as f32 - 5.0, 0.0, j as f32 - 5.0);
             // All gltfs must exist because this is guarded by the `AssetBarrier`.
             let gltf = gltfs.get(&foxes.0[index]).unwrap();
             let scene = gltf.scenes.first().unwrap().clone();

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -241,5 +241,9 @@ fn wait_on_load(
 }
 
 fn get_async_loading_state(state: Res<AsyncLoadingState>, mut text: Query<&mut Text>) {
-    state.0.lock().unwrap().clone_into(&mut text.single_mut().sections[0].value);
+    state
+        .0
+        .lock()
+        .unwrap()
+        .clone_into(&mut text.single_mut().sections[0].value);
 }

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -1,0 +1,247 @@
+//! This example illustrates various ways to load assets.
+
+use std::{
+    f32::consts::PI,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+    task::{Context, Poll, Waker},
+};
+
+use bevy::{gltf::Gltf, prelude::*, tasks::AsyncComputeTaskPool};
+use futures_lite::Future;
+
+/// Holds a bunch of [`Gltf`]s that takes time to load.
+#[derive(Debug, Resource)]
+pub struct OneHundredThings([Handle<Gltf>; 100]);
+
+/// This is required to support both sync and async.
+///
+/// For sync only the easiest implementation is
+/// [`Arc<()>`] and use [`Arc::strong_count`] for completion.
+/// [`Arc<Atomic*>`] is a more robust alternative.
+#[derive(Debug, Resource, Deref)]
+pub struct AssetBarrier(Arc<AssetBarrierInner>);
+
+/// This guard is to be acquired by [`AssetServer::load_acquire`]
+/// and dropped once finished.
+#[derive(Debug, Deref)]
+pub struct AssetBarrierGuard(Arc<AssetBarrierInner>);
+
+/// Tracks how many guards are remaining.
+#[derive(Debug, Resource)]
+pub struct AssetBarrierInner {
+    count: AtomicU32,
+    /// This is not optimal, preferably use `event_listener::Event`
+    wakers: Mutex<Vec<Waker>>,
+}
+
+/// This is required to support both sync and async.
+///
+/// For sync only the easiest implementation is
+/// [`Arc<()>`] and use [`Arc::strong_count`] for completion.
+/// [`Arc<Atomic*>`] is a more robust alternative.
+#[derive(Debug, Resource, Deref)]
+pub struct AssetBarrierFuture(Arc<AssetBarrierInner>);
+
+impl Future for AssetBarrierFuture {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.count.load(Ordering::Acquire) == 0 {
+            Poll::Ready(())
+        } else {
+            self.wakers.lock().unwrap().push(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+/// State of loading asynchronously.
+#[derive(Debug, Resource)]
+pub struct AsyncLoadingState(Arc<Mutex<String>>);
+
+/// Entities that are to be removed once loading finished
+#[derive(Debug, Component)]
+pub struct Loading;
+
+impl AssetBarrier {
+    /// Create an [`AssetBarrier`] with a [`AssetBarrierGuard`].
+    pub fn new() -> (AssetBarrier, AssetBarrierGuard) {
+        let inner = Arc::new(AssetBarrierInner {
+            count: AtomicU32::new(1),
+            wakers: Mutex::default(),
+        });
+        (AssetBarrier(inner.clone()), AssetBarrierGuard(inner))
+    }
+
+    /// Returns true if all [`AssetBarrierGuard`] is dropped.
+    pub fn is_ready(&self) -> bool {
+        self.count.load(Ordering::Acquire) == 0
+    }
+
+    /// Wait for all [`AssetBarrierGuard`]s to be dropped asynchronously.
+    pub fn wait_async(&self) -> AssetBarrierFuture {
+        AssetBarrierFuture(self.0.clone())
+    }
+}
+
+impl Clone for AssetBarrierGuard {
+    fn clone(&self) -> Self {
+        self.count.fetch_add(1, Ordering::AcqRel);
+        AssetBarrierGuard(self.0.clone())
+    }
+}
+
+impl Drop for AssetBarrierGuard {
+    fn drop(&mut self) {
+        let prev = self.count.fetch_sub(1, Ordering::AcqRel);
+        if prev == 1 {
+            self.wakers.lock().unwrap().drain(..).for_each(|w| w.wake());
+        }
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .insert_resource(AmbientLight {
+            color: Color::WHITE,
+            brightness: 2000.,
+        })
+        .add_systems(Startup, setup)
+        .add_systems(Update, wait_on_load)
+        .add_systems(Update, get_async_loading_state)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let (barrier, guard) = AssetBarrier::new();
+    commands.insert_resource(OneHundredThings(std::array::from_fn(|i| match i % 5 {
+        0 => asset_server.load_acquire("models/GolfBall/GolfBall.glb", guard.clone()),
+        1 => asset_server.load_acquire("models/AlienCake/alien.glb", guard.clone()),
+        2 => asset_server.load_acquire("models/AlienCake/cakeBirthday.glb", guard.clone()),
+        3 => asset_server.load_acquire("models/FlightHelmet/FlightHelmet.gltf", guard.clone()),
+        4 => asset_server.load_acquire("models/torus/torus.gltf", guard.clone()),
+        _ => unreachable!(),
+    })));
+    let future = barrier.wait_async();
+    commands.insert_resource(barrier);
+
+    let loading_state = Arc::new(Mutex::new("Loading..".to_owned()));
+    commands.insert_resource(AsyncLoadingState(loading_state.clone()));
+
+    AsyncComputeTaskPool::get()
+        .spawn(async move {
+            future.await;
+            *loading_state.lock().unwrap() = "Loading Complete!".to_owned();
+        })
+        .detach();
+
+    // Display the result of async loading.
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
+                justify_content: JustifyContent::End,
+
+                ..default()
+            },
+            ..default()
+        })
+        .with_children(|b| {
+            b.spawn(TextBundle {
+                text: Text {
+                    sections: vec![TextSection {
+                        value: "".to_owned(),
+                        style: TextStyle {
+                            font_size: 64.0,
+                            color: Color::BLACK,
+                            ..Default::default()
+                        },
+                    }],
+                    justify: JustifyText::Right,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        });
+
+    // Camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(10.0, 10.0, 15.0)
+            .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+        ..default()
+    });
+
+    // Light
+    commands.spawn(DirectionalLightBundle {
+        transform: Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
+        directional_light: DirectionalLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        ..default()
+    });
+
+    // Plane
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Plane3d::default().mesh().size(50000.0, 50000.0)),
+            material: materials.add(Color::srgb(0.7, 0.2, 0.2)),
+            ..default()
+        },
+        Loading,
+    ));
+}
+
+fn wait_on_load(
+    mut commands: Commands,
+    foxes: Res<OneHundredThings>,
+    barrier: Option<Res<AssetBarrier>>,
+    loading: Query<Entity, With<Loading>>,
+    gltfs: Res<Assets<Gltf>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    if barrier.map(|b| b.is_ready()) != Some(true) {
+        return;
+    };
+    commands.entity(loading.single()).despawn();
+    commands.remove_resource::<AssetBarrier>();
+    // Plane
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Plane3d::default().mesh().size(50000.0, 50000.0)),
+            material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
+            ..default()
+        },
+        Loading,
+    ));
+    for i in 0..10 {
+        for j in 0..10 {
+            let index = i * 10 + j;
+            let position = Vec3::new(i as f32 - 5.0, 0.0, j as f32 - 5.0) * 1.0;
+            // All gltfs must exist because this is guarded by the `AssetBarrier`.
+            let gltf = gltfs.get(&foxes.0[index]).unwrap();
+            let scene = gltf.scenes.first().unwrap().clone();
+            commands.spawn(SceneBundle {
+                scene,
+                transform: Transform::from_translation(position),
+                ..Default::default()
+            });
+        }
+    }
+}
+
+fn get_async_loading_state(state: Res<AsyncLoadingState>, mut text: Query<&mut Text>) {
+    text.single_mut().sections[0].value = state.0.lock().unwrap().clone();
+}

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -23,9 +23,11 @@ fn main() {
         .add_systems(Startup, setup_assets)
         .add_systems(Startup, setup_scene)
         .add_systems(Startup, setup_ui)
-        // This showcases how to wait for assets synchronously.
+        // This showcases how to wait for assets using sync code.
+        // This approach polls a value in a system.
         .add_systems(Update, wait_on_load.run_if(assets_loaded))
-        // This showcases how to wait for assets asynchronously.
+        // This showcases how to wait for assets using async
+        // by spawning a `Future` in `AsyncComputeTaskPool`.
         .add_systems(
             Update,
             get_async_loading_state.run_if(in_state(LoadingState::Loading)),
@@ -237,7 +239,7 @@ fn assets_loaded(barrier: Option<Res<AssetBarrier>>) -> bool {
     barrier.map(|b| b.is_ready()) == Some(true)
 }
 
-// This showcases how to wait for assets synchronously.
+// This showcases how to wait for assets using sync code and systems.
 //
 // This function only runs if `assets_loaded` returns true.
 fn wait_on_load(
@@ -272,7 +274,7 @@ fn wait_on_load(
     }
 }
 
-// This showcases how to wait for assets asynchronously.
+// This showcases how to wait for assets using async.
 fn get_async_loading_state(
     state: Res<AsyncLoadingState>,
     mut next_loading_state: ResMut<NextState<LoadingState>>,

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -139,7 +139,7 @@ fn setup(
     AsyncComputeTaskPool::get()
         .spawn(async move {
             future.await;
-            *loading_state.lock().unwrap() = "Loading Complete!".to_owned();
+            "Loading Complete!".clone_into(&mut loading_state.lock().unwrap());
         })
         .detach();
 
@@ -241,5 +241,5 @@ fn wait_on_load(
 }
 
 fn get_async_loading_state(state: Res<AsyncLoadingState>, mut text: Query<&mut Text>) {
-    text.single_mut().sections[0].value = state.0.lock().unwrap().clone();
+    state.0.lock().unwrap().clone_into(&mut text.single_mut().sections[0].value);
 }


### PR DESCRIPTION
# Objective

Supercedes #12881 . Added a simple implementation that allows the user to react to multiple asset loads both synchronously and asynchronously.

## Solution

Added `load_acquire`, that holds an item and drops it when loading is finished or failed.

When used synchronously 

Hold an `Arc<()>`, check for `Arc::strong_count() == 1` when all loading completed.

When used asynchronously 

Hold a `SemaphoreGuard`, await on `acquire_all` for completion.

This implementation has more freedom than the original in my opinion.

