### PR TITLE
Remove unnecessary .view_layouts

### DIFF
--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -115,7 +115,6 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
 
         let view_layout = self
             .mesh_pipeline
-            .view_layouts
             .get_view_layout(key.view_key.into())
             .clone();
 
@@ -209,7 +208,6 @@ impl SpecializedRenderPipeline for LineJointGizmoPipeline {
 
         let view_layout = self
             .mesh_pipeline
-            .view_layouts
             .get_view_layout(key.view_key.into())
             .clone();
 

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -320,10 +320,7 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
         RenderPipelineDescriptor {
             label: Some("deferred_lighting_pipeline".into()),
             layout: vec![
-                self.mesh_pipeline
-                    .view_layouts
-                    .get_view_layout(key.into())
-                    .clone(),
+                self.mesh_pipeline.get_view_layout(key.into()).clone(),
                 self.bind_group_layout_1.clone(),
             ],
             vertex: VertexState {

--- a/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
@@ -165,10 +165,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
             let pipeline_descriptor = RenderPipelineDescriptor {
                 label: material_pipeline_descriptor.label,
                 layout: vec![
-                    mesh_pipeline
-                        .view_layouts
-                        .get_view_layout(view_key.into())
-                        .clone(),
+                    mesh_pipeline.get_view_layout(view_key.into()).clone(),
                     gpu_scene.material_draw_bind_group_layout(),
                     material_pipeline.material_layout.clone(),
                 ],

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1557,7 +1557,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
             shader_defs.push("PBR_MULTI_LAYER_MATERIAL_TEXTURES_SUPPORTED".into());
         }
 
-        let mut bind_group_layout = vec![self.view_layouts.get_view_layout(key.into()).clone()];
+        let mut bind_group_layout = vec![self.get_view_layout(key.into()).clone()];
 
         if key.msaa_samples() > 1 {
             shader_defs.push("MULTISAMPLED".into());


### PR DESCRIPTION
# Objective

- The volumetric fog PR originally needed to be modified to use `.view_layouts` but that was changed in another PR. The merge with main still kept those around.

## Solution

- Remove them because they aren't necessary