### PR TITLE
Additional doc aliases for `WindingOrder` in `bevy_math`

### DIFF
--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -17,13 +17,15 @@ pub trait Primitive3d {}
 
 /// The winding order for a set of points
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[doc(alias = "Orientation")]
 pub enum WindingOrder {
     /// A clockwise winding order
     Clockwise,
     /// A counterclockwise winding order
+    #[doc(alias = "AntiClockwise")]
     CounterClockwise,
     /// An invalid winding order indicating that it could not be computed reliably.
     /// This often happens in *degenerate cases* where the points lie on the same line
-    #[doc(alias = "Degenerate")]
+    #[doc(alias("Degenerate", "Collinear"))]
     Invalid,
 }


### PR DESCRIPTION
# Objective

Adds a few extra `#[doc(alias)]` entries to the `bevy_math::primitives::WindingOrder` enum and its variants to improve searchability.

## Solution

- Add "Orientation" for `WindingOrder` itself
- Add "AntiClockwise" for `CounterClockwise` variant
- Add "Collinear" for `Invalid` variant

These alternate terms seem to be quite common, especially in the contexts of rendering and collision-detection.