### PR TITLE
Add `RefreshState` resource and support same-state transitions

### DIFF
--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -337,6 +337,7 @@ impl SubApp {
             .contains_resource::<Events<StateTransitionEvent<S>>>()
         {
             setup_state_transitions_in_world(&mut self.world, Some(Startup.intern()));
+            self.init_resource::<RefreshState<S>>();
             self.add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_computed_state_systems(schedule);

--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -38,7 +38,7 @@ pub mod prelude {
     pub use crate::condition::*;
     #[doc(hidden)]
     pub use crate::state::{
-        apply_state_transition, ComputedStates, NextState, OnEnter, OnExit, OnTransition, State,
-        StateSet, StateTransition, StateTransitionEvent, States, SubStates,
+        apply_state_transition, ComputedStates, NextState, OnEnter, OnExit, OnTransition,
+        RefreshState, State, StateSet, StateTransition, StateTransitionEvent, States, SubStates,
     };
 }

--- a/crates/bevy_state/src/state/resources.rs
+++ b/crates/bevy_state/src/state/resources.rs
@@ -5,7 +5,9 @@ use bevy_ecs::{
     world::{FromWorld, World},
 };
 
-use super::{freely_mutable_state::FreelyMutableState, states::States};
+use super::{
+    computed_states::ComputedStates, freely_mutable_state::FreelyMutableState, states::States,
+};
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_ecs::prelude::ReflectResource;
@@ -132,19 +134,25 @@ impl<S: FreelyMutableState> NextState<S> {
     }
 }
 
-/// The flag that determines whether the computed or sub state `S` will be refreshed this frame.
+/// The flag that determines whether the computed state `S` will be refreshed this frame.
 ///
 /// Refreshing a state will apply its state transition even if nothing has changed, in which case
 /// there will be a state transition from the current state to itself.
-#[derive(Resource, Debug, Default)]
+#[derive(Resource, Debug)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(bevy_reflect::Reflect),
     reflect(Resource)
 )]
-pub struct RefreshState<S: States>(pub bool, PhantomData<S>);
+pub struct RefreshState<S: ComputedStates>(pub bool, PhantomData<S>);
 
-impl<S: States> RefreshState<S> {
+impl<S: ComputedStates> Default for RefreshState<S> {
+    fn default() -> Self {
+        Self(false, PhantomData)
+    }
+}
+
+impl<S: ComputedStates> RefreshState<S> {
     /// Plan to refresh the computed state `S`.
     pub fn refresh(&mut self) {
         self.0 = true;

--- a/crates/bevy_state/src/state/resources.rs
+++ b/crates/bevy_state/src/state/resources.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{marker::PhantomData, ops::Deref};
 
 use bevy_ecs::{
     system::Resource,
@@ -129,5 +129,24 @@ impl<S: FreelyMutableState> NextState<S> {
     /// Remove any pending changes to [`State<S>`]
     pub fn reset(&mut self) {
         *self = Self::Unchanged;
+    }
+}
+
+/// The flag that determines whether the computed or sub state `S` will be refreshed this frame.
+///
+/// Refreshing a state will apply its state transition even if nothing has changed, in which case
+/// there will be a state transition from the current state to itself.
+#[derive(Resource, Debug, Default)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(bevy_reflect::Reflect),
+    reflect(Resource)
+)]
+pub struct RefreshState<S: States>(pub bool, PhantomData<S>);
+
+impl<S: States> RefreshState<S> {
+    /// Plan to refresh the computed state `S`.
+    pub fn refresh(&mut self) {
+        self.0 = true;
     }
 }

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -143,14 +143,12 @@ impl<S: InnerStateSet> StateSet for S {
     fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
         schedule: &mut Schedule,
     ) {
-        let system = |refresh: Option<ResMut<RefreshState<T>>>,
-                      mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
+        let system = |mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
                       event: EventWriter<StateTransitionEvent<T>>,
                       commands: Commands,
                       current_state: Option<ResMut<State<T>>>,
                       state_set: Option<Res<State<S::RawState>>>| {
-            let refresh = refresh.is_some_and(|mut x| std::mem::take(&mut x.0));
-            if !refresh && parent_changed.is_empty() {
+            if parent_changed.is_empty() {
                 return;
             }
             parent_changed.clear();
@@ -243,14 +241,12 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let system = |refresh: Option<ResMut<RefreshState<T>>>,
-                              ($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,),
+                let system = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,),
                               event: EventWriter<StateTransitionEvent<T>>,
                               commands: Commands,
                               current_state: Option<ResMut<State<T>>>,
                               ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                    let refresh = refresh.is_some_and(|mut x| std::mem::take(&mut x.0));
-                    if !refresh && ($($evt.is_empty())&&*) {
+                    if ($($evt.is_empty())&&*) {
                         return;
                     }
                     $($evt.clear();)*

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -94,13 +94,14 @@ impl<S: InnerStateSet> StateSet for S {
     fn register_computed_state_systems_in_schedule<T: ComputedStates<SourceStates = Self>>(
         schedule: &mut Schedule,
     ) {
-        let system = |refresh: Option<Res<RefreshState<T>>>,
+        let system = |refresh: Option<ResMut<RefreshState<T>>>,
                       mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
                       event: EventWriter<StateTransitionEvent<T>>,
                       commands: Commands,
                       current_state: Option<ResMut<State<T>>>,
                       state_set: Option<Res<State<S::RawState>>>| {
-            if refresh.map_or(true, |x| !x.0) && parent_changed.is_empty() {
+            let refresh = refresh.is_some_and(|mut x| std::mem::take(&mut x.0));
+            if !refresh && parent_changed.is_empty() {
                 return;
             }
             parent_changed.clear();
@@ -142,13 +143,14 @@ impl<S: InnerStateSet> StateSet for S {
     fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
         schedule: &mut Schedule,
     ) {
-        let system = |refresh: Option<Res<RefreshState<T>>>,
+        let system = |refresh: Option<ResMut<RefreshState<T>>>,
                       mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
                       event: EventWriter<StateTransitionEvent<T>>,
                       commands: Commands,
                       current_state: Option<ResMut<State<T>>>,
                       state_set: Option<Res<State<S::RawState>>>| {
-            if refresh.map_or(true, |x| !x.0) && parent_changed.is_empty() {
+            let refresh = refresh.is_some_and(|mut x| std::mem::take(&mut x.0));
+            if !refresh && parent_changed.is_empty() {
                 return;
             }
             parent_changed.clear();
@@ -205,13 +207,14 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_computed_state_systems_in_schedule<T: ComputedStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let system = |refresh: Option<Res<RefreshState<T>>>,
+                let system = |refresh: Option<ResMut<RefreshState<T>>>,
                               ($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,),
                               event: EventWriter<StateTransitionEvent<T>>,
                               commands: Commands,
                               current_state: Option<ResMut<State<T>>>,
                               ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                    if refresh.map_or(true, |x| !x.0) && ($($evt.is_empty())&&*) {
+                    let refresh = refresh.is_some_and(|mut x| std::mem::take(&mut x.0));
+                    if !refresh && ($($evt.is_empty())&&*) {
                         return;
                     }
                     $($evt.clear();)*
@@ -240,13 +243,14 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let system = |refresh: Option<Res<RefreshState<T>>>,
+                let system = |refresh: Option<ResMut<RefreshState<T>>>,
                               ($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,),
                               event: EventWriter<StateTransitionEvent<T>>,
                               commands: Commands,
                               current_state: Option<ResMut<State<T>>>,
                               ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                    if refresh.map_or(true, |x| !x.0) && ($($evt.is_empty())&&*) {
+                    let refresh = refresh.is_some_and(|mut x| std::mem::take(&mut x.0));
+                    if !refresh && ($($evt.is_empty())&&*) {
                         return;
                     }
                     $($evt.clear();)*

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -106,7 +106,12 @@ impl<S: InnerStateSet> StateSet for S {
             }
             parent_changed.clear();
 
-            let new_state = S::convert_to_usable_state(state_set.as_deref()).and_then(T::compute);
+            let new_state =
+                if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
+                    T::compute(state_set)
+                } else {
+                    None
+                };
 
             let same_state = current_state.as_ref().map(|x| x.get()) == new_state.as_ref();
             if same_state && !should_refresh {
@@ -153,7 +158,12 @@ impl<S: InnerStateSet> StateSet for S {
             }
             parent_changed.clear();
 
-            let new_state = S::convert_to_usable_state(state_set.as_deref()).and_then(T::should_exist);
+            let new_state =
+                if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
+                    T::should_exist(state_set)
+                } else {
+                    None
+                };
 
             if current_state.is_none() || new_state.is_none() {
                 internal_apply_state_transition(event, commands, current_state, new_state);

--- a/crates/bevy_state/src/state/transitions.rs
+++ b/crates/bevy_state/src/state/transitions.rs
@@ -154,11 +154,17 @@ pub fn apply_state_transition<S: FreelyMutableState>(
     current_state: Option<ResMut<State<S>>>,
     next_state: Option<ResMut<NextState<S>>>,
 ) {
+    // We want to check if the State and NextState resources exist
     let Some(mut next_state) = next_state else {
         return;
     };
+    let next_state = mem::take(next_state.as_mut());
 
-    if let NextState::Pending(next_state) = mem::take(next_state.as_mut()) {
+    if current_state.is_none() {
+        return;
+    }
+
+    if let NextState::Pending(next_state) = next_state {
         internal_apply_state_transition(event, commands, current_state, Some(next_state));
     }
 }

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -35,6 +35,7 @@ fn main() {
                 rotate_bonus,
                 scoreboard_system,
                 spawn_bonus,
+                restart_keyboard,
             )
                 .run_if(in_state(GameState::Playing)),
         )
@@ -120,6 +121,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.i = BOARD_SIZE_I / 2;
     game.player.j = BOARD_SIZE_J / 2;
     game.player.move_cooldown = Timer::from_seconds(0.3, TimerMode::Once);
+    game.bonus.entity = None;
 
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(4.0, 10.0, 4.0),
@@ -385,7 +387,17 @@ fn scoreboard_system(game: Res<Game>, mut query: Query<&mut Text>) {
     text.sections[0].value = format!("Sugar Rush: {}", game.score);
 }
 
-// restart the game when pressing spacebar
+// restart the game on R press
+fn restart_keyboard(
+    mut next_state: ResMut<NextState<GameState>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyR) {
+        next_state.set(GameState::Playing);
+    }
+}
+
+// start a new game on spacebar press
 fn gameover_keyboard(
     mut next_state: ResMut<NextState<GameState>>,
     keyboard_input: Res<ButtonInput<KeyCode>>,


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/9130.

## Solution

Allow same-state transitions for freely mutable states via `next_state.set(current_state)`. Support same-state transitions for computed states via a new `RefreshState<S>` resource that explicitly flags a specific computed state to transition regardless of whether its value changes.

`RefreshState` can be understood as a limited `NextState` for computed states that can only trigger same-state transitions, necessary because same-state transitions for computed states cannot be implicitly assumed.

## Testing

- Manually tested the restart feature added to `cargo run --example alien_cake_addict`.
- **Have not yet tested refreshing computed states with `RefreshState`. This will require a new unit test and example.**

---

## Changelog

- Removed the check preventing state transitions from the current state to itself.
- Added a resource `RefreshState<S>` to flag a computed or sub state to transition regardless of whether its value changes.

## Migration Guide

`NextState<S>` can now trigger state transitions from the current state to itself. To preserve the old behavior, check the current state in `State<S>` before setting the next state.