### PR TITLE
`Curve` implementation for cubic curves

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1,6 +1,5 @@
 //! Provides types for building cubic splines for rendering curves and use with animation easing.
 
-use std::clone;
 use std::{fmt::Debug, iter::once, marker::PhantomData};
 
 use crate::{Vec2, VectorSpace};

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -73,7 +73,10 @@ impl<P: VectorSpace> CubicGenerator<NoGuarantees, P> for CubicBezier<P> {
             .map(|p| CubicSegment::coefficients(*p, char_matrix))
             .collect();
 
-        CubicCurve { segments, _phantom: PhantomData }
+        CubicCurve {
+            segments,
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -146,7 +149,10 @@ impl<P: VectorSpace> CubicGenerator<C1, P> for CubicHermite<P> {
             })
             .collect();
 
-        CubicCurve { segments, _phantom: PhantomData }
+        CubicCurve {
+            segments,
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -216,7 +222,10 @@ impl<P: VectorSpace> CubicGenerator<C1, P> for CubicCardinalSpline<P> {
 
         // Early return to avoid accessing an invalid index
         if length < 2 {
-            return CubicCurve { segments: vec![], _phantom: PhantomData };
+            return CubicCurve {
+                segments: vec![],
+                _phantom: PhantomData,
+            };
         }
 
         // Extend the list of control points by mirroring the last second-to-last control points on each end;
@@ -236,7 +245,10 @@ impl<P: VectorSpace> CubicGenerator<C1, P> for CubicCardinalSpline<P> {
             .map(|p| CubicSegment::coefficients([*p[0], *p[1], *p[2], *p[3]], char_matrix))
             .collect();
 
-        CubicCurve { segments, _phantom: PhantomData }
+        CubicCurve {
+            segments,
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -300,7 +312,10 @@ impl<P: VectorSpace> CubicGenerator<C2, P> for CubicBSpline<P> {
             .map(|p| CubicSegment::coefficients([p[0], p[1], p[2], p[3]], char_matrix))
             .collect();
 
-        CubicCurve { segments, _phantom: PhantomData }
+        CubicCurve {
+            segments,
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -612,7 +627,10 @@ impl<P: VectorSpace> CubicGenerator<C0, P> for LinearSpline<P> {
                 }
             })
             .collect();
-        CubicCurve { segments, _phantom: PhantomData }
+        CubicCurve {
+            segments,
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -687,7 +705,7 @@ impl CubicSegment<Vec2> {
     pub fn new_bezier(p1: impl Into<Vec2>, p2: impl Into<Vec2>) -> Self {
         let (p0, p3) = (Vec2::ZERO, Vec2::ONE);
         let bezier = CubicBezier::new([[p0, p1.into(), p2.into(), p3]]).to_curve();
-        bezier.segments[0].clone()
+        bezier.segments[0]
     }
 
     /// Maximum allowable error for iterative Bezier solve
@@ -787,7 +805,7 @@ impl CubicSegment<Vec2> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CubicCurve<L: Smoothness, P: VectorSpace> {
     segments: Vec<CubicSegment<P>>,
-    _phantom: PhantomData<L>
+    _phantom: PhantomData<L>,
 }
 
 impl<L: Smoothness, P: VectorSpace> CubicCurve<L, P> {
@@ -1393,21 +1411,21 @@ mod tests {
 pub trait Smoothness {}
 
 /// Marker type for curves with no global continuity guarantees.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct NoGuarantees {}
 
 /// Marker type for curves with global continuity.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct C0 {}
 
 /// Marker type for curves with global differentiability and continuity of derivatives in addition
 /// to ordinary continuity.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct C1 {}
 
-/// Marker type for curves with continuous global second derivatives in addition to first 
-/// derivatives and ordinary continuity. 
-#[derive(Clone, Copy)]
+/// Marker type for curves with continuous global second derivatives in addition to first
+/// derivatives and ordinary continuity.
+#[derive(Clone, Copy, Debug)]
 pub struct C2 {}
 
 impl Smoothness for NoGuarantees {}
@@ -1472,7 +1490,7 @@ pub trait ToC0Curve<P: VectorSpace> {
     fn to_curve_c0(&self) -> Self::CurveType;
 }
 
-/// A trait for a type that can be turned into a curve which is continuous and also has 
+/// A trait for a type that can be turned into a curve which is continuous and also has
 /// continuous derivatives.
 pub trait ToC1Curve<P: VectorSpace> {
     /// The type of the curve.
@@ -1493,8 +1511,8 @@ pub trait ToC2Curve<P: VectorSpace> {
 }
 
 /// A wrapper struct which actually implements the [`Curve`] trait associated to its level.
-/// Here, the `Smoothness` parameter is actually precise; a `CubicCurveWrapper` with a 
-/// `Smoothness` of `C2` does not access the `C0` data, for example. 
+/// Here, the `Smoothness` parameter is actually precise; a `CubicCurveWrapper` with a
+/// `Smoothness` of `C2` does not access the `C0` data, for example.
 pub struct CubicCurveWrapper<L, P>
 where
     L: Smoothness,
@@ -1505,9 +1523,7 @@ where
 
 impl<L: Smoothness, P: VectorSpace> From<CubicCurve<L, P>> for CubicCurveWrapper<L, P> {
     fn from(value: CubicCurve<L, P>) -> Self {
-        Self {
-            inner: value
-        }
+        Self { inner: value }
     }
 }
 
@@ -1518,7 +1534,9 @@ impl<P: VectorSpace> Curve<C0Data<P>> for CubicCurveWrapper<C0, P> {
     }
 
     fn sample(&self, t: f32) -> C0Data<P> {
-        C0Data { position: self.inner.position(t) }
+        C0Data {
+            position: self.inner.position(t),
+        }
     }
 }
 
@@ -1529,7 +1547,7 @@ impl<P: VectorSpace> Curve<C1Data<P>> for CubicCurveWrapper<C1, P> {
     }
 
     fn sample(&self, t: f32) -> C1Data<P> {
-        C1Data { 
+        C1Data {
             position: self.inner.position(t),
             velocity: self.inner.velocity(t),
         }
@@ -1543,7 +1561,7 @@ impl<P: VectorSpace> Curve<C2Data<P>> for CubicCurveWrapper<C2, P> {
     }
 
     fn sample(&self, t: f32) -> C2Data<P> {
-        C2Data { 
+        C2Data {
             position: self.inner.position(t),
             velocity: self.inner.velocity(t),
             acceleration: self.inner.acceleration(t),
@@ -1576,8 +1594,8 @@ impl<P: VectorSpace> ToC2Curve<P> for CubicCurve<C2, P> {
 }
 
 /// A wrapper struct that actually implements the [`Curve`] trait associated to its level.
-/// Here, the `Smoothness` parameter is actually precise; a `CubicSegmentWrapper` with a 
-/// `Smoothness` of `C2` does not access the `C0` data, for example. 
+/// Here, the `Smoothness` parameter is actually precise; a `CubicSegmentWrapper` with a
+/// `Smoothness` of `C2` does not access the `C0` data, for example.
 pub struct CubicSegmentWrapper<L: Smoothness, P: VectorSpace> {
     inner: CubicSegment<P>,
     _phantom: PhantomData<L>,
@@ -1589,7 +1607,9 @@ impl<P: VectorSpace> Curve<C0Data<P>> for CubicSegmentWrapper<C0, P> {
     }
 
     fn sample(&self, t: f32) -> C0Data<P> {
-        C0Data { position: self.inner.position(t) }
+        C0Data {
+            position: self.inner.position(t),
+        }
     }
 }
 
@@ -1680,13 +1700,13 @@ pub trait BlessC2<P: VectorSpace> {
     fn bless_c2(self) -> Self::UpgradedCurve;
 }
 
-/// A trait for a curve type that can be explicitly demoted. 
+/// A trait for a curve type that can be explicitly demoted.
 pub trait Downgrade {
     /// The type that this will be changed to when downgraded.
     type DowngradedCurve;
     /// Downgrade this curve to one without any guarantees for its smoothness, allowing direct
     /// manipulation of curve segments but disallowing formation of global [`Curve`] data.
-    /// 
+    ///
     /// One of the `bless` functions must be called in order to restore access.
     fn downgrade(self) -> Self::DowngradedCurve;
 }
@@ -1725,12 +1745,15 @@ impl WorseThanC2 for C1 {}
 
 impl<L: Smoothness, P: VectorSpace> CubicCurve<L, P> {
     fn transmute_smoothness<S: Smoothness>(self) -> CubicCurve<S, P> {
-        CubicCurve { segments: self.segments, _phantom: PhantomData }
+        CubicCurve {
+            segments: self.segments,
+            _phantom: PhantomData,
+        }
     }
 }
 
 impl<L, P> BlessC0<P> for CubicCurve<L, P>
-where 
+where
     L: WorseThanC0,
     P: VectorSpace,
 {
@@ -1762,7 +1785,7 @@ where
     }
 }
 
-impl<L, P> Downgrade for CubicCurve<L, P> 
+impl<L, P> Downgrade for CubicCurve<L, P>
 where
     L: AtLeastC0,
     P: VectorSpace,

--- a/crates/bevy_math/src/curve.rs
+++ b/crates/bevy_math/src/curve.rs
@@ -1,0 +1,662 @@
+//! Houses the [`Curve`] trait together with the [`Interpolable`] trait that it depends on.
+
+use std::{cmp::max, marker::PhantomData};
+use crate::Quat;
+// use serde::{de::DeserializeOwned, Serialize};
+
+use crate::VectorSpace;
+
+/// A trait for types whose values can be intermediately interpolated between two given values
+/// with an auxiliary parameter.
+pub trait Interpolable: Clone {
+    /// Interpolate between this value and the `other` given value using the parameter `t`.
+    /// Note that the parameter `t` is not necessarily clamped to lie between `0` and `1`.
+    fn interpolate(&self, other: &Self, t: f32) -> Self;
+}
+
+impl<S, T> Interpolable for (S, T)
+where
+    S: Interpolable,
+    T: Interpolable,
+{
+    fn interpolate(&self, other: &Self, t: f32) -> Self {
+        (
+            self.0.interpolate(&other.0, t),
+            self.1.interpolate(&other.1, t),
+        )
+    }
+}
+
+impl<T> Interpolable for T
+where
+    T: VectorSpace,
+{
+    fn interpolate(&self, other: &Self, t: f32) -> Self {
+        self.lerp(*other, t)
+    }
+}
+
+impl Interpolable for Quat {
+    fn interpolate(&self, other: &Self, t: f32) -> Self {
+        self.slerp(*other, t)
+    }
+}
+
+
+/// A trait for a type that can represent values of type `T` parametrized over a fixed interval.
+/// Typical examples of this are actual geometric curves where `T: VectorSpace`, but other kinds
+/// of interpolable data can be represented instead (or in addition).
+pub trait Curve<T>
+where
+    T: Interpolable,
+{
+    /// The point at which parameter values of this curve end. That is, this curve is parametrized
+    /// on the interval `[0, self.duration()]`.
+    fn duration(&self) -> f32;
+
+    /// Sample a point on this curve at the parameter value `t`, extracting the associated value.
+    fn sample(&self, t: f32) -> T;
+
+    /// Resample this [`Curve`] to produce a new one that is defined by interpolation over equally
+    /// spaced values. A total of `samples` samples are used.
+    ///
+    /// Panics if `samples == 0`.
+    fn resample(&self, samples: usize) -> SampleCurve<T> {
+        assert!(samples != 0);
+
+        // When `samples` is 1, we just record the starting point, and `step` doesn't matter.
+        let subdivisions = max(1, samples - 1);
+        let step = self.duration() / subdivisions as f32;
+        let samples: Vec<T> = (0..samples).map(|s| self.sample(s as f32 * step)).collect();
+        SampleCurve {
+            duration: self.duration(),
+            samples,
+        }
+    }
+
+    /// Resample this [`Curve`] to produce a new one that is defined by interpolation over samples
+    /// taken at the given set of times. The given `sample_times` are expected to be strictly
+    /// increasing and nonempty.
+    fn resample_uneven(&self, sample_times: impl IntoIterator<Item = f32>) -> UnevenSampleCurve<T> {
+        let mut iter = sample_times.into_iter();
+        let Some(first) = iter.next() else {
+            panic!("Empty iterator supplied")
+        };
+        // Offset by the first element so that we get a curve starting at zero.
+        let first_sample = self.sample(first);
+        let mut timed_samples = vec![(0.0, first_sample)];
+        timed_samples.extend(iter.map(|t| (t - first, self.sample(t))));
+        UnevenSampleCurve { timed_samples }
+    }
+
+    /// Create a new curve by mapping the values of this curve via a function `f`; i.e., if the
+    /// sample at time `t` for this curve is `x`, the value at time `t` on the new curve will be
+    /// `f(x)`.
+    fn map<S>(self, f: impl Fn(T) -> S) -> impl Curve<S>
+    where
+        Self: Sized,
+        S: Interpolable,
+    {
+        MapCurve {
+            preimage: self,
+            f,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Create a new [`Curve`] whose parameter space is related to the parameter space of this curve
+    /// by `f`. For each time `t`, the sample from the new curve at time `t` is the sample from
+    /// this curve at time `f(t)`. The given `duration` will be the duration of the new curve. The
+    /// function `f` is expected to take `[0, duration]` into `[0, self.duration]`.
+    ///
+    /// Note that this is the opposite of what one might expect intuitively; for example, if this
+    /// curve has a parameter interval of `[0, 1]`, then linearly mapping the parameter domain to
+    /// `[0, 2]` would be performed as follows, dividing by what might be perceived as the scaling
+    /// factor rather than multiplying:
+    /// ```
+    /// # use bevy_math::curve::*;
+    /// # let my_curve = constant_curve(1.0, 1.0);
+    /// let dur = my_curve.duration();
+    /// let scaled_curve = my_curve.reparametrize(dur * 2.0, |t| t / 2.0);
+    /// ```
+    /// This kind of linear remapping is provided by the convenience method
+    /// [`Curve::reparametrize_linear`], which requires only the desired duration for the new curve.
+    ///
+    /// # Examples
+    /// ```
+    /// // Reverse a curve:
+    /// # use bevy_math::curve::*;
+    /// # use bevy_math::vec2;
+    /// # let my_curve = constant_curve(1.0, 1.0);
+    /// let dur = my_curve.duration();
+    /// let reversed_curve = my_curve.reparametrize(dur, |t| dur - t);
+    ///
+    /// // Take a segment of a curve:
+    /// # let my_curve = constant_curve(1.0, 1.0);
+    /// let curve_segment = my_curve.reparametrize(0.5, |t| 0.5 + t);
+    ///
+    /// // Reparametrize by an easing curve:
+    /// # let my_curve = constant_curve(1.0, 1.0);
+    /// # let easing_curve = constant_curve(1.0, vec2(1.0, 1.0));
+    /// let dur = my_curve.duration();
+    /// let eased_curve = my_curve.reparametrize(dur, |t| easing_curve.sample(t).y);
+    /// ```
+    ///
+    /// # Panics
+    /// Panics if `duration` is not greater than `0.0`.
+    fn reparametrize(self, duration: f32, f: impl Fn(f32) -> f32) -> impl Curve<T>
+    where
+        Self: Sized,
+    {
+        assert!(duration > 0.0);
+        ReparamCurve {
+            duration,
+            base: self,
+            f,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Linearly reparametrize this [`Curve`], producing a new curve whose duration is the given
+    /// `duration` instead of the current one.
+    fn reparametrize_linear(self, duration: f32) -> impl Curve<T>
+    where
+        Self: Sized,
+    {
+        assert!(duration > 0.0);
+        let old_duration = self.duration();
+        Curve::reparametrize(self, duration, move |t| t * (old_duration / duration))
+    }
+
+    /// Reparametrize this [`Curve`] by sampling from another curve.
+    fn reparametrize_by_curve(self, other: &impl Curve<f32>) -> impl Curve<T>
+    where
+        Self: Sized,
+    {
+        self.reparametrize(other.duration(), |t| other.sample(t))
+    }
+
+    /// Create a new [`Curve`] which is the graph of this one; that is, its output includes the
+    /// parameter itself in the samples. For example, if this curve outputs `x` at time `t`, then
+    /// the produced curve will produce `(t, x)` at time `t`.
+    fn graph(self) -> impl Curve<(f32, T)>
+    where
+        Self: Sized,
+    {
+        GraphCurve {
+            base: self,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Create a new [`Curve`] by joining this curve together with another. The sample at time `t`
+    /// in the new curve is `(x, y)`, where `x` is the sample of `self` at time `t` and `y` is the
+    /// sample of `other` at time `t`. The duration of the new curve is the smaller of the two
+    /// between `self` and `other`.
+    fn and<S, C>(self, other: C) -> impl Curve<(T, S)>
+    where
+        Self: Sized,
+        S: Interpolable,
+        C: Curve<S> + Sized,
+    {
+        ProductCurve {
+            first: self,
+            second: other,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// A [`Curve`] which takes a constant value over its duration.
+pub struct ConstantCurve<T>
+where
+    T: Interpolable,
+{
+    duration: f32,
+    value: T,
+}
+
+impl<T> Curve<T> for ConstantCurve<T>
+where
+    T: Interpolable,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.duration
+    }
+
+    #[inline]
+    fn sample(&self, _t: f32) -> T {
+        self.value.clone()
+    }
+}
+
+/// A [`Curve`] defined by a function.
+pub struct FunctionCurve<T, F> 
+where
+    T: Interpolable,
+    F: Fn(f32) -> T,
+{
+    duration: f32,
+    f: F,
+}
+
+impl<T, F> Curve<T> for FunctionCurve<T, F> 
+where
+    T: Interpolable,
+    F: Fn(f32) -> T,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.duration
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> T {
+        (self.f)(t)
+    }
+}
+
+/// A [`Curve`] that is defined by neighbor interpolation over a set of samples.
+pub struct SampleCurve<T>
+where
+    T: Interpolable,
+{
+    duration: f32,
+
+    /// The list of samples that define this curve by interpolation.
+    pub samples: Vec<T>,
+}
+
+impl<T> SampleCurve<T>
+where
+    T: Interpolable,
+{
+    /// Like [`Curve::map`], but with a concrete return type.
+    pub fn map_concrete<S>(self, f: impl Fn(T) -> S) -> SampleCurve<S>
+    where
+        S: Interpolable,
+    {
+        let new_samples: Vec<S> = self.samples.into_iter().map(f).collect();
+        SampleCurve {
+            duration: self.duration,
+            samples: new_samples,
+        }
+    }
+
+    /// Like [`Curve::graph`], but with a concrete return type.
+    pub fn graph_concrete(self) -> SampleCurve<(f32, T)> {
+        let subdivisions = max(1, self.samples.len() - 1);
+        let step = self.duration() / subdivisions as f32;
+        let times: Vec<f32> = (0..self.samples.len()).map(|s| s as f32 * step).collect();
+        let new_samples: Vec<(f32, T)> = times.into_iter().zip(self.samples).collect();
+        SampleCurve {
+            duration: self.duration,
+            samples: new_samples,
+        }
+    }
+}
+
+impl<T> Curve<T> for SampleCurve<T>
+where
+    T: Interpolable,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.duration
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> T {
+        let num_samples = self.samples.len();
+        // If there is only one sample, then we return the single sample point. We also clamp `t`
+        // to `[0, self.duration]` here.
+        if num_samples == 1 || t <= 0.0 {
+            return self.samples[0].clone();
+        }
+        if t >= self.duration {
+            return self.samples[self.samples.len() - 1].clone();
+        }
+
+        // Inside the curve itself, interpolate between the two nearest sample values.
+        let subdivs = num_samples - 1;
+        let step = self.duration / subdivs as f32;
+        let lower_index = (t / step).floor() as usize;
+        let upper_index = (t / step).ceil() as usize;
+        let f = (t / step).fract();
+        self.samples[lower_index].interpolate(&self.samples[upper_index], f)
+    }
+
+    fn map<S>(self, f: impl Fn(T) -> S) -> impl Curve<S>
+    where
+        Self: Sized,
+        S: Interpolable,
+    {
+        self.map_concrete(f)
+    }
+
+    fn graph(self) -> impl Curve<(f32, T)>
+    where
+        Self: Sized,
+    {
+        self.graph_concrete()
+    }
+}
+
+/// A [`Curve`] that is defined by interpolation over unevenly spaced samples.
+pub struct UnevenSampleCurve<T>
+where
+    T: Interpolable,
+{
+    timed_samples: Vec<(f32, T)>,
+}
+
+impl<T> UnevenSampleCurve<T>
+where
+    T: Interpolable,
+{
+    /// Like [`Curve::map`], but with a concrete return type..
+    pub fn map_concrete<S>(self, f: impl Fn(T) -> S) -> UnevenSampleCurve<S>
+    where
+        S: Interpolable,
+    {
+        let new_samples: Vec<(f32, S)> = self
+            .timed_samples
+            .into_iter()
+            .map(|(t, x)| (t, f(x)))
+            .collect();
+        UnevenSampleCurve {
+            timed_samples: new_samples,
+        }
+    }
+
+    /// Like [`Curve::graph`], but with a concrete return type.
+    pub fn graph_concrete(self) -> UnevenSampleCurve<(f32, T)> {
+        let new_samples: Vec<(f32, (f32, T))> = self
+            .timed_samples
+            .into_iter()
+            .map(|(t, x)| (t, (t, x)))
+            .collect();
+        UnevenSampleCurve {
+            timed_samples: new_samples,
+        }
+    }
+}
+
+impl<T> Curve<T> for UnevenSampleCurve<T>
+where
+    T: Interpolable,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.timed_samples.last().unwrap().0
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> T {
+        match self
+            .timed_samples
+            .binary_search_by(|(pt, _)| pt.partial_cmp(&t).unwrap())
+        {
+            Ok(index) => self.timed_samples[index].1.clone(),
+            Err(index) => {
+                if index == 0 {
+                    self.timed_samples.first().unwrap().1.clone()
+                } else if index == self.timed_samples.len() {
+                    self.timed_samples.last().unwrap().1.clone()
+                } else {
+                    let (t_lower, v_lower) = self.timed_samples.get(index - 1).unwrap();
+                    let (t_upper, v_upper) = self.timed_samples.get(index).unwrap();
+                    let s = (t - t_lower) / (t_upper - t_lower);
+                    v_lower.interpolate(v_upper, s)
+                }
+            }
+        }
+    }
+
+    fn map<S>(self, f: impl Fn(T) -> S) -> impl Curve<S>
+    where
+        Self: Sized,
+        S: Interpolable,
+    {
+        self.map_concrete(f)
+    }
+
+    fn graph(self) -> impl Curve<(f32, T)>
+    where
+        Self: Sized,
+    {
+        self.graph_concrete()
+    }
+}
+
+/// A [`Curve`] whose samples are defined by mapping samples from another curve through a
+/// given function.
+pub struct MapCurve<S, T, C, F>
+where
+    S: Interpolable,
+    T: Interpolable,
+    C: Curve<S>,
+    F: Fn(S) -> T,
+{
+    preimage: C,
+    f: F,
+    _phantom: PhantomData<(S, T)>,
+}
+
+impl<S, T, C, F> Curve<T> for MapCurve<S, T, C, F>
+where
+    S: Interpolable,
+    T: Interpolable,
+    C: Curve<S>,
+    F: Fn(S) -> T,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.preimage.duration()
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> T {
+        (self.f)(self.preimage.sample(t))
+    }
+}
+
+/// A [`Curve`] whose sample space is mapped onto that of some base curve's before sampling.
+pub struct ReparamCurve<T, C, F>
+where
+    T: Interpolable,
+    C: Curve<T>,
+    F: Fn(f32) -> f32,
+{
+    duration: f32,
+    base: C,
+    f: F,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, C, F> Curve<T> for ReparamCurve<T, C, F>
+where
+    T: Interpolable,
+    C: Curve<T>,
+    F: Fn(f32) -> f32,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.duration
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> T {
+        self.base.sample((self.f)(t))
+    }
+}
+
+/// A [`Curve`] that is the graph of another curve over its parameter space.
+pub struct GraphCurve<T, C>
+where
+    T: Interpolable,
+    C: Curve<T>,
+{
+    base: C,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, C> Curve<(f32, T)> for GraphCurve<T, C>
+where
+    T: Interpolable,
+    C: Curve<T>,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        self.base.duration()
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> (f32, T) {
+        (t, self.base.sample(t))
+    }
+}
+
+/// A [`Curve`] that combines the data from two constituent curves into a tuple output type.
+pub struct ProductCurve<S, T, C, D>
+where
+    S: Interpolable,
+    T: Interpolable,
+    C: Curve<S>,
+    D: Curve<T>,
+{
+    first: C,
+    second: D,
+    _phantom: PhantomData<(S, T)>,
+}
+
+impl<S, T, C, D> Curve<(S, T)> for ProductCurve<S, T, C, D>
+where
+    S: Interpolable,
+    T: Interpolable,
+    C: Curve<S>,
+    D: Curve<T>,
+{
+    #[inline]
+    fn duration(&self) -> f32 {
+        f32::min(self.first.duration(), self.second.duration())
+    }
+
+    #[inline]
+    fn sample(&self, t: f32) -> (S, T) {
+        (self.first.sample(t), self.second.sample(t))
+    }
+}
+
+// Experimental stuff:
+
+// TODO: See how much this needs to be extended / whether it's actually useful.
+// The actual point here is to give access to additional trait constraints that are
+// satisfied by the output, but not guaranteed depending on the actual data
+// that underpins the invoking implementation.
+
+// pub trait MapConcreteCurve<T>: Curve<T> + Serialize + DeserializeOwned
+// where T: Interpolable {
+//     fn map_concrete<S>(self, f: impl Fn(T) -> S) -> impl MapConcreteCurve<S>
+//     where S: Interpolable;
+// }
+
+// Library functions:
+
+/// Create a [`Curve`] that constantly takes the given `value` over the given `duration`.
+pub fn constant_curve<T: Interpolable>(duration: f32, value: T) -> impl Curve<T> {
+    ConstantCurve { duration, value }
+}
+
+/// Convert the given function `f` into a [`Curve`] with the given `duration`, sampled by
+/// evaluating the function.
+pub fn function_curve<T, F>(duration: f32, f: F) -> impl Curve<T>
+where 
+    T: Interpolable,
+    F: Fn(f32) -> T,
+{
+    FunctionCurve { duration, f }
+}
+
+/// Flip a curve that outputs tuples so that the tuples are arranged the other way.
+pub fn flip<S, T>(curve: impl Curve<(S, T)>) -> impl Curve<(T, S)>
+where
+    S: Interpolable,
+    T: Interpolable,
+{
+    curve.map(|(s, t)| (t, s))
+}
+
+/// An error indicating that the implicit function theorem algorithm failed to apply because
+/// the input curve did not meet its criteria.
+pub struct IftError;
+
+/// Given a monotone `curve`, produces the curve that it is the graph of, up to reparametrization.
+/// This is an algorithmic manifestation of the implicit function theorem; it is a numerical
+/// procedure which is only performed to the specified resolutions.
+///
+/// The `search_resolution` dictates how many samples are taken of the input curve; linear
+/// interpolation is used between these samples to estimate the inverse image.
+///
+/// The `outgoing_resolution` dictates the number of samples that are used in the construction of
+/// the output itself.
+///
+/// The input curve must have its first x-value be `0` or an error will be returned. Furthermore,
+/// if the curve is non-monotone, the output of this function may be nonsensical even if an error
+/// does not occur.
+pub fn ift<T>(
+    curve: &impl Curve<(f32, T)>,
+    search_resolution: usize,
+    outgoing_resolution: usize,
+) -> Result<SampleCurve<T>, IftError>
+where
+    T: Interpolable,
+{
+    // The duration of the output curve is the maximum x-value of the input curve.
+    let (duration, _) = curve.sample(curve.duration());
+    let discrete_curve = curve.resample(search_resolution);
+
+    let subdivisions = max(1, outgoing_resolution - 1);
+    let step = duration / subdivisions as f32;
+    let times: Vec<f32> = (0..outgoing_resolution).map(|s| s as f32 * step).collect();
+
+    let mut values: Vec<T> = vec![];
+    for t in times {
+        // Find a value on the curve where the x-value is close to `t`.
+        match discrete_curve
+            .samples
+            .binary_search_by(|(x, _y)| x.partial_cmp(&t).unwrap())
+        {
+            // We found an exact match in our samples (pretty unlikely).
+            Ok(index) => {
+                let y = discrete_curve.samples[index].1.clone();
+                values.push(y);
+            }
+
+            // We did not find an exact match, so we must interpolate.
+            Err(index) => {
+                // The value should be between `index - 1` and `index`.
+                // If `index` is the sample length or 0, then something went wrong; `t` is outside
+                // of the range of the function projection.
+                if index == 0 || index == search_resolution {
+                    return Err(IftError);
+                } else {
+                    let (t_lower, y_lower) = discrete_curve.samples.get(index - 1).unwrap();
+                    let (t_upper, y_upper) = discrete_curve.samples.get(index).unwrap();
+                    if t_lower >= t_upper {
+                        return Err(IftError);
+                    }
+                    // Inverse lerp on projected values to interpolate the y-value.
+                    let s = (t - t_lower) / (t_upper - t_lower);
+                    let value = y_lower.interpolate(y_upper, s);
+                    values.push(value);
+                }
+            }
+        }
+    }
+    Ok(SampleCurve {
+        duration,
+        samples: values,
+    })
+}

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -16,6 +16,7 @@ mod aspect_ratio;
 pub mod bounding;
 mod common_traits;
 pub mod cubic_splines;
+pub mod curve;
 mod direction;
 mod float_ord;
 pub mod primitives;

--- a/examples/animation/color_animation.rs
+++ b/examples/animation/color_animation.rs
@@ -1,6 +1,9 @@
 //! Demonstrates how to animate colors in different color spaces using mixing and splines.
 
-use bevy::{math::VectorSpace, prelude::*};
+use bevy::{
+    math::{cubic_splines::NoGuarantees, VectorSpace},
+    prelude::*,
+};
 
 // We define this trait so we can reuse the same code for multiple color types that may be implemented using curves.
 trait CurveColor: VectorSpace + Into<Color> + Send + Sync + 'static {}
@@ -11,7 +14,7 @@ trait MixedColor: Mix + Into<Color> + Send + Sync + 'static {}
 impl<T: Mix + Into<Color> + Send + Sync + 'static> MixedColor for T {}
 
 #[derive(Debug, Component)]
-struct Curve<T: CurveColor>(CubicCurve<T>);
+struct Curve<T: CurveColor>(CubicCurve<NoGuarantees, T>);
 
 #[derive(Debug, Component)]
 struct Mixed<T: MixedColor>([T; 4]);

--- a/examples/animation/cubic_curve.rs
+++ b/examples/animation/cubic_curve.rs
@@ -2,12 +2,12 @@
 
 use bevy::{
     color::palettes::css::{ORANGE, SILVER, WHITE},
-    math::vec3,
+    math::{cubic_splines::NoGuarantees, vec3},
     prelude::*,
 };
 
 #[derive(Component)]
-struct Curve(CubicCurve<Vec3>);
+struct Curve(CubicCurve<NoGuarantees, Vec3>);
 
 fn main() {
     App::new()


### PR DESCRIPTION
This is an in-progress prototype implementation of `Curve` for the geometric curves created in `bevy_math`. Everything here is subject to heavy renaming; I just wanted to get something functional up and running. Notably, this design presently excludes NURBS curves, which is a whole new bag of worms. 

# Objective

Add support for returning data in the form of a `Curve` (in the sense of the [curve-trait RFC](https://github.com/bevyengine/rfcs/pull/80)) to the `bevy_math` cubic curves. 

The output data of these curves is somewhat stratified. For example, the output of the `CubicBezier` builder has very few guarantees on its output compared to `CubicBSpline`; in the first case, it doesn't make too much sense to ask about derivatives globally, in general (since there is no reason for them to match up between segments), whereas in the latter, one always has globally valid first and second derivatives. The aim is for the API to reflect this in some way without getting in the user's way excessively. 

## Solution

### Technical changes

This particular prototype represents, essentially, the most "overengineered" part of the solution space, since it provides explicit type-level safeguards that prevent users from, for instance, accessing a `Curve` holding both the position and velocity for curve constructions which are not globally C1 (although this limitation can be bypassed). It consists of a number of moving parts to accomplish this:
- Firstly, `CubicCurve` now has a second parameter which serves as a marker. This is limited to a set of marker types which satisfy a marker trait, `Smoothness`, and the set of all of them consists of `NoGuarantees`, `C0`, `C1`, and `C2`. 
- Secondly, there are a few new data types which play the role of `T` in `Curve<T>`; these combine position, velocity, and acceleration data into convenient packages to be used together; e.g.:
    ```rust
    pub struct C0Data<P: VectorSpace> {
        position: P,
    }

    pub struct C1Data<P: VectorSpace> {
        position: P,
        velocity: P,
    }

    pub struct C2Data<P: VectorSpace> {
        position: P,
        velocity: P,
        acceleration: P,
    }
    ```
- Next, each of these has a corresponding trait which dictates whether a curve with that output can be created from the given data; e.g.:
    ```rust
    /// A trait for a type that can be turned into a curve which is continuous and also has
    /// continuous derivatives.
    pub trait ToC1Curve<P: VectorSpace> {
    /// The type of the curve.
    type CurveType: Curve<C1Data<P>>;

    /// Yield a C1 curve.
    fn to_curve_c1(&self) -> Self::CurveType;
    }
    ```
- These traits are implemented using wrapper structs; the point is that, for example, `ToC1Curve` is implemented by any `CubicCurve` with a marker value at least C1 (so, `C1` and `C2` in that case):
    ```rust
    /// A wrapper struct which actually implements the [`Curve`] trait associated to its level.
    /// Here, the `Smoothness` parameter is actually precise; a `CubicCurveWrapper` with a
    /// `Smoothness` of `C2` does not access the `C0` data, for example.
    pub struct CubicCurveWrapper<L, P>
    where
        L: Smoothness,
        P: VectorSpace,
    {
        inner: CubicCurve<L, P>,
    }

    // ...

    impl<L, P> ToC1Curve<P> for CubicCurve<L, P>
    where
        L: AtLeastC1,
        P: VectorSpace,
    {
        type CurveType = CubicCurveWrapper<C1, P>;

        fn to_curve_c1(&self) -> Self::CurveType {
            CubicCurveWrapper {
                inner: self.clone().transmute_smoothness(),
            }
        }
    }
    ```
- Furthermore, the `Smoothness` parameter can be raised explicitly by using `bless` functions which otherwise have no effect. This allows, for example, `C1` data to be accessed on a curve whose continuity of derivatives cannot be guaranteed at the type level (either for hacky reasons or because the type jsut fails to capture enough knowledge); these have signatures that end up looking like this (although they are actually implemented using traits):
    ```rust
    /// Grants access to C1-level curve data that cannot be guaranteed to be valid by the
    /// invariants from this curve's construction.
    fn bless_c1(self) -> CubicCurve<C1, P> { //... }
    ```

### Usage

What this actually ends up looking like for users is this; let's suppose, for example, that we want to extract a `Curve` from a cubic B-spline:
```rust
// ... definition of `control_points` ...
// Use the B-spline construction to get a `CubicCurve<C2, P>`
let my_curve = CubicBSpline::new(control_points).to_curve();
// Now we can get something which is actually a `Curve<C1Data<P>>` by using one of the trait methods:
let position_and_velocity_curve = my_curve.to_curve_c1();
```

On the other hand, suppose that we have something like a Hermite interpolation:
```rust
// ... definitions of `control_points`, `tangents`, ...
// Use the data to get a curve from a Hermite spline (`CubicCurve<C1, P>`):
let my_curve = CubicHermite::new(control_points, tangents).to_curve();
// It's only C1, but I want the acceleration anyway!!! HAHAHA!!!
// This is a `Curve<C2Data<P>>`; the resulting acceleration might be discontinuous.
let c2_data_curve = my_curve.bless_c2().to_curve_c2();
```
(As you can see, the terminology is presently quite suboptimal.)

---

## Changelog



## Migration Guide

Any external code explicitly using the `CubicCurve` type (e.g. as part of a Component) will need to be demarcated with a marker type depending on how it is used. 

## Discussion

As I wrote above, this feels slightly overengineered to me, and the places where that actually comes through negatively, in my opinion, are:
* When users have to actually interact with the marker types it's weird
* The `C0Data`, `C1Data`, etc. bundling doesn't feel necessarily natural from a user perspective (especially with names like `to_curve_c1`, but perhaps that can be remedied somehow).

Another direction I could see going with this is just not bundling the position/velocity/acceleration data together, and instead just having separate methods splitting out `Curve<P>`s for the position, velocity, and acceleration separately. This has the advantage that it requires potentially less interfacing with technical jargon, but users would often need to zip the data together to use it in other processes (e.g. basically anything that requires the velocity would probably require position as well). Of course, this could still be gated behind the "smoothness" bounds in essentially the same way. 