### PR TITLE
install rust target for arm ios simulator

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -33,7 +33,7 @@ jobs:
           key: ${{ runner.os }}-ios-install-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Add iOS targets
-        run: rustup target add aarch64-apple-ios x86_64-apple-ios
+        run: rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 
       - name: Build and install iOS app in iOS Simulator.
         run: cd examples/mobile && make install

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -32,6 +32,7 @@ jobs:
             target
           key: ${{ runner.os }}-ios-install-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
 
+      # TODO: remove x86 target once it always run on arm GitHub runners
       - name: Add iOS targets
         run: rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
 


### PR DESCRIPTION
# Objective

- GitHub action running iOS CI has been updated to use arm runner
- This makes iOS test fail as it's not installing the correct rust target

## Solution

- add the correct rust target, do not remove x86 targets for now as it may be some time for a partial rollout
