### PR TITLE
bevy_reflect: Nested `TypeInfo` getters

### DIFF
--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.rs
@@ -13,6 +13,7 @@ struct NoReflect(f32);
 fn main() {
     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
     //~^ ERROR: `NoReflect` does not provide type registration information
+    //~| ERROR: `NoReflect` can not provide type information through reflection
 
     // foo doesn't implement Reflect because NoReflect doesn't implement Reflect
     foo.get_field::<NoReflect>("a").unwrap();

--- a/crates/bevy_reflect/derive/src/utility.rs
+++ b/crates/bevy_reflect/derive/src/utility.rs
@@ -227,6 +227,9 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
                 quote!(
                     #ty : #reflect_bound
                         + #bevy_reflect_path::TypePath
+                        // Needed for `Typed` impls
+                        + #bevy_reflect_path::MaybeTyped
+                        // Needed for `GetTypeRegistration` impls
                         + #bevy_reflect_path::__macro_exports::RegisterForReflection
                 )
             }))

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,6 +1,6 @@
 use crate::{
-    self as bevy_reflect, utility::reflect_hasher, ApplyError, Reflect, ReflectKind, ReflectMut,
-    ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable,
+    self as bevy_reflect, utility::reflect_hasher, ApplyError, MaybeTyped, Reflect, ReflectKind,
+    ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable,
 };
 use bevy_reflect_derive::impl_type_path;
 use std::{
@@ -79,6 +79,7 @@ pub trait Array: Reflect {
 pub struct ArrayInfo {
     type_path: TypePathTable,
     type_id: TypeId,
+    item_info: fn() -> Option<&'static TypeInfo>,
     item_type_path: TypePathTable,
     item_type_id: TypeId,
     capacity: usize,
@@ -93,10 +94,13 @@ impl ArrayInfo {
     ///
     /// * `capacity`: The maximum capacity of the underlying array.
     ///
-    pub fn new<TArray: Array + TypePath, TItem: Reflect + TypePath>(capacity: usize) -> Self {
+    pub fn new<TArray: Array + TypePath, TItem: Reflect + MaybeTyped + TypePath>(
+        capacity: usize,
+    ) -> Self {
         Self {
             type_path: TypePathTable::of::<TArray>(),
             type_id: TypeId::of::<TArray>(),
+            item_info: TItem::maybe_type_info,
             item_type_path: TypePathTable::of::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
             capacity,
@@ -141,6 +145,14 @@ impl ArrayInfo {
     /// Check if the given type matches the array type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
+    }
+
+    /// The [`TypeInfo`] of the array item.
+    ///
+    /// Returns `None` if the array item does not contain static type information,
+    /// such as for dynamic types.
+    pub fn item_info(&self) -> Option<&'static TypeInfo> {
+        (self.item_info)()
     }
 
     /// A representation of the type path of the array item.

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -50,6 +50,18 @@ mod tests {
             if let VariantInfo::Tuple(variant) = info.variant("B").unwrap() {
                 assert!(variant.field_at(0).unwrap().is::<usize>());
                 assert!(variant.field_at(1).unwrap().is::<i32>());
+                assert!(variant
+                    .field_at(0)
+                    .unwrap()
+                    .type_info()
+                    .unwrap()
+                    .is::<usize>());
+                assert!(variant
+                    .field_at(1)
+                    .unwrap()
+                    .type_info()
+                    .unwrap()
+                    .is::<i32>());
             } else {
                 panic!("Expected `VariantInfo::Tuple`");
             }
@@ -60,6 +72,12 @@ mod tests {
             if let VariantInfo::Struct(variant) = info.variant("C").unwrap() {
                 assert!(variant.field_at(0).unwrap().is::<f32>());
                 assert!(variant.field("foo").unwrap().is::<f32>());
+                assert!(variant
+                    .field("foo")
+                    .unwrap()
+                    .type_info()
+                    .unwrap()
+                    .is::<f32>());
             } else {
                 panic!("Expected `VariantInfo::Struct`");
             }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,5 +1,5 @@
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
-use crate::{Reflect, TypePath, TypePathTable};
+use crate::{MaybeTyped, Reflect, TypeInfo, TypePath, TypePathTable};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 
@@ -7,6 +7,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct NamedField {
     name: &'static str,
+    type_info: fn() -> Option<&'static TypeInfo>,
     type_path: TypePathTable,
     type_id: TypeId,
     custom_attributes: Arc<CustomAttributes>,
@@ -16,9 +17,10 @@ pub struct NamedField {
 
 impl NamedField {
     /// Create a new [`NamedField`].
-    pub fn new<T: Reflect + TypePath>(name: &'static str) -> Self {
+    pub fn new<T: Reflect + MaybeTyped + TypePath>(name: &'static str) -> Self {
         Self {
             name,
+            type_info: T::maybe_type_info,
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
             custom_attributes: Arc::new(CustomAttributes::default()),
@@ -44,6 +46,15 @@ impl NamedField {
     /// The name of the field.
     pub fn name(&self) -> &'static str {
         self.name
+    }
+
+    /// The [`TypeInfo`] of the field.
+    ///
+    ///
+    /// Returns `None` if the field does not contain static type information,
+    /// such as for dynamic types.
+    pub fn type_info(&self) -> Option<&'static TypeInfo> {
+        (self.type_info)()
     }
 
     /// A representation of the type path of the field.
@@ -86,6 +97,7 @@ impl NamedField {
 #[derive(Clone, Debug)]
 pub struct UnnamedField {
     index: usize,
+    type_info: fn() -> Option<&'static TypeInfo>,
     type_path: TypePathTable,
     type_id: TypeId,
     custom_attributes: Arc<CustomAttributes>,
@@ -94,9 +106,10 @@ pub struct UnnamedField {
 }
 
 impl UnnamedField {
-    pub fn new<T: Reflect + TypePath>(index: usize) -> Self {
+    pub fn new<T: Reflect + MaybeTyped + TypePath>(index: usize) -> Self {
         Self {
             index,
+            type_info: T::maybe_type_info,
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
             custom_attributes: Arc::new(CustomAttributes::default()),
@@ -122,6 +135,15 @@ impl UnnamedField {
     /// Returns the index of the field.
     pub fn index(&self) -> usize {
         self.index
+    }
+
+    /// The [`TypeInfo`] of the field.
+    ///
+    ///
+    /// Returns `None` if the field does not contain static type information,
+    /// such as for dynamic types.
+    pub fn type_info(&self) -> Option<&'static TypeInfo> {
+        (self.type_info)()
     }
 
     /// A representation of the type path of the field.

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -6,13 +6,13 @@ use std::any::Any;
 use crate::utility::GenericTypeInfoCell;
 use crate::{
     self as bevy_reflect, ApplyError, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
-    ListIter, Reflect, ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
-    TypePath, TypeRegistration, Typed,
+    ListIter, MaybeTyped, Reflect, ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed,
 };
 
 impl<T: SmallArray + TypePath + Send + Sync> List for SmallVec<T>
 where
-    T::Item: FromReflect + TypePath,
+    T::Item: FromReflect + MaybeTyped + TypePath,
 {
     fn get(&self, index: usize) -> Option<&dyn Reflect> {
         if index < SmallVec::len(self) {
@@ -79,7 +79,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync> Reflect for SmallVec<T>
 where
-    T::Item: FromReflect + TypePath,
+    T::Item: FromReflect + MaybeTyped + TypePath,
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
@@ -149,7 +149,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync + 'static> Typed for SmallVec<T>
 where
-    T::Item: FromReflect + TypePath,
+    T::Item: FromReflect + MaybeTyped + TypePath,
 {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
@@ -161,7 +161,7 @@ impl_type_path!(::smallvec::SmallVec<T: SmallArray>);
 
 impl<T: SmallArray + TypePath + Send + Sync> FromReflect for SmallVec<T>
 where
-    T::Item: FromReflect + TypePath,
+    T::Item: FromReflect + MaybeTyped + TypePath,
 {
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
         if let ReflectRef::List(ref_list) = reflect.reflect_ref() {
@@ -178,7 +178,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync> GetTypeRegistration for SmallVec<T>
 where
-    T::Item: FromReflect + TypePath,
+    T::Item: FromReflect + MaybeTyped + TypePath,
 {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<SmallVec<T>>();
@@ -188,4 +188,4 @@ where
 }
 
 #[cfg(feature = "functions")]
-crate::func::macros::impl_function_traits!(SmallVec<T>; <T: SmallArray + TypePath + Send + Sync> where T::Item: FromReflect + TypePath);
+crate::func::macros::impl_function_traits!(SmallVec<T>; <T: SmallArray + TypePath + Send + Sync> where T::Item: FromReflect + MaybeTyped + TypePath);

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1555,6 +1555,7 @@ mod tests {
         assert_eq!(MyStruct::type_path(), info.type_path());
         assert_eq!(i32::type_path(), info.field("foo").unwrap().type_path());
         assert_eq!(TypeId::of::<i32>(), info.field("foo").unwrap().type_id());
+        assert!(info.field("foo").unwrap().type_info().unwrap().is::<i32>());
         assert!(info.field("foo").unwrap().is::<i32>());
         assert_eq!("foo", info.field("foo").unwrap().name());
         assert_eq!(usize::type_path(), info.field_at(1).unwrap().type_path());
@@ -1571,11 +1572,11 @@ mod tests {
         }
 
         let info = <MyGenericStruct<i32>>::type_info().as_struct().unwrap();
-
         assert!(info.is::<MyGenericStruct<i32>>());
         assert_eq!(MyGenericStruct::<i32>::type_path(), info.type_path());
         assert_eq!(i32::type_path(), info.field("foo").unwrap().type_path());
         assert_eq!("foo", info.field("foo").unwrap().name());
+        assert!(info.field("foo").unwrap().type_info().unwrap().is::<i32>());
         assert_eq!(usize::type_path(), info.field_at(1).unwrap().type_path());
 
         let value: &dyn Reflect = &MyGenericStruct {
@@ -1594,6 +1595,7 @@ mod tests {
         assert!(info.is::<MyTupleStruct>());
         assert_eq!(MyTupleStruct::type_path(), info.type_path());
         assert_eq!(i32::type_path(), info.field_at(1).unwrap().type_path());
+        assert!(info.field_at(1).unwrap().type_info().unwrap().is::<i32>());
         assert!(info.field_at(1).unwrap().is::<i32>());
 
         // Tuple
@@ -1604,6 +1606,7 @@ mod tests {
         assert!(info.is::<MyTuple>());
         assert_eq!(MyTuple::type_path(), info.type_path());
         assert_eq!(f32::type_path(), info.field_at(1).unwrap().type_path());
+        assert!(info.field_at(1).unwrap().type_info().unwrap().is::<f32>());
 
         let value: &dyn Reflect = &(123_u32, 1.23_f32, String::from("Hello!"));
         let info = value.get_represented_type_info().unwrap();
@@ -1616,6 +1619,7 @@ mod tests {
 
         assert!(info.is::<MyList>());
         assert!(info.item_is::<usize>());
+        assert!(info.item_info().unwrap().is::<usize>());
         assert_eq!(MyList::type_path(), info.type_path());
         assert_eq!(usize::type_path(), info.item_type_path_table().path());
 
@@ -1631,6 +1635,7 @@ mod tests {
             let info = MySmallVec::type_info().as_list().unwrap();
             assert!(info.is::<MySmallVec>());
             assert!(info.item_is::<String>());
+            assert!(info.item_info().unwrap().is::<String>());
             assert_eq!(MySmallVec::type_path(), info.type_path());
             assert_eq!(String::type_path(), info.item_type_path_table().path());
 
@@ -1646,6 +1651,7 @@ mod tests {
         let info = MyArray::type_info().as_array().unwrap();
         assert!(info.is::<MyArray>());
         assert!(info.item_is::<usize>());
+        assert!(info.item_info().unwrap().is::<usize>());
         assert_eq!(MyArray::type_path(), info.type_path());
         assert_eq!(usize::type_path(), info.item_type_path_table().path());
         assert_eq!(3, info.capacity());
@@ -1673,6 +1679,7 @@ mod tests {
 
         assert!(info.is::<MyCowSlice>());
         assert!(info.item_is::<u8>());
+        assert!(info.item_info().unwrap().is::<u8>());
         assert_eq!(std::any::type_name::<MyCowSlice>(), info.type_path());
         assert_eq!(
             std::any::type_name::<u8>(),
@@ -1691,6 +1698,8 @@ mod tests {
         assert!(info.is::<MyMap>());
         assert!(info.key_is::<usize>());
         assert!(info.value_is::<f32>());
+        assert!(info.key_info().unwrap().is::<usize>());
+        assert!(info.value_info().unwrap().is::<f32>());
         assert_eq!(MyMap::type_path(), info.type_path());
         assert_eq!(usize::type_path(), info.key_type_path_table().path());
         assert_eq!(f32::type_path(), info.value_type_path_table().path());

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1586,6 +1586,36 @@ mod tests {
         let info = value.get_represented_type_info().unwrap();
         assert!(info.is::<MyGenericStruct<String>>());
 
+        // Struct (dynamic field)
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct MyDynamicStruct {
+            foo: DynamicStruct,
+            bar: usize,
+        }
+
+        let info = MyDynamicStruct::type_info();
+        if let TypeInfo::Struct(info) = info {
+            assert!(info.is::<MyDynamicStruct>());
+            assert_eq!(MyDynamicStruct::type_path(), info.type_path());
+            assert_eq!(
+                DynamicStruct::type_path(),
+                info.field("foo").unwrap().type_path()
+            );
+            assert_eq!("foo", info.field("foo").unwrap().name());
+            assert!(info.field("foo").unwrap().type_info().is_none());
+            assert_eq!(usize::type_path(), info.field_at(1).unwrap().type_path());
+        } else {
+            panic!("Expected `TypeInfo::Struct`");
+        }
+
+        let value: &dyn Reflect = &MyDynamicStruct {
+            foo: DynamicStruct::default(),
+            bar: 321,
+        };
+        let info = value.get_represented_type_info().unwrap();
+        assert!(info.is::<MyDynamicStruct>());
+
         // Tuple Struct
         #[derive(Reflect)]
         struct MyTupleStruct(usize, i32, MyStruct);

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -6,8 +6,8 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::utility::reflect_hasher;
 use crate::{
-    self as bevy_reflect, ApplyError, FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
-    ReflectRef, TypeInfo, TypePath, TypePathTable,
+    self as bevy_reflect, ApplyError, FromReflect, MaybeTyped, Reflect, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable,
 };
 
 /// A trait used to power [list-like] operations via [reflection].
@@ -110,6 +110,7 @@ pub trait List: Reflect {
 pub struct ListInfo {
     type_path: TypePathTable,
     type_id: TypeId,
+    item_info: fn() -> Option<&'static TypeInfo>,
     item_type_path: TypePathTable,
     item_type_id: TypeId,
     #[cfg(feature = "documentation")]
@@ -118,10 +119,11 @@ pub struct ListInfo {
 
 impl ListInfo {
     /// Create a new [`ListInfo`].
-    pub fn new<TList: List + TypePath, TItem: FromReflect + TypePath>() -> Self {
+    pub fn new<TList: List + TypePath, TItem: FromReflect + MaybeTyped + TypePath>() -> Self {
         Self {
             type_path: TypePathTable::of::<TList>(),
             type_id: TypeId::of::<TList>(),
+            item_info: TItem::maybe_type_info,
             item_type_path: TypePathTable::of::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
             #[cfg(feature = "documentation")]
@@ -160,6 +162,14 @@ impl ListInfo {
     /// Check if the given type matches the list type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
+    }
+
+    /// The [`TypeInfo`] of the list item.
+    ///
+    /// Returns `None` if the list item does not contain static type information,
+    /// such as for dynamic types.
+    pub fn item_info(&self) -> Option<&'static TypeInfo> {
+        (self.item_info)()
     }
 
     /// A representation of the type path of the list item.

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -5,8 +5,8 @@ use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
 use crate::{
-    self as bevy_reflect, ApplyError, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
-    TypeInfo, TypePath, TypePathTable,
+    self as bevy_reflect, ApplyError, MaybeTyped, Reflect, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, TypeInfo, TypePath, TypePathTable,
 };
 
 /// A trait used to power [map-like] operations via [reflection].
@@ -96,8 +96,10 @@ pub trait Map: Reflect {
 pub struct MapInfo {
     type_path: TypePathTable,
     type_id: TypeId,
+    key_info: fn() -> Option<&'static TypeInfo>,
     key_type_path: TypePathTable,
     key_type_id: TypeId,
+    value_info: fn() -> Option<&'static TypeInfo>,
     value_type_path: TypePathTable,
     value_type_id: TypeId,
     #[cfg(feature = "documentation")]
@@ -106,13 +108,18 @@ pub struct MapInfo {
 
 impl MapInfo {
     /// Create a new [`MapInfo`].
-    pub fn new<TMap: Map + TypePath, TKey: Reflect + TypePath, TValue: Reflect + TypePath>() -> Self
-    {
+    pub fn new<
+        TMap: Map + TypePath,
+        TKey: Reflect + MaybeTyped + TypePath,
+        TValue: Reflect + MaybeTyped + TypePath,
+    >() -> Self {
         Self {
             type_path: TypePathTable::of::<TMap>(),
             type_id: TypeId::of::<TMap>(),
+            key_info: TKey::maybe_type_info,
             key_type_path: TypePathTable::of::<TKey>(),
             key_type_id: TypeId::of::<TKey>(),
+            value_info: TValue::maybe_type_info,
             value_type_path: TypePathTable::of::<TValue>(),
             value_type_id: TypeId::of::<TValue>(),
             #[cfg(feature = "documentation")]
@@ -153,6 +160,14 @@ impl MapInfo {
         TypeId::of::<T>() == self.type_id
     }
 
+    /// The [`TypeInfo`] of the key type.
+    ///
+    /// Returns `None` if the key type does not contain static type information,
+    /// such as for dynamic types.
+    pub fn key_info(&self) -> Option<&'static TypeInfo> {
+        (self.key_info)()
+    }
+
     /// A representation of the type path of the key type.
     ///
     /// Provides dynamic access to all methods on [`TypePath`].
@@ -168,6 +183,14 @@ impl MapInfo {
     /// Check if the given type matches the key type.
     pub fn key_is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.key_type_id
+    }
+
+    /// The [`TypeInfo`] of the value type.
+    ///
+    /// Returns `None` if the value type does not contain static type information,
+    /// such as for dynamic types.
+    pub fn value_info(&self) -> Option<&'static TypeInfo> {
+        (self.value_info)()
     }
 
     /// A representation of the type path of the value type.

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -3,8 +3,8 @@ use bevy_utils::all_tuples;
 
 use crate::{
     self as bevy_reflect, utility::GenericTypePathCell, ApplyError, FromReflect,
-    GetTypeRegistration, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypeRegistration, TypeRegistry, Typed, UnnamedField,
+    GetTypeRegistration, MaybeTyped, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
+    TypePath, TypeRegistration, TypeRegistry, Typed, UnnamedField,
 };
 use crate::{ReflectKind, TypePathTable};
 use std::any::{Any, TypeId};
@@ -483,7 +483,7 @@ pub fn tuple_debug(dyn_tuple: &dyn Tuple, f: &mut Formatter<'_>) -> std::fmt::Re
 
 macro_rules! impl_reflect_tuple {
     {$($index:tt : $name:tt),*} => {
-        impl<$($name: Reflect + TypePath + GetTypeRegistration),*> Tuple for ($($name,)*) {
+        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> Tuple for ($($name,)*) {
             #[inline]
             fn field(&self, index: usize) -> Option<&dyn Reflect> {
                 match index {
@@ -534,7 +534,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: Reflect + TypePath + GetTypeRegistration),*> Reflect for ($($name,)*) {
+        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> Reflect for ($($name,)*) {
             fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
                 Some(<Self as Typed>::type_info())
             }
@@ -601,7 +601,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl <$($name: Reflect + TypePath + GetTypeRegistration),*> Typed for ($($name,)*) {
+        impl <$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> Typed for ($($name,)*) {
             fn type_info() -> &'static TypeInfo {
                 static CELL: $crate::utility::GenericTypeInfoCell = $crate::utility::GenericTypeInfoCell::new();
                 CELL.get_or_insert::<Self, _>(|| {
@@ -614,7 +614,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: Reflect + TypePath + GetTypeRegistration),*> GetTypeRegistration for ($($name,)*) {
+        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> GetTypeRegistration for ($($name,)*) {
             fn get_type_registration() -> TypeRegistration {
                 TypeRegistration::of::<($($name,)*)>()
             }
@@ -624,7 +624,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: FromReflect + TypePath + GetTypeRegistration),*> FromReflect for ($($name,)*)
+        impl<$($name: FromReflect + MaybeTyped + TypePath + GetTypeRegistration),*> FromReflect for ($($name,)*)
         {
             fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
                 if let ReflectRef::Tuple(_ref_tuple) = reflect.reflect_ref() {
@@ -722,7 +722,7 @@ const _: () = {
 
     macro_rules! impl_from_arg_tuple {
     ($($name: ident),*) => {
-        $crate::func::args::impl_from_arg!(($($name,)*); <$($name: FromReflect + TypePath + GetTypeRegistration),*>);
+        $crate::func::args::impl_from_arg!(($($name,)*); <$($name: FromReflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
     };
 }
 
@@ -730,7 +730,7 @@ const _: () = {
 
     macro_rules! impl_into_return_tuple {
     ($($name: ident),+) => {
-        $crate::func::impl_into_return!(($($name,)*); <$($name: FromReflect + TypePath + GetTypeRegistration),*>);
+        $crate::func::impl_into_return!(($($name,)*); <$($name: FromReflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
     };
 }
 

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -135,7 +135,7 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 ///
 /// struct Foo<T>(T);
 ///
-/// impl<T: Reflect + TypePath> Typed for Foo<T> {
+/// impl<T: Reflect + Typed + TypePath> Typed for Foo<T> {
 ///     fn type_info() -> &'static TypeInfo {
 ///         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
 ///         CELL.get_or_insert::<Self, _>(|| {
@@ -149,7 +149,7 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 /// #     fn type_path() -> &'static str { todo!() }
 /// #     fn short_type_path() -> &'static str { todo!() }
 /// # }
-/// # impl<T: Reflect + TypePath> Reflect for Foo<T> {
+/// # impl<T: Reflect + Typed + TypePath> Reflect for Foo<T> {
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }


### PR DESCRIPTION
# Objective

Right now, `TypeInfo` can be accessed directly from a type using either `Typed::type_info` or `Reflect::get_represented_type_info`.

However, once that `TypeInfo` is accessed, any nested types must be accessed via the `TypeRegistry`.

```rust
#[derive(Reflect)]
struct Foo {
  bar: usize
}

let registry = TypeRegistry::default();

let TypeInfo::Struct(type_info) = Foo::type_info() else {
  panic!("expected struct info");
};

let field = type_info.field("bar").unwrap();

let field_info = registry.get_type_info(field.type_id()).unwrap();
assert!(field_info.is::<usize>());;
```

## Solution

Enable nested types within a `TypeInfo` to be retrieved directly.

```rust
#[derive(Reflect)]
struct Foo {
  bar: usize
}

let TypeInfo::Struct(type_info) = Foo::type_info() else {
  panic!("expected struct info");
};

let field = type_info.field("bar").unwrap();

let field_info = field.type_info().unwrap();
assert!(field_info.is::<usize>());;
```

The particular implementation was chosen for two reasons.

Firstly, we can't just store `TypeInfo` inside another `TypeInfo` directly. This is because some types are recursive and would result in a deadlock when trying to create the `TypeInfo` (i.e. it has to create the `TypeInfo` before it can use it, but it also needs the `TypeInfo` before it can create it). Therefore, we must instead store the function so it can be retrieved lazily.

I had considered also using a `OnceLock` or something to lazily cache the info, but I figured we can look into optimizations later. The API should remain the same with or without the `OnceLock`.

Secondly, a new wrapper trait had to be introduced: `MaybeTyped`. Like `RegisterForReflection`, this trait is `#[doc(hidden)]` and only exists so that we can properly handle dynamic type fields without requiring them to implement `Typed`. We don't want dynamic types to implement `Typed` due to the fact that it would make the return type `Option<&'static TypeInfo>` for all types even though only the dynamic types ever need to return `None` (see #6971 for details).

Users should never have to interact with this trait as it has a blanket impl for all `Typed` types. And `Typed` is automatically implemented when deriving `Reflect` (as it is required).

The one downside is we do need to return `Option<&'static TypeInfo>` from all these new methods so that we can handle the dynamic cases. If we didn't have to, we'd be able to get rid of the `Option` entirely. But I think that's an okay tradeoff for this one part of the API, and keeps the other APIs intact.

## Testing

This PR contains tests to verify everything works as expected. You can test locally by running:

```
cargo test --package bevy_reflect
```

---

## Changelog

### Public Changes

- Added `ArrayInfo::item_info` method
- Added `NamedField::type_info` method
- Added `UnnamedField::type_info` method
- Added `ListInfo::item_info` method
- Added `MapInfo::key_info` method
- Added `MapInfo::value_info` method
- All active fields now have a `Typed` bound (remember that this is automatically satisfied for all types that derive `Reflect`)

### Internal Changes

- Added `MaybeTyped` trait

## Migration Guide

All active fields for reflected types (including lists, maps, tuples, etc.), must implement `Typed`. For the majority of users this won't have any visible impact.

However, users implementing `Reflect` manually may need to update their types to implement `Typed` if they weren't already.

Additionally, custom dynamic types will need to implement the new hidden `MaybeTyped` trait.