### PR TITLE
Remove bevy log's usage of non send resource

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -54,6 +54,15 @@ use tracing_log::LogTracer;
 #[cfg(feature = "tracing-chrome")]
 use tracing_subscriber::fmt::{format::DefaultFields, FormattedFields};
 use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
+#[cfg(feature = "tracing-chrome")]
+use {bevy_ecs::system::Resource, bevy_utils::synccell::SyncCell};
+
+/// Wrapper resource for `tracing-chrome`'s flush guard.
+/// When the guard is dropped the chrome log is written to file.
+#[cfg(feature = "tracing-chrome")]
+#[allow(dead_code)]
+#[derive(Resource)]
+pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 
 /// Adds logging to Apps. This plugin is part of the `DefaultPlugins`. Adding
 /// this plugin will setup a collector appropriate to your target platform:
@@ -177,7 +186,7 @@ impl Plugin for LogPlugin {
                         }
                     }))
                     .build();
-                app.insert_non_send_resource(guard);
+                app.insert_resource(FlushGuard(SyncCell::new(guard)));
                 chrome_layer
             };
 


### PR DESCRIPTION
# Objective

I'm adopting #9122 and pulling some of the non controversial changes out to make the final pr easier to review. 

This pr removes the NonSend resource usage from `bevy_log`. 

## Solution

`tracing-chrome` uses a guard that is stored in the world, so that when it is dropped the json log file is written out. The guard is  Send + !Sync, so we can store it in a SyncCell to hold it in a regular resource instead of using a non send resource.

## Testing

Tested by running an example with `-F tracing chrome` and making sure there weren't any errors and the json file was created.

---

## Changelog

- replaced `bevy_log`'s usage of a non send resource.