### PR TITLE
Don't update app if we're already exiting

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -42,7 +42,7 @@ use bevy_input::{
 use bevy_math::{ivec2, DVec2, Vec2};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
-use bevy_utils::tracing::{error, debug, trace, warn};
+use bevy_utils::tracing::{debug, error, trace, warn};
 #[allow(deprecated)]
 use bevy_window::{
     exit_on_all_closed, ApplicationLifetime, CursorEntered, CursorLeft, CursorMoved,
@@ -283,7 +283,6 @@ pub fn winit_runner(mut app: App) -> AppExit {
 
     // Create a channel with a size of 1, since ideally only one exit code will be sent before exiting the app.
     let (exit_sender, exit_receiver) = sync_channel(1);
-    let mut exit_happened = None;
 
     // prepare structures to access data in the world
     let mut redraw_event_reader = ManualEventReader::<RequestRedraw>::default();
@@ -312,7 +311,6 @@ pub fn winit_runner(mut app: App) -> AppExit {
             &mut redraw_event_reader,
             &mut winit_events,
             &exit_sender,
-            &mut exit_happened,
             event,
             event_loop,
         );
@@ -346,7 +344,6 @@ fn handle_winit_event(
     redraw_event_reader: &mut ManualEventReader<RequestRedraw>,
     winit_events: &mut Vec<WinitEvent>,
     exit_notify: &SyncSender<AppExit>,
-    exit_happened: &mut Option<AppExit>,
     event: Event<UserEvent>,
     event_loop: &EventLoopWindowTarget<UserEvent>,
 ) {
@@ -361,7 +358,7 @@ fn handle_winit_event(
     //       which winit events we need to handle after the app exited and letting
     //       those through. The non-send PR (#9122) will be replacing all of this so
     //       we'll likely fix this then or a bit after.
-    if exit_happened.is_some() && event != Event::LoopExiting {
+    if event_loop.exiting() {
         debug!("App is exiting. Dropping event: {event:?}");
         return;
     }
@@ -788,28 +785,13 @@ fn handle_winit_event(
         Event::UserEvent(RequestRedraw) => {
             runner_state.redraw_requested = true;
         }
-        Event::LoopExiting => {
-            let exit = exit_happened.clone().unwrap_or_else(|| {
-                error!("App exited without raising a `AppExit`!");
-                // Even though an error occurred, we still want to return an `AppExit` because it is preferable to panicking.
-                AppExit::error()
-            });
-
-            if let Err(err) = exit_notify.send(exit) {
-                error!("Failed to send a app exit notification! This is a bug. Reason: {err:?}");
-            }
-
-            // The app is exiting there's no reason to forward_winit_events after this.
-            return;
-        }
         _ => (),
     }
 
     if let Some(app_exit) = app.should_exit() {
-        match exit_happened {
-            Some(_) => error!("Unreachable! Tried to trigger a second exit while app was exiting."),
-            None => *exit_happened = Some(app_exit),
-        }
+        if let Err(err) = exit_notify.try_send(app_exit) {
+            error!("Failed to send a app exit notification! This is a bug. Reason: {err}");
+        };
         event_loop.exit();
         return;
     }


### PR DESCRIPTION
# Objective

As was notice on [discord](https://discord.com/channels/691052431525675048/692572690833473578/1235819217618604135). Running an app currently output `ERROR bevy_winit: Failed to send a app exit notification! This is a bug. Reason: sending on a full channel`. This happens because after [triggering](https://github.com/bevyengine/bevy/blob/2089a28717192d588cb82796dfb60914ef057dcf/crates/bevy_winit/src/lib.rs#L778-L784) a event loop exit we still receive queued events. This triggers the event loop exit code again causing the warning. If one of the events we receive is `AboutToWait` we also update the app which goes against the promise made in the `AppExit` [documentation](https://docs.rs/bevy/latest/bevy/app/struct.AppExit.html).

## Solution

- Add a `exit_happened` flag that gets set when we trigger a app exit.
- After a app exit has been triggered. Only handle the [`LoopExiting`](https://docs.rs/winit/0.29.15/winit/event/enum.Event.html#variant.LoopExiting) event.
- While handling the `LoopExiting` event send the `AppExit` that triggered the exit to the winit_runner.

## Testing

- Run the scene 3d example.
```sh
cargo run --example 3d_scene
```
- Close the window.
- You should only see one `No windows are open, exiting` message and no errors.

If somebody could test this code on wasm I'd really appreciate it. Every time I try to do it I get a `GPU lacks support: TextureFormat::R16Float does not support TextureUsages::STORAGE_BINDING.` error, so I can't test it myself. 
