### PR TITLE
Increase SSAO occupancy

### DIFF
--- a/crates/bevy_pbr/src/ssao/gtao.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao.wgsl
@@ -87,7 +87,7 @@ fn load_and_reconstruct_view_space_position(uv: vec2<f32>, sample_mip_level: f32
 }
 
 @compute
-@workgroup_size(8, 8, 1)
+@workgroup_size(16, 8, 1)
 fn gtao(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let slice_count = f32(#SLICE_COUNT);
     let samples_per_slice_side = f32(#SAMPLES_PER_SLICE_SIDE);

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -264,7 +264,7 @@ impl ViewNode for SsaoNode {
                 &[view_uniform_offset.offset],
             );
             gtao_pass.dispatch_workgroups(
-                div_ceil(camera_size.x, 8),
+                div_ceil(camera_size.x, 16),
                 div_ceil(camera_size.y, 8),
                 1,
             );


### PR DESCRIPTION
# Objective
- Increase SSAO occupancy

## Solution
- Switch to 16x8 (128) workgroups

## Testing
65% -> 85% occupancy on my RTX 3080 testing the meshlet example at Ultra settings at ~4k.

Needs testing on other hardware and scenes, as a large part of the meshlet example is an empty screen / flat surface, and the RTX 3080 is a bit weird when it comes to warp slots.

Doesn't seem to improve overall, but hey, more occupancy.

Before
![image](https://github.com/bevyengine/bevy/assets/47158642/017c0c16-e8a0-4e9e-83f6-765b4033687c)
After
![image](https://github.com/bevyengine/bevy/assets/47158642/4fc8f466-67ee-44cf-9193-55eacf1ba8b9)

## Notes
- NSight says reducing register count next would help
- If we had the ability, putting SSAO on an async compute queue and overlapping it with shadow map draws would probably be a large win