### PR TITLE
Fix unfinished sentence in a comment in asset_settings example

### DIFF
--- a/examples/asset/asset_settings.rs
+++ b/examples/asset/asset_settings.rs
@@ -21,7 +21,8 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Without any .meta file specifying settings, the default sampler [ImagePlugin::default()] is used for loading images.
     // If you are using a very small image and rendering it larger like seen here, the default linear filtering will result in a blurry image.
-    // Useful note: The default sampler specified by the ImagePlugin is *not* the
+    // Useful note: The default sampler specified by the ImagePlugin is *not* the same as the default implementation of sampler. This is why 
+    // everything uses linear by default but if you look at the default of sampler, it uses nearest. 
     commands.spawn(SpriteBundle {
         texture: asset_server.load("bevy_pixel_dark.png"),
         sprite: Sprite {

--- a/examples/asset/asset_settings.rs
+++ b/examples/asset/asset_settings.rs
@@ -21,8 +21,8 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Without any .meta file specifying settings, the default sampler [ImagePlugin::default()] is used for loading images.
     // If you are using a very small image and rendering it larger like seen here, the default linear filtering will result in a blurry image.
-    // Useful note: The default sampler specified by the ImagePlugin is *not* the same as the default implementation of sampler. This is why 
-    // everything uses linear by default but if you look at the default of sampler, it uses nearest. 
+    // Useful note: The default sampler specified by the ImagePlugin is *not* the same as the default implementation of sampler. This is why
+    // everything uses linear by default but if you look at the default of sampler, it uses nearest.
     commands.spawn(SpriteBundle {
         texture: asset_server.load("bevy_pixel_dark.png"),
         sprite: Sprite {


### PR DESCRIPTION
# Objective

- In PR #12882 I added a new example which contained a comment with an unfinished and cut off sentence. This wasn't caught until after the PR was merged.
- This simply finishes that comment.

## Solution

- Finished the incomplete comment.

## Testing

- This is simply a comment change so no testing needed other than reading it.