### PR TITLE
new format for ci config file

### DIFF
--- a/.github/example-run/alien_cake_addict.ron
+++ b/.github/example-run/alien_cake_addict.ron
@@ -1,3 +1,5 @@
 (
-    exit_after: Some(300)
+    events: [
+        (300, "AppExit::Success"),
+    ]
 )

--- a/.github/example-run/alien_cake_addict.ron
+++ b/.github/example-run/alien_cake_addict.ron
@@ -1,5 +1,5 @@
 (
     events: [
-        (300, "AppExit::Success"),
+        (300, AppExit),
     ]
 )

--- a/.github/example-run/breakout.ron
+++ b/.github/example-run/breakout.ron
@@ -1,9 +1,9 @@
 (
     setup: (
-        frame_time: Some(0.03),
+        fixed_frame_time: Some(0.03),
     ),
     events: [
-        (200, "Screenshot"),
-        (900, "AppExit::Success"),
+        (200, Screenshot),
+        (900, AppExit),
     ]
 )

--- a/.github/example-run/breakout.ron
+++ b/.github/example-run/breakout.ron
@@ -1,5 +1,9 @@
 (
-    exit_after: Some(900),
-    frame_time: Some(0.03),
-    screenshot_frames: [200],
+    setup: (
+        frame_time: Some(0.03),
+    ),
+    events: [
+        (200, "Screenshot"),
+        (900, "AppExit::Success"),
+    ]
 )

--- a/.github/example-run/contributors.ron
+++ b/.github/example-run/contributors.ron
@@ -1,5 +1,5 @@
 (
     events: [
-        (900, "AppExit::Success"),
+        (900, AppExit),
     ]
 )

--- a/.github/example-run/contributors.ron
+++ b/.github/example-run/contributors.ron
@@ -1,3 +1,5 @@
 (
-    exit_after: Some(900)
+    events: [
+        (900, "AppExit::Success"),
+    ]
 )

--- a/.github/example-run/load_gltf.ron
+++ b/.github/example-run/load_gltf.ron
@@ -3,7 +3,7 @@
         frame_time: Some(0.03),
     ),
     events: [
-        (100, "Screenshot"),
-        (300, "AppExit::Success"),
+        (100, Screenshot),
+        (300, AppExit),
     ]
 )

--- a/.github/example-run/load_gltf.ron
+++ b/.github/example-run/load_gltf.ron
@@ -1,5 +1,9 @@
 (
-    exit_after: Some(300),
-    frame_time: Some(0.03),
-    screenshot_frames: [100],
+    setup: (
+        frame_time: Some(0.03),
+    ),
+    events: [
+        (100, "Screenshot"),
+        (300, "AppExit::Success"),
+    ]
 )

--- a/.github/example-run/no_renderer.ron
+++ b/.github/example-run/no_renderer.ron
@@ -1,3 +1,5 @@
 (
-    exit_after: Some(100)
+    events: [
+        (100, "AppExit::Success"),
+    ]
 )

--- a/.github/example-run/no_renderer.ron
+++ b/.github/example-run/no_renderer.ron
@@ -1,5 +1,5 @@
 (
     events: [
-        (100, "AppExit::Success"),
+        (100, AppExit),
     ]
 )

--- a/.github/example-run/scene.ron
+++ b/.github/example-run/scene.ron
@@ -1,3 +1,5 @@
 (
-    exit_after: Some(100)
+    events: [
+        (100, "AppExit::Success"),
+    ]
 )

--- a/.github/example-run/scene.ron
+++ b/.github/example-run/scene.ron
@@ -1,5 +1,5 @@
 (
     events: [
-        (100, "AppExit::Success"),
+        (100, AppExit),
     ]
 )

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
     let mut features: Vec<&str> = cli.features.iter().map(|f| f.as_str()).collect();
     if let Some(frames) = cli.frames {
         let mut file = File::create("ci_testing_config.ron").unwrap();
-        file.write_fmt(format_args!("(exit_after: Some({frames}))"))
+        file.write_fmt(format_args!("(events: [({frames}, AppExit)])"))
             .unwrap();
         features.push("bevy_ci_testing");
     }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -168,7 +168,7 @@ fn main() {
                 (true, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: None, frame_time: Some(0.05), screenshot_frames: [100])",
+                        br#"(setup: (frame_time: Some(0.05)), events: [(100, "Screenshot")])"#,
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -178,7 +178,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(250), frame_time: Some(0.05), screenshot_frames: [100])",
+                        br#"(setup: (frame_time: Some(0.05)), events: [(100, "Screenshot"), (250, "AppExit::Success")])"#,
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -186,7 +186,8 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(250))").unwrap();
+                    file.write_all(br#"(events: [(250, "AppExit::Success")])"#)
+                        .unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -168,7 +168,7 @@ fn main() {
                 (true, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        br#"(setup: (frame_time: Some(0.05)), events: [(100, "Screenshot")])"#,
+                        b"(setup: (fixed_frame_time: Some(0.05)), events: [(100, Screenshot)])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -178,7 +178,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        br#"(setup: (frame_time: Some(0.05)), events: [(100, "Screenshot"), (250, "AppExit::Success")])"#,
+                        b"(setup: (fixed_frame_time: Some(0.05)), events: [(100, Screenshot), (250, AppExit)])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -186,8 +186,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(br#"(events: [(250, "AppExit::Success")])"#)
-                        .unwrap();
+                    file.write_all(b"(events: [(250, AppExit)])").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }


### PR DESCRIPTION
# Objective

- Current config file is hard to extend

## Solution

- Instead of an hard coded list of field, the file now has a list of `(frame, event)`, and will deal with know events (exiting or taking a screenshot), or send an event for others that can be dealt by third party plugins
