### PR TITLE
Simplify runner app exit code.

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -867,17 +867,7 @@ impl App {
     pub fn should_exit(&self) -> Option<AppExit> {
         let mut reader = ManualEventReader::default();
 
-        self.should_exit_manual(&mut reader)
-    }
-
-    /// Several app runners in this crate keep their own [`ManualEventReader<AppExit>`].
-    /// This exists to accommodate them.
-    pub(crate) fn should_exit_manual(
-        &self,
-        reader: &mut ManualEventReader<AppExit>,
-    ) -> Option<AppExit> {
         let events = self.world().get_resource::<Events<AppExit>>()?;
-
         let mut events = reader.read(events);
 
         if events.len() != 0 {

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -3,7 +3,6 @@ use crate::{
     plugin::Plugin,
     PluginsState,
 };
-use bevy_ecs::event::ManualEventReader;
 use bevy_utils::{Duration, Instant};
 
 #[cfg(target_arch = "wasm32")]
@@ -82,26 +81,25 @@ impl Plugin for ScheduleRunnerPlugin {
                 app.cleanup();
             }
 
-            let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
             match run_mode {
                 RunMode::Once => {
                     app.update();
 
-                    if let Some(exit) = app.should_exit_manual(&mut app_exit_event_reader) {
+                    if let Some(exit) = app.should_exit() {
                         return exit;
                     }
 
                     AppExit::Success
                 }
                 RunMode::Loop { wait } => {
-                    let mut tick = move |app: &mut App,
-                                         wait: Option<Duration>|
+                    let tick = move |app: &mut App,
+                                     wait: Option<Duration>|
                           -> Result<Option<Duration>, AppExit> {
                         let start_time = Instant::now();
 
                         app.update();
 
-                        if let Some(exit) = app.should_exit_manual(&mut app_exit_event_reader) {
+                        if let Some(exit) = app.should_exit() {
                             return Err(exit);
                         };
 


### PR DESCRIPTION
# Objective

Both the shedule and winit runners use/reimplement `app_exit_manual` even tough they can use `app_exit`

## Solution

Nuke `app_exit_manual` from orbit.