### PR TITLE
Use `ptr::from_ref` and `ptr::addr_eq` in macro

### DIFF
--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -176,11 +176,9 @@ macro_rules! define_label {
             fn ref_eq(&self, other: &Self) -> bool {
                 use ::std::ptr;
 
-                if self.as_dyn_eq().type_id() == other.as_dyn_eq().type_id() {
-                    ptr::addr_eq(ptr::from_ref::<Self>(self), ptr::from_ref::<Self>(other))
-                } else {
-                    false
-                }
+                // Test that both the type id and pointer address are equivalent.
+                self.as_dyn_eq().type_id() == other.as_dyn_eq().type_id()
+                    && ptr::addr_eq(ptr::from_ref::<Self>(self), ptr::from_ref::<Self>(other))
             }
 
             fn ref_hash<H: ::std::hash::Hasher>(&self, state: &mut H) {

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -174,17 +174,19 @@ macro_rules! define_label {
             }
 
             fn ref_eq(&self, other: &Self) -> bool {
+                use ::std::ptr;
+
                 if self.as_dyn_eq().type_id() == other.as_dyn_eq().type_id() {
-                    (self as *const Self).cast::<()>() == (other as *const Self).cast::<()>()
+                    ptr::addr_eq(ptr::from_ref::<Self>(self), ptr::from_ref::<Self>(other))
                 } else {
                     false
                 }
             }
 
             fn ref_hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
-                use ::std::hash::Hash;
+                use ::std::{hash::Hash, ptr};
                 self.as_dyn_eq().type_id().hash(state);
-                (self as *const Self).cast::<()>().hash(state);
+                ptr::from_ref::<Self>(self).cast::<()>().hash(state);
             }
         }
 

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -185,7 +185,12 @@ macro_rules! define_label {
 
             fn ref_hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
                 use ::std::{hash::Hash, ptr};
+
+                // Hash the type id...
                 self.as_dyn_eq().type_id().hash(state);
+
+                // ...and the pointer address.
+                // Cast to a unit `()` first to discard any pointer metadata.
                 ptr::from_ref::<Self>(self).cast::<()>().hash(state);
             }
         }


### PR DESCRIPTION
# Objective

- Clippy raises a few warnings on the latest nightly release. 📎

## Solution

- Use `ptr::from_ref` when possible, because it prevents you from accidentally changing the mutability as well as its type.
- Use `ptr::addr_eq` when comparing two pointers, ignoring pointer metadata.