### PR TITLE
Fix normals during mesh scaling

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -764,7 +764,7 @@ impl Mesh {
         {
             // Transform normals, taking into account non-uniform scaling and rotation
             normals.iter_mut().for_each(|normal| {
-                let scaled_normal = Vec3::from_slice(normal) * covector_scale;
+                let scaled_normal = Vec3::from_slice(normal) * transform.scale;
                 *normal = (transform.rotation * scaled_normal.normalize_or_zero()).to_array();
             });
         }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -774,7 +774,7 @@ impl Mesh {
         {
             // Transform tangents, taking into account non-uniform scaling and rotation
             tangents.iter_mut().for_each(|tangent| {
-                let scaled_tangent = Vec3::from_slice(tangent) * scale_recip;
+                let scaled_tangent = Vec3::from_slice(tangent) * transform.scale;
                 *tangent = (transform.rotation * scaled_tangent.normalize_or_zero()).to_array();
             });
         }
@@ -886,7 +886,7 @@ impl Mesh {
         {
             // Transform tangents, taking into account non-uniform scaling
             tangents.iter_mut().for_each(|tangent| {
-                let scaled_tangent = Vec3::from_slice(tangent) * scale_recip;
+                let scaled_tangent = Vec3::from_slice(tangent) * scale;
                 *tangent = scaled_tangent.normalize_or_zero().to_array();
             });
         }
@@ -1672,7 +1672,7 @@ fn scale_normal(normal: Vec3, scale_recip: Vec3) -> Vec3 {
         (normal * scale_recip).normalize_or_zero()
     } else {
         // This is basically just `normal * scale_recip` but with the added rule that `0. * anything == 0.`
-        // This is neccessary because one of the components of `scale_recip` is infinite
+        // This is necessary because one of the components of `scale_recip` is infinite
         let n = Vec3::new(
             if normal.x == 0. {
                 0.

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -878,7 +878,7 @@ impl Mesh {
         {
             // Transform normals, taking into account non-uniform scaling
             normals.iter_mut().for_each(|normal| {
-                let scaled_normal = Vec3::from_slice(normal) * covector_scale;
+                let scaled_normal = Vec3::from_slice(normal) * scale;
                 *normal = scaled_normal.normalize_or_zero().to_array();
             });
         }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -1670,8 +1670,6 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
 
 #[cfg(test)]
 mod tests {
-    use std::f32::consts::FRAC_PI_2;
-
     use super::Mesh;
     use crate::{mesh::VertexAttributeValues, render_asset::RenderAssetUsages};
     use bevy_math::Vec3;
@@ -1714,7 +1712,7 @@ mod tests {
             assert_eq!(
                 positions,
                 &vec![[-4.0, -2.0, -4.0], [0.0, -2.0, -4.0], [-2.0, -2.0, -4.0]]
-            )
+            );
         } else {
             panic!("Mesh does not have a position attribute");
         }
@@ -1722,13 +1720,13 @@ mod tests {
         if let Some(VertexAttributeValues::Float32x3(normals)) =
             mesh.attribute(Mesh::ATTRIBUTE_NORMAL)
         {
-            assert_eq!(normals, &vec![[0., 0., -1.]; 3])
+            assert_eq!(normals, &vec![[0., 0., -1.]; 3]);
         } else {
             panic!("Mesh does not have a normal attribute");
         }
 
         if let Some(VertexAttributeValues::Float32x2(uvs)) = mesh.attribute(Mesh::ATTRIBUTE_UV_0) {
-            assert_eq!(uvs, &vec![[0., 0.], [1., 0.], [0.5, 1.]])
+            assert_eq!(uvs, &vec![[0., 0.], [1., 0.], [0.5, 1.]]);
         } else {
             panic!("Mesh does not have a uv attribute");
         }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -1669,15 +1669,15 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
 /// Correctly scales and renormalizes an already normalized `normal` by the scale determined by its reciprocal `scale_recip`
 fn scale_normal(normal: Vec3, scale_recip: Vec3) -> Vec3 {
     // This is basically just `normal * scale_recip` but with the added rule that `0. * anything == 0.`
-    // This is necessary because one of the components of `scale_recip` is infinite
+    // This is necessary because components of `scale_recip` may be infinities, which do not multiply to zero
     let n = Vec3::select(normal.cmpeq(Vec3::ZERO), Vec3::ZERO, normal * scale_recip);
 
-    // If n is finite, the normal was perpendicular to the flattened axis
-    // else the
+    // If n is finite, no component of `scale_recip` was infinite or the normal was perpendicular to the scale
+    // else the scale had at least one zero-component and the normal needs to point along the direction of that component
     if n.is_finite() {
         n.normalize_or_zero()
     } else {
-        Vec3::select(n.abs().cmpeq(Vec3::INFINITY), n.signum(), Vec3::ZERO)
+        Vec3::select(n.abs().cmpeq(Vec3::INFINITY), n.signum(), Vec3::ZERO).normalize()
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes scaling normals and tangents of meshes

## Solution

- When scaling a mesh  by `Vec3::new(1., 1., -1.)`, the normals should be flipped along the Z-axis. For example a normal of `Vec3::new(0.,  0., 1.)` should become `Vec3::new(0., 0., -1.)` after scaling. This is achieved by multiplying the normal by the reciprocal of the scale, cheking for infinity and normalizing. Before, the normal was multiplied by a covector of the scale, which is incorrect for normals.
- Tangents need to be multiplied by the `scale`, not its reciprocal as before