### PR TITLE
Update release workflow pr body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,3 @@ jobs:
           title: "Preparing Next Release"
           body: |
             Preparing next release. This PR has been auto-generated.
-            UI tests have not been automatically bumped to the latest version, please fix them manually.


### PR DESCRIPTION
# Objective

With #13245 merged ui tests no longer specify dependency versions.

## Solution

Revert the change to `release.yml` made in #12810 as it's no longer required.

## Testing

- Merge.
- Wait for a release.
- Observe the release PR body.

cc @BD103 
