### PR TITLE
Clarify comment about camera coordinate system

### DIFF
--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -122,7 +122,8 @@ fn create_cube_mesh() -> Mesh {
     Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD)
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_POSITION,
-        // Each array is an [x, y, z] coordinate in local space. Bevy uses a right-handed Y-up coordinate system.
+        // Each array is an [x, y, z] coordinate in local space.
+        // The camera coordinate space is right-handed x-right, y-up, z-back. This means "forward" is -Z.
         // Meshes always rotate around their local [0, 0, 0] when a rotation is applied to their Transform.
         // By centering our mesh around the origin, rotating the mesh preserves its center of mass.
         vec![


### PR DESCRIPTION
# Objective

Clarify the comment about the camera's coordinate system in `examples/3d/generate_custom_mesh.rs` by explicitly stating which axes point where.
Fixes #13018

## Solution

Copy the wording from #13012 into the example.
