### PR TITLE
Add `cargo ci` alias for `ci` tool

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -144,3 +144,8 @@ rustflags = [
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
 # [profile.dev]
 # debug = 1
+
+# This is enables you to run the CI tool using `cargo ci`.
+# This is not enabled by default, you need to copy this file to `config.toml`.
+[alias]
+ci = "run --package ci --"


### PR DESCRIPTION
# Objective

- Running `cargo run --package ci -- ...` is lengthy, and `cargo r -p ci -- ...` isn't much better.
- Closes #13197.

## Solution

- Add an opt-in alias to the `ci` tool with `cargo ci ...`.
  - You need to copy `config_fast_builds.toml` to `config.toml` to enable this functionality.

## Testing

- Copy `config_fast_builds.toml` to `config.toml`, then run `cargo ci --help`.

---

## Changelog

- Added `cargo ci` alias for internal `ci` tool.
