### PR TITLE
Add a process for working groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,44 @@ Take a look at the sections that follow to pick a route (or five) that appeal to
 
 If you ever find yourself at a loss for what to do, or in need of mentorship or advice on how to contribute to Bevy, feel free to ask in [Discord] and one of our more experienced community members will be happy to help.
 
+### Join a working group
+
+Active initiatives in Bevy are organized into temporary working groups: choosing one of those and asking how to help can be a fantastic way to get up to speed and be immediately useful.
+
+Working groups are public, open-membership groups that work together to tackle a broad-but-scoped initiative.
+The work that they do is coordinated in a forum-channel on [Discord](https://discord.gg/bevy), although they also create issues and may use project boards for tangible work that needs to be done.
+
+There's no special requirements to be a member, and no formal membership list.
+Working groups are *spaces*, not clubs.
+
+### Start a working group
+
+When tackling a complex initiative, it can make things go much more smoothly to make friends and allies to help.
+
+To start a working group:
+
+1. Decide what the working group is going to focus on. This should be tightly focused and achievable!
+2. Gather at least 3 people including yourself who are willing to be in the working group.
+3. Ping the `@Maintainer` role on Discord in #engine-dev announcing your mutual intent.
+
+One of the maintainers will then create a forum channel for you, as a purely administrative task.
+Your next task is writing up a design doc: laying out the scope of work and general implementation strategy.
+
+Once that's ready, get a sign-off on the broad vision and goals from the appropriate SMEs and maintainers.
+This is the critical review step: maintainers and SMEs should be broadly patient and supportive even if they're skeptical until a proper design doc is in hand to evaluate.
+
+With a sign-off in hand, post the design doc to [Github Discussions](https://github.com/bevyengine/bevy/discussions) for archival purposes and begin work on implementation.
+Post PRs that you need review on in the forum channel, ask for advice and share the load.
+Controversial PRs are still `S-Controversial`, but with a sign-off-in-priniciple, things should go more smoothly.
+
+If work peters out and the initiative dies, maintainers can wind down working groups (in consultation with SMEs and the working group itself).
+This is normal and expected: projects fail for all sorts of reasons!
+However, it's important to both keep the number of working groups relatively small and ensure they're active:
+they serve a vital role in onboarding new contributors.
+
+Once your implementation work laid out in your initial design doc is complete, it's time to wind down the working group.
+Feel free to make another one though to tackle the next step in your grand vision!
+
 ### Battle-testing Bevy
 
 Ultimately, Bevy is a tool that's designed to help people make cool games.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,13 +207,15 @@ To start a working group:
 
 1. Decide what the working group is going to focus on. This should be tightly focused and achievable!
 2. Gather at least 3 people including yourself who are willing to be in the working group.
-3. Ping the `@Maintainer` role on Discord in #engine-dev announcing your mutual intent.
+3. Ping the `@Maintainer` role on Discord in #engine-dev announcing your mutual intent and a one or two sentence description of your plans.
 
-One of the maintainers will then create a forum channel for you, as a purely administrative task.
-Your next task is writing up a design doc: laying out the scope of work and general implementation strategy.
+The maintainers will briefly evaluate the proposal in consultation with the relevant SMEs and give you a thumbs up or down on whether this is something Bevy can and wants to explore right now.
+You don't need a concrete plan at this stage, just a sensible argument for both "why is this something that could be useful to Bevy" and "why there aren't any serious barriers in implementing this in the near future".
+If they're in favor, a maintainer will create a forum channel for you and you're off to the races.
 
+Your initial task is writing up a design doc: laying out the scope of work and general implementation strategy.
 Once that's ready, get a sign-off on the broad vision and goals from the appropriate SMEs and maintainers.
-This is the critical review step: maintainers and SMEs should be broadly patient and supportive even if they're skeptical until a proper design doc is in hand to evaluate.
+This is the primary review step: maintainers and SMEs should be broadly patient and supportive even if they're skeptical until a proper design doc is in hand to evaluate.
 
 With a sign-off in hand, post the design doc to [Github Discussions](https://github.com/bevyengine/bevy/discussions) for archival purposes and begin work on implementation.
 Post PRs that you need review on in the forum channel, ask for advice, and share the load.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,12 +196,12 @@ Active initiatives in Bevy are organized into temporary working groups: choosing
 Working groups are public, open-membership groups that work together to tackle a broad-but-scoped initiative.
 The work that they do is coordinated in a forum-channel on [Discord](https://discord.gg/bevy), although they also create issues and may use project boards for tangible work that needs to be done.
 
-There's no special requirements to be a member, and no formal membership list.
+There are no special requirements to be a member, and no formal membership list.
 Working groups are *spaces*, not clubs.
 
 ### Start a working group
 
-When tackling a complex initiative, it can make things go much more smoothly to make friends and allies to help.
+When tackling a complex initiative, friends and allies can make things go much more smoothly.
 
 To start a working group:
 
@@ -216,7 +216,7 @@ Once that's ready, get a sign-off on the broad vision and goals from the appropr
 This is the critical review step: maintainers and SMEs should be broadly patient and supportive even if they're skeptical until a proper design doc is in hand to evaluate.
 
 With a sign-off in hand, post the design doc to [Github Discussions](https://github.com/bevyengine/bevy/discussions) for archival purposes and begin work on implementation.
-Post PRs that you need review on in the forum channel, ask for advice and share the load.
+Post PRs that you need review on in the forum channel, ask for advice, and share the load.
 Controversial PRs are still `S-Controversial`, but with a sign-off-in-priniciple, things should go more smoothly.
 
 If work peters out and the initiative dies, maintainers can wind down working groups (in consultation with SMEs and the working group itself).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,8 @@ Active initiatives in Bevy are organized into temporary working groups: choosing
 Working groups are public, open-membership groups that work together to tackle a broad-but-scoped initiative.
 The work that they do is coordinated in a forum-channel on [Discord](https://discord.gg/bevy), although they also create issues and may use project boards for tangible work that needs to be done.
 
-There are no special requirements to be a member, and no formal membership list.
+There are no special requirements to be a member, and no formal membership list or leadership.
+Anyone can help, and you should expect to compromise and work together with others to bring a shared vision to life.
 Working groups are *spaces*, not clubs.
 
 ### Start a working group
@@ -207,18 +208,20 @@ To start a working group:
 
 1. Decide what the working group is going to focus on. This should be tightly focused and achievable!
 2. Gather at least 3 people including yourself who are willing to be in the working group.
-3. Ping the `@Maintainer` role on Discord in #engine-dev announcing your mutual intent and a one or two sentence description of your plans.
+3. Ping the `@Maintainer` role on Discord in [#engine-dev](https://discord.com/channels/691052431525675048/692572690833473578) announcing your mutual intent and a one or two sentence description of your plans.
 
 The maintainers will briefly evaluate the proposal in consultation with the relevant SMEs and give you a thumbs up or down on whether this is something Bevy can and wants to explore right now.
 You don't need a concrete plan at this stage, just a sensible argument for both "why is this something that could be useful to Bevy" and "why there aren't any serious barriers in implementing this in the near future".
 If they're in favor, a maintainer will create a forum channel for you and you're off to the races.
 
 Your initial task is writing up a design doc: laying out the scope of work and general implementation strategy.
+Here's a [solid example of a design doc](https://github.com/bevyengine/bevy/issues/12365), although feel free to use whatever format works best for your team.
+
 Once that's ready, get a sign-off on the broad vision and goals from the appropriate SMEs and maintainers.
 This is the primary review step: maintainers and SMEs should be broadly patient and supportive even if they're skeptical until a proper design doc is in hand to evaluate.
 
-With a sign-off in hand, post the design doc to [Github Discussions](https://github.com/bevyengine/bevy/discussions) for archival purposes and begin work on implementation.
-Post PRs that you need review on in the forum channel, ask for advice, and share the load.
+With a sign-off in hand, post the design doc to [Github Discussions](https://github.com/bevyengine/bevy/discussions) with the [`C-Design-Doc` label](https://github.com/bevyengine/bevy/discussions?discussions_q=is%3Aopen+label%3A%22C-Design+Doc%22) for archival purposes and begin work on implementation.
+Post PRs that you need review on in your group's forum thread, ask for advice, and share the load.
 Controversial PRs are still `S-Controversial`, but with a sign-off-in-priniciple, things should go more smoothly.
 
 If work peters out and the initiative dies, maintainers can wind down working groups (in consultation with SMEs and the working group itself).


### PR DESCRIPTION
# Objective

Coordinating work can be hard, and figuring out how to get started with contributions is always a challenge.


We've had great success with informal working groups in the past (primitives, bevy_color, stageless). However, they're not at all discoverable, are hard to keep track of and tend to flood the dev channels that they're in.

When their messages are moved to Discord threads, they then get completely scattered and buried.

## Solution

We can formalize the working groups in a very process-light way, and give them a discoverable home by using a curated forum channel on Discord.

While we'll still need more stringent PR reviews for particularly complex or architectural changes made as part of these initiatives, a broad sign off on the course of action goes a long way to building consensus. By baking that into the process, I think we can avoid a lot of wasted work and relitigation without encouraging mega-PRs or RFCs.