### PR TITLE
More gizmos builders

### DIFF
--- a/crates/bevy_gizmos/src/circles.rs
+++ b/crates/bevy_gizmos/src/circles.rs
@@ -362,7 +362,7 @@ where
         // draws one great circle around each of the local axes
         let rotation = rotation.normalize();
         Vec3::AXES.into_iter().for_each(|axis| {
-            let normal = *center + (rotation * axis) * *radius;
+            let normal = rotation * axis;
             self.gizmos
                 .circle(*center, Dir3::new_unchecked(normal), *radius, *color)
                 .segments(*segments);

--- a/crates/bevy_gizmos/src/circles.rs
+++ b/crates/bevy_gizmos/src/circles.rs
@@ -178,6 +178,45 @@ where
             segments: DEFAULT_CIRCLE_SEGMENTS,
         }
     }
+
+    /// Draw a wireframe sphere in 3D made out of 3 circles around the axes.
+    ///
+    /// This should be called for each frame the sphere needs to be rendered.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_render::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use bevy_color::Color;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.sphere(Vec3::ZERO, Quat::IDENTITY, 1., Color::BLACK);
+    ///
+    ///     // Each circle has 32 line-segments by default.
+    ///     // You may want to increase this for larger spheres.
+    ///     gizmos
+    ///         .sphere(Vec3::ZERO, Quat::IDENTITY, 5., Color::BLACK)
+    ///         .circle_segments(64);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    #[inline]
+    pub fn sphere(
+        &mut self,
+        position: Vec3,
+        rotation: Quat,
+        radius: f32,
+        color: impl Into<Color>,
+    ) -> SphereBuilder<'_, 'w, 's, Config, Clear> {
+        SphereBuilder {
+            gizmos: self,
+            radius,
+            position,
+            rotation,
+            color: color.into(),
+            segments: DEFAULT_CIRCLE_SEGMENTS,
+        }
+    }
 }
 
 /// A builder returned by [`Gizmos::ellipse`].
@@ -264,5 +303,69 @@ where
             .map(|vec2| self.rotation * vec2)
             .map(|vec2| vec2 + self.position);
         self.gizmos.linestrip_2d(positions, self.color);
+    }
+}
+
+/// Builder for configuring the drawing options of [`Sphere`].
+pub struct SphereBuilder<'a, 'w, 's, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    gizmos: &'a mut Gizmos<'w, 's, Config, Clear>,
+
+    // Radius of the sphere
+    radius: f32,
+
+    // Rotation of the sphere around the origin in 3D space
+    rotation: Quat,
+    // Center position of the sphere in 3D space
+    position: Vec3,
+    // Color of the sphere
+    color: Color,
+
+    // Number of segments used to approximate the sphere geometry
+    segments: usize,
+}
+
+impl<Config, Clear> SphereBuilder<'_, '_, '_, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    /// Set the number of segments used to approximate the sphere geometry.
+    pub fn segments(mut self, segments: usize) -> Self {
+        self.segments = segments;
+        self
+    }
+}
+
+impl<Config, Clear> Drop for SphereBuilder<'_, '_, '_, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    fn drop(&mut self) {
+        if !self.gizmos.enabled {
+            return;
+        }
+
+        let SphereBuilder {
+            radius,
+            position: center,
+            rotation,
+            color,
+            segments,
+            ..
+        } = self;
+
+        // draws one great circle around each of the local axes
+        let rotation = rotation.normalize();
+        Vec3::AXES.into_iter().for_each(|axis| {
+            let normal = *center + (rotation * axis) * *radius;
+            self.gizmos
+                .circle(*center, Dir3::new_unchecked(normal), *radius, *color)
+                .segments(*segments);
+        });
     }
 }

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -2,14 +2,13 @@
 
 use std::{iter, marker::PhantomData, mem};
 
-use crate::primitives::dim3::{GizmoPrimitive3d, SphereBuilder};
 use bevy_color::{Color, LinearRgba};
 use bevy_ecs::{
     component::Tick,
     system::{Deferred, ReadOnlySystemParam, Res, Resource, SystemBuffer, SystemMeta, SystemParam},
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
-use bevy_math::{primitives::Sphere, Quat, Rotation2d, Vec2, Vec3};
+use bevy_math::{Quat, Rotation2d, Vec2, Vec3};
 use bevy_transform::TransformPoint;
 use bevy_utils::default;
 
@@ -457,38 +456,6 @@ where
 
         strip_positions.push(Vec3::NAN);
         strip_colors.push(LinearRgba::NAN);
-    }
-
-    /// Draw a wireframe sphere in 3D made out of 3 circles around the axes.
-    ///
-    /// This should be called for each frame the sphere needs to be rendered.
-    ///
-    /// # Example
-    /// ```
-    /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
-    /// # use bevy_math::prelude::*;
-    /// # use bevy_color::Color;
-    /// fn system(mut gizmos: Gizmos) {
-    ///     gizmos.sphere(Vec3::ZERO, Quat::IDENTITY, 1., Color::BLACK);
-    ///
-    ///     // Each circle has 32 line-segments by default.
-    ///     // You may want to increase this for larger spheres.
-    ///     gizmos
-    ///         .sphere(Vec3::ZERO, Quat::IDENTITY, 5., Color::BLACK)
-    ///         .circle_segments(64);
-    /// }
-    /// # bevy_ecs::system::assert_is_system(system);
-    /// ```
-    #[inline]
-    pub fn sphere(
-        &mut self,
-        position: Vec3,
-        rotation: Quat,
-        radius: f32,
-        color: impl Into<Color>,
-    ) -> SphereBuilder<'_, 'w, 's, Config, Clear> {
-        self.primitive_3d(Sphere { radius }, position, rotation, color)
     }
 
     /// Draw a wireframe rectangle in 3D.

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -51,7 +51,7 @@ fn point_light_gizmo(
         .segments(16);
     gizmos
         .sphere(position, Quat::IDENTITY, point_light.range, color)
-        .circle_segments(32);
+        .segments(32);
 }
 
 /// Draws a sphere for the radius, two cones for the inner and outer angles, plus two 3d arcs crossing the

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -106,27 +106,83 @@ where
 
 // annulus 2d
 
+/// Builder for configuring the drawing options of [`Annulus`].
+pub struct Annulus2dBuilder<'a, 'w, 's, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    gizmos: &'a mut Gizmos<'w, 's, Config, Clear>,
+    position: Vec2,
+    inner_radius: f32,
+    outer_radius: f32,
+    color: Color,
+    segments: usize,
+}
+
+impl<Config, Clear> Annulus2dBuilder<'_, '_, '_, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    /// Set the number of line-segments for each circle of the annulus.
+    pub fn segments(mut self, segments: usize) -> Self {
+        self.segments = segments;
+        self
+    }
+}
+
 impl<'w, 's, Config, Clear> GizmoPrimitive2d<Annulus> for Gizmos<'w, 's, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    type Output<'a> = () where Self: 'a;
+    type Output<'a> = Annulus2dBuilder<'a, 'w, 's, Config, Clear> where Self: 'a;
 
     fn primitive_2d(
         &mut self,
         primitive: Annulus,
         position: Vec2,
-        angle: f32,
+        _angle: f32,
         color: impl Into<Color>,
     ) -> Self::Output<'_> {
-        if !self.enabled {
-            return;
+        Annulus2dBuilder {
+            gizmos: self,
+            position,
+            inner_radius: primitive.inner_circle.radius,
+            outer_radius: primitive.outer_circle.radius,
+            color: color.into(),
+            segments: crate::circles::DEFAULT_CIRCLE_SEGMENTS,
         }
+    }
+}
 
-        let color = color.into();
-        self.primitive_2d(primitive.inner_circle, position, angle, color);
-        self.primitive_2d(primitive.outer_circle, position, angle, color);
+impl<Config, Clear> Drop for Annulus2dBuilder<'_, '_, '_, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    fn drop(&mut self) {
+        if !self.gizmos.enabled {
+            return;
+        };
+
+        let Annulus2dBuilder {
+            gizmos,
+            position,
+            inner_radius,
+            outer_radius,
+            segments,
+            color,
+            ..
+        } = self;
+
+        gizmos
+            .circle_2d(*position, *outer_radius, *color)
+            .segments(*segments);
+        gizmos
+            .circle_2d(*position, *inner_radius, *color)
+            .segments(*segments);
     }
 }
 

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -71,7 +71,7 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    type Output<'a> = () where Self: 'a;
+    type Output<'a> = crate::circles::Ellipse2dBuilder<'a, 'w, 's, Config, Clear> where Self: 'a;
 
     fn primitive_2d(
         &mut self,
@@ -80,11 +80,7 @@ where
         _angle: f32,
         color: impl Into<Color>,
     ) -> Self::Output<'_> {
-        if !self.enabled {
-            return;
-        }
-
-        self.circle_2d(position, primitive.radius, color);
+        self.circle_2d(position, primitive.radius, color)
     }
 }
 
@@ -95,20 +91,16 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    type Output<'a> = () where Self: 'a;
+    type Output<'a> = crate::circles::Ellipse2dBuilder<'a, 'w, 's, Config, Clear> where Self: 'a;
 
-    fn primitive_2d(
+    fn primitive_2d<'a>(
         &mut self,
         primitive: Ellipse,
         position: Vec2,
         angle: f32,
         color: impl Into<Color>,
     ) -> Self::Output<'_> {
-        if !self.enabled {
-            return;
-        }
-
-        self.ellipse_2d(position, angle, primitive.half_size, color);
+        self.ellipse_2d(position, angle, primitive.half_size, color)
     }
 }
 

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -10,6 +10,7 @@ use bevy_math::primitives::{
 };
 use bevy_math::{Dir3, Quat, Vec3};
 
+use crate::circles::SphereBuilder;
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 
 const DEFAULT_NUMBER_SEGMENTS: usize = 5;
@@ -55,40 +56,6 @@ where
 
 // sphere
 
-/// Builder for configuring the drawing options of [`Sphere`].
-pub struct SphereBuilder<'a, 'w, 's, Config, Clear>
-where
-    Config: GizmoConfigGroup,
-    Clear: 'static + Send + Sync,
-{
-    gizmos: &'a mut Gizmos<'w, 's, Config, Clear>,
-
-    // Radius of the sphere
-    radius: f32,
-
-    // Rotation of the sphere around the origin in 3D space
-    rotation: Quat,
-    // Center position of the sphere in 3D space
-    position: Vec3,
-    // Color of the sphere
-    color: Color,
-
-    // Number of segments used to approximate the sphere geometry
-    segments: usize,
-}
-
-impl<Config, Clear> SphereBuilder<'_, '_, '_, Config, Clear>
-where
-    Config: GizmoConfigGroup,
-    Clear: 'static + Send + Sync,
-{
-    /// Set the number of segments used to approximate the sphere geometry.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
-        self
-    }
-}
-
 impl<'w, 's, Config, Clear> GizmoPrimitive3d<Sphere> for Gizmos<'w, 's, Config, Clear>
 where
     Config: GizmoConfigGroup,
@@ -103,52 +70,7 @@ where
         rotation: Quat,
         color: impl Into<Color>,
     ) -> Self::Output<'_> {
-        SphereBuilder {
-            gizmos: self,
-            radius: primitive.radius,
-            position,
-            rotation,
-            color: color.into(),
-            segments: DEFAULT_NUMBER_SEGMENTS,
-        }
-    }
-}
-
-impl<Config, Clear> Drop for SphereBuilder<'_, '_, '_, Config, Clear>
-where
-    Config: GizmoConfigGroup,
-    Clear: 'static + Send + Sync,
-{
-    fn drop(&mut self) {
-        if !self.gizmos.enabled {
-            return;
-        }
-
-        let SphereBuilder {
-            radius,
-            position: center,
-            rotation,
-            color,
-            segments,
-            ..
-        } = self;
-
-        // draws the upper and lower semi spheres
-        [-1.0, 1.0].into_iter().for_each(|sign| {
-            let top = *center + (*rotation * Vec3::Y) * sign * *radius;
-            draw_semi_sphere(
-                self.gizmos,
-                *radius,
-                *segments,
-                *rotation,
-                *center,
-                top,
-                *color,
-            );
-        });
-
-        // draws one great circle of the sphere
-        draw_circle_3d(self.gizmos, *radius, *segments, *rotation, *center, *color);
+        self.sphere(position, rotation, primitive.radius, color)
     }
 }
 

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -134,7 +134,7 @@ fn draw_example_collection(
         .segments(64);
     my_gizmos
         .sphere(Vec3::ZERO, Quat::IDENTITY, 3.2, BLACK)
-        .circle_segments(64);
+        .segments(64);
 
     gizmos.arrow(Vec3::ZERO, Vec3::ONE * 1.5, YELLOW);
 

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -418,8 +418,12 @@ fn draw_gizmos_2d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::RectangleAndCuboid => {
             gizmos.primitive_2d(RECTANGLE, POSITION, angle, color);
         }
-        PrimitiveSelected::CircleAndSphere => gizmos.primitive_2d(CIRCLE, POSITION, angle, color),
-        PrimitiveSelected::Ellipse => gizmos.primitive_2d(ELLIPSE, POSITION, angle, color),
+        PrimitiveSelected::CircleAndSphere => {
+            gizmos.primitive_2d(CIRCLE, POSITION, angle, color);
+        }
+        PrimitiveSelected::Ellipse => {
+            gizmos.primitive_2d(ELLIPSE, POSITION, angle, color);
+        }
         PrimitiveSelected::Triangle => gizmos.primitive_2d(TRIANGLE, POSITION, angle, color),
         PrimitiveSelected::Plane => gizmos.primitive_2d(PLANE_2D, POSITION, angle, color),
         PrimitiveSelected::Line => drop(gizmos.primitive_2d(LINE2D, POSITION, angle, color)),
@@ -433,7 +437,9 @@ fn draw_gizmos_2d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Cylinder => {}
         PrimitiveSelected::Cone => {}
         PrimitiveSelected::ConicalFrustum => {}
-        PrimitiveSelected::Torus => gizmos.primitive_2d(ANNULUS, POSITION, angle, color),
+        PrimitiveSelected::Torus => {
+            gizmos.primitive_2d(ANNULUS, POSITION, angle, color);
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Add GizmoBuilders for some primitives

## Solution

- `gizmos.primitive_2d(CIRCLE)` and `gizmos.primitive_2d(ELLIPSE)` now return `Ellipse2dBuilder` aswell.
- `gizmos.primitive_3d(SPHERE)` and `gizmos.sphere()` now return the same `SphereBuilder`.
  - the `.circle_segments` method on the `SphereBuilder` that used to be returned by `.sphere()` is now called `.segments`
- `gizmos.primitive_2d(ANNULUS)` now returns a `Annulus2dBuilder` allowing the configuration of the `segments`

