### PR TITLE
Doc custom CameraProjection requires use of plugin

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -70,6 +70,9 @@ pub struct CameraUpdateSystem;
 /// to recompute the camera projection matrix of the [`Camera`] component attached to
 /// the same entity as the component implementing this trait.
 ///
+/// Use the plugins [`CameraProjectionPlugin`] and `bevy::pbr::PbrProjectionPlugin` to setup the
+/// systems for your [`CameraProjection`] implementation.
+///
 /// [`Camera`]: crate::camera::Camera
 pub trait CameraProjection {
     fn get_projection_matrix(&self) -> Mat4;


### PR DESCRIPTION
# Objective

Documentation should mention the two plugins required for your custom `CameraProjection` to work.

## Solution

Documented!

---

I tried linking to `bevy_pbr::PbrProjectionPlugin` from `bevy_render::camera::CameraProjection` but it wasn't in scope. Is there a trick to it?
