### PR TITLE
Add json output flags to our CI tool

### DIFF
--- a/crates/bevy_utils/README.md
+++ b/crates/bevy_utils/README.md
@@ -1,9 +1,0 @@
-# Bevy Utilities
-
-[![License](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/bevyengine/bevy#license)
-[![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy_utils)
-[![Downloads](https://img.shields.io/crates/d/bevy_utils.svg)](https://crates.io/crates/bevy_utils)
-[![Docs](https://docs.rs/bevy_utils/badge.svg)](https://docs.rs/bevy_utils/latest/bevy_utils/)
-[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)
-
-A Collection of Utilities for the [Bevy Engine](https://bevyengine.org/).

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -9,6 +9,8 @@ license = "MIT OR Apache-2.0"
 argh = "0.1"
 xshell = "0.2"
 bitflags = "2.3"
+serde_json = "1.0.116"
+serde = { version = "1.0.200", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/tools/ci/src/ci.rs
+++ b/tools/ci/src/ci.rs
@@ -3,6 +3,8 @@ use crate::{
     prepare::{Flag, Prepare, PreparedCommand},
 };
 use argh::FromArgs;
+use std::io::stdout;
+use std::process::ExitCode;
 
 /// The CI command line tool for Bevy.
 #[derive(FromArgs)]
@@ -20,42 +22,56 @@ impl CI {
     ///
     /// When run locally, results may differ from actual CI runs triggered by `.github/workflows/ci.yml`.
     /// This is usually related to differing toolchains and configuration.
-    pub fn run(self) {
+    pub fn run(self) -> ExitCode {
         let sh = xshell::Shell::new().unwrap();
 
         let prepared_commands = self.prepare(&sh);
 
         let mut failures = vec![];
+        let mut json_output = vec![];
 
-        for command in prepared_commands {
-            // If the CI test is to be executed in a subdirectory, we move there before running the command.
-            // This will automatically move back to the original directory once dropped.
-            let _subdir_hook = command.subdir.map(|path| sh.push_dir(path));
+        for mut command in prepared_commands {
+            match command.run(&sh) {
+                Ok(None) => {}
+                Ok(Some(json)) => json_output.push(json),
+                Err(json) => {
+                    if let Some(json) = json {
+                        json_output.push(json);
+                    }
 
-            // Execute each command, checking if it returned an error.
-            if command.command.envs(command.env_vars).run().is_err() {
-                let name = command.name;
-                let message = command.failure_message;
+                    let name = command.name;
+                    let message = command.failure_message;
 
-                if self.keep_going {
-                    // We use bullet points here because there can be more than one error.
-                    failures.push(format!("- {name}: {message}"));
-                } else {
-                    failures.push(format!("{name}: {message}"));
-                    break;
+                    if self.keep_going {
+                        // We use bullet points here because there can be more than one error.
+                        failures.push(format!("- {name}: {message}"));
+                    } else {
+                        failures.push(format!("{name}: {message}"));
+                        break;
+                    }
                 }
             }
+        }
+
+        // Write JSON output to stdout.
+        if !json_output.is_empty() {
+            serde_json::to_writer(stdout(), &json_output).unwrap();
         }
 
         // Log errors at the very end.
         if !failures.is_empty() {
             let failures = failures.join("\n");
 
-            panic!(
+            // Write error messages to stderr.
+            eprintln!(
                 "One or more CI commands failed:\n\
                 {failures}"
             );
+
+            return ExitCode::FAILURE;
         }
+
+        ExitCode::SUCCESS
     }
 
     fn prepare<'a>(&self, sh: &'a xshell::Shell) -> Vec<PreparedCommand<'a>> {

--- a/tools/ci/src/commands/bench_check.rs
+++ b/tools/ci/src/commands/bench_check.rs
@@ -1,20 +1,28 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Checks that the benches compile.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "bench-check")]
-pub struct BenchCheckCommand {}
+pub struct BenchCheckCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for BenchCheckCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
+
             cmd!(
                 sh,
-                "cargo check --benches --target-dir ../target --manifest-path ./benches/Cargo.toml"
+                "cargo check --benches {format_flag} --target-dir ../target --manifest-path ./benches/Cargo.toml"
             ),
             "Failed to check the benches.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/clippy.rs
+++ b/tools/ci/src/commands/clippy.rs
@@ -1,20 +1,27 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Check for clippy warnings and errors.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "clippy")]
-pub struct ClippyCommand {}
+pub struct ClippyCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for ClippyCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo clippy --workspace --all-targets --all-features -- -Dwarnings"
+                "cargo clippy --workspace --all-targets --all-features {format_flag} -- -Dwarnings"
             ),
             "Please fix clippy errors in output above.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/compile_check.rs
+++ b/tools/ci/src/commands/compile_check.rs
@@ -1,17 +1,24 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Checks that the project compiles.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "compile-check")]
-pub struct CompileCheckCommand {}
+pub struct CompileCheckCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for CompileCheckCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
-            cmd!(sh, "cargo check --workspace"),
+            cmd!(sh, "cargo check {format_flag} --workspace"),
             "Please fix compiler errors in output above.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/doc.rs
+++ b/tools/ci/src/commands/doc.rs
@@ -7,13 +7,25 @@ use argh::FromArgs;
 /// Alias for running the `doc-test` and `doc-check` subcommands.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "doc")]
-pub struct DocCommand {}
+pub struct DocCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for DocCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
         let mut commands = vec![];
-        commands.append(&mut DocTestCommand::default().prepare(sh, flags));
-        commands.append(&mut DocCheckCommand::default().prepare(sh, flags));
+        commands.append(
+            &mut DocTestCommand::default()
+                .with_json(self.emit_json)
+                .prepare(sh, flags),
+        );
+        commands.append(
+            &mut DocCheckCommand::default()
+                .with_json(self.emit_json)
+                .prepare(sh, flags),
+        );
         commands
     }
 }

--- a/tools/ci/src/commands/doc_check.rs
+++ b/tools/ci/src/commands/doc_check.rs
@@ -1,21 +1,36 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Checks that all docs compile.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "doc-check")]
-pub struct DocCheckCommand {}
+pub struct DocCheckCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
+
+impl DocCheckCommand {
+    pub fn with_json(mut self, emit_json: bool) -> Self {
+        self.emit_json = emit_json;
+        self
+    }
+}
 
 impl Prepare for DocCheckCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo doc --workspace --all-features --no-deps --document-private-items --keep-going"
+
+                "cargo doc --workspace {format_flag} --all-features --no-deps --document-private-items --keep-going"
+
             ),
             "Please fix doc warnings in output above.",
         )
-        .with_env_var("RUSTDOCFLAGS", "-D warnings")]
+        .with_env_var("RUSTDOCFLAGS", "-D warnings").with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/doc_test.rs
+++ b/tools/ci/src/commands/doc_test.rs
@@ -1,11 +1,22 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Runs all doc tests.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "doc-test")]
-pub struct DocTestCommand {}
+pub struct DocTestCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
+
+impl DocTestCommand {
+    pub fn with_json(mut self, emit_json: bool) -> Self {
+        self.emit_json = emit_json;
+        self
+    }
+}
 
 impl Prepare for DocTestCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
@@ -14,9 +25,15 @@ impl Prepare for DocTestCommand {
             .then_some("--no-fail-fast")
             .unwrap_or_default();
 
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
-            cmd!(sh, "cargo test --workspace --doc {no_fail_fast}"),
+            cmd!(
+                sh,
+                "cargo test {format_flag} --workspace --doc {no_fail_fast}"
+            ),
             "Please fix failing doc tests in output above.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/example_check.rs
+++ b/tools/ci/src/commands/example_check.rs
@@ -1,17 +1,24 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Checks that the examples compile.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "example-check")]
-pub struct ExampleCheckCommand {}
+pub struct ExampleCheckCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for ExampleCheckCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
-            cmd!(sh, "cargo check --workspace --examples"),
+            cmd!(sh, "cargo check --workspace {format_flag} --examples"),
             "Please fix compiler errors for examples in output above.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -1,11 +1,15 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Runs all tests (except for doc tests).
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "test")]
-pub struct TestCommand {}
+pub struct TestCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for TestCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
@@ -14,14 +18,17 @@ impl Prepare for TestCommand {
             .then_some("--no-fail-fast")
             .unwrap_or_default();
 
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
                 // `--benches` runs each benchmark once in order to verify that they behave
                 // correctly and do not panic.
-                "cargo test --workspace --lib --bins --tests --benches {no_fail_fast}"
+                "cargo test {format_flag} --workspace --lib --bins --tests --benches {no_fail_fast}"
             ),
             "Please fix failing tests in output above.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/commands/test_check.rs
+++ b/tools/ci/src/commands/test_check.rs
@@ -1,17 +1,24 @@
-use crate::{Flag, Prepare, PreparedCommand};
+use crate::{json::message_format_option, Flag, Prepare, PreparedCommand};
 use argh::FromArgs;
 use xshell::cmd;
 
 /// Checks that all tests compile.
 #[derive(FromArgs, Default)]
 #[argh(subcommand, name = "test-check")]
-pub struct TestCheckCommand {}
+pub struct TestCheckCommand {
+    #[argh(switch)]
+    /// emit errors as json
+    emit_json: bool,
+}
 
 impl Prepare for TestCheckCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let format_flag = message_format_option(self.emit_json);
+
         vec![PreparedCommand::new::<Self>(
-            cmd!(sh, "cargo check --workspace --tests"),
+            cmd!(sh, "cargo check {format_flag} --workspace --tests"),
             "Please fix compiler examples for tests in output above.",
-        )]
+        )
+        .with_json(self.emit_json)]
     }
 }

--- a/tools/ci/src/json.rs
+++ b/tools/ci/src/json.rs
@@ -1,0 +1,57 @@
+//! Everything we need to handle json output and input.
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+pub fn message_format_option(emit_json: bool) -> &'static str {
+    if emit_json {
+        "--message-format=json"
+    } else {
+        "--message-format=human"
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonCommandOutput {
+    pub command_name: String,
+    pub messages: Vec<Map<String, Value>>,
+}
+
+impl JsonCommandOutput {
+    pub fn from_cargo_output(output: Vec<u8>, command_name: String) -> Option<JsonCommandOutput> {
+        /// Used to filter out compiler messages we don't care about
+        ///
+        /// The cargo json output format is rather verbose and tends to produce
+        /// long lines. It would be expensive to deserialize them all especially
+        /// when for most of them we'll check one field and then discard them.
+        const COMPILER_MESSAGE_FILTER: &str = r#""reason":"compiler-message""#;
+
+        let json_string = core::str::from_utf8(&output).ok()?;
+
+        let mut messages = vec![];
+
+        // Each line is an individual JSON object that can be parsed separately.
+        for line in json_string.lines() {
+            if !line.contains(COMPILER_MESSAGE_FILTER) {
+                continue;
+            }
+
+            // Parse the JSON, silently skipping it on failure.
+            let Ok(mut message) = serde_json::from_str::<Map<String, Value>>(line) else {
+                continue;
+            };
+
+            // Retrieve the message, skipping it if unavailable.
+            let Some(Value::Object(inner_message)) = message.remove("message") else {
+                continue;
+            };
+
+            messages.push(inner_message);
+        }
+
+        Some(JsonCommandOutput {
+            command_name,
+            messages,
+        })
+    }
+}

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -2,10 +2,12 @@
 
 mod ci;
 mod commands;
+mod json;
 mod prepare;
 
 pub use self::{ci::*, prepare::*};
+use std::process::ExitCode;
 
-fn main() {
-    argh::from_env::<CI>().run();
+fn main() -> ExitCode {
+    argh::from_env::<CI>().run()
 }

--- a/tools/ci/src/prepare.rs
+++ b/tools/ci/src/prepare.rs
@@ -1,4 +1,9 @@
+use std::io::{stderr, stdout, Write};
+
 use bitflags::bitflags;
+use xshell::Shell;
+
+use crate::json::JsonCommandOutput;
 
 /// Trait for preparing a subcommand to be run.
 pub trait Prepare {
@@ -24,7 +29,7 @@ pub trait Prepare {
     ///     }
     /// }
     /// ```
-    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>>;
+    fn prepare<'a>(&self, sh: &'a Shell, flags: Flag) -> Vec<PreparedCommand<'a>>;
 }
 
 bitflags! {
@@ -53,6 +58,9 @@ pub struct PreparedCommand<'a> {
 
     /// Environment variables that need to be set before the test runs
     pub env_vars: Vec<(&'static str, &'static str)>,
+
+    /// The command outputs cargo formatted json
+    pub emit_json: bool,
 }
 
 impl<'a> PreparedCommand<'a> {
@@ -73,6 +81,7 @@ impl<'a> PreparedCommand<'a> {
             failure_message,
             subdir: None,
             env_vars: vec![],
+            emit_json: false,
         }
     }
 
@@ -86,5 +95,44 @@ impl<'a> PreparedCommand<'a> {
     pub fn with_env_var(mut self, key: &'static str, value: &'static str) -> Self {
         self.env_vars.push((key, value));
         self
+    }
+
+    /// A builder that controls whetever this command outputs json
+    pub fn with_json(mut self, emit_json: bool) -> Self {
+        self.emit_json = emit_json;
+        self
+    }
+
+    /// Runs this command
+    ///
+    /// If the command otputs json will return a [`JsonCommandOutput`]
+    pub fn run(
+        &mut self,
+        shell: &Shell,
+    ) -> Result<Option<JsonCommandOutput>, Option<JsonCommandOutput>> {
+        // If the CI test is to be executed in a subdirectory, we move there before running the command.
+        // This will automatically move back to the original directory once dropped.
+        let _subdir_hook = self.subdir.map(|path| shell.push_dir(path));
+
+        // For json outputting commands we want to read stdout even when things fail.
+        self.command.set_ignore_status(true);
+
+        let output = self.command.output().map_err(|_| None)?;
+
+        let json = if self.emit_json {
+            JsonCommandOutput::from_cargo_output(output.stdout, self.name.to_string())
+        } else {
+            stdout().write_all(&output.stdout).unwrap();
+            None
+        };
+
+        stderr().write_all(&output.stderr).unwrap();
+
+        if output.status.success() {
+            Ok(json)
+        } else {
+            eprintln!("{}", self.failure_message);
+            Err(json)
+        }
     }
 }


### PR DESCRIPTION
This is part 1 of what I'm planing to be a 3 part project to improve how our CI reports errors.
- Part 1 (this) will introduce a way to output structured error messages which other tools may ingest.
- Part 2 will be a refactor of how we handle commands so they can do more than invoke the shell.
- Part 3 will be a command that ingests the structured output from other commands and spits out [GitHub workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) for our CI.

# Objective

Add a way for our CI tool to output messages in a structured form usable by other tools.

## Solution

Most everything we currently use in our tools can be configured to output [`json]`(https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages). So we just need to process it a bit and output effectively that.

The only thing that can't do json are our compile fail tests and formatting. Formatting can't do it because the `check` flag for `rustfmt` doesn't support json output. The compile fail tests can't do it because they use a custom test harness. We'd maybe be able to switch them to the standard cargo harness. We would likely loose the ability to show stderr diffs which is less than ideal but they don't work right now so it isn't much of a blocker.

The result is that everything that supports json output gets a `emit_json` flag and I've refactored how we invoke our commands so we can parse the json output they now output.

## Testing

The code was linted through our CI tool using the clippy subcommand using it with and without the `emit_json` flag,

cc @BD103 