### PR TITLE
Ignore emissive_light when multiplying with exposure

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -585,7 +585,7 @@ fn apply_pbr_lighting(
 
     // Total light
     output_color = vec4<f32>(
-        view_bindings::view.exposure * (transmitted_light + direct_light + indirect_light + emissive_light),
+        (view_bindings::view.exposure * (transmitted_light + direct_light + indirect_light)) + emissive_light,
         output_color.a
     );
 


### PR DESCRIPTION
# Objective

- Google's Filament uses an exposure compensation for emissive surfaces: https://google.github.io/filament/Filament.md.html#imagingpipeline/physicallybasedcamera/bloom
- PR #11347 ignores this which results in height emissive values needed
- Fixes #13133

## Solution

- This solution just ignores emissive_light when multiplying with exposure

## Testing

![emissive_fix](https://github.com/bevyengine/bevy/assets/688816/1618dd1f-ae49-43e2-bc12-a7779d73be71)
