### PR TITLE
Fixed incorrect behaviour of headless_renderer depending on image dimensions

### DIFF
--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -492,6 +492,7 @@ fn update(
                     // Fill correct data from channel to image
                     let img_bytes = images.get_mut(image.id()).unwrap();
 
+                    // We need to ensure that this works regardless of the image dimensions
                     let row_bytes = img_bytes.width() as usize
                         * img_bytes.texture_descriptor.format.pixel_size();
                     let aligned_row_bytes = RenderDevice::align_copy_bytes_per_row(row_bytes);

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -493,6 +493,8 @@ fn update(
                     let img_bytes = images.get_mut(image.id()).unwrap();
 
                     // We need to ensure that this works regardless of the image dimensions
+                    // If the image became wider when copying from the texture to the buffer,
+                    // then the data is reduced to its original size when copying from the buffer to the image.
                     let row_bytes = img_bytes.width() as usize
                         * img_bytes.texture_descriptor.format.pixel_size();
                     let aligned_row_bytes = RenderDevice::align_copy_bytes_per_row(row_bytes);

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -360,6 +360,10 @@ impl render_graph::Node for ImageCopyDriver {
             let block_dimensions = src_image.texture_format.block_dimensions();
             let block_size = src_image.texture_format.block_copy_size(None).unwrap();
 
+            // Calculating correct size of image row because
+            // copy_texture_to_buffer can copy image only by rows aligned wgpu::COPY_BYTES_PER_ROW_ALIGNMENT
+            // That's why image in buffer can be little bit wider
+            // This should be taken into account at copy from buffer stage
             let padded_bytes_per_row = RenderDevice::align_copy_bytes_per_row(
                 (src_image.size.x as usize / block_dimensions.0 as usize) * block_size as usize,
             );

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -508,7 +508,7 @@ fn update(
                         // shrink data to original image size
                         img_bytes.data = image_data
                             .chunks(aligned_row_bytes)
-                            .flat_map(|row| &row[..row_bytes])
+                            .flat_map(|row| &row[..row_bytes.min(row.len())])
                             .cloned()
                             .collect();
                     }

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -508,6 +508,7 @@ fn update(
                         // shrink data to original image size
                         img_bytes.data = image_data
                             .chunks(aligned_row_bytes)
+                            .take(img_bytes.height() as usize)
                             .flat_map(|row| &row[..row_bytes.min(row.len())])
                             .cloned()
                             .collect();


### PR DESCRIPTION
# Objective

- Fixes #13384 .

## Solution

- If the image became wider when copying from the texture to the buffer, then the data is reduced to its original size when copying from the buffer to the image.

## Testing

- Ran example with 1919x1080 resolution
![000](https://github.com/bevyengine/bevy/assets/17225606/47d95ed7-1c8c-4be4-a45a-1f485a3d6aa7)