### PR TITLE
Use `Dir3` for local axis methods in `GlobalTransform`

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -910,7 +910,7 @@ pub fn prepare_lights(
             // we don't use the alpha at all, so no reason to multiply only [0..3]
             color: Vec4::from_slice(&light.color.to_f32_array()) * light.illuminance,
             // direction is negated to be ready for N.L
-            dir_to_light: light.transform.back(),
+            dir_to_light: light.transform.back().into(),
             flags: flags.bits(),
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -43,7 +43,7 @@ macro_rules! impl_local_axis {
         #[doc=std::concat!("Return the local ", std::stringify!($pos_name), " vector (", std::stringify!($axis) ,").")]
         #[inline]
         pub fn $pos_name(&self) -> Dir3 {
-            Dir3::new((self.0.matrix3 * Vec3::$axis).normalize()).unwrap()
+            Dir3::new_unchecked((self.0.matrix3 * Vec3::$axis).normalize())
         }
 
         #[doc=std::concat!("Return the local ", std::stringify!($neg_name), " vector (-", std::stringify!($axis) ,").")]

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -2,7 +2,7 @@ use std::ops::Mul;
 
 use super::Transform;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
-use bevy_math::{Affine3A, Mat4, Quat, Vec3, Vec3A};
+use bevy_math::{Affine3A, Dir3, Mat4, Quat, Vec3, Vec3A};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 /// Describe the position of an entity relative to the reference frame.
@@ -42,13 +42,13 @@ macro_rules! impl_local_axis {
     ($pos_name: ident, $neg_name: ident, $axis: ident) => {
         #[doc=std::concat!("Return the local ", std::stringify!($pos_name), " vector (", std::stringify!($axis) ,").")]
         #[inline]
-        pub fn $pos_name(&self) -> Vec3 {
-            (self.0.matrix3 * Vec3::$axis).normalize()
+        pub fn $pos_name(&self) -> Dir3 {
+            Dir3::new((self.0.matrix3 * Vec3::$axis).normalize()).unwrap()
         }
 
         #[doc=std::concat!("Return the local ", std::stringify!($neg_name), " vector (-", std::stringify!($axis) ,").")]
         #[inline]
-        pub fn $neg_name(&self) -> Vec3 {
+        pub fn $neg_name(&self) -> Dir3 {
             -self.$pos_name()
         }
     };

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -37,12 +37,7 @@ fn draw_cursor(
     let point = ray.get_point(distance);
 
     // Draw a circle just above the ground plane at that position.
-    gizmos.circle(
-        point + ground.up() * 0.01,
-        ground.up(),
-        0.2,
-        Color::WHITE,
-    );
+    gizmos.circle(point + ground.up() * 0.01, ground.up(), 0.2, Color::WHITE);
 }
 
 #[derive(Component)]

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -39,7 +39,7 @@ fn draw_cursor(
     // Draw a circle just above the ground plane at that position.
     gizmos.circle(
         point + ground.up() * 0.01,
-        Dir3::new_unchecked(ground.up()), // Up vector is already normalized.
+        ground.up(),
         0.2,
         Color::WHITE,
     );


### PR DESCRIPTION
Switched the return type from `Vec3` to `Dir3` for directional axis methods within the `GlobalTransform` component.

## Migration Guide
The `GlobalTransform` component's directional axis methods (e.g., `right()`, `left()`, `up()`, `down()`, `back()`, `forward()`) have been updated from returning `Vec3` to `Dir3`.