### PR TITLE
bevy_reflect: Reflection diffing

### DIFF
--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -162,6 +162,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             }
 
             fn apply_enum_diff(&mut self, diff: #bevy_reflect_path::diff::EnumDiff) -> #bevy_reflect_path::diff::DiffApplyResult {
+                println!("Diffing... {}", #bevy_reflect_path::DynamicTypePath::reflect_type_path(self));
                 let info = <Self as #bevy_reflect_path::Typed>::type_info();
 
                 if info.type_id() != diff.type_info().type_id() {

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -204,6 +204,11 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             }
 
             #[inline]
+            fn diff<'new>(&self, other: &'new dyn #bevy_reflect_path::Reflect) -> #bevy_reflect_path::diff::DiffResult<'_, 'new> {
+                #bevy_reflect_path::diff::diff_enum(self, other)
+            }
+
+            #[inline]
             fn set(&mut self, #ref_value: #FQBox<dyn #bevy_reflect_path::Reflect>) -> #FQResult<(), #FQBox<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(#ref_value)?;
                 #FQResult::Ok(())

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -121,6 +121,25 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::Reflect::clone_value(&self.#field_idents));)*
                 dynamic
             }
+
+            fn apply_struct_diff(&mut self, diff: #bevy_reflect_path::diff::StructDiff) -> #bevy_reflect_path::diff::DiffApplyResult {
+                let info = <Self as #bevy_reflect_path::Typed>::type_info();
+
+                if info.type_id() != diff.type_info().type_id() {
+                    return #FQResult::Err(#bevy_reflect_path::diff::DiffApplyError::TypeMismatch);
+                }
+
+                let mut diffs = diff.take_changes();
+
+                #(
+                    #bevy_reflect_path::Reflect::apply_diff(
+                        &mut self.#field_idents,
+                        diffs.remove(#field_names).ok_or(#bevy_reflect_path::diff::DiffApplyError::MissingField)?
+                    )?;
+                )*
+
+                #FQResult::Ok(())
+            }
         }
 
         impl #impl_generics #bevy_reflect_path::Reflect for #struct_path #ty_generics #where_reflect_clause {

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -165,6 +165,11 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             }
 
             #[inline]
+            fn diff<'new>(&self, other: &'new dyn #bevy_reflect_path::Reflect) -> #bevy_reflect_path::diff::DiffResult<'_, 'new> {
+                #bevy_reflect_path::diff::diff_struct(self, other)
+            }
+
+            #[inline]
             fn set(&mut self, value: #FQBox<dyn #bevy_reflect_path::Reflect>) -> #FQResult<(), #FQBox<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
                 #FQResult::Ok(())

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -90,6 +90,25 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
                 #(dynamic.insert_boxed(#bevy_reflect_path::Reflect::clone_value(&self.#field_idents));)*
                 dynamic
             }
+
+            fn apply_tuple_struct_diff(&mut self, diff: #bevy_reflect_path::diff::TupleStructDiff) -> #bevy_reflect_path::diff::DiffApplyResult {
+                let info = <Self as #bevy_reflect_path::Typed>::type_info();
+
+                if info.type_id() != diff.type_info().type_id() {
+                    return #FQResult::Err(#bevy_reflect_path::diff::DiffApplyError::TypeMismatch);
+                }
+
+                let mut diffs = diff.take_changes().into_iter();
+
+                #(
+                    #bevy_reflect_path::Reflect::apply_diff(
+                        &mut self.#field_idents,
+                        diffs.next().ok_or(#bevy_reflect_path::diff::DiffApplyError::MissingField)?
+                    )?;
+                )*
+
+                #FQResult::Ok(())
+            }
         }
 
         impl #impl_generics #bevy_reflect_path::Reflect for #struct_path #ty_generics #where_reflect_clause {

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -134,6 +134,11 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             }
 
             #[inline]
+            fn diff<'new>(&self, other: &'new dyn #bevy_reflect_path::Reflect) -> #bevy_reflect_path::diff::DiffResult<'_, 'new> {
+                #bevy_reflect_path::diff::diff_tuple_struct(self, other)
+            }
+
+            #[inline]
             fn set(&mut self, value: #FQBox<dyn #bevy_reflect_path::Reflect>) -> #FQResult<(), #FQBox<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
                 #FQResult::Ok(())

--- a/crates/bevy_reflect/derive/src/impls/values.rs
+++ b/crates/bevy_reflect/derive/src/impls/values.rs
@@ -127,6 +127,11 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
                 #bevy_reflect_path::ReflectOwned::Value(self)
             }
 
+            #[inline]
+            fn diff<'new>(&self, other: &'new dyn #bevy_reflect_path::Reflect) -> #bevy_reflect_path::diff::DiffResult<'_, 'new> {
+                #bevy_reflect_path::diff::diff_value(self, other)
+            }
+
             #hash_fn
 
             #partial_eq_fn

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -366,13 +366,15 @@ impl Array for DynamicArray {
     }
 
     fn apply_array_diff(&mut self, diff: ArrayDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
-        };
-
-        if info.type_id() != diff.type_info().type_id() || self.len() != diff.len() {
+        if self.len() != diff.len() {
             return Err(DiffApplyError::TypeMismatch);
         }
+
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
+        };
 
         for (index, diff) in diff.take_changes().into_iter().enumerate() {
             self.get_mut(index)

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,3 +1,4 @@
+use crate::diff::{diff_array, DiffResult};
 use crate::{
     self as bevy_reflect, utility::reflect_hasher, ApplyError, Reflect, ReflectKind, ReflectMut,
     ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable,
@@ -295,6 +296,11 @@ impl Reflect for DynamicArray {
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_array(self, other)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,4 +1,4 @@
-use crate::diff::{diff_array, DiffResult};
+use crate::diff::{diff_array, ArrayDiff, DiffApplyError, DiffApplyResult, DiffResult};
 use crate::{
     self as bevy_reflect, utility::reflect_hasher, ApplyError, Reflect, ReflectKind, ReflectMut,
     ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable,
@@ -73,6 +73,9 @@ pub trait Array: Reflect {
             values: self.iter().map(|value| value.clone_value()).collect(),
         }
     }
+
+    /// Apply the given [`ArrayDiff`] to this value.
+    fn apply_array_diff(&mut self, diff: ArrayDiff) -> DiffApplyResult;
 }
 
 /// A container for compile-time array info.
@@ -360,6 +363,24 @@ impl Array for DynamicArray {
                 .map(|value| value.clone_value())
                 .collect(),
         }
+    }
+
+    fn apply_array_diff(&mut self, diff: ArrayDiff) -> DiffApplyResult {
+        let Some(info) = self.get_represented_type_info() else {
+            return Err(DiffApplyError::MissingTypeInfo);
+        };
+
+        if info.type_id() != diff.type_info().type_id() || self.len() != diff.len() {
+            return Err(DiffApplyError::TypeMismatch);
+        }
+
+        for (index, diff) in diff.take_changes().into_iter().enumerate() {
+            self.get_mut(index)
+                .ok_or(DiffApplyError::MissingField)?
+                .apply_diff(diff)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/bevy_reflect/src/diff/array_diff.rs
+++ b/crates/bevy_reflect/src/diff/array_diff.rs
@@ -1,0 +1,89 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Array, Reflect, ReflectKind, ReflectRef};
+use std::fmt::{Debug, Formatter};
+use std::slice::Iter;
+
+/// Diff object for [arrays](Array).
+#[derive(Clone)]
+pub struct DiffedArray<'old, 'new> {
+    new_value: &'new dyn Array,
+    elements: Vec<Diff<'old, 'new>>,
+}
+
+impl<'old, 'new> DiffedArray<'old, 'new> {
+    /// Returns the "new" array value.
+    pub fn new_value(&self) -> &'new dyn Array {
+        self.new_value
+    }
+
+    /// Returns the [`Diff`] for the field at the given index.
+    pub fn get(&self, index: usize) -> Option<&Diff<'old, 'new>> {
+        self.elements.get(index)
+    }
+
+    /// Returns the number of elements in the array.
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Returns true if the array contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns an iterator over the [`Diff`] for _every_ element.
+    pub fn iter(&self) -> Iter<'_, Diff<'old, 'new>> {
+        self.elements.iter()
+    }
+}
+
+impl<'old, 'new> Debug for DiffedArray<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedArray")
+            .field("elements", &self.elements)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`Array`] objects.
+pub fn diff_array<'old, 'new, T: Array>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::Array(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::Array,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old.len() != new.len() || old_info.type_id() != new_info.type_id() {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let mut diff = DiffedArray {
+        new_value: new,
+        elements: Vec::with_capacity(old.len()),
+    };
+
+    let mut was_modified = false;
+    for (old_field, new_field) in old.iter().zip(new.iter()) {
+        let field_diff = old_field.diff(new_field)?;
+        was_modified |= !matches!(field_diff, Diff::NoChange);
+        diff.elements.push(field_diff);
+    }
+
+    if was_modified {
+        Ok(Diff::Modified(DiffType::Array(diff)))
+    } else {
+        Ok(Diff::NoChange)
+    }
+}

--- a/crates/bevy_reflect/src/diff/array_diff.rs
+++ b/crates/bevy_reflect/src/diff/array_diff.rs
@@ -4,12 +4,12 @@ use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
 
 /// Diff object for [arrays](Array).
-pub struct DiffedArray<'old, 'new> {
+pub struct ArrayDiff<'old, 'new> {
     type_info: &'static TypeInfo,
     elements: Vec<Diff<'old, 'new>>,
 }
 
-impl<'old, 'new> DiffedArray<'old, 'new> {
+impl<'old, 'new> ArrayDiff<'old, 'new> {
     /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
     pub fn type_info(&self) -> &TypeInfo {
         self.type_info
@@ -36,9 +36,9 @@ impl<'old, 'new> DiffedArray<'old, 'new> {
     }
 }
 
-impl<'old, 'new> Debug for DiffedArray<'old, 'new> {
+impl<'old, 'new> Debug for ArrayDiff<'old, 'new> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DiffedArray")
+        f.debug_struct("ArrayDiff")
             .field("elements", &self.elements)
             .finish()
     }
@@ -68,7 +68,7 @@ pub fn diff_array<'old, 'new, T: Array>(
         return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
-    let mut diff = DiffedArray {
+    let mut diff = ArrayDiff {
         type_info: old_info,
         elements: Vec::with_capacity(old.len()),
     };

--- a/crates/bevy_reflect/src/diff/array_diff.rs
+++ b/crates/bevy_reflect/src/diff/array_diff.rs
@@ -34,6 +34,11 @@ impl<'old, 'new> ArrayDiff<'old, 'new> {
     pub fn iter(&self) -> Iter<'_, Diff<'old, 'new>> {
         self.elements.iter()
     }
+
+    /// Take the changes contained in this diff.
+    pub fn take_changes(self) -> Vec<Diff<'old, 'new>> {
+        self.elements
+    }
 }
 
 impl<'old, 'new> Debug for ArrayDiff<'old, 'new> {

--- a/crates/bevy_reflect/src/diff/array_diff.rs
+++ b/crates/bevy_reflect/src/diff/array_diff.rs
@@ -39,6 +39,13 @@ impl<'old, 'new> ArrayDiff<'old, 'new> {
     pub fn take_changes(self) -> Vec<Diff<'old, 'new>> {
         self.elements
     }
+
+    pub fn clone_diff(&self) -> ArrayDiff<'static, 'static> {
+        ArrayDiff {
+            type_info: self.type_info,
+            elements: self.elements.iter().map(Diff::clone_diff).collect(),
+        }
+    }
 }
 
 impl<'old, 'new> Debug for ArrayDiff<'old, 'new> {
@@ -81,13 +88,13 @@ pub fn diff_array<'old, 'new, T: Array>(
     let mut was_modified = false;
     for (old_field, new_field) in old.iter().zip(new.iter()) {
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange(_));
+        was_modified |= !matches!(field_diff, Diff::NoChange);
         diff.elements.push(field_diff);
     }
 
     if was_modified {
         Ok(Diff::Modified(DiffType::Array(diff)))
     } else {
-        Ok(Diff::NoChange(old))
+        Ok(Diff::NoChange)
     }
 }

--- a/crates/bevy_reflect/src/diff/array_diff.rs
+++ b/crates/bevy_reflect/src/diff/array_diff.rs
@@ -77,13 +77,13 @@ pub fn diff_array<'old, 'new, T: Array>(
     let mut was_modified = false;
     for (old_field, new_field) in old.iter().zip(new.iter()) {
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange);
+        was_modified |= !matches!(field_diff, Diff::NoChange(_));
         diff.elements.push(field_diff);
     }
 
     if was_modified {
         Ok(Diff::Modified(DiffType::Array(diff)))
     } else {
-        Ok(Diff::NoChange)
+        Ok(Diff::NoChange(old))
     }
 }

--- a/crates/bevy_reflect/src/diff/diff.rs
+++ b/crates/bevy_reflect/src/diff/diff.rs
@@ -1,0 +1,97 @@
+use crate::diff::{
+    DiffError, DiffedArray, DiffedList, DiffedMap, DiffedStruct, DiffedTuple, DiffedTupleStruct,
+    EnumDiff, ValueDiff,
+};
+use crate::{Reflect, TypeInfo};
+
+/// Indicates the difference between two [`Reflect`] objects.
+///
+/// [`Reflect`]: crate::Reflect
+#[derive(Debug)]
+pub enum Diff<'old, 'new> {
+    /// Indicates no change.
+    ///
+    /// Contains the "old" value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::Diff};
+    /// let old = 123;
+    /// let new = 123;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::NoChange(_)));
+    /// ```
+    ///
+    NoChange(&'old dyn Reflect),
+    /// Indicates that the type has been changed.
+    ///
+    /// Contains the "new" value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::Diff};
+    /// let old: bool = true;
+    /// let new: i32 = 123;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::Replaced(..)));
+    /// ```
+    ///
+    Replaced(ValueDiff<'new>),
+    /// Indicates that the value has been modified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::Diff};
+    /// let old: i32 = 123;
+    /// let new: i32 = 456;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::Modified(..)));
+    /// ```
+    ///
+    Modified(DiffType<'old, 'new>),
+}
+
+/// Contains diffing details for each [reflection type].
+///
+/// [reflection type]: crate::ReflectRef
+#[derive(Debug)]
+pub enum DiffType<'old, 'new> {
+    Value(ValueDiff<'new>),
+    Tuple(DiffedTuple<'old, 'new>),
+    Array(DiffedArray<'old, 'new>),
+    List(DiffedList<'new>),
+    Map(DiffedMap<'old, 'new>),
+    TupleStruct(DiffedTupleStruct<'old, 'new>),
+    Struct(DiffedStruct<'old, 'new>),
+    Enum(EnumDiff<'old, 'new>),
+}
+
+impl<'old, 'new> DiffType<'old, 'new> {
+    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
+    pub fn type_info(&self) -> &TypeInfo {
+        match self {
+            DiffType::Value(value_diff) => value_diff.type_info(),
+            DiffType::Tuple(tuple_diff) => tuple_diff.type_info(),
+            DiffType::Array(array_diff) => array_diff.type_info(),
+            DiffType::List(list_diff) => list_diff.type_info(),
+            DiffType::Map(map_diff) => map_diff.type_info(),
+            DiffType::TupleStruct(tuple_struct_diff) => tuple_struct_diff.type_info(),
+            DiffType::Struct(struct_diff) => struct_diff.type_info(),
+            DiffType::Enum(enum_diff) => enum_diff.type_info(),
+        }
+    }
+}
+
+/// Alias for a `Result` that returns either [`Ok(Diff)`](Diff) or [`Err(DiffError)`](DiffError).
+///
+/// This is most commonly used by the [`Reflect::diff`] method as well as the utility functions
+/// provided in this module.
+///
+/// [`Reflect::diff`]: crate::Reflect::diff
+pub type DiffResult<'old, 'new> = Result<Diff<'old, 'new>, DiffError>;

--- a/crates/bevy_reflect/src/diff/diff.rs
+++ b/crates/bevy_reflect/src/diff/diff.rs
@@ -1,6 +1,6 @@
 use crate::diff::{
-    DiffError, DiffedArray, DiffedList, DiffedMap, DiffedStruct, DiffedTuple, DiffedTupleStruct,
-    EnumDiff, ValueDiff,
+    ArrayDiff, DiffError, EnumDiff, ListDiff, MapDiff, StructDiff, TupleDiff, TupleStructDiff,
+    ValueDiff,
 };
 use crate::{Reflect, TypeInfo};
 
@@ -63,12 +63,12 @@ pub enum Diff<'old, 'new> {
 #[derive(Debug)]
 pub enum DiffType<'old, 'new> {
     Value(ValueDiff<'new>),
-    Tuple(DiffedTuple<'old, 'new>),
-    Array(DiffedArray<'old, 'new>),
-    List(DiffedList<'new>),
-    Map(DiffedMap<'old, 'new>),
-    TupleStruct(DiffedTupleStruct<'old, 'new>),
-    Struct(DiffedStruct<'old, 'new>),
+    Tuple(TupleDiff<'old, 'new>),
+    Array(ArrayDiff<'old, 'new>),
+    List(ListDiff<'new>),
+    Map(MapDiff<'old, 'new>),
+    TupleStruct(TupleStructDiff<'old, 'new>),
+    Struct(StructDiff<'old, 'new>),
     Enum(EnumDiff<'old, 'new>),
 }
 

--- a/crates/bevy_reflect/src/diff/enum_diff.rs
+++ b/crates/bevy_reflect/src/diff/enum_diff.rs
@@ -1,0 +1,181 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Enum, Reflect, ReflectKind, ReflectRef, VariantType};
+use bevy_utils::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::slice::Iter;
+
+/// Contains diffing details for [tuple](crate::VariantType::Tuple)
+/// and [struct](crate::VariantType::Struct) enum variants.
+///
+/// This does not contain details for [unit](crate::VariantType::Unit) variants as those are completely
+/// handled by both [`Diff::NoChange`] and [`Diff::Replaced`].
+#[derive(Clone, Debug)]
+pub enum EnumDiff<'old, 'new> {
+    Tuple(DiffedTupleVariant<'old, 'new>),
+    Struct(DiffedStructVariant<'old, 'new>),
+}
+
+/// Diff object for [tuple variants](crate::VariantType::Tuple).
+#[derive(Clone)]
+pub struct DiffedTupleVariant<'old, 'new> {
+    new_value: &'new dyn Enum,
+    fields: Vec<Diff<'old, 'new>>,
+}
+
+impl<'old, 'new> DiffedTupleVariant<'old, 'new> {
+    /// Returns the "new" enum value.
+    ///
+    /// This is guaranteed to be a [tuple variant](crate::VariantType::Tuple).
+    pub fn new_value(&self) -> &'new dyn Enum {
+        self.new_value
+    }
+
+    /// Returns the [`Diff`] for the field at the given index.
+    pub fn field(&self, index: usize) -> Option<&Diff<'old, 'new>> {
+        self.fields.get(index)
+    }
+
+    /// Returns the number of fields in the tuple variant.
+    pub fn field_len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns an iterator over the [`Diff`] for _every_ field.
+    pub fn field_iter(&self) -> Iter<'_, Diff<'old, 'new>> {
+        self.fields.iter()
+    }
+}
+
+impl<'old, 'new> Debug for DiffedTupleVariant<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedTupleVariant")
+            .field("fields", &self.fields)
+            .finish()
+    }
+}
+
+/// Diff object for [struct variants](crate::VariantType::Struct).
+#[derive(Clone)]
+pub struct DiffedStructVariant<'old, 'new> {
+    new_value: &'new dyn Enum,
+    fields: HashMap<&'old str, Diff<'old, 'new>>,
+    field_order: Vec<&'old str>,
+}
+
+impl<'old, 'new> DiffedStructVariant<'old, 'new> {
+    /// Returns the "new" enum value.
+    ///
+    /// This is guaranteed to be a [struct variant](crate::VariantType::Struct).
+    pub fn new_value(&self) -> &'new dyn Enum {
+        self.new_value
+    }
+
+    /// Returns the [`Diff`] for the field with the given name.
+    pub fn field(&self, name: &str) -> Option<&Diff<'old, 'new>> {
+        self.fields.get(name)
+    }
+
+    /// Returns the [`Diff`] for the field at the given index.
+    pub fn field_at(&self, index: usize) -> Option<&Diff<'old, 'new>> {
+        self.field_order
+            .get(index)
+            .and_then(|name| self.fields.get(name))
+    }
+
+    /// Returns the number of fields in the struct variant.
+    pub fn field_len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns an iterator over the name and [`Diff`] for _every_ field.
+    pub fn field_iter(&self) -> impl Iterator<Item = (&'old str, &'_ Diff<'old, 'new>)> {
+        self.field_order
+            .iter()
+            .copied()
+            .map(|name| (name, self.fields.get(name).unwrap()))
+    }
+}
+
+impl<'old, 'new> Debug for DiffedStructVariant<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedStructVariant")
+            .field("fields", &self.fields)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`Enum`] objects.
+pub fn diff_enum<'old, 'new, T: Enum>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::Enum(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::Enum,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old.variant_type() != new.variant_type()
+        || old.variant_name() != new.variant_name()
+        || old_info.type_id() != new_info.type_id()
+    {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let diff = match old.variant_type() {
+        VariantType::Struct => {
+            let mut diff = DiffedStructVariant {
+                new_value: new,
+                fields: HashMap::with_capacity(new.field_len()),
+                field_order: Vec::with_capacity(new.field_len()),
+            };
+
+            let mut was_modified = false;
+            for old_field in old.iter_fields() {
+                let field_name = old_field.name().unwrap();
+                let new_field = new.field(field_name).ok_or(DiffError::MissingField)?;
+                let field_diff = old_field.value().diff(new_field)?;
+                was_modified |= !matches!(field_diff, Diff::NoChange);
+                diff.fields.insert(field_name, field_diff);
+                diff.field_order.push(field_name);
+            }
+
+            if was_modified {
+                Diff::Modified(DiffType::Enum(EnumDiff::Struct(diff)))
+            } else {
+                Diff::NoChange
+            }
+        }
+        VariantType::Tuple => {
+            let mut diff = DiffedTupleVariant {
+                new_value: new,
+                fields: Vec::with_capacity(old.field_len()),
+            };
+
+            let mut was_modified = false;
+            for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
+                let field_diff = old_field.value().diff(new_field.value())?;
+                was_modified |= !matches!(field_diff, Diff::NoChange);
+                diff.fields.push(field_diff);
+            }
+
+            if was_modified {
+                Diff::Modified(DiffType::Enum(EnumDiff::Tuple(diff)))
+            } else {
+                Diff::NoChange
+            }
+        }
+        VariantType::Unit => Diff::NoChange,
+    };
+
+    Ok(diff)
+}

--- a/crates/bevy_reflect/src/diff/enum_diff.rs
+++ b/crates/bevy_reflect/src/diff/enum_diff.rs
@@ -144,7 +144,7 @@ pub fn diff_enum<'old, 'new, T: Enum>(
                 let field_name = old_field.name().unwrap();
                 let new_field = new.field(field_name).ok_or(DiffError::MissingField)?;
                 let field_diff = old_field.value().diff(new_field)?;
-                was_modified |= !matches!(field_diff, Diff::NoChange);
+                was_modified |= !matches!(field_diff, Diff::NoChange(_));
                 diff.fields.insert(field_name, field_diff);
                 diff.field_order.push(field_name);
             }
@@ -152,7 +152,7 @@ pub fn diff_enum<'old, 'new, T: Enum>(
             if was_modified {
                 Diff::Modified(DiffType::Enum(EnumDiff::Struct(diff)))
             } else {
-                Diff::NoChange
+                Diff::NoChange(old)
             }
         }
         VariantType::Tuple => {
@@ -164,17 +164,17 @@ pub fn diff_enum<'old, 'new, T: Enum>(
             let mut was_modified = false;
             for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
                 let field_diff = old_field.value().diff(new_field.value())?;
-                was_modified |= !matches!(field_diff, Diff::NoChange);
+                was_modified |= !matches!(field_diff, Diff::NoChange(_));
                 diff.fields.push(field_diff);
             }
 
             if was_modified {
                 Diff::Modified(DiffType::Enum(EnumDiff::Tuple(diff)))
             } else {
-                Diff::NoChange
+                Diff::NoChange(old)
             }
         }
-        VariantType::Unit => Diff::NoChange,
+        VariantType::Unit => Diff::NoChange(old),
     };
 
     Ok(diff)

--- a/crates/bevy_reflect/src/diff/enum_diff.rs
+++ b/crates/bevy_reflect/src/diff/enum_diff.rs
@@ -1,4 +1,4 @@
-use crate::diff::{Diff, DiffError, DiffResult, DiffType, DiffedStruct, DiffedTuple, ValueDiff};
+use crate::diff::{Diff, DiffError, DiffResult, DiffType, StructDiff, TupleDiff, ValueDiff};
 use crate::{Enum, Reflect, ReflectKind, ReflectRef, TypeInfo, VariantType};
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -20,8 +20,8 @@ pub enum EnumDiff<'old, 'new> {
     /// ```
     ///
     Swapped(ValueDiff<'new>),
-    Tuple(DiffedTuple<'old, 'new>),
-    Struct(DiffedStruct<'old, 'new>),
+    Tuple(TupleDiff<'old, 'new>),
+    Struct(StructDiff<'old, 'new>),
 }
 
 impl<'old, 'new> EnumDiff<'old, 'new> {
@@ -67,7 +67,7 @@ pub fn diff_enum<'old, 'new, T: Enum>(
 
     let diff = match old.variant_type() {
         VariantType::Struct => {
-            let mut diff = DiffedStruct::new(old_info, new.field_len());
+            let mut diff = StructDiff::new(old_info, new.field_len());
 
             let mut was_modified = false;
             for old_field in old.iter_fields() {
@@ -85,7 +85,7 @@ pub fn diff_enum<'old, 'new, T: Enum>(
             }
         }
         VariantType::Tuple => {
-            let mut diff = DiffedTuple::new(old_info, new.field_len());
+            let mut diff = TupleDiff::new(old_info, new.field_len());
 
             let mut was_modified = false;
             for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {

--- a/crates/bevy_reflect/src/diff/enum_diff.rs
+++ b/crates/bevy_reflect/src/diff/enum_diff.rs
@@ -1,110 +1,37 @@
-use crate::diff::{Diff, DiffError, DiffResult, DiffType, ValueDiff};
+use crate::diff::{Diff, DiffError, DiffResult, DiffType, DiffedStruct, DiffedTuple, ValueDiff};
 use crate::{Enum, Reflect, ReflectKind, ReflectRef, TypeInfo, VariantType};
-use bevy_utils::HashMap;
 use std::borrow::Cow;
-use std::fmt::{Debug, Formatter};
-use std::slice::Iter;
+use std::fmt::Debug;
 
-/// Contains diffing details for [tuple](crate::VariantType::Tuple)
-/// and [struct](crate::VariantType::Struct) enum variants.
-///
-/// This does not contain details for [unit](crate::VariantType::Unit) variants as those are completely
-/// handled by both [`Diff::NoChange`] and [`Diff::Replaced`].
+/// Contains diffing details for [enums](crate::Enum).
 #[derive(Debug)]
 pub enum EnumDiff<'old, 'new> {
-    Tuple(DiffedTupleVariant<'old, 'new>),
-    Struct(DiffedStructVariant<'old, 'new>),
+    /// Functionally similar to [`Diff::Replaced`], but for variants within the same enum.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::{Diff, DiffType, EnumDiff}};
+    /// let old: Option<i32> = Some(123);
+    /// let new: Option<i32> = None;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::Modified(DiffType::Enum(EnumDiff::Swapped(..)))));
+    /// ```
+    ///
+    Swapped(ValueDiff<'new>),
+    Tuple(DiffedTuple<'old, 'new>),
+    Struct(DiffedStruct<'old, 'new>),
 }
 
 impl<'old, 'new> EnumDiff<'old, 'new> {
     /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
     pub fn type_info(&self) -> &TypeInfo {
         match self {
-            EnumDiff::Tuple(tuple_variant_diff) => tuple_variant_diff.type_info(),
-            EnumDiff::Struct(struct_variant_diff) => struct_variant_diff.type_info(),
+            Self::Swapped(value_diff) => value_diff.type_info(),
+            Self::Tuple(tuple_diff) => tuple_diff.type_info(),
+            Self::Struct(struct_diff) => struct_diff.type_info(),
         }
-    }
-}
-
-/// Diff object for [tuple variants](crate::VariantType::Tuple).
-pub struct DiffedTupleVariant<'old, 'new> {
-    type_info: &'static TypeInfo,
-    fields: Vec<Diff<'old, 'new>>,
-}
-
-impl<'old, 'new> DiffedTupleVariant<'old, 'new> {
-    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
-    pub fn type_info(&self) -> &TypeInfo {
-        self.type_info
-    }
-
-    /// Returns the [`Diff`] for the field at the given index.
-    pub fn field(&self, index: usize) -> Option<&Diff<'old, 'new>> {
-        self.fields.get(index)
-    }
-
-    /// Returns the number of fields in the tuple variant.
-    pub fn field_len(&self) -> usize {
-        self.fields.len()
-    }
-
-    /// Returns an iterator over the [`Diff`] for _every_ field.
-    pub fn field_iter(&self) -> Iter<'_, Diff<'old, 'new>> {
-        self.fields.iter()
-    }
-}
-
-impl<'old, 'new> Debug for DiffedTupleVariant<'old, 'new> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DiffedTupleVariant")
-            .field("fields", &self.fields)
-            .finish()
-    }
-}
-
-/// Diff object for [struct variants](crate::VariantType::Struct).
-pub struct DiffedStructVariant<'old, 'new> {
-    type_info: &'static TypeInfo,
-    fields: HashMap<Cow<'old, str>, Diff<'old, 'new>>,
-    field_order: Vec<Cow<'old, str>>,
-}
-
-impl<'old, 'new> DiffedStructVariant<'old, 'new> {
-    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
-    pub fn type_info(&self) -> &TypeInfo {
-        self.type_info
-    }
-
-    /// Returns the [`Diff`] for the field with the given name.
-    pub fn field(&self, name: &str) -> Option<&Diff<'old, 'new>> {
-        self.fields.get(name)
-    }
-
-    /// Returns the [`Diff`] for the field at the given index.
-    pub fn field_at(&self, index: usize) -> Option<&Diff<'old, 'new>> {
-        self.field_order
-            .get(index)
-            .and_then(|name| self.fields.get(name))
-    }
-
-    /// Returns the number of fields in the struct variant.
-    pub fn field_len(&self) -> usize {
-        self.fields.len()
-    }
-
-    /// Returns an iterator over the name and [`Diff`] for _every_ field.
-    pub fn field_iter(&self) -> impl Iterator<Item = (&'_ str, &'_ Diff<'old, 'new>)> {
-        self.field_order
-            .iter()
-            .map(|name| (name.as_ref(), self.fields.get(name).unwrap()))
-    }
-}
-
-impl<'old, 'new> Debug for DiffedStructVariant<'old, 'new> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DiffedStructVariant")
-            .field("fields", &self.fields)
-            .finish()
     }
 }
 
@@ -128,20 +55,19 @@ pub fn diff_enum<'old, 'new, T: Enum>(
         .zip(new.get_represented_type_info())
         .ok_or(DiffError::MissingInfo)?;
 
-    if old.variant_type() != new.variant_type()
-        || old.variant_name() != new.variant_name()
-        || old_info.type_id() != new_info.type_id()
-    {
+    if old_info.type_id() != new_info.type_id() {
         return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
+    }
+
+    if old.variant_type() != new.variant_type() || old.variant_name() != new.variant_name() {
+        return Ok(Diff::Modified(DiffType::Enum(EnumDiff::Swapped(
+            ValueDiff::Borrowed(new.as_reflect()),
+        ))));
     }
 
     let diff = match old.variant_type() {
         VariantType::Struct => {
-            let mut diff = DiffedStructVariant {
-                type_info: old_info,
-                fields: HashMap::with_capacity(new.field_len()),
-                field_order: Vec::with_capacity(new.field_len()),
-            };
+            let mut diff = DiffedStruct::new(old_info, new.field_len());
 
             let mut was_modified = false;
             for old_field in old.iter_fields() {
@@ -149,8 +75,7 @@ pub fn diff_enum<'old, 'new, T: Enum>(
                 let new_field = new.field(field_name).ok_or(DiffError::MissingField)?;
                 let field_diff = old_field.value().diff(new_field)?;
                 was_modified |= !matches!(field_diff, Diff::NoChange(_));
-                diff.fields.insert(Cow::Borrowed(field_name), field_diff);
-                diff.field_order.push(Cow::Borrowed(field_name));
+                diff.push(Cow::Borrowed(field_name), field_diff);
             }
 
             if was_modified {
@@ -160,16 +85,13 @@ pub fn diff_enum<'old, 'new, T: Enum>(
             }
         }
         VariantType::Tuple => {
-            let mut diff = DiffedTupleVariant {
-                type_info: old_info,
-                fields: Vec::with_capacity(old.field_len()),
-            };
+            let mut diff = DiffedTuple::new(old_info, new.field_len());
 
             let mut was_modified = false;
             for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
                 let field_diff = old_field.value().diff(new_field.value())?;
                 was_modified |= !matches!(field_diff, Diff::NoChange(_));
-                diff.fields.push(field_diff);
+                diff.push(field_diff);
             }
 
             if was_modified {

--- a/crates/bevy_reflect/src/diff/error.rs
+++ b/crates/bevy_reflect/src/diff/error.rs
@@ -1,0 +1,21 @@
+use crate::ReflectKind;
+use thiserror::Error;
+
+/// Error enum used when diffing two [`Reflect`](crate::Reflect) objects.
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum DiffError {
+    /// Attempted to diff two values of differing [kinds].
+    ///
+    /// [kinds]: ReflectKind
+    #[error("expected {expected}, but found {received}")]
+    KindMismatch {
+        expected: ReflectKind,
+        received: ReflectKind,
+    },
+    #[error("expected a required field")]
+    MissingField,
+    #[error("expected type information to be present")]
+    MissingInfo,
+    #[error("the given values cannot be compared")]
+    Incomparable,
+}

--- a/crates/bevy_reflect/src/diff/error.rs
+++ b/crates/bevy_reflect/src/diff/error.rs
@@ -1,4 +1,4 @@
-use crate::ReflectKind;
+use crate::{ApplyError, ReflectKind, VariantType};
 use thiserror::Error;
 
 /// Error enum used when diffing two [`Reflect`](crate::Reflect) objects.
@@ -18,4 +18,34 @@ pub enum DiffError {
     MissingInfo,
     #[error("the given values cannot be compared")]
     Incomparable,
+}
+
+/// Error enum used when applying a diff to a [`Reflect`](crate::Reflect) object.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DiffApplyError {
+    /// Attempted to apply a diff of a different [kind].
+    ///
+    /// [kinds]: ReflectKind
+    #[error("expected {expected}, but found {received}")]
+    KindMismatch {
+        expected: ReflectKind,
+        received: ReflectKind,
+    },
+    #[error("expected a {expected} variant, but found a {received} variant")]
+    VariantMismatch {
+        expected: VariantType,
+        received: VariantType,
+    },
+    #[error("expected a required field")]
+    MissingField,
+    #[error("expected type information to be present")]
+    MissingTypeInfo,
+    #[error("expected a diff")]
+    MissingDiff,
+    #[error("received a mismatched type")]
+    TypeMismatch,
+    #[error(transparent)]
+    ReflectApplyError(#[from] ApplyError),
+    #[error("failed to apply diff: {0}")]
+    Other(String),
 }

--- a/crates/bevy_reflect/src/diff/list_diff.rs
+++ b/crates/bevy_reflect/src/diff/list_diff.rs
@@ -20,6 +20,15 @@ impl<'new> ElementDiff<'new> {
             Self::Deleted(index) | Self::Inserted(index, _) => *index,
         }
     }
+
+    pub fn clone_diff(&self) -> ElementDiff<'static> {
+        match self {
+            Self::Deleted(index) => ElementDiff::Deleted(*index),
+            Self::Inserted(index, value_diff) => {
+                ElementDiff::Inserted(*index, value_diff.clone_diff())
+            }
+        }
+    }
 }
 
 /// Diff object for [lists](List).
@@ -73,6 +82,14 @@ impl<'new> ListDiff<'new> {
     pub fn take_changes(self) -> Vec<ElementDiff<'new>> {
         self.changes
     }
+
+    pub fn clone_diff(&self) -> ListDiff<'static> {
+        ListDiff {
+            type_info: self.type_info,
+            changes: self.changes.iter().map(ElementDiff::clone_diff).collect(),
+            total_insertions: self.total_insertions,
+        }
+    }
 }
 
 impl<'new> Debug for ListDiff<'new> {
@@ -114,7 +131,7 @@ pub fn diff_list<'old, 'new, T: List>(
             new_info, changes,
         ))))
     } else {
-        Ok(Diff::NoChange(old))
+        Ok(Diff::NoChange)
     }
 }
 

--- a/crates/bevy_reflect/src/diff/list_diff.rs
+++ b/crates/bevy_reflect/src/diff/list_diff.rs
@@ -1,0 +1,271 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{List, Reflect, ReflectKind, ReflectRef};
+use std::fmt::{Debug, Formatter};
+use std::slice::Iter;
+
+/// Indicates the difference between two [`List`] elements.
+///
+/// See the [module-level docs](crate::diff) for more details.
+#[derive(Clone, Debug)]
+pub enum ListDiff<'new> {
+    /// The element at the given index was deleted.
+    Deleted(usize),
+    /// An element was inserted _before_ the given index.
+    Inserted(usize, &'new dyn Reflect),
+}
+
+/// Diff object for [lists](List).
+#[derive(Clone)]
+pub struct DiffedList<'new> {
+    new_value: &'new dyn List,
+    changes: Vec<ListDiff<'new>>,
+}
+
+impl<'new> DiffedList<'new> {
+    /// Returns the "new" list value.
+    pub fn new_value(&self) -> &'new dyn List {
+        self.new_value
+    }
+
+    /// Returns the number of _changes_ made to the list.
+    pub fn len_changes(&self) -> usize {
+        self.changes.len()
+    }
+
+    /// Returns an iterator over the sequence of edits needed to transform
+    /// the "old" list into the "new" one.
+    pub fn iter_changes(&self) -> Iter<'_, ListDiff<'new>> {
+        self.changes.iter()
+    }
+}
+
+impl<'new> Debug for DiffedList<'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedList")
+            .field("changes", &self.changes)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`List`] objects.
+pub fn diff_list<'old, 'new, T: List>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::List(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::List,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old_info.type_id() != new_info.type_id() {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let changes = ListDiffer::new(old, new).diff()?;
+
+    if let Some(changes) = changes {
+        Ok(Diff::Modified(DiffType::List(DiffedList {
+            new_value: new,
+            changes,
+        })))
+    } else {
+        Ok(Diff::NoChange)
+    }
+}
+
+/// A helper struct for diffing two lists based on the [Myers Diffing Algorithm].
+///
+/// [Myers Diffing Algorithm]: http://www.xmailserver.org/diff2.pdf
+struct ListDiffer<'old, 'new> {
+    // AKA `a`.
+    old: &'old dyn List,
+    // AKA `b`.
+    new: &'new dyn List,
+    // AKA `MAX`.
+    max_moves: i32,
+    // AKA `V`.
+    endpoints: Vec<i32>,
+    snapshots: Vec<Vec<i32>>,
+}
+
+impl<'old, 'new> ListDiffer<'old, 'new> {
+    pub fn new(old: &'old dyn List, new: &'new dyn List) -> Self {
+        // Maximum Moves = Delete all of old + insert all of new
+        let max_moves = old.len() + new.len();
+
+        Self {
+            old,
+            new,
+            max_moves: max_moves as i32,
+            endpoints: vec![0; 2 * max_moves + 1],
+            snapshots: Vec::with_capacity(max_moves),
+        }
+    }
+
+    /// Perform the diff computation.
+    ///
+    /// Returns `None` if there was no change or `Some(changes)` if there was.
+    pub fn diff(mut self) -> Result<Option<Vec<ListDiff<'new>>>, DiffError> {
+        if self.old.len() == 0 && self.new.len() == 0 {
+            return Ok(None);
+        }
+
+        if self.old.len() == 0 && self.new.len() > 0 {
+            return Ok(Some(
+                self.new
+                    .iter()
+                    .map(|value| ListDiff::Inserted(0, value))
+                    .collect(),
+            ));
+        }
+
+        if self.old.len() > 0 && self.new.len() == 0 {
+            return Ok(Some(vec![ListDiff::Deleted(0); self.new.len()]));
+        }
+
+        let ses = self.find_shortest_edit_script()?;
+        if ses == 0 {
+            Ok(None)
+        } else {
+            self.create_change_list(ses).map(Some)
+        }
+    }
+
+    /// Uses the SES computation to create a list of changes to transform the [old] list to the [new] one.
+    ///
+    /// [old]: Self::old
+    /// [new]: Self::new
+    fn create_change_list(&self, ses: i32) -> Result<Vec<ListDiff<'new>>, DiffError> {
+        let mut x = self.old.len() as i32;
+        let mut y = self.new.len() as i32;
+
+        let mut changes = Vec::<ListDiff<'new>>::with_capacity(ses as usize);
+
+        // Start at end and work backwards to d = 0 (exclusive)
+        for d in (1..=ses).rev() {
+            let snapshot = &self.snapshots[d as usize - 1];
+
+            let k = x - y;
+            let x_insert = Self::get_wrapped(k + 1, snapshot);
+            let x_delete = Self::get_wrapped(k - 1, snapshot);
+
+            let (prev_x, prev_y, diff) = if k == -d || (k != d && x_insert > x_delete) {
+                // Insertion was performed
+                let prev_y = x_insert - (k + 1);
+                let diff = ListDiff::Inserted(x_insert as usize, self.new_value(prev_y as usize));
+                (x_insert, prev_y, diff)
+            } else {
+                // Deletion was performed
+                let prev_y = x_delete - (k - 1);
+                let diff = ListDiff::Deleted(x_delete as usize);
+                (x_delete, prev_y, diff)
+            };
+
+            (x, y) = (prev_x, prev_y);
+            changes.push(diff);
+        }
+
+        // Out changes are in reverse order at this point, reverse them to the correct order
+        changes.reverse();
+        Ok(changes)
+    }
+
+    /// Finds the SES between the [old] and [new] lists.
+    ///
+    /// [old]: Self::old
+    /// [new]: Self::new
+    fn find_shortest_edit_script(&mut self) -> Result<i32, DiffError> {
+        let max_moves = self.max_moves;
+        let n = self.old.len() as i32;
+        let m = self.new.len() as i32;
+
+        for d in 0..=max_moves {
+            for k in (-d..=d).step_by(2) {
+                let x_insert = self.get_endpoint(k + 1);
+                let x_delete = self.get_endpoint(k - 1);
+
+                let mut x = if k == -d || (k != d && x_insert > x_delete) {
+                    // Perform an insertion
+                    x_insert
+                } else {
+                    // Perform a deletion
+                    x_delete + 1
+                };
+
+                let mut y = x - k;
+
+                while x < n
+                    && y < m
+                    && self.is_equal(self.old_value(x as usize), self.new_value(y as usize))?
+                {
+                    // Cross the diagonals (i.e. no change)
+                    x += 1;
+                    y += 1;
+                }
+
+                self.set_endpoint(k, x);
+
+                if x >= n && y >= m {
+                    // End reached - SES found!
+                    return Ok(d);
+                }
+            }
+
+            self.snapshots.push(self.endpoints.clone());
+        }
+
+        unreachable!("The list diffing algorithm should guarantee we find the SES");
+    }
+
+    fn is_equal(&self, a: &dyn Reflect, b: &dyn Reflect) -> Result<bool, DiffError> {
+        a.reflect_partial_eq(b).ok_or(DiffError::Incomparable)
+    }
+
+    fn old_value(&self, index: usize) -> &'old dyn Reflect {
+        self.old.get(index).unwrap()
+    }
+
+    fn new_value(&self, index: usize) -> &'new dyn Reflect {
+        self.new.get(index).unwrap()
+    }
+
+    fn get_endpoint(&self, index: i32) -> i32 {
+        Self::get_wrapped(index, &self.endpoints)
+    }
+
+    fn set_endpoint(&mut self, index: i32, value: i32) {
+        Self::set_wrapped(index, value, &mut self.endpoints);
+    }
+
+    /// Gets an element from the given slice at a _wrapped_ index,
+    /// where negative values are offset from the end of the slice.
+    fn get_wrapped(index: i32, slice: &[i32]) -> i32 {
+        if index >= 0 {
+            slice[index as usize]
+        } else {
+            let len = slice.len() as i32;
+            slice[(len + index) as usize]
+        }
+    }
+
+    /// Sets an element from the given slice at a _wrapped_ index,
+    /// where negative values are offset from the end of the slice.
+    fn set_wrapped(index: i32, value: i32, slice: &mut [i32]) {
+        if index >= 0 {
+            slice[index as usize] = value;
+        } else {
+            let len = slice.len() as i32;
+            slice[(len + index) as usize] = value;
+        }
+    }
+}

--- a/crates/bevy_reflect/src/diff/list_diff.rs
+++ b/crates/bevy_reflect/src/diff/list_diff.rs
@@ -115,11 +115,11 @@ impl<'old, 'new> ListDiffer<'old, 'new> {
     ///
     /// Returns `None` if there was no change or `Some(changes)` if there was.
     pub fn diff(mut self) -> Result<Option<Vec<ListDiff<'new>>>, DiffError> {
-        if self.old.len() == 0 && self.new.len() == 0 {
+        if self.old.is_empty() && self.new.is_empty() {
             return Ok(None);
         }
 
-        if self.old.len() == 0 && self.new.len() > 0 {
+        if self.old.is_empty() && !self.new.is_empty() {
             return Ok(Some(
                 self.new
                     .iter()
@@ -128,7 +128,7 @@ impl<'old, 'new> ListDiffer<'old, 'new> {
             ));
         }
 
-        if self.old.len() > 0 && self.new.len() == 0 {
+        if !self.old.is_empty() && self.new.is_empty() {
             let mut vec = Vec::with_capacity(self.new.len());
             vec.fill_with(|| ListDiff::Deleted(0));
             return Ok(Some(vec));

--- a/crates/bevy_reflect/src/diff/list_diff.rs
+++ b/crates/bevy_reflect/src/diff/list_diff.rs
@@ -1,30 +1,29 @@
-use crate::diff::{Diff, DiffError, DiffResult, DiffType};
-use crate::{List, Reflect, ReflectKind, ReflectRef};
+use crate::diff::{Diff, DiffError, DiffResult, DiffType, ValueDiff};
+use crate::{List, Reflect, ReflectKind, ReflectRef, TypeInfo};
 use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
 
 /// Indicates the difference between two [`List`] elements.
 ///
 /// See the [module-level docs](crate::diff) for more details.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum ListDiff<'new> {
     /// The element at the given index was deleted.
     Deleted(usize),
     /// An element was inserted _before_ the given index.
-    Inserted(usize, &'new dyn Reflect),
+    Inserted(usize, ValueDiff<'new>),
 }
 
 /// Diff object for [lists](List).
-#[derive(Clone)]
 pub struct DiffedList<'new> {
-    new_value: &'new dyn List,
+    type_info: &'static TypeInfo,
     changes: Vec<ListDiff<'new>>,
 }
 
 impl<'new> DiffedList<'new> {
-    /// Returns the "new" list value.
-    pub fn new_value(&self) -> &'new dyn List {
-        self.new_value
+    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
+    pub fn type_info(&self) -> &TypeInfo {
+        self.type_info
     }
 
     /// Returns the number of _changes_ made to the list.
@@ -68,14 +67,14 @@ pub fn diff_list<'old, 'new, T: List>(
         .ok_or(DiffError::MissingInfo)?;
 
     if old_info.type_id() != new_info.type_id() {
-        return Ok(Diff::Replaced(new.as_reflect()));
+        return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
     let changes = ListDiffer::new(old, new).diff()?;
 
     if let Some(changes) = changes {
         Ok(Diff::Modified(DiffType::List(DiffedList {
-            new_value: new,
+            type_info: old_info,
             changes,
         })))
     } else {
@@ -124,13 +123,15 @@ impl<'old, 'new> ListDiffer<'old, 'new> {
             return Ok(Some(
                 self.new
                     .iter()
-                    .map(|value| ListDiff::Inserted(0, value))
+                    .map(|value| ListDiff::Inserted(0, ValueDiff::Borrowed(value)))
                     .collect(),
             ));
         }
 
         if self.old.len() > 0 && self.new.len() == 0 {
-            return Ok(Some(vec![ListDiff::Deleted(0); self.new.len()]));
+            let mut vec = Vec::with_capacity(self.new.len());
+            vec.fill_with(|| ListDiff::Deleted(0));
+            return Ok(Some(vec));
         }
 
         let ses = self.find_shortest_edit_script()?;
@@ -162,7 +163,10 @@ impl<'old, 'new> ListDiffer<'old, 'new> {
             let (prev_x, prev_y, diff) = if k == -d || (k != d && x_insert > x_delete) {
                 // Insertion was performed
                 let prev_y = x_insert - (k + 1);
-                let diff = ListDiff::Inserted(x_insert as usize, self.new_value(prev_y as usize));
+                let diff = ListDiff::Inserted(
+                    x_insert as usize,
+                    ValueDiff::Borrowed(self.new_value(prev_y as usize)),
+                );
                 (x_insert, prev_y, diff)
             } else {
                 // Deletion was performed

--- a/crates/bevy_reflect/src/diff/list_diff.rs
+++ b/crates/bevy_reflect/src/diff/list_diff.rs
@@ -79,7 +79,7 @@ pub fn diff_list<'old, 'new, T: List>(
             changes,
         })))
     } else {
-        Ok(Diff::NoChange)
+        Ok(Diff::NoChange(old))
     }
 }
 

--- a/crates/bevy_reflect/src/diff/map_diff.rs
+++ b/crates/bevy_reflect/src/diff/map_diff.rs
@@ -82,7 +82,7 @@ pub fn diff_map<'old, 'new, T: Map>(
     for (old_key, old_value) in old.iter() {
         if let Some(new_value) = new.get(old_key) {
             let value_diff = old_value.diff(new_value)?;
-            if !matches!(value_diff, Diff::NoChange) {
+            if !matches!(value_diff, Diff::NoChange(_)) {
                 was_modified = true;
                 diff.changes.push(MapDiff::Modified(old_key, value_diff));
             }
@@ -102,6 +102,6 @@ pub fn diff_map<'old, 'new, T: Map>(
     if was_modified {
         Ok(Diff::Modified(DiffType::Map(diff)))
     } else {
-        Ok(Diff::NoChange)
+        Ok(Diff::NoChange(old))
     }
 }

--- a/crates/bevy_reflect/src/diff/map_diff.rs
+++ b/crates/bevy_reflect/src/diff/map_diff.rs
@@ -94,7 +94,7 @@ pub fn diff_map<'old, 'new, T: Map>(
     }
 
     for (new_key, new_value) in new.iter() {
-        if matches!(old.get(new_key), None) {
+        if old.get(new_key).is_none() {
             was_modified = true;
             diff.changes.push(MapDiff::Inserted(
                 ValueDiff::Borrowed(new_key),

--- a/crates/bevy_reflect/src/diff/map_diff.rs
+++ b/crates/bevy_reflect/src/diff/map_diff.rs
@@ -1,0 +1,107 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Map, Reflect, ReflectKind, ReflectRef};
+use std::fmt::{Debug, Formatter};
+use std::slice::Iter;
+
+/// Indicates the difference between two [`Map`] entries.
+///
+/// See the [module-level docs](crate::diff) for more details.
+#[derive(Clone, Debug)]
+pub enum MapDiff<'old, 'new> {
+    /// An entry with the given key was removed.
+    Deleted(&'old dyn Reflect),
+    /// An entry with the given key and value was added.
+    Inserted(&'new dyn Reflect, &'new dyn Reflect),
+    /// The entry with the given key was modified.
+    Modified(&'old dyn Reflect, Diff<'old, 'new>),
+}
+
+/// Diff object for [maps](Map).
+#[derive(Clone)]
+pub struct DiffedMap<'old, 'new> {
+    new_value: &'new dyn Map,
+    changes: Vec<MapDiff<'old, 'new>>,
+}
+
+impl<'old, 'new> DiffedMap<'old, 'new> {
+    /// Returns the "new" map value.
+    pub fn new_value(&self) -> &'new dyn Map {
+        self.new_value
+    }
+
+    /// Returns the number of _changes_ made to the map.
+    pub fn len_changes(&self) -> usize {
+        self.changes.len()
+    }
+
+    /// Returns an iterator over the unordered sequence of edits needed to transform
+    /// the "old" map into the "new" one.
+    pub fn iter_changes(&self) -> Iter<'_, MapDiff<'old, 'new>> {
+        self.changes.iter()
+    }
+}
+
+impl<'old, 'new> Debug for DiffedMap<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedMap")
+            .field("changes", &self.changes)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`Map`] objects.
+pub fn diff_map<'old, 'new, T: Map>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::Map(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::Map,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old_info.type_id() != new_info.type_id() {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let mut diff = DiffedMap::<'old, 'new> {
+        new_value: new,
+        changes: Vec::with_capacity(new.len()),
+    };
+
+    let mut was_modified = false;
+    for (old_key, old_value) in old.iter() {
+        if let Some(new_value) = new.get(old_key) {
+            let value_diff = old_value.diff(new_value)?;
+            if !matches!(value_diff, Diff::NoChange) {
+                was_modified = true;
+                diff.changes.push(MapDiff::Modified(old_key, value_diff));
+            }
+        } else {
+            was_modified = true;
+            diff.changes.push(MapDiff::Deleted(old_key));
+        }
+    }
+
+    for (new_key, new_value) in new.iter() {
+        if matches!(old.get(new_key), None) {
+            was_modified = true;
+            diff.changes.push(MapDiff::Inserted(new_key, new_value));
+        }
+    }
+
+    if was_modified {
+        Ok(Diff::Modified(DiffType::Map(diff)))
+    } else {
+        Ok(Diff::NoChange)
+    }
+}

--- a/crates/bevy_reflect/src/diff/map_diff.rs
+++ b/crates/bevy_reflect/src/diff/map_diff.rs
@@ -38,6 +38,11 @@ impl<'old, 'new> MapDiff<'old, 'new> {
     pub fn iter_changes(&self) -> Iter<'_, EntryDiff<'old, 'new>> {
         self.changes.iter()
     }
+
+    /// Take the changes contained in this diff.
+    pub fn take_changes(self) -> Vec<EntryDiff<'old, 'new>> {
+        self.changes
+    }
 }
 
 impl<'old, 'new> Debug for MapDiff<'old, 'new> {

--- a/crates/bevy_reflect/src/diff/mod.rs
+++ b/crates/bevy_reflect/src/diff/mod.rs
@@ -151,11 +151,10 @@ mod tests {
     macro_rules! assert_apply_diff {
         ($old: ident, $new: ident) => {{
             let mut _old = $old.clone();
-
             let diff = Reflect::diff(&$old, $new.as_reflect()).unwrap();
 
             match &diff {
-                Diff::NoChange(..) => {
+                Diff::NoChange => {
                     assert!(
                         _old.reflect_partial_eq($new.as_reflect())
                             .unwrap_or_default(),
@@ -194,7 +193,7 @@ mod tests {
         let new = 123_i32;
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old = 123_i32;
@@ -218,7 +217,7 @@ mod tests {
         let new = (1, 2, 3);
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old = (1, 2, 3);
@@ -236,12 +235,12 @@ mod tests {
             if let DiffType::Tuple(tuple_diff) = modified {
                 let mut fields = tuple_diff.field_iter();
 
-                assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
                 assert!(matches!(
                     fields.next(),
                     Some(Diff::Modified(DiffType::Value(..)))
                 ));
-                assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
                 assert!(fields.next().is_none());
             } else {
                 panic!("expected `DiffType::Tuple`");
@@ -258,7 +257,7 @@ mod tests {
         let new = [1, 2, 3];
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old = [1, 2, 3];
@@ -276,12 +275,12 @@ mod tests {
             if let DiffType::Array(array_diff) = modified {
                 let mut fields = array_diff.iter();
 
-                assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
                 assert!(matches!(
                     fields.next(),
                     Some(Diff::Modified(DiffType::Value(..)))
                 ));
-                assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
                 assert!(fields.next().is_none());
             } else {
                 panic!("expected `DiffType::Array`");
@@ -298,7 +297,7 @@ mod tests {
         let new = vec![1, 2, 3];
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old: Vec<i32> = vec![1, 2, 3];
@@ -412,7 +411,7 @@ mod tests {
         let new = map! {3: 333, 1: 111, 2: 222};
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old: HashMap<i32, i32> = map! {1: 111, 2: 222, 3: 333};
@@ -497,7 +496,7 @@ mod tests {
         let new = Foo(1, 2, 3);
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old = Foo(1, 2, 3);
@@ -515,12 +514,12 @@ mod tests {
             if let DiffType::TupleStruct(tuple_struct_diff) = modified {
                 let mut fields = tuple_struct_diff.field_iter();
 
-                assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
                 assert!(matches!(
                     fields.next(),
                     Some(Diff::Modified(DiffType::Value(..)))
                 ));
-                assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
                 assert!(fields.next().is_none());
             } else {
                 panic!("expected `DiffType::TupleStruct`");
@@ -549,7 +548,7 @@ mod tests {
         let new = Foo { a: 123, b: 1.23 };
 
         let diff = old.diff(&new).unwrap();
-        assert!(matches!(diff, Diff::NoChange(_)));
+        assert!(matches!(diff, Diff::NoChange));
         assert_apply_diff!(old, new);
 
         let old = Foo { a: 123, b: 1.23 };
@@ -571,7 +570,7 @@ mod tests {
             if let DiffType::Struct(struct_diff) = modified {
                 let mut fields = struct_diff.field_iter();
 
-                assert!(matches!(fields.next(), Some(("a", Diff::NoChange(_)))));
+                assert!(matches!(fields.next(), Some(("a", Diff::NoChange))));
                 assert!(matches!(
                     fields.next(),
                     Some(("b", Diff::Modified(DiffType::Value(..))))
@@ -606,7 +605,7 @@ mod tests {
             let new = Foo::A;
 
             let diff = old.diff(&new).unwrap();
-            assert!(matches!(diff, Diff::NoChange(_)));
+            assert!(matches!(diff, Diff::NoChange));
             assert_apply_diff!(old, new);
 
             let old = Foo::A;
@@ -644,7 +643,7 @@ mod tests {
             let new = Foo::A(1, 2, 3);
 
             let diff = old.diff(&new).unwrap();
-            assert!(matches!(diff, Diff::NoChange(_)));
+            assert!(matches!(diff, Diff::NoChange));
             assert_apply_diff!(old, new);
 
             let old = Foo::A(1, 2, 3);
@@ -673,12 +672,12 @@ mod tests {
                     if let EnumDiff::Tuple(tuple_diff) = enum_diff {
                         let mut fields = tuple_diff.field_iter();
 
-                        assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                        assert!(matches!(fields.next(), Some(Diff::NoChange)));
                         assert!(matches!(
                             fields.next(),
                             Some(Diff::Modified(DiffType::Value(..)))
                         ));
-                        assert!(matches!(fields.next(), Some(Diff::NoChange(_))));
+                        assert!(matches!(fields.next(), Some(Diff::NoChange)));
                         assert!(fields.next().is_none());
                     } else {
                         panic!("expected `EnumDiff::Tuple`");
@@ -709,7 +708,7 @@ mod tests {
             let new = Foo::A { x: 1.23, y: 4.56 };
 
             let diff = old.diff(&new).unwrap();
-            assert!(matches!(diff, Diff::NoChange(_)));
+            assert!(matches!(diff, Diff::NoChange));
             assert_apply_diff!(old, new);
 
             let old = Foo::A { x: 1.23, y: 4.56 };
@@ -738,7 +737,7 @@ mod tests {
                     if let EnumDiff::Struct(struct_diff) = enum_diff {
                         let mut fields = struct_diff.field_iter();
 
-                        assert!(matches!(fields.next(), Some(("x", Diff::NoChange(_)))));
+                        assert!(matches!(fields.next(), Some(("x", Diff::NoChange))));
                         assert!(matches!(
                             fields.next(),
                             Some(("y", Diff::Modified(DiffType::Value(..))))
@@ -755,5 +754,19 @@ mod tests {
             }
             assert_apply_diff!(old, new);
         }
+    }
+
+    #[test]
+    fn diff_should_be_clonable() {
+        let old = vec![1, 2, 3];
+        let new = vec![0, 2, 4];
+
+        let diff = old.diff(&new).unwrap();
+        let cloned = diff.clone_diff();
+
+        let mut value = vec![1, 2, 3];
+        value.apply_diff(cloned).unwrap();
+
+        assert_eq!(value, new);
     }
 }

--- a/crates/bevy_reflect/src/diff/mod.rs
+++ b/crates/bevy_reflect/src/diff/mod.rs
@@ -1,0 +1,722 @@
+//! Tools for diffing two [`Reflect`] objects.
+//!
+//! The core of diffing revolves around the [`Diff`] and [`DiffType`] enums.
+//! With these enums, diffs can be generated recursively for all reflect types.
+//!
+//! When diffing, the two objects are often referred to as "old" and "new".
+//! This use of this particular language is purely for clarity's sake and does not necessarily
+//! indicate that the "old" value is to be replaced by the "new" one.
+//! These terms better indicate the directionality of the diffing operations,
+//! which asks _"how can we transform `old` into `new`?"_
+//! Other terms include "src" and "dst" as well as "a" and "b".
+//!
+//! To compute the diff between two objects, use the [`Reflect::diff`] method.
+//! This will return the [`Diff`] or an error if diffing failed.
+//!
+//! With this, we can determine whether a value was [modified], [replaced], or had [no change].
+//! When a value is [modified], it contains data related to the modification,
+//! which may recursively contain more [`Diff`] objects.
+//!
+//! # Lists & Maps
+//!
+//! It's important to note that both [List](crate::List) and [Map](crate::Map) types work a bit differently
+//! than the other types.
+//! This is due to the fact that their size fields are not known at compile time.
+//! For example, a list can grow and shrink dynamically, and a map can add or remove entries just as easily.
+//!
+//! This means there has to be a better approach to representing their diffs that take such factors
+//! into account.
+//!
+//! ## Lists
+//!
+//! [Lists](crate::List) are diffed using the [Myers Diffing Algorithm].
+//! Instead of diffing elements individually in sequence, we try to find the minimum number of edits
+//! to transform the "old" list into the "new" one.
+//!
+//! The available edits are [`ListDiff::Inserted`] and [`ListDiff::Deleted`].
+//! When calling [`DiffedList::iter_changes`], we iterate over a collection of these edits.
+//! Each edit is given an index to determine where the transformation should take place in the "old" list.
+//! [`ListDiff::Deleted`] edits are given the index of the element to delete,
+//! while [`ListDiff::Inserted`] edits are given both the index of the element they should appear _before_
+//! as well as the actual data to insert.
+//!
+//! Note: Multiple inserts may share the same index.
+//! This is because, as far as each insertion is concerned, they all come before the element in the
+//! "old" list at that index.
+//!
+//! ```
+//! # use bevy_reflect::{Reflect, diff::{Diff, DiffType, ListDiff}};
+//! let old = vec![8, -1, 5];
+//! let new = vec![9, 8, 7, 6, 5];
+//!
+//! let diff = old.diff(&new).unwrap();
+//!
+//! if let Diff::Modified(DiffType::List(list_diff)) = diff {
+//!   let mut changes = list_diff.iter_changes();
+//!
+//!   assert!(matches!(changes.next(), Some(ListDiff::Inserted(0, _))));
+//!   assert!(matches!(changes.next(), Some(ListDiff::Deleted(1))));
+//!   assert!(matches!(changes.next(), Some(ListDiff::Inserted(2, _))));
+//!   assert!(matches!(changes.next(), Some(ListDiff::Inserted(2, _))));
+//!   assert!(matches!(changes.next(), None));
+//! }
+//! ```
+//!
+//! ## Maps
+//!
+//! [Maps](crate::Map) also include edits for [insertion](`MapDiff::Inserted`) and [deletion](MapDiff::Deleted),
+//! but contain a third option: [`MapDiff::Modified`].
+//! Unlike lists, these edits are unordered and do not make use of the [Myers Diffing Algorithm].
+//! Instead, the [`MapDiff::Inserted`] and [`MapDiff::Deleted`] edits simply indicate whether an entry with a given
+//! key was inserted or deleted,
+//! while the [`MapDiff::Modified`] edit indicates that the _value_ of an entry was edited.
+//!
+//! ```
+//! # use bevy_reflect::{Reflect, diff::{Diff, DiffType, MapDiff}};
+//! # use bevy_utils::HashMap;
+//! let old = HashMap::from([(1, 111), (2, 222), (3, 333)]);
+//! let new = HashMap::from([(2, 999), (3, 333), (4, 444)]);
+//!
+//! let diff = old.diff(&new).unwrap();
+//!
+//! if let Diff::Modified(DiffType::Map(map_diff)) = diff {
+//!   for change in map_diff.iter_changes() {
+//!     match change {
+//!       MapDiff::Deleted(key) => {
+//!         assert!(key.reflect_partial_eq(&1).unwrap(), "expected key 1 to be deleted");
+//!       }
+//!       MapDiff::Inserted(key, value) => {
+//!         assert!(
+//!           key.reflect_partial_eq(&4).unwrap() && value.reflect_partial_eq(&444).unwrap(),
+//!           "expected key 4 to be inserted with value 444"
+//!         );
+//!       }
+//!       MapDiff::Modified(key, value_diff) => {
+//!         assert!(
+//!           key.reflect_partial_eq(&2).unwrap() && matches!(value_diff, Diff::Modified(..)),
+//!           "expected key 2 to be modified"
+//!         );
+//!       }
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! [`Reflect`]: crate::Reflect
+//! [`Diff`]: crate::diff::Diff
+//! [`DiffType`]: crate::diff::DiffType
+//! [modified]: Diff::Modified
+//! [replaced]: Diff::Replaced
+//! [no change]: Diff::NoChange
+//! [Myers Diffing Algorithm]: http://www.xmailserver.org/diff2.pdf
+
+mod array_diff;
+mod enum_diff;
+mod error;
+mod list_diff;
+mod map_diff;
+mod struct_diff;
+mod tuple_diff;
+mod tuple_struct_diff;
+
+use crate::Reflect;
+pub use array_diff::*;
+pub use enum_diff::*;
+pub use error::*;
+pub use list_diff::*;
+pub use map_diff::*;
+pub use struct_diff::*;
+pub use tuple_diff::*;
+pub use tuple_struct_diff::*;
+
+/// Indicates the difference between two [`Reflect`] objects.
+#[derive(Clone, Debug)]
+pub enum Diff<'old, 'new> {
+    /// Indicates no change.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::Diff};
+    /// let old = 123;
+    /// let new = 123;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::NoChange));
+    /// ```
+    ///
+    NoChange,
+    /// Indicates that the type has been changed.
+    ///
+    /// Note that for enums, this is also used when the variant has been changed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::Diff};
+    /// let old: bool = true;
+    /// let new: i32 = 123;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::Replaced(..)));
+    /// ```
+    ///
+    Replaced(&'new dyn Reflect),
+    /// Indicates that the value has been modified.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, diff::Diff};
+    /// let old: i32 = 123;
+    /// let new: i32 = 456;
+    ///
+    /// let diff = old.diff(&new).unwrap();
+    /// assert!(matches!(diff, Diff::Modified(..)));
+    /// ```
+    ///
+    Modified(DiffType<'old, 'new>),
+}
+
+/// Contains diffing details for each [reflection type].
+///
+/// [reflection type]: crate::ReflectRef
+#[derive(Clone, Debug)]
+pub enum DiffType<'old, 'new> {
+    Value(&'new dyn Reflect),
+    Tuple(DiffedTuple<'old, 'new>),
+    Array(DiffedArray<'old, 'new>),
+    List(DiffedList<'new>),
+    Map(DiffedMap<'old, 'new>),
+    TupleStruct(DiffedTupleStruct<'old, 'new>),
+    Struct(DiffedStruct<'old, 'new>),
+    Enum(EnumDiff<'old, 'new>),
+}
+
+/// Alias for a `Result` that returns either [`Ok(Diff)`](Diff) or [`Err(DiffError)`](DiffError).
+///
+/// This is most commonly used by the [`Reflect::diff`] method as well as the utility functions
+/// provided in this module.
+pub type DiffResult<'old, 'new> = Result<Diff<'old, 'new>, DiffError>;
+
+#[cfg(test)]
+mod tests {
+    use crate as bevy_reflect;
+    use crate::diff::{Diff, DiffType, EnumDiff, ListDiff, MapDiff};
+    use crate::Reflect;
+    use bevy_utils::HashMap;
+
+    #[test]
+    fn should_diff_value() {
+        let old = 123_i32;
+        let new = 123_i32;
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old = 123_i32;
+        let new = 321_i32;
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Modified(..)));
+
+        let old = 123_i32;
+        let new = 123_u32;
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(..)));
+    }
+
+    #[test]
+    fn should_diff_tuple() {
+        let old = (1, 2, 3);
+        let new = (1, 2, 3);
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old = (1, 2, 3);
+        let new = (1, 2, 3, 4);
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(..)));
+
+        let old = (1, 2, 3);
+        let new = (1, 0, 3);
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::Tuple(tuple_diff) = modified {
+                let mut fields = tuple_diff.field_iter();
+
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                assert!(matches!(
+                    fields.next(),
+                    Some(Diff::Modified(DiffType::Value(..)))
+                ));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                assert!(matches!(fields.next(), None));
+            } else {
+                panic!("expected `DiffType::Tuple`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+    }
+
+    #[test]
+    fn should_diff_array() {
+        let old = [1, 2, 3];
+        let new = [1, 2, 3];
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old = [1, 2, 3];
+        let new = [1, 2, 3, 4];
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(..)));
+
+        let old = [1, 2, 3];
+        let new = [1, 0, 3];
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::Array(array_diff) = modified {
+                let mut fields = array_diff.iter();
+
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                assert!(matches!(
+                    fields.next(),
+                    Some(Diff::Modified(DiffType::Value(..)))
+                ));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                assert!(matches!(fields.next(), None));
+            } else {
+                panic!("expected `DiffType::Array`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+    }
+
+    #[test]
+    fn should_diff_list() {
+        let old = vec![1, 2, 3];
+        let new = vec![1, 2, 3];
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old: Vec<i32> = vec![1, 2, 3];
+        let new: Vec<u32> = vec![1, 2, 3];
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(_)));
+
+        let old = vec![1, 2, 3];
+        let new = vec![9, 1, 2, 3];
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::List(list_diff) = modified {
+                let mut changes = list_diff.iter_changes();
+
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(0, _ /* 9 */))
+                ));
+                assert!(matches!(changes.next(), None));
+            } else {
+                panic!("expected `DiffType::List`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+
+        let old: Vec<i32> = vec![];
+        let new: Vec<i32> = vec![1, 2, 3];
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::List(list_diff) = modified {
+                let mut changes = list_diff.iter_changes();
+
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(0, _ /* 1 */))
+                ));
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(0, _ /* 2 */))
+                ));
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(0, _ /* 3 */))
+                ));
+                assert!(matches!(changes.next(), None));
+            } else {
+                panic!("expected `DiffType::List`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+
+        let old = vec![1, 2, 3, 4, 5];
+        let new = vec![1, 0, 3, 6, 8, 4, 7];
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::List(list_diff) = modified {
+                let mut changes = list_diff.iter_changes();
+
+                assert!(matches!(changes.next(), Some(ListDiff::Deleted(1 /* 2 */))));
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(2, _ /* 0 */))
+                ));
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(3, _ /* 6 */))
+                ));
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(3, _ /* 8 */))
+                ));
+                assert!(matches!(changes.next(), Some(ListDiff::Deleted(4 /* 5 */))));
+                assert!(matches!(
+                    changes.next(),
+                    Some(ListDiff::Inserted(5, _ /* 7 */))
+                ));
+                assert!(matches!(changes.next(), None));
+            } else {
+                panic!("expected `DiffType::List`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+    }
+
+    #[test]
+    fn should_diff_map() {
+        macro_rules! map {
+            ($($key: tt : $value: expr),* $(,)?) => {
+                HashMap::from([$((($key, $value))),*])
+            };
+        }
+
+        let old = map! {1: 111, 2: 222, 3: 333};
+        let new = map! {3: 333, 1: 111, 2: 222};
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old: HashMap<i32, i32> = map! {1: 111, 2: 222, 3: 333};
+        let new: HashMap<i32, u32> = map! {1: 111, 2: 222, 3: 333};
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(_)));
+
+        let old = map! {1: 111, 2: 222, 3: 333};
+        let new = map! {1: 111, 3: 333};
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::Map(map_diff) = modified {
+                let mut changes = map_diff.iter_changes();
+
+                assert!(matches!(changes.next(), Some(MapDiff::Deleted(_ /* 2 */))));
+                assert!(matches!(changes.next(), None));
+            } else {
+                panic!("expected `DiffType::Map`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+
+        let old = map! {1: 111, 2: 222, 3: 333};
+        let new = map! {1: 111, 2: 222, 3: 333, 4: 444};
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::Map(map_diff) = modified {
+                let mut changes = map_diff.iter_changes();
+
+                assert!(matches!(
+                    changes.next(),
+                    Some(MapDiff::Inserted(_ /* 4 */, _ /* 444 */))
+                ));
+                assert!(matches!(changes.next(), None));
+            } else {
+                panic!("expected `DiffType::Map`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+
+        let old = map! {1: 111, 2: 222, 3: 333};
+        let new = map! {1: 111, 2: 999, 3: 333};
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::Map(map_diff) = modified {
+                let mut changes = map_diff.iter_changes();
+
+                assert!(matches!(
+                    changes.next(),
+                    Some(MapDiff::Modified(_ /* 2 */, _ /* 999 */))
+                ));
+                assert!(matches!(changes.next(), None));
+            } else {
+                panic!("expected `DiffType::Map`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+    }
+
+    #[test]
+    fn should_diff_tuple_struct() {
+        #[derive(Reflect)]
+        struct Foo(i32, i32, i32);
+        #[derive(Reflect)]
+        struct Bar(i32, i32, i32, i32);
+
+        let old = Foo(1, 2, 3);
+        let new = Foo(1, 2, 3);
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old = Foo(1, 2, 3);
+        let new = Bar(1, 2, 3, 4);
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(..)));
+
+        let old = Foo(1, 2, 3);
+        let new = Foo(1, 0, 3);
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::TupleStruct(tuple_struct_diff) = modified {
+                let mut fields = tuple_struct_diff.field_iter();
+
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                assert!(matches!(
+                    fields.next(),
+                    Some(Diff::Modified(DiffType::Value(..)))
+                ));
+                assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                assert!(matches!(fields.next(), None));
+            } else {
+                panic!("expected `DiffType::TupleStruct`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+    }
+
+    #[test]
+    fn should_diff_struct() {
+        #[derive(Reflect)]
+        struct Foo {
+            a: i32,
+            b: f32,
+        }
+        #[derive(Reflect)]
+        struct Bar {
+            a: i32,
+            b: f32,
+            c: usize,
+        }
+
+        let old = Foo { a: 123, b: 1.23 };
+        let new = Foo { a: 123, b: 1.23 };
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::NoChange));
+
+        let old = Foo { a: 123, b: 1.23 };
+        let new = Bar {
+            a: 123,
+            b: 1.23,
+            c: 123,
+        };
+
+        let diff = old.diff(&new).unwrap();
+        assert!(matches!(diff, Diff::Replaced(..)));
+
+        let old = Foo { a: 123, b: 1.23 };
+        let new = Foo { a: 123, b: 3.21 };
+
+        let diff = old.diff(&new).unwrap();
+        if let Diff::Modified(modified) = diff {
+            if let DiffType::Struct(struct_diff) = modified {
+                let mut fields = struct_diff.field_iter();
+
+                assert!(matches!(fields.next(), Some(("a", Diff::NoChange))));
+                assert!(matches!(
+                    fields.next(),
+                    Some(("b", Diff::Modified(DiffType::Value(..))))
+                ));
+                assert!(matches!(fields.next(), None));
+            } else {
+                panic!("expected `DiffType::Struct`");
+            }
+        } else {
+            panic!("expected `Diff::Modified`");
+        }
+    }
+    mod enums {
+        use super::*;
+
+        #[test]
+        fn should_diff_unit_variant() {
+            #[derive(Reflect)]
+            enum Foo {
+                A,
+                B,
+            }
+            #[derive(Reflect)]
+            enum Bar {
+                A,
+                B,
+            }
+
+            let old = Foo::A;
+            let new = Foo::A;
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::NoChange));
+
+            let old = Foo::A;
+            let new = Foo::B;
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::Replaced(..)));
+
+            let old = Foo::A;
+            let new = Bar::A;
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::Replaced(..)));
+        }
+
+        #[test]
+        fn should_diff_tuple_variant() {
+            #[derive(Reflect)]
+            enum Foo {
+                A(i32, i32, i32),
+                B(i32, i32, i32),
+            }
+            #[derive(Reflect)]
+            enum Bar {
+                A(i32, i32, i32),
+                B(i32, i32, i32),
+            }
+
+            let old = Foo::A(1, 2, 3);
+            let new = Foo::A(1, 2, 3);
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::NoChange));
+
+            let old = Foo::A(1, 2, 3);
+            let new = Foo::B(1, 2, 3);
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::Replaced(..)));
+
+            let old = Foo::A(1, 2, 3);
+            let new = Bar::A(1, 2, 3);
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::Replaced(..)));
+
+            let old = Foo::A(1, 2, 3);
+            let new = Foo::A(1, 0, 3);
+
+            let diff = old.diff(&new).unwrap();
+            if let Diff::Modified(modified) = diff {
+                if let DiffType::Enum(enum_diff) = modified {
+                    if let EnumDiff::Tuple(tuple_diff) = enum_diff {
+                        let mut fields = tuple_diff.field_iter();
+
+                        assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                        assert!(matches!(
+                            fields.next(),
+                            Some(Diff::Modified(DiffType::Value(..)))
+                        ));
+                        assert!(matches!(fields.next(), Some(Diff::NoChange)));
+                        assert!(matches!(fields.next(), None));
+                    } else {
+                        panic!("expected `EnumDiff::Tuple`");
+                    }
+                } else {
+                    panic!("expected `DiffType::Enum`");
+                }
+            } else {
+                panic!("expected `Diff::Modified`");
+            }
+        }
+
+        #[test]
+        fn should_diff_struct_variant() {
+            #[derive(Reflect)]
+            enum Foo {
+                A { x: f32, y: f32 },
+                B { x: f32, y: f32 },
+            }
+            #[derive(Reflect)]
+            enum Bar {
+                A { x: f32, y: f32 },
+                B { x: f32, y: f32 },
+            }
+
+            let old = Foo::A { x: 1.23, y: 4.56 };
+            let new = Foo::A { x: 1.23, y: 4.56 };
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::NoChange));
+
+            let old = Foo::A { x: 1.23, y: 4.56 };
+            let new = Foo::B { x: 1.23, y: 4.56 };
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::Replaced(..)));
+
+            let old = Foo::A { x: 1.23, y: 4.56 };
+            let new = Bar::A { x: 1.23, y: 4.56 };
+
+            let diff = old.diff(&new).unwrap();
+            assert!(matches!(diff, Diff::Replaced(..)));
+
+            let old = Foo::A { x: 1.23, y: 4.56 };
+            let new = Foo::A { x: 1.23, y: 7.89 };
+
+            let diff = old.diff(&new).unwrap();
+            if let Diff::Modified(modified) = diff {
+                if let DiffType::Enum(enum_diff) = modified {
+                    if let EnumDiff::Struct(struct_diff) = enum_diff {
+                        let mut fields = struct_diff.field_iter();
+
+                        assert!(matches!(fields.next(), Some(("x", Diff::NoChange))));
+                        assert!(matches!(
+                            fields.next(),
+                            Some(("y", Diff::Modified(DiffType::Value(..))))
+                        ));
+                        assert!(matches!(fields.next(), None));
+                    } else {
+                        panic!("expected `EnumDiff::Struct`");
+                    }
+                } else {
+                    panic!("expected `DiffType::Enum`");
+                }
+            } else {
+                panic!("expected `Diff::Modified`");
+            }
+        }
+    }
+}

--- a/crates/bevy_reflect/src/diff/mod.rs
+++ b/crates/bevy_reflect/src/diff/mod.rs
@@ -156,8 +156,6 @@ pub enum Diff<'old, 'new> {
     ///
     /// Contains the "new" value.
     ///
-    /// Note that for enums, this is also used when the variant has been changed.
-    ///
     /// # Example
     ///
     /// ```
@@ -623,7 +621,10 @@ mod tests {
             let new = Foo::B;
 
             let diff = old.diff(&new).unwrap();
-            assert!(matches!(diff, Diff::Replaced(..)));
+            assert!(matches!(
+                diff,
+                Diff::Modified(DiffType::Enum(EnumDiff::Swapped(..)))
+            ));
 
             let old = Foo::A;
             let new = Bar::A;
@@ -655,7 +656,10 @@ mod tests {
             let new = Foo::B(1, 2, 3);
 
             let diff = old.diff(&new).unwrap();
-            assert!(matches!(diff, Diff::Replaced(..)));
+            assert!(matches!(
+                diff,
+                Diff::Modified(DiffType::Enum(EnumDiff::Swapped(..)))
+            ));
 
             let old = Foo::A(1, 2, 3);
             let new = Bar::A(1, 2, 3);
@@ -713,7 +717,10 @@ mod tests {
             let new = Foo::B { x: 1.23, y: 4.56 };
 
             let diff = old.diff(&new).unwrap();
-            assert!(matches!(diff, Diff::Replaced(..)));
+            assert!(matches!(
+                diff,
+                Diff::Modified(DiffType::Enum(EnumDiff::Swapped(..)))
+            ));
 
             let old = Foo::A { x: 1.23, y: 4.56 };
             let new = Bar::A { x: 1.23, y: 4.56 };

--- a/crates/bevy_reflect/src/diff/mod.rs
+++ b/crates/bevy_reflect/src/diff/mod.rs
@@ -17,6 +17,28 @@
 //! When a value is [modified], it contains data related to the modification,
 //! which may recursively contain more [`Diff`] objects.
 //!
+//! # Applying Diffs
+//!
+//! Diffs store the changes between two values, but they also allow for these changes to be applied to a value.
+//!
+//! To apply a diff, you can use either the [`Reflect::apply_diff`] method or the [`Diff::apply`] method.
+//!
+//! Note that diff's hold on to references to both the "old" and "new" values.
+//! This means you won't be able to apply a diff to the "old" value unless you clone the diff
+//! with [`Diff::clone_diff`] first.
+//!
+//! ```
+//! # use bevy_reflect::Reflect;
+//! let old = (1, 2, 3);
+//! let new = (0, 2, 4);
+//!
+//! let diff = old.diff(&new).unwrap();
+//!
+//! let mut value = (1, 2, 3);
+//! diff.apply(&mut value).unwrap();
+//! assert_eq!(value, new);
+//! ```
+//!
 //! # Lists & Maps
 //!
 //! It's important to note that both [List](crate::List) and [Map](crate::Map) types work a bit differently
@@ -109,6 +131,7 @@
 //! [modified]: Diff::Modified
 //! [replaced]: Diff::Replaced
 //! [no change]: Diff::NoChange
+//! [`Reflect::apply_diff`]: crate::Reflect::apply_diff
 //! [Myers Diffing Algorithm]: http://www.xmailserver.org/diff2.pdf
 
 mod array_diff;

--- a/crates/bevy_reflect/src/diff/struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/struct_diff.rs
@@ -1,20 +1,20 @@
-use crate::diff::{Diff, DiffError, DiffResult, DiffType};
-use crate::{Reflect, ReflectKind, ReflectRef, Struct};
+use crate::diff::{Diff, DiffError, DiffResult, DiffType, ValueDiff};
+use crate::{Reflect, ReflectKind, ReflectRef, Struct, TypeInfo};
 use bevy_utils::HashMap;
+use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 
 /// Diff object for (structs)[Struct].
-#[derive(Clone)]
 pub struct DiffedStruct<'old, 'new> {
-    new_value: &'new dyn Struct,
-    fields: HashMap<&'old str, Diff<'old, 'new>>,
-    field_order: Vec<&'old str>,
+    type_info: &'static TypeInfo,
+    fields: HashMap<Cow<'old, str>, Diff<'old, 'new>>,
+    field_order: Vec<Cow<'old, str>>,
 }
 
 impl<'old, 'new> DiffedStruct<'old, 'new> {
-    /// Returns the "new" struct value.
-    pub fn new_value(&self) -> &'new dyn Struct {
-        self.new_value
+    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
+    pub fn type_info(&self) -> &TypeInfo {
+        self.type_info
     }
 
     /// Returns the [`Diff`] for the field with the given name.
@@ -35,11 +35,10 @@ impl<'old, 'new> DiffedStruct<'old, 'new> {
     }
 
     /// Returns an iterator over the name and [`Diff`] for _every_ field.
-    pub fn field_iter(&self) -> impl Iterator<Item = (&'old str, &'_ Diff<'old, 'new>)> {
+    pub fn field_iter(&self) -> impl Iterator<Item = (&'_ str, &'_ Diff<'old, 'new>)> {
         self.field_order
             .iter()
-            .copied()
-            .map(|name| (name, self.fields.get(name).unwrap()))
+            .map(|name| (name.as_ref(), self.fields.get(name).unwrap()))
     }
 }
 
@@ -72,11 +71,11 @@ pub fn diff_struct<'old, 'new, T: Struct>(
         .ok_or(DiffError::MissingInfo)?;
 
     if old_info.type_id() != new_info.type_id() {
-        return Ok(Diff::Replaced(new.as_reflect()));
+        return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
     let mut diff = DiffedStruct {
-        new_value: new,
+        type_info: old_info,
         fields: HashMap::with_capacity(new.field_len()),
         field_order: Vec::with_capacity(new.field_len()),
     };
@@ -87,8 +86,8 @@ pub fn diff_struct<'old, 'new, T: Struct>(
         let new_field = new.field(field_name).ok_or(DiffError::MissingField)?;
         let field_diff = old_field.diff(new_field)?;
         was_modified |= !matches!(field_diff, Diff::NoChange(_));
-        diff.fields.insert(field_name, field_diff);
-        diff.field_order.push(field_name);
+        diff.fields.insert(Cow::Borrowed(field_name), field_diff);
+        diff.field_order.push(Cow::Borrowed(field_name));
     }
 
     if was_modified {

--- a/crates/bevy_reflect/src/diff/struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/struct_diff.rs
@@ -86,7 +86,7 @@ pub fn diff_struct<'old, 'new, T: Struct>(
         let field_name = old.name_at(field_idx).unwrap();
         let new_field = new.field(field_name).ok_or(DiffError::MissingField)?;
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange);
+        was_modified |= !matches!(field_diff, Diff::NoChange(_));
         diff.fields.insert(field_name, field_diff);
         diff.field_order.push(field_name);
     }
@@ -94,6 +94,6 @@ pub fn diff_struct<'old, 'new, T: Struct>(
     if was_modified {
         Ok(Diff::Modified(DiffType::Struct(diff)))
     } else {
-        Ok(Diff::NoChange)
+        Ok(Diff::NoChange(old))
     }
 }

--- a/crates/bevy_reflect/src/diff/struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/struct_diff.rs
@@ -5,13 +5,13 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 
 /// Diff object for (structs)[Struct].
-pub struct DiffedStruct<'old, 'new> {
+pub struct StructDiff<'old, 'new> {
     type_info: &'static TypeInfo,
     fields: HashMap<Cow<'old, str>, Diff<'old, 'new>>,
     field_order: Vec<Cow<'old, str>>,
 }
 
-impl<'old, 'new> DiffedStruct<'old, 'new> {
+impl<'old, 'new> StructDiff<'old, 'new> {
     pub(crate) fn new(type_info: &'static TypeInfo, field_len: usize) -> Self {
         Self {
             type_info,
@@ -55,9 +55,9 @@ impl<'old, 'new> DiffedStruct<'old, 'new> {
     }
 }
 
-impl<'old, 'new> Debug for DiffedStruct<'old, 'new> {
+impl<'old, 'new> Debug for StructDiff<'old, 'new> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DiffedStruct")
+        f.debug_struct("StructDiff")
             .field("fields", &self.fields)
             .finish()
     }
@@ -87,7 +87,7 @@ pub fn diff_struct<'old, 'new, T: Struct>(
         return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
-    let mut diff = DiffedStruct::new(old_info, new.field_len());
+    let mut diff = StructDiff::new(old_info, new.field_len());
 
     let mut was_modified = false;
     for (field_idx, old_field) in old.iter_fields().enumerate() {

--- a/crates/bevy_reflect/src/diff/struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/struct_diff.rs
@@ -1,0 +1,99 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Reflect, ReflectKind, ReflectRef, Struct};
+use bevy_utils::HashMap;
+use std::fmt::{Debug, Formatter};
+
+/// Diff object for (structs)[Struct].
+#[derive(Clone)]
+pub struct DiffedStruct<'old, 'new> {
+    new_value: &'new dyn Struct,
+    fields: HashMap<&'old str, Diff<'old, 'new>>,
+    field_order: Vec<&'old str>,
+}
+
+impl<'old, 'new> DiffedStruct<'old, 'new> {
+    /// Returns the "new" struct value.
+    pub fn new_value(&self) -> &'new dyn Struct {
+        self.new_value
+    }
+
+    /// Returns the [`Diff`] for the field with the given name.
+    pub fn field(&self, name: &str) -> Option<&Diff<'old, 'new>> {
+        self.fields.get(name)
+    }
+
+    /// Returns the [`Diff`] for the field at the given index.
+    pub fn field_at(&self, index: usize) -> Option<&Diff<'old, 'new>> {
+        self.field_order
+            .get(index)
+            .and_then(|name| self.fields.get(name))
+    }
+
+    /// Returns the number of fields in the struct.
+    pub fn field_len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns an iterator over the name and [`Diff`] for _every_ field.
+    pub fn field_iter(&self) -> impl Iterator<Item = (&'old str, &'_ Diff<'old, 'new>)> {
+        self.field_order
+            .iter()
+            .copied()
+            .map(|name| (name, self.fields.get(name).unwrap()))
+    }
+}
+
+impl<'old, 'new> Debug for DiffedStruct<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedStruct")
+            .field("fields", &self.fields)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`Struct`] objects.
+pub fn diff_struct<'old, 'new, T: Struct>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::Struct(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::Struct,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old_info.type_id() != new_info.type_id() {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let mut diff = DiffedStruct {
+        new_value: new,
+        fields: HashMap::with_capacity(new.field_len()),
+        field_order: Vec::with_capacity(new.field_len()),
+    };
+
+    let mut was_modified = false;
+    for (field_idx, old_field) in old.iter_fields().enumerate() {
+        let field_name = old.name_at(field_idx).unwrap();
+        let new_field = new.field(field_name).ok_or(DiffError::MissingField)?;
+        let field_diff = old_field.diff(new_field)?;
+        was_modified |= !matches!(field_diff, Diff::NoChange);
+        diff.fields.insert(field_name, field_diff);
+        diff.field_order.push(field_name);
+    }
+
+    if was_modified {
+        Ok(Diff::Modified(DiffType::Struct(diff)))
+    } else {
+        Ok(Diff::NoChange)
+    }
+}

--- a/crates/bevy_reflect/src/diff/struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/struct_diff.rs
@@ -53,6 +53,11 @@ impl<'old, 'new> StructDiff<'old, 'new> {
         self.fields.insert(field_name.clone(), field_diff);
         self.field_order.push(field_name);
     }
+
+    /// Take the changes contained in this diff.
+    pub fn take_changes(self) -> HashMap<Cow<'old, str>, Diff<'old, 'new>> {
+        self.fields
+    }
 }
 
 impl<'old, 'new> Debug for StructDiff<'old, 'new> {

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -45,6 +45,13 @@ impl<'old, 'new> TupleDiff<'old, 'new> {
     pub fn take_changes(self) -> Vec<Diff<'old, 'new>> {
         self.fields
     }
+
+    pub fn clone_diff(&self) -> TupleDiff<'static, 'static> {
+        TupleDiff {
+            type_info: self.type_info,
+            fields: self.fields.iter().map(Diff::clone_diff).collect(),
+        }
+    }
 }
 
 impl<'old, 'new> Debug for TupleDiff<'old, 'new> {
@@ -84,13 +91,13 @@ pub fn diff_tuple<'old, 'new, T: Tuple>(
     let mut was_modified = false;
     for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange(_));
+        was_modified |= !matches!(field_diff, Diff::NoChange);
         diff.push(field_diff);
     }
 
     if was_modified {
         Ok(Diff::Modified(DiffType::Tuple(diff)))
     } else {
-        Ok(Diff::NoChange(old))
+        Ok(Diff::NoChange)
     }
 }

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -1,0 +1,84 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Reflect, ReflectKind, ReflectRef, Tuple};
+use std::fmt::{Debug, Formatter};
+use std::slice::Iter;
+
+/// Diff object for (tuples)[Tuple].
+#[derive(Clone)]
+pub struct DiffedTuple<'old, 'new> {
+    new_value: &'new dyn Tuple,
+    fields: Vec<Diff<'old, 'new>>,
+}
+
+impl<'old, 'new> DiffedTuple<'old, 'new> {
+    /// Returns the "new" tuple value.
+    pub fn new_value(&self) -> &'new dyn Tuple {
+        self.new_value
+    }
+
+    /// Returns the [`Diff`] for the field at the given index.
+    pub fn field(&self, index: usize) -> Option<&Diff<'old, 'new>> {
+        self.fields.get(index)
+    }
+
+    /// Returns the number of fields in the tuple.
+    pub fn field_len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns an iterator over the [`Diff`] for _every_ field.
+    pub fn field_iter(&self) -> Iter<'_, Diff<'old, 'new>> {
+        self.fields.iter()
+    }
+}
+
+impl<'old, 'new> Debug for DiffedTuple<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedTuple")
+            .field("fields", &self.fields)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`Tuple`] objects.
+pub fn diff_tuple<'old, 'new, T: Tuple>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::Tuple(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::Tuple,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old.field_len() != new.field_len() || old_info.type_id() != new_info.type_id() {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let mut diff = DiffedTuple {
+        new_value: new,
+        fields: Vec::with_capacity(old.field_len()),
+    };
+
+    let mut was_modified = false;
+    for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
+        let field_diff = old_field.diff(new_field)?;
+        was_modified |= !matches!(field_diff, Diff::NoChange);
+        diff.fields.push(field_diff);
+    }
+
+    if was_modified {
+        Ok(Diff::Modified(DiffType::Tuple(diff)))
+    } else {
+        Ok(Diff::NoChange)
+    }
+}

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -72,13 +72,13 @@ pub fn diff_tuple<'old, 'new, T: Tuple>(
     let mut was_modified = false;
     for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange);
+        was_modified |= !matches!(field_diff, Diff::NoChange(_));
         diff.fields.push(field_diff);
     }
 
     if was_modified {
         Ok(Diff::Modified(DiffType::Tuple(diff)))
     } else {
-        Ok(Diff::NoChange)
+        Ok(Diff::NoChange(old))
     }
 }

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -1,19 +1,18 @@
-use crate::diff::{Diff, DiffError, DiffResult, DiffType};
-use crate::{Reflect, ReflectKind, ReflectRef, Tuple};
+use crate::diff::{Diff, DiffError, DiffResult, DiffType, ValueDiff};
+use crate::{Reflect, ReflectKind, ReflectRef, Tuple, TypeInfo};
 use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
 
 /// Diff object for (tuples)[Tuple].
-#[derive(Clone)]
 pub struct DiffedTuple<'old, 'new> {
-    new_value: &'new dyn Tuple,
+    type_info: &'static TypeInfo,
     fields: Vec<Diff<'old, 'new>>,
 }
 
 impl<'old, 'new> DiffedTuple<'old, 'new> {
-    /// Returns the "new" tuple value.
-    pub fn new_value(&self) -> &'new dyn Tuple {
-        self.new_value
+    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
+    pub fn type_info(&self) -> &TypeInfo {
+        self.type_info
     }
 
     /// Returns the [`Diff`] for the field at the given index.
@@ -61,11 +60,11 @@ pub fn diff_tuple<'old, 'new, T: Tuple>(
         .ok_or(DiffError::MissingInfo)?;
 
     if old.field_len() != new.field_len() || old_info.type_id() != new_info.type_id() {
-        return Ok(Diff::Replaced(new.as_reflect()));
+        return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
     let mut diff = DiffedTuple {
-        new_value: new,
+        type_info: old_info,
         fields: Vec::with_capacity(old.field_len()),
     };
 

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -4,12 +4,12 @@ use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
 
 /// Diff object for (tuples)[Tuple].
-pub struct DiffedTuple<'old, 'new> {
+pub struct TupleDiff<'old, 'new> {
     type_info: &'static TypeInfo,
     fields: Vec<Diff<'old, 'new>>,
 }
 
-impl<'old, 'new> DiffedTuple<'old, 'new> {
+impl<'old, 'new> TupleDiff<'old, 'new> {
     pub(crate) fn new(type_info: &'static TypeInfo, field_len: usize) -> Self {
         Self {
             type_info,
@@ -42,9 +42,9 @@ impl<'old, 'new> DiffedTuple<'old, 'new> {
     }
 }
 
-impl<'old, 'new> Debug for DiffedTuple<'old, 'new> {
+impl<'old, 'new> Debug for TupleDiff<'old, 'new> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DiffedTuple")
+        f.debug_struct("TupleDiff")
             .field("fields", &self.fields)
             .finish()
     }
@@ -74,7 +74,7 @@ pub fn diff_tuple<'old, 'new, T: Tuple>(
         return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
-    let mut diff = DiffedTuple::new(old_info, new.field_len());
+    let mut diff = TupleDiff::new(old_info, new.field_len());
 
     let mut was_modified = false;
     for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -40,6 +40,11 @@ impl<'old, 'new> TupleDiff<'old, 'new> {
     pub(crate) fn push(&mut self, field_diff: Diff<'old, 'new>) {
         self.fields.push(field_diff);
     }
+
+    /// Take the changes contained in this diff.
+    pub fn take_changes(self) -> Vec<Diff<'old, 'new>> {
+        self.fields
+    }
 }
 
 impl<'old, 'new> Debug for TupleDiff<'old, 'new> {

--- a/crates/bevy_reflect/src/diff/tuple_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_diff.rs
@@ -10,6 +10,13 @@ pub struct DiffedTuple<'old, 'new> {
 }
 
 impl<'old, 'new> DiffedTuple<'old, 'new> {
+    pub(crate) fn new(type_info: &'static TypeInfo, field_len: usize) -> Self {
+        Self {
+            type_info,
+            fields: Vec::with_capacity(field_len),
+        }
+    }
+
     /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
     pub fn type_info(&self) -> &TypeInfo {
         self.type_info
@@ -28,6 +35,10 @@ impl<'old, 'new> DiffedTuple<'old, 'new> {
     /// Returns an iterator over the [`Diff`] for _every_ field.
     pub fn field_iter(&self) -> Iter<'_, Diff<'old, 'new>> {
         self.fields.iter()
+    }
+
+    pub(crate) fn push(&mut self, field_diff: Diff<'old, 'new>) {
+        self.fields.push(field_diff);
     }
 }
 
@@ -63,16 +74,13 @@ pub fn diff_tuple<'old, 'new, T: Tuple>(
         return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
-    let mut diff = DiffedTuple {
-        type_info: old_info,
-        fields: Vec::with_capacity(old.field_len()),
-    };
+    let mut diff = DiffedTuple::new(old_info, new.field_len());
 
     let mut was_modified = false;
     for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
         let field_diff = old_field.diff(new_field)?;
         was_modified |= !matches!(field_diff, Diff::NoChange(_));
-        diff.fields.push(field_diff);
+        diff.push(field_diff);
     }
 
     if was_modified {

--- a/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
@@ -72,13 +72,13 @@ pub fn diff_tuple_struct<'old, 'new, T: TupleStruct>(
     let mut was_modified = false;
     for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange);
+        was_modified |= !matches!(field_diff, Diff::NoChange(_));
         diff.fields.push(field_diff);
     }
 
     if was_modified {
         Ok(Diff::Modified(DiffType::TupleStruct(diff)))
     } else {
-        Ok(Diff::NoChange)
+        Ok(Diff::NoChange(old))
     }
 }

--- a/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
@@ -29,6 +29,11 @@ impl<'old, 'new> TupleStructDiff<'old, 'new> {
     pub fn field_iter(&self) -> Iter<'_, Diff<'old, 'new>> {
         self.fields.iter()
     }
+
+    /// Take the changes contained in this diff.
+    pub fn take_changes(self) -> Vec<Diff<'old, 'new>> {
+        self.fields
+    }
 }
 
 impl<'old, 'new> Debug for TupleStructDiff<'old, 'new> {

--- a/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
@@ -1,0 +1,84 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Reflect, ReflectKind, ReflectRef, TupleStruct};
+use std::fmt::{Debug, Formatter};
+use std::slice::Iter;
+
+/// Diff object for [tuple structs](TupleStruct).
+#[derive(Clone)]
+pub struct DiffedTupleStruct<'old, 'new> {
+    new_value: &'new dyn TupleStruct,
+    fields: Vec<Diff<'old, 'new>>,
+}
+
+impl<'old, 'new> DiffedTupleStruct<'old, 'new> {
+    /// Returns the "new" tuple struct value.
+    pub fn new_value(&self) -> &'new dyn TupleStruct {
+        self.new_value
+    }
+
+    /// Returns the [`Diff`] for the field at the given index.
+    pub fn field(&self, index: usize) -> Option<&Diff<'old, 'new>> {
+        self.fields.get(index)
+    }
+
+    /// Returns the number of fields in the tuple struct.
+    pub fn field_len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Returns an iterator over the [`Diff`] for _every_ field.
+    pub fn field_iter(&self) -> Iter<'_, Diff<'old, 'new>> {
+        self.fields.iter()
+    }
+}
+
+impl<'old, 'new> Debug for DiffedTupleStruct<'old, 'new> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffedTupleStruct")
+            .field("fields", &self.fields)
+            .finish()
+    }
+}
+
+/// Utility function for diffing two [`TupleStruct`] objects.
+pub fn diff_tuple_struct<'old, 'new, T: TupleStruct>(
+    old: &'old T,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    let new = match new.reflect_ref() {
+        ReflectRef::TupleStruct(new) => new,
+        new => {
+            return Err(DiffError::KindMismatch {
+                expected: ReflectKind::TupleStruct,
+                received: new.kind(),
+            })
+        }
+    };
+
+    let (old_info, new_info) = old
+        .get_represented_type_info()
+        .zip(new.get_represented_type_info())
+        .ok_or(DiffError::MissingInfo)?;
+
+    if old.field_len() != new.field_len() || old_info.type_id() != new_info.type_id() {
+        return Ok(Diff::Replaced(new.as_reflect()));
+    }
+
+    let mut diff = DiffedTupleStruct {
+        new_value: new,
+        fields: Vec::with_capacity(old.field_len()),
+    };
+
+    let mut was_modified = false;
+    for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
+        let field_diff = old_field.diff(new_field)?;
+        was_modified |= !matches!(field_diff, Diff::NoChange);
+        diff.fields.push(field_diff);
+    }
+
+    if was_modified {
+        Ok(Diff::Modified(DiffType::TupleStruct(diff)))
+    } else {
+        Ok(Diff::NoChange)
+    }
+}

--- a/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
@@ -4,12 +4,12 @@ use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
 
 /// Diff object for [tuple structs](TupleStruct).
-pub struct DiffedTupleStruct<'old, 'new> {
+pub struct TupleStructDiff<'old, 'new> {
     type_info: &'static TypeInfo,
     fields: Vec<Diff<'old, 'new>>,
 }
 
-impl<'old, 'new> DiffedTupleStruct<'old, 'new> {
+impl<'old, 'new> TupleStructDiff<'old, 'new> {
     /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
     pub fn type_info(&self) -> &TypeInfo {
         self.type_info
@@ -31,9 +31,9 @@ impl<'old, 'new> DiffedTupleStruct<'old, 'new> {
     }
 }
 
-impl<'old, 'new> Debug for DiffedTupleStruct<'old, 'new> {
+impl<'old, 'new> Debug for TupleStructDiff<'old, 'new> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DiffedTupleStruct")
+        f.debug_struct("TupleStructDiff")
             .field("fields", &self.fields)
             .finish()
     }
@@ -63,7 +63,7 @@ pub fn diff_tuple_struct<'old, 'new, T: TupleStruct>(
         return Ok(Diff::Replaced(ValueDiff::Borrowed(new.as_reflect())));
     }
 
-    let mut diff = DiffedTupleStruct {
+    let mut diff = TupleStructDiff {
         type_info: old_info,
         fields: Vec::with_capacity(old.field_len()),
     };

--- a/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
+++ b/crates/bevy_reflect/src/diff/tuple_struct_diff.rs
@@ -34,6 +34,13 @@ impl<'old, 'new> TupleStructDiff<'old, 'new> {
     pub fn take_changes(self) -> Vec<Diff<'old, 'new>> {
         self.fields
     }
+
+    pub fn clone_diff(&self) -> TupleStructDiff<'static, 'static> {
+        TupleStructDiff {
+            type_info: self.type_info,
+            fields: self.fields.iter().map(Diff::clone_diff).collect(),
+        }
+    }
 }
 
 impl<'old, 'new> Debug for TupleStructDiff<'old, 'new> {
@@ -76,13 +83,13 @@ pub fn diff_tuple_struct<'old, 'new, T: TupleStruct>(
     let mut was_modified = false;
     for (old_field, new_field) in old.iter_fields().zip(new.iter_fields()) {
         let field_diff = old_field.diff(new_field)?;
-        was_modified |= !matches!(field_diff, Diff::NoChange(_));
+        was_modified |= !matches!(field_diff, Diff::NoChange);
         diff.fields.push(field_diff);
     }
 
     if was_modified {
         Ok(Diff::Modified(DiffType::TupleStruct(diff)))
     } else {
-        Ok(Diff::NoChange(old))
+        Ok(Diff::NoChange)
     }
 }

--- a/crates/bevy_reflect/src/diff/value_diff.rs
+++ b/crates/bevy_reflect/src/diff/value_diff.rs
@@ -25,6 +25,13 @@ impl<'a> ValueDiff<'a> {
             Self::Owned(value) => T::take_from_reflect(value).ok(),
         }
     }
+
+    pub fn clone_diff(&self) -> ValueDiff<'static> {
+        match self {
+            Self::Borrowed(value) => ValueDiff::Owned(value.clone_value()),
+            Self::Owned(value) => ValueDiff::Owned(value.clone_value()),
+        }
+    }
 }
 
 impl<'a> Deref for ValueDiff<'a> {
@@ -68,7 +75,7 @@ pub fn diff_value<'old, 'new>(
             }
 
             match old.reflect_partial_eq(new) {
-                Some(true) => Ok(Diff::NoChange(old)),
+                Some(true) => Ok(Diff::NoChange),
                 Some(false) => Ok(Diff::Modified(DiffType::Value(ValueDiff::Borrowed(new)))),
                 None => Err(DiffError::Incomparable),
             }

--- a/crates/bevy_reflect/src/diff/value_diff.rs
+++ b/crates/bevy_reflect/src/diff/value_diff.rs
@@ -1,0 +1,29 @@
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::{Reflect, ReflectKind};
+
+/// Utility function for diffing two [`Reflect`] objects.
+///
+/// This should be used for [value] types such as primitives.
+/// For structs, enums, and other data structures, see the similar methods in the [diff] module.
+///
+/// [value]: crate::ReflectRef::Value
+/// [diff]: crate::diff
+pub fn diff_value<'old, 'new>(
+    old: &'old dyn Reflect,
+    new: &'new dyn Reflect,
+) -> DiffResult<'old, 'new> {
+    match (old.reflect_kind(), new.reflect_kind()) {
+        (ReflectKind::Value, ReflectKind::Value) => {
+            if old.type_id() != new.type_id() {
+                return Ok(Diff::Replaced(new));
+            }
+
+            match old.reflect_partial_eq(new) {
+                Some(true) => Ok(Diff::NoChange(old)),
+                Some(false) => Ok(Diff::Modified(DiffType::Value(new))),
+                None => Err(DiffError::Incomparable),
+            }
+        }
+        (expected, received) => Err(DiffError::KindMismatch { expected, received }),
+    }
+}

--- a/crates/bevy_reflect/src/diff/value_diff.rs
+++ b/crates/bevy_reflect/src/diff/value_diff.rs
@@ -1,5 +1,47 @@
 use crate::diff::{Diff, DiffError, DiffResult, DiffType};
-use crate::{Reflect, ReflectKind};
+use crate::{Reflect, ReflectKind, TypeInfo};
+
+use std::ops::Deref;
+
+/// Represents a plain value in a [`Diff`](crate::diff::Diff).
+///
+/// This can contain either an owned [`Reflect`] object or an immutable/mutable reference to one.
+#[derive(Debug)]
+pub enum ValueDiff<'a> {
+    Borrowed(&'a dyn Reflect),
+    Owned(Box<dyn Reflect>),
+}
+
+impl<'a> ValueDiff<'a> {
+    /// Returns the [`TypeInfo`] of the reflected value currently being diffed.
+    pub fn type_info(&self) -> &TypeInfo {
+        self.get_represented_type_info()
+            .expect("reflected value type should have TypeInfo")
+    }
+}
+
+impl<'a> Deref for ValueDiff<'a> {
+    type Target = dyn Reflect;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(value) => *value,
+            Self::Owned(value) => value.as_ref(),
+        }
+    }
+}
+
+impl<'a> From<&'a dyn Reflect> for ValueDiff<'a> {
+    fn from(value: &'a dyn Reflect) -> Self {
+        Self::Borrowed(value)
+    }
+}
+
+impl<'a> From<Box<dyn Reflect>> for ValueDiff<'a> {
+    fn from(value: Box<dyn Reflect>) -> Self {
+        Self::Owned(value)
+    }
+}
 
 /// Utility function for diffing two [`Reflect`] objects.
 ///
@@ -15,12 +57,12 @@ pub fn diff_value<'old, 'new>(
     match (old.reflect_kind(), new.reflect_kind()) {
         (ReflectKind::Value, ReflectKind::Value) => {
             if old.type_id() != new.type_id() {
-                return Ok(Diff::Replaced(new));
+                return Ok(Diff::Replaced(ValueDiff::Borrowed(new)));
             }
 
             match old.reflect_partial_eq(new) {
                 Some(true) => Ok(Diff::NoChange(old)),
-                Some(false) => Ok(Diff::Modified(DiffType::Value(new))),
+                Some(false) => Ok(Diff::Modified(DiffType::Value(ValueDiff::Borrowed(new)))),
                 None => Err(DiffError::Incomparable),
             }
         }

--- a/crates/bevy_reflect/src/diff/value_diff.rs
+++ b/crates/bevy_reflect/src/diff/value_diff.rs
@@ -1,5 +1,5 @@
 use crate::diff::{Diff, DiffError, DiffResult, DiffType};
-use crate::{Reflect, ReflectKind, TypeInfo};
+use crate::{FromReflect, Reflect, ReflectKind, TypeInfo};
 
 use std::ops::Deref;
 
@@ -17,6 +17,13 @@ impl<'a> ValueDiff<'a> {
     pub fn type_info(&self) -> &TypeInfo {
         self.get_represented_type_info()
             .expect("reflected value type should have TypeInfo")
+    }
+
+    pub(crate) fn take_from_reflect<T: FromReflect>(self) -> Option<T> {
+        match self {
+            Self::Borrowed(value) => T::from_reflect(value),
+            Self::Owned(value) => T::take_from_reflect(value).ok(),
+        }
     }
 }
 

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -288,13 +288,11 @@ impl Enum for DynamicEnum {
     }
 
     fn apply_enum_diff(&mut self, diff: EnumDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
         };
-
-        if info.type_id() != diff.type_info().type_id() {
-            return Err(DiffApplyError::TypeMismatch);
-        }
 
         match diff {
             EnumDiff::Swapped(value_diff) => {

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -1,3 +1,4 @@
+use crate::diff::{diff_enum, DiffResult};
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
@@ -406,6 +407,11 @@ impl Reflect for DynamicEnum {
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_enum(self, other)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,4 +1,5 @@
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
+use crate::diff::{DiffApplyResult, EnumDiff};
 use crate::{DynamicEnum, Reflect, TypePath, TypePathTable, VariantInfo, VariantType};
 use bevy_utils::HashMap;
 use std::any::{Any, TypeId};
@@ -130,6 +131,9 @@ pub trait Enum: Reflect {
     fn variant_path(&self) -> String {
         format!("{}::{}", self.reflect_type_path(), self.variant_name())
     }
+
+    /// Apply the given [`EnumDiff`] to this value.
+    fn apply_enum_diff(&mut self, diff: EnumDiff) -> DiffApplyResult;
 }
 
 /// A container for compile-time enum info, used by [`TypeInfo`](crate::TypeInfo).

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -1,6 +1,7 @@
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{NamedField, UnnamedField};
 use bevy_utils::HashMap;
+use core::fmt::{Display, Formatter};
 use std::slice::Iter;
 use std::sync::Arc;
 
@@ -33,6 +34,16 @@ pub enum VariantType {
     /// }
     /// ```
     Unit,
+}
+
+impl Display for VariantType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            VariantType::Struct => f.pad("struct"),
+            VariantType::Tuple => f.pad("tuple"),
+            VariantType::Unit => f.pad("unit"),
+        }
+    }
 }
 
 /// A container for compile-time enum variant info.

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -3,6 +3,7 @@ use smallvec::SmallVec;
 
 use std::any::Any;
 
+use crate::diff::{diff_list, DiffResult};
 use crate::utility::GenericTypeInfoCell;
 use crate::{
     self as bevy_reflect, ApplyError, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
@@ -140,6 +141,10 @@ where
 
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_list(self, other)
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,3 +1,4 @@
+use crate::diff::{diff_array, diff_list, diff_map, DiffResult};
 use crate::std_traits::ReflectDefault;
 use crate::utility::{
     reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell,
@@ -343,6 +344,10 @@ macro_rules! impl_reflect_for_veclike {
                 Box::new(self.clone_dynamic())
             }
 
+            fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+                diff_list(self, other)
+            }
+
             fn reflect_hash(&self) -> Option<u64> {
                 crate::list_hash(self)
             }
@@ -571,6 +576,10 @@ macro_rules! impl_reflect_for_hashmap {
 
             fn clone_value(&self) -> Box<dyn Reflect> {
                 Box::new(self.clone_dynamic())
+            }
+
+            fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+                diff_map(self, other)
             }
 
             fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
@@ -802,6 +811,10 @@ where
         Box::new(self.clone_dynamic())
     }
 
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_map(self, other)
+    }
+
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
         map_partial_eq(self, value)
     }
@@ -955,6 +968,11 @@ impl<T: Reflect + TypePath + GetTypeRegistration, const N: usize> Reflect for [T
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_array(self, other)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,4 +1,7 @@
-use crate::diff::{diff_array, diff_list, diff_map, diff_value, DiffResult};
+use crate::diff::{
+    diff_array, diff_list, diff_map, diff_value, ArrayDiff, DiffApplyError, DiffApplyResult,
+    DiffResult, ElementDiff, EntryDiff, ListDiff, MapDiff, ValueDiff,
+};
 use crate::std_traits::ReflectDefault;
 use crate::utility::{
     reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell,
@@ -280,6 +283,58 @@ macro_rules! impl_reflect_for_veclike {
                     .map(|value| Box::new(value) as Box<dyn Reflect>)
                     .collect()
             }
+
+            fn apply_list_diff(&mut self, diff: ListDiff) -> DiffApplyResult {
+                let info = <Self as Typed>::type_info();
+
+                if info.type_id() != diff.type_info().type_id() {
+                    return Err(DiffApplyError::TypeMismatch);
+                }
+
+                let new_len = (self.len() + diff.total_insertions()) - diff.total_deletions();
+                let mut new = Self::with_capacity(new_len);
+
+                let mut changes = diff.take_changes();
+                changes.reverse();
+
+                fn has_change(changes: &[ElementDiff], index: usize) -> bool {
+                    changes
+                        .last()
+                        .map(|change| change.index() == index)
+                        .unwrap_or_default()
+                }
+
+                let insert = |value: ValueDiff, list: &mut Self| -> Result<(), DiffApplyError> {
+                    Ok($push(
+                        list,
+                        <T as FromReflect>::from_reflect(value.as_reflect())
+                            .ok_or(DiffApplyError::TypeMismatch)?,
+                    ))
+                };
+
+                'outer: for (curr_index, element) in self.drain(..).enumerate() {
+                    while has_change(&changes, curr_index) {
+                        match changes.pop().unwrap() {
+                            ElementDiff::Deleted(_) => {
+                                continue 'outer;
+                            }
+                            ElementDiff::Inserted(_, value) => {
+                                insert(value, &mut new)?;
+                            }
+                        }
+                    }
+
+                    $push(&mut new, element);
+                }
+
+                // Insert any remaining elements
+                while let Some(ElementDiff::Inserted(_, value)) = changes.pop() {
+                    insert(value, &mut new)?;
+                }
+
+                *self = new;
+                Ok(())
+            }
         }
 
         impl<T: FromReflect + TypePath + GetTypeRegistration> Reflect for $ty {
@@ -507,6 +562,38 @@ macro_rules! impl_reflect_for_hashmap {
                     })
                     .and_then(|key| self.remove(key))
                     .map(|value| Box::new(value) as Box<dyn Reflect>)
+            }
+
+            fn apply_map_diff(&mut self, diff: MapDiff) -> DiffApplyResult {
+                let info = <Self as Typed>::type_info();
+
+                if info.type_id() != diff.type_info().type_id() {
+                    return Err(DiffApplyError::TypeMismatch);
+                }
+
+                for change in diff.take_changes() {
+                    match change {
+                        EntryDiff::Deleted(key) => {
+                            Map::remove(self, key.as_reflect());
+                        }
+                        EntryDiff::Inserted(key, value) => {
+                            let key = key
+                                .take_from_reflect()
+                                .ok_or(DiffApplyError::TypeMismatch)?;
+                            let value = value
+                                .take_from_reflect()
+                                .ok_or(DiffApplyError::TypeMismatch)?;
+                            self.insert(key, value);
+                        }
+                        EntryDiff::Modified(key, diff) => {
+                            if let Some(value) = Map::get_mut(self, key.as_reflect()) {
+                                value.apply_diff(diff)?;
+                            }
+                        }
+                    }
+                }
+
+                Ok(())
             }
         }
 
@@ -742,6 +829,38 @@ where
             .and_then(|key| self.remove(key))
             .map(|value| Box::new(value) as Box<dyn Reflect>)
     }
+
+    fn apply_map_diff(&mut self, diff: MapDiff) -> DiffApplyResult {
+        let info = <Self as Typed>::type_info();
+
+        if info.type_id() != diff.type_info().type_id() {
+            return Err(DiffApplyError::TypeMismatch);
+        }
+
+        for change in diff.take_changes() {
+            match change {
+                EntryDiff::Deleted(key) => {
+                    Map::remove(self, key.as_reflect());
+                }
+                EntryDiff::Inserted(key, value) => {
+                    let key = key
+                        .take_from_reflect()
+                        .ok_or(DiffApplyError::TypeMismatch)?;
+                    let value = value
+                        .take_from_reflect()
+                        .ok_or(DiffApplyError::TypeMismatch)?;
+                    self.insert(key, value);
+                }
+                EntryDiff::Modified(key, diff) => {
+                    if let Some(value) = Map::get_mut(self, key.as_reflect()) {
+                        value.apply_diff(diff)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<K, V> Reflect for ::std::collections::BTreeMap<K, V>
@@ -891,6 +1010,13 @@ impl<T: Reflect + TypePath + GetTypeRegistration, const N: usize> Array for [T; 
         self.into_iter()
             .map(|value| Box::new(value) as Box<dyn Reflect>)
             .collect()
+    }
+
+    fn apply_array_diff(&mut self, diff: ArrayDiff) -> DiffApplyResult {
+        for (index, diff) in diff.take_changes().into_iter().enumerate() {
+            self[index].apply_diff(diff)?;
+        }
+        Ok(())
     }
 }
 
@@ -1261,6 +1387,58 @@ impl<T: FromReflect + Clone + TypePath + GetTypeRegistration> List for Cow<'stat
             .into_iter()
             .map(|value| value.clone_value())
             .collect()
+    }
+
+    fn apply_list_diff(&mut self, diff: ListDiff) -> DiffApplyResult {
+        let info = <Self as Typed>::type_info();
+
+        if info.type_id() != diff.type_info().type_id() {
+            return Err(DiffApplyError::TypeMismatch);
+        }
+
+        let new_len = (self.len() + diff.total_insertions()) - diff.total_deletions();
+        let mut new = Vec::<T>::with_capacity(new_len);
+
+        let mut changes = diff.take_changes();
+        changes.reverse();
+
+        fn has_change(changes: &[ElementDiff], index: usize) -> bool {
+            changes
+                .last()
+                .map(|change| change.index() == index)
+                .unwrap_or_default()
+        }
+
+        let insert = |value: ValueDiff, list: &mut Vec<T>| -> Result<(), DiffApplyError> {
+            list.push(
+                <T as FromReflect>::from_reflect(value.as_reflect())
+                    .ok_or(DiffApplyError::TypeMismatch)?,
+            );
+            Ok(())
+        };
+
+        'outer: for (curr_index, element) in self.to_mut().drain(..).enumerate() {
+            while has_change(&changes, curr_index) {
+                match changes.pop().unwrap() {
+                    ElementDiff::Deleted(_) => {
+                        continue 'outer;
+                    }
+                    ElementDiff::Inserted(_, value) => {
+                        insert(value, &mut new)?;
+                    }
+                }
+            }
+
+            new.push(element);
+        }
+
+        // Insert any remaining elements
+        while let Some(ElementDiff::Inserted(_, value)) = changes.pop() {
+            insert(value, &mut new)?;
+        }
+
+        *self = new.into();
+        Ok(())
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,4 +1,4 @@
-use crate::diff::{diff_array, diff_list, diff_map, DiffResult};
+use crate::diff::{diff_array, diff_list, diff_map, diff_value, DiffResult};
 use crate::std_traits::ReflectDefault;
 use crate::utility::{
     reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell,
@@ -1137,6 +1137,10 @@ impl Reflect for Cow<'static, str> {
         Box::new(self.clone())
     }
 
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_value(self, other)
+    }
+
     fn reflect_hash(&self) -> Option<u64> {
         let mut hasher = reflect_hasher();
         Hash::hash(&std::any::Any::type_id(self), &mut hasher);
@@ -1322,6 +1326,10 @@ impl<T: FromReflect + Clone + TypePath + GetTypeRegistration> Reflect for Cow<'s
         Box::new(List::clone_dynamic(self))
     }
 
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_list(self, other)
+    }
+
     fn reflect_hash(&self) -> Option<u64> {
         crate::list_hash(self)
     }
@@ -1425,6 +1433,10 @@ impl Reflect for &'static str {
 
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(*self)
+    }
+
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_value(self, other)
     }
 
     fn reflect_hash(&self) -> Option<u64> {
@@ -1537,6 +1549,10 @@ impl Reflect for &'static Path {
         Box::new(*self)
     }
 
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_value(self, other)
+    }
+
     fn reflect_hash(&self) -> Option<u64> {
         let mut hasher = reflect_hasher();
         Hash::hash(&std::any::Any::type_id(self), &mut hasher);
@@ -1640,6 +1656,10 @@ impl Reflect for Cow<'static, Path> {
 
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone())
+    }
+
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_value(self, other)
     }
 
     fn reflect_hash(&self) -> Option<u64> {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -474,6 +474,7 @@
 //! [derive `Reflect`]: derive@crate::Reflect
 
 mod array;
+pub mod diff;
 mod fields;
 mod from_reflect;
 mod list;

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use bevy_reflect_derive::impl_type_path;
 
+use crate::diff::{diff_list, DiffResult};
 use crate::utility::reflect_hasher;
 use crate::{
     self as bevy_reflect, ApplyError, FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
@@ -345,6 +346,11 @@ impl Reflect for DynamicList {
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_list(self, other)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -278,13 +278,11 @@ impl List for DynamicList {
     }
 
     fn apply_list_diff(&mut self, diff: ListDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
         };
-
-        if info.type_id() != diff.type_info().type_id() {
-            return Err(DiffApplyError::TypeMismatch);
-        }
 
         let new_len = (self.len() + diff.total_insertions()) - diff.total_deletions();
         let mut new = Vec::with_capacity(new_len);

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -4,7 +4,9 @@ use std::hash::{Hash, Hasher};
 
 use bevy_reflect_derive::impl_type_path;
 
-use crate::diff::{diff_list, DiffResult};
+use crate::diff::{
+    diff_list, DiffApplyError, DiffApplyResult, DiffResult, ElementDiff, ListDiff, ValueDiff,
+};
 use crate::utility::reflect_hasher;
 use crate::{
     self as bevy_reflect, ApplyError, FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
@@ -104,6 +106,9 @@ pub trait List: Reflect {
             values: self.iter().map(|value| value.clone_value()).collect(),
         }
     }
+
+    /// Apply the given [`ListDiff`] to this value.
+    fn apply_list_diff(&mut self, diff: ListDiff) -> DiffApplyResult;
 }
 
 /// A container for compile-time list info.
@@ -270,6 +275,65 @@ impl List for DynamicList {
                 .map(|value| value.clone_value())
                 .collect(),
         }
+    }
+
+    fn apply_list_diff(&mut self, diff: ListDiff) -> DiffApplyResult {
+        let Some(info) = self.get_represented_type_info() else {
+            return Err(DiffApplyError::MissingTypeInfo);
+        };
+
+        if info.type_id() != diff.type_info().type_id() {
+            return Err(DiffApplyError::TypeMismatch);
+        }
+
+        let new_len = (self.len() + diff.total_insertions()) - diff.total_deletions();
+        let mut new = Vec::with_capacity(new_len);
+
+        let mut changes = diff.take_changes();
+        changes.reverse();
+
+        fn has_change(changes: &[ElementDiff], index: usize) -> bool {
+            changes
+                .last()
+                .map(|change| change.index() == index)
+                .unwrap_or_default()
+        }
+
+        fn insert(
+            value: ValueDiff,
+            list: &mut Vec<Box<dyn Reflect>>,
+        ) -> Result<(), DiffApplyError> {
+            match value {
+                ValueDiff::Borrowed(value) => list.push(value.clone_value()),
+                ValueDiff::Owned(value) => list.push(value),
+            }
+
+            Ok(())
+        }
+
+        'outer: for (curr_index, element) in self.values.drain(..).enumerate() {
+            while has_change(&changes, curr_index) {
+                match changes.pop().unwrap() {
+                    ElementDiff::Deleted(_) => {
+                        continue 'outer;
+                    }
+                    ElementDiff::Inserted(_, value) => {
+                        insert(value, &mut new)?;
+                    }
+                }
+            }
+
+            new.push(element);
+        }
+
+        // Insert any remaining elements
+        while let Some(ElementDiff::Inserted(_, value)) = changes.pop() {
+            insert(value, &mut new)?;
+        }
+
+        self.values = new;
+
+        Ok(())
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Formatter};
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
+use crate::diff::{diff_map, DiffResult};
 use crate::{
     self as bevy_reflect, ApplyError, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
     TypeInfo, TypePath, TypePathTable,
@@ -372,6 +373,10 @@ impl Reflect for DynamicMap {
 
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_map(self, other)
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -4,7 +4,9 @@ use std::fmt::{Debug, Formatter};
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
-use crate::diff::{diff_map, DiffResult};
+use crate::diff::{
+    diff_map, DiffApplyError, DiffApplyResult, DiffResult, EntryDiff, MapDiff, ValueDiff,
+};
 use crate::{
     self as bevy_reflect, ApplyError, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
     TypeInfo, TypePath, TypePathTable,
@@ -90,6 +92,9 @@ pub trait Map: Reflect {
     /// If the map did not have this key present, `None` is returned.
     /// If the map did have this key present, the removed value is returned.
     fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>>;
+
+    /// Apply the given [`MapDiff`] to this value.
+    fn apply_map_diff(&mut self, diff: MapDiff) -> DiffApplyResult;
 }
 
 /// A container for compile-time map info.
@@ -306,6 +311,66 @@ impl Map for DynamicMap {
             .remove(&key.reflect_hash().expect(HASH_ERROR))?;
         let (_key, value) = self.values.remove(index);
         Some(value)
+    }
+
+    fn apply_map_diff(&mut self, diff: MapDiff) -> DiffApplyResult {
+        let Some(info) = self.get_represented_type_info() else {
+            return Err(DiffApplyError::MissingTypeInfo);
+        };
+
+        if info.type_id() != diff.type_info().type_id() {
+            return Err(DiffApplyError::TypeMismatch);
+        }
+
+        for change in diff.take_changes() {
+            match change {
+                EntryDiff::Deleted(key) => {
+                    let hash = match key {
+                        ValueDiff::Borrowed(key) => key.reflect_hash().expect(HASH_ERROR),
+                        ValueDiff::Owned(key) => key.reflect_hash().expect(HASH_ERROR),
+                    };
+                    if let Some(index) = self.indices.remove(&hash) {
+                        self.values.remove(index);
+                    }
+                }
+                EntryDiff::Inserted(key, value) => {
+                    let key = match key {
+                        ValueDiff::Borrowed(key) => key.clone_value(),
+                        ValueDiff::Owned(key) => key,
+                    };
+                    let mut value = match value {
+                        ValueDiff::Borrowed(value) => value.clone_value(),
+                        ValueDiff::Owned(value) => value,
+                    };
+
+                    match self.indices.entry(key.reflect_hash().expect(HASH_ERROR)) {
+                        Entry::Occupied(entry) => {
+                            let (_old_key, old_value) = self.values.get_mut(*entry.get()).unwrap();
+                            std::mem::swap(old_value, &mut value);
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(self.values.len());
+                            self.values.push((key, value));
+                        }
+                    }
+                }
+                EntryDiff::Modified(key, diff) => {
+                    let hash = match key {
+                        ValueDiff::Borrowed(key) => key.reflect_hash().expect(HASH_ERROR),
+                        ValueDiff::Owned(key) => key.reflect_hash().expect(HASH_ERROR),
+                    };
+                    if let Some(index) = self.indices.remove(&hash) {
+                        let (key, mut value) = self.values.swap_remove(index);
+                        value.apply_diff(diff)?;
+                        self.values.push((key, value));
+                        let end = self.values.len() - 1;
+                        self.values.swap(index, end);
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -314,13 +314,11 @@ impl Map for DynamicMap {
     }
 
     fn apply_map_diff(&mut self, diff: MapDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
         };
-
-        if info.type_id() != diff.type_info().type_id() {
-            return Err(DiffApplyError::TypeMismatch);
-        }
 
         for change in diff.take_changes() {
             match change {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -10,7 +10,7 @@ use std::{
 
 use thiserror::Error;
 
-use crate::diff::{Diff, DiffError, DiffResult, DiffType};
+use crate::diff::DiffResult;
 use crate::utility::NonGenericTypeInfoCell;
 
 macro_rules! impl_reflect_enum {
@@ -313,24 +313,7 @@ pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// The computed diff should indicate how this value can be transformed into `other`.
     ///
     /// See the [module-level docs](crate::diff) for more details.
-    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
-        // Default implementation which should handle `ReflectRef::Value` types
-
-        match (self.reflect_kind(), other.reflect_kind()) {
-            (ReflectKind::Value, ReflectKind::Value) => {
-                if self.type_id() != other.type_id() {
-                    return Ok(Diff::Replaced(other));
-                }
-
-                match self.reflect_partial_eq(other) {
-                    Some(true) => Ok(Diff::NoChange),
-                    Some(false) => Ok(Diff::Modified(DiffType::Value(other))),
-                    None => Err(DiffError::Incomparable),
-                }
-            }
-            (expected, received) => Err(DiffError::KindMismatch { expected, received }),
-        }
-    }
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new>;
 
     /// Returns a hash of the value (which includes the type).
     ///

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -10,6 +10,7 @@ use std::{
 
 use thiserror::Error;
 
+use crate::diff::{Diff, DiffError, DiffResult, DiffType};
 use crate::utility::NonGenericTypeInfoCell;
 
 macro_rules! impl_reflect_enum {
@@ -306,6 +307,30 @@ pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// Implementors of other `Reflect` subtraits (e.g. [`List`], [`Map`]) should
     /// use those subtraits' respective `clone_dynamic` methods.
     fn clone_value(&self) -> Box<dyn Reflect>;
+
+    /// Compute the [diff](crate::diff::Diff) between this value and `other`.
+    ///
+    /// The computed diff should indicate how this value can be transformed into `other`.
+    ///
+    /// See the [module-level docs](crate::diff) for more details.
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        // Default implementation which should handle `ReflectRef::Value` types
+
+        match (self.reflect_kind(), other.reflect_kind()) {
+            (ReflectKind::Value, ReflectKind::Value) => {
+                if self.type_id() != other.type_id() {
+                    return Ok(Diff::Replaced(other));
+                }
+
+                match self.reflect_partial_eq(other) {
+                    Some(true) => Ok(Diff::NoChange),
+                    Some(false) => Ok(Diff::Modified(DiffType::Value(other))),
+                    None => Err(DiffError::Incomparable),
+                }
+            }
+            (expected, received) => Err(DiffError::KindMismatch { expected, received }),
+        }
+    }
 
     /// Returns a hash of the value (which includes the type).
     ///

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -402,12 +402,10 @@ impl Struct for DynamicStruct {
     }
 
     fn apply_struct_diff(&mut self, diff: StructDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
-        };
-
-        if info.type_id() != diff.type_info().type_id() {
-            return Err(DiffApplyError::TypeMismatch);
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
         }
 
         for (field_name, field_diff) in diff.take_changes() {

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,4 +1,5 @@
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
+use crate::diff::{diff_struct, DiffResult};
 use crate::{
     self as bevy_reflect, ApplyError, NamedField, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, TypeInfo, TypePath, TypePathTable,
@@ -480,6 +481,11 @@ impl Reflect for DynamicStruct {
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_struct(self, other)
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -303,12 +303,14 @@ impl Tuple for DynamicTuple {
     }
 
     fn apply_tuple_diff(&mut self, diff: TupleDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
-        };
-
-        if info.type_id() != diff.type_info().type_id() || self.field_len() != diff.field_len() {
+        if self.field_len() != diff.field_len() {
             return Err(DiffApplyError::TypeMismatch);
+        }
+
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
         }
 
         for (index, diff) in diff.take_changes().into_iter().enumerate() {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,3 +1,4 @@
+use crate::diff::{diff_tuple, DiffResult};
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::all_tuples;
 
@@ -373,6 +374,11 @@ impl Reflect for DynamicTuple {
         tuple_try_apply(self, value)
     }
 
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_tuple(self, other)
+    }
+
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
         tuple_partial_eq(self, value)
     }
@@ -594,6 +600,10 @@ macro_rules! impl_reflect_tuple {
 
             fn clone_value(&self) -> Box<dyn Reflect> {
                 Box::new(self.clone_dynamic())
+            }
+
+            fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+                diff_tuple(self, other)
             }
 
             fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -313,13 +313,11 @@ impl TupleStruct for DynamicTupleStruct {
     }
 
     fn apply_tuple_struct_diff(&mut self, diff: TupleStructDiff) -> DiffApplyResult {
-        let Some(info) = self.get_represented_type_info() else {
-            return Err(DiffApplyError::MissingTypeInfo);
+        if let Some(info) = self.get_represented_type_info() {
+            if info.type_id() != diff.type_info().type_id() {
+                return Err(DiffApplyError::TypeMismatch);
+            }
         };
-
-        if info.type_id() != diff.type_info().type_id() {
-            return Err(DiffApplyError::TypeMismatch);
-        }
 
         for (index, diff) in diff.take_changes().into_iter().enumerate() {
             self.fields

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,6 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
+use crate::diff::{diff_tuple_struct, DiffResult};
 use crate::{
     self as bevy_reflect, ApplyError, DynamicTuple, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, Tuple, TypeInfo, TypePath, TypePathTable, UnnamedField,
@@ -388,6 +389,11 @@ impl Reflect for DynamicTupleStruct {
     #[inline]
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    #[inline]
+    fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> {
+        diff_tuple_struct(self, other)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -26,6 +26,7 @@ use std::fmt::Debug;
 /// ```
 /// # use std::any::Any;
 /// # use bevy_reflect::{DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, TypeInfo, TypePath, ValueInfo, ApplyError};
+/// # use bevy_reflect::diff::DiffResult;
 /// # use bevy_reflect::utility::NonGenericTypeInfoCell;
 /// use bevy_reflect::Typed;
 ///
@@ -66,6 +67,7 @@ use std::fmt::Debug;
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }
 /// #   fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// #   fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// #   fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> { todo!() }
 /// # }
 /// ```
 ///

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -50,6 +50,7 @@ mod sealed {
 /// ```
 /// # use std::any::Any;
 /// # use bevy_reflect::{DynamicTypePath, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, Typed, TypeInfo, TypePath, ApplyError};
+/// # use bevy_reflect::diff::DiffResult;
 /// use bevy_reflect::utility::NonGenericTypeInfoCell;
 ///
 /// struct Foo {
@@ -84,6 +85,7 @@ mod sealed {
 /// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// #     fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// #     fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> { todo!() }
 /// # }
 /// ```
 ///
@@ -131,6 +133,7 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 /// ```
 /// # use std::any::Any;
 /// # use bevy_reflect::{DynamicTypePath, Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, TypePath, UnnamedField, ApplyError};
+/// # use bevy_reflect::diff::DiffResult;
 /// use bevy_reflect::utility::GenericTypeInfoCell;
 ///
 /// struct Foo<T>(T);
@@ -163,6 +166,7 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 /// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
 /// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
 /// #     fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// #     fn diff<'new>(&self, other: &'new dyn Reflect) -> DiffResult<'_, 'new> { todo!() }
 /// # }
 /// ```
 ///


### PR DESCRIPTION
# Objective

Closes #5563.

> [!note]
> Much of this code was actually written almost two years ago. I did my best to revive the work, but there may be subtle inconsistencies with the rest of the codebase or reduced quality in some areas (I was young okay!). So please do feel free to point those out so I can correct them!

Sometimes you need more information than just "are these two values equal?" Sometimes you need something more like "_why_ aren't these two values equal?" This is where _diffing_ comes in.

With diffing, we can pinpoint exactly why two values differ from each other. This can be really helpful for handling specific differences, which would otherwise require lots of specific if-statement spaghetti.

Additionally, because diffing is solely concerned with the changes, it means they can also be more efficient in memory usage. Rather than storing a copy of the entire changed value, we can simply store a copy of the change itself. This can be a massive win for large structs where only a single field is changed.

Because of the smaller memory usage, it can also have huge gains on networking. Instead of sending entire objects to the server, you can just send the changes.

This PR is an attempt to add some basic support for diffing within `bevy_reflect`.

## Solution

Adds reflection-based diffing.

This adds two methods to `Reflect`: `Reflect::diff` and `Reflect::apply_diff`.

### `Reflect::diff`

When `Reflect::diff` is called on two values, it will return a `Diff` enum.

This enum contains variants for: `NoChange`, `Replaced`, and `Modified`.

`NoChange` is pretty self-explanatory. There is no perceived change[^1] between the two values.

`Replaced` usually means that the two values are not of the same type. There's no good way to assess differences between two different types, so we just say that it was replaced.

`Modified` is where the fun begins. This contains a `DiffType` which is another enum that holds kind-specific diffs, such as `StructDiff`, `MapDiff`, and `TupleDiff`. These values are recursive in that they may contain other `Diff` values.

```rust
#[derive(Reflect)]
struct Foo {
    bar: Vec<i32>
}

let old = Foo { bar: vec![1, 2, 3] };
let new = Foo { bar: vec![1, 2, 4, 5] };
dbg!(old.diff(&new).unwrap());
// Output (with some whitespace/commas removed):
// Modified(
//   Struct(
//     StructDiff {
//       fields: {
//         "bar": Modified(
//           List(
//             ListDiff {
//               changes: [
//                 Deleted(2),
//                 Inserted(3, Borrowed(4)),
//                 Inserted(3, Borrowed(5)),
//               ],
//             },
//           ),
//         ),
//       },
//     },
//   ),
// )
```

### `Reflect::apply_diff`

With a `Diff` created, you can then apply the changes to the old value to get the new one.

By default, `Diff` will attempt to store references (hence the `Borrowed` in the output above) rather than owned data. The full type is actually `Diff<'old, 'new>`. However, note that you can convert this to an owned instance using `Diff::clone_diff`, which returns a `Diff<'static, 'static>`.

We'll need to convert this to an owned diff if we wish to modify the original value (see Open Questions for details).

```rust
let mut old = Foo { bar: vec![1, 2, 3] };
let new = Foo { bar: vec![1, 2, 4, 5], };
let diff = old.diff(&new).unwrap().clone_diff();

diff.apply(&mut old).unwrap();
assert_eq!(old.bar, vec![1, 2, 4, 5]);
```

And with this, we have successfully applied our changes to the original value. Note that `Reflect::apply` is strictly additive, so calling `old.apply(&new)` would not have removed the `3` from `bar`. We can consider addressing this in the future (perhaps by internally using diffing).

### Mini-Example

As a fun sample of how this can be used, here's a proof-of-concept undo/redo system:

<details>
<summary>Undo/Redo Example</summary>

```rust
#[derive(Debug)]
struct HistoryEvent {
    forwards: Diff<'static, 'static>,
    backwards: Diff<'static, 'static>,
}

impl HistoryEvent {
    pub fn new(old: &dyn Reflect, new: &dyn Reflect) -> Result<Self, DiffError> {
        Ok(Self {
            forwards: old.diff(new)?.clone_diff(),
            backwards: new.diff(old)?.clone_diff(),
        })
    }

    pub fn undo(&self, value: &mut dyn Reflect) -> Result<(), DiffApplyError> {
        self.backwards.clone_diff().apply(value)
    }

    pub fn redo(&self, value: &mut dyn Reflect) -> Result<(), DiffApplyError> {
        self.forwards.clone_diff().apply(value)
    }
}

#[derive(Default)]
struct History {
    events: Vec<HistoryEvent>,
    index: usize,
}

impl History {
    pub fn push(&mut self, event: HistoryEvent) {
        self.events.truncate(self.index);
        self.events.push(event);
        self.index += 1;
    }

    pub fn undo(&mut self, value: &mut dyn Reflect) -> Result<(), DiffApplyError> {
        if self.index == 0 {
            return Ok(());
        }

        self.index -= 1;
        self.events[self.index].undo(value)
    }

    pub fn redo(&mut self, value: &mut dyn Reflect) -> Result<(), DiffApplyError> {
        if self.index == self.events.len() {
            return Ok(());
        }

        self.events[self.index].redo(value)?;
        self.index += 1;

        Ok(())
    }
}

// ------------------------------- //

#[derive(Reflect, Debug, PartialEq)]
struct Player {
    health: i32,
    mana: i32,
}

impl Player {
    pub fn take_damage(&mut self, damage: i32) {
        self.health -= damage;
    }

    pub fn consume_mana(&mut self, cost: i32) {
        self.mana -= cost;
    }
}

let mut history = History::default();

let mut player = Player {
    health: 100,
    mana: 100,
};

let old = player.clone_value();
player.take_damage(25);

history.push(HistoryEvent::new(&*old, &player).unwrap());

let old = player.clone_value();
player.consume_mana(35);

history.push(HistoryEvent::new(&*old, &player).unwrap());

history.undo(&mut player).unwrap();

assert_eq!(
    player,
    Player {
        health: 75,
        mana: 100
    }
);

history.undo(&mut player).unwrap();

assert_eq!(
    player,
    Player {
        health: 100,
        mana: 100
    }
);

history.redo(&mut player).unwrap();

assert_eq!(
    player,
    Player {
        health: 75,
        mana: 100
    }
);
```

</details>

### Open Questions

Currently, `Diff` is required to contain the `'old` lifetime due to the `EntryDiff::Deleted` variant: https://github.com/bevyengine/bevy/blob/c4be47909a032dc7946db01678395b67c1451743/crates/bevy_reflect/src/diff/map_diff.rs#L11-L12

We could consider storing an owned value instead of a borrowed one, but this raises two problems. First, it eagerly clones data we might not want (some applications may just want to examine a diff rather than apply it). Second, there are currently some issues regarding dynamic types and hashing (see #6601). By eagerly cloning this data, we risk users hitting that issue more often. Although, this hashing problem will already be experienced if users call `clone_diff` before applying the diff.

Should we go ahead and convert it to an owned value to get rid of the `'old` requirement?

### Future Work

This PR sets the groundwork for more diffing work.

Specifically, I want to make these diffs serializable. This will make it much easier to compactly serialize and send these diffs over the network or even between processes.

I originally had that work done, but probably due to a git stash malfunction, I can't seem to find it. If this PR gets general consensus among the community, I'll restart work on that front as well.

[^1]: Recall that reflection is not perfect at detecting differences. Fields could be ignored which might make it seem like two values are the same when in actuality they are not. This is something users of reflection should expect, but it's important as a reminder nonetheless.

## Testing

To test, you can run the tests for the `bevy_reflect` crate:

```
cargo test --package bevy_reflect
```

---

## Changelog

### TL;DR

- Added reflection-based diffing

### Added

- `Reflect::diff` trait method
- `Reflect::apply_diff` trait method (with default implementation)
- `Array::apply_array_diff` trait method
- `Enum::apply_enum_diff` trait method
- `List::apply_list_diff` trait method
- `Map::apply_map_diff` trait method
- `Struct::apply_struct_diff` trait method
- `Tuple::apply_tuple_diff` trait method
- `TupleStruct::apply_tuple_struct_diff` trait method
- `diff` module
  - `ArrayDiff` struct
  - `DiffApplyError` enum
  - `DiffApplyResult` type alias
  - `DiffError` enum
  - `DiffResult` type alias
  - `DiffType` enum
  - `Diff` enum
  - `ElementDiff` enum
  - `EntryDiff` enum
  - `EnumDiff` enum
  - `ListDiff` struct
  - `MapDiff` struct
  - `StructDiff` struct
  - `TupleDiff` struct
  - `TupleStructDiff` struct
  - `ValueDiff` enum
  - `diff_array` function
  - `diff_enum` function
  - `diff_list` function
  - `diff_map` function
  - `diff_struct` function
  - `diff_tuple_struct` function
  - `diff_tuple` function
  - `diff_value` function

## Migration Guide

Manual implementors of `Reflect` will need to add an implementation for the new `Reflect::diff` method.

Additionally, they may need to add an implementation for the relevant subtrait method:

- `Array::apply_array_diff`
- `Enum::apply_enum_diff`
- `List::apply_list_diff`
- `Map::apply_map_diff`
- `Struct::apply_struct_diff`
- `Tuple::apply_tuple_diff`
- `TupleStruct::apply_tuple_struct_diff`