### PR TITLE
gizmos: take normal of normal on plane 3d before rotation

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -245,7 +245,7 @@ where
         let normal = self.rotation * *self.normal;
         self.gizmos
             .primitive_3d(self.normal, self.position, self.rotation, self.color);
-        let normals_normal = normal.any_orthonormal_vector();
+        let normals_normal = self.rotation * self.normal.any_orthonormal_vector();
 
         // draws the axes
         // get rotation for each direction


### PR DESCRIPTION
# Objective

- Example `render_primitives` is painful to look at for the plane in 3d, the gizmo seems to have extra rotations

https://github.com/bevyengine/bevy/assets/8672791/08509624-14ac-4f00-a758-9a14233ef1a9

## Solution

- Take the normal of the normal before rotation, then rotate it

## Testing

- Run the example, rotations are more in sync

https://github.com/bevyengine/bevy/assets/8672791/91c26ce4-4b7b-4575-ba32-7c32026e4596



