### PR TITLE
Make the prepass shader compile when lightmaps are present.

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -18,11 +18,11 @@ fn prepass_alpha_discard(in: VertexOutput) {
     var output_color: vec4<f32> = pbr_bindings::material.base_color;
 
 #ifdef VERTEX_UVS
-#ifdef VERTEX_UVS_A
-    var uv = in.uv;
-#else   // VERTEX_UVS_A
+#ifdef STANDARD_MATERIAL_BASE_COLOR_UV_B
     var uv = in.uv_b;
-#endif  // VERTEX_UVS_A
+#else   // STANDARD_MATERIAL_BASE_COLOR_UV_B
+    var uv = in.uv;
+#endif  // STANDARD_MATERIAL_BASE_COLOR_UV_B
 
 #endif
     let uv_transform = pbr_bindings::material.uv_transform;

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -20,13 +20,10 @@ fn prepass_alpha_discard(in: VertexOutput) {
 #ifdef VERTEX_UVS
 #ifdef VERTEX_UVS_A
     var uv = in.uv;
-#else
+#else   // VERTEX_UVS_A
     var uv = in.uv_b;
-#endif
-#ifdef VERTEX_UVS_B
-    if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_UV_BIT) != 0u) {
-        uv = in.uv_b;
-    }
+#endif  // VERTEX_UVS_A
+
 #endif
     let uv_transform = pbr_bindings::material.uv_transform;
     uv = (uv_transform * vec3(uv, 1.0)).xy;

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -24,7 +24,6 @@ fn prepass_alpha_discard(in: VertexOutput) {
     var uv = in.uv;
 #endif  // STANDARD_MATERIAL_BASE_COLOR_UV_B
 
-#endif
     let uv_transform = pbr_bindings::material.uv_transform;
     uv = (uv_transform * vec3(uv, 1.0)).xy;
     if (pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u {


### PR DESCRIPTION
Commit 3f5a090b1bf6bb8b97972feb5504777f6b380559 added a reference to `STANDARD_MATERIAL_FLAGS_BASE_COLOR_UV_BIT`, a nonexistent identifier, in the alpha discard portion of the prepass shader. Moreover, the logic didn't make sense to me. I think the code was trying to choose between the two UV sets depending on which is present, so I made it do that.

I noticed this when trying Bistro with #13277. I'm not sure why this issue didn't manifest itself before, but it's clearly a bug, so here's a fix. We should probably merge this before 0.14.