### PR TITLE
Implement Reflect for Result<T, E> as enum

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -96,10 +96,6 @@ impl_reflect_value!(::std::path::PathBuf(
     Default
 ));
 impl_reflect_value!(::std::any::TypeId(Debug, Hash, PartialEq,));
-impl_reflect_value!(
-    ::core::result::Result < T: Clone + Reflect + TypePath,
-    E: Clone + Reflect + TypePath > ()
-);
 impl_reflect_value!(::std::collections::BTreeSet<T: Ord + Eq + Clone + Send + Sync>());
 impl_reflect_value!(::std::collections::HashSet<T: Hash + Eq + Clone + Send + Sync, S: TypePath + Clone + Send + Sync>());
 impl_reflect_value!(::bevy_utils::hashbrown::HashSet<T: Hash + Eq + Clone + Send + Sync, S: TypePath + Clone + Send + Sync>());
@@ -1003,6 +999,14 @@ impl_reflect! {
     enum Option<T> {
         None,
         Some(T),
+    }
+}
+
+impl_reflect! {
+    #[type_path = "core::result"]
+    enum Result<T, E> {
+        Ok(T),
+        Err(E),
     }
 }
 


### PR DESCRIPTION
# Objective

- Make `Result<T, E>` implement Reflect such that it is an Enum rather than a Value
- Fixes #13178

## Solution

- Use the correct macro

## Testing

- Did you test these changes? 

I tried it out locally, and it does what it says on the tin. Not sure how to test it in context of the crate?


---

## Changelog

### Changed

- Result now uses `ReflectKind::Enum` rather than `ReflectKind::Value`, allowing for inspection of its constituents

## Migration Guide

`Result<T, E>` has had its `Reflect` implementation changed to align it with `Option<T>` and its intended semantics: A carrier of either an `Ok` or `Err` value, and the ability to access it. To achieve this it is no longer a `ReflectKind::Value` but rather a `ReflectKind::Enum` and as such carries these changes with it:

For `Result<T, E>`
- Both `T` and `E` no longer require to be `Clone` and now require to be `FromReflect`
- `<Result<T, E> as Reflect>::reflect_*` now returns a `ReflectKind::Enum`, so any code that previously relied on it being a `Value` kind will have to be adapted.
- `Result<T, E>` now implements `Enum`

Since the migration is highly dependent on the previous usage, no automatic upgrade path can be given.