### PR TITLE
Give alt text to Bevy logo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::single_component_path_imports)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-//! [![](https://bevyengine.org/assets/bevy_logo_docs.svg)](https://bevyengine.org)
+//! [![Bevy Logo](https://bevyengine.org/assets/bevy_logo_docs.svg)](https://bevyengine.org)
 //!
 //! Bevy is an open-source modular game engine built in Rust, with a focus on developer productivity
 //! and performance.


### PR DESCRIPTION
# Objective

- In the documentation of the `bevy` crate, we embed the Bevy logo. ([docs.rs](https://docs.rs/bevy/0.13.2/bevy/index.html), [logo](https://bevyengine.org/assets/bevy_logo_docs.svg))
- It was first added in 9aae341.
- Markdown supports adding alternate descriptions for images that either cannot be loaded or for screen readers.

## Solution

- Add alt text for the Bevy logo.

---

## Changelog

- Added alt text to Bevy logo.
