### PR TITLE
Inherit uncontroversial workspace metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,14 @@ members = [
   "errors",
 ]
 
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+rust-version = "1.77.0"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+documentation = "https://docs.rs/bevy"
+
 [workspace.lints.clippy]
 type_complexity = "allow"
 doc_markdown = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.77.0"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
-documentation = "https://docs.rs/bevy"
 
 [workspace.lints.clippy]
 type_complexity = "allow"

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy", "accessibility", "a11y"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_a11y"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides accessibility support for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy", "accessibility", "a11y"]
 
 [dependencies]

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_animation"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides animation functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_app"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides core App functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 trace = []

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_asset"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides asset functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -7,8 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
 
 [features]
 file_watcher = ["notify-debouncer-full", "watch"]

--- a/crates/bevy_asset/macros/Cargo.toml
+++ b/crates/bevy_asset/macros/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_asset/macros/Cargo.toml
+++ b/crates/bevy_asset/macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_asset_macros"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Derive implementations for bevy_asset"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_audio"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides audio functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy", "color"]
+rust-version.workspace = true
 
 [dependencies]
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_color"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Types for representing and manipulating color values"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy", "color"]
 
 [dependencies]

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -7,7 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
-
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_core"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides core functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 dds = ["bevy_render/dds"]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "bevy_core_pipeline"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 authors = [
   "Bevy Contributors <bevyengine@gmail.com>",
   "Carter Anderson <mcanders1@gmail.com>",
 ]
 description = "Provides a core render pipeline for Bevy Engine."
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_derive"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides derive implementations for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_derive/compile_fail/Cargo.toml
+++ b/crates/bevy_derive/compile_fail/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "bevy_derive_compile_fail"
-edition = "2021"
+edition.workspace = true
 description = "Compile fail tests for Bevy Engine's various macros"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_dev_tools"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Collection of developer tools for the Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = ["bevy_ui_debug"]

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_diagnostic"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides diagnostic functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_dylib"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Force the Bevy Engine to be dynamically linked for faster linking"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 crate-type = ["dylib"]

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_dynamic_plugin"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides dynamic plugin loading capabilities for non-wasm platforms"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
+rust-version.workspace = true
 
 [features]
 trace = []

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_ecs"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Bevy Engine's entity component system"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
 

--- a/crates/bevy_ecs/compile_fail/Cargo.toml
+++ b/crates/bevy_ecs/compile_fail/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "bevy_ecs_compile_fail"
-edition = "2021"
+edition.workspace = true
 description = "Compile fail tests for Bevy Engine's entity component system"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.14.0-dev"
 description = "Bevy ECS Macros"
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -2,8 +2,8 @@
 name = "bevy_ecs_macros"
 version = "0.14.0-dev"
 description = "Bevy ECS Macros"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_encase_derive"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Bevy derive macro for encase"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_gilrs"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Gamepad system made using Gilrs for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_gizmos"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides gizmos for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 webgl = []

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_gizmos_macros"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Derive implementations for bevy_gizmos"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 dds = ["bevy_render/dds"]

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_gltf"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Bevy Engine GLTF loading"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = ["bevy_app"]

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_hierarchy"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides hierarchy functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_input"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides input functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 categories = ["game-engines", "graphics", "gui", "rendering"]
+rust-version.workspace = true
 
 [features]
 trace = [

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_internal"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "An internal Bevy crate used to facilitate optional dynamic linking via the 'dynamic_linking' feature"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 categories = ["game-engines", "graphics", "gui", "rendering"]
 

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_log"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides logging for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 trace = ["tracing-error"]

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 toml_edit = { version = "0.22.7", default-features = false, features = [

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_macro_utils"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "A collection of utils for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_math"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides math functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 glam = { version = "0.27", features = ["bytemuck"] }

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
+rust-version.workspace = true
 
 [dependencies]
 glam = "0.27"

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_mikktspace"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 authors = [
   "Benjamin Wasty <benny.wasty@gmail.com>",
   "David Harvey-Macaulay <alteous@outlook.com>",
@@ -9,8 +9,8 @@ authors = [
 ]
 description = "Mikkelsen tangent space algorithm"
 documentation = "https://docs.rs/bevy"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
+homepage.workspace = true
+repository.workspace = true
 license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 

--- a/crates/bevy_mikktspace/README.md
+++ b/crates/bevy_mikktspace/README.md
@@ -10,8 +10,6 @@ This is a fork of [https://github.com/gltf-rs/mikktspace](https://github.com/glt
 
 Port of the [Mikkelsen Tangent Space Algorithm](https://en.blender.org/index.php/Dev:Shading/Tangent_Space_Normal_Maps) reference implementation.
 
-Requires at least Rust 1.52.1.
-
 ## Examples
 
 ### generate

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_pbr"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Adds PBR rendering to Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 webgl = []

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_ptr"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Utilities for working with untyped pointers in a more safe way"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy", "no_std"]
 
 [dependencies]

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy", "no_std"]
+rust-version.workspace = true
 
 [dependencies]
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_reflect"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Dynamically interact with rust types"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = ["smallvec"]

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_reflect_derive"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Derive implementations for bevy_reflect"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_reflect/compile_fail/Cargo.toml
+++ b/crates/bevy_reflect/compile_fail/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "bevy_reflect_compile_fail"
-edition = "2021"
+edition.workspace = true
 description = "Compile fail tests for Bevy Engine's reflection system"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_render"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides rendering functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 png = ["image/png"]

--- a/crates/bevy_render/macros/Cargo.toml
+++ b/crates/bevy_render/macros/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_render_macros"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Derive implementations for bevy_render"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [lib]

--- a/crates/bevy_render/macros/Cargo.toml
+++ b/crates/bevy_render/macros/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_scene"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides scene functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = ["serialize"]

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 webgl = []

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_sprite"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides sprite functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_tasks"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "A task executor for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 multi-threaded = ["dep:async-channel", "dep:concurrent-queue"]

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 subpixel_glyph_atlas = []

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_text"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides text functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_time"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides time functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_transform"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides transform functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [dependencies]
 # bevy

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_ui"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "A custom ECS-driven UI framework built specifically for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [dependencies]

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 detailed_trace = []

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_utils"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "A collection of utils for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_utils/macros/Cargo.toml
+++ b/crates/bevy_utils/macros/Cargo.toml
@@ -2,9 +2,9 @@
 name = "bevy_utils_proc_macros"
 version = "0.14.0-dev"
 description = "Bevy Utils Proc Macros"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/bevyengine/bevy"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_utils/macros/Cargo.toml
+++ b/crates/bevy_utils/macros/Cargo.toml
@@ -5,6 +5,7 @@ description = "Bevy Utils Proc Macros"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_window"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "Provides windowing functionality for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bevy_winit"
 version = "0.14.0-dev"
-edition = "2021"
+edition.workspace = true
 description = "A winit window and input backend for Bevy Engine"
-homepage = "https://bevyengine.org"
-repository = "https://github.com/bevyengine/bevy"
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 keywords = ["bevy"]
 
 [features]

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["bevy"]
+rust-version.workspace = true
 
 [features]
 trace = []


### PR DESCRIPTION
# Objective

- Cargo supports inheriting properties in a workspace through [the `[workspace.package]` table](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table).
- This can decrease the amount of duplicated information. If one of these properties ever change in the future, a single file can be edited instead of every `Cargo.toml`.
- Previously attempted in #6089, related to #13211.

## Solution

- Use workspace inheritance for uncontroversial properties, specifically: `edition`, `license`, `rust-version`, `homepage`, and `repository`.
- In the future we can inherit dependencies or the Bevy version, but those caused #6089 to be marked as controversial so I'm leaving them for the future.

---

## Changelog

- Crates' `Cargo.toml`s now inherit certain properties from the workspace.
