### PR TITLE
Determine msrv for every standalone bevy_* crate.

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "color"]
+rust-version = "1.76.0"
 
 [dependencies]
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
-
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev", features = [

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
+rust-version = "1.77.0"
 
 [features]
 trace = []

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
+rust-version = "1.68.2"
 
 [dependencies]
 glam = { version = "0.27", features = ["bytemuck"] }

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -13,6 +13,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
+rust-version = "1.76.0"
 
 [dependencies]
 glam = "0.27"

--- a/crates/bevy_mikktspace/README.md
+++ b/crates/bevy_mikktspace/README.md
@@ -10,7 +10,7 @@ This is a fork of [https://github.com/gltf-rs/mikktspace](https://github.com/glt
 
 Port of the [Mikkelsen Tangent Space Algorithm](https://en.blender.org/index.php/Dev:Shading/Tangent_Space_Normal_Maps) reference implementation.
 
-Requires at least Rust 1.52.1.
+Requires at least Rust 1.76.0.
 
 ## Examples
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
+rust-version = "1.76.0"
 
 [features]
 default = ["smallvec"]


### PR DESCRIPTION
# Objective

As was pointed out in #13183, `bevy_mikktspace` is missing it's msrv from it `Cargo.toml`. This promted me to check the msrv of every `bevy_*` crate. Closes #13183.

## Solution

- Call `cargo check` with different rust versions on every bevy crate until it doesn't complain.
- Write down the rust version `cargo check` started working.

## Testing

- Install `cargo-msrv`.
- Run `cargo msrv verify`.
- Rejoice.

---

## Changelog

Every published bevy crate now specifies a MSRV. If your rust toolchain isn't at least version `1.77.0` You'll likely not be able to compile most of bevy.

## Migration Guide

If your rust toolchain is bellow version`1.77.0, update.
