### PR TITLE
Add simple preferences API

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -28,6 +28,10 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 downcast-rs = "1.2.0"
 thiserror = "1.0"
 
+[dev-dependencies]
+serde_json = "1.0"
+serde = "1.0"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = ["Window"] }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -12,6 +12,7 @@ mod main_schedule;
 mod panic_handler;
 mod plugin;
 mod plugin_group;
+mod preferences;
 mod schedule_runner;
 mod sub_app;
 
@@ -21,6 +22,7 @@ pub use main_schedule::*;
 pub use panic_handler::*;
 pub use plugin::*;
 pub use plugin_group::*;
+pub use preferences::*;
 pub use schedule_runner::*;
 pub use sub_app::*;
 

--- a/crates/bevy_app/src/preferences.rs
+++ b/crates/bevy_app/src/preferences.rs
@@ -78,19 +78,19 @@ pub struct Preferences {
 }
 
 impl Preferences {
-    /// Set preferences of type `P`.
+    /// Set preferences entry of type `P`, potentially overwriting an existing entry.
     pub fn set<P: Reflect>(&mut self, value: P) {
         let path = value.reflect_short_type_path().to_string();
         self.map.insert(path, value);
     }
 
-    /// Set preferences from a boxed trait object of unknown type.
+    /// Set preferences entry from a boxed trait object of unknown type.
     pub fn set_dyn(&mut self, value: Box<dyn Reflect>) {
         let path = value.reflect_short_type_path().to_string();
         self.map.insert_boxed(Box::new(path), value);
     }
 
-    /// Get preferences of type `P`.
+    /// Get preferences entry of type `P`.
     pub fn get<P: Reflect + TypePath>(&self) -> Option<&P> {
         let key = P::short_type_path().to_string();
         self.map
@@ -98,7 +98,7 @@ impl Preferences {
             .and_then(|val| val.downcast_ref())
     }
 
-    /// Get a mutable reference to preferences of type `P`.
+    /// Get a mutable reference to a preferences entry of type `P`.
     pub fn get_mut<P: Reflect + TypePath>(&mut self) -> Option<&mut P> {
         let key = P::short_type_path().to_string();
         self.map

--- a/crates/bevy_app/src/preferences.rs
+++ b/crates/bevy_app/src/preferences.rs
@@ -1,0 +1,165 @@
+use bevy_ecs::system::Resource;
+use bevy_reflect::{Map, Reflect, TypePath};
+
+use crate::Plugin;
+
+/// Adds application [`Preferences`] functionality.
+pub struct PreferencesPlugin;
+
+impl Plugin for PreferencesPlugin {
+    fn build(&self, app: &mut crate::App) {
+        app.init_resource::<Preferences>();
+    }
+}
+
+/// A map that stores all application preferences.
+///
+/// Preferences are strongly typed, and defined independently by any `Plugin` that needs persistent
+/// settings. Choice of serialization format and behavior is up to the application developer. The
+/// preferences resource simply provides a common API surface to consolidate preferences for all
+/// plugins in one location.
+///
+/// ### Usage
+///
+/// Preferences only require that the type implements [`Reflect`].
+///
+/// ```
+/// # use bevy_reflect::Reflect;
+/// #[derive(Reflect)]
+/// struct MyPluginPreferences {
+///     do_things: bool,
+///     fizz_buzz_count: usize
+/// }
+/// ```
+/// You can [`Self::get`] or [`Self::set`] preferences by accessing this type as a [`Resource`]
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_app::Preferences;
+/// # use bevy_reflect::Reflect;
+/// #
+/// # #[derive(Reflect)]
+/// # struct MyPluginPreferences {
+/// #     do_things: bool,
+/// #     fizz_buzz_count: usize
+/// # }
+/// #
+/// fn update(mut prefs: ResMut<Preferences>) {
+///     let settings = MyPluginPreferences {
+///         do_things: false,
+///         fizz_buzz_count: 9000,
+///     };
+///     prefs.set(settings);
+///
+///     // Accessing preferences only requires the type:
+///     let mut new_settings = prefs.get::<MyPluginPreferences>().unwrap();
+///
+///     // If you are updating an existing struct, all type information can be inferred:
+///     new_settings = prefs.get().unwrap();
+/// }
+/// ```
+#[derive(Resource, Default, Debug)]
+pub struct Preferences {
+    map: bevy_reflect::DynamicMap,
+}
+
+impl Preferences {
+    /// Set preferences of type `P`.
+    pub fn set<P: Reflect + TypePath>(&mut self, value: P) {
+        self.map.insert(P::short_type_path(), value);
+    }
+
+    /// Get preferences of type `P`.
+    pub fn get<P: Reflect + TypePath>(&self) -> Option<&P> {
+        let key = P::short_type_path();
+        self.map
+            .get(key.as_reflect())
+            .and_then(|val| val.downcast_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_ecs::system::ResMut;
+    use bevy_reflect::{Map, Reflect};
+
+    use crate::{App, PreferencesPlugin, Startup};
+
+    use super::Preferences;
+
+    #[test]
+    fn typed_get() {
+        #[derive(Reflect, Clone, PartialEq, Debug)]
+        struct FooPrefsV1 {
+            name: String,
+        }
+
+        #[derive(Reflect, Clone, PartialEq, Debug)]
+        struct FooPrefsV2 {
+            name: String,
+            age: usize,
+        }
+
+        let mut preferences = Preferences::default();
+
+        let v1 = FooPrefsV1 {
+            name: "Bevy".into(),
+        };
+
+        let v2 = FooPrefsV2 {
+            name: "Boovy".into(),
+            age: 42,
+        };
+
+        preferences.set(v1.clone());
+        preferences.set(v2.clone());
+        assert_eq!(preferences.get::<FooPrefsV1>(), Some(&v1));
+        assert_eq!(preferences.get::<FooPrefsV2>(), Some(&v2));
+    }
+
+    #[test]
+    fn overwrite() {
+        #[derive(Reflect, Clone, PartialEq, Debug)]
+        struct FooPrefs(String);
+
+        let mut preferences = Preferences::default();
+
+        let bevy = FooPrefs("Bevy".into());
+        let boovy = FooPrefs("Boovy".into());
+
+        preferences.set(bevy.clone());
+        preferences.set(boovy.clone());
+        assert_eq!(preferences.get::<FooPrefs>(), Some(&boovy));
+    }
+
+    #[test]
+    fn init_exists() {
+        #[derive(Reflect, Clone, PartialEq, Debug)]
+        struct FooPrefs(String);
+
+        let mut app = App::new();
+        app.add_plugins(PreferencesPlugin);
+        app.update();
+        assert!(app.world().resource::<Preferences>().map.is_empty());
+    }
+
+    #[test]
+    fn startup_sets_value() {
+        #[derive(Reflect, Clone, PartialEq, Debug)]
+        struct FooPrefs(String);
+
+        let mut app = App::new();
+        app.add_plugins(PreferencesPlugin);
+        app.add_systems(Startup, |mut prefs: ResMut<Preferences>| {
+            prefs.set(FooPrefs("Initial".into()));
+        });
+        app.update();
+        assert_eq!(
+            app.world()
+                .resource::<Preferences>()
+                .get::<FooPrefs>()
+                .unwrap()
+                .0,
+            "Initial"
+        );
+    }
+}

--- a/crates/bevy_app/src/preferences.rs
+++ b/crates/bevy_app/src/preferences.rs
@@ -75,6 +75,14 @@ impl Preferences {
             .get(key.as_reflect())
             .and_then(|val| val.downcast_ref())
     }
+
+    /// Get a mutable reference to preferences of type `P`.
+    pub fn get_mut<P: Reflect + TypePath>(&mut self) -> Option<&mut P> {
+        let key = P::short_type_path();
+        self.map
+            .get_mut(key.as_reflect())
+            .and_then(|val| val.downcast_mut())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

- Partially implements #13311

## Solution

```rs
// Preferences only require that the type implements [`Reflect`].
#[derive(Reflect)]
struct MyPluginPreferences {
    do_things: bool,
    fizz_buzz_count: usize
}

fn update(mut prefs: ResMut<Preferences>) {
    let settings = MyPluginPreferences {
        do_things: false,
        fizz_buzz_count: 9000,
    };
    prefs.set(settings);

    // Accessing preferences only requires the type:
    let mut new_settings = prefs.get::<MyPluginPreferences>().unwrap();

    // If you are updating an existing struct, all type information can be inferred:
    new_settings = prefs.get().unwrap();
}
```

- Provide a typed key-value store that can be used by any plugin. This is built entirely on `bevy_reflect`, so the footprint is pretty tiny.
- Choosing where to store this to disk is out of scope, and is closely tied to platforms and app deployment. That work can be done in follow up PRs. The community can build tools on top of this API in the meantime. It is completely agnostic to file saving strategy or format, and adds no new concepts.
- Use the struct name (from reflect) as the key in the map. This keeps implementation simple, and makes things like versioned preferences trivial for users to implement. This might be the most controversial aspect of the PR.
- While it can be made easier, I've added a unit test that demonstrates how preferences can be round tripped through an arbitrary file type using serde.

## Open Questions

- Where should this go? `bevy_app` seems wrong, but I'm unsure where to put it.
  
## Testing

- Unit tests have been added to the module.

---

## Changelog

- Added a `Preferences` resource to act as a centralized store of persistent plugin state. This does not yet implement serialization of any data to disk, however it does give plugin authors a common target for adding preferences.