### PR TITLE
Remove async-task as a dependency

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -9,14 +9,13 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-multi-threaded = ["dep:async-channel", "dep:async-task", "dep:concurrent-queue"]
+multi-threaded = ["dep:async-channel", "dep:concurrent-queue"]
 
 [dependencies]
 futures-lite = "2.0.1"
-async-executor = "1.7.2"
+async-executor = "1.11"
 async-channel = { version = "2.2.0", optional = true }
 async-io = { version = "2.0.0", optional = true }
-async-task = { version = "4.2.0", optional = true }
 concurrent-queue = { version = "2.0.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_tasks/src/task.rs
+++ b/crates/bevy_tasks/src/task.rs
@@ -12,7 +12,6 @@ use std::{
 /// more gracefully and wait until it stops running, use the [`Task::cancel()`] method.
 ///
 /// Tasks that panic get immediately canceled. Awaiting a canceled task also causes a panic.
-/// Wraps `async_executor::Task`
 #[derive(Debug)]
 #[must_use = "Tasks are canceled when dropped, use `.detach()` to run them in the background."]
 pub struct Task<T>(async_executor::Task<T>);

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -7,7 +7,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 
-use async_task::FallibleTask;
+use async_executor::FallibleTask;
 use concurrent_queue::ConcurrentQueue;
 use futures_lite::FutureExt;
 


### PR DESCRIPTION
# Objective
Follow up to #13062. As of async-executor 1.11, the crate reexports FallibleTask, which is the only reason bevy_tasks has a direct dependency on  async-task. This should avoid the two dependencies getting out of sync in the future and causing spurious compilation failures.

## Solution
Bump async-executor to 1.11, use the reexport, remove the dependency on async-task.