### PR TITLE
Add guidance on closing PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,28 @@ We use [Milestones](https://github.com/bevyengine/bevy/milestones) to track issu
 
 There are also two priority labels: [`P-Critical`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-Critical) and [`P-High`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-High) that can be used to find issues and PRs that need to be resolved urgently.
 
+### Closing PRs
+
+From time to time, PRs are unsuitable to be merged in a way that cannot be readily fixed.
+Rather than leaving these PRs open in limbo indefinitely, they should simply be closed.
+
+This might happen if:
+
+1. The PR is spam or malicious.
+2. The work is particularly low quality, and the author is resistant to coaching.
+3. The work adds features or abstraction of limited value, especially in a way that could easily be recreated outside of the engine.
+4. The work has been sitting in review for so long and accumulated so many conflicts that it would be simpler to redo it from scratch.
+
+There are four paths for PRs to be closed:
+
+1. Obviously, authors may close their own PRs for any reason at any time.
+2. If a PR is clearly spam or malicious, anyone with triage rights is encouraged to close out the PR and report it to Github.
+3. SMEs or maintainers may and are encouraged to unilaterally close PRs that fall into one or more of the remaining categories.
+4. In the case of PRs where some members of the community (other than the author) are in favor and some are opposed, any two relevant SMEs or maintainers may act in concert to close the PR.
+
+When closing a PR, check if it has an issue linked.
+If it does not, you should strongly consider creating an issue and linking the now-closed PR to help make sure the previous work can be discovered and credited.
+
 ## Making changes to Bevy
 
 Most changes don't require much "process". If your change is relatively straightforward, just do the following:


### PR DESCRIPTION
# Objective

- Bevy has a large number of open PRs in the backlog.
- When there are problems with these PRs, contributors, maintainers and SMEs are all often left wondering what to do with them and are reluctant to close them fully.
- Instead, PRs that are a bad idea end up sititng with Controversial status forever, while severely rotten PRs have Adopt-Me on them when it would be more appropriate to simply remake them.

## Solution

- Add clear guidance on how and when to close PRs.