### PR TITLE
EntityRef/Mut get_components

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -161,7 +161,7 @@ impl<'w> EntityRef<'w> {
 
     /// Returns read-only components for the current entity that match the query `Q`.
     pub fn get_components<Q: ReadOnlyQueryData>(&self) -> Option<Q::Item<'w>> {
-        // SAFETY: &mut self implies exclusive access for duration of returned value
+        // SAFETY: We have read-only access to all components of this entity.
         unsafe { self.0.get_components::<Q>() }
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -371,7 +371,7 @@ impl<'w> EntityMut<'w> {
 
     /// Returns read-only components for the current entity that match the query `Q`.
     pub fn get_components<Q: ReadOnlyQueryData>(&self) -> Option<Q::Item<'_>> {
-        // SAFETY: &mut self implies exclusive access for duration of returned value
+        // SAFETY: We have read-only access to all components of this entity.
         unsafe { self.0.get_components::<Q>() }
     }
 

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -10,6 +10,7 @@ use crate::{
     component::{ComponentId, ComponentTicks, Components, StorageType, Tick, TickCells},
     entity::{Entities, Entity, EntityLocation},
     prelude::Component,
+    query::{DebugCheckedUnwrap, QueryData},
     removal_detection::RemovedComponentEvents,
     storage::{Column, ComponentSparseSet, Storages},
     system::{Res, Resource},
@@ -816,6 +817,52 @@ impl<'w> UnsafeEntityCell<'w> {
                 value: value.assert_unique().deref_mut::<T>(),
                 ticks: TicksMut::from_tick_cells(cells, last_change_tick, change_tick),
             })
+        }
+    }
+
+    /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`UnsafeEntityCell`] has permission to access the queried data mutably
+    /// - no other references to the queried data exist at the same time
+    pub(crate) unsafe fn get_components<Q: QueryData>(&self) -> Option<Q::Item<'_>> {
+        // SAFETY: World is only used to access query data and initialize query state
+        let state = unsafe {
+            let world = self.world().world();
+            Q::get_state(world)?
+        };
+        let location = self.location();
+        // SAFETY: Location is guaranteed to exist
+        let archetype = unsafe {
+            self.world
+                .archetypes()
+                .get(location.archetype_id)
+                .debug_checked_unwrap()
+        };
+        if Q::matches_component_set(&state, &|id| archetype.contains(id)) {
+            // SAFETY: state was initialized above using the world passed into this function
+            let mut fetch = unsafe {
+                Q::init_fetch(
+                    self.world,
+                    &state,
+                    self.world.last_change_tick(),
+                    self.world.change_tick(),
+                )
+            };
+            // SAFETY: Table is guaranteed to exist
+            let table = unsafe {
+                self.world
+                    .storages()
+                    .tables
+                    .get(location.table_id)
+                    .debug_checked_unwrap()
+            };
+            // SAFETY: Archetype and table are from the same world used to initialize state and fetch.
+            // Table corresponds to archetype. State is the same state used to init fetch above.
+            unsafe { Q::set_archetype(&mut fetch, &state, archetype, table) }
+            // SAFETY: Called after set_archetype above. Entity and location are guaranteed to exist.
+            unsafe { Some(Q::fetch(&mut fetch, self.id(), location.table_row)) }
+        } else {
+            None
         }
     }
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -824,12 +824,8 @@ impl<'w> UnsafeEntityCell<'w> {
     /// It is the callers responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the queried data mutably
     /// - no other references to the queried data exist at the same time
-    pub(crate) unsafe fn get_components<Q: QueryData>(&self) -> Option<Q::Item<'_>> {
-        // SAFETY: World is only used to access query data and initialize query state
-        let state = unsafe {
-            let world = self.world().world();
-            Q::get_state(world)?
-        };
+    pub(crate) unsafe fn get_components<Q: QueryData>(&self) -> Option<Q::Item<'w>> {
+        let state = Q::get_state(self.world().components())?;
         let location = self.location();
         // SAFETY: Location is guaranteed to exist
         let archetype = unsafe {

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -151,7 +151,7 @@ fn main() {
 
                 query.iter_mut(&mut world).for_each(|filtered_entity| {
                     let terms = filtered_entity
-                        .components()
+                        .accessed_components()
                         .map(|id| {
                             let ptr = filtered_entity.get_by_id(id).unwrap();
                             let info = component_info.get(&id).unwrap();


### PR DESCRIPTION
# Objective

Implements #13127

`EntityRef` / `EntityMut` usage is currently unnecessarily verbose and borrow-checker-constrained. It is currently impossible to use `EntityMut` to get mutable references to more than one component at the same time:

```rust
let mut entity = world.entity_mut(some_entity);
let mut a = entity.get_mut::<A>();
// this fails to compile because `entity` is already borrowed mutably
let mut b = entity.get_mut::<B>();
```

This makes `EntityMut` significantly less useful than it could be. Querying necessary components on demand is a pattern many prefer to use over traditional top-level queries. 

## Solution

Implement new `get_components` and `components` methods for `EntityRef` and `EntityMut` (and mutable variants for `EntityMut`) to provide multi-component access:

```rust
let (a, b) = world.entity(SOME_ENTITY).components::<(&A, &B)>();
let (a, b) = world.entity(SOME_ENTITY).get_components::<(&A, &B)>().unwrap();
let (mut a, b) = world.entity_mut(SOME_ENTITY).components_mut::<(&mut A, &B)>();
let (mut a, b) = world.entity_mut(SOME_ENTITY).get_components_mut::<(&mut A, &B)>().unwrap();
```


This is implemented using our existing Query implementation to provide multi-component access. It checks access without actually computing QueryState / access using the very convenient `Q::matches_component_set`.

## Next Steps

* This doesn't add `FilteredEntityRef` and `FilteredEntityMut` variants, as checking that access is actually more challenging (and with the current methods, likely prohibitively expensive because I think we need to compute `Access<ComponentId>` )
* This doesn't do the `components` to `get` and `get_components` to `try_get` renaming / unification I proposed in #13127 as I suspect that will be more controversial, and it also touches a lot of code. 

---

## Changelog

### Added

- `EntityRef::components`, `EntityRef::get_components`, `EntityMut::components`, `EntityMut::get_components`, `EntityMut::components_mut`, and `EntityMut::get_components_mut`.

### Changed

- Renamed `FilteredEntityRef::components` to `FilteredEntityRef::accessed_components` and `FilteredEntityMut::components` to `FilteredEntityMut::accessed_components` to avoid future name clashes

## Migration Guide

- Rename `FilteredEntityRef::components` to `FilteredEntityRef::accessed_components` and `FilteredEntityMut::components` to `FilteredEntityMut::accessed_components`