### PR TITLE
Add reflect impls for bevy_math curve structs

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -42,7 +42,8 @@ use thiserror::Error;
 /// ```
 #[derive(Clone, Debug)]
 pub struct CubicBezier<P: VectorSpace> {
-    control_points: Vec<[P; 4]>,
+    /// The control points of the Bezier curve
+    pub control_points: Vec<[P; 4]>,
 }
 
 impl<P: VectorSpace> CubicBezier<P> {
@@ -114,7 +115,8 @@ impl<P: VectorSpace> CubicGenerator<P> for CubicBezier<P> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct CubicHermite<P: VectorSpace> {
-    control_points: Vec<(P, P)>,
+    /// The control points of the Hermite curve
+    pub control_points: Vec<(P, P)>,
 }
 impl<P: VectorSpace> CubicHermite<P> {
     /// Create a new Hermite curve from sets of control points.
@@ -181,8 +183,10 @@ impl<P: VectorSpace> CubicGenerator<P> for CubicHermite<P> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct CubicCardinalSpline<P: VectorSpace> {
-    tension: f32,
-    control_points: Vec<P>,
+    /// Tension
+    pub tension: f32,
+    /// The control points of the Cardinal spline
+    pub control_points: Vec<P>,
 }
 
 impl<P: VectorSpace> CubicCardinalSpline<P> {
@@ -269,7 +273,8 @@ impl<P: VectorSpace> CubicGenerator<P> for CubicCardinalSpline<P> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct CubicBSpline<P: VectorSpace> {
-    control_points: Vec<P>,
+    /// The control points of the spline
+    pub control_points: Vec<P>,
 }
 impl<P: VectorSpace> CubicBSpline<P> {
     /// Build a new B-Spline.
@@ -387,9 +392,12 @@ pub enum CubicNurbsError {
 /// ```
 #[derive(Clone, Debug)]
 pub struct CubicNurbs<P: VectorSpace> {
-    control_points: Vec<P>,
-    weights: Vec<f32>,
-    knots: Vec<f32>,
+    /// The control points of the NURBS
+    pub control_points: Vec<P>,
+    /// Weights
+    pub weights: Vec<f32>,
+    /// Knots
+    pub knots: Vec<f32>,
 }
 impl<P: VectorSpace> CubicNurbs<P> {
     /// Build a Non-Uniform Rational B-Spline.
@@ -592,7 +600,8 @@ impl<P: VectorSpace> RationalGenerator<P> for CubicNurbs<P> {
 /// The curve is C0 continuous, meaning it has no holes or jumps.
 #[derive(Clone, Debug)]
 pub struct LinearSpline<P: VectorSpace> {
-    points: Vec<P>,
+    /// The control points of the NURBS
+    pub points: Vec<P>,
 }
 impl<P: VectorSpace> LinearSpline<P> {
     /// Create a new linear spline
@@ -632,7 +641,8 @@ pub trait CubicGenerator<P: VectorSpace> {
 /// Segments can be chained together to form a longer compound curve.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct CubicSegment<P: VectorSpace> {
-    coeff: [P; 4],
+    /// Coefficients of the segment
+    pub coeff: [P; 4],
 }
 
 impl<P: VectorSpace> CubicSegment<P> {
@@ -790,7 +800,8 @@ impl CubicSegment<Vec2> {
 /// [`CubicBezier`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct CubicCurve<P: VectorSpace> {
-    segments: Vec<CubicSegment<P>>,
+    /// Segments of the curve
+    pub segments: Vec<CubicSegment<P>>,
 }
 
 impl<P: VectorSpace> CubicCurve<P> {
@@ -923,11 +934,11 @@ pub trait RationalGenerator<P: VectorSpace> {
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct RationalSegment<P: VectorSpace> {
     /// The coefficients matrix of the cubic curve.
-    coeff: [P; 4],
+    pub coeff: [P; 4],
     /// The homogeneous weight coefficients.
-    weight_coeff: [f32; 4],
+    pub weight_coeff: [f32; 4],
     /// The width of the domain of this segment.
-    knot_span: f32,
+    pub knot_span: f32,
 }
 
 impl<P: VectorSpace> RationalSegment<P> {
@@ -1049,7 +1060,8 @@ impl<P: VectorSpace> RationalSegment<P> {
 /// [`CubicNurbs`], or convert [`CubicCurve`] using `into/from`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RationalCurve<P: VectorSpace> {
-    segments: Vec<RationalSegment<P>>,
+    /// The segments in the curve
+    pub segments: Vec<RationalSegment<P>>,
 }
 
 impl<P: VectorSpace> RationalCurve<P> {

--- a/crates/bevy_reflect/src/impls/math/cubic_splines.rs
+++ b/crates/bevy_reflect/src/impls/math/cubic_splines.rs
@@ -1,0 +1,93 @@
+use crate as bevy_reflect;
+// use crate::{ReflectDeserialize, ReflectSerialize};
+use bevy_math::{cubic_splines::*, VectorSpace};
+use bevy_reflect_derive::impl_reflect;
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicBezier<P: VectorSpace> {
+        control_points: Vec<[P; 4]>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicHermite<P: VectorSpace> {
+        control_points: Vec<(P, P)>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicCardinalSpline<P: VectorSpace> {
+        tension: f32,
+        control_points: Vec<P>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicBSpline<P: VectorSpace> {
+        control_points: Vec<P>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicNurbs<P: VectorSpace> {
+        control_points: Vec<P>,
+        weights: Vec<f32>,
+        knots: Vec<f32>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct LinearSpline<P: VectorSpace> {
+        points: Vec<P>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[reflect(PartialEq, where P: PartialEq)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicSegment<P: VectorSpace> {
+        coeff: [P; 4],
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[reflect(PartialEq, where P: PartialEq)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct CubicCurve<P: VectorSpace> {
+        segments: Vec<CubicSegment<P>>,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[reflect(PartialEq, where P: PartialEq)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct RationalSegment<P: VectorSpace> {
+        coeff: [P; 4],
+        weight_coeff: [f32; 4],
+        knot_span: f32,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug)]
+    #[reflect(PartialEq, where P: PartialEq)]
+    #[type_path = "bevy_math::cubic_splines"]
+    struct RationalCurve<P: VectorSpace> {
+        segments: Vec<RationalSegment<P>>,
+    }
+);

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -493,6 +493,7 @@ mod impls {
 
     #[cfg(feature = "bevy_math")]
     mod math {
+        mod cubic_splines;
         mod direction;
         mod primitives2d;
         mod primitives3d;


### PR DESCRIPTION
# Objective

Fixes #13189

## Solution

To add the reflect impls I needed to make all the struct fields pub. I don't think there's any harm for these types, but just a note for review.
