### PR TITLE
Remove `ClampColor`

### DIFF
--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,5 @@
 use crate::util;
-use bevy_color::{ClampColor, Laba, LinearRgba, Oklaba, Srgba, Xyza};
+use bevy_color::{Laba, LinearRgba, Oklaba, Srgba, Xyza};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -63,7 +63,7 @@ macro_rules! impl_color_animatable {
             #[inline]
             fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
                 let value = *a * (1. - t) + *b * t;
-                value.clamped()
+                value
             }
 
             #[inline]
@@ -76,7 +76,7 @@ macro_rules! impl_color_animatable {
                         value = Self::interpolate(&value, &input.value, input.weight);
                     }
                 }
-                value.clamped()
+                value
             }
         }
     };

--- a/crates/bevy_color/src/color_ops.rs
+++ b/crates/bevy_color/src/color_ops.rs
@@ -82,23 +82,6 @@ pub trait Hue: Sized {
     }
 }
 
-/// Trait with methods for asserting a colorspace is within bounds.
-///
-/// During ordinary usage (e.g. reading images from disk, rendering images, picking colors for UI), colors should always be within their ordinary bounds (such as 0 to 1 for RGB colors).
-/// However, some applications, such as high dynamic range rendering or bloom rely on unbounded colors to naturally represent a wider array of choices.
-pub trait ClampColor: Sized {
-    /// Return a new version of this color clamped, with all fields in bounds.
-    fn clamped(&self) -> Self;
-
-    /// Changes all the fields of this color to ensure they are within bounds.
-    fn clamp(&mut self) {
-        *self = self.clamped();
-    }
-
-    /// Are all the fields of this color in bounds?
-    fn is_within_bounds(&self) -> bool;
-}
-
 /// Trait with methods for converting colors to non-color types
 pub trait ColorToComponents {
     /// Convert to an f32 array

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Alpha, ClampColor, ColorToComponents, Hsva, Hue, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
+    Alpha, ColorToComponents, Hsva, Hue, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
     StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
@@ -175,24 +175,6 @@ impl Luminance for Hsla {
             lightness: (self.lightness + amount).min(1.),
             ..*self
         }
-    }
-}
-
-impl ClampColor for Hsla {
-    fn clamped(&self) -> Self {
-        Self {
-            hue: self.hue.rem_euclid(360.),
-            saturation: self.saturation.clamp(0., 1.),
-            lightness: self.lightness.clamp(0., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=360.).contains(&self.hue)
-            && (0. ..=1.).contains(&self.saturation)
-            && (0. ..=1.).contains(&self.lightness)
-            && (0. ..=1.).contains(&self.alpha)
     }
 }
 
@@ -439,22 +421,5 @@ mod tests {
 
             assert_approx_eq!(color.hue, reference.hue, 0.001);
         }
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Hsla::hsl(361., 2., -1.);
-        let color_2 = Hsla::hsl(250.2762, 1., 0.67);
-        let mut color_3 = Hsla::hsl(-50., 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Hsla::hsl(1., 1., 0.));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Hsla::hsl(310., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Alpha, ClampColor, ColorToComponents, Hue, Hwba, Lcha, LinearRgba, Mix, Srgba, StandardColor,
-    Xyza,
+    Alpha, ColorToComponents, Hue, Hwba, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -121,24 +120,6 @@ impl Hue for Hsva {
     #[inline]
     fn set_hue(&mut self, hue: f32) {
         self.hue = hue;
-    }
-}
-
-impl ClampColor for Hsva {
-    fn clamped(&self) -> Self {
-        Self {
-            hue: self.hue.rem_euclid(360.),
-            saturation: self.saturation.clamp(0., 1.),
-            value: self.value.clamp(0., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=360.).contains(&self.hue)
-            && (0. ..=1.).contains(&self.saturation)
-            && (0. ..=1.).contains(&self.value)
-            && (0. ..=1.).contains(&self.alpha)
     }
 }
 
@@ -315,22 +296,5 @@ mod tests {
             assert_approx_eq!(color.hsv.value, hsv2.value, 0.001);
             assert_approx_eq!(color.hsv.alpha, hsv2.alpha, 0.001);
         }
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Hsva::hsv(361., 2., -1.);
-        let color_2 = Hsva::hsv(250.2762, 1., 0.67);
-        let mut color_3 = Hsva::hsv(-50., 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Hsva::hsv(1., 1., 0.));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Hsva::hsv(310., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,9 +2,7 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use crate::{
-    Alpha, ClampColor, ColorToComponents, Hue, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
-};
+use crate::{Alpha, ColorToComponents, Hue, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza};
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
 
@@ -124,24 +122,6 @@ impl Hue for Hwba {
     #[inline]
     fn set_hue(&mut self, hue: f32) {
         self.hue = hue;
-    }
-}
-
-impl ClampColor for Hwba {
-    fn clamped(&self) -> Self {
-        Self {
-            hue: self.hue.rem_euclid(360.),
-            whiteness: self.whiteness.clamp(0., 1.),
-            blackness: self.blackness.clamp(0., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=360.).contains(&self.hue)
-            && (0. ..=1.).contains(&self.whiteness)
-            && (0. ..=1.).contains(&self.blackness)
-            && (0. ..=1.).contains(&self.alpha)
     }
 }
 
@@ -347,22 +327,5 @@ mod tests {
             assert_approx_eq!(color.hwb.blackness, hwb2.blackness, 0.001);
             assert_approx_eq!(color.hwb.alpha, hwb2.alpha, 0.001);
         }
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Hwba::hwb(361., 2., -1.);
-        let color_2 = Hwba::hwb(250.2762, 1., 0.67);
-        let mut color_3 = Hwba::hwb(-50., 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Hwba::hwb(1., 1., 0.));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Hwba::hwb(310., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_componentwise_vector_space, Alpha, ClampColor, ColorToComponents, Hsla, Hsva, Hwba,
-    LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    impl_componentwise_vector_space, Alpha, ColorToComponents, Hsla, Hsva, Hwba, LinearRgba,
+    Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -115,24 +115,6 @@ impl Alpha for Laba {
     #[inline]
     fn set_alpha(&mut self, alpha: f32) {
         self.alpha = alpha;
-    }
-}
-
-impl ClampColor for Laba {
-    fn clamped(&self) -> Self {
-        Self {
-            lightness: self.lightness.clamp(0., 1.5),
-            a: self.a.clamp(-1.5, 1.5),
-            b: self.b.clamp(-1.5, 1.5),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.5).contains(&self.lightness)
-            && (-1.5..=1.5).contains(&self.a)
-            && (-1.5..=1.5).contains(&self.b)
-            && (0. ..=1.).contains(&self.alpha)
     }
 }
 
@@ -431,22 +413,5 @@ mod tests {
             }
             assert_approx_eq!(color.lab.alpha, laba.alpha, 0.001);
         }
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Laba::lab(-1., 2., -2.);
-        let color_2 = Laba::lab(1., 1.5, -1.2);
-        let mut color_3 = Laba::lab(-0.4, 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Laba::lab(0., 1.5, -1.5));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Laba::lab(0., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Alpha, ClampColor, ColorToComponents, Hue, Laba, LinearRgba, Luminance, Mix, Srgba,
-    StandardColor, Xyza,
+    Alpha, ColorToComponents, Hue, Laba, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -183,24 +182,6 @@ impl Luminance for Lcha {
             self.hue,
             self.alpha,
         )
-    }
-}
-
-impl ClampColor for Lcha {
-    fn clamped(&self) -> Self {
-        Self {
-            lightness: self.lightness.clamp(0., 1.5),
-            chroma: self.chroma.clamp(0., 1.5),
-            hue: self.hue.rem_euclid(360.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.5).contains(&self.lightness)
-            && (0. ..=1.5).contains(&self.chroma)
-            && (0. ..=360.).contains(&self.hue)
-            && (0. ..=1.).contains(&self.alpha)
     }
 }
 
@@ -403,22 +384,5 @@ mod tests {
             }
             assert_approx_eq!(color.lch.alpha, lcha.alpha, 0.001);
         }
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Lcha::lch(-1., 2., 400.);
-        let color_2 = Lcha::lch(1., 1.5, 249.54);
-        let mut color_3 = Lcha::lch(-0.4, 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Lcha::lch(0., 1.5, 40.));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Lcha::lch(0., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,6 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, impl_componentwise_vector_space, Alpha, ClampColor,
-    ColorToComponents, Luminance, Mix, StandardColor,
+    color_difference::EuclideanDistance, impl_componentwise_vector_space, Alpha, ColorToComponents,
+    Luminance, Mix, StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -263,24 +263,6 @@ impl EuclideanDistance for LinearRgba {
     }
 }
 
-impl ClampColor for LinearRgba {
-    fn clamped(&self) -> Self {
-        Self {
-            red: self.red.clamp(0., 1.),
-            green: self.green.clamp(0., 1.),
-            blue: self.blue.clamp(0., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.).contains(&self.red)
-            && (0. ..=1.).contains(&self.green)
-            && (0. ..=1.).contains(&self.blue)
-            && (0. ..=1.).contains(&self.alpha)
-    }
-}
-
 impl ColorToComponents for LinearRgba {
     fn to_f32_array(self) -> [f32; 4] {
         [self.red, self.green, self.blue, self.alpha]
@@ -454,22 +436,5 @@ mod tests {
         let lighter2 = lighter1.lighter(0.1);
         let twice_as_light = color.lighter(0.2);
         assert!(lighter2.distance_squared(&twice_as_light) < 0.0001);
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = LinearRgba::rgb(2., -1., 0.4);
-        let color_2 = LinearRgba::rgb(0.031, 0.749, 1.);
-        let mut color_3 = LinearRgba::rgb(-1., 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), LinearRgba::rgb(1., 0., 0.4));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, LinearRgba::rgb(0., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,7 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, impl_componentwise_vector_space, Alpha, ClampColor,
-    ColorToComponents, Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor,
-    Xyza,
+    color_difference::EuclideanDistance, impl_componentwise_vector_space, Alpha, ColorToComponents,
+    Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -154,24 +153,6 @@ impl EuclideanDistance for Oklaba {
         (self.lightness - other.lightness).powi(2)
             + (self.a - other.a).powi(2)
             + (self.b - other.b).powi(2)
-    }
-}
-
-impl ClampColor for Oklaba {
-    fn clamped(&self) -> Self {
-        Self {
-            lightness: self.lightness.clamp(0., 1.),
-            a: self.a.clamp(-1., 1.),
-            b: self.b.clamp(-1., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.).contains(&self.lightness)
-            && (-1. ..=1.).contains(&self.a)
-            && (-1. ..=1.).contains(&self.b)
-            && (0. ..=1.).contains(&self.alpha)
     }
 }
 
@@ -405,22 +386,5 @@ mod tests {
         assert_approx_eq!(oklaba.a, oklaba2.a, 0.001);
         assert_approx_eq!(oklaba.b, oklaba2.b, 0.001);
         assert_approx_eq!(oklaba.alpha, oklaba2.alpha, 0.001);
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Oklaba::lab(-1., 2., -2.);
-        let color_2 = Oklaba::lab(1., 0.42, -0.4);
-        let mut color_3 = Oklaba::lab(-0.4, 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Oklaba::lab(0., 1., -1.));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Oklaba::lab(0., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,6 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, Alpha, ClampColor, ColorToComponents, Hsla, Hsva, Hue,
-    Hwba, Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    color_difference::EuclideanDistance, Alpha, ColorToComponents, Hsla, Hsva, Hue, Hwba, Laba,
+    Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -280,24 +280,6 @@ impl From<Oklcha> for Oklaba {
     }
 }
 
-impl ClampColor for Oklcha {
-    fn clamped(&self) -> Self {
-        Self {
-            lightness: self.lightness.clamp(0., 1.),
-            chroma: self.chroma.clamp(0., 1.),
-            hue: self.hue.rem_euclid(360.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.).contains(&self.lightness)
-            && (0. ..=1.).contains(&self.chroma)
-            && (0. ..=360.).contains(&self.hue)
-            && (0. ..=1.).contains(&self.alpha)
-    }
-}
-
 // Derived Conversions
 
 impl From<Hsla> for Oklcha {
@@ -443,22 +425,5 @@ mod tests {
         assert_approx_eq!(oklcha.chroma, oklcha2.chroma, 0.001);
         assert_approx_eq!(oklcha.hue, oklcha2.hue, 0.001);
         assert_approx_eq!(oklcha.alpha, oklcha2.alpha, 0.001);
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Oklcha::lch(-1., 2., 400.);
-        let color_2 = Oklcha::lch(1., 1., 249.54);
-        let mut color_3 = Oklcha::lch(-0.4, 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Oklcha::lch(0., 1., 40.));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Oklcha::lch(0., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,7 +1,7 @@
 use crate::color_difference::EuclideanDistance;
 use crate::{
-    impl_componentwise_vector_space, Alpha, ClampColor, ColorToComponents, LinearRgba, Luminance,
-    Mix, StandardColor, Xyza,
+    impl_componentwise_vector_space, Alpha, ColorToComponents, LinearRgba, Luminance, Mix,
+    StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -314,24 +314,6 @@ impl EuclideanDistance for Srgba {
     }
 }
 
-impl ClampColor for Srgba {
-    fn clamped(&self) -> Self {
-        Self {
-            red: self.red.clamp(0., 1.),
-            green: self.green.clamp(0., 1.),
-            blue: self.blue.clamp(0., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.).contains(&self.red)
-            && (0. ..=1.).contains(&self.green)
-            && (0. ..=1.).contains(&self.blue)
-            && (0. ..=1.).contains(&self.alpha)
-    }
-}
-
 impl ColorToComponents for Srgba {
     fn to_f32_array(self) -> [f32; 4] {
         [self.red, self.green, self.blue, self.alpha]
@@ -514,22 +496,5 @@ mod tests {
 
         assert!(matches!(Srgba::hex("yyy"), Err(HexColorError::Parse(_))));
         assert!(matches!(Srgba::hex("##fff"), Err(HexColorError::Parse(_))));
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Srgba::rgb(2., -1., 0.4);
-        let color_2 = Srgba::rgb(0.031, 0.749, 1.);
-        let mut color_3 = Srgba::rgb(-1., 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Srgba::rgb(1., 0., 0.4));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Srgba::rgb(0., 1., 1.));
     }
 }

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_componentwise_vector_space, Alpha, ClampColor, ColorToComponents, LinearRgba, Luminance,
-    Mix, StandardColor,
+    impl_componentwise_vector_space, Alpha, ColorToComponents, LinearRgba, Luminance, Mix,
+    StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
 use bevy_reflect::prelude::*;
@@ -144,24 +144,6 @@ impl Mix for Xyza {
     }
 }
 
-impl ClampColor for Xyza {
-    fn clamped(&self) -> Self {
-        Self {
-            x: self.x.clamp(0., 1.),
-            y: self.y.clamp(0., 1.),
-            z: self.z.clamp(0., 1.),
-            alpha: self.alpha.clamp(0., 1.),
-        }
-    }
-
-    fn is_within_bounds(&self) -> bool {
-        (0. ..=1.).contains(&self.x)
-            && (0. ..=1.).contains(&self.y)
-            && (0. ..=1.).contains(&self.z)
-            && (0. ..=1.).contains(&self.alpha)
-    }
-}
-
 impl ColorToComponents for Xyza {
     fn to_f32_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.alpha]
@@ -289,22 +271,5 @@ mod tests {
             assert_approx_eq!(color.xyz.z, xyz2.z, 0.001);
             assert_approx_eq!(color.xyz.alpha, xyz2.alpha, 0.001);
         }
-    }
-
-    #[test]
-    fn test_clamp() {
-        let color_1 = Xyza::xyz(2., -1., 0.4);
-        let color_2 = Xyza::xyz(0.031, 0.749, 1.);
-        let mut color_3 = Xyza::xyz(-1., 1., 1.);
-
-        assert!(!color_1.is_within_bounds());
-        assert_eq!(color_1.clamped(), Xyza::xyz(1., 0., 0.4));
-
-        assert!(color_2.is_within_bounds());
-        assert_eq!(color_2, color_2.clamped());
-
-        color_3.clamp();
-        assert!(color_3.is_within_bounds());
-        assert_eq!(color_3, Xyza::xyz(0., 1., 1.));
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #12543

## Solution

- Removed `ClampColor`

## Testing

- CI Passed

---

## Migration Guide

Manually clamp the various colour components yourself if this behaviour is still required.

```rust
fn clamped_srgba(color: Srgba) -> Srgba {
    Srgba {
        red: color.red.clamp(0., 1.),
        green: color.green.clamp(0., 1.),
        blue: color.blue.clamp(0., 1.),
        alpha: color.alpha.clamp(0., 1.),
    }
}
```