### PR TITLE
fix normals computation for gltf

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -502,7 +502,7 @@ async fn load_gltf<'a, 'b, 'c>(
                 bevy_utils::tracing::debug!(
                     "Automatically calculating missing vertex normals for geometry."
                 );
-                mesh.compute_flat_normals();
+                mesh.compute_normals();
             }
 
             if let Some(vertex_attribute) = reader


### PR DESCRIPTION
# Objective

- some gltf files are broken since #13333 

```
thread 'IO Task Pool (2)' panicked at crates/bevy_render/src/mesh/mesh/mod.rs:581:9:
`compute_flat_normals` can't work on indexed geometry. Consider calling either `Mesh::compute_smooth_normals` or `Mesh::duplicate_vertices` followed by `Mesh::compute_flat_normals`.
```

- test with example `custom_gltf_vertex_attribute` or `gltf_skinned_mesh`


## Solution

- Call the wrapper function for normals that will either call `compute_flat_normals` or `compute_smooth_normals` as appropriate

## Testing

- Ran the two examples mentioned above