### PR TITLE
Enable depth of field on webgpu

### DIFF
--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -797,7 +797,7 @@ fn extract_depth_of_field_settings(
     mut commands: Commands,
     mut query: Extract<Query<(Entity, &DepthOfFieldSettings, &Projection)>>,
 ) {
-    if !DEPTH_TEXTURE_LOADING_SUPPORTED {
+    if !DEPTH_TEXTURE_SAMPLING_SUPPORTED {
         info_once!(
             "Disabling depth of field on this platform because depth textures aren't supported correctly"
         );
@@ -894,7 +894,7 @@ impl DepthOfFieldPipelines {
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-const DEPTH_TEXTURE_LOADING_SUPPORTED: bool = false;
+const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = false;
 /// Returns true if multisampled depth textures are supported on this platform.
 ///
 /// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,
@@ -903,4 +903,4 @@ const DEPTH_TEXTURE_LOADING_SUPPORTED: bool = false;
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
 #[cfg(not(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))))]
-const DEPTH_TEXTURE_LOADING_SUPPORTED: bool = true;
+const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = true;

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -889,7 +889,7 @@ impl DepthOfFieldPipelines {
 /// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
 fn depth_textures_are_supported() -> bool {
     false
 }
@@ -901,7 +901,7 @@ fn depth_textures_are_supported() -> bool {
 /// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))))]
 fn depth_textures_are_supported() -> bool {
     true
 }

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -119,16 +119,21 @@ pub enum DepthOfFieldMode {
     ///
     /// For more information, see [Wikipedia's article on *bokeh*].
     ///
-    /// This is the default.
+    /// This doesn't work on webgpu.
     ///
     /// [Wikipedia's article on *bokeh*]: https://en.wikipedia.org/wiki/Bokeh
-    #[default]
     Bokeh,
 
     /// A faster simulation, in which out-of-focus areas are simply blurred.
     ///
     /// This is less accurate to actual lens behavior and is generally less
     /// aesthetically pleasing but requires less video memory bandwidth.
+    ///
+    /// This is the default.
+    ///
+    /// This works on native and webgpu.
+    /// If targetting native platforms, consider using [`DepthOfFieldMode::Bokeh`] instead.
+    #[default]
     Gaussian,
 }
 

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -895,6 +895,7 @@ impl DepthOfFieldPipelines {
 /// disable depth of field entirely on WebGL 2.
 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
 const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = false;
+
 /// Returns true if multisampled depth textures are supported on this platform.
 ///
 /// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -119,7 +119,7 @@ pub enum DepthOfFieldMode {
     ///
     /// For more information, see [Wikipedia's article on *bokeh*].
     ///
-    /// This doesn't work on webgpu.
+    /// This doesn't work on WebGPU.
     ///
     /// [Wikipedia's article on *bokeh*]: https://en.wikipedia.org/wiki/Bokeh
     Bokeh,

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -132,7 +132,7 @@ pub enum DepthOfFieldMode {
     /// This is the default.
     ///
     /// This works on native and webgpu.
-    /// If targetting native platforms, consider using [`DepthOfFieldMode::Bokeh`] instead.
+    /// If targeting native platforms, consider using [`DepthOfFieldMode::Bokeh`] instead.
     #[default]
     Gaussian,
 }

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -795,12 +795,11 @@ impl SpecializedRenderPipeline for DepthOfFieldPipeline {
 /// Extracts all [`DepthOfFieldSettings`] components into the render world.
 fn extract_depth_of_field_settings(
     mut commands: Commands,
-    msaa: Extract<Res<Msaa>>,
     mut query: Extract<Query<(Entity, &DepthOfFieldSettings, &Projection)>>,
 ) {
-    if **msaa != Msaa::Off && !depth_textures_are_supported() {
+    if !depth_textures_are_supported() {
         info_once!(
-            "Disabling depth of field on this platform because depth textures aren't available"
+            "Disabling depth of field on this platform because depth textures aren't supported correctly"
         );
         return;
     }

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -902,5 +902,5 @@ const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = false;
 /// `sampler2DShadow` and will cheerfully generate invalid GLSL that tries to
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
-#[cfg(not(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))))]
+#[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
 const DEPTH_TEXTURE_SAMPLING_SUPPORTED: bool = true;

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -797,7 +797,7 @@ fn extract_depth_of_field_settings(
     mut commands: Commands,
     mut query: Extract<Query<(Entity, &DepthOfFieldSettings, &Projection)>>,
 ) {
-    if !depth_textures_are_supported() {
+    if !DEPTH_TEXTURE_LOADING_SUPPORTED {
         info_once!(
             "Disabling depth of field on this platform because depth textures aren't supported correctly"
         );
@@ -894,10 +894,7 @@ impl DepthOfFieldPipelines {
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-fn depth_textures_are_supported() -> bool {
-    false
-}
-
+const DEPTH_TEXTURE_LOADING_SUPPORTED: bool = false;
 /// Returns true if multisampled depth textures are supported on this platform.
 ///
 /// In theory, Naga supports depth textures on WebGL 2. In practice, it doesn't,
@@ -906,6 +903,4 @@ fn depth_textures_are_supported() -> bool {
 /// perform non-percentage-closer-filtering with such a sampler. Therefore we
 /// disable depth of field entirely on WebGL 2.
 #[cfg(not(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))))]
-fn depth_textures_are_supported() -> bool {
-    true
-}
+const DEPTH_TEXTURE_LOADING_SUPPORTED: bool = true;

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -131,7 +131,7 @@ pub enum DepthOfFieldMode {
     ///
     /// This is the default.
     ///
-    /// This works on native and webgpu.
+    /// This works on native and WebGPU.
     /// If targeting native platforms, consider using [`DepthOfFieldMode::Bokeh`] instead.
     #[default]
     Gaussian,


### PR DESCRIPTION
# Objective

- Depth of field is currently disabled on any wasm targets, but the bug it's trying to avoid is only an issue in webgl.

## Solution

- Enable dof when compiling for webgpu
- I also remove the msaa check because sampling a depth texture doesn't work with or without msaa in webgl
- Unfortunately, Bokeh seems to be broken when using webgpu, so default to Gaussian instead to make sure the defaults have the broadest platform support

## Testing

- I added dof to the 3d_shapes example and compiled it to webgpu to confirm it works
- I also tried compiling to webgl to confirm things still works and dof isn't rendered.