### PR TITLE
bevy_reflect: Remove `ContainerAttributes::merge`

### DIFF
--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -183,7 +183,7 @@ impl<'a> ReflectDerive<'a> {
         input: &'a DeriveInput,
         provenance: ReflectProvenance,
     ) -> Result<Self, syn::Error> {
-        let mut traits = ContainerAttributes::default();
+        let mut container_attributes = ContainerAttributes::default();
         // Should indicate whether `#[reflect_value]` was used.
         let mut reflect_mode = None;
         // Should indicate whether `#[type_path = "..."]` was used.
@@ -205,9 +205,7 @@ impl<'a> ReflectDerive<'a> {
                     }
 
                     reflect_mode = Some(ReflectMode::Normal);
-                    let new_traits =
-                        ContainerAttributes::parse_meta_list(meta_list, provenance.trait_)?;
-                    traits.merge(new_traits)?;
+                    container_attributes.parse_meta_list(meta_list, provenance.trait_)?;
                 }
                 Meta::List(meta_list) if meta_list.path.is_ident(REFLECT_VALUE_ATTRIBUTE_NAME) => {
                     if !matches!(reflect_mode, None | Some(ReflectMode::Value)) {
@@ -218,9 +216,7 @@ impl<'a> ReflectDerive<'a> {
                     }
 
                     reflect_mode = Some(ReflectMode::Value);
-                    let new_traits =
-                        ContainerAttributes::parse_meta_list(meta_list, provenance.trait_)?;
-                    traits.merge(new_traits)?;
+                    container_attributes.parse_meta_list(meta_list, provenance.trait_)?;
                 }
                 Meta::Path(path) if path.is_ident(REFLECT_VALUE_ATTRIBUTE_NAME) => {
                     if !matches!(reflect_mode, None | Some(ReflectMode::Value)) {
@@ -296,7 +292,7 @@ impl<'a> ReflectDerive<'a> {
             generics: &input.generics,
         };
 
-        let meta = ReflectMeta::new(type_path, traits);
+        let meta = ReflectMeta::new(type_path, container_attributes);
 
         if provenance.source == ReflectImplSource::ImplRemoteType
             && meta.type_path_attrs().should_auto_derive()
@@ -439,7 +435,7 @@ impl<'a> ReflectMeta<'a> {
         Self { docs, ..self }
     }
 
-    /// The registered reflect traits on this struct.
+    /// The registered reflect attributes on this struct.
     pub fn attrs(&self) -> &ContainerAttributes {
         &self.attrs
     }

--- a/crates/bevy_reflect/derive/src/reflect_value.rs
+++ b/crates/bevy_reflect/derive/src/reflect_value.rs
@@ -55,7 +55,11 @@ impl ReflectValueDef {
         if input.peek(Paren) {
             let content;
             parenthesized!(content in input);
-            traits = Some(ContainerAttributes::parse_terminated(&content, trait_)?);
+            traits = Some({
+                let mut attrs = ContainerAttributes::default();
+                attrs.parse_terminated(&content, trait_)?;
+                attrs
+            });
         }
         Ok(ReflectValueDef {
             attrs,


### PR DESCRIPTION
# Objective

Unblocks #11659.

Currently the `Reflect` derive macro has to go through a merge process for each `#[reflect]`/`#[reflet_value]` attribute encountered on a container type.

Not only is this a bit inefficient, but it also has a soft requirement that we can compare attributes such that an error can be thrown on duplicates, invalid states, etc.

While working on #11659 this proved to be challenging due to the fact that `syn` types don't implement `PartialEq` or `Hash` without enabling the `extra-traits` feature.

Ideally, we wouldn't have to enable another feature just to accommodate this one use case.

## Solution

Removed `ContainerAttributes::merge`.

This was a fairly simple change as we could just have the parsing functions take `&mut self` instead of returning `Self`.

## Testing

CI should build as there should be no user-facing change.