### PR TITLE
Fix ClearColor in 2d pipelines

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -31,7 +31,7 @@ impl ViewNode for MainTransparentPass2dNode {
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
 
-        if !transparent_phase.items.is_empty() {
+        {
             #[cfg(feature = "trace")]
             let _main_pass_2d = info_span!("main_transparent_pass_2d").entered();
 

--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -55,7 +55,7 @@ impl ViewNode for MainTransparentPass2dNode {
             if !transparent_phase.items.is_empty() {
                 transparent_phase.render(&mut render_pass, world, view_entity);
             }
-            
+
             pass_span.end(&mut render_pass);
         }
 

--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -31,6 +31,7 @@ impl ViewNode for MainTransparentPass2dNode {
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
 
+        // This needs to run at least once to clear the background color, even if there are no items to render
         {
             #[cfg(feature = "trace")]
             let _main_pass_2d = info_span!("main_transparent_pass_2d").entered();

--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -52,8 +52,10 @@ impl ViewNode for MainTransparentPass2dNode {
                 render_pass.set_camera_viewport(viewport);
             }
 
-            transparent_phase.render(&mut render_pass, world, view_entity);
-
+            if !transparent_phase.items.is_empty() {
+                transparent_phase.render(&mut render_pass, world, view_entity);
+            }
+            
             pass_span.end(&mut render_pass);
         }
 


### PR DESCRIPTION
# Objective

- Fixes #13377
- Fixes https://github.com/bevyengine/bevy/issues/13383

## Solution

- Even if the number of renderables is empty, the transparent phase need to run to set the clear color.

## Testing

- Tested on the `clear_color` example
