### PR TITLE
disable gpu preprocessing on android with Adreno 6xx GPU

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -222,7 +222,9 @@ impl FromWorld for GpuPreprocessingSupport {
         let adapter = world.resource::<RenderAdapter>();
         let device = world.resource::<RenderDevice>();
 
-        if device.limits().max_compute_workgroup_size_x == 0 {
+        if device.limits().max_compute_workgroup_size_x == 0 ||
+            !device.features().contains(Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING)
+        {
             GpuPreprocessingSupport::None
         } else if !device
             .features()

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -223,7 +223,8 @@ impl FromWorld for GpuPreprocessingSupport {
         let device = world.resource::<RenderDevice>();
 
         if device.limits().max_compute_workgroup_size_x == 0 ||
-            !device.features().contains(Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING)
+            // filter lower end / older devices on Android as they crash when using GPU preprocessing
+            (cfg!(target_os = "android") && !device.features().contains(Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING))
         {
             GpuPreprocessingSupport::None
         } else if !device

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -224,7 +224,7 @@ impl FromWorld for GpuPreprocessingSupport {
 
         if device.limits().max_compute_workgroup_size_x == 0 ||
             // filter lower end / older devices on Android as they crash when using GPU preprocessing
-            (cfg!(target_os = "android") && !device.features().contains(Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING))
+            (cfg!(target_os = "android") && adapter.get_info().name.starts_with("Adreno (TM) 6"))
         {
             GpuPreprocessingSupport::None
         } else if !device


### PR DESCRIPTION
# Objective

- Fixes #13038 

## Solution

- Disable gpu preprocessing when feature `SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING` is not available

## Testing

- Tested on android device that used to crash
