### PR TITLE
example render_to_texture: remove extra light

### DIFF
--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -85,14 +85,16 @@ fn setup(
         first_pass_layer.clone(),
     ));
 
-    // Light for the first pass
-    // NOTE: Lights only work properly when in one render layer.
+    // Light
+    // NOTE: we add the light to both layers so it affects both the rendered-to-texture cube, and the cube on which we display the texture
+    // Setting the layer to RenderLayers::layer(0) would cause the main view to be lit, but the rendered-to-texture cube to be unlit.
+    // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.
     commands.spawn((
         PointLightBundle {
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
             ..default()
         },
-        first_pass_layer.clone(),
+        RenderLayers::layer(0).with(1),
     ));
 
     commands.spawn((
@@ -134,17 +136,6 @@ fn setup(
         MainPassCube,
     ));
 
-    // Light
-    // NOTE: we add the light to both layers so it affects both the rendered-to-texture cube, and the cube on which we display the texture
-    // Setting the layer to RenderLayers::layer(0) would cause the main view to be lit, but the rendered-to-texture cube to be unlit.
-    // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.
-    commands.spawn((
-        PointLightBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-            ..default()
-        },
-        RenderLayers::layer(0).with(1),
-    ));
     // The main pass camera.
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),


### PR DESCRIPTION
# Objective

- in example `render_to_texture`, #13317 changed the comment on the existing light saying lights don't work on multiple layers, then add a light on multiple layers explaining that it will work. it's confusing

## Solution

- Keep the original light, with the updated comment

## Testing

- Run example `render_to_texture`, lighting is correct
