### PR TITLE
Revert "Add `on_unimplemented` Diagnostics to Most Public Traits"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.78.0"
+rust-version = "1.77.0"
 
 [workspace]
 exclude = [

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -54,7 +54,7 @@ use std::any::Any;
 ///     }
 /// }
 /// # fn damp_flickering() {}
-/// ```
+/// ````
 pub trait Plugin: Downcast + Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -223,11 +223,6 @@ impl Plugin for AssetPlugin {
     }
 }
 
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not an `Asset`",
-    label = "invalid `Asset`",
-    note = "consider annotating `{Self}` with `#[derive(Asset)]`"
-)]
 pub trait Asset: VisitAssetDependencies + TypePath + Send + Sync + 'static {}
 
 pub trait VisitAssetDependencies {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -141,11 +141,6 @@ use std::ptr::NonNull;
 // bundle, in the _exact_ order that [`DynamicBundle::get_components`] is called.
 // - [`Bundle::from_components`] must call `func` exactly once for each [`ComponentId`] returned by
 //   [`Bundle::component_ids`].
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a `Bundle`",
-    label = "invalid `Bundle`",
-    note = "consider annotating `{Self}` with `#[derive(Component)]` or `#[derive(Bundle)]`"
-)]
 pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
     /// Gets this [`Bundle`]'s component ids, in the order of this bundle's [`Component`]s
     #[doc(hidden)]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -150,11 +150,6 @@ use std::{
 ///
 /// [`SyncCell`]: bevy_utils::synccell::SyncCell
 /// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a `Component`",
-    label = "invalid `Component`",
-    note = "consider annotating `{Self}` with `#[derive(Component)]`"
-)]
 pub trait Component: Send + Sync + 'static {
     /// A constant indicating the storage type used for this component.
     const STORAGE_TYPE: StorageType;

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -37,6 +37,7 @@ use super::EntityHashMap;
 ///     }
 /// }
 /// ```
+///
 pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -28,11 +28,6 @@ use std::{
 /// You can conveniently access events using the [`EventReader`] and [`EventWriter`] system parameter.
 ///
 /// Events must be thread-safe.
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not an `Event`",
-    label = "invalid `Event`",
-    note = "consider annotating `{Self}` with `#[derive(Event]`"
-)]
 pub trait Event: Send + Sync + 'static {}
 
 /// An `EventId` uniquely identifies an event stored in a specific [`World`].

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -268,10 +268,6 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///
 /// [`Query`]: crate::system::Query
 /// [`ReadOnly`]: Self::ReadOnly
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not valid to request as data in a `Query`",
-    label = "invalid `Query` data"
-)]
 pub unsafe trait QueryData: WorldQuery {
     /// The read-only variant of this [`QueryData`], which satisfies the [`ReadOnlyQueryData`] trait.
     type ReadOnly: ReadOnlyQueryData<State = <Self as WorldQuery>::State>;

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -70,11 +70,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// [`matches_component_set`]: Self::matches_component_set
 /// [`Query`]: crate::system::Query
 /// [`State`]: Self::State
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a valid `Query` filter",
-    label = "invalid `Query` filter",
-    note = "a `QueryFilter` typically uses a combination of `With<T>` and `Without<T>` statements"
-)]
+
 pub trait QueryFilter: WorldQuery {
     /// Returns true if (and only if) this Filter relies strictly on archetypes to limit which
     /// components are accessed by the Query.
@@ -942,11 +938,6 @@ impl<T: Component> QueryFilter for Changed<T> {
 ///
 /// [`Added`] and [`Changed`] works with entities, and therefore are not archetypal. As such
 /// they do not implement [`ArchetypeFilter`].
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a valid `Query` filter based on archetype information",
-    label = "invalid `Query` filter",
-    note = "an `ArchetypeFilter` typically uses a combination of `With<T>` and `Without<T>` statements"
-)]
 pub trait ArchetypeFilter: QueryFilter {}
 
 impl<T: Component> ArchetypeFilter for With<T> {}

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -288,10 +288,6 @@ impl<T> NodeConfigs<T> {
 ///     )
 /// );
 /// ```
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` does not describe a valid system configuration",
-    label = "invalid system configuration"
-)]
 pub trait IntoSystemConfigs<Marker>
 where
     Self: Sized,
@@ -566,10 +562,6 @@ impl SystemSetConfig {
 pub type SystemSetConfigs = NodeConfigs<InternedSystemSet>;
 
 /// Types that can convert into a [`SystemSetConfigs`].
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` does not describe a valid system set configuration",
-    label = "invalid system set configuration"
-)]
 pub trait IntoSystemSetConfigs
 where
     Self: Sized,

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -149,10 +149,6 @@ impl SystemSet for AnonymousSet {
 }
 
 /// Types that can be converted into a [`SystemSet`].
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a system set",
-    label = "invalid system set"
-)]
 pub trait IntoSystemSet<Marker>: Sized {
     /// The type of [`SystemSet`] this instance converts into.
     type Set: SystemSet;

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -39,10 +39,6 @@ use crate::{schedule::InternedSystemSet, world::unsafe_world_cell::UnsafeWorldCe
 /// # system.initialize(&mut world);
 /// # assert!(system.run((), &mut world));
 /// ```
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not adapt a system of type `{S}`",
-    label = "invalid system adapter"
-)]
 pub trait Adapt<S: System>: Send + Sync + 'static {
     /// The [input](System::In) type for an [`AdapterSystem`].
     type In;

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -83,11 +83,6 @@ use super::{ReadOnlySystem, System};
 /// # assert!(world.resource::<RanFlag>().0);
 /// # world.resource_mut::<RanFlag>().0 = false;
 /// ```
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not combine systems `{A}` and `{B}`",
-    label = "invalid system combination",
-    note = "the inputs and outputs of `{A}` and `{B}` are not compatible with this combiner"
-)]
 pub trait Combine<A: System, B: System> {
     /// The [input](System::In) type for a [`CombinatorSystem`].
     type In;

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -161,10 +161,6 @@ where
 ///
 /// This trait can be useful for making your own systems which accept other systems,
 /// sometimes called higher order systems.
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not an exclusive system",
-    label = "invalid system"
-)]
 pub trait ExclusiveSystemParamFunction<Marker>: Send + Sync + 'static {
     /// The input type to this system. See [`System::In`].
     type In;
@@ -172,7 +168,7 @@ pub trait ExclusiveSystemParamFunction<Marker>: Send + Sync + 'static {
     /// The return type of this system. See [`System::Out`].
     type Out;
 
-    /// The [`ExclusiveSystemParam`]'s defined by this system's `fn` parameters.
+    /// The [`ExclusiveSystemParam`]/s defined by this system's `fn` parameters.
     type Param: ExclusiveSystemParam;
 
     /// Executes this system once. See [`System::run`].

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -10,10 +10,6 @@ use std::marker::PhantomData;
 
 /// A parameter that can be used in an exclusive system (a system with an `&mut World` parameter).
 /// Any parameters implementing this trait must come after the `&mut World` parameter.
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not be used as a parameter for an exclusive system",
-    label = "invalid system parameter"
-)]
 pub trait ExclusiveSystemParam: Sized {
     /// Used to store data which persists across invocations of a system.
     type State: Send + Sync + 'static;

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -626,10 +626,6 @@ where
 /// ```
 /// [`PipeSystem`]: crate::system::PipeSystem
 /// [`ParamSet`]: crate::system::ParamSet
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a valid system",
-    label = "invalid system"
-)]
 pub trait SystemParamFunction<Marker>: Send + Sync + 'static {
     /// The input type to this system. See [`System::In`].
     type In;

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -147,10 +147,6 @@ use crate::world::World;
 // This trait has to be generic because we have potentially overlapping impls, in particular
 // because Rust thinks a type could impl multiple different `FnMut` combinations
 // even though none can currently
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a valid system with input `{In}` and output `{Out}`",
-    label = "invalid system"
-)]
 pub trait IntoSystem<In, Out, Marker>: Sized {
     /// The type of [`System`] that this instance converts into.
     type System: System<In = In, Out = Out>;

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -22,7 +22,6 @@ use super::IntoSystem;
 /// Systems are executed in parallel, in opportunistic order; data access is managed automatically.
 /// It's possible to specify explicit execution order between specific systems,
 /// see [`IntoSystemConfigs`](crate::schedule::IntoSystemConfigs).
-#[diagnostic::on_unimplemented(message = "`{Self}` is not a system", label = "invalid system")]
 pub trait System: Send + Sync + 'static {
     /// The system's input. See [`In`](crate::system::In) for
     /// [`FunctionSystem`](crate::system::FunctionSystem)s.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -432,11 +432,6 @@ impl_param_set!();
 /// ```
 ///
 /// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` is not a `Resource`",
-    label = "invalid `Resource`",
-    note = "consider annotating `{Self}` with `#[derive(Resource)]`"
-)]
 pub trait Resource: Send + Sync + 'static {}
 
 // SAFETY: Res only reads a single World resource

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.rs
@@ -12,9 +12,9 @@ struct NoReflect(f32);
 
 fn main() {
     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
-    //~^ ERROR: `NoReflect` does not provide type registration information
+    //~^ ERROR: not satisfied
 
     // foo doesn't implement Reflect because NoReflect doesn't implement Reflect
     foo.get_field::<NoReflect>("a").unwrap();
-    //~^ ERROR: `NoReflect` can not be reflected
+    //~^ ERROR: not satisfied
 }

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `NoReflect` can not be reflected
+error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
    --> tests/reflect_derive/generics_fail.rs:18:21
     |
 18  |     foo.get_field::<NoReflect>("a").unwrap();
@@ -6,7 +6,6 @@ error[E0277]: `NoReflect` can not be reflected
     |         |
     |         required by a bound introduced by this call
     |
-    = note: Try using `#[derive(Reflect)]`
     = help: the following other types implement trait `Reflect`:
               bool
               char
@@ -18,19 +17,17 @@ error[E0277]: `NoReflect` can not be reflected
               i128
             and 74 others
 note: required by a bound in `bevy_reflect::GetField::get_field`
-   --> $BEVY_ROOT/crates/bevy_reflect/src/struct_trait.rs:244:21
+   --> $BEVY_ROOT/crates/bevy_reflect/src/struct_trait.rs:242:21
     |
-244 |     fn get_field<T: Reflect>(&self, name: &str) -> Option<&T>;
+242 |     fn get_field<T: Reflect>(&self, name: &str) -> Option<&T>;
     |                     ^^^^^^^ required by this bound in `GetField::get_field`
 
-error[E0277]: `NoReflect` does not provide type registration information
+error[E0277]: the trait bound `NoReflect: GetTypeRegistration` is not satisfied
   --> tests/reflect_derive/generics_fail.rs:14:36
    |
 14 |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid Type
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GetTypeRegistration` is not implemented for `NoReflect`, which is required by `Foo<NoReflect>: bevy_reflect::Struct`
    |
-   = help: the trait `GetTypeRegistration` is not implemented for `NoReflect`, which is required by `Foo<NoReflect>: bevy_reflect::Struct`
-   = note: Try using `#[derive(Reflect)]`
    = help: the following other types implement trait `GetTypeRegistration`:
              bool
              char

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -21,10 +21,6 @@ use crate::{FromType, Reflect};
 /// [derive macro]: bevy_reflect_derive::FromReflect
 /// [`DynamicStruct`]: crate::DynamicStruct
 /// [crate-level documentation]: crate
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not be created through reflection",
-    note = "consider annotating `{Self}` with `#[derive(FromReflect)]`"
-)]
 pub trait FromReflect: Reflect + Sized {
     /// Constructs a concrete instance of `Self` from a reflected value.
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self>;

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -230,10 +230,6 @@ impl<'a> ReflectPath<'a> for &'a str {
 /// [`List`]: crate::List
 /// [`Array`]: crate::Array
 /// [`Enum`]: crate::Enum
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` does not provide a reflection path",
-    note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
-)]
 pub trait GetPath: Reflect {
     /// Returns a reference to the value specified by `path`.
     ///

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -179,10 +179,6 @@ impl std::fmt::Display for ReflectKind {
 /// [`bevy_reflect`]: crate
 /// [derive macro]: bevy_reflect_derive::Reflect
 /// [crate-level documentation]: crate
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not be reflected",
-    note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
-)]
 pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// Returns the [`TypeInfo`] of the type _represented_ by this value.
     ///

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -70,10 +70,6 @@ use std::fmt::Debug;
 /// ```
 ///
 /// [utility]: crate::utility
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not provide type information through reflection",
-    note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
-)]
 pub trait Typed: Reflect + TypePath {
     /// Returns the compile-time [info] for the underlying type.
     ///

--- a/crates/bevy_reflect/src/type_path.rs
+++ b/crates/bevy_reflect/src/type_path.rs
@@ -79,10 +79,6 @@ use std::fmt;
 /// [`crate_name`]: TypePath::crate_name
 /// [`module_path`]: TypePath::module_path
 /// [`type_ident`]: TypePath::type_ident
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` does not have a type path",
-    note = "consider annotating `{Self}` with `#[derive(Reflect)]` or `#[derive(TypePath)]`"
-)]
 pub trait TypePath: 'static {
     /// Returns the fully qualified path of the underlying type.
     ///
@@ -133,10 +129,6 @@ pub trait TypePath: 'static {
 /// Since this is a supertrait of [`Reflect`] its methods can be called on a `dyn Reflect`.
 ///
 /// [`Reflect`]: crate::Reflect
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not be used as a dynamic type path",
-    note = "consider annotating `{Self}` with `#[derive(Reflect)]` or `#[derive(TypePath)]`"
-)]
 pub trait DynamicTypePath {
     /// See [`TypePath::type_path`].
     fn reflect_type_path(&self) -> &str;

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -56,10 +56,6 @@ impl Debug for TypeRegistryArc {
 /// See the [crate-level documentation] for more information on type registration.
 ///
 /// [crate-level documentation]: crate
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` does not provide type registration information",
-    note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
-)]
 pub trait GetTypeRegistration: 'static {
     /// Returns the default [`TypeRegistration`] for this type.
     fn get_type_registration() -> TypeRegistration;

--- a/crates/bevy_state/src/state/freely_mutable_state.rs
+++ b/crates/bevy_state/src/state/freely_mutable_state.rs
@@ -9,7 +9,6 @@ use super::transitions::*;
 ///
 /// While ordinary states are freely mutable (and implement this trait as part of their derive macro),
 /// computed states are not: instead, they can *only* change when the states that drive them do.
-#[diagnostic::on_unimplemented(note = "consider annotating `{Self}` with `#[derive(States)]`")]
 pub trait FreelyMutableState: States {
     /// This function registers all the necessary systems to apply state changes and run transition schedules
     fn register_state(schedule: &mut Schedule) {

--- a/crates/bevy_state/src/state/states.rs
+++ b/crates/bevy_state/src/state/states.rs
@@ -54,11 +54,6 @@ use std::hash::Hash;
 /// app.add_systems(Update, handle_escape_pressed.run_if(in_state(GameState::MainMenu)));
 /// app.add_systems(OnEnter(GameState::SettingsMenu), open_settings_menu);
 /// ```
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not be used as a state",
-    label = "invalid state",
-    note = "consider annotating `{Self}` with `#[derive(States)]`"
-)]
 pub trait States: 'static + Send + Sync + Clone + PartialEq + Eq + Hash + Debug {
     /// How many other states this state depends on.
     /// Used to help order transitions and de-duplicate [`ComputedStates`](crate::state::ComputedStates), as well as prevent cyclical

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -143,11 +143,6 @@ pub use bevy_state_macros::SubStates;
 ///
 /// impl FreelyMutableState for GamePhase {}
 /// ```
-#[diagnostic::on_unimplemented(
-    message = "`{Self}` can not be used as a sub-state",
-    label = "invalid sub-state",
-    note = "consider annotating `{Self}` with `#[derive(SubStates)]`"
-)]
 pub trait SubStates: States + FreelyMutableState {
     /// The set of states from which the [`Self`] is derived.
     ///


### PR DESCRIPTION
# Objective

- Rust 1.78 breaks all Android support, see https://github.com/bevyengine/bevy/issues/13331
- We should not bump the MSRV to 1.78 until that's resolved in #13366.

## Solution

- Temporarily revert https://github.com/bevyengine/bevy/pull/13347