### PR TITLE
Skip redundant mesh_position_local_to_world call in vertex prepass shader

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -5,6 +5,7 @@
     skinning,
     morph,
     mesh_view_bindings::view,
+    view_transformations::position_world_to_clip,
 }
 
 #ifdef DEFERRED_PREPASS
@@ -50,7 +51,8 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var model = mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
 #endif // SKINNED
 
-    out.position = mesh_functions::mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
+    out.world_position = mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
+    out.position = position_world_to_clip(out.world_position.xyz);
 #ifdef DEPTH_CLAMP_ORTHO
     out.clip_position_unclamped = out.position;
     out.position.z = min(out.position.z, 1.0);
@@ -90,8 +92,6 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #ifdef VERTEX_COLORS
     out.color = vertex.color;
 #endif
-
-    out.world_position = mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
 
 #ifdef MOTION_VECTOR_PREPASS
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.


### PR DESCRIPTION
# Objective

Optimize vertex prepass shader maybe?
Make it consistent with the base vertex shader

## Solution

`mesh_position_local_to_clip` just calls `mesh_position_local_to_world` and then `position_world_to_clip`
since `out.world_position` is getting calculated anyway a few lines below, just move it up and use it's output to calculate `out.position`.

It is the same as in the base vertex shader (`mesh.wgsl`).

Note: I have no idea if there is a reason that it was this way. I'm not an expert, just noticed this inconsistency while messing with custom shaders.