### PR TITLE
Add `AXES` iterators for `Dir` types

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -825,14 +825,9 @@ where
         if !self.gizmos.enabled {
             return;
         }
-        for axis in Vec3::AXES {
+        for axis in Dir3::AXES {
             self.gizmos
-                .circle(
-                    self.position,
-                    Dir3::new_unchecked(self.rotation * axis),
-                    self.radius,
-                    self.color,
-                )
+                .circle(self.position, self.rotation * axis, self.radius, self.color)
                 .segments(self.circle_segments);
         }
     }

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -92,6 +92,8 @@ impl Dir2 {
     pub const NEG_X: Self = Self(Vec2::NEG_X);
     /// A unit vector pointing along the negative Y axis.
     pub const NEG_Y: Self = Self(Vec2::NEG_Y);
+    /// The directional axes.
+    pub const AXES: [Self; 2] = [Self::X, Self::Y];
 
     /// Create a direction from a finite, nonzero [`Vec2`].
     ///
@@ -254,6 +256,8 @@ impl Dir3 {
     pub const NEG_Y: Self = Self(Vec3::NEG_Y);
     /// A unit vector pointing along the negative Z axis.
     pub const NEG_Z: Self = Self(Vec3::NEG_Z);
+    /// The directional axes.
+    pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
 
     /// Create a direction from a finite, nonzero [`Vec3`].
     ///
@@ -419,6 +423,8 @@ impl Dir3A {
     pub const NEG_Y: Self = Self(Vec3A::NEG_Y);
     /// A unit vector pointing along the negative Z axis.
     pub const NEG_Z: Self = Self(Vec3A::NEG_Z);
+    /// The directional axes.
+    pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
 
     /// Create a direction from a finite, nonzero [`Vec3A`].
     ///


### PR DESCRIPTION
# Objective

Sometimes it's nice to iterate over all the coordinate axes using something like `Vec3::AXES`. This was not available for the corresponding `Dir` types and now it is.

## Solution

We already have things like `Dir2::X`, `Dir3::Z` and so on, so I just threw them in an array like the vector types do it. I also slightly refactored the sphere gizmo code to use `Dir3::AXES` and operate on directions instead of using `Dir3::new_unchecked`.

## Testing

I looked at the sphere in the `3d_gizmos` example and it seems to work, so I assume I didn't break anything.
