### PR TITLE
Ensure clean exit

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{entity::EntityHashMap, prelude::*};
 use bevy_utils::warn_once;
 use bevy_utils::{default, tracing::debug, HashSet};
 use bevy_window::{
-    CompositeAlphaMode, PresentMode, PrimaryWindow, RawHandleWrapper, Window, WindowClosed,
+    CompositeAlphaMode, PresentMode, PrimaryWindow, RawHandleWrapper, Window, WindowClosing,
 };
 use std::{
     num::NonZeroU32,
@@ -117,7 +117,7 @@ impl DerefMut for ExtractedWindows {
 fn extract_windows(
     mut extracted_windows: ResMut<ExtractedWindows>,
     screenshot_manager: Extract<Res<ScreenshotManager>>,
-    mut closed: Extract<EventReader<WindowClosed>>,
+    mut closing: Extract<EventReader<WindowClosing>>,
     windows: Extract<Query<(Entity, &Window, &RawHandleWrapper, Option<&PrimaryWindow>)>>,
     mut removed: Extract<RemovedComponents<RawHandleWrapper>>,
     mut window_surfaces: ResMut<WindowSurfaces>,
@@ -177,9 +177,9 @@ fn extract_windows(
         }
     }
 
-    for closed_window in closed.read() {
-        extracted_windows.remove(&closed_window.window);
-        window_surfaces.remove(&closed_window.window);
+    for closing_window in closing.read() {
+        extracted_windows.remove(&closing_window.window);
+        window_surfaces.remove(&closing_window.window);
     }
     for removed_window in removed.read() {
         extracted_windows.remove(&removed_window);

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -94,6 +94,20 @@ pub struct WindowClosed {
     pub window: Entity,
 }
 
+/// An event that is sent whenever a window is closing. This will be sent when
+/// after a [`WindowCloseRequested`] event is received and the window is in the process of closing.
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct WindowClosing {
+    /// Window that has been requested to close and is the process of closing.
+    pub window: Entity,
+}
+
 /// An event that is sent whenever a window is destroyed by the underlying window system.
 ///
 /// Note that if your application only has a single window, this event may be your last chance to

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -89,6 +89,7 @@ impl Plugin for WindowPlugin {
         #[allow(deprecated)]
         app.add_event::<WindowResized>()
             .add_event::<WindowCreated>()
+            .add_event::<WindowClosing>()
             .add_event::<WindowClosed>()
             .add_event::<WindowCloseRequested>()
             .add_event::<WindowDestroyed>()
@@ -139,6 +140,7 @@ impl Plugin for WindowPlugin {
             .register_type::<RequestRedraw>()
             .register_type::<WindowCreated>()
             .register_type::<WindowCloseRequested>()
+            .register_type::<WindowClosing>()
             .register_type::<WindowClosed>()
             .register_type::<CursorMoved>()
             .register_type::<CursorEntered>()

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -1,4 +1,4 @@
-use crate::{PrimaryWindow, Window, WindowCloseRequested};
+use crate::{ClosingWindow, PrimaryWindow, Window, WindowCloseRequested};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
@@ -39,8 +39,17 @@ pub fn exit_on_primary_closed(
 /// Ensure that you read the caveats documented on that field if doing so.
 ///
 /// [`WindowPlugin`]: crate::WindowPlugin
-pub fn close_when_requested(mut commands: Commands, mut closed: EventReader<WindowCloseRequested>) {
+pub fn close_when_requested(
+    mut commands: Commands,
+    mut closed: EventReader<WindowCloseRequested>,
+    closing: Query<Entity, With<ClosingWindow>>,
+) {
+    // This was inserted by us on the last frame so now we can despawn the window
+    for window in closing.iter() {
+        commands.entity(window).despawn();
+    }
+    // Mark the window as closing so we can despawn it on the next frame
     for event in closed.read() {
-        commands.entity(event.window).despawn();
+        commands.entity(event.window).insert(ClosingWindow);
     }
 }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1171,6 +1171,11 @@ impl Default for EnabledButtons {
     }
 }
 
+/// Marker component for a [`Window`] that has been requested to close and
+/// is in the process of closing (on the next frame).
+#[derive(Component)]
+pub struct ClosingWindow;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -776,6 +776,11 @@ fn handle_winit_event(
     }
 
     if let Some(app_exit) = app.should_exit() {
+        // The event loop is in the process of exiting, but we might still be processing events.
+        if event_loop.exiting() {
+            return;
+        }
+
         if let Err(err) = exit_notify.try_send(app_exit) {
             error!("Failed to send a app exit notification! This is a bug. Reason: {err}");
         };

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -302,6 +302,11 @@ pub fn winit_runner(mut app: App) -> AppExit {
     let mut winit_events = Vec::default();
     // set up the event loop
     let event_handler = move |event, event_loop: &EventLoopWindowTarget<UserEvent>| {
+        // The event loop is in the process of exiting, so don't deliver any new events
+        if event_loop.exiting() {
+            return;
+        }
+
         handle_winit_event(
             &mut app,
             &mut runner_state,
@@ -776,11 +781,6 @@ fn handle_winit_event(
     }
 
     if let Some(app_exit) = app.should_exit() {
-        // The event loop is in the process of exiting, but we might still be processing events.
-        if event_loop.exiting() {
-            return;
-        }
-
         if let Err(err) = exit_notify.try_send(app_exit) {
             error!("Failed to send a app exit notification! This is a bug. Reason: {err}");
         };


### PR DESCRIPTION
# Objective

Fixes two issues related to #13208.

First, we ensure render resources for a window are always dropped first to ensure that the `winit::Window` always drops on the main thread when it is removed from `WinitWindows`. Previously, changes in #12978 caused the window to drop in the render world, causing issues.

We accomplish this by delaying despawning the window by a frame by inserting a marker component `ClosingWindow` that indicates the window has been requested to close and is in the process of closing. The render world now responds to the equivalent `WindowClosing` event rather than `WindowCloseed` which now fires after the render resources are guarunteed to be cleaned up.

Secondly, fixing the above caused (revealed?) that additional events were being delivered to the the event loop handler after exit had already been requested: in my testing `RedrawRequested` and `LoopExiting`. This caused errors to be reported try to send an exit event on the close channel. There are two options here:
 - Guard the handler so no additional events are delivered once the  app is exiting. I ~considered this but worried it might be confusing or bug prone if in the future someone wants to handle `LoopExiting` or some other event to clean-up while exiting.~ We are now taking this approach.
 - Only send an exit signal if we are not already exiting. ~It doesn't appear to cause any problems to handle the extra events so this seems safer.~ 
 
Fixing this also appears to have fixed #13231.

Fixes #10260.

## Testing

Tested on mac only.

---

## Changelog

### Added
-  A `WindowClosing` event has been added that indicates the window will be despawned on the next frame.

### Changed
- Windows now close a frame after their exit has been requested.

## Migration Guide
- Ensure custom exit logic does not rely on the app exiting the same frame as a window is closed.