### PR TITLE
Specify units in `AmbientLight::brightness` docs

### DIFF
--- a/crates/bevy_pbr/src/light/ambient_light.rs
+++ b/crates/bevy_pbr/src/light/ambient_light.rs
@@ -20,6 +20,10 @@ use super::*;
 pub struct AmbientLight {
     pub color: Color,
     /// A direct scale factor multiplied with `color` before being passed to the shader.
+    ///
+    /// After applying this multiplier, the resulting value should be in units of [cd/m^2].
+    ///
+    /// [cd/m^2]: https://en.wikipedia.org/wiki/Candela_per_square_metre
     pub brightness: f32,
 }
 


### PR DESCRIPTION
# Objective

- Fixes #11933.
- Related: #12280.

## Solution

- Specify that, after applying `AmbientLight`, the resulting units are in cd/m^2.
- This is based on [@fintelia's comment](https://github.com/bevyengine/bevy/issues/11933#issuecomment-1995427587), and will need to be verified.

---

## Changelog

- Specified units for `AmbientLight`'s `brightness` field.
