### PR TITLE
Add `Annulus`-gizmos

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -6,7 +6,7 @@ use super::helpers::*;
 
 use bevy_color::Color;
 use bevy_math::primitives::{
-    BoxedPolygon, BoxedPolyline2d, Capsule2d, Circle, Ellipse, Line2d, Plane2d, Polygon,
+    Annulus, BoxedPolygon, BoxedPolyline2d, Capsule2d, Circle, Ellipse, Line2d, Plane2d, Polygon,
     Polyline2d, Primitive2d, Rectangle, RegularPolygon, Segment2d, Triangle2d,
 };
 use bevy_math::{Dir2, Mat2, Vec2};
@@ -109,6 +109,32 @@ where
         }
 
         self.ellipse_2d(position, angle, primitive.half_size, color);
+    }
+}
+
+// annulus 2d
+
+impl<'w, 's, Config, Clear> GizmoPrimitive2d<Annulus> for Gizmos<'w, 's, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    type Output<'a> = () where Self: 'a;
+
+    fn primitive_2d(
+        &mut self,
+        primitive: Annulus,
+        position: Vec2,
+        angle: f32,
+        color: impl Into<Color>,
+    ) -> Self::Output<'_> {
+        if !self.enabled {
+            return;
+        }
+
+        let color = color.into();
+        self.primitive_2d(primitive.inner_circle, position, angle, color);
+        self.primitive_2d(primitive.outer_circle, position, angle, color);
     }
 }
 

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -240,6 +240,11 @@ const CONICAL_FRUSTUM: ConicalFrustum = ConicalFrustum {
     height: BIG_3D,
 };
 
+const ANNULUS: Annulus = Annulus {
+    inner_circle: Circle { radius: SMALL_2D },
+    outer_circle: Circle { radius: BIG_2D },
+};
+
 const TORUS: Torus = Torus {
     minor_radius: SMALL_3D / 2.0,
     major_radius: SMALL_3D * 1.5,
@@ -428,7 +433,7 @@ fn draw_gizmos_2d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Cylinder => {}
         PrimitiveSelected::Cone => {}
         PrimitiveSelected::ConicalFrustum => {}
-        PrimitiveSelected::Torus => {}
+        PrimitiveSelected::Torus => gizmos.primitive_2d(ANNULUS, POSITION, angle, color),
     }
 }
 
@@ -470,7 +475,7 @@ fn spawn_primitive_2d(
         None, // cylinder
         None, // cone
         None, // conical frustum
-        None, // torus
+        Some(ANNULUS.mesh().build()),
     ]
     .into_iter()
     .zip(PrimitiveSelected::ALL)


### PR DESCRIPTION
# Objective

- Add support for drawing `Annulus`-gizmos using `gizmos.primitive_2d(...)`

## Changelog

- Updated the example `math/render_primitives`
