### PR TITLE
Example setup for tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -987,7 +987,12 @@ description = "Meshlet rendering for dense high-poly scenes (experimental)"
 category = "3D Rendering"
 wasm = false
 setup = [
-  "curl -o assets/models/bunny.meshlet_mesh https://github.com/JMS55/bevy_meshlet_asset/blob/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh",
+  [
+    "curl",
+    "-o",
+    "assets/models/bunny.meshlet_mesh",
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh",
+  ],
 ]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -986,6 +986,9 @@ name = "Meshlet"
 description = "Meshlet rendering for dense high-poly scenes (experimental)"
 category = "3D Rendering"
 wasm = false
+setup = [
+  "curl -o assets/models/bunny.meshlet_mesh https://github.com/JMS55/bevy_meshlet_asset/blob/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh",
+]
 
 [[example]]
 name = "lightmaps"

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -16,7 +16,7 @@ use bevy::{
 use camera_controller::{CameraController, CameraControllerPlugin};
 use std::{f32::consts::PI, path::Path, process::ExitCode};
 
-const ASSET_URL: &str = "https://github.com/JMS55/bevy_meshlet_asset/blob/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh";
+const ASSET_URL: &str = "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh";
 
 fn main() -> ExitCode {
     if !Path::new("./assets/models/bunny.meshlet_mesh").exists() {

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -755,14 +755,27 @@ fn parse_examples() -> Vec<Example> {
         .collect()
 }
 
+/// Data for this struct comes from both the entry for an example in the Cargo.toml file, and its associated metadata.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 struct Example {
+    // From the example entry
+    /// Name of the example, used to start it from the cargo CLI with `--example`
     technical_name: String,
+    /// Path to the example file
     path: String,
-    name: String,
-    description: String,
-    category: String,
-    wasm: bool,
+    /// List of non default required features
     required_features: Vec<String>,
+
+    // From the example metadata
+    /// Pretty name, used for display
+    name: String,
+    /// Description of the example, for discoverability
+    description: String,
+    /// Pretty category name, matching the folder containing the example
+    category: String,
+    /// Does this example work in wasm?
+    // TODO: be able to differentiate between WebGL2, WebGPU, both, or neither (for examples that could run on wasm without a renderer)
+    wasm: bool,
+    /// List of commands to run before the example. Can be used for example to specify data to download
     setup: Vec<Vec<String>>,
 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -276,6 +276,11 @@ fn main() {
                     .map(|s| s.to_string())
                     .chain(required_features.iter().cloned())
                     .collect::<Vec<_>>();
+
+                for command in &to_run.setup {
+                    let _ = cmd!(sh, "{command}").run();
+                }
+
                 let _ = cmd!(
                     sh,
                     "cargo build --profile {profile} --example {example} {local_extra_parameters...}"
@@ -726,6 +731,17 @@ fn parse_examples() -> Vec<Example> {
                             .collect()
                     })
                     .unwrap_or_default(),
+                setup: metadata
+                    .get("setup")
+                    .map(|setup| {
+                        setup
+                            .as_array()
+                            .unwrap()
+                            .into_iter()
+                            .map(|v| v.as_str().unwrap().to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             })
         })
         .collect()
@@ -740,4 +756,5 @@ struct Example {
     category: String,
     wasm: bool,
     required_features: Vec<String>,
+    setup: Vec<String>,
 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -280,7 +280,7 @@ fn main() {
                 for command in &to_run.setup {
                     let exe = &command[0];
                     let args = &command[1..];
-                    let _ = cmd!(sh, "{exe} {args...}").run().unwrap();
+                    cmd!(sh, "{exe} {args...}").run().unwrap();
                 }
 
                 let _ = cmd!(

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -278,7 +278,9 @@ fn main() {
                     .collect::<Vec<_>>();
 
                 for command in &to_run.setup {
-                    let _ = cmd!(sh, "{command}").run();
+                    let exe = &command[0];
+                    let args = &command[1..];
+                    let _ = cmd!(sh, "{exe} {args...}").run().unwrap();
                 }
 
                 let _ = cmd!(
@@ -738,7 +740,13 @@ fn parse_examples() -> Vec<Example> {
                             .as_array()
                             .unwrap()
                             .into_iter()
-                            .map(|v| v.as_str().unwrap().to_string())
+                            .map(|v| {
+                                v.as_array()
+                                    .unwrap()
+                                    .into_iter()
+                                    .map(|v| v.as_str().unwrap().to_string())
+                                    .collect()
+                            })
                             .collect()
                     })
                     .unwrap_or_default(),
@@ -756,5 +764,5 @@ struct Example {
     category: String,
     wasm: bool,
     required_features: Vec<String>,
-    setup: Vec<String>,
+    setup: Vec<Vec<String>>,
 }


### PR DESCRIPTION
# Objective

- #12755 introduced the need to download a file to run an example
- This means the example fails to run in CI without downloading that file

## Solution

- Add a new metadata to examples "setup" that provides setup instructions
- Replace the URL in the meshlet example to one that can actually be downloaded
- example-showcase execute the setup before running an example