### PR TITLE
Implementation of `temp://` Asset Source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1446,7 +1446,7 @@ doc-scrape-examples = true
 name = "Temporary assets"
 description = "How to use the temporary asset source"
 category = "Assets"
-wasm = false
+wasm = true
 
 # Async Tasks
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1437,6 +1437,17 @@ description = "Demonstrates how to wait for multiple assets to be loaded."
 category = "Assets"
 wasm = true
 
+[[example]]
+name = "temp_asset"
+path = "examples/asset/temp_asset.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.temp_asset]
+name = "Temporary assets"
+description = "How to use the temporary asset source"
+category = "Assets"
+wasm = false
+
 # Async Tasks
 [[example]]
 name = "async_compute"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -57,6 +57,7 @@ js-sys = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.3.1", optional = true }
+tempfile = "3.10.1"
 
 [dev-dependencies]
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -51,9 +51,19 @@ web-sys = { version = "0.3", features = [
   "Window",
   "Response",
   "WorkerGlobalScope",
+  "Navigator",
+  "StorageManager",
+  "FileSystemFileHandle",
+  "FileSystemDirectoryHandle",
+  "FileSystemGetDirectoryOptions",
+  "FileSystemGetFileOptions",
+  "File",
+  "FileSystemWritableFileStream",
+  "FileSystemRemoveOptions",
 ] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
+async-channel = "2.2.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.3.1", optional = true }

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -8,6 +8,10 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;
 
+mod opfs;
+
+pub use opfs::*;
+
 /// Represents the global object in the JavaScript context
 #[wasm_bindgen]
 extern "C" {

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -8,9 +8,9 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;
 
-mod opfs;
+mod web_file_system;
 
-pub use opfs::*;
+pub use web_file_system::*;
 
 /// Represents the global object in the JavaScript context
 #[wasm_bindgen]

--- a/crates/bevy_asset/src/io/wasm/opfs.rs
+++ b/crates/bevy_asset/src/io/wasm/opfs.rs
@@ -1,504 +1,175 @@
 use crate::io::wasm::Global;
 use crate::io::{
     get_meta_path, AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream,
-    Reader, VecReader, Writer,
+    Reader, Writer,
 };
-use async_channel::TrySendError;
-use bevy_utils::tracing::{error, info};
-use futures_io::AsyncWrite;
-use futures_lite::{pin, AsyncReadExt, AsyncWriteExt, FutureExt, Stream, StreamExt};
-use js_sys::{ArrayBuffer, AsyncIterator, JsString, Uint8Array, JSON};
+use futures_lite::{AsyncReadExt, AsyncWriteExt, Stream, StreamExt};
+use js_sys::{JsString, JSON};
 use std::path::{Component, Path, PathBuf};
-use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
-use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
-use wasm_bindgen_futures::{spawn_local, JsFuture};
+use wasm_bindgen_futures::spawn_local;
 use web_sys::{
     FileSystemDirectoryHandle, FileSystemFileHandle, FileSystemGetDirectoryOptions,
     FileSystemGetFileOptions, FileSystemRemoveOptions, FileSystemWritableFileStream,
-    StorageManager,
 };
 
-#[wasm_bindgen(inline_js = "export function get_keys_for_handle(a) { return a.keys(); }")]
-extern "C" {
-    /// Workaround to provide [keys](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/keys)
-    fn get_keys_for_handle(a: &FileSystemDirectoryHandle) -> AsyncIterator;
-}
-
-fn js_value_to_err(
-    context: &str,
-    kind: std::io::ErrorKind,
-) -> impl FnOnce(JsValue) -> std::io::Error + '_ {
-    move |value| {
-        let message = match JSON::stringify(&value) {
-            Ok(js_str) => format!("JS Failure: '{context}': {js_str}"),
-            Err(_) => {
-                format!("Failed to {context} and also failed to stringify the JSValue of the error")
-            }
-        };
-
-        std::io::Error::new(kind, message)
-    }
-}
-
-/// Get the [`StorageManager`] from the global context. Will return [`None`] if the context is not either
-/// standard (e.g., with access to `window`), or a worker.
-fn get_storage_manager() -> std::io::Result<StorageManager> {
-    let global: Global = js_sys::global().unchecked_into();
-
-    if !global.window().is_undefined() {
-        let window: web_sys::Window = global.unchecked_into();
-        Ok(window.navigator().storage())
-    } else if !global.worker().is_undefined() {
-        let worker: web_sys::WorkerGlobalScope = global.unchecked_into();
-        Ok(worker.navigator().storage())
-    } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "Unsupported global context",
-        ))
-    }
-}
-
-/// Extension method to allow for a more ergonomic handling of [promises](`js_sys::Promise`).
-trait IntoJsFuture: Into<JsFuture> {
-    /// Convert this [thenable](`js_sys::Promise`) into a [`JsFuture`].
-    fn into_js_future(self) -> JsFuture {
-        self.into()
-    }
-}
-
-impl<T: Into<JsFuture>> IntoJsFuture for T {}
-
-/// Get the [`FileSystemDirectoryHandle`] for the root Origin Private File System. See
-/// [MDN](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/getDirectory) for details.
-///
-/// Can fail if a `SecurityError` exception is thrown by the JS runtime.
-async fn get_storage_root() -> std::io::Result<FileSystemDirectoryHandle> {
-    get_storage_manager()?
-        .get_directory()
-        .into_js_future()
-        .await
-        .map_err(js_value_to_err(
-            "Cannot get StorageManager",
-            std::io::ErrorKind::PermissionDenied,
-        ))
-        .map(|value| value.unchecked_into())
-}
-
-/// Open a directory relative to `start` from a given `path`.
-/// Will create directories based on the provided `path` if `create` is `true`.
-async fn get_directory(
-    start: &FileSystemDirectoryHandle,
-    path: impl AsRef<Path>,
-    create: bool,
-) -> std::io::Result<FileSystemDirectoryHandle> {
-    let path = path.as_ref();
-
-    let mut options = FileSystemGetDirectoryOptions::new();
-    options.create(create);
-
-    let mut current = start.clone();
-
-    for component in path.components() {
-        match component {
-            Component::Prefix(x) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("Cannot parse path '{path:?}': Prefix '{x:?}' is not supported"),
-                ));
-            }
-            Component::RootDir => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("Cannot parse path '{path:?}': Cannot use an absolute path"),
-                ));
-            }
-            Component::ParentDir => {
-                return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Cannot parse path '{path:?}': Relative traversal up the hierarchy is not supported")));
-            }
-            Component::CurDir => {
-                // No-op
-                continue;
-            }
-            Component::Normal(name) => {
-                let Some(name) = name.to_str() else {
-                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Cannot parse path '{path:?}': Segment '{name:?}' cannot be used as a UTF-8 string")));
-                };
-
-                current = current
-                    .get_directory_handle_with_options(name, &options)
-                    .into_js_future()
-                    .await
-                    .map_err(js_value_to_err(
-                        "Cannot get Directory Handle",
-                        std::io::ErrorKind::Other,
-                    ))
-                    .map(|value| value.unchecked_into())?;
-            }
-        }
-    }
-
-    Ok(current)
-}
-
-/// Get child entries of this directory.
-async fn get_entries(start: &FileSystemDirectoryHandle) -> impl Stream<Item = PathBuf> + Unpin {
-    struct EntriesStream {
-        inner: AsyncIterator,
-        current: Option<JsFuture>,
-    }
-
-    impl Stream for EntriesStream {
-        type Item = PathBuf;
-
-        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            let mut current = match self.current.take() {
-                Some(current) => current,
-                None => {
-                    let Ok(next) = self.inner.next() else {
-                        return Poll::Ready(None);
-                    };
-
-                    next.into_js_future()
-                }
-            };
-
-            match current.poll(cx) {
-                Poll::Ready(result) => {
-                    let result = result
-                        .ok()
-                        .and_then(|value| value.dyn_ref::<JsString>().cloned())
-                        .map(String::from)
-                        .map(PathBuf::from);
-
-                    Poll::Ready(result)
-                }
-                Poll::Pending => {
-                    self.current = Some(current);
-
-                    Poll::Pending
-                }
-            }
-        }
-    }
-
-    EntriesStream {
-        inner: get_keys_for_handle(start),
-        current: None,
-    }
-}
-
-/// Open a file relative to `start` from a given `path`.
-/// Will create directories and the final file based on the provided `path` if `create` is `true`.
-async fn get_file(
-    start: &FileSystemDirectoryHandle,
-    path: impl AsRef<Path>,
-    create_file: bool,
-    create_path: bool,
-) -> std::io::Result<FileSystemFileHandle> {
-    let path = path.as_ref();
-
-    let mut components = path.components();
-
-    let Some(file_name) = components.next_back() else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Provided path is empty",
-        ));
-    };
-
-    let Component::Normal(file_name) = file_name else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Cannot parse path '{path:?}': final component must be a file name"),
-        ));
-    };
-
-    let Some(file_name) = file_name.to_str() else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!(
-                "Cannot parse path '{path:?}': file name '{file_name:?}' cannot be used as a UTF-8 string"
-            ),
-        ));
-    };
-
-    get_directory(start, components.collect::<PathBuf>(), create_path)
-        .await?
-        .get_file_handle_with_options(file_name, &{
-            let mut options = FileSystemGetFileOptions::new();
-            options.create(create_file);
-            options
-        })
-        .into_js_future()
-        .await
-        .map_err(js_value_to_err(
-            format!("File not available: '{path:?}'").as_str(),
-            std::io::ErrorKind::NotFound,
-        ))
-        .map(|value| value.unchecked_into())
-}
-
-/// Read the contents of a [file handle](`FileSystemFileHandle`).
-async fn read_file<'a>(handle: &FileSystemFileHandle) -> std::io::Result<Box<Reader<'a>>> {
-    let file: web_sys::File = handle
-        .get_file()
-        .into_js_future()
-        .await
-        .map_err(js_value_to_err(
-            "Cannot get File from Handle",
-            std::io::ErrorKind::Other,
-        ))?
-        .unchecked_into();
-
-    let buffer: ArrayBuffer = file
-        .array_buffer()
-        .into_js_future()
-        .await
-        .map_err(js_value_to_err(
-            "Cannot get Buffer from File",
-            std::io::ErrorKind::Other,
-        ))?
-        .unchecked_into();
-
-    let bytes = Uint8Array::new(&buffer).to_vec();
-
-    Ok(Box::new(VecReader::new(bytes)))
-}
-
-async fn write_file(handle: &FileSystemFileHandle) -> std::io::Result<Box<Writer>> {
-    enum Command {
-        Write(Box<[u8]>, Waker),
-        Flush(Waker),
-        Close(Waker),
-    }
-
-    struct FileStreamWriter {
-        commands: async_channel::Sender<Command>,
-    }
-
-    impl AsyncWrite for FileStreamWriter {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            match self.commands.try_send(Command::Write(
-                buf.to_owned().into_boxed_slice(),
-                cx.waker().clone(),
-            )) {
-                Ok(()) => Poll::Ready(Ok(buf.len())),
-                Err(TrySendError::Closed(..)) => Poll::Ready(Ok(0)),
-                Err(TrySendError::Full(..)) => Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "Could not send write request to writer",
-                ))),
-            }
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            match self.commands.try_send(Command::Flush(cx.waker().clone())) {
-                Ok(()) => Poll::Ready(Ok(())),
-                Err(TrySendError::Closed(..)) => Poll::Ready(Ok(())),
-                Err(TrySendError::Full(..)) => Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "Could not send flush request to writer",
-                ))),
-            }
-        }
-
-        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            match self.commands.try_send(Command::Close(cx.waker().clone())) {
-                Ok(()) => Poll::Pending,
-                Err(TrySendError::Closed(..)) => Poll::Ready(Ok(())),
-                Err(TrySendError::Full(..)) => Poll::Ready(Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "Could not send close request to writer",
-                ))),
-            }
-        }
-    }
-
-    let stream: FileSystemWritableFileStream = handle
-        .create_writable()
-        .into_js_future()
-        .await
-        .map_err(js_value_to_err(
-            "Cannot get Create Writable Stream",
-            std::io::ErrorKind::Other,
-        ))?
-        .unchecked_into();
-
-    let (sender, receiver) = async_channel::unbounded::<Command>();
-
-    spawn_local(async move {
-        info!("Starting a writer...");
-        let stream = stream;
-        let receiver = receiver;
-        pin!(receiver);
-
-        let maybe_waker = loop {
-            let Some(command) = receiver.next().await else {
-                break None;
-            };
-
-            match command {
-                Command::Write(buf, waker) => {
-                    info!("Writing {:?}", buf);
-                    let Ok(promise) = stream.write_with_u8_array(&buf) else {
-                        error!("Cannot Write to Stream!");
-                        break None;
-                    };
-
-                    let Ok(_) = promise.into_js_future().await else {
-                        error!("Cannot Write to Stream!");
-                        break None;
-                    };
-
-                    waker.wake();
-                }
-                Command::Flush(waker) => {
-                    info!("Flushing");
-                    waker.wake();
-                }
-                Command::Close(waker) => {
-                    info!("Closing");
-                    let Ok(_) = stream.close().into_js_future().await else {
-                        error!("Cannot Close Stream!");
-                        break None;
-                    };
-
-                    break Some(waker);
-                }
-            }
-        };
-
-        drop(receiver);
-
-        if let Some(waker) = maybe_waker {
-            waker.wake();
-        } else {
-            if stream.close().into_js_future().await.is_err() {
-                error!("Stream was closed unexpectedly and could not be closed properly.");
-            }
-        }
-    });
-
-    Ok(Box::new(FileStreamWriter { commands: sender }))
-}
-
-async fn remove_entry(handle: &FileSystemDirectoryHandle, entry: &str) -> std::io::Result<()> {
-    handle
-        .remove_entry_with_options(entry, &{
-            let mut options = FileSystemRemoveOptions::new();
-            options.recursive(true);
-            options
-        })
-        .into_js_future()
-        .await
-        .map_err(js_value_to_err(
-            "Cannot remove Directory",
-            std::io::ErrorKind::Other,
-        ))?
-        .is_undefined()
-        .then_some(())
-        .ok_or(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to remove entry",
-        ))
-}
+use utils::*;
 
 /// Bevy compatible wrapper for the [Origin Private File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)
 pub struct OriginPrivateFileSystem {
-    root: PathBuf,
+    root: Vec<String>,
 }
 
 impl OriginPrivateFileSystem {
     /// Constructs a new [`OriginPrivateFileSystem`] with the provided shadow-root.
     pub fn new(root: PathBuf) -> Self {
+        let root = Self::canonical(&root)
+            .expect("Provided path is not valid")
+            .into_iter()
+            .map(|component| component.to_owned())
+            .collect();
+
         Self { root }
+    }
+
+    /// Constructs a canonical path (as components) from the provided `path`.
+    pub(crate) fn canonical<'a>(path: &'a Path) -> std::io::Result<Vec<&'a str>> {
+        let mut canonical_path = Vec::new();
+
+        for component in path.components() {
+            match component {
+                Component::Prefix(x) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("Cannot parse path '{path:?}': Prefix '{x:?}' is not supported"),
+                    ));
+                }
+                Component::ParentDir => {
+                    let Some(_) = canonical_path.pop() else {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            format!(
+                                "Cannot parse path '{path:?}': Cannot get parent directory of root"
+                            ),
+                        ));
+                    };
+                }
+                Component::RootDir => {
+                    let _ = canonical_path.drain(..);
+                }
+                Component::CurDir => {
+                    // No-op
+                    continue;
+                }
+                Component::Normal(name) => {
+                    let Some(name) = name.to_str() else {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            format!("Cannot parse path '{path:?}': Segment '{name:?}' cannot be used as a UTF-8 string"),
+                        ));
+                    };
+
+                    canonical_path.push(name);
+                }
+            }
+        }
+
+        Ok(canonical_path)
+    }
+
+    /// Get the [`FileSystemDirectoryHandle`] for the root directory pointed to by `self.root`.
+    pub(crate) async fn shadow_root(&self) -> std::io::Result<FileSystemDirectoryHandle> {
+        let global: Global = js_sys::global().unchecked_into();
+
+        let storage_manager = if !global.window().is_undefined() {
+            let window: web_sys::Window = global.unchecked_into();
+            Ok(window.navigator().storage())
+        } else if !global.worker().is_undefined() {
+            let worker: web_sys::WorkerGlobalScope = global.unchecked_into();
+            Ok(worker.navigator().storage())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Unsupported global context",
+            ))
+        }?;
+
+        let root = storage_manager
+            .get_directory()
+            .into_js_future()
+            .await
+            .map_err(js_value_to_err(
+                "Cannot get StorageManager",
+                std::io::ErrorKind::PermissionDenied,
+            ))
+            .map(|value| value.unchecked_into())?;
+
+        get_directory(&root, self.root.iter().map(|value| value.as_str()), true).await
     }
 }
 
 impl AssetReader for OriginPrivateFileSystem {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let handle = get_file(&shadow_root, path, false, false)
-            .await
-            .map_err(|error| AssetReaderError::NotFound(path.to_owned()))?;
-        let reader = read_file(&handle).await?;
+        let shadow_root = self.shadow_root().await?;
 
-        Ok(reader)
+        let reader = get_file(&shadow_root, Self::canonical(path)?, false, false)
+            .await
+            .map_err(|_error| AssetReaderError::NotFound(path.to_owned()))?
+            .get_file()
+            .into_js_future()
+            .await
+            .map_err(js_value_to_err(
+                "Cannot get File from Handle",
+                std::io::ErrorKind::Other,
+            ))?
+            .unchecked_into::<web_sys::File>()
+            .get_async_reader()
+            .await?;
+
+        Ok(Box::new(reader))
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
         let path = &get_meta_path(path);
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let handle = get_file(&shadow_root, path, false, false)
-            .await
-            .map_err(|error| AssetReaderError::NotFound(path.to_owned()))?;
-        let reader = read_file(&handle).await?;
+        let shadow_root = self.shadow_root().await?;
 
-        Ok(reader)
+        let reader = get_file(&shadow_root, Self::canonical(path)?, false, false)
+            .await
+            .map_err(|_error| AssetReaderError::NotFound(path.to_owned()))?
+            .get_file()
+            .into_js_future()
+            .await
+            .map_err(js_value_to_err(
+                "Cannot get File from Handle",
+                std::io::ErrorKind::Other,
+            ))?
+            .unchecked_into::<web_sys::File>()
+            .get_async_reader()
+            .await?;
+
+        Ok(Box::new(reader))
     }
 
     async fn read_directory<'a>(
         &'a self,
         path: &'a Path,
     ) -> Result<Box<PathStream>, AssetReaderError> {
-        struct VecStream<T> {
-            inner: Box<[T]>,
-            cursor: usize,
-        }
+        let shadow_root = self.shadow_root().await?;
+        let handle = get_directory(&shadow_root, Self::canonical(path)?, false).await?;
+        let entries = get_entries(&handle).await;
 
-        impl<T: Clone> Stream for VecStream<T> {
-            type Item = T;
+        let (stream, task) = IndirectStream::wrap(entries);
 
-            fn poll_next(
-                mut self: Pin<&mut Self>,
-                _cx: &mut Context<'_>,
-            ) -> Poll<Option<Self::Item>> {
-                let item = self.inner.get(self.cursor).cloned();
+        spawn_local(task);
 
-                if item.is_some() {
-                    self.cursor += 1;
-                }
-
-                Poll::Ready(item)
-            }
-
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                let remaining = self.inner.len().saturating_sub(self.cursor);
-
-                (remaining, Some(remaining))
-            }
-        }
-
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let handle = get_directory(&shadow_root, path, false).await?;
-
-        let mut entries = get_entries(&handle).await;
-        let mut final_entries = Vec::new();
-
-        while let Some(entry) = entries.next().await {
-            final_entries.push(entry);
-        }
-
-        Ok(Box::new(VecStream {
-            inner: final_entries.into_boxed_slice(),
-            cursor: 0,
-        }))
+        Ok(Box::new(stream))
     }
 
     async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let result = get_directory(&shadow_root, path, false).await.is_ok();
+        let shadow_root = self.shadow_root().await?;
+        let result = get_directory(&shadow_root, Self::canonical(path)?, false)
+            .await
+            .is_ok();
 
         Ok(result)
     }
@@ -506,12 +177,20 @@ impl AssetReader for OriginPrivateFileSystem {
 
 impl AssetWriter for OriginPrivateFileSystem {
     async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let handle = get_file(&shadow_root, path, true, true).await?;
-        let writer = write_file(&handle).await?;
+        let shadow_root = self.shadow_root().await?;
+        let handle = get_file(&shadow_root, Self::canonical(path)?, true, true).await?;
 
-        Ok(writer)
+        let stream: FileSystemWritableFileStream = handle
+            .create_writable()
+            .into_js_future()
+            .await
+            .map_err(js_value_to_err(
+                "Cannot get Create Writable Stream",
+                std::io::ErrorKind::Other,
+            ))?
+            .unchecked_into();
+
+        Ok(Box::new(stream.into_async_writer()))
     }
 
     async fn write_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
@@ -519,39 +198,17 @@ impl AssetWriter for OriginPrivateFileSystem {
     }
 
     async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, false).await?;
-        let _ = get_file(&shadow_root, path, false, false).await?;
+        let shadow_root = self.shadow_root().await?;
+        let canon = Self::canonical(path)?;
+        let _ = get_file(&shadow_root, canon.iter().copied(), false, false).await?;
 
-        let mut components = path.components();
-
-        let Some(entry) = components.next_back() else {
-            return Err(AssetWriterError::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Provided path is empty",
-            )));
+        let [parent @ .., file] = canon.as_slice() else {
+            unreachable!("path valid based on above guard");
         };
 
-        let Component::Normal(entry) = entry else {
-            return Err(AssetWriterError::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Cannot parse path '{path:?}': final component must be an entry name"),
-            )));
-        };
+        let parent_handle = get_directory(&shadow_root, parent.iter().copied(), false).await?;
 
-        let Some(entry) = entry.to_str() else {
-            return Err(AssetWriterError::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "Cannot parse path '{path:?}': entry name '{entry:?}' cannot be used as a UTF-8 string"
-                ),
-            )));
-        };
-
-        let parent_handle =
-            get_directory(&shadow_root, components.collect::<PathBuf>(), false).await?;
-
-        remove_entry(&parent_handle, entry).await?;
+        remove_entry(&parent_handle, file).await?;
 
         Ok(())
     }
@@ -590,47 +247,25 @@ impl AssetWriter for OriginPrivateFileSystem {
     }
 
     async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let _ = get_directory(&shadow_root, path, true).await?;
+        let shadow_root = self.shadow_root().await?;
+        let canon = Self::canonical(path)?;
+        let _ = get_directory(&shadow_root, canon.iter().copied(), true).await?;
 
-        let mut components = path.components();
-
-        let Some(entry) = components.next_back() else {
-            return Err(AssetWriterError::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Provided path is empty",
-            )));
+        let [parent @ .., directory] = canon.as_slice() else {
+            unreachable!("path valid based on above guard");
         };
 
-        let Component::Normal(entry) = entry else {
-            return Err(AssetWriterError::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Cannot parse path '{path:?}': final component must be an entry name"),
-            )));
-        };
+        let parent_handle = get_directory(&shadow_root, parent.iter().copied(), false).await?;
 
-        let Some(entry) = entry.to_str() else {
-            return Err(AssetWriterError::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "Cannot parse path '{path:?}': entry name '{entry:?}' cannot be used as a UTF-8 string"
-                ),
-            )));
-        };
-
-        let parent_handle =
-            get_directory(&shadow_root, components.collect::<PathBuf>(), false).await?;
-
-        remove_entry(&parent_handle, entry).await?;
+        remove_entry(&parent_handle, directory).await?;
 
         Ok(())
     }
 
     async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let handle = get_directory(&shadow_root, path, true).await?;
+        let shadow_root = self.shadow_root().await?;
+        let canon = Self::canonical(path)?;
+        let handle = get_directory(&shadow_root, canon, true).await?;
         let mut stream = get_entries(&handle).await;
 
         if stream.next().await.is_some() {
@@ -647,9 +282,8 @@ impl AssetWriter for OriginPrivateFileSystem {
         &'a self,
         path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let root = get_storage_root().await?;
-        let shadow_root = get_directory(&root, &self.root, true).await?;
-        let handle = get_directory(&shadow_root, path, true).await?;
+        let shadow_root = self.shadow_root().await?;
+        let handle = get_directory(&shadow_root, Self::canonical(path)?, true).await?;
         let mut stream = get_entries(&handle).await;
 
         while let Some(entry) = stream.next().await {
@@ -661,5 +295,441 @@ impl AssetWriter for OriginPrivateFileSystem {
         }
 
         Ok(())
+    }
+}
+
+/// Reduced boilerplate for generating [error](std::io::Error) values.
+fn js_value_to_err(
+    context: &str,
+    kind: std::io::ErrorKind,
+) -> impl FnOnce(JsValue) -> std::io::Error + '_ {
+    move |value| {
+        let error = JSON::stringify(&value)
+            .map(String::from)
+            .ok()
+            .unwrap_or_else(|| "failed to stringify the JSValue of the error".to_owned());
+
+        let message = format!("JS Failure: '{context}': {error}");
+
+        std::io::Error::new(kind, message)
+    }
+}
+
+/// Open a directory relative to `start` from a given `path`.
+/// Will create directories based on the provided `path` if `create` is `true`.
+async fn get_directory(
+    start: &FileSystemDirectoryHandle,
+    path: impl IntoIterator<Item = &str>,
+    create: bool,
+) -> std::io::Result<FileSystemDirectoryHandle> {
+    let options = {
+        let mut options = FileSystemGetDirectoryOptions::new();
+        options.create(create);
+        options
+    };
+
+    let mut current = start.clone();
+
+    for component in path {
+        current = current
+            .get_directory_handle_with_options(component, &options)
+            .into_js_future()
+            .await
+            .map_err(js_value_to_err(
+                "Cannot get Directory Handle",
+                std::io::ErrorKind::NotFound,
+            ))
+            .map(|value| value.unchecked_into())?;
+    }
+
+    Ok(current)
+}
+
+/// Get child entries of this directory.
+async fn get_entries(start: &FileSystemDirectoryHandle) -> impl Stream<Item = PathBuf> + Unpin {
+    JsStream::from(start.keys())
+        .flat_map(|result| futures_lite::stream::iter(result.ok()))
+        .flat_map(|value| futures_lite::stream::iter(value.dyn_into::<JsString>().ok()))
+        .map(String::from)
+        .map(PathBuf::from)
+}
+
+/// Open a file relative to `start` from a given `path`.
+/// Will create directories and the final file based on the provided `path` if `create` is `true`.
+async fn get_file(
+    start: &FileSystemDirectoryHandle,
+    path: impl IntoIterator<Item = &str>,
+    create_file: bool,
+    create_path: bool,
+) -> std::io::Result<FileSystemFileHandle> {
+    let mut current = start.clone();
+
+    let mut iter = path.into_iter().peekable();
+
+    let options = {
+        let mut options = FileSystemGetDirectoryOptions::new();
+        options.create(create_path);
+        options
+    };
+
+    let file_name = loop {
+        let Some(path) = iter.next() else {
+            break None;
+        };
+
+        if iter.peek().is_none() {
+            break Some(path);
+        };
+
+        current = current
+            .get_directory_handle_with_options(path, &options)
+            .into_js_future()
+            .await
+            .map_err(js_value_to_err(
+                "Cannot get Directory Handle",
+                std::io::ErrorKind::NotFound,
+            ))
+            .map(|value| value.unchecked_into())?;
+    };
+
+    let Some(file_name) = file_name else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Provided path is empty",
+        ));
+    };
+
+    current
+        .get_file_handle_with_options(file_name, &{
+            let mut options = FileSystemGetFileOptions::new();
+            options.create(create_file);
+            options
+        })
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "File not available",
+            std::io::ErrorKind::NotFound,
+        ))
+        .map(|value| value.unchecked_into())
+}
+
+async fn remove_entry(handle: &FileSystemDirectoryHandle, entry: &str) -> std::io::Result<()> {
+    handle
+        .remove_entry_with_options(entry, &{
+            let mut options = FileSystemRemoveOptions::new();
+            options.recursive(true);
+            options
+        })
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "Cannot remove Directory",
+            std::io::ErrorKind::Other,
+        ))?
+        .is_undefined()
+        .then_some(())
+        .ok_or(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to remove entry",
+        ))
+}
+
+mod utils {
+    use crate::io::wasm::opfs::js_value_to_err;
+    use crate::io::VecReader;
+    use async_channel::{TryRecvError, TrySendError};
+    use bevy_utils::tracing::error;
+    use futures_io::{AsyncRead, AsyncSeek, AsyncWrite};
+    use futures_lite::{pin, FutureExt, Stream, StreamExt};
+    use js_sys::{ArrayBuffer, AsyncIterator, IteratorNext, Uint8Array};
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+    use wasm_bindgen::prelude::wasm_bindgen;
+    use wasm_bindgen::{JsCast, JsValue};
+    use wasm_bindgen_futures::{spawn_local, JsFuture};
+    use web_sys::{Blob, FileSystemDirectoryHandle, FileSystemWritableFileStream};
+
+    /// Extension method to allow for a more ergonomic handling of [promises](`js_sys::Promise`).
+    pub(crate) trait IntoJsFuture: Into<JsFuture> {
+        /// Convert this [thenable](`js_sys::Promise`) into a [`JsFuture`].
+        fn into_js_future(self) -> JsFuture {
+            self.into()
+        }
+    }
+
+    impl<T: Into<JsFuture>> IntoJsFuture for T {}
+
+    /// A [`Stream`] that yields values from an underlying [`AsyncIterator`]
+    ///
+    /// Based on [`wasm_bindgen_futures::stream::JsStream`](https://github.com/olanod/wasm-bindgen/blob/a8edfb117c79654773cf3d9b4da3e4a01b9884ab/crates/futures/src/stream.rs).
+    /// Can be removed once [#2399](https://github.com/rustwasm/wasm-bindgen/issues/2399) is resolved.
+    pub(crate) struct JsStream {
+        iter: AsyncIterator,
+        next: Option<JsFuture>,
+        done: bool,
+    }
+
+    impl Stream for JsStream {
+        type Item = Result<JsValue, JsValue>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if self.done {
+                return Poll::Ready(None);
+            }
+
+            let future = match self.next.as_mut() {
+                Some(val) => val,
+                None => match self.iter.next().map(JsFuture::from) {
+                    Ok(val) => {
+                        self.next = Some(val);
+                        self.next.as_mut().unwrap()
+                    }
+                    Err(e) => {
+                        self.done = true;
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                },
+            };
+
+            match Pin::new(future).poll(cx) {
+                Poll::Ready(res) => match res {
+                    Ok(iter_next) => {
+                        let next = iter_next.unchecked_into::<IteratorNext>();
+                        if next.done() {
+                            self.done = true;
+                            Poll::Ready(None)
+                        } else {
+                            self.next.take();
+                            Poll::Ready(Some(Ok(next.value())))
+                        }
+                    }
+                    Err(e) => {
+                        self.done = true;
+                        Poll::Ready(Some(Err(e)))
+                    }
+                },
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl From<AsyncIterator> for JsStream {
+        fn from(value: AsyncIterator) -> Self {
+            Self {
+                iter: value,
+                next: None,
+                done: false,
+            }
+        }
+    }
+
+    /// Extension trait providing access to the async iterator methods on [`FileSystemDirectoryHandle`]
+    /// which are currently missing from [`wasm-bindgen`](`wasm_bindgen`)
+    pub(crate) trait FileSystemDirectoryHandleExt {
+        fn keys(&self) -> AsyncIterator;
+    }
+
+    impl FileSystemDirectoryHandleExt for FileSystemDirectoryHandle {
+        /// The `keys()` method.
+        ///
+        /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/keys)
+        ///
+        /// *This API requires the following crate features to be activated: `FileSystemDirectoryHandle`*
+        fn keys(&self) -> AsyncIterator {
+            #[wasm_bindgen(
+                inline_js = "export function get_keys_for_handle(a) { return a.keys(); }"
+            )]
+            extern "C" {
+                fn get_keys_for_handle(a: &FileSystemDirectoryHandle) -> AsyncIterator;
+            }
+
+            get_keys_for_handle(self)
+        }
+    }
+
+    /// Uses channels to create a [`Send`] + [`Sync`] wrapper around a [`Stream`].
+    pub(crate) struct IndirectStream<T> {
+        request: Pin<Box<async_channel::Sender<Waker>>>,
+        response: Pin<Box<async_channel::Receiver<T>>>,
+    }
+
+    impl<T> Stream for IndirectStream<T> {
+        type Item = T;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            match self.response.try_recv() {
+                Ok(value) => Poll::Ready(Some(value)),
+                Err(TryRecvError::Closed) => Poll::Ready(None),
+                Err(TryRecvError::Empty) => match self.request.try_send(cx.waker().clone()) {
+                    Ok(_) | Err(TrySendError::Full(_)) => Poll::Pending,
+                    Err(TrySendError::Closed(_)) => Poll::Ready(None),
+                },
+            }
+        }
+    }
+
+    impl<T: Send + Sync + 'static> IndirectStream<T> {
+        /// Take the provided `stream` and split it into a [`Send`] + [`Sync`] stream and a backing task.
+        /// It is the callers responsibility to ensure the task is run on an appropriate runtime.
+        ///
+        /// Internally uses [async channels](`async_channel`) to request values from the stream whilst
+        /// also passing an appropriate [`Waker`].
+        pub(crate) fn wrap(
+            stream: impl Stream<Item = T> + 'static,
+        ) -> (Self, impl std::future::Future<Output = ()>) {
+            let (send_waker, receive_waker) = async_channel::bounded::<Waker>(1);
+            let (send_value, receive_value) = async_channel::bounded::<T>(1);
+
+            let task = async move {
+                pin!(stream);
+                pin!(receive_waker);
+                pin!(send_value);
+
+                while let Some(waker) = receive_waker.next().await {
+                    if let Some(item) = stream.next().await {
+                        if let Ok(_) = send_value.send(item).await {
+                            waker.wake();
+                            continue;
+                        }
+                    }
+
+                    waker.wake();
+                    break;
+                }
+            };
+
+            let stream = Self {
+                request: Box::into_pin(Box::new(send_waker)),
+                response: Box::into_pin(Box::new(receive_value)),
+            };
+
+            (stream, task)
+        }
+    }
+
+    pub(crate) trait BlobExt {
+        async fn get_async_reader(
+            &self,
+        ) -> std::io::Result<impl AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static>;
+    }
+
+    impl BlobExt for Blob {
+        async fn get_async_reader(
+            &self,
+        ) -> std::io::Result<impl AsyncRead + AsyncSeek + Unpin + Send + Sync + 'static> {
+            let buffer: ArrayBuffer = self
+                .array_buffer()
+                .into_js_future()
+                .await
+                .map_err(js_value_to_err(
+                    "Cannot get Buffer from Blob",
+                    std::io::ErrorKind::Other,
+                ))?
+                .unchecked_into();
+
+            let bytes = Uint8Array::new(&buffer).to_vec();
+
+            Ok(VecReader::new(bytes))
+        }
+    }
+
+    pub(crate) trait FileSystemWritableFileStreamExt {
+        fn into_async_writer(self) -> impl AsyncWrite + Unpin + Send + Sync;
+    }
+
+    impl FileSystemWritableFileStreamExt for FileSystemWritableFileStream {
+        /// Create an [async writer](`AsyncWrite`) from this [`FileSystemWritableFileStream`].
+        fn into_async_writer(self) -> impl AsyncWrite + Unpin + Send + Sync {
+            struct FileStreamWriter {
+                writes: async_channel::Sender<Box<[u8]>>,
+                wake_on_closed: async_channel::Sender<Waker>,
+            }
+
+            impl AsyncWrite for FileStreamWriter {
+                fn poll_write(
+                    self: Pin<&mut Self>,
+                    _cx: &mut Context<'_>,
+                    buf: &[u8],
+                ) -> Poll<std::io::Result<usize>> {
+                    if self.writes.is_full() {
+                        return Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "Could not send write request to writer",
+                        )));
+                    }
+
+                    if self.writes.is_closed() {
+                        return Poll::Ready(Ok(0));
+                    }
+
+                    let write = buf.to_owned().into_boxed_slice();
+
+                    let Ok(_) = self.writes.try_send(write) else {
+                        return Poll::Ready(Ok(0));
+                    };
+
+                    Poll::Ready(Ok(buf.len()))
+                }
+
+                fn poll_flush(
+                    self: Pin<&mut Self>,
+                    _cx: &mut Context<'_>,
+                ) -> Poll<std::io::Result<()>> {
+                    return Poll::Ready(Ok(()));
+                }
+
+                fn poll_close(
+                    self: Pin<&mut Self>,
+                    cx: &mut Context<'_>,
+                ) -> Poll<std::io::Result<()>> {
+                    if self.wake_on_closed.is_closed() {
+                        return Poll::Ready(Ok(()));
+                    }
+
+                    match self.wake_on_closed.try_send(cx.waker().clone()) {
+                        Ok(_) => Poll::Pending,
+                        Err(TrySendError::Closed(_)) => Poll::Ready(Ok(())),
+                        Err(TrySendError::Full(_)) => Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "Could not send close request to AsyncWrite stream",
+                        ))),
+                    }
+                }
+            }
+
+            let (send_bytes, receive_bytes) = async_channel::unbounded::<Box<[u8]>>();
+            let (send_waker, receive_waker) = async_channel::unbounded::<Waker>();
+
+            spawn_local(async move {
+                pin!(receive_bytes);
+                pin!(receive_waker);
+
+                while let Some(buf) = receive_bytes.next().await {
+                    if let Ok(promise) = self.write_with_u8_array(&buf) {
+                        if let Ok(_) = promise.into_js_future().await {
+                            continue;
+                        }
+                    }
+
+                    break;
+                }
+
+                receive_bytes.close();
+
+                if self.close().into_js_future().await.is_err() {
+                    error!("FileSystemWritableFileStream could not be closed properly.");
+                }
+
+                while let Ok(waker) = receive_waker.try_recv() {
+                    waker.wake()
+                }
+            });
+
+            FileStreamWriter {
+                writes: send_bytes,
+                wake_on_closed: send_waker,
+            }
+        }
     }
 }

--- a/crates/bevy_asset/src/io/wasm/opfs.rs
+++ b/crates/bevy_asset/src/io/wasm/opfs.rs
@@ -1,0 +1,665 @@
+use crate::io::wasm::Global;
+use crate::io::{
+    get_meta_path, AssetReader, AssetReaderError, AssetWriter, AssetWriterError, PathStream,
+    Reader, VecReader, Writer,
+};
+use async_channel::TrySendError;
+use bevy_utils::tracing::{error, info};
+use futures_io::AsyncWrite;
+use futures_lite::{pin, AsyncReadExt, AsyncWriteExt, FutureExt, Stream, StreamExt};
+use js_sys::{ArrayBuffer, AsyncIterator, JsString, Uint8Array, JSON};
+use std::path::{Component, Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+use web_sys::{
+    FileSystemDirectoryHandle, FileSystemFileHandle, FileSystemGetDirectoryOptions,
+    FileSystemGetFileOptions, FileSystemRemoveOptions, FileSystemWritableFileStream,
+    StorageManager,
+};
+
+#[wasm_bindgen(inline_js = "export function get_keys_for_handle(a) { return a.keys(); }")]
+extern "C" {
+    /// Workaround to provide [keys](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/keys)
+    fn get_keys_for_handle(a: &FileSystemDirectoryHandle) -> AsyncIterator;
+}
+
+fn js_value_to_err(
+    context: &str,
+    kind: std::io::ErrorKind,
+) -> impl FnOnce(JsValue) -> std::io::Error + '_ {
+    move |value| {
+        let message = match JSON::stringify(&value) {
+            Ok(js_str) => format!("JS Failure: '{context}': {js_str}"),
+            Err(_) => {
+                format!("Failed to {context} and also failed to stringify the JSValue of the error")
+            }
+        };
+
+        std::io::Error::new(kind, message)
+    }
+}
+
+/// Get the [`StorageManager`] from the global context. Will return [`None`] if the context is not either
+/// standard (e.g., with access to `window`), or a worker.
+fn get_storage_manager() -> std::io::Result<StorageManager> {
+    let global: Global = js_sys::global().unchecked_into();
+
+    if !global.window().is_undefined() {
+        let window: web_sys::Window = global.unchecked_into();
+        Ok(window.navigator().storage())
+    } else if !global.worker().is_undefined() {
+        let worker: web_sys::WorkerGlobalScope = global.unchecked_into();
+        Ok(worker.navigator().storage())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Unsupported global context",
+        ))
+    }
+}
+
+/// Extension method to allow for a more ergonomic handling of [promises](`js_sys::Promise`).
+trait IntoJsFuture: Into<JsFuture> {
+    /// Convert this [thenable](`js_sys::Promise`) into a [`JsFuture`].
+    fn into_js_future(self) -> JsFuture {
+        self.into()
+    }
+}
+
+impl<T: Into<JsFuture>> IntoJsFuture for T {}
+
+/// Get the [`FileSystemDirectoryHandle`] for the root Origin Private File System. See
+/// [MDN](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/getDirectory) for details.
+///
+/// Can fail if a `SecurityError` exception is thrown by the JS runtime.
+async fn get_storage_root() -> std::io::Result<FileSystemDirectoryHandle> {
+    get_storage_manager()?
+        .get_directory()
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "Cannot get StorageManager",
+            std::io::ErrorKind::PermissionDenied,
+        ))
+        .map(|value| value.unchecked_into())
+}
+
+/// Open a directory relative to `start` from a given `path`.
+/// Will create directories based on the provided `path` if `create` is `true`.
+async fn get_directory(
+    start: &FileSystemDirectoryHandle,
+    path: impl AsRef<Path>,
+    create: bool,
+) -> std::io::Result<FileSystemDirectoryHandle> {
+    let path = path.as_ref();
+
+    let mut options = FileSystemGetDirectoryOptions::new();
+    options.create(create);
+
+    let mut current = start.clone();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(x) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Cannot parse path '{path:?}': Prefix '{x:?}' is not supported"),
+                ));
+            }
+            Component::RootDir => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Cannot parse path '{path:?}': Cannot use an absolute path"),
+                ));
+            }
+            Component::ParentDir => {
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Cannot parse path '{path:?}': Relative traversal up the hierarchy is not supported")));
+            }
+            Component::CurDir => {
+                // No-op
+                continue;
+            }
+            Component::Normal(name) => {
+                let Some(name) = name.to_str() else {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Cannot parse path '{path:?}': Segment '{name:?}' cannot be used as a UTF-8 string")));
+                };
+
+                current = current
+                    .get_directory_handle_with_options(name, &options)
+                    .into_js_future()
+                    .await
+                    .map_err(js_value_to_err(
+                        "Cannot get Directory Handle",
+                        std::io::ErrorKind::Other,
+                    ))
+                    .map(|value| value.unchecked_into())?;
+            }
+        }
+    }
+
+    Ok(current)
+}
+
+/// Get child entries of this directory.
+async fn get_entries(start: &FileSystemDirectoryHandle) -> impl Stream<Item = PathBuf> + Unpin {
+    struct EntriesStream {
+        inner: AsyncIterator,
+        current: Option<JsFuture>,
+    }
+
+    impl Stream for EntriesStream {
+        type Item = PathBuf;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let mut current = match self.current.take() {
+                Some(current) => current,
+                None => {
+                    let Ok(next) = self.inner.next() else {
+                        return Poll::Ready(None);
+                    };
+
+                    next.into_js_future()
+                }
+            };
+
+            match current.poll(cx) {
+                Poll::Ready(result) => {
+                    let result = result
+                        .ok()
+                        .and_then(|value| value.dyn_ref::<JsString>().cloned())
+                        .map(String::from)
+                        .map(PathBuf::from);
+
+                    Poll::Ready(result)
+                }
+                Poll::Pending => {
+                    self.current = Some(current);
+
+                    Poll::Pending
+                }
+            }
+        }
+    }
+
+    EntriesStream {
+        inner: get_keys_for_handle(start),
+        current: None,
+    }
+}
+
+/// Open a file relative to `start` from a given `path`.
+/// Will create directories and the final file based on the provided `path` if `create` is `true`.
+async fn get_file(
+    start: &FileSystemDirectoryHandle,
+    path: impl AsRef<Path>,
+    create_file: bool,
+    create_path: bool,
+) -> std::io::Result<FileSystemFileHandle> {
+    let path = path.as_ref();
+
+    let mut components = path.components();
+
+    let Some(file_name) = components.next_back() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Provided path is empty",
+        ));
+    };
+
+    let Component::Normal(file_name) = file_name else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Cannot parse path '{path:?}': final component must be a file name"),
+        ));
+    };
+
+    let Some(file_name) = file_name.to_str() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "Cannot parse path '{path:?}': file name '{file_name:?}' cannot be used as a UTF-8 string"
+            ),
+        ));
+    };
+
+    get_directory(start, components.collect::<PathBuf>(), create_path)
+        .await?
+        .get_file_handle_with_options(file_name, &{
+            let mut options = FileSystemGetFileOptions::new();
+            options.create(create_file);
+            options
+        })
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            format!("File not available: '{path:?}'").as_str(),
+            std::io::ErrorKind::NotFound,
+        ))
+        .map(|value| value.unchecked_into())
+}
+
+/// Read the contents of a [file handle](`FileSystemFileHandle`).
+async fn read_file<'a>(handle: &FileSystemFileHandle) -> std::io::Result<Box<Reader<'a>>> {
+    let file: web_sys::File = handle
+        .get_file()
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "Cannot get File from Handle",
+            std::io::ErrorKind::Other,
+        ))?
+        .unchecked_into();
+
+    let buffer: ArrayBuffer = file
+        .array_buffer()
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "Cannot get Buffer from File",
+            std::io::ErrorKind::Other,
+        ))?
+        .unchecked_into();
+
+    let bytes = Uint8Array::new(&buffer).to_vec();
+
+    Ok(Box::new(VecReader::new(bytes)))
+}
+
+async fn write_file(handle: &FileSystemFileHandle) -> std::io::Result<Box<Writer>> {
+    enum Command {
+        Write(Box<[u8]>, Waker),
+        Flush(Waker),
+        Close(Waker),
+    }
+
+    struct FileStreamWriter {
+        commands: async_channel::Sender<Command>,
+    }
+
+    impl AsyncWrite for FileStreamWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            match self.commands.try_send(Command::Write(
+                buf.to_owned().into_boxed_slice(),
+                cx.waker().clone(),
+            )) {
+                Ok(()) => Poll::Ready(Ok(buf.len())),
+                Err(TrySendError::Closed(..)) => Poll::Ready(Ok(0)),
+                Err(TrySendError::Full(..)) => Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Could not send write request to writer",
+                ))),
+            }
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            match self.commands.try_send(Command::Flush(cx.waker().clone())) {
+                Ok(()) => Poll::Ready(Ok(())),
+                Err(TrySendError::Closed(..)) => Poll::Ready(Ok(())),
+                Err(TrySendError::Full(..)) => Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Could not send flush request to writer",
+                ))),
+            }
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            match self.commands.try_send(Command::Close(cx.waker().clone())) {
+                Ok(()) => Poll::Pending,
+                Err(TrySendError::Closed(..)) => Poll::Ready(Ok(())),
+                Err(TrySendError::Full(..)) => Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Could not send close request to writer",
+                ))),
+            }
+        }
+    }
+
+    let stream: FileSystemWritableFileStream = handle
+        .create_writable()
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "Cannot get Create Writable Stream",
+            std::io::ErrorKind::Other,
+        ))?
+        .unchecked_into();
+
+    let (sender, receiver) = async_channel::unbounded::<Command>();
+
+    spawn_local(async move {
+        info!("Starting a writer...");
+        let stream = stream;
+        let receiver = receiver;
+        pin!(receiver);
+
+        let maybe_waker = loop {
+            let Some(command) = receiver.next().await else {
+                break None;
+            };
+
+            match command {
+                Command::Write(buf, waker) => {
+                    info!("Writing {:?}", buf);
+                    let Ok(promise) = stream.write_with_u8_array(&buf) else {
+                        error!("Cannot Write to Stream!");
+                        break None;
+                    };
+
+                    let Ok(_) = promise.into_js_future().await else {
+                        error!("Cannot Write to Stream!");
+                        break None;
+                    };
+
+                    waker.wake();
+                }
+                Command::Flush(waker) => {
+                    info!("Flushing");
+                    waker.wake();
+                }
+                Command::Close(waker) => {
+                    info!("Closing");
+                    let Ok(_) = stream.close().into_js_future().await else {
+                        error!("Cannot Close Stream!");
+                        break None;
+                    };
+
+                    break Some(waker);
+                }
+            }
+        };
+
+        drop(receiver);
+
+        if let Some(waker) = maybe_waker {
+            waker.wake();
+        } else {
+            if stream.close().into_js_future().await.is_err() {
+                error!("Stream was closed unexpectedly and could not be closed properly.");
+            }
+        }
+    });
+
+    Ok(Box::new(FileStreamWriter { commands: sender }))
+}
+
+async fn remove_entry(handle: &FileSystemDirectoryHandle, entry: &str) -> std::io::Result<()> {
+    handle
+        .remove_entry_with_options(entry, &{
+            let mut options = FileSystemRemoveOptions::new();
+            options.recursive(true);
+            options
+        })
+        .into_js_future()
+        .await
+        .map_err(js_value_to_err(
+            "Cannot remove Directory",
+            std::io::ErrorKind::Other,
+        ))?
+        .is_undefined()
+        .then_some(())
+        .ok_or(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to remove entry",
+        ))
+}
+
+/// Bevy compatible wrapper for the [Origin Private File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)
+pub struct OriginPrivateFileSystem {
+    root: PathBuf,
+}
+
+impl OriginPrivateFileSystem {
+    /// Constructs a new [`OriginPrivateFileSystem`] with the provided shadow-root.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+impl AssetReader for OriginPrivateFileSystem {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let handle = get_file(&shadow_root, path, false, false)
+            .await
+            .map_err(|error| AssetReaderError::NotFound(path.to_owned()))?;
+        let reader = read_file(&handle).await?;
+
+        Ok(reader)
+    }
+
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+        let path = &get_meta_path(path);
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let handle = get_file(&shadow_root, path, false, false)
+            .await
+            .map_err(|error| AssetReaderError::NotFound(path.to_owned()))?;
+        let reader = read_file(&handle).await?;
+
+        Ok(reader)
+    }
+
+    async fn read_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<PathStream>, AssetReaderError> {
+        struct VecStream<T> {
+            inner: Box<[T]>,
+            cursor: usize,
+        }
+
+        impl<T: Clone> Stream for VecStream<T> {
+            type Item = T;
+
+            fn poll_next(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Option<Self::Item>> {
+                let item = self.inner.get(self.cursor).cloned();
+
+                if item.is_some() {
+                    self.cursor += 1;
+                }
+
+                Poll::Ready(item)
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                let remaining = self.inner.len().saturating_sub(self.cursor);
+
+                (remaining, Some(remaining))
+            }
+        }
+
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let handle = get_directory(&shadow_root, path, false).await?;
+
+        let mut entries = get_entries(&handle).await;
+        let mut final_entries = Vec::new();
+
+        while let Some(entry) = entries.next().await {
+            final_entries.push(entry);
+        }
+
+        Ok(Box::new(VecStream {
+            inner: final_entries.into_boxed_slice(),
+            cursor: 0,
+        }))
+    }
+
+    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let result = get_directory(&shadow_root, path, false).await.is_ok();
+
+        Ok(result)
+    }
+}
+
+impl AssetWriter for OriginPrivateFileSystem {
+    async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let handle = get_file(&shadow_root, path, true, true).await?;
+        let writer = write_file(&handle).await?;
+
+        Ok(writer)
+    }
+
+    async fn write_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
+        self.write(&get_meta_path(path)).await
+    }
+
+    async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, false).await?;
+        let _ = get_file(&shadow_root, path, false, false).await?;
+
+        let mut components = path.components();
+
+        let Some(entry) = components.next_back() else {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Provided path is empty",
+            )));
+        };
+
+        let Component::Normal(entry) = entry else {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Cannot parse path '{path:?}': final component must be an entry name"),
+            )));
+        };
+
+        let Some(entry) = entry.to_str() else {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Cannot parse path '{path:?}': entry name '{entry:?}' cannot be used as a UTF-8 string"
+                ),
+            )));
+        };
+
+        let parent_handle =
+            get_directory(&shadow_root, components.collect::<PathBuf>(), false).await?;
+
+        remove_entry(&parent_handle, entry).await?;
+
+        Ok(())
+    }
+
+    async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+        self.remove(&get_meta_path(path)).await
+    }
+
+    async fn rename<'a>(
+        &'a self,
+        old_path: &'a Path,
+        new_path: &'a Path,
+    ) -> Result<(), AssetWriterError> {
+        let mut buffer = Vec::new();
+
+        self.read(old_path)
+            .await
+            .map_err(|error| {
+                AssetWriterError::from(std::io::Error::new(std::io::ErrorKind::Other, error))
+            })?
+            .read_to_end(&mut buffer)
+            .await?;
+        self.write(new_path).await?.write(&buffer).await?;
+        self.remove(old_path).await?;
+
+        Ok(())
+    }
+
+    async fn rename_meta<'a>(
+        &'a self,
+        old_path: &'a Path,
+        new_path: &'a Path,
+    ) -> Result<(), AssetWriterError> {
+        self.rename(&get_meta_path(old_path), &get_meta_path(new_path))
+            .await
+    }
+
+    async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let _ = get_directory(&shadow_root, path, true).await?;
+
+        let mut components = path.components();
+
+        let Some(entry) = components.next_back() else {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Provided path is empty",
+            )));
+        };
+
+        let Component::Normal(entry) = entry else {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Cannot parse path '{path:?}': final component must be an entry name"),
+            )));
+        };
+
+        let Some(entry) = entry.to_str() else {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Cannot parse path '{path:?}': entry name '{entry:?}' cannot be used as a UTF-8 string"
+                ),
+            )));
+        };
+
+        let parent_handle =
+            get_directory(&shadow_root, components.collect::<PathBuf>(), false).await?;
+
+        remove_entry(&parent_handle, entry).await?;
+
+        Ok(())
+    }
+
+    async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let handle = get_directory(&shadow_root, path, true).await?;
+        let mut stream = get_entries(&handle).await;
+
+        if stream.next().await.is_some() {
+            return Err(AssetWriterError::from(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Directory is not empty",
+            )));
+        }
+
+        self.remove_directory(path).await
+    }
+
+    async fn remove_assets_in_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<(), AssetWriterError> {
+        let root = get_storage_root().await?;
+        let shadow_root = get_directory(&root, &self.root, true).await?;
+        let handle = get_directory(&shadow_root, path, true).await?;
+        let mut stream = get_entries(&handle).await;
+
+        while let Some(entry) = stream.next().await {
+            let Some(entry) = entry.to_str() else {
+                unreachable!("Only valid UTF-8 is storable in the Origin Private File System")
+            };
+
+            remove_entry(&handle, entry).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -32,7 +32,6 @@ mod path;
 mod reflect;
 mod server;
 
-#[cfg(not(target_arch = "wasm32"))]
 mod temp;
 
 pub use assets::*;
@@ -50,8 +49,6 @@ pub use loader_builders::{
 pub use path::*;
 pub use reflect::*;
 pub use server::*;
-
-#[cfg(not(target_arch = "wasm32"))]
 pub use temp::TempDirectory;
 
 /// Rusty Object Notation, a crate used to serialize and deserialize bevy assets.
@@ -178,21 +175,18 @@ impl Plugin for AssetPlugin {
             embedded.register_source(&mut sources);
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            match temp::get_temp_source(app.world_mut(), self.temporary_file_path.clone()) {
-                Ok(source) => {
-                    let mut sources = app
-                        .world_mut()
-                        .get_resource_or_insert_with::<AssetSourceBuilders>(Default::default);
+        match temp::get_temp_source(app.world_mut(), self.temporary_file_path.clone()) {
+            Ok(source) => {
+                let mut sources = app
+                    .world_mut()
+                    .get_resource_or_insert_with::<AssetSourceBuilders>(Default::default);
 
-                    sources.insert("temp", source);
-                }
-                Err(error) => {
-                    error!("Could not setup temp:// AssetSource due to an IO Error: {error}");
-                }
-            };
-        }
+                sources.insert("temp", source);
+            }
+            Err(error) => {
+                error!("Could not setup temp:// AssetSource due to an IO Error: {error}");
+            }
+        };
 
         {
             let mut watch = cfg!(feature = "watch");

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -51,6 +51,9 @@ pub use path::*;
 pub use reflect::*;
 pub use server::*;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use temp::TempDirectory;
+
 /// Rusty Object Notation, a crate used to serialize and deserialize bevy assets.
 pub use ron;
 

--- a/crates/bevy_asset/src/temp.rs
+++ b/crates/bevy_asset/src/temp.rs
@@ -38,7 +38,7 @@ pub(crate) fn get_temp_source(
         Some(resource) => resource,
         None => match temporary_file_path {
             Some(path) => TempDirectory::Persist(path.into()),
-            None => TempDirectory::Delete(tempfile::tempdir()?),
+            None => TempDirectory::Delete(tempfile::TempDir::with_prefix("bevy")?),
         },
     };
 

--- a/crates/bevy_asset/src/temp.rs
+++ b/crates/bevy_asset/src/temp.rs
@@ -1,0 +1,56 @@
+use std::{
+    io::{Error, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use bevy_ecs::{system::Resource, world::World};
+
+use crate::io::AssetSourceBuilder;
+
+/// Private resource to store the temporary directory used by `temp://`.
+/// Kept private as it should only be removed on application exit.
+#[derive(Resource)]
+enum TempDirectory {
+    /// Uses [`TempDir`](tempfile::TempDir)'s drop behaviour to delete the directory.
+    /// Note that this is not _guaranteed_ to succeed, so it is possible to leak files from this
+    /// option until the underlying OS cleans temporary directories. For secure files, consider using
+    /// [`tempfile`](tempfile::tempfile) directly.
+    Delete(tempfile::TempDir),
+    /// Will not delete the temporary directory on exit, leaving cleanup the responsibility of
+    /// the user or their system.
+    Persist(PathBuf),
+}
+
+impl TempDirectory {
+    fn path(&self) -> &Path {
+        match self {
+            TempDirectory::Delete(x) => x.path(),
+            TempDirectory::Persist(x) => x.as_ref(),
+        }
+    }
+}
+
+pub(crate) fn get_temp_source(
+    world: &mut World,
+    temporary_file_path: Option<String>,
+) -> std::io::Result<AssetSourceBuilder> {
+    let temp_dir = match world.remove_resource::<TempDirectory>() {
+        Some(resource) => resource,
+        None => match temporary_file_path {
+            Some(path) => TempDirectory::Persist(path.into()),
+            None => TempDirectory::Delete(tempfile::tempdir()?),
+        },
+    };
+
+    let path = temp_dir
+        .path()
+        .as_os_str()
+        .try_into()
+        .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+
+    let source = AssetSourceBuilder::platform_default(path, None);
+
+    world.insert_resource(temp_dir);
+
+    Ok(source)
+}

--- a/crates/bevy_asset/src/temp.rs
+++ b/crates/bevy_asset/src/temp.rs
@@ -4,14 +4,55 @@ use std::{
 };
 
 use bevy_ecs::{system::Resource, world::World};
+use bevy_utils::Duration;
 
-use crate::io::AssetSourceBuilder;
+use crate::io::{
+    AssetReader, AssetSource, AssetSourceBuilder, AssetSourceEvent, AssetWatcher, AssetWriter,
+    ErasedAssetReader, ErasedAssetWriter,
+};
+
+/// A [resource](`Resource`) providing access to the temporary directory used by the `temp://`
+/// [asset source](`AssetSource`).
+#[derive(Resource)]
+pub struct TempDirectory {
+    directory: TempDirectoryKind,
+}
+
+impl TempDirectory {
+    /// Try to create a new [`TempDirectory`] resource, which uses a randomly created
+    /// directory in the user's temporary directory. This can fail if the platform does not
+    /// provide an appropriate temporary directory, or the directory itself could not be created.
+    pub fn new_transient() -> std::io::Result<Self> {
+        let directory = TempDirectoryKind::new_transient()?;
+
+        Ok(Self { directory })
+    }
+
+    /// Create a new [`TempDirectory`] resource, which uses a provided directory to store temporary
+    /// assets. It is assumed this directory already exists, and it will _not_ be deleted on exit.
+    pub fn new_persistent(path: impl Into<PathBuf>) -> Self {
+        let directory = TempDirectoryKind::new_persistent(path);
+
+        Self { directory }
+    }
+
+    /// Get the [`Path`] to the directory used for temporary assets.
+    pub fn path(&self) -> &Path {
+        self.directory.path()
+    }
+
+    /// Persist the current temporary asset directory after application exit.
+    pub fn persist(&mut self) -> &mut Self {
+        self.directory.persist();
+
+        self
+    }
+}
 
 /// Private resource to store the temporary directory used by `temp://`.
 /// Kept private as it should only be removed on application exit.
-#[derive(Resource)]
-enum TempDirectory {
-    /// Uses [`TempDir`](tempfile::TempDir)'s drop behaviour to delete the directory.
+enum TempDirectoryKind {
+    /// Uses [`TempDir`](tempfile::TempDir)'s drop behavior to delete the directory.
     /// Note that this is not _guaranteed_ to succeed, so it is possible to leak files from this
     /// option until the underlying OS cleans temporary directories. For secure files, consider using
     /// [`tempfile`](tempfile::tempfile) directly.
@@ -21,12 +62,36 @@ enum TempDirectory {
     Persist(PathBuf),
 }
 
-impl TempDirectory {
+impl TempDirectoryKind {
+    fn new_transient() -> std::io::Result<Self> {
+        let directory = tempfile::TempDir::with_prefix("bevy_")?;
+        Ok(Self::Delete(directory))
+    }
+
+    fn new_persistent(path: impl Into<PathBuf>) -> Self {
+        Self::Persist(path.into())
+    }
+
     fn path(&self) -> &Path {
         match self {
-            TempDirectory::Delete(x) => x.path(),
-            TempDirectory::Persist(x) => x.as_ref(),
+            Self::Delete(x) => x.as_ref(),
+            Self::Persist(x) => x.as_ref(),
         }
+    }
+
+    fn persist(&mut self) -> &mut Self {
+        let mut swap = Self::Persist(PathBuf::new());
+
+        std::mem::swap(self, &mut swap);
+
+        let new = match swap {
+            Self::Delete(x) => Self::Persist(x.into_path()),
+            x @ Self::Persist(_) => x,
+        };
+
+        *self = new;
+
+        self
     }
 }
 
@@ -37,20 +102,177 @@ pub(crate) fn get_temp_source(
     let temp_dir = match world.remove_resource::<TempDirectory>() {
         Some(resource) => resource,
         None => match temporary_file_path {
-            Some(path) => TempDirectory::Persist(path.into()),
-            None => TempDirectory::Delete(tempfile::TempDir::with_prefix("bevy")?),
+            Some(path) => TempDirectory::new_persistent(path),
+            None => TempDirectory::new_transient()?,
         },
     };
 
-    let path = temp_dir
+    let path: &str = temp_dir
         .path()
         .as_os_str()
         .try_into()
         .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
 
-    let source = AssetSourceBuilder::platform_default(path, None);
+    let path = path.to_owned();
+    let debounce = Duration::from_millis(300);
+
+    let source = AssetSourceBuilder::default()
+        .with_reader(TempAssetReader::get_default(path.clone()))
+        .with_writer(TempAssetWriter::get_default(path.clone()))
+        .with_watcher(TempAssetWatcher::get_default(path.clone(), debounce))
+        .with_watch_warning(TempAssetWatcher::get_default_watch_warning());
 
     world.insert_resource(temp_dir);
 
     Ok(source)
 }
+
+struct TempAssetReader {
+    inner: Box<dyn ErasedAssetReader>,
+}
+
+impl TempAssetReader {
+    fn get_default(path: String) -> impl FnMut() -> Box<dyn ErasedAssetReader> + Send + Sync {
+        move || {
+            let mut getter = AssetSource::get_default_reader(path.clone());
+            let inner = getter();
+
+            Box::new(Self { inner })
+        }
+    }
+}
+
+impl AssetReader for TempAssetReader {
+    async fn read<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<crate::io::Reader<'a>>, crate::io::AssetReaderError> {
+        self.inner.read(path).await
+    }
+
+    async fn read_meta<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<crate::io::Reader<'a>>, crate::io::AssetReaderError> {
+        self.inner.read_meta(path).await
+    }
+
+    async fn read_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<crate::io::PathStream>, crate::io::AssetReaderError> {
+        self.inner.read_directory(path).await
+    }
+
+    async fn is_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<bool, crate::io::AssetReaderError> {
+        self.inner.is_directory(path).await
+    }
+}
+
+struct TempAssetWriter {
+    inner: Box<dyn ErasedAssetWriter>,
+}
+
+impl TempAssetWriter {
+    fn get_default(
+        path: String,
+    ) -> impl FnMut(bool) -> Option<Box<dyn ErasedAssetWriter>> + Send + Sync {
+        move |condition| {
+            let mut getter = AssetSource::get_default_writer(path.clone());
+            let inner = getter(condition)?;
+
+            Some(Box::new(Self { inner }))
+        }
+    }
+}
+
+impl AssetWriter for TempAssetWriter {
+    async fn write<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<crate::io::Writer>, crate::io::AssetWriterError> {
+        self.inner.write(path).await
+    }
+
+    async fn write_meta<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<crate::io::Writer>, crate::io::AssetWriterError> {
+        self.inner.write_meta(path).await
+    }
+
+    async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.remove(path).await
+    }
+
+    async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.remove_meta(path).await
+    }
+
+    async fn rename<'a>(
+        &'a self,
+        old_path: &'a Path,
+        new_path: &'a Path,
+    ) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.rename(old_path, new_path).await
+    }
+
+    async fn rename_meta<'a>(
+        &'a self,
+        old_path: &'a Path,
+        new_path: &'a Path,
+    ) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.rename_meta(old_path, new_path).await
+    }
+
+    async fn remove_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.remove_directory(path).await
+    }
+
+    async fn remove_empty_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.remove_empty_directory(path).await
+    }
+
+    async fn remove_assets_in_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<(), crate::io::AssetWriterError> {
+        self.inner.remove_assets_in_directory(path).await
+    }
+}
+
+struct TempAssetWatcher {
+    _inner: Box<dyn AssetWatcher>,
+}
+
+impl TempAssetWatcher {
+    fn get_default(
+        path: String,
+        file_debounce_wait_time: Duration,
+    ) -> impl FnMut(crossbeam_channel::Sender<AssetSourceEvent>) -> Option<Box<dyn AssetWatcher>>
+           + Send
+           + Sync {
+        move |channel| {
+            let mut getter =
+                AssetSource::get_default_watcher(path.clone(), file_debounce_wait_time);
+            let _inner = getter(channel)?;
+
+            Some(Box::new(Self { _inner }))
+        }
+    }
+
+    fn get_default_watch_warning() -> &'static str {
+        AssetSource::get_default_watch_warning()
+    }
+}
+
+impl AssetWatcher for TempAssetWatcher {}

--- a/examples/README.md
+++ b/examples/README.md
@@ -217,6 +217,7 @@ Example | Description
 [Hot Reloading of Assets](../examples/asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk
 [Mult-asset synchronization](../examples/asset/multi_asset_sync.rs) | Demonstrates how to wait for multiple assets to be loaded.
 [Repeated texture configuration](../examples/asset/repeated_texture.rs) | How to configure the texture to repeat instead of the default clamp to edges
+[Temporary assets](../examples/asset/temp_asset.rs) | How to use the temporary asset source
 
 ## Async Tasks
 

--- a/examples/asset/temp_asset.rs
+++ b/examples/asset/temp_asset.rs
@@ -19,7 +19,7 @@ fn main() {
         .init_asset::<TextAsset>()
         .register_asset_loader(TextLoader)
         .add_systems(Startup, (save_temp_asset, setup_ui))
-        .add_systems(Update, (wait_until_temp_saved, display_text))
+        .add_systems(Update, (load_or_unload_asset, display_text))
         .run();
 }
 
@@ -56,8 +56,8 @@ fn save_temp_asset(assets: Res<AssetServer>, temp_directory: Res<TempDirectory>)
     );
 }
 
-/// Poll the save tasks until completion, and then start loading our temporary text asset.
-fn wait_until_temp_saved(
+/// Load or unload the temporary asset based on user input
+fn load_or_unload_asset(
     assets: Res<AssetServer>,
     mut commands: Commands,
     keyboard_input: Res<ButtonInput<KeyCode>>,


### PR DESCRIPTION
# Objective

- Fixes #13403

## Solution

Created a new `temp://` asset source which can be configured through the `AssetPlugin` via a new optional field `temporary_file_path`. If a path is provided, it will be considered as a persistent temporary directory, otherwise a directory is created in a platform appropriate location which will be automatically deleted on application exit.

## Example Usage

A typical use for a temporary directory is the storage of data which you may need at some point, but don't right now (e.g., pre-fetching a map from a game server). In the below example, we create an asset `my_text_asset`, save it to the `temp://` source, and later retrieve it.

```rust
// This is the asset we will attempt to save.
let my_text_asset = TextAsset("Hello World!".to_owned());

// To ensure the `Task` can outlive this function, we must provide owned versions
// of the `AssetServer` and our desired path.
let path = AssetPath::from("temp://message.txt").into_owned();
let server = assets.clone();

// Pass to the IoTaskPool to complete in the background
IoTaskPool::get().spawn(async move {
    save_asset(my_text_asset, path, server, TextSaver)
        .await
        .unwrap();
}).detach();

// ...

// Can later retrieve the saved asset
let my_text_asset = assets.load("temp://message.txt");
```

Since the `temp://` source is on-disk, the unloaded asset will free memory for the rest of the application to use. In the above example, the memory used is trivial, but in a more complex game, a pre-fetched level could be significantly larger.

## Testing

- Tested the included example on my local devices (Windows and Linux).
- Have _not_ tested on mobile (I suspect iOS may be problematic here but cannot confirm).
- Tested in Firefox when compiling to WASM.

---

## Changelog

- Added `temp://` Asset Source
- Added `pub temporary_file_path: Option<String>` to `AssetPlugin` (defaults to `None`)
- Added a new example, `temp_asset`, which demonstrates how to save and load arbitrary assets in the new temporary asset source.
- Added `OriginPrivateFileSystem` for the WASM platform as an `AssetReader` / `AssetWriter` for the [Origin Private File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)

## Migration Guide

- If you were using the `temp://` asset source ID, please use an alternate ID (e.g., `my_temp://`)
- If constructing `AssetPlugin` manually, use `..default()` to populate the new field with an appropriate default, or configure it yourself.