### PR TITLE
Fix `asset-source-website.patch` line number

### DIFF
--- a/tools/example-showcase/asset-source-website.patch
+++ b/tools/example-showcase/asset-source-website.patch
@@ -1,8 +1,8 @@
 diff --git a/crates/bevy_asset/src/lib.rs b/crates/bevy_asset/src/lib.rs
-index 004f87a85..3c8656efc 100644
+index ea8caf003..1b4b4bbf9 100644
 --- a/crates/bevy_asset/src/lib.rs
 +++ b/crates/bevy_asset/src/lib.rs
-@@ -105,7 +105,7 @@ impl Default for AssetPlugin {
+@@ -134,7 +134,7 @@ impl Default for AssetPlugin {
      fn default() -> Self {
          Self {
              mode: AssetMode::Unprocessed,
@@ -10,4 +10,4 @@ index 004f87a85..3c8656efc 100644
 +            file_path: "/assets/examples".to_string(),
              processed_file_path: Self::DEFAULT_PROCESSED_FILE_PATH.to_string(),
              watch_for_changes_override: None,
-         }
+             meta_check: AssetMetaCheck::default(),

--- a/typos.toml
+++ b/typos.toml
@@ -2,6 +2,7 @@
 extend-exclude = [
   "*.pbxproj",    # metadata file
   "CHANGELOG.md", # To keep consistency between the commit history/PRs.
+  "*.patch",      # Automatically generated files that should not be manually modified.
 ]
 
 # Corrections take the form of a key/value pair. The key is the incorrect word


### PR DESCRIPTION
# Objective

- Ever since #13177, the `check-example-showcase-patches-still-work` job has been failing in the merge queue.
- Specifically, the `asset-source-website.patch` file which modifies `bevy_asset`'s `lib.rs`.

## Solution

- Re-create the patch.
  - Due to new content being added, the line numbers were off.
- Also, turns out that `typos` was checking patch files. This turned into a CI error, so I disabled that too. Patches shouldn't really be modified manually, the original source should be. (Also it was erroring on the commit hash.)

## Testing

- Test the new patch works by running `git apply tools/example-showcase/asset-source-website.patch`.
- Verify the merge queue passes with the `check-example-showcase-patches-still-work` job succeeding.