### PR TITLE
Fix non-normalized vector issue in quaternion multiplication

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -829,7 +829,7 @@ where
             self.gizmos
                 .circle(
                     self.position,
-                    Dir3::new_unchecked(self.rotation * axis),
+                    Dir3::new(self.rotation * axis).unwrap(),
                     self.radius,
                     self.color,
                 )

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -254,7 +254,7 @@ where
             .map(|angle| Quat::from_axis_angle(normal, angle))
             .for_each(|quat| {
                 let axis_direction = quat * normals_normal;
-                let direction = Dir3::new_unchecked(axis_direction);
+                let direction = Dir3::new(axis_direction).unwrap();
 
                 // for each axis draw dotted line
                 (0..)


### PR DESCRIPTION
Add a normalization step after the multiplication of quaternion and normalized vector.
