### PR TITLE
#12502 Remove limit on RenderLayers.

### DIFF
--- a/benches/benches/bevy_render/render_layers.rs
+++ b/benches/benches/bevy_render/render_layers.rs
@@ -1,0 +1,19 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use bevy_render::view::RenderLayers;
+
+fn render_layers(c: &mut Criterion) {
+    c.bench_function("layers_intersect", |b| {
+        let layer_a = RenderLayers::layer(1).with(2);
+        let layer_b = RenderLayers::layer(1);
+        b.iter(|| {
+            black_box(layer_a.intersects(&layer_b))
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    render_layers,
+);
+criterion_main!(benches);

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -28,7 +28,7 @@ mod inset;
 /// The [`Camera::order`] index used by the layout debug camera.
 pub const LAYOUT_DEBUG_CAMERA_ORDER: isize = 255;
 /// The [`RenderLayers`] used by the debug gizmos and the debug camera.
-pub const LAYOUT_DEBUG_LAYERS: RenderLayers = RenderLayers::none_with(16);
+pub const LAYOUT_DEBUG_LAYERS: RenderLayers = RenderLayers::layer(16);
 
 #[derive(Clone, Copy)]
 struct LayoutRect {

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -28,7 +28,7 @@ mod inset;
 /// The [`Camera::order`] index used by the layout debug camera.
 pub const LAYOUT_DEBUG_CAMERA_ORDER: isize = 255;
 /// The [`RenderLayers`] used by the debug gizmos and the debug camera.
-pub const LAYOUT_DEBUG_LAYERS: RenderLayers = RenderLayers::none().with(16);
+pub const LAYOUT_DEBUG_LAYERS: RenderLayers = RenderLayers::none().with_const(16);
 
 #[derive(Clone, Copy)]
 struct LayoutRect {

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -27,8 +27,6 @@ mod inset;
 
 /// The [`Camera::order`] index used by the layout debug camera.
 pub const LAYOUT_DEBUG_CAMERA_ORDER: isize = 255;
-/// The [`RenderLayers`] used by the debug gizmos and the debug camera.
-pub const LAYOUT_DEBUG_LAYERS: RenderLayers = RenderLayers::none().with_const(16);
 
 #[derive(Clone, Copy)]
 struct LayoutRect {
@@ -86,6 +84,7 @@ fn update_debug_camera(
             config.enabled = false;
         }
     } else {
+        let layout_debug_layers: RenderLayers = RenderLayers::none().with_const(16);
         let spawn_cam = || {
             cmds.spawn((
                 Camera2dBundle {
@@ -101,7 +100,7 @@ fn update_debug_camera(
                     },
                     ..default()
                 },
-                LAYOUT_DEBUG_LAYERS,
+                layout_debug_layers.clone(),
                 DebugOverlayCamera,
                 Name::new("Layout Debug Camera"),
             ))
@@ -109,7 +108,7 @@ fn update_debug_camera(
         };
         if let Some((config, _)) = gizmo_config.get_config_mut_dyn(&TypeId::of::<UiGizmosDebug>()) {
             config.enabled = true;
-            config.render_layers = LAYOUT_DEBUG_LAYERS;
+            config.render_layers = layout_debug_layers;
         }
         let cam = *options.layout_gizmos_camera.get_or_insert_with(spawn_cam);
         let Ok(mut cam) = debug_cams.get_mut(cam) else {

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -27,6 +27,8 @@ mod inset;
 
 /// The [`Camera::order`] index used by the layout debug camera.
 pub const LAYOUT_DEBUG_CAMERA_ORDER: isize = 255;
+/// The [`RenderLayers`] used by the debug gizmos and the debug camera.
+pub const LAYOUT_DEBUG_LAYERS: RenderLayers = RenderLayers::none_with(16);
 
 #[derive(Clone, Copy)]
 struct LayoutRect {
@@ -84,7 +86,6 @@ fn update_debug_camera(
             config.enabled = false;
         }
     } else {
-        let layout_debug_layers: RenderLayers = RenderLayers::none().with(16);
         let spawn_cam = || {
             cmds.spawn((
                 Camera2dBundle {
@@ -100,7 +101,7 @@ fn update_debug_camera(
                     },
                     ..default()
                 },
-                layout_debug_layers.clone(),
+                LAYOUT_DEBUG_LAYERS.clone(),
                 DebugOverlayCamera,
                 Name::new("Layout Debug Camera"),
             ))
@@ -108,7 +109,7 @@ fn update_debug_camera(
         };
         if let Some((config, _)) = gizmo_config.get_config_mut_dyn(&TypeId::of::<UiGizmosDebug>()) {
             config.enabled = true;
-            config.render_layers = layout_debug_layers.clone();
+            config.render_layers = LAYOUT_DEBUG_LAYERS.clone();
         }
         let cam = *options.layout_gizmos_camera.get_or_insert_with(spawn_cam);
         let Ok(mut cam) = debug_cams.get_mut(cam) else {

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -108,7 +108,7 @@ fn update_debug_camera(
         };
         if let Some((config, _)) = gizmo_config.get_config_mut_dyn(&TypeId::of::<UiGizmosDebug>()) {
             config.enabled = true;
-            config.render_layers = layout_debug_layers;
+            config.render_layers = layout_debug_layers.clone();
         }
         let cam = *options.layout_gizmos_camera.get_or_insert_with(spawn_cam);
         let Ok(mut cam) = debug_cams.get_mut(cam) else {

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -84,7 +84,7 @@ fn update_debug_camera(
             config.enabled = false;
         }
     } else {
-        let layout_debug_layers: RenderLayers = RenderLayers::none().with_const(16);
+        let layout_debug_layers: RenderLayers = RenderLayers::none().with(16);
         let spawn_cam = || {
             cmds.spawn((
                 Camera2dBundle {

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -197,7 +197,7 @@ impl From<&GizmoConfig> for GizmoMeshConfig {
         GizmoMeshConfig {
             line_perspective: item.line_perspective,
             line_style: item.line_style,
-            render_layers: item.render_layers,
+            render_layers: item.render_layers.clone(),
         }
     }
 }

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -271,7 +271,7 @@ fn queue_line_gizmos_2d(
 
         let render_layers = render_layers.unwrap_or_default();
         for (entity, handle, config) in &line_gizmos {
-            if !config.render_layers.intersects(&render_layers) {
+            if !config.render_layers.intersects(render_layers) {
                 continue;
             }
 
@@ -327,7 +327,7 @@ fn queue_line_joint_gizmos_2d(
 
         let render_layers = render_layers.unwrap_or_default();
         for (entity, handle, config) in &line_gizmos {
-            if !config.render_layers.intersects(&render_layers) {
+            if !config.render_layers.intersects(render_layers) {
                 continue;
             }
 

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -269,8 +269,8 @@ fn queue_line_gizmos_2d(
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
+        let render_layers = render_layers.unwrap_or_default();
         for (entity, handle, config) in &line_gizmos {
-            let render_layers = render_layers.copied().unwrap_or_default();
             if !config.render_layers.intersects(&render_layers) {
                 continue;
             }
@@ -325,8 +325,8 @@ fn queue_line_joint_gizmos_2d(
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
+        let render_layers = render_layers.unwrap_or_default();
         for (entity, handle, config) in &line_gizmos {
-            let render_layers = render_layers.copied().unwrap_or_default();
             if !config.render_layers.intersects(&render_layers) {
                 continue;
             }

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -325,7 +325,7 @@ fn queue_line_gizmos_3d(
         }
 
         for (entity, handle, config) in &line_gizmos {
-            if !config.render_layers.intersects(&render_layers) {
+            if !config.render_layers.intersects(render_layers) {
                 continue;
             }
 
@@ -411,7 +411,7 @@ fn queue_line_joint_gizmos_3d(
         }
 
         for (entity, handle, config) in &line_gizmos {
-            if !config.render_layers.intersects(&render_layers) {
+            if !config.render_layers.intersects(render_layers) {
                 continue;
             }
 

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -303,7 +303,7 @@ fn queue_line_gizmos_3d(
         (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass),
     ) in &mut views
     {
-        let render_layers = render_layers.copied().unwrap_or_default();
+        let render_layers = render_layers.unwrap_or_default();
 
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
             | MeshPipelineKey::from_hdr(view.hdr);
@@ -389,7 +389,7 @@ fn queue_line_joint_gizmos_3d(
         (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass),
     ) in &mut views
     {
-        let render_layers = render_layers.copied().unwrap_or_default();
+        let render_layers = render_layers.unwrap_or_default();
 
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
             | MeshPipelineKey::from_hdr(view.hdr);

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -23,6 +23,7 @@ use crate::*;
 
 mod ambient_light;
 pub use ambient_light::AmbientLight;
+
 mod point_light;
 pub use point_light::PointLight;
 mod spot_light;
@@ -1015,7 +1016,7 @@ pub(crate) fn directional_light_order(
         .then_with(|| entity_1.cmp(entity_2)) // stable
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 // data required for assigning lights to clusters
 pub(crate) struct PointLightAssignmentData {
     entity: Entity,
@@ -1105,7 +1106,7 @@ pub(crate) fn assign_lights_to_clusters(
                         shadows_enabled: point_light.shadows_enabled,
                         range: point_light.range,
                         spot_light_angle: None,
-                        render_layers: maybe_layers.copied().unwrap_or_default(),
+                        render_layers: maybe_layers.unwrap_or_default().clone(),
                     }
                 },
             ),
@@ -1122,7 +1123,7 @@ pub(crate) fn assign_lights_to_clusters(
                         shadows_enabled: spot_light.shadows_enabled,
                         range: spot_light.range,
                         spot_light_angle: Some(spot_light.outer_angle),
-                        render_layers: maybe_layers.copied().unwrap_or_default(),
+                        render_layers: maybe_layers.unwrap_or_default().clone(),
                     }
                 },
             ),
@@ -1196,7 +1197,7 @@ pub(crate) fn assign_lights_to_clusters(
         mut visible_lights,
     ) in &mut views
     {
-        let view_layers = maybe_layers.copied().unwrap_or_default();
+        let view_layers = maybe_layers.unwrap_or_default().clone();
         let clusters = clusters.into_inner();
 
         if matches!(config, ClusterConfig::None) {
@@ -1919,7 +1920,7 @@ pub fn check_light_mesh_visibility(
             continue;
         }
 
-        let view_mask = maybe_view_mask.copied().unwrap_or_default();
+        let view_mask = maybe_view_mask.unwrap_or_default().clone();
 
         for (
             entity,
@@ -1934,7 +1935,7 @@ pub fn check_light_mesh_visibility(
                 continue;
             }
 
-            let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
+            let entity_mask = maybe_entity_mask.unwrap_or_default().clone();
             if !view_mask.intersects(&entity_mask) {
                 continue;
             }
@@ -1999,7 +2000,7 @@ pub fn check_light_mesh_visibility(
                     continue;
                 }
 
-                let view_mask = maybe_view_mask.copied().unwrap_or_default();
+                let view_mask = maybe_view_mask.unwrap_or_default().clone();
                 let light_sphere = Sphere {
                     center: Vec3A::from(transform.translation()),
                     radius: point_light.range,
@@ -2018,7 +2019,7 @@ pub fn check_light_mesh_visibility(
                         continue;
                     }
 
-                    let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
+                    let entity_mask = maybe_entity_mask.unwrap_or_default().clone();
                     if !view_mask.intersects(&entity_mask) {
                         continue;
                     }
@@ -2064,7 +2065,7 @@ pub fn check_light_mesh_visibility(
                     continue;
                 }
 
-                let view_mask = maybe_view_mask.copied().unwrap_or_default();
+                let view_mask = maybe_view_mask.unwrap_or_default().clone();
                 let light_sphere = Sphere {
                     center: Vec3A::from(transform.translation()),
                     radius: point_light.range,
@@ -2083,7 +2084,7 @@ pub fn check_light_mesh_visibility(
                         continue;
                     }
 
-                    let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
+                    let entity_mask = maybe_entity_mask.unwrap_or_default().clone();
                     if !view_mask.intersects(&entity_mask) {
                         continue;
                     }

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -1936,7 +1936,7 @@ pub fn check_light_mesh_visibility(
             }
 
             let entity_mask = maybe_entity_mask.unwrap_or_default();
-            if !view_mask.intersects(&entity_mask) {
+            if !view_mask.intersects(entity_mask) {
                 continue;
             }
 
@@ -2020,7 +2020,7 @@ pub fn check_light_mesh_visibility(
                     }
 
                     let entity_mask = maybe_entity_mask.unwrap_or_default();
-                    if !view_mask.intersects(&entity_mask) {
+                    if !view_mask.intersects(entity_mask) {
                         continue;
                     }
 
@@ -2085,7 +2085,7 @@ pub fn check_light_mesh_visibility(
                     }
 
                     let entity_mask = maybe_entity_mask.unwrap_or_default();
-                    if !view_mask.intersects(&entity_mask) {
+                    if !view_mask.intersects(entity_mask) {
                         continue;
                     }
 

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -1197,7 +1197,7 @@ pub(crate) fn assign_lights_to_clusters(
         mut visible_lights,
     ) in &mut views
     {
-        let view_layers = maybe_layers.unwrap_or_default().clone();
+        let view_layers = maybe_layers.unwrap_or_default();
         let clusters = clusters.into_inner();
 
         if matches!(config, ClusterConfig::None) {
@@ -1920,7 +1920,7 @@ pub fn check_light_mesh_visibility(
             continue;
         }
 
-        let view_mask = maybe_view_mask.unwrap_or_default().clone();
+        let view_mask = maybe_view_mask.unwrap_or_default();
 
         for (
             entity,
@@ -1935,7 +1935,7 @@ pub fn check_light_mesh_visibility(
                 continue;
             }
 
-            let entity_mask = maybe_entity_mask.unwrap_or_default().clone();
+            let entity_mask = maybe_entity_mask.unwrap_or_default();
             if !view_mask.intersects(&entity_mask) {
                 continue;
             }
@@ -2000,7 +2000,7 @@ pub fn check_light_mesh_visibility(
                     continue;
                 }
 
-                let view_mask = maybe_view_mask.unwrap_or_default().clone();
+                let view_mask = maybe_view_mask.unwrap_or_default();
                 let light_sphere = Sphere {
                     center: Vec3A::from(transform.translation()),
                     radius: point_light.range,
@@ -2019,7 +2019,7 @@ pub fn check_light_mesh_visibility(
                         continue;
                     }
 
-                    let entity_mask = maybe_entity_mask.unwrap_or_default().clone();
+                    let entity_mask = maybe_entity_mask.unwrap_or_default();
                     if !view_mask.intersects(&entity_mask) {
                         continue;
                     }
@@ -2065,7 +2065,7 @@ pub fn check_light_mesh_visibility(
                     continue;
                 }
 
-                let view_mask = maybe_view_mask.unwrap_or_default().clone();
+                let view_mask = maybe_view_mask.unwrap_or_default();
                 let light_sphere = Sphere {
                     center: Vec3A::from(transform.translation()),
                     radius: point_light.range,
@@ -2084,7 +2084,7 @@ pub fn check_light_mesh_visibility(
                         continue;
                     }
 
-                    let entity_mask = maybe_entity_mask.unwrap_or_default().clone();
+                    let entity_mask = maybe_entity_mask.unwrap_or_default();
                     if !view_mask.intersects(&entity_mask) {
                         continue;
                     }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1148,6 +1148,11 @@ pub fn prepare_lights(
                 continue;
             }
 
+            // Only deal with cascades when shadows are enabled.
+            if (gpu_light.flags & DirectionalLightFlags::SHADOWS_ENABLED.bits()) == 0u32 {
+                continue;
+            }
+
             let cascades = light
                 .cascades
                 .get(&entity)

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -164,7 +164,6 @@ pub struct GpuDirectionalCascade {
 
 #[derive(Copy, Clone, ShaderType, Default, Debug)]
 pub struct GpuDirectionalLight {
-    skip: u32,
     cascades: [GpuDirectionalCascade; MAX_CASCADES_PER_LIGHT],
     color: Vec4,
     dir_to_light: Vec3,
@@ -174,6 +173,7 @@ pub struct GpuDirectionalLight {
     num_cascades: u32,
     cascades_overlap_proportion: f32,
     depth_texture_base_index: u32,
+    skip: u32,
 }
 
 // NOTE: These must match the bit flags in bevy_pbr/src/render/mesh_view_types.wgsl!

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -23,6 +23,7 @@ struct DirectionalCascade {
 }
 
 struct DirectionalLight {
+    skip: u32,
     cascades: array<DirectionalCascade, #{MAX_CASCADES_PER_LIGHT}>,
     color: vec4<f32>,
     direction_to_light: vec3<f32>,
@@ -33,7 +34,6 @@ struct DirectionalLight {
     num_cascades: u32,
     cascades_overlap_proportion: f32,
     depth_texture_base_index: u32,
-    render_layers: u32,
 };
 
 const DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT: u32 = 1u;

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -23,7 +23,6 @@ struct DirectionalCascade {
 }
 
 struct DirectionalLight {
-    skip: u32,
     cascades: array<DirectionalCascade, #{MAX_CASCADES_PER_LIGHT}>,
     color: vec4<f32>,
     direction_to_light: vec3<f32>,
@@ -34,6 +33,7 @@ struct DirectionalLight {
     num_cascades: u32,
     cascades_overlap_proportion: f32,
     depth_texture_base_index: u32,
+    skip: u32,
 };
 
 const DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT: u32 = 1u;

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -281,10 +281,10 @@ fn apply_pbr_lighting(
     // directional lights (direct)
     let n_directional_lights = view_bindings::lights.n_directional_lights;
     for (var i: u32 = 0u; i < n_directional_lights; i = i + 1u) {
-        // check the directional light render layers intersect the view render layers
-        // note this is not necessary for point and spot lights, as the relevant lights are filtered in `assign_lights_to_clusters`
+        // check if this light should be skipped, which occurs if this light does not intersect with the view
+        // note point and spot lights aren't skippable, as the relevant lights are filtered in `assign_lights_to_clusters`
         let light = &view_bindings::lights.directional_lights[i];
-        if ((*light).render_layers & view_bindings::view.render_layers) == 0u {
+        if (*light).skip != 0u {
             continue;
         }
 

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -100,7 +100,7 @@ profiling = { version = "1", features = [
 ], optional = true }
 async-channel = "2.2.0"
 nonmax = "0.5"
-smallvec = "1.11"
+smallvec = {  version = "1.11", features = ["const_new"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Omit the `glsl` feature in non-WebAssembly by default.

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -100,7 +100,7 @@ profiling = { version = "1", features = [
 ], optional = true }
 async-channel = "2.2.0"
 nonmax = "0.5"
-smallvec = {  version = "1.11", features = ["const_new"] }
+smallvec = { version = "1.11", features = ["const_new"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Omit the `glsl` feature in non-WebAssembly by default.

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -916,7 +916,7 @@ pub fn extract_cameras(
             }
 
             if let Some(render_layers) = render_layers {
-                commands.insert(*render_layers);
+                commands.insert(render_layers.clone());
             }
 
             if let Some(perspective) = projection {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -408,7 +408,6 @@ pub struct ViewUniform {
     frustum: [Vec4; 6],
     color_grading: ColorGradingUniform,
     mip_bias: f32,
-    render_layers: u32,
 }
 
 #[derive(Resource, Default)]
@@ -691,7 +690,6 @@ pub fn prepare_view_uniforms(
         Option<&Frustum>,
         Option<&TemporalJitter>,
         Option<&MipBias>,
-        Option<&RenderLayers>,
     )>,
 ) {
     let view_iter = views.iter();
@@ -710,7 +708,6 @@ pub fn prepare_view_uniforms(
         frustum,
         temporal_jitter,
         mip_bias,
-        maybe_layers,
     ) in &views
     {
         let viewport = extracted_view.viewport.as_vec4();
@@ -755,7 +752,6 @@ pub fn prepare_view_uniforms(
                 frustum,
                 color_grading: extracted_view.color_grading.clone().into(),
                 mip_bias: mip_bias.unwrap_or(&MipBias(0.0)).0,
-                render_layers: maybe_layers.copied().unwrap_or_default().bits(),
             }),
         };
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -701,15 +701,7 @@ pub fn prepare_view_uniforms(
     else {
         return;
     };
-    for (
-        entity,
-        extracted_camera,
-        extracted_view,
-        frustum,
-        temporal_jitter,
-        mip_bias,
-    ) in &views
-    {
+    for (entity, extracted_camera, extracted_view, frustum, temporal_jitter, mip_bias) in &views {
         let viewport = extracted_view.viewport.as_vec4();
         let unjittered_projection = extracted_view.projection;
         let mut projection = unjittered_projection;

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -28,5 +28,4 @@ struct View {
     frustum: array<vec4<f32>, 6>,
     color_grading: ColorGrading,
     mip_bias: f32,
-    render_layers: u32,
 };

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -444,7 +444,7 @@ pub fn check_visibility<QF>(
                 }
 
                 let entity_mask = maybe_entity_mask.unwrap_or_default();
-                if !view_mask.intersects(&entity_mask) {
+                if !view_mask.intersects(entity_mask) {
                     return;
                 }
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -422,7 +422,7 @@ pub fn check_visibility<QF>(
             continue;
         }
 
-        let view_mask = maybe_view_mask.copied().unwrap_or_default();
+        let view_mask = maybe_view_mask.unwrap_or_default();
 
         visible_aabb_query.par_iter_mut().for_each_init(
             || thread_queues.borrow_local_mut(),
@@ -443,7 +443,7 @@ pub fn check_visibility<QF>(
                     return;
                 }
 
-                let entity_mask = maybe_entity_mask.copied().unwrap_or_default();
+                let entity_mask = maybe_entity_mask.unwrap_or_default();
                 if !view_mask.intersects(&entity_mask) {
                     return;
                 }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::{Reflect};
+use bevy_reflect::Reflect;
 use smallvec::SmallVec;
 
 pub const DEFAULT_LAYERS: &RenderLayers = &RenderLayers::layer(0);

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -108,6 +108,12 @@ impl RenderLayers {
     /// A `RenderLayers` with no layers will not match any other
     /// `RenderLayers`, even another with no layers.
     pub fn intersects(&self, other: &RenderLayers) -> bool {
+        // Check for the common case where the view layer and entity layer
+        // both point towards our default layer.
+        if self.0.as_ptr() == other.0.as_ptr() {
+            return true;
+        }
+
         for (self_layer, other_layer) in self.0.iter().zip(other.0.iter()) {
             if (*self_layer & *other_layer) != 0 {
                 return true;

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -1,7 +1,7 @@
-use smallvec::SmallVec;
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
+use smallvec::SmallVec;
 
 pub const DEFAULT_LAYERS: &RenderLayers = &RenderLayers::layer(0);
 
@@ -57,7 +57,10 @@ impl RenderLayers {
     /// Create a new `RenderLayers` belonging to the given layer.
     pub const fn layer(n: Layer) -> Self {
         let (buffer_index, bit) = Self::layer_info(n);
-        assert!(buffer_index < 1, "layer is out of bounds for const construction");
+        assert!(
+            buffer_index < 1,
+            "layer is out of bounds for const construction"
+        );
         RenderLayers(SmallVec::from_const([bit]))
     }
 
@@ -139,7 +142,6 @@ impl RenderLayers {
         self.0.resize(new_size, 0u64);
     }
 
-
     fn iter_layers(mut buffer: u64) -> impl Iterator<Item = Layer> + 'static {
         let mut layer: usize = 0;
         std::iter::from_fn(move || {
@@ -156,8 +158,8 @@ impl RenderLayers {
 
 #[cfg(test)]
 mod rendering_mask_tests {
-    use smallvec::SmallVec;
     use super::{Layer, RenderLayers};
+    use smallvec::SmallVec;
 
     #[test]
     fn rendering_mask_sanity() {
@@ -171,7 +173,11 @@ mod rendering_mask_tests {
         assert_eq!(layer_0_1.0.len(), 1, "layer 0 + 1 is one buffer");
         assert_eq!(layer_0_1.0[0], 3, "layer 0 + 1 is mask 3");
         let layer_0_1_without_0 = layer_0_1.without(0);
-        assert_eq!(layer_0_1_without_0.0.len(), 1, "layer 0 + 1 - 0 is one buffer");
+        assert_eq!(
+            layer_0_1_without_0.0.len(),
+            1,
+            "layer 0 + 1 - 0 is one buffer"
+        );
         assert_eq!(layer_0_1_without_0.0[0], 2, "layer 0 + 1 - 0 is mask 2");
         assert!(
             RenderLayers::layer(1).intersects(&RenderLayers::layer(1)),

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -176,8 +176,14 @@ mod rendering_mask_tests {
         let layer_0_2345 = RenderLayers::layer(0).with(2345);
         assert_eq!(layer_0_2345.0.len(), 37, "layer 0 + 2345 is 37 buffers");
         assert_eq!(layer_0_2345.0[0], 1, "layer 0 + 2345 is mask 1");
-        assert_eq!(layer_0_2345.0[36], 2199023255552, "layer 0 + 2345 is mask 2199023255552");
-        assert!(layer_0_2345.intersects(&layer_0), "layer 0 + 2345 intersects 0");
+        assert_eq!(
+            layer_0_2345.0[36], 2199023255552,
+            "layer 0 + 2345 is mask 2199023255552"
+        );
+        assert!(
+            layer_0_2345.intersects(&layer_0),
+            "layer 0 + 2345 intersects 0"
+        );
         assert!(
             RenderLayers::layer(1).intersects(&RenderLayers::layer(1)),
             "layers match like layers"

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -81,7 +81,7 @@ impl RenderLayers {
     #[must_use]
     pub fn with(mut self, layer: Layer) -> Self {
         let (buffer_index, bit) = Self::layer_info(layer);
-        Self(SmallVec::new_const()).extend_buffer(buffer_index + 1);
+        self.extend_buffer(buffer_index + 1);
         self.0[buffer_index] |= bit;
         self
     }
@@ -173,6 +173,11 @@ mod rendering_mask_tests {
             "layer 0 + 1 - 0 is one buffer"
         );
         assert_eq!(layer_0_1_without_0.0[0], 2, "layer 0 + 1 - 0 is mask 2");
+        let layer_0_2345 = RenderLayers::layer(0).with(2345);
+        assert_eq!(layer_0_2345.0.len(), 37, "layer 0 + 2345 is 37 buffers");
+        assert_eq!(layer_0_2345.0[0], 1, "layer 0 + 2345 is mask 1");
+        assert_eq!(layer_0_2345.0[36], 2199023255552, "layer 0 + 2345 is mask 2199023255552");
+        assert!(layer_0_2345.intersects(&layer_0), "layer 0 + 2345 intersects 0");
         assert!(
             RenderLayers::layer(1).intersects(&RenderLayers::layer(1)),
             "layers match like layers"

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -248,5 +248,11 @@ mod rendering_mask_tests {
         let layers = RenderLayers::from_layers(&tricky_layers);
         let out = layers.iter().collect::<Vec<_>>();
         assert_eq!(tricky_layers, out, "tricky layers roundtrip");
+
+        let none_with_10 = RenderLayers::none_with(10);
+        assert!(
+            !RenderLayers::default().intersects(&none_with_10),
+            "none_with_1025 is not default"
+        );
     }
 }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -66,7 +66,9 @@ impl RenderLayers {
 
     /// Create a new `RenderLayers` belonging to the given layer but without layer `0`.
     pub const fn none_with(n: Layer) -> Self {
-        let (buffer_index, bit) = Self::layer_info(n);
+        let buffer_index = n / 64;
+        let bit_index = n % 64;
+        let bit = 0u64 << bit_index;
         assert!(
             buffer_index < 1,
             "layer is out of bounds for const construction"

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -86,23 +86,6 @@ impl RenderLayers {
         self
     }
 
-    /// Add the given layer.
-    ///
-    /// This may be called multiple times to allow an entity to belong
-    /// to multiple rendering layers
-    ///
-    /// # Panics
-    /// Panics when called with a layer greater than `64`.
-    pub const fn with_const(mut self, layer: Layer) -> Self {
-        let (buffer_index, bit) = Self::layer_info(layer);
-        assert!(
-            buffer_index < 1,
-            "layer is out of bounds for const construction"
-        );
-        self.0[buffer_index] |= bit;
-        self
-    }
-
     /// Removes the given rendering layer.
     #[must_use]
     pub fn without(mut self, layer: Layer) -> Self {
@@ -110,20 +93,6 @@ impl RenderLayers {
         if buffer_index < self.0.len() {
             self.0[buffer_index] &= !bit;
         }
-        self
-    }
-
-    /// Remove the given layer.
-    ///
-    /// # Panics
-    /// Panics when called with a layer greater than `64`.
-    pub const fn without_const(mut self, layer: Layer) -> Self {
-        let (buffer_index, bit) = Self::layer_info(layer);
-        assert!(
-            buffer_index < 1,
-            "layer is out of bounds for const construction"
-        );
-        self.0[buffer_index] &= !bit;
         self
     }
 

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -71,8 +71,7 @@ impl RenderLayers {
             buffer_index < 1,
             "layer is out of bounds for const construction"
         );
-        let mask = 0 | bit;
-        RenderLayers(SmallVec::from_const([mask]))
+        RenderLayers(SmallVec::from_const([bit]))
     }
 
     /// Create a new `RenderLayers` that belongs to no layers.

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -64,6 +64,17 @@ impl RenderLayers {
         RenderLayers(SmallVec::from_const([bit]))
     }
 
+    /// Create a new `RenderLayers` belonging to the given layer but without layer `0`.
+    pub const fn none_with(n: Layer) -> Self {
+        let (buffer_index, bit) = Self::layer_info(n);
+        assert!(
+            buffer_index < 1,
+            "layer is out of bounds for const construction"
+        );
+        let mask = 0 | bit;
+        RenderLayers(SmallVec::from_const([mask]))
+    }
+
     /// Create a new `RenderLayers` that belongs to no layers.
     pub const fn none() -> Self {
         RenderLayers(SmallVec::from_const([0]))

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -77,10 +77,7 @@ impl RenderLayers {
     /// Add the given layer.
     ///
     /// This may be called multiple times to allow an entity to belong
-    /// to multiple rendering layers. The maximum layer is `TOTAL_LAYERS - 1`.
-    ///
-    /// # Panics
-    /// Panics when called with a layer greater than `TOTAL_LAYERS - 1`.
+    /// to multiple rendering layers.
     #[must_use]
     pub fn with(mut self, layer: Layer) -> Self {
         let (buffer_index, bit) = Self::layer_info(layer);
@@ -89,16 +86,44 @@ impl RenderLayers {
         self
     }
 
-    /// Removes the given rendering layer.
+    /// Add the given layer.
+    ///
+    /// This may be called multiple times to allow an entity to belong
+    /// to multiple rendering layers
     ///
     /// # Panics
-    /// Panics when called with a layer greater than `TOTAL_LAYERS - 1`.
+    /// Panics when called with a layer greater than `64`.
+    pub const fn with_const(mut self, layer: Layer) -> Self {
+        let (buffer_index, bit) = Self::layer_info(layer);
+        assert!(
+            buffer_index < 1,
+            "layer is out of bounds for const construction"
+        );
+        self.0[buffer_index] |= bit;
+        self
+    }
+
+    /// Removes the given rendering layer.
     #[must_use]
     pub fn without(mut self, layer: Layer) -> Self {
         let (buffer_index, bit) = Self::layer_info(layer);
         if buffer_index < self.0.len() {
             self.0[buffer_index] &= !bit;
         }
+        self
+    }
+
+    /// Remove the given layer.
+    ///
+    /// # Panics
+    /// Panics when called with a layer greater than `64`.
+    pub const fn without_const(mut self, layer: Layer) -> Self {
+        let (buffer_index, bit) = Self::layer_info(layer);
+        assert!(
+            buffer_index < 1,
+            "layer is out of bounds for const construction"
+        );
+        self.0[buffer_index] &= !bit;
         self
     }
 

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::{List, Reflect};
+use bevy_reflect::{Reflect};
 use smallvec::SmallVec;
 
 pub const DEFAULT_LAYERS: &RenderLayers = &RenderLayers::layer(0);

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -64,18 +64,6 @@ impl RenderLayers {
         RenderLayers(SmallVec::from_const([bit]))
     }
 
-    /// Create a new `RenderLayers` belonging to the given layer but without layer `0`.
-    pub const fn none_with(n: Layer) -> Self {
-        let buffer_index = n / 64;
-        let bit_index = n % 64;
-        let bit = 0u64 << bit_index;
-        assert!(
-            buffer_index < 1,
-            "layer is out of bounds for const construction"
-        );
-        RenderLayers(SmallVec::from_const([bit]))
-    }
-
     /// Create a new `RenderLayers` that belongs to no layers.
     pub const fn none() -> Self {
         RenderLayers(SmallVec::from_const([0]))
@@ -248,11 +236,5 @@ mod rendering_mask_tests {
         let layers = RenderLayers::from_layers(&tricky_layers);
         let out = layers.iter().collect::<Vec<_>>();
         assert_eq!(tricky_layers, out, "tricky layers roundtrip");
-
-        let none_with_10 = RenderLayers::none_with(10);
-        assert!(
-            !RenderLayers::default().intersects(&none_with_10),
-            "none_with_1025 is not default"
-        );
     }
 }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::{Component, ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
+use bevy_reflect::{List, Reflect};
 use smallvec::SmallVec;
 
 pub const DEFAULT_LAYERS: &RenderLayers = &RenderLayers::layer(0);
@@ -98,7 +98,8 @@ impl RenderLayers {
 
     /// Get an iterator of the layers.
     pub fn iter(&self) -> impl Iterator<Item = Layer> + '_ {
-        self.0.iter().copied().zip(0..).flat_map(Self::iter_layers)    }
+        self.0.iter().copied().zip(0..).flat_map(Self::iter_layers)
+    }
 
     /// Determine if a `RenderLayers` intersects another.
     ///

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -134,14 +134,17 @@ fn setup(
         MainPassCube,
     ));
 
-    // Light for the main pass cube
-    // NOTE: Lights only work properly when in one render layer, so we need separate lights for the first and
-    // main passes.
-    commands.spawn((PointLightBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-        ..default()
-    },));
-
+    // Light
+    // NOTE: we add the light to both layers so it affects both the rendered-to-texture cube, and the cube on which we display the texture
+    // Setting the layer to RenderLayers::layer(0) would cause the main view to be lit, but the rendered-to-texture cube to be unlit.
+    // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.    
+    commands.spawn((
+        PointLightBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+            ..default()
+        },
+        RenderLayers::layer(0).with(1),
+    ));
     // The main pass camera.
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -137,7 +137,7 @@ fn setup(
     // Light
     // NOTE: we add the light to both layers so it affects both the rendered-to-texture cube, and the cube on which we display the texture
     // Setting the layer to RenderLayers::layer(0) would cause the main view to be lit, but the rendered-to-texture cube to be unlit.
-    // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.    
+    // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.
     commands.spawn((
         PointLightBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -82,19 +82,17 @@ fn setup(
             ..default()
         },
         FirstPassCube,
-        first_pass_layer,
+        first_pass_layer.clone(),
     ));
 
-    // Light
-    // NOTE: we add the light to all layers so it affects both the rendered-to-texture cube, and the cube on which we display the texture
-    // Setting the layer to RenderLayers::layer(0) would cause the main view to be lit, but the rendered-to-texture cube to be unlit.
-    // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.
+    // Light for the first pass
+    // NOTE: Lights only work properly when in one render layer.
     commands.spawn((
         PointLightBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
             ..default()
         },
-        RenderLayers::all(),
+        first_pass_layer.clone(),
     ));
 
     commands.spawn((
@@ -135,6 +133,14 @@ fn setup(
         },
         MainPassCube,
     ));
+
+    // Light for the main pass cube
+    // NOTE: Lights only work properly when in one render layer, so we need separate lights for the first and
+    // main passes.
+    commands.spawn((PointLightBundle {
+        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+        ..default()
+    },));
 
     // The main pass camera.
     commands.spawn(Camera3dBundle {


### PR DESCRIPTION
# Objective

Remove the limit of `RenderLayer` by using a growable mask using `SmallVec`.

Changes adopted from @UkoeHB's initial PR here https://github.com/bevyengine/bevy/pull/12502 that contained additional changes related to propagating render layers.

Changes

## Solution

The main thing needed to unblock this is removing `RenderLayers` from our shader code. This primarily affects `DirectionalLight`. We are now computing a `skip` field on the CPU that is then used to skip the light in the shader.

## Testing

Checked a variety of examples and did a quick benchmark on `many_cubes`. There were some existing problems identified during the development of the original pr (see: https://discord.com/channels/691052431525675048/1220477928605749340/1221190112939872347). This PR shouldn't change any existing behavior besides removing the layer limit (sans the comment in migration about `all` layers no longer being possible). 

---

## Changelog

Removed the limit on `RenderLayers` by using a growable bitset that only allocates when layers greater than 64 are used.

## Migration Guide

- `RenderLayers::all()` no longer exists. Entities expecting to be visible on all layers, e.g. lights, should compute the active layers that are in use.