### PR TITLE
[bevy_ui/layout] Make fields private in UiSurface

### DIFF
--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -1,101 +1,17 @@
-use std::fmt::Write;
-
-use taffy::{NodeId, TraversePartialTree};
-
-use bevy_ecs::prelude::Entity;
-use bevy_utils::HashMap;
-
 use crate::layout::ui_surface::UiSurface;
 
-/// Prints a debug representation of the computed layout of the UI layout tree for each window.
+/// Prints a debug representation of the computed layout of the UI layout tree for each camera.
+#[deprecated(
+    since = "0.13.3",
+    note = "use `ui_surface.ui_layout_tree_debug_string()` instead"
+)]
 pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
-    let taffy_to_entity: HashMap<NodeId, Entity> = ui_surface
-        .entity_to_taffy()
-        .iter()
-        .map(|(&ui_entity, &taffy_node)| (taffy_node, ui_entity))
-        .collect::<HashMap<NodeId, Entity>>();
-    for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes().iter() {
-        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity}");
-        for &root_node_entity in root_node_set.iter() {
-            let Some(implicit_viewport_node) = ui_surface
-                .root_node_data()
-                .get(&root_node_entity)
-                .map(|rnd| rnd.implicit_viewport_node)
-            else {
-                continue;
-            };
-            let mut out = String::new();
-            print_node(
-                ui_surface,
-                &taffy_to_entity,
-                camera_entity,
-                implicit_viewport_node,
-                false,
-                String::new(),
-                &mut out,
-            );
-
-            bevy_utils::tracing::info!("{out}");
+    let debug_layout_tree = match ui_surface.ui_layout_tree_debug_string() {
+        Ok(output) => output,
+        Err(err) => {
+            bevy_utils::tracing::error!("Failed to print ui layout tree: {err}");
+            return;
         }
-    }
-}
-
-/// Recursively navigates the layout tree printing each node's information.
-fn print_node(
-    ui_surface: &UiSurface,
-    taffy_to_entity: &HashMap<NodeId, Entity>,
-    entity: Entity,
-    node: NodeId,
-    has_sibling: bool,
-    lines_string: String,
-    acc: &mut String,
-) {
-    let tree = &ui_surface.taffy();
-    let layout = tree.layout(node).unwrap();
-    let style = tree.style(node).unwrap();
-
-    let num_children = tree.child_count(node);
-
-    let display_variant = match (num_children, style.display) {
-        (_, taffy::style::Display::None) => "NONE",
-        (0, _) => "LEAF",
-        (_, taffy::style::Display::Flex) => "FLEX",
-        (_, taffy::style::Display::Grid) => "GRID",
-        (_, taffy::style::Display::Block) => "BLOCK",
     };
-
-    let fork_string = if has_sibling {
-        "├── "
-    } else {
-        "└── "
-    };
-    writeln!(
-        acc,
-        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({entity:?}) {measured}",
-        lines = lines_string,
-        fork = fork_string,
-        display = display_variant,
-        x = layout.location.x,
-        y = layout.location.y,
-        width = layout.size.width,
-        height = layout.size.height,
-        measured = if tree.get_node_context(node).is_some() { "measured" } else { "" }
-    ).ok();
-    let bar = if has_sibling { "│   " } else { "    " };
-    let new_string = lines_string + bar;
-
-    // Recurse into children
-    for (index, child_node) in tree.children(node).unwrap().iter().enumerate() {
-        let has_sibling = index < num_children - 1;
-        let child_entity = taffy_to_entity.get(child_node).unwrap();
-        print_node(
-            ui_surface,
-            taffy_to_entity,
-            *child_entity,
-            *child_node,
-            has_sibling,
-            new_string.clone(),
-            acc,
-        );
-    }
+    bevy_utils::tracing::info!("{debug_layout_tree}");
 }

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -10,15 +10,15 @@ use crate::layout::ui_surface::UiSurface;
 /// Prints a debug representation of the computed layout of the UI layout tree for each window.
 pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
     let taffy_to_entity: HashMap<NodeId, Entity> = ui_surface
-        .entity_to_taffy
+        .entity_to_taffy()
         .iter()
         .map(|(&ui_entity, &taffy_node)| (taffy_node, ui_entity))
         .collect::<HashMap<NodeId, Entity>>();
-    for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes.iter() {
+    for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes().iter() {
         bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity}");
         for &root_node_entity in root_node_set.iter() {
             let Some(implicit_viewport_node) = ui_surface
-                .root_node_data
+                .root_node_data()
                 .get(&root_node_entity)
                 .map(|rnd| rnd.implicit_viewport_node)
             else {
@@ -50,7 +50,7 @@ fn print_node(
     lines_string: String,
     acc: &mut String,
 ) {
-    let tree = &ui_surface.taffy;
+    let tree = &ui_surface.taffy();
     let layout = tree.layout(node).unwrap();
     let style = tree.style(node).unwrap();
 

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -12,22 +12,31 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
     let taffy_to_entity: HashMap<NodeId, Entity> = ui_surface
         .entity_to_taffy
         .iter()
-        .map(|(entity, node)| (*node, *entity))
-        .collect();
-    for (&entity, roots) in &ui_surface.camera_roots {
-        let mut out = String::new();
-        for root in roots {
+        .map(|(&ui_entity, &taffy_node)| (taffy_node, ui_entity))
+        .collect::<HashMap<NodeId, Entity>>();
+    for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes.iter() {
+        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity}");
+        for &root_node_entity in root_node_set.iter() {
+            let Some(implicit_viewport_node) = ui_surface
+                .root_node_data
+                .get(&root_node_entity)
+                .map(|rnd| rnd.implicit_viewport_node)
+            else {
+                continue;
+            };
+            let mut out = String::new();
             print_node(
                 ui_surface,
                 &taffy_to_entity,
-                entity,
-                root.implicit_viewport_node,
+                camera_entity,
+                implicit_viewport_node,
                 false,
                 String::new(),
                 &mut out,
             );
+
+            bevy_utils::tracing::info!("{out}");
         }
-        bevy_utils::tracing::info!("Layout tree for camera entity: {entity:?}\n{out}");
     }
 }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -476,8 +476,8 @@ mod tests {
 
         // no UI entities in world, none in UiSurface
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.entity_to_taffy.is_empty());
-        assert!(ui_surface.root_node_data.is_empty());
+        assert!(ui_surface.entity_to_taffy().is_empty());
+        assert!(ui_surface.root_node_data().is_empty());
 
         let ui_entity = world.spawn(NodeBundle::default()).id();
 
@@ -485,10 +485,10 @@ mod tests {
         ui_schedule.run(world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.entity_to_taffy.contains_key(&ui_entity));
-        assert_eq!(ui_surface.entity_to_taffy.len(), 1);
-        assert!(ui_surface.root_node_data.contains_key(&ui_entity));
-        assert_eq!(ui_surface.root_node_data.len(), 1);
+        assert!(ui_surface.entity_to_taffy().contains_key(&ui_entity));
+        assert_eq!(ui_surface.entity_to_taffy().len(), 1);
+        assert!(ui_surface.root_node_data().contains_key(&ui_entity));
+        assert_eq!(ui_surface.root_node_data().len(), 1);
 
         let child_entity = world.spawn(NodeBundle::default()).id();
         world.commands().entity(ui_entity).add_child(child_entity);
@@ -497,17 +497,17 @@ mod tests {
         ui_schedule.run(world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.entity_to_taffy.contains_key(&child_entity));
-        assert_eq!(ui_surface.entity_to_taffy.len(), 2);
+        assert!(ui_surface.entity_to_taffy().contains_key(&child_entity));
+        assert_eq!(ui_surface.entity_to_taffy().len(), 2);
         assert!(
-            !ui_surface.root_node_data.contains_key(&child_entity),
+            !ui_surface.root_node_data().contains_key(&child_entity),
             "child should not have been added as a root node"
         );
-        assert_eq!(ui_surface.root_node_data.len(), 1);
-        let ui_taffy = ui_surface.entity_to_taffy.get(&ui_entity).unwrap();
-        let child_taffy = ui_surface.entity_to_taffy.get(&child_entity).unwrap();
+        assert_eq!(ui_surface.root_node_data().len(), 1);
+        let ui_taffy = ui_surface.entity_to_taffy().get(&ui_entity).unwrap();
+        let child_taffy = ui_surface.entity_to_taffy().get(&child_entity).unwrap();
         assert_eq!(
-            ui_surface.taffy.parent(*child_taffy),
+            ui_surface.taffy().parent(*child_taffy),
             Some(*ui_taffy),
             "expected to be child of root node"
         );
@@ -526,11 +526,11 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(!ui_surface.entity_to_taffy.contains_key(&ui_entity));
-        assert_eq!(ui_surface.entity_to_taffy.len(), 1);
-        assert!(!ui_surface.root_node_data.contains_key(&ui_entity));
-        assert!(ui_surface.root_node_data.is_empty());
-        assert_eq!(ui_surface.taffy.total_node_count(), 1);
+        assert!(!ui_surface.entity_to_taffy().contains_key(&ui_entity));
+        assert_eq!(ui_surface.entity_to_taffy().len(), 1);
+        assert!(!ui_surface.root_node_data().contains_key(&ui_entity));
+        assert!(ui_surface.root_node_data().is_empty());
+        assert_eq!(ui_surface.taffy().total_node_count(), 1);
     }
 
     #[test]
@@ -544,11 +544,11 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(!ui_surface.entity_to_taffy.contains_key(&ui_entity));
-        assert!(ui_surface.entity_to_taffy.is_empty());
-        assert!(!ui_surface.root_node_data.contains_key(&ui_entity));
-        assert!(ui_surface.root_node_data.is_empty());
-        assert_eq!(ui_surface.taffy.total_node_count(), 0);
+        assert!(!ui_surface.entity_to_taffy().contains_key(&ui_entity));
+        assert!(ui_surface.entity_to_taffy().is_empty());
+        assert!(!ui_surface.root_node_data().contains_key(&ui_entity));
+        assert!(ui_surface.root_node_data().is_empty());
+        assert_eq!(ui_surface.taffy().total_node_count(), 0);
     }
 
     #[test]
@@ -562,11 +562,11 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.entity_to_taffy.contains_key(&ui_entity));
-        assert_eq!(ui_surface.entity_to_taffy.len(), 1);
-        assert!(ui_surface.root_node_data.contains_key(&ui_entity));
-        assert_eq!(ui_surface.root_node_data.len(), 1);
-        assert_eq!(ui_surface.taffy.total_node_count(), 2);
+        assert!(ui_surface.entity_to_taffy().contains_key(&ui_entity));
+        assert_eq!(ui_surface.entity_to_taffy().len(), 1);
+        assert!(ui_surface.root_node_data().contains_key(&ui_entity));
+        assert_eq!(ui_surface.root_node_data().len(), 1);
+        assert_eq!(ui_surface.taffy().total_node_count(), 2);
     }
 
     #[test]
@@ -586,7 +586,7 @@ mod tests {
 
         // no UI entities in world, none in UiSurface
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.camera_root_nodes.is_empty());
+        assert!(ui_surface.camera_root_nodes().is_empty());
 
         // respawn camera
         let camera_entity = world.spawn(Camera2dBundle::default()).id();
@@ -599,8 +599,8 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
-        assert_eq!(ui_surface.camera_root_nodes.len(), 1);
+        assert!(ui_surface.camera_root_nodes().contains_key(&camera_entity));
+        assert_eq!(ui_surface.camera_root_nodes().len(), 1);
 
         world.despawn(ui_entity);
         world.despawn(camera_entity);
@@ -609,8 +609,8 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
-        assert!(ui_surface.camera_root_nodes.is_empty());
+        assert!(!ui_surface.camera_root_nodes().contains_key(&camera_entity));
+        assert!(ui_surface.camera_root_nodes().is_empty());
     }
 
     #[test]
@@ -625,7 +625,7 @@ mod tests {
 
         // retrieve the ui node corresponding to `ui_entity` from ui surface
         let ui_surface = world.resource::<UiSurface>();
-        let ui_node = ui_surface.entity_to_taffy[&ui_entity];
+        let ui_node = ui_surface.entity_to_taffy()[&ui_entity];
 
         world.despawn(ui_entity);
 
@@ -635,9 +635,9 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
 
-        assert_eq!(ui_surface.taffy.total_node_count(), 0);
+        assert_eq!(ui_surface.taffy().total_node_count(), 0);
         // `ui_node` is removed, attempting to retrieve a style for `ui_node` panics
-        let _ = ui_surface.taffy.style(ui_node);
+        let _ = ui_surface.taffy().style(ui_node);
     }
 
     #[test]
@@ -650,10 +650,10 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        let ui_parent_node = ui_surface.entity_to_taffy[&ui_parent_entity];
+        let ui_parent_node = ui_surface.entity_to_taffy()[&ui_parent_entity];
 
         // `ui_parent_node` shouldn't have any children yet
-        assert_eq!(ui_surface.taffy.child_count(ui_parent_node), 0);
+        assert_eq!(ui_surface.taffy().child_count(ui_parent_node), 0);
 
         let mut ui_child_entities = (0..10)
             .map(|_| {
@@ -668,23 +668,23 @@ mod tests {
         // `ui_parent_node` should have children now
         let ui_surface = world.resource::<UiSurface>();
         assert_eq!(
-            ui_surface.entity_to_taffy.len(),
+            ui_surface.entity_to_taffy().len(),
             1 + ui_child_entities.len()
         );
         assert_eq!(
-            ui_surface.taffy.child_count(ui_parent_node),
+            ui_surface.taffy().child_count(ui_parent_node),
             ui_child_entities.len()
         );
 
         let child_node_map = HashMap::from_iter(
             ui_child_entities
                 .iter()
-                .map(|child_entity| (*child_entity, ui_surface.entity_to_taffy[child_entity])),
+                .map(|child_entity| (*child_entity, ui_surface.entity_to_taffy()[child_entity])),
         );
 
         // the children should have a corresponding ui node and that ui node's parent should be `ui_parent_node`
         for node in child_node_map.values() {
-            assert_eq!(ui_surface.taffy.parent(*node), Some(ui_parent_node));
+            assert_eq!(ui_surface.taffy().parent(*node), Some(ui_parent_node));
         }
 
         // delete every second child
@@ -699,21 +699,21 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
         assert_eq!(
-            ui_surface.entity_to_taffy.len(),
+            ui_surface.entity_to_taffy().len(),
             1 + ui_child_entities.len()
         );
         assert_eq!(
-            ui_surface.taffy.child_count(ui_parent_node),
+            ui_surface.taffy().child_count(ui_parent_node),
             ui_child_entities.len()
         );
 
         // the remaining children should still have nodes in the layout tree
         for child_entity in &ui_child_entities {
             let child_node = child_node_map[child_entity];
-            assert_eq!(ui_surface.entity_to_taffy[child_entity], child_node);
-            assert_eq!(ui_surface.taffy.parent(child_node), Some(ui_parent_node));
+            assert_eq!(ui_surface.entity_to_taffy()[child_entity], child_node);
+            assert_eq!(ui_surface.taffy().parent(child_node), Some(ui_parent_node));
             assert!(ui_surface
-                .taffy
+                .taffy()
                 .children(ui_parent_node)
                 .unwrap()
                 .contains(&child_node));
@@ -722,11 +722,11 @@ mod tests {
         // the nodes of the deleted children should have been removed from the layout tree
         for deleted_child_entity in &deleted_children {
             assert!(!ui_surface
-                .entity_to_taffy
+                .entity_to_taffy()
                 .contains_key(deleted_child_entity));
             let deleted_child_node = child_node_map[deleted_child_entity];
             assert!(!ui_surface
-                .taffy
+                .taffy()
                 .children(ui_parent_node)
                 .unwrap()
                 .contains(&deleted_child_node));
@@ -739,8 +739,8 @@ mod tests {
 
         // all nodes should have been deleted
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.entity_to_taffy.is_empty());
-        assert_eq!(ui_surface.taffy.total_node_count(), 0);
+        assert!(ui_surface.entity_to_taffy().is_empty());
+        assert_eq!(ui_surface.taffy().total_node_count(), 0);
     }
 
     /// regression test for >=0.13.1 root node layouts
@@ -903,7 +903,7 @@ mod tests {
         }
 
         fn get_taffy_node_count(world: &World) -> usize {
-            world.resource::<UiSurface>().taffy.total_node_count()
+            world.resource::<UiSurface>().taffy().total_node_count()
         }
 
         let (mut world, mut ui_schedule) = setup_ui_test_world();
@@ -1015,10 +1015,10 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        let ui_node = ui_surface.entity_to_taffy[&ui_entity];
+        let ui_node = ui_surface.entity_to_taffy()[&ui_entity];
 
         // a node with a content size should have taffy context
-        assert!(ui_surface.taffy.get_node_context(ui_node).is_some());
+        assert!(ui_surface.taffy().get_node_context(ui_node).is_some());
         let layout = ui_surface.get_layout(ui_entity).unwrap();
         assert_eq!(layout.size.width, content_size.x);
         assert_eq!(layout.size.height, content_size.y);
@@ -1029,7 +1029,7 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
         // a node without a content size should not have taffy context
-        assert!(ui_surface.taffy.get_node_context(ui_node).is_none());
+        assert!(ui_surface.taffy().get_node_context(ui_node).is_none());
 
         // Without a content size, the node has no width or height constraints so the length of both dimensions is 0.
         let layout = ui_surface.get_layout(ui_entity).unwrap();
@@ -1181,7 +1181,7 @@ mod tests {
         let ui_surface = world.get_resource::<UiSurface>().unwrap();
         // 1 for root node, 1 for implicit viewport node
         // 2 children
-        assert_eq!(ui_surface.taffy.total_node_count(), 4);
+        assert_eq!(ui_surface.taffy().total_node_count(), 4);
 
         (
             world,
@@ -1208,11 +1208,11 @@ mod tests {
 
         let ui_surface = world.get_resource::<UiSurface>().unwrap();
 
-        let parent_taffy = *ui_surface.entity_to_taffy.get(&parent_entity).unwrap();
-        let child1_taffy = *ui_surface.entity_to_taffy.get(&child1_entity).unwrap();
-        let child2_taffy = *ui_surface.entity_to_taffy.get(&child2_entity).unwrap();
-        assert_eq!(ui_surface.taffy.parent(child2_taffy), Some(child1_taffy));
-        assert_eq!(ui_surface.taffy.parent(child1_taffy), Some(parent_taffy));
+        let parent_taffy = *ui_surface.entity_to_taffy().get(&parent_entity).unwrap();
+        let child1_taffy = *ui_surface.entity_to_taffy().get(&child1_entity).unwrap();
+        let child2_taffy = *ui_surface.entity_to_taffy().get(&child2_entity).unwrap();
+        assert_eq!(ui_surface.taffy().parent(child2_taffy), Some(child1_taffy));
+        assert_eq!(ui_surface.taffy().parent(child1_taffy), Some(parent_taffy));
 
         world.commands().entity(parent_entity).despawn_recursive();
 
@@ -1220,7 +1220,7 @@ mod tests {
 
         let ui_surface = world.get_resource::<UiSurface>().unwrap();
         // all nodes should be removed
-        assert_eq!(ui_surface.taffy.total_node_count(), 0);
+        assert_eq!(ui_surface.taffy().total_node_count(), 0);
     }
 
     #[test]
@@ -1237,11 +1237,11 @@ mod tests {
 
         let ui_surface = world.get_resource::<UiSurface>().unwrap();
 
-        let parent_taffy = *ui_surface.entity_to_taffy.get(&parent_entity).unwrap();
-        let child1_taffy = *ui_surface.entity_to_taffy.get(&child1_entity).unwrap();
-        let child2_taffy = *ui_surface.entity_to_taffy.get(&child2_entity).unwrap();
-        assert_eq!(ui_surface.taffy.parent(child2_taffy), Some(child1_taffy));
-        assert_eq!(ui_surface.taffy.parent(child1_taffy), Some(parent_taffy));
+        let parent_taffy = *ui_surface.entity_to_taffy().get(&parent_entity).unwrap();
+        let child1_taffy = *ui_surface.entity_to_taffy().get(&child1_entity).unwrap();
+        let child2_taffy = *ui_surface.entity_to_taffy().get(&child2_entity).unwrap();
+        assert_eq!(ui_surface.taffy().parent(child2_taffy), Some(child1_taffy));
+        assert_eq!(ui_surface.taffy().parent(child1_taffy), Some(parent_taffy));
 
         world.commands().entity(child1_entity).despawn_recursive();
 
@@ -1249,6 +1249,6 @@ mod tests {
 
         let ui_surface = world.get_resource::<UiSurface>().unwrap();
         // only root node and implicit viewport left
-        assert_eq!(ui_surface.taffy.total_node_count(), 2);
+        assert_eq!(ui_surface.taffy().total_node_count(), 2);
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -220,7 +220,7 @@ pub fn ui_layout_system(
     for (camera_id, camera) in &camera_layout_info {
         let inverse_target_scale_factor = camera.scale_factor.recip();
 
-        ui_surface.compute_camera_layout(*camera_id, camera.size);
+        ui_surface.compute_camera_layout(camera_id, camera.size);
         for root in &camera.root_nodes {
             update_uinode_geometry_recursive(
                 *root,
@@ -357,7 +357,10 @@ mod tests {
     use bevy_ecs::schedule::Schedule;
     use bevy_ecs::system::RunSystemOnce;
     use bevy_ecs::world::World;
-    use bevy_hierarchy::{despawn_with_children_recursive, BuildWorldChildren, Children, Parent};
+    use bevy_hierarchy::{
+        despawn_with_children_recursive, BuildChildren, BuildWorldChildren, Children,
+        DespawnRecursiveExt, Parent,
+    };
     use bevy_math::{vec2, Rect, UVec2, Vec2};
     use bevy_render::camera::ManualTextureViews;
     use bevy_render::camera::OrthographicProjection;
@@ -468,24 +471,54 @@ mod tests {
         }
     }
 
-    #[test]
-    fn ui_surface_tracks_ui_entities() {
-        let (mut world, mut ui_schedule) = setup_ui_test_world();
-
-        ui_schedule.run(&mut world);
+    fn _track_ui_entity_setup(world: &mut World, ui_schedule: &mut Schedule) -> (Entity, Entity) {
+        ui_schedule.run(world);
 
         // no UI entities in world, none in UiSurface
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface.entity_to_taffy.is_empty());
+        assert!(ui_surface.root_node_data.is_empty());
 
         let ui_entity = world.spawn(NodeBundle::default()).id();
 
         // `ui_layout_system` should map `ui_entity` to a ui node in `UiSurface::entity_to_taffy`
-        ui_schedule.run(&mut world);
+        ui_schedule.run(world);
 
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface.entity_to_taffy.contains_key(&ui_entity));
         assert_eq!(ui_surface.entity_to_taffy.len(), 1);
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity));
+        assert_eq!(ui_surface.root_node_data.len(), 1);
+
+        let child_entity = world.spawn(NodeBundle::default()).id();
+        world.commands().entity(ui_entity).add_child(child_entity);
+
+        // `ui_layout_system` should add `child_entity` as a child of `ui_entity`
+        ui_schedule.run(world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.entity_to_taffy.contains_key(&child_entity));
+        assert_eq!(ui_surface.entity_to_taffy.len(), 2);
+        assert!(
+            !ui_surface.root_node_data.contains_key(&child_entity),
+            "child should not have been added as a root node"
+        );
+        assert_eq!(ui_surface.root_node_data.len(), 1);
+        let ui_taffy = ui_surface.entity_to_taffy.get(&ui_entity).unwrap();
+        let child_taffy = ui_surface.entity_to_taffy.get(&child_entity).unwrap();
+        assert_eq!(
+            ui_surface.taffy.parent(*child_taffy),
+            Some(*ui_taffy),
+            "expected to be child of root node"
+        );
+
+        (ui_entity, child_entity)
+    }
+
+    #[test]
+    fn ui_surface_tracks_ui_entities_despawn() {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+        let (ui_entity, _child_entity) = _track_ui_entity_setup(&mut world, &mut ui_schedule);
 
         world.despawn(ui_entity);
 
@@ -494,7 +527,46 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
         assert!(!ui_surface.entity_to_taffy.contains_key(&ui_entity));
+        assert_eq!(ui_surface.entity_to_taffy.len(), 1);
+        assert!(!ui_surface.root_node_data.contains_key(&ui_entity));
+        assert!(ui_surface.root_node_data.is_empty());
+        assert_eq!(ui_surface.taffy.total_node_count(), 1);
+    }
+
+    #[test]
+    fn ui_surface_tracks_ui_entities_despawn_recursive() {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+        let (ui_entity, _child_entity) = _track_ui_entity_setup(&mut world, &mut ui_schedule);
+
+        despawn_with_children_recursive(&mut world, ui_entity);
+
+        // `ui_layout_system` should remove `ui_entity` and `child_entity` from `UiSurface::entity_to_taffy`
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(!ui_surface.entity_to_taffy.contains_key(&ui_entity));
         assert!(ui_surface.entity_to_taffy.is_empty());
+        assert!(!ui_surface.root_node_data.contains_key(&ui_entity));
+        assert!(ui_surface.root_node_data.is_empty());
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
+    }
+
+    #[test]
+    fn ui_surface_tracks_ui_entities_despawn_descendants() {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+        let (ui_entity, _child_entity) = _track_ui_entity_setup(&mut world, &mut ui_schedule);
+
+        world.commands().entity(ui_entity).despawn_descendants();
+
+        // `ui_layout_system` should remove `child_entity` from `UiSurface::entity_to_taffy`
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.resource::<UiSurface>();
+        assert!(ui_surface.entity_to_taffy.contains_key(&ui_entity));
+        assert_eq!(ui_surface.entity_to_taffy.len(), 1);
+        assert!(ui_surface.root_node_data.contains_key(&ui_entity));
+        assert_eq!(ui_surface.root_node_data.len(), 1);
+        assert_eq!(ui_surface.taffy.total_node_count(), 2);
     }
 
     #[test]
@@ -514,7 +586,7 @@ mod tests {
 
         // no UI entities in world, none in UiSurface
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.camera_entity_to_taffy.is_empty());
+        assert!(ui_surface.camera_root_nodes.is_empty());
 
         // respawn camera
         let camera_entity = world.spawn(Camera2dBundle::default()).id();
@@ -527,10 +599,8 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface
-            .camera_entity_to_taffy
-            .contains_key(&camera_entity));
-        assert_eq!(ui_surface.camera_entity_to_taffy.len(), 1);
+        assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
+        assert_eq!(ui_surface.camera_root_nodes.len(), 1);
 
         world.despawn(ui_entity);
         world.despawn(camera_entity);
@@ -539,10 +609,8 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        assert!(!ui_surface
-            .camera_entity_to_taffy
-            .contains_key(&camera_entity));
-        assert!(ui_surface.camera_entity_to_taffy.is_empty());
+        assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
+        assert!(ui_surface.camera_root_nodes.is_empty());
     }
 
     #[test]
@@ -567,6 +635,7 @@ mod tests {
 
         let ui_surface = world.resource::<UiSurface>();
 
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
         // `ui_node` is removed, attempting to retrieve a style for `ui_node` panics
         let _ = ui_surface.taffy.style(ui_node);
     }
@@ -671,6 +740,7 @@ mod tests {
         // all nodes should have been deleted
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface.entity_to_taffy.is_empty());
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
     }
 
     /// regression test for >=0.13.1 root node layouts
@@ -1080,5 +1150,105 @@ mod tests {
         world.entity_mut(ui_root).add_child(ui_child);
 
         ui_schedule.run(&mut world);
+    }
+
+    struct DespawnTestEntityReference {
+        parent_entity: Entity,
+        child1_entity: Entity,
+        child2_entity: Entity,
+    }
+    fn recursive_despawn_setup() -> (World, Schedule, DespawnTestEntityReference) {
+        let (mut world, mut ui_schedule) = setup_ui_test_world();
+
+        let mut child1_entity = None;
+        let mut child2_entity = None;
+        let parent_entity = world
+            .spawn(NodeBundle::default())
+            .with_children(|children| {
+                child1_entity = Some(
+                    children
+                        .spawn(NodeBundle::default())
+                        .with_children(|children| {
+                            child2_entity = Some(children.spawn(NodeBundle::default()).id());
+                        })
+                        .id(),
+                );
+            })
+            .id();
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.get_resource::<UiSurface>().unwrap();
+        // 1 for root node, 1 for implicit viewport node
+        // 2 children
+        assert_eq!(ui_surface.taffy.total_node_count(), 4);
+
+        (
+            world,
+            ui_schedule,
+            DespawnTestEntityReference {
+                parent_entity,
+                child1_entity: child1_entity.expect("expected child 1"),
+                child2_entity: child2_entity.expect("expected child 2"),
+            },
+        )
+    }
+
+    #[test]
+    fn test_recursive_despawn_on_parent() {
+        let (
+            mut world,
+            mut ui_schedule,
+            DespawnTestEntityReference {
+                parent_entity,
+                child1_entity,
+                child2_entity,
+            },
+        ) = recursive_despawn_setup();
+
+        let ui_surface = world.get_resource::<UiSurface>().unwrap();
+
+        let parent_taffy = *ui_surface.entity_to_taffy.get(&parent_entity).unwrap();
+        let child1_taffy = *ui_surface.entity_to_taffy.get(&child1_entity).unwrap();
+        let child2_taffy = *ui_surface.entity_to_taffy.get(&child2_entity).unwrap();
+        assert_eq!(ui_surface.taffy.parent(child2_taffy), Some(child1_taffy));
+        assert_eq!(ui_surface.taffy.parent(child1_taffy), Some(parent_taffy));
+
+        world.commands().entity(parent_entity).despawn_recursive();
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.get_resource::<UiSurface>().unwrap();
+        // all nodes should be removed
+        assert_eq!(ui_surface.taffy.total_node_count(), 0);
+    }
+
+    #[test]
+    fn test_recursive_despawn_on_child() {
+        let (
+            mut world,
+            mut ui_schedule,
+            DespawnTestEntityReference {
+                parent_entity,
+                child1_entity,
+                child2_entity,
+            },
+        ) = recursive_despawn_setup();
+
+        let ui_surface = world.get_resource::<UiSurface>().unwrap();
+
+        let parent_taffy = *ui_surface.entity_to_taffy.get(&parent_entity).unwrap();
+        let child1_taffy = *ui_surface.entity_to_taffy.get(&child1_entity).unwrap();
+        let child2_taffy = *ui_surface.entity_to_taffy.get(&child2_entity).unwrap();
+        assert_eq!(ui_surface.taffy.parent(child2_taffy), Some(child1_taffy));
+        assert_eq!(ui_surface.taffy.parent(child1_taffy), Some(parent_taffy));
+
+        world.commands().entity(child1_entity).despawn_recursive();
+
+        ui_schedule.run(&mut world);
+
+        let ui_surface = world.get_resource::<UiSurface>().unwrap();
+        // only root node and implicit viewport left
+        assert_eq!(ui_surface.taffy.total_node_count(), 2);
     }
 }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -60,13 +60,13 @@ pub struct UiSurface {
     /// Maintains an entry for each root ui node (parentless), and any of its children
     ///
     /// (does not include the `implicit_viewport_node`)
-    pub(super) entity_to_taffy: EntityHashMap<taffy::NodeId>,
+    entity_to_taffy: EntityHashMap<taffy::NodeId>,
     /// Maps root ui node (parentless) `Entity` to its corresponding `RootNodeData`
-    pub(super) root_node_data: EntityHashMap<RootNodeData>,
+    root_node_data: EntityHashMap<RootNodeData>,
     /// Maps camera `Entity` to an associated `EntityHashSet` of root nodes (parentless)
-    pub(super) camera_root_nodes: EntityHashMap<EntityHashSet>,
+    camera_root_nodes: EntityHashMap<EntityHashSet>,
     /// Manages the UI Node Tree
-    pub(super) taffy: TaffyTree<NodeMeasure>,
+    taffy: TaffyTree<NodeMeasure>,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {
@@ -423,6 +423,23 @@ with UI components as a child of an entity without UI components, results may be
             );
             Err(LayoutError::InvalidHierarchy)
         }
+    }
+}
+
+// Expose readonly accessors for tests in mod
+#[cfg(test)]
+impl UiSurface {
+    pub(super) fn entity_to_taffy(&self) -> &EntityHashMap<taffy::NodeId> {
+        &self.entity_to_taffy
+    }
+    pub(super) fn root_node_data(&self) -> &EntityHashMap<RootNodeData> {
+        &self.root_node_data
+    }
+    pub(super) fn camera_root_nodes(&self) -> &EntityHashMap<EntityHashSet> {
+        &self.camera_root_nodes
+    }
+    pub(super) fn taffy(&self) -> &TaffyTree<NodeMeasure> {
+        &self.taffy
     }
 }
 


### PR DESCRIPTION
Blocked on:
- [x] https://github.com/bevyengine/bevy/pull/12803
- [ ] ~~https://github.com/bevyengine/bevy/pull/12804~~ https://github.com/bevyengine/bevy/pull/16362

---

# Objective

- Restrict read/write access to UiSurface fields to encourage using or writing functions that maintain the internal state exclusively inside `UiSurface`

## Solution

Since the fields were originally `pub(super)` and not used outside of testing, replacing direct access with `pub(super)` get accessors for `#[cfg(test)]` seemed like the path of least resistance.

## Testing

- Did you test these changes? If so, how? 
  - Tests passing
- Are there any parts that need more testing? 
  - Unlikely due to the scope
- How can other people (reviewers) test your changes? Is there anything specific they need to know? 
  - Evaluating the tests in `layout/mod` and how they've been updated to use the accessors. 
  - Determining a better name or method for the `ui_layout_tree_debug_string()`. Or if the function is an appropriate level of responsibility for the `UiSurface` struct in the first place. A trait that you have to import might be interesting. 
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  -  Linux

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Made `UiSurface` fields private and replaced direct `pub(super)` access with `pub(super)` get accessors for `layout/mod`.
- Added associated function to get the UI layout tree debug string (originally being directly printed in `layout/debug`)
