### PR TITLE
Use BindGroupLayoutEntryBuilder in texture_binding_array example

### DIFF
--- a/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
@@ -13,7 +13,7 @@ use wgpu::{BindGroupLayoutEntry, BindingType, ShaderStages};
 ///         ShaderStages::FRAGMENT,
 ///         (
 ///             // Screen texture
-///             (2, tepxture_2d(TextureSampleType::Float { filterable: true })),
+///             (2, texture_2d(TextureSampleType::Float { filterable: true })),
 ///             // Sampler
 ///             (3, sampler(SamplerBindingType::Filtering)),
 ///         ),

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -6,7 +6,10 @@ use bevy::{
     reflect::TypePath,
     render::{
         render_asset::RenderAssets,
-        render_resource::*,
+        render_resource::{
+            binding_types::{sampler, texture_2d},
+            *,
+        },
         renderer::RenderDevice,
         texture::{FallbackImage, GpuImage},
         RenderApp,
@@ -148,29 +151,36 @@ impl AsBindGroup for BindlessMaterial {
     where
         Self: Sized,
     {
-        vec![
-            // @group(2) @binding(0) var textures: binding_array<texture_2d<f32>>;
-            BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::FRAGMENT,
-                ty: BindingType::Texture {
-                    sample_type: TextureSampleType::Float { filterable: true },
-                    view_dimension: TextureViewDimension::D2,
-                    multisampled: false,
-                },
-                count: NonZeroU32::new(MAX_TEXTURE_COUNT as u32),
-            },
-            // @group(2) @binding(1) var nearest_sampler: sampler;
-            BindGroupLayoutEntry {
-                binding: 1,
-                visibility: ShaderStages::FRAGMENT,
-                ty: BindingType::Sampler(SamplerBindingType::Filtering),
-                count: None,
-                // Note: as textures, multiple samplers can also be bound onto one binding slot.
-                // One may need to pay attention to the limit of sampler binding amount on some platforms.
-                // count: NonZeroU32::new(MAX_TEXTURE_COUNT as u32),
-            },
-        ]
+        BindGroupLayoutEntries::with_indices(
+            // The layout entries will only be visible in the fragment stage
+            ShaderStages::FRAGMENT,
+            (
+                // Screen texture
+                //
+                // @group(2) @binding(0) var textures: binding_array<texture_2d<f32>>;
+                (
+                    0,
+                    texture_2d(TextureSampleType::Float { filterable: true })
+                        .count(NonZeroU32::new(MAX_TEXTURE_COUNT as u32).unwrap()),
+                ),
+                // Sampler
+                //
+                // @group(2) @binding(1) var nearest_sampler: sampler;
+                //
+                // Note: as with textures, multiple samplers can also be bound
+                // onto one binding slot:
+                //
+                // ```
+                // sampler(SamplerBindingType::Filtering)
+                //     .count(NonZeroU32::new(MAX_TEXTURE_COUNT as u32).unwrap()),
+                // ```
+                //
+                // One may need to pay attention to the limit of sampler binding
+                // amount on some platforms.
+                (1, sampler(SamplerBindingType::Filtering)),
+            ),
+        )
+        .to_vec()
     }
 }
 


### PR DESCRIPTION
# Objective

- I've been using the `texture_binding_array` example as a base to use multiple textures in meshes in my program
- I only realised once I was deep in render code that these helpers existed to create layouts
- I wish I knew the existed earlier because the alternative (filling in every struct field) is so much more verbose

## Solution

- Use `BindGroupLayoutEntries::with_indices` to teach users that the helper exists
- Also fix typo which should be `texture_2d`.

## Alternatives considered

- Just leave it as is to teach users about every single struct field
- However, leaving as is leaves users writing roughly 29 lines versus roughly 2 lines for 2 entries and I'd prefer the 2 line approach

## Testing

Ran the example locally and compared before and after.

Before: 

<img width="1280" alt="image" src="https://github.com/bevyengine/bevy/assets/135186256/f5897210-2560-4110-b92b-85497be9023c">

After:

<img width="1279" alt="image" src="https://github.com/bevyengine/bevy/assets/135186256/8d13a939-b1ce-4a49-a9da-0b1779c8cb6a">
