### PR TITLE
Pack multiple meshes into vertex and index buffers.

### DIFF
--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -33,7 +33,7 @@ use bevy_asset::AssetId;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
-    mesh::Mesh,
+    mesh::{Mesh, MeshSlabHash},
     render_phase::{
         BinnedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem,
         PhaseItemExtraIndex,
@@ -128,19 +128,21 @@ pub struct Opaque3dPrepass {
 /// The data used to bin each opaque 3D mesh in the prepass and deferred pass.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpaqueNoLightmap3dBinKey {
+    pub slab_hash: MeshSlabHash,
+
     /// The ID of the GPU pipeline.
     pub pipeline: CachedRenderPipelineId,
 
     /// The function used to draw the mesh.
     pub draw_function: DrawFunctionId,
 
-    /// The ID of the mesh.
-    pub asset_id: AssetId<Mesh>,
-
     /// The ID of a bind group specific to the material.
     ///
     /// In the case of PBR, this is the `MaterialBindGroupId`.
     pub material_bind_group_id: Option<BindGroupId>,
+
+    /// The ID of the mesh.
+    pub asset_id: AssetId<Mesh>,
 }
 
 impl PhaseItem for Opaque3dPrepass {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -7,8 +7,8 @@ use crate::*;
 use bevy_asset::{Asset, AssetId, AssetServer};
 use bevy_core_pipeline::{
     core_3d::{
-        AlphaMask3d, Camera3d, Opaque3d, Opaque3dBinKey, ScreenSpaceTransmissionQuality,
-        Transmissive3d, Transparent3d,
+        AlphaMask3d, Camera3d, MeshCompareFlags, Opaque3d, Opaque3dBinKey,
+        ScreenSpaceTransmissionQuality, Transmissive3d, Transparent3d,
     },
     prepass::{
         DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass, OpaqueNoLightmap3dBinKey,
@@ -723,7 +723,8 @@ pub fn queue_material_meshes<M: Material>(
                             pipeline: pipeline_id,
                             asset_id: mesh_instance.mesh_asset_id,
                             material_bind_group_id: material.get_bind_group_id().0,
-                            lightmap_image,
+                            lightmap_image: lightmap_image.unwrap_or_default(),
+                            flags: MeshCompareFlags::new(lightmap_image.is_some(), mesh.slab_hash),
                         };
                         opaque_phase.add(bin_key, *visible_entity, mesh_instance.should_batch());
                     }
@@ -746,6 +747,7 @@ pub fn queue_material_meshes<M: Material>(
                             draw_function: draw_alpha_mask_pbr,
                             pipeline: pipeline_id,
                             asset_id: mesh_instance.mesh_asset_id,
+                            slab_hash: mesh.slab_hash,
                             material_bind_group_id: material.get_bind_group_id().0,
                         };
                         alpha_mask_phase.add(

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -860,6 +860,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 pipeline: pipeline_id,
                                 asset_id: mesh_instance.mesh_asset_id,
                                 material_bind_group_id: material.get_bind_group_id().0,
+                                slab_hash: mesh.slab_hash,
                             },
                             *visible_entity,
                             mesh_instance.should_batch(),
@@ -871,6 +872,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 pipeline: pipeline_id,
                                 asset_id: mesh_instance.mesh_asset_id,
                                 material_bind_group_id: material.get_bind_group_id().0,
+                                slab_hash: mesh.slab_hash,
                             },
                             *visible_entity,
                             mesh_instance.should_batch(),
@@ -885,6 +887,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                             draw_function: alpha_mask_draw_deferred,
                             asset_id: mesh_instance.mesh_asset_id,
                             material_bind_group_id: material.get_bind_group_id().0,
+                            slab_hash: mesh.slab_hash,
                         };
                         alpha_mask_deferred_phase.as_mut().unwrap().add(
                             bin_key,
@@ -897,6 +900,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                             draw_function: alpha_mask_draw_prepass,
                             asset_id: mesh_instance.mesh_asset_id,
                             material_bind_group_id: material.get_bind_group_id().0,
+                            slab_hash: mesh.slab_hash,
                         };
                         alpha_mask_phase.add(
                             bin_key,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -3,7 +3,7 @@ use bevy_core_pipeline::core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT};
 use bevy_ecs::prelude::*;
 use bevy_ecs::{entity::EntityHashMap, system::lifetimeless::Read};
 use bevy_math::{Mat4, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
-use bevy_render::mesh::Mesh;
+use bevy_render::mesh::{Mesh, MeshSlabHash};
 use bevy_render::{
     camera::Camera,
     diagnostic::RecordDiagnostics,
@@ -1719,6 +1719,7 @@ pub fn queue_shadows<M: Material>(
                     ShadowBinKey {
                         draw_function: draw_shadow_mesh,
                         pipeline: pipeline_id,
+                        slab_hash: mesh.slab_hash,
                         asset_id: mesh_instance.mesh_asset_id,
                     },
                     entity,
@@ -1738,6 +1739,8 @@ pub struct Shadow {
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ShadowBinKey {
+    pub slab_hash: MeshSlabHash,
+
     /// The identifier of the render pipeline.
     pub pipeline: CachedRenderPipelineId,
 
@@ -1745,6 +1748,8 @@ pub struct ShadowBinKey {
     pub draw_function: DrawFunctionId,
 
     /// The mesh.
+    ///
+    /// This is at the end to minimize binding changes.
     pub asset_id: AssetId<Mesh>,
 }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -2,7 +2,10 @@ use std::mem;
 
 use bevy_asset::{load_internal_asset, AssetId};
 use bevy_core_pipeline::{
-    core_3d::{AlphaMask3d, Opaque3d, Transmissive3d, Transparent3d, CORE_3D_DEPTH_FORMAT},
+    core_3d::{
+        AlphaMask3d, Opaque3d, Transmissive3d, Transparent3d,
+        CORE_3D_DEPTH_FORMAT,
+    },
     deferred::{AlphaMask3dDeferred, Opaque3dDeferred},
 };
 use bevy_derive::{Deref, DerefMut};
@@ -14,6 +17,7 @@ use bevy_ecs::{
 };
 use bevy_math::{Affine3, Rect, UVec2, Vec3, Vec4};
 use bevy_render::{
+    allocator::GpuAllocator,
     batching::{
         gpu_preprocessing::{
             self, GpuPreprocessingSupport, IndirectParameters, IndirectParametersBuffer,
@@ -1160,6 +1164,7 @@ impl GetBatchData for MeshPipeline {
         SRes<RenderLightmaps>,
         SRes<RenderAssets<GpuMesh>>,
     );
+
     // The material bind group ID, the mesh ID, and the lightmap ID,
     // respectively.
     type CompareData = (MaterialBindGroupId, AssetId<Mesh>, Option<AssetId<Image>>);
@@ -1177,6 +1182,7 @@ impl GetBatchData for MeshPipeline {
             );
             return None;
         };
+
         let mesh_instance = mesh_instances.get(&entity)?;
         let maybe_lightmap = lightmaps.render_lightmaps.get(&entity);
 
@@ -1298,23 +1304,30 @@ fn get_batch_indirect_parameters_index(
     let mesh_instance = mesh_instances.get(&entity)?;
     let mesh = meshes.get(mesh_instance.mesh_asset_id)?;
 
+    let vertex_offset = mesh.vertex_buffer.offset();
+
     // Note that `IndirectParameters` covers both of these structures, even
     // though they actually have distinct layouts. See the comment above that
     // type for more information.
     let indirect_parameters = match mesh.buffer_info {
         GpuBufferInfo::Indexed {
-            count: index_count, ..
-        } => IndirectParameters {
-            vertex_or_index_count: index_count,
-            instance_count: 0,
-            first_vertex: 0,
-            base_vertex_or_first_instance: 0,
-            first_instance: instance_index,
-        },
+            ref allocation,
+            count: index_count,
+            ..
+        } => {
+            let index_offset = allocation.offset();
+            IndirectParameters {
+                vertex_or_index_count: index_count,
+                instance_count: 0,
+                first_vertex_or_index: index_offset,
+                base_vertex_or_first_instance: vertex_offset,
+                first_instance: instance_index,
+            }
+        }
         GpuBufferInfo::NonIndexed => IndirectParameters {
             vertex_or_index_count: mesh.vertex_count,
             instance_count: 0,
-            first_vertex: 0,
+            first_vertex_or_index: vertex_offset,
             base_vertex_or_first_instance: instance_index,
             first_instance: instance_index,
         },
@@ -2043,6 +2056,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         SRes<RenderMeshInstances>,
         SRes<IndirectParametersBuffer>,
         SRes<PipelineCache>,
+        SRes<GpuAllocator>,
         Option<SRes<PreprocessPipelines>>,
     );
     type ViewQuery = Has<PreprocessBindGroup>;
@@ -2052,7 +2066,14 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         item: &P,
         has_preprocess_bind_group: ROQueryItem<Self::ViewQuery>,
         _item_query: Option<()>,
-        (meshes, mesh_instances, indirect_parameters_buffer, pipeline_cache, preprocess_pipelines): SystemParamItem<'w, '_, Self::Param>,
+        (
+            meshes,
+            mesh_instances,
+            indirect_parameters_buffer,
+            pipeline_cache,
+            allocator,
+            preprocess_pipelines,
+        ): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         // If we're using GPU preprocessing, then we're dependent on that
@@ -2069,6 +2090,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         let meshes = meshes.into_inner();
         let mesh_instances = mesh_instances.into_inner();
         let indirect_parameters_buffer = indirect_parameters_buffer.into_inner();
+        let allocator = allocator.into_inner();
 
         let Some(mesh_asset_id) = mesh_instances.mesh_asset_id(item.entity()) else {
             return RenderCommandResult::Failure;
@@ -2092,21 +2114,32 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
             },
         };
 
-        pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
+        let vertex_buffer = allocator.buffer(&gpu_mesh.vertex_buffer);
+        let vertex_offset = gpu_mesh.vertex_buffer.offset();
+
+        pass.set_vertex_buffer(0, vertex_buffer.slice(..));
 
         let batch_range = item.batch_range();
 
         // Draw either directly or indirectly, as appropriate.
         match &gpu_mesh.buffer_info {
             GpuBufferInfo::Indexed {
-                buffer,
+                allocation,
                 index_format,
                 count,
             } => {
-                pass.set_index_buffer(buffer.slice(..), 0, *index_format);
+                let index_buffer = allocator.buffer(allocation);
+                let index_offset = allocation.offset();
+
+                pass.set_index_buffer(index_buffer.slice(..), 0, *index_format);
+
                 match indirect_parameters {
                     None => {
-                        pass.draw_indexed(0..*count, 0, batch_range.clone());
+                        pass.draw_indexed(
+                            index_offset..(index_offset + *count),
+                            vertex_offset as i32,
+                            batch_range.clone(),
+                        );
                     }
                     Some((indirect_parameters_offset, indirect_parameters_buffer)) => pass
                         .draw_indexed_indirect(
@@ -2117,7 +2150,10 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
             }
             GpuBufferInfo::NonIndexed => match indirect_parameters {
                 None => {
-                    pass.draw(0..gpu_mesh.vertex_count, batch_range.clone());
+                    pass.draw(
+                        vertex_offset..(vertex_offset + gpu_mesh.vertex_count),
+                        batch_range.clone(),
+                    );
                 }
                 Some((indirect_parameters_offset, indirect_parameters_buffer)) => {
                     pass.draw_indirect(indirect_parameters_buffer, indirect_parameters_offset);

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -101,6 +101,8 @@ profiling = { version = "1", features = [
 async-channel = "2.2.0"
 nonmax = "0.5"
 smallvec = "1.11"
+offset-allocator = "0.1"
+slotmap = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Omit the `glsl` feature in non-WebAssembly by default.

--- a/crates/bevy_render/src/allocator.rs
+++ b/crates/bevy_render/src/allocator.rs
@@ -1,0 +1,411 @@
+//! GPU memory buffer allocation.
+
+use std::{
+    fmt::{self, Debug, Display, Formatter},
+    hash::{DefaultHasher, Hash, Hasher},
+    iter,
+    sync::{Arc, RwLock},
+};
+
+use bevy_app::{App, Plugin};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{
+    schedule::IntoSystemConfigs,
+    system::{ResMut, Resource},
+};
+use bevy_time::common_conditions::on_timer;
+use bevy_utils::{hashbrown::HashMap, prelude::default, tracing::error, Duration};
+use offset_allocator::{Allocation, Allocator};
+use slotmap::{new_key_type, SlotMap};
+use wgpu::{util::BufferInitDescriptor, BufferDescriptor, BufferUsages, IndexFormat};
+
+use crate::{
+    mesh::MeshVertexBufferLayoutRef,
+    render_resource::Buffer,
+    renderer::{RenderDevice, RenderQueue},
+    Render, RenderApp,
+};
+
+const SWEEP_INTERVAL: Duration = Duration::from_secs(10);
+
+pub struct GpuAllocatorPlugin {
+    slab_size: u64,
+}
+
+#[derive(Resource, Clone)]
+pub struct GpuAllocator {
+    slabs: HashMap<SlabId, Buffer>,
+    slab_size: u64,
+    next_slab_id: SlabId,
+    classes: HashMap<GpuAllocationClass, GpuClassAllocator>,
+}
+
+#[derive(Clone, Default, Deref, DerefMut)]
+struct GpuClassAllocator(Arc<RwLock<GpuClassAllocatorData>>);
+
+#[derive(Default)]
+struct GpuClassAllocatorData {
+    regular_slabs: SlotMap<RegularSlabId, (Allocator, SlabId)>,
+    large_slabs: SlotMap<LargeSlabId, SlabId>,
+    free_large_slabs: Vec<SlabId>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum GpuAllocationClass {
+    VertexBuffer(MeshVertexBufferLayoutRef),
+    IndexBuffer(IndexFormat),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Deref, DerefMut, Debug)]
+#[repr(transparent)]
+pub struct SlabId(pub u32);
+
+new_key_type! {
+    pub struct RegularSlabId;
+}
+
+new_key_type! {
+    pub struct LargeSlabId;
+}
+
+#[derive(Clone)]
+pub struct GpuAllocation {
+    allocation_id: GpuAllocationId,
+    slab_id: SlabId,
+
+    /// This is the offset in `unit_size` elements. It may differ from the
+    /// offset in `Allocation` because the one in `Allocation` is in multiples
+    /// of `aligned_unit_size`, while this one is in multiples of `unit_size`.
+    offset: u32,
+
+    // Only needed when dropping.
+    class_allocator: GpuClassAllocator,
+}
+
+#[derive(Clone)]
+enum GpuAllocationId {
+    Regular(RegularSlabId, Allocation),
+    Large(LargeSlabId),
+}
+
+impl Plugin for GpuAllocatorPlugin {
+    fn build(&self, app: &mut App) {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .insert_resource(GpuAllocator {
+                slabs: HashMap::default(),
+                slab_size: self.slab_size,
+                next_slab_id: SlabId::default(),
+                classes: HashMap::default(),
+            })
+            .add_systems(Render, free_unused_slabs.run_if(on_timer(SWEEP_INTERVAL)));
+    }
+}
+
+impl Default for GpuAllocatorPlugin {
+    fn default() -> Self {
+        // 32 MB slabs by default.
+        Self {
+            slab_size: 32 * 1024 * 1024,
+        }
+    }
+}
+
+impl Drop for GpuAllocation {
+    fn drop(&mut self) {
+        // This is written to avoid panics.
+        let Ok(mut class_allocator) = self.class_allocator.write() else {
+            error!("Couldn't lock the class allocator; just leaking");
+            return;
+        };
+
+        match self.allocation_id {
+            GpuAllocationId::Regular(regular_slab_id, allocation) => {
+                let Some((ref mut allocator, _)) =
+                    class_allocator.regular_slabs.get_mut(regular_slab_id)
+                else {
+                    error!(
+                        "Couldn't find the slab that this allocation came from; just leaking. \
+                        (Is the allocator corrupt?)"
+                    );
+                    return;
+                };
+
+                // Free the allocation.
+                allocator.free(allocation);
+            }
+
+            GpuAllocationId::Large(large_slab_id) => {
+                let Some(slab) = class_allocator.large_slabs.remove(large_slab_id) else {
+                    error!(
+                        "Couldn't find the slab that this allocation came from; just leaking. \
+                        (Is the allocator corrupt?)"
+                    );
+                    return;
+                };
+
+                // Mark the slab as free.
+                class_allocator.free_large_slabs.push(slab);
+            }
+        }
+    }
+}
+
+impl GpuAllocationClass {
+    fn unit_size(&self) -> u32 {
+        match *self {
+            GpuAllocationClass::VertexBuffer(ref layout) => layout.0.layout().array_stride as u32,
+            GpuAllocationClass::IndexBuffer(IndexFormat::Uint16) => 2,
+            GpuAllocationClass::IndexBuffer(IndexFormat::Uint32) => 4,
+        }
+    }
+
+    fn aligned_unit_size(&self) -> u32 {
+        let mut unit_size = self.unit_size();
+        if unit_size % 4 != 0 {
+            unit_size += 4 - unit_size % 4;
+        }
+        unit_size
+    }
+}
+
+impl GpuAllocator {
+    pub fn buffer(&self, allocation: &GpuAllocation) -> &Buffer {
+        &self.slabs[&allocation.slab_id]
+    }
+}
+
+impl GpuAllocation {
+    /// This is in elements, not bytes.
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub fn slab_id(&self) -> SlabId {
+        self.slab_id
+    }
+}
+
+impl GpuAllocator {
+    pub fn allocate_with(
+        &mut self,
+        render_device: &RenderDevice,
+        render_queue: &RenderQueue,
+        class: &GpuAllocationClass,
+        contents: &[u8],
+    ) -> GpuAllocation {
+        if (contents.len() as u64) > self.slab_size {
+            return self.allocate_large_with(render_device, class, contents);
+        }
+
+        let class_allocator = self.classes.entry(class.clone()).or_insert_with(default);
+
+        let mut class_allocator_data = class_allocator
+            .write()
+            .expect("Failed to lock the class allocator for writing");
+
+        let (unit_size, aligned_unit_size) = (class.unit_size(), class.aligned_unit_size());
+        let aligned_contents_size = contents.len().div_ceil(aligned_unit_size as usize) as u32;
+
+        // First-fit.
+        let mut found_allocation = None;
+        for (regular_slab_id, (ref mut allocator, slab_id)) in
+            class_allocator_data.regular_slabs.iter_mut()
+        {
+            if let Some(allocation) = allocator.allocate(aligned_contents_size) {
+                found_allocation = Some(GpuAllocation {
+                    allocation_id: GpuAllocationId::Regular(regular_slab_id, allocation),
+                    offset: (allocation.offset as u64 * aligned_unit_size as u64 / unit_size as u64)
+                        as u32,
+                    slab_id: *slab_id,
+                    class_allocator: class_allocator.clone(),
+                });
+                break;
+            }
+        }
+
+        let allocation = found_allocation.unwrap_or_else(|| {
+            // We need buffers to have `COPY_DST` so we can, well, copy data
+            // into them.
+            let buffer = render_device.create_buffer(&BufferDescriptor {
+                label: Some(&format!("regular slab ({})", class)),
+                size: self.slab_size,
+                usage: class.buffer_usage() | BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let slab_id = self.next_slab_id;
+            *self.next_slab_id += 1;
+            self.slabs.insert(slab_id, buffer);
+
+            let mut allocator = Allocator::new((self.slab_size / aligned_unit_size as u64) as u32);
+            let allocation = allocator
+                .allocate(aligned_contents_size)
+                .expect("Initial allocation should never fail");
+            let regular_slab_id = class_allocator_data
+                .regular_slabs
+                .insert((allocator, slab_id));
+
+            GpuAllocation {
+                allocation_id: GpuAllocationId::Regular(regular_slab_id, allocation),
+                offset: (allocation.offset as u64 * aligned_unit_size as u64 / unit_size as u64)
+                    as u32,
+                slab_id,
+                class_allocator: class_allocator.clone(),
+            }
+        });
+
+        // Copy data in. Pad out data to be a multiple of 4 bytes in size if
+        // necessary. (This is unfortunate!)
+        let buffer = &self.slabs[&allocation.slab_id];
+        let byte_offset = allocation.offset() as u64 * unit_size as u64;
+        if contents.len() % 4 == 0 {
+            render_queue.write_buffer(buffer, byte_offset, contents);
+        } else {
+            let contents = contents
+                .iter()
+                .copied()
+                .chain(iter::repeat(0).take(4 - (contents.len() % 4)))
+                .collect::<Vec<_>>();
+
+            render_queue.write_buffer(buffer, byte_offset, &contents);
+        };
+
+        allocation
+    }
+
+    pub fn allocate_large_with(
+        &mut self,
+        render_device: &RenderDevice,
+        class: &GpuAllocationClass,
+        contents: &[u8],
+    ) -> GpuAllocation {
+        let class_allocator = self.classes.entry(class.clone()).or_insert_with(default);
+
+        let mut class_allocator_data = class_allocator
+            .write()
+            .expect("Failed to lock the class allocator for writing");
+
+        // First-fit.
+        let mut slab_id = None;
+        for slab_index in 0..class_allocator_data.free_large_slabs.len() {
+            if self.slabs[&class_allocator_data.free_large_slabs[slab_index]].size()
+                >= contents.len() as u64 * 4
+            {
+                slab_id = Some(
+                    class_allocator_data
+                        .free_large_slabs
+                        .swap_remove(slab_index),
+                );
+                break;
+            }
+        }
+
+        let slab_id = slab_id.unwrap_or_else(|| {
+            let slab_id = self.next_slab_id;
+            *self.next_slab_id += 1;
+            self.slabs.insert(
+                slab_id,
+                render_device.create_buffer_with_data(&BufferInitDescriptor {
+                    label: Some(&format!("large slab ({})", class)),
+                    contents,
+                    usage: class.buffer_usage(),
+                }),
+            );
+            slab_id
+        });
+
+        let large_slab_id = class_allocator_data.large_slabs.insert(slab_id);
+
+        GpuAllocation {
+            allocation_id: GpuAllocationId::Large(large_slab_id),
+            offset: 0,
+            slab_id,
+            class_allocator: class_allocator.clone(),
+        }
+    }
+}
+
+impl GpuClassAllocatorData {
+    fn is_empty(&self) -> bool {
+        self.regular_slabs.is_empty() && self.large_slabs.is_empty()
+    }
+}
+
+fn free_unused_slabs(allocator: ResMut<GpuAllocator>) {
+    let allocator = allocator.into_inner();
+    let slab_size = allocator.slab_size;
+    let mut slabs_to_free = vec![];
+
+    allocator.classes.retain(|_, class| {
+        let Ok(mut class) = class.write() else {
+            return true;
+        };
+
+        // Free regular slabs.
+        class.regular_slabs.retain(|_, (allocator, slab_id)| {
+            let free = allocator.storage_report().total_free_space as u64 == slab_size;
+            if free {
+                slabs_to_free.push(*slab_id);
+            }
+            !free
+        });
+
+        // Free large slabs.
+        slabs_to_free.append(&mut class.free_large_slabs);
+
+        !class.is_empty()
+    });
+
+    for slab in slabs_to_free {
+        if let Some(buffer) = allocator.slabs.remove(&slab) {
+            buffer.destroy();
+        }
+    }
+}
+
+impl Display for GpuAllocationClass {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            GpuAllocationClass::VertexBuffer(ref layout) => {
+                let mut hasher = DefaultHasher::new();
+                layout.0.hash(&mut hasher);
+                let hash = hasher.finish();
+                write!(f, "vertex buffer ({:16x})", hash)
+            }
+            GpuAllocationClass::IndexBuffer(IndexFormat::Uint16) => {
+                f.write_str("index buffer (u16)")
+            }
+            GpuAllocationClass::IndexBuffer(IndexFormat::Uint32) => {
+                f.write_str("index buffer (u32)")
+            }
+        }
+    }
+}
+
+impl GpuAllocationClass {
+    fn buffer_usage(&self) -> BufferUsages {
+        match *self {
+            GpuAllocationClass::VertexBuffer(_) => BufferUsages::VERTEX,
+            GpuAllocationClass::IndexBuffer(_) => BufferUsages::INDEX,
+        }
+    }
+}
+
+impl Debug for GpuAllocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?} @ {:?}", self.allocation_id, self.slab_id)
+    }
+}
+
+impl Debug for GpuAllocationId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Regular(slab, allocation) => write!(f, "R({:?}, {})", slab, allocation.offset),
+            Self::Large(slab) => write!(f, "L({:?})", slab),
+        }
+    }
+}

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -183,7 +183,7 @@ pub struct IndirectParameters {
     pub instance_count: u32,
 
     /// The index of the first vertex we're to draw.
-    pub first_vertex: u32,
+    pub first_vertex_or_index: u32,
 
     /// For `ArrayIndirectParameters`, `first_instance`; for
     /// `ElementIndirectParameters`, `base_vertex`.

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -12,6 +12,7 @@ compile_error!("bevy_render cannot compile for a 16-bit platform.");
 
 extern crate core;
 
+pub mod allocator;
 pub mod alpha;
 pub mod batching;
 pub mod camera;
@@ -52,6 +53,7 @@ pub mod prelude {
     };
 }
 
+use allocator::GpuAllocatorPlugin;
 use batching::gpu_preprocessing::BatchingPlugin;
 use bevy_ecs::schedule::ScheduleBuildSettings;
 use bevy_utils::prelude::default;
@@ -336,6 +338,7 @@ impl Plugin for RenderPlugin {
             GlobalsPlugin,
             MorphPlugin,
             BatchingPlugin,
+            GpuAllocatorPlugin::default(),
         ));
 
         app.init_resource::<RenderAssetBytesPerFrame>()


### PR DESCRIPTION
This reduces the number of binding changes and paves the way for multidraw. To manage memory within the buffers, it uses the [`offset-allocator`] crate, which is a Rust port of Sebastian Aaltonen's [OffsetAllocator] library for C++.

This isn't quite ready because it's not well tested and the documentation is lacking, so I'm marking it as a draft.

[`offset-allocator`]: https://github.com/pcwalton/offset-allocator/

[OffsetAllocator]: https://github.com/sebbbi/OffsetAllocator/

## Changelog

### Changed
* Vertex and index buffers are now managed with the `GpuAllocator` resource, which can pack them together to reduce binding changes.

## Migration Guide

* Vertex and index buffers now take `GpuAllocation`s instead of just `Buffer`s, for efficiency. To retrieve the `Buffer` corresponding to a `GpuAllocation`, use the `GpuAllocator::buffer()` method. `GpuAllocator` is a resource in the render world.
