### PR TITLE
Bump async-task

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -16,7 +16,7 @@ futures-lite = "2.0.1"
 async-executor = "1.7.2"
 async-channel = { version = "2.2.0", optional = true }
 async-io = { version = "2.0.0", optional = true }
-async-task = { version = "4.2.0", optional = true }
+async-task = { version = "4.7.0", optional = true }
 concurrent-queue = { version = "2.0.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Bumps `async-task` to 4.7.0 , note this is what Cargo.lock has as well.  Building as a dependency gives the following:

```
   Compiling async-channel v1.8.0
   Compiling futures-lite v1.12.0
error[E0432]: unresolved import `async_task::Builder`
  --> /Users/daniel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-executor-1.8.0/src/lib.rs:46:18
   |
46 | use async_task::{Builder, Runnable};
   |                  ^^^^^^^ no `Builder` in the root
   |
   = help: consider importing this struct instead:
           std::thread::Builder

For more information about this error, try `rustc --explain E0432`.
error: could not compile `async-executor` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

With this change, builds correctly