### PR TITLE
Fix CI using Rust 1.78

### DIFF
--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -639,7 +639,7 @@ fn update_ui_state(
         {
             if let Some(ref value_label) = value_label {
                 for section in &mut text.sections {
-                    section.value = value_label.clone();
+                    section.value.clone_from(&value_label);
                 }
             }
         }


### PR DESCRIPTION
# Objective

- [This run](https://github.com/bevyengine/bevy/actions/runs/8924250188/job/24510192976) failed when trying to merge #13164
- I suspect this is due to Rust 1.78 having just been released. New lints are causing new CI errors.
- Fixes https://github.com/bevyengine/bevy/issues/13179

## Solution

- Fix Clippy errors on Rust 1.78

## Testing

- The CI should automatically confirm that this change works.
