### PR TITLE
Store render target size in `View`

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -2,7 +2,7 @@ use bevy_asset::AssetId;
 use bevy_core_pipeline::core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT};
 use bevy_ecs::prelude::*;
 use bevy_ecs::{entity::EntityHashMap, system::lifetimeless::Read};
-use bevy_math::{Mat4, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
+use bevy_math::{Mat4, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
 use bevy_render::mesh::Mesh;
 use bevy_render::{
     camera::Camera,
@@ -1053,6 +1053,10 @@ pub fn prepare_lights(
                                 point_light_shadow_map.size as u32,
                                 point_light_shadow_map.size as u32,
                             ),
+                            target_size: UVec2::new(
+                                point_light_shadow_map.size as u32,
+                                point_light_shadow_map.size as u32,
+                            ),
                             transform: view_translation * *view_rotation,
                             view_projection: None,
                             projection: cube_face_projection,
@@ -1111,6 +1115,10 @@ pub fn prepare_lights(
                             0,
                             directional_light_shadow_map.size as u32,
                             directional_light_shadow_map.size as u32,
+                        ),
+                        target_size: UVec2::new(
+                            point_light_shadow_map.size as u32,
+                            point_light_shadow_map.size as u32,
                         ),
                         transform: spot_view_transform,
                         projection: spot_projection,
@@ -1191,6 +1199,10 @@ pub fn prepare_lights(
                                 0,
                                 directional_light_shadow_map.size as u32,
                                 directional_light_shadow_map.size as u32,
+                            ),
+                            target_size: UVec2::new(
+                                point_light_shadow_map.size as u32,
+                                point_light_shadow_map.size as u32,
                             ),
                             transform: GlobalTransform::from(cascade.view_transform),
                             projection: cascade.projection,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -898,6 +898,7 @@ pub fn extract_cameras(
                         viewport_size.x,
                         viewport_size.y,
                     ),
+                    target_size,
                     color_grading,
                 },
                 visible_entities.clone(),

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -123,7 +123,7 @@ pub struct ExtractedView {
     /// is the subset of the render target that is actually being rendered to.
     ///
     /// In most cases, the viewport origin and size will be more relevant -- the target size
-    /// is only useful when directly indexing into the render target's buffers.
+    /// is mainly useful in specific cases such as directly indexing into the render target's buffers.
     pub target_size: UVec2,
     pub color_grading: ColorGrading,
 }

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -19,6 +19,7 @@ struct View {
     exposure: f32,
     // viewport(x_origin, y_origin, width, height)
     viewport: vec4<f32>,
+    target_size: vec2u,
     frustum: array<vec4<f32>, 6>,
     color_grading: ColorGrading,
     mip_bias: f32,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -670,10 +670,12 @@ pub fn extract_default_ui_camera_view<T: Component>(
                 ..
             }),
             Some(physical_size),
+            Some(target_size),
         ) = (
             camera.logical_viewport_size(),
             camera.physical_viewport_rect(),
             camera.physical_viewport_size(),
+            camera.physical_target_size(),
         ) {
             // use a projection matrix with the origin in the top left instead of the bottom left that comes with OrthographicProjection
             let projection_matrix = Mat4::orthographic_rh(
@@ -700,6 +702,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
                         physical_size.x,
                         physical_size.y,
                     ),
+                    target_size,
                     color_grading: Default::default(),
                 })
                 .id();


### PR DESCRIPTION
# Objective

Sometimes when writing shaders (such as a custom rasterizer), you need to index directly into the render target's buffers, which requires you to know the size of the current view's target.

## Solution

Add the render target size to `ViewUniform`

---

## Changelog

* Added the size of the render target to `ViewUniform`, corresponding to the `View` type in shader code.

## Migration Guide

The `ExtractedView` type now contains the `target_size` field, which represents the size of the render target in physical pixels. If you have any custom code for extracting views, you now must populate this field.