### PR TITLE
Fix incorrect workgroupBarrier and OOB array access in auto_exposure

### DIFF
--- a/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
+++ b/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
@@ -95,10 +95,12 @@ fn compute_histogram(
     @builtin(local_invocation_index) local_invocation_index: u32
 ) {
     // Clear the workgroup shared histogram
-    histogram_shared[local_invocation_index] = 0u;
+    if local_invocation_index < 64 {
+        histogram_shared[local_invocation_index] = 0u;
+    }
 
     // Wait for all workgroup threads to clear the shared histogram
-    storageBarrier();
+    workgroupBarrier();
 
     let dim = vec2<u32>(textureDimensions(tex_color));
     let uv = vec2<f32>(global_invocation_id.xy) / vec2<f32>(dim);


### PR DESCRIPTION
This commit fixes two issues in auto_exposure.wgsl:
* A `storageBarrier()` was incorrectly used where a `workgroupBarrier()` should be used instead;
* Resetting the `histogram_shared` array would write beyond the 64th index, which is out of bounds.

## Solution

The first issue is fixed by using the appropriate workgroupBarrier instead;
The second issue is fixed by adding a range check before setting `histogram_shared[local_invocation_index] = 0u`.

## Testing

These changes were tested using the Xcode metal profiler, and I could not find any noticable change in compute shader performance.
