### PR TITLE
Remove `version` field for non-publish crates and update descriptions

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "benches"
-version = "0.1.0"
 edition = "2021"
-description = "Benchmarks for Bevy engine"
+description = "Benchmarks that test Bevy's performance"
 publish = false
 license = "MIT OR Apache-2.0"
 

--- a/crates/bevy_ecs_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_ecs_compile_fail_tests/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bevy_ecs_compile_fail_tests"
-version = "0.1.0"
 edition = "2021"
 description = "Compile fail tests for Bevy Engine's entity component system"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_macros_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_macros_compile_fail_tests/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bevy_macros_compile_fail_tests"
-version = "0.1.0"
 edition = "2021"
 description = "Compile fail tests for Bevy Engine's various macros"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_reflect_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_reflect_compile_fail_tests/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bevy_reflect_compile_fail_tests"
-version = "0.1.0"
 edition = "2021"
 description = "Compile fail tests for Bevy Engine's reflection system"
 homepage = "https://bevyengine.org"

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "errors"
-version = "0.1.0"
 edition = "2021"
-description = "Bevy's error codes"
+description = "Documentation and tests for Bevy's error codes"
 publish = false
 license = "MIT OR Apache-2.0"
-
 
 [dependencies]
 bevy = { path = ".." }

--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bevy_mobile_example"
-version = "0.1.0"
 edition = "2021"
 description = "Example for building an iOS or Android app with Bevy"
 publish = false

--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "bevy_mobile_example"
+# Version is required by `cargo-apk`, though this value will never change.
+version = "0.0.0"
 edition = "2021"
 description = "Example for building an iOS or Android app with Bevy"
 publish = false

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "build-templated-pages"
-version = "0.14.0-dev"
 edition = "2021"
-description = "handle templated pages in Bevy repository"
+description = "Tool that checks and fixes undocumented features and examples"
 publish = false
 license = "MIT OR Apache-2.0"
-
 
 [dependencies]
 toml_edit = { version = "0.22.7", default-features = false, features = [

--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "build-wasm-example"
-version = "0.1.0"
 edition = "2021"
-description = "Build an example for wasm"
+description = "Tool for building example for WASM"
 publish = false
 license = "MIT OR Apache-2.0"
 

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "ci"
-version = "0.1.0"
 edition = "2021"
-description = "CI script for Bevy"
+description = "Tool that enables running CI checks locally."
 publish = false
 license = "MIT OR Apache-2.0"
 

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "example-showcase"
-version = "0.14.0-dev"
 edition = "2021"
-description = "Run examples"
+description = "Tool for running examples or generating a showcase page for the website."
 publish = false
 license = "MIT OR Apache-2.0"
-
 
 [dependencies]
 xshell = "0.2"


### PR DESCRIPTION
# Objective

- The [`version`] field in `Cargo.toml` is optional for crates not published on <https://crates.io>.
- We have several `publish = false` tools in this repository that still have a version field, even when it's not useful.

[`version`]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

## Solution

- Remove the [`version`] field for all crates where `publish = false`.
- Update the description on a few crates and remove extra newlines as well.
