### PR TITLE
UI: Image fills aspect_ratio of texture dimensions

### DIFF
--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -108,9 +108,12 @@ pub fn update_image_content_size_system(
                     // multiply the image size by the scale factor to get the physical size
                     size: size.as_vec2() * combined_scale_factor,
                 }));
+                // Image should keep its proportions even if no width or height is specified in its style
                 if let Some(mut style) = style {
-                    let Vec2 { x, y } = size.as_vec2();
-                    style.aspect_ratio = Some(x / y);
+                    if style.aspect_ratio.is_none() {
+                        let Vec2 { x, y } = size.as_vec2();
+                        style.aspect_ratio = Some(x / y);
+                    }
                 }
             }
         }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,5 +1,5 @@
 use crate::{
-    measurement::AvailableSpace, ContentSize, Measure, Node, NodeMeasure, UiImage, UiScale,
+    measurement::AvailableSpace, ContentSize, Measure, Node, NodeMeasure, Style, UiImage, UiScale,
 };
 use bevy_asset::Assets;
 use bevy_ecs::prelude::*;
@@ -82,6 +82,7 @@ pub fn update_image_content_size_system(
             &UiImage,
             &mut UiImageSize,
             Option<&TextureAtlas>,
+            Option<&mut Style>,
         ),
         UpdateImageFilter,
     >,
@@ -92,7 +93,7 @@ pub fn update_image_content_size_system(
         .unwrap_or(1.)
         * ui_scale.0;
 
-    for (mut content_size, image, mut image_size, atlas_image) in &mut query {
+    for (mut content_size, image, mut image_size, atlas_image, style) in &mut query {
         if let Some(size) = match atlas_image {
             Some(atlas) => atlas.texture_rect(&atlases).map(|t| t.size()),
             None => textures.get(&image.texture).map(|t| t.size()),
@@ -107,6 +108,10 @@ pub fn update_image_content_size_system(
                     // multiply the image size by the scale factor to get the physical size
                     size: size.as_vec2() * combined_scale_factor,
                 }));
+                if let Some(mut style) = style {
+                    let Vec2 { x, y } = size.as_vec2();
+                    style.aspect_ratio = Some(x / y);
+                }
             }
         }
     }


### PR DESCRIPTION
# Objective

- Fixes #13155 .

## Solution

- Style::aspect_ratio is filled at same time as UiImageSize

## Testing

Run example  `game_menu`
![image](https://github.com/bevyengine/bevy/assets/17225606/01a2d17b-eb3f-4fb6-b2d3-b5e04b250c4f)
 and `overflow_debug`
![image](https://github.com/bevyengine/bevy/assets/17225606/13143977-6a88-4d5e-96ab-cd22b22c1584)

