### PR TITLE
Allow shapes to be constructed with zero values

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -726,7 +726,10 @@ impl RegularPolygon {
     /// Panics if `circumradius` is negative
     #[inline(always)]
     pub fn new(circumradius: f32, sides: usize) -> Self {
-        assert!(circumradius.is_sign_positive(), "polygon has a negative radius");
+        assert!(
+            circumradius.is_sign_positive(),
+            "polygon has a negative radius"
+        );
         assert!(sides > 2, "polygon has less than 3 sides");
 
         Self {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -726,7 +726,7 @@ impl RegularPolygon {
     /// Panics if `circumradius` is negative
     #[inline(always)]
     pub fn new(circumradius: f32, sides: usize) -> Self {
-        assert!(circumradius >= 0.0, "polygon has a negative radius");
+        assert!(circumradius.is_sign_positive(), "polygon has a negative radius");
         assert!(sides > 2, "polygon has less than 3 sides");
 
         Self {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -723,10 +723,10 @@ impl RegularPolygon {
     ///
     /// # Panics
     ///
-    /// Panics if `circumradius` is non-positive
+    /// Panics if `circumradius` is negative
     #[inline(always)]
     pub fn new(circumradius: f32, sides: usize) -> Self {
-        assert!(circumradius > 0.0, "polygon has a non-positive radius");
+        assert!(circumradius >= 0.0, "polygon has a negative radius");
         assert!(sides > 2, "polygon has less than 3 sides");
 
         Self {


### PR DESCRIPTION
# Objective

Fixes #13332.

## Solution

The assertion `circumradius >= 0.0` to allow zero.

Are there any other shapes that need to be allowed to be constructed with zero?