### PR TITLE
Better SystemId to Entity conversions

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -581,10 +581,7 @@ impl<'w, 's> Commands<'w, 's> {
     ) -> SystemId<I, O> {
         let entity = self.spawn_empty().id();
         self.queue.push(RegisterSystem::new(system, entity));
-        SystemId {
-            entity,
-            marker: std::marker::PhantomData,
-        }
+        SystemId::from_entity(entity)
     }
 
     /// Pushes a generic [`Command`] to the command queue.

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -44,13 +44,20 @@ pub struct SystemId<I = (), O = ()> {
 }
 
 impl<I, O> SystemId<I, O> {
-    /// Get the underlying [`Entity`] value of a [`SystemId`].
+    /// Transforms a [`SystemId`] into the [`Entity`] that holds the one-shot system's state.
+    ///
+    /// It's trivial to convert [`SystemId`] into an [`Entity`] since a system
+    /// is really an entity with associated handler function.
+    ///
+    /// For example, this is useful if you want to assign a name label to a system.
     pub fn entity(self) -> Entity {
         self.entity
     }
 
-    /// Create [`SystemId`] from an [`Entity`].
-    /// The entity must be a system & the `I` + `O` types must be correct to use this for running.
+    /// Create [`SystemId`] from an [`Entity`]. Useful when you only have entity handles to avoid
+    /// adding extra compnents that have a [`SystemId`] everywhere. To run a system with this ID
+    ///  - The entity must be a system
+    ///  - The `I` + `O` types must be correct
     pub fn from_entity(entity: Entity) -> Self {
         Self {
             entity,

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -43,6 +43,22 @@ pub struct SystemId<I = (), O = ()> {
     pub(crate) marker: std::marker::PhantomData<fn(I) -> O>,
 }
 
+impl<I, O> SystemId<I, O> {
+    /// Get the underlying [`Entity`] value of a [`SystemId`].
+    pub fn entity(self) -> Entity {
+        self.entity
+    }
+
+    /// Create [`SystemId`] from an [`Entity`].
+    /// The entity must be a system & the `I` + `O` types must be correct to use this for running.
+    pub fn from_entity(entity: Entity) -> Self {
+        Self {
+            entity,
+            marker: std::marker::PhantomData,
+        }
+    }
+}
+
 impl<I, O> Eq for SystemId<I, O> {}
 
 // A manual impl is used because the trait bounds should ignore the `I` and `O` phantom parameters.
@@ -75,18 +91,6 @@ impl<I, O> std::fmt::Debug for SystemId<I, O> {
             .field(&self.entity)
             .field(&self.entity)
             .finish()
-    }
-}
-
-impl<I, O> From<SystemId<I, O>> for Entity {
-    /// Transforms a [`SystemId`] into the [`Entity`] that holds the one-shot system's state.
-    ///
-    /// It's trivial to convert [`SystemId`] into an [`Entity`] since a system
-    /// is really an entity with associated handler function.
-    ///
-    /// For example, this is useful if you want to assign a name label to a system.
-    fn from(SystemId { entity, .. }: SystemId<I, O>) -> Self {
-        entity
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -55,7 +55,7 @@ impl<I, O> SystemId<I, O> {
     }
 
     /// Create [`SystemId`] from an [`Entity`]. Useful when you only have entity handles to avoid
-    /// adding extra compnents that have a [`SystemId`] everywhere. To run a system with this ID
+    /// adding extra components that have a [`SystemId`] everywhere. To run a system with this ID
     ///  - The entity must be a system
     ///  - The `I` + `O` types must be correct
     pub fn from_entity(entity: Entity) -> Self {

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -46,7 +46,7 @@ pub struct SystemId<I = (), O = ()> {
 impl<I, O> SystemId<I, O> {
     /// Transforms a [`SystemId`] into the [`Entity`] that holds the one-shot system's state.
     ///
-    /// It's trivial to convert [`SystemId`] into an [`Entity`] since a system
+    /// It's trivial to convert [`SystemId`] into an [`Entity`] since a one-shot system
     /// is really an entity with associated handler function.
     ///
     /// For example, this is useful if you want to assign a name label to a system.


### PR DESCRIPTION
# Objective

- Better `SystemId` <-> `Entity` conversion.

## Solution

- Provide a method `SystemId::from_entity` to create a `SystemId<I, O>` form an `Entity`. When users want to deal with the entities manually they need a way to convert the `Entity` back to a `SystemId` to actually run the system with `Commands` or `World`.
- Provide a method `SystemId::entity` that returns an `Entity` from `SystemId`. The current `From` impl is not very discoverable as it does not appear on the `SystemId` doc page.
- Remove old `From` impl.

## Migration Guide

```rust
let system_id = world.register_system(my_sys);

// old
let entity = Entity::from(system_id);

// new
let entity = system_id.entity();
```