### PR TITLE
Add more load_direct implementations

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -515,12 +515,12 @@ mod tests {
             let mut ron: CoolTextRon = ron::de::from_bytes(&bytes)?;
             let mut embedded = String::new();
             for dep in ron.embedded_dependencies {
-                let loaded = load_context.load_direct(&dep).await.map_err(|_| {
+                let loaded = load_context.load_direct::<CoolText>(&dep).await.map_err(|_| {
                     Self::Error::CannotLoadDependency {
                         dependency: dep.into(),
                     }
                 })?;
-                let cool = loaded.get::<CoolText>().unwrap();
+                let cool = loaded.get();
                 embedded.push_str(&cool.text);
             }
             Ok(CoolText {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -516,8 +516,7 @@ mod tests {
             let mut embedded = String::new();
             for dep in ron.embedded_dependencies {
                 let loaded = load_context
-                    .load_direct(&dep)
-                    .load::<CoolText>()
+                    .load_direct::<CoolText>(&dep)
                     .await
                     .map_err(|_| Self::Error::CannotLoadDependency {
                         dependency: dep.into(),

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -516,7 +516,8 @@ mod tests {
             let mut embedded = String::new();
             for dep in ron.embedded_dependencies {
                 let loaded = load_context
-                    .load_direct::<CoolText>(&dep)
+                    .load_direct(&dep)
+                    .load::<CoolText>()
                     .await
                     .map_err(|_| Self::Error::CannotLoadDependency {
                         dependency: dep.into(),

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -515,11 +515,12 @@ mod tests {
             let mut ron: CoolTextRon = ron::de::from_bytes(&bytes)?;
             let mut embedded = String::new();
             for dep in ron.embedded_dependencies {
-                let loaded = load_context.load_direct::<CoolText>(&dep).await.map_err(|_| {
-                    Self::Error::CannotLoadDependency {
+                let loaded = load_context
+                    .load_direct::<CoolText>(&dep)
+                    .await
+                    .map_err(|_| Self::Error::CannotLoadDependency {
                         dependency: dep.into(),
-                    }
-                })?;
+                    })?;
                 let cool = loaded.get();
                 embedded.push_str(&cool.text);
             }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,4 +1,3 @@
-use crate::meta::MetaTransform;
 use crate::{
     io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
     meta::{
@@ -18,7 +17,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     any::{Any, TypeId},
     path::{Path, PathBuf},
-    sync::Arc,
 };
 use thiserror::Error;
 
@@ -310,164 +308,6 @@ pub enum DeserializeMetaError {
     DeserializeMinimal(SpannedError),
 }
 
-pub struct DirectLoadContext<'a, 'b, 'c> {
-    load_context: &'b mut LoadContext<'a>,
-    path: AssetPath<'static>,
-    reader: Option<&'b mut Reader<'c>>,
-    meta_transform: Option<MetaTransform>,
-    asset_type_id: Option<TypeId>,
-}
-
-impl<'a: 'c, 'b, 'c> DirectLoadContext<'a, 'b, 'c> {
-    fn with_transform(
-        mut self,
-        transform: impl Fn(&mut dyn AssetMetaDyn) + Send + Sync + 'static,
-    ) -> Self {
-        if let Some(prev_transform) = self.meta_transform {
-            self.meta_transform = Some(Box::new(move |meta| {
-                prev_transform(meta);
-                transform(meta);
-            }));
-        } else {
-            self.meta_transform = Some(Box::new(transform));
-        }
-        self
-    }
-
-    /// Configure the settings used to load the asset.
-    ///
-    /// If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
-    /// and the asset load will fail.
-    pub fn with_settings<S: Settings>(
-        self,
-        settings: impl Fn(&mut S) + Send + Sync + 'static,
-    ) -> Self {
-        self.with_transform(move |meta| meta_transform_settings(meta, &settings))
-    }
-
-    /// Specify the reader to use to read the asset data.
-    pub fn with_reader(mut self, reader: &'b mut Reader<'c>) -> Self {
-        self.reader = Some(reader);
-        self
-    }
-
-    /// Specify the output asset type.
-    pub fn with_asset_type<A: Asset>(mut self) -> Self {
-        self.asset_type_id = Some(TypeId::of::<A>());
-        self
-    }
-
-    /// Specify the output asset type.
-    pub fn with_asset_type_id(mut self, asset_type_id: TypeId) -> Self {
-        self.asset_type_id = Some(asset_type_id);
-        self
-    }
-
-    async fn load_internal(
-        self,
-    ) -> Result<(Arc<dyn ErasedAssetLoader>, ErasedLoadedAsset), LoadDirectError> {
-        enum ReaderRef<'a, 'b> {
-            Borrowed(&'a mut Reader<'b>),
-            Boxed(Box<Reader<'b>>),
-        }
-
-        impl<'a, 'b> ReaderRef<'a, 'b> {
-            pub fn as_mut(&mut self) -> &mut Reader {
-                match self {
-                    ReaderRef::Borrowed(r) => r,
-                    ReaderRef::Boxed(b) => &mut *b,
-                }
-            }
-        }
-
-        let (mut meta, loader, mut reader) = if let Some(reader) = self.reader {
-            let loader = if let Some(asset_type_id) = self.asset_type_id {
-                self.load_context
-                    .asset_server
-                    .get_asset_loader_with_asset_type_id(asset_type_id)
-                    .await
-                    .map_err(|error| LoadDirectError {
-                        dependency: self.path.clone(),
-                        error: error.into(),
-                    })?
-            } else {
-                self.load_context
-                    .asset_server
-                    .get_path_asset_loader(&self.path)
-                    .await
-                    .map_err(|error| LoadDirectError {
-                        dependency: self.path.clone(),
-                        error: error.into(),
-                    })?
-            };
-            let meta = loader.default_meta();
-            (meta, loader, ReaderRef::Borrowed(reader))
-        } else {
-            let (meta, loader, reader) = self
-                .load_context
-                .asset_server
-                .get_meta_loader_and_reader(&self.path, self.asset_type_id)
-                .await
-                .map_err(|error| LoadDirectError {
-                    dependency: self.path.clone(),
-                    error,
-                })?;
-            (meta, loader, ReaderRef::Boxed(reader))
-        };
-
-        if let Some(meta_transform) = self.meta_transform {
-            meta_transform(&mut *meta);
-        }
-
-        let asset = self
-            .load_context
-            .load_direct_internal(self.path.clone(), meta, &*loader, reader.as_mut())
-            .await?;
-        Ok((loader, asset))
-    }
-
-    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
-    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
-    /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
-    /// "load dependency".
-    ///
-    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
-    /// changing a "load dependency" will result in re-processing of the asset.
-    ///
-    /// [`Process`]: crate::processor::Process
-    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
-    pub async fn load<A: Asset>(self) -> Result<LoadedAsset<A>, LoadDirectError> {
-        let path = self.path.clone();
-        self.load_internal()
-            .await
-            .and_then(move |(loader, untyped_asset)| {
-                untyped_asset.downcast::<A>().map_err(|_| LoadDirectError {
-                    dependency: path.clone(),
-                    error: AssetLoadError::RequestedHandleTypeMismatch {
-                        path,
-                        requested: TypeId::of::<A>(),
-                        actual_asset_name: loader.asset_type_name(),
-                        loader_name: loader.type_name(),
-                    },
-                })
-            })
-    }
-
-    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
-    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
-    /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
-    /// "load dependency".
-    ///
-    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
-    /// changing a "load dependency" will result in re-processing of the asset.
-    ///
-    /// [`Process`]: crate::processor::Process
-    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
-    pub async fn load_untyped(self) -> Result<ErasedLoadedAsset, LoadDirectError> {
-        self.load_internal().await.map(|(_, asset)| asset)
-    }
-}
-
 /// A context that provides access to assets in [`AssetLoader`]s, tracks dependencies, and collects asset load state.
 /// Any asset state accessed by [`LoadContext`] will be tracked and stored for use in dependency events and asset preprocessing.
 pub struct LoadContext<'a> {
@@ -728,7 +568,7 @@ impl<'a> LoadContext<'a> {
         handle
     }
 
-    async fn load_direct_internal(
+    async fn load_direct_untyped_internal(
         &mut self,
         path: AssetPath<'static>,
         meta: Box<dyn AssetMetaDyn>,
@@ -759,9 +599,66 @@ impl<'a> LoadContext<'a> {
         Ok(loaded_asset)
     }
 
-    /// Create a builder for loading assets at the given `path` directly.
-    /// This operation is asynchronous and will not complete until the asset is fully loaded.
-    /// Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
+    async fn load_direct_internal<A: Asset>(
+        &mut self,
+        path: AssetPath<'static>,
+        meta: Box<dyn AssetMetaDyn>,
+        loader: &dyn ErasedAssetLoader,
+        reader: &mut Reader<'_>,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        self.load_direct_untyped_internal(path.clone(), meta, loader, &mut *reader)
+            .await
+            .and_then(move |untyped_asset| {
+                untyped_asset.downcast::<A>().map_err(|_| LoadDirectError {
+                    dependency: path.clone(),
+                    error: AssetLoadError::RequestedHandleTypeMismatch {
+                        path,
+                        requested: TypeId::of::<A>(),
+                        actual_asset_name: loader.asset_type_name(),
+                        loader_name: loader.type_name(),
+                    },
+                })
+            })
+    }
+
+    async fn load_direct_untyped_with_transform(
+        &mut self,
+        path: AssetPath<'static>,
+        meta_transform: impl FnOnce(&mut dyn AssetMetaDyn),
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        let (mut meta, loader, mut reader) = self
+            .asset_server
+            .get_meta_loader_and_reader(&path, None)
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error,
+            })?;
+        meta_transform(&mut *meta);
+        self.load_direct_untyped_internal(path.clone(), meta, &*loader, &mut *reader)
+            .await
+    }
+
+    async fn load_direct_with_transform<A: Asset>(
+        &mut self,
+        path: AssetPath<'static>,
+        meta_transform: impl FnOnce(&mut dyn AssetMetaDyn),
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let (mut meta, loader, mut reader) = self
+            .asset_server
+            .get_meta_loader_and_reader(&path, Some(TypeId::of::<A>()))
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error,
+            })?;
+        meta_transform(&mut *meta);
+        self.load_direct_internal(path.clone(), meta, &*loader, &mut *reader)
+            .await
+    }
+
+    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
     /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
     /// "load dependency".
     ///
@@ -770,18 +667,155 @@ impl<'a> LoadContext<'a> {
     ///
     /// [`Process`]: crate::processor::Process
     /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
-    #[must_use]
-    pub fn load_direct<'b, 'c>(
+    pub async fn load_direct<'b, A: Asset>(
         &mut self,
         path: impl Into<AssetPath<'b>>,
-    ) -> DirectLoadContext<'a, '_, 'c> {
-        DirectLoadContext {
-            load_context: self,
-            path: path.into().into_owned(),
-            reader: None,
-            meta_transform: None,
-            asset_type_id: None,
-        }
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        self.load_direct_with_transform(path.into().into_owned(), |_| {})
+            .await
+    }
+
+    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
+    /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
+    /// and the asset load will fail.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_with_settings<'b, A: Asset, S: Settings + Default>(
+        &mut self,
+        path: impl Into<AssetPath<'b>>,
+        settings: impl Fn(&mut S) + Send + Sync + 'static,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        self.load_direct_with_transform(path.into().into_owned(), move |meta| {
+            meta_transform_settings(meta, &settings);
+        })
+        .await
+    }
+
+    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
+    /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_untyped<'b>(
+        &mut self,
+        path: impl Into<AssetPath<'b>>,
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        self.load_direct_untyped_with_transform(path.into().into_owned(), |_| {})
+            .await
+    }
+
+    /// Loads the asset at the given `path` directly from the provided `reader`. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset, and that value comes from your [`Reader`].
+    /// For example, if you are deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_with_reader<'b, A: Asset>(
+        &mut self,
+        reader: &mut Reader<'_>,
+        path: impl Into<AssetPath<'b>>,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let path = path.into().into_owned();
+
+        let loader = self
+            .asset_server
+            .get_asset_loader_with_asset_type::<A>()
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error: error.into(),
+            })?;
+
+        let meta = loader.default_meta();
+
+        self.load_direct_internal(path, meta, &*loader, reader)
+            .await
+    }
+
+    /// Loads the asset at the given `path` directly from the provided `reader`. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset, and that value comes from your [`Reader`].
+    /// For example, if you are deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
+    /// and the asset load will fail.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_with_reader_and_settings<'b, A: Asset, S: Settings + Default>(
+        &mut self,
+        reader: &mut Reader<'_>,
+        path: impl Into<AssetPath<'b>>,
+        settings: impl Fn(&mut S) + Send + Sync + 'static,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let path = path.into().into_owned();
+
+        let loader = self
+            .asset_server
+            .get_asset_loader_with_asset_type::<A>()
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error: error.into(),
+            })?;
+
+        let mut meta = loader.default_meta();
+        meta_transform_settings(&mut *meta, &settings);
+
+        self.load_direct_internal(path, meta, &*loader, reader)
+            .await
+    }
+
+    /// Loads the asset at the given `path` directly from the provided `reader`. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset, and that value comes from your [`Reader`].
+    /// For example, if you are deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_untyped_with_reader<'b>(
+        &mut self,
+        reader: &mut Reader<'_>,
+        path: impl Into<AssetPath<'b>>,
+    ) -> Result<ErasedLoadedAsset, LoadDirectError> {
+        let path = path.into().into_owned();
+
+        let loader = self
+            .asset_server
+            .get_path_asset_loader(&path)
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error: error.into(),
+            })?;
+
+        let meta = loader.default_meta();
+
+        self.load_direct_untyped_internal(path, meta, &*loader, reader)
+            .await
     }
 }
 

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,8 +1,8 @@
 use crate::{
     io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
     meta::{
-        loader_settings_meta_transform, AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfoMinimal,
-        Settings,
+        loader_settings_meta_transform, meta_transform_settings, AssetHash, AssetMeta, AssetMetaDyn,
+        ProcessedInfoMinimal, Settings,
     },
     path::AssetPath,
     Asset, AssetLoadError, AssetServer, AssetServerMode, Assets, Handle, LoadedUntypedAsset,
@@ -165,6 +165,30 @@ impl<A: Asset> LoadedAsset<A> {
             meta,
         }
     }
+
+    /// Cast (and take ownership) of the [`Asset`] value of the given type. This will return [`Some`] if
+    /// the stored type matches `A` and [`None`] if it does not.
+    pub fn take(self) -> A {
+        self.value
+    }
+
+    /// Retrieves a reference to the internal [`Asset`] type, if it matches the type `A`. Otherwise returns [`None`].
+    pub fn get(&self) -> &A {
+        &self.value
+    }
+
+    /// Returns the [`ErasedLoadedAsset`] for the given label, if it exists.
+    pub fn get_labeled(
+        &self,
+        label: impl Into<CowArc<'static, str>>,
+    ) -> Option<&ErasedLoadedAsset> {
+        self.labeled_assets.get(&label.into()).map(|a| &a.asset)
+    }
+
+    /// Iterate over all labels for "labeled assets" in the loaded asset
+    pub fn iter_labels(&self) -> impl Iterator<Item=&str> {
+        self.labeled_assets.keys().map(|s| &**s)
+    }
 }
 
 impl<A: Asset> From<A> for LoadedAsset<A> {
@@ -227,6 +251,26 @@ impl ErasedLoadedAsset {
     /// Iterate over all labels for "labeled assets" in the loaded asset
     pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
         self.labeled_assets.keys().map(|s| &**s)
+    }
+
+    /// Cast this loaded asset as the given type. If the type does not match,
+    /// the original type-erased asset is returned.
+    pub fn downcast<A: Asset>(mut self) -> Result<LoadedAsset<A>, ErasedLoadedAsset> {
+        match self.value.downcast::<A>() {
+            Ok(value) => {
+                Ok(LoadedAsset {
+                    value: *value,
+                    dependencies: self.dependencies,
+                    loader_dependencies: self.loader_dependencies,
+                    labeled_assets: self.labeled_assets,
+                    meta: self.meta,
+                })
+            }
+            Err(value) => {
+                self.value = value;
+                Err(self)
+            }
+        }
     }
 }
 
@@ -464,7 +508,7 @@ impl<'a> LoadContext<'a> {
     /// Retrieves a handle for the asset at the given path and adds that path as a dependency of the asset.
     /// If the current context is a normal [`AssetServer::load`], an actual asset load will be kicked off immediately, which ensures the load happens
     /// as soon as possible.
-    /// "Normal loads" kicked from within a normal Bevy App will generally configure the context to kick off loads immediately.  
+    /// "Normal loads" kicked from within a normal Bevy App will generally configure the context to kick off loads immediately.
     /// If the current context is configured to not load dependencies automatically (ex: [`AssetProcessor`](crate::processor::AssetProcessor)),
     /// a load will not be kicked off automatically. It is then the calling context's responsibility to begin a load if necessary.
     pub fn load<'b, A: Asset>(&mut self, path: impl Into<AssetPath<'b>>) -> Handle<A> {
@@ -495,7 +539,7 @@ impl<'a> LoadContext<'a> {
 
     /// Loads the [`Asset`] of type `A` at the given `path` with the given [`AssetLoader::Settings`] settings `S`. This is a "deferred"
     /// load. If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
-    /// and the asset load will fail.  
+    /// and the asset load will fail.
     pub fn load_with_settings<'b, A: Asset, S: Settings + Default>(
         &mut self,
         path: impl Into<AssetPath<'b>>,
@@ -535,7 +579,122 @@ impl<'a> LoadContext<'a> {
     ///
     /// [`Process`]: crate::processor::Process
     /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
-    pub async fn load_direct<'b>(
+    pub async fn load_direct<'b, A: Asset>(
+        &mut self,
+        path: impl Into<AssetPath<'b>>,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let path = path.into().into_owned();
+        let to_error = |e: AssetLoadError| -> LoadDirectError {
+            LoadDirectError {
+                dependency: path.clone(),
+                error: e,
+            }
+        };
+        let loaded_asset = {
+            let (meta, loader, mut reader) = self
+                .asset_server
+                .get_meta_loader_and_reader(&path, Some(TypeId::of::<A>()))
+                .await
+                .map_err(to_error)?;
+            let untyped_asset = self.asset_server
+                .load_with_meta_loader_and_reader(
+                    &path,
+                    meta,
+                    &*loader,
+                    &mut *reader,
+                    false,
+                    self.populate_hashes,
+                )
+                .await
+                .map_err(to_error)?;
+            untyped_asset.downcast::<A>()
+                .map_err(|_| to_error(AssetLoadError::RequestedHandleTypeMismatch {
+                    path: path.clone(),
+                    requested: TypeId::of::<A>(),
+                    actual_asset_name: loader.asset_type_name(),
+                    loader_name: loader.type_name(),
+                }))?
+        };
+        let info = loaded_asset
+            .meta
+            .as_ref()
+            .and_then(|m| m.processed_info().as_ref());
+        let hash = info.map(|i| i.full_hash).unwrap_or(Default::default());
+        self.loader_dependencies.insert(path, hash);
+        Ok(loaded_asset)
+    }
+
+    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
+    /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
+    /// and the asset load will fail.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_with_settings<'b, A: Asset, S: Settings + Default>(
+        &mut self,
+        path: impl Into<AssetPath<'b>>,
+        settings: impl Fn(&mut S) + Send + Sync + 'static,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let path = path.into().into_owned();
+        let to_error = |e: AssetLoadError| -> LoadDirectError {
+            LoadDirectError {
+                dependency: path.clone(),
+                error: e,
+            }
+        };
+        let loaded_asset = {
+            let (mut meta, loader, mut reader) = self
+                .asset_server
+                .get_meta_loader_and_reader(&path, Some(TypeId::of::<A>()))
+                .await
+                .map_err(to_error)?;
+            meta_transform_settings(&mut *meta, &settings);
+            let untyped_asset = self.asset_server
+                .load_with_meta_loader_and_reader(
+                    &path,
+                    meta,
+                    &*loader,
+                    &mut *reader,
+                    false,
+                    self.populate_hashes,
+                )
+                .await
+                .map_err(to_error)?;
+            untyped_asset.downcast::<A>()
+                .map_err(|_| to_error(AssetLoadError::RequestedHandleTypeMismatch {
+                    path: path.clone(),
+                    requested: TypeId::of::<A>(),
+                    actual_asset_name: loader.asset_type_name(),
+                    loader_name: loader.type_name(),
+                }))?
+        };
+        let info = loaded_asset
+            .meta
+            .as_ref()
+            .and_then(|m| m.processed_info().as_ref());
+        let hash = info.map(|i| i.full_hash).unwrap_or(Default::default());
+        self.loader_dependencies.insert(path, hash);
+        Ok(loaded_asset)
+    }
+
+    /// Loads the asset at the given `path` directly. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset. For example, if you are
+    /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_untyped<'b>(
         &mut self,
         path: impl Into<AssetPath<'b>>,
     ) -> Result<ErasedLoadedAsset, LoadDirectError> {
@@ -583,7 +742,136 @@ impl<'a> LoadContext<'a> {
     ///
     /// [`Process`]: crate::processor::Process
     /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
-    pub async fn load_direct_with_reader<'b>(
+    pub async fn load_direct_with_reader<'b, A: Asset>(
+        &mut self,
+        reader: &mut Reader<'_>,
+        path: impl Into<AssetPath<'b>>,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let path = path.into().into_owned();
+
+        let loader = self
+            .asset_server
+            .get_asset_loader_with_asset_type::<A>()
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error: error.into(),
+            })?;
+
+        let meta = loader.default_meta();
+
+        let loaded_asset = self
+            .asset_server
+            .load_with_meta_loader_and_reader(
+                &path,
+                meta,
+                &*loader,
+                reader,
+                false,
+                self.populate_hashes,
+            )
+            .await
+            .and_then(|asset| asset.downcast()
+                .map_err(|_| AssetLoadError::RequestedHandleTypeMismatch {
+                    path: path.clone(),
+                    requested: TypeId::of::<A>(),
+                    actual_asset_name: loader.asset_type_name(),
+                    loader_name: loader.type_name(),
+                }))
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error,
+            })?;
+
+        let info = loaded_asset
+            .meta
+            .as_ref()
+            .and_then(|m| m.processed_info().as_ref());
+
+        let hash = info.map(|i| i.full_hash).unwrap_or_default();
+
+        self.loader_dependencies.insert(path, hash);
+
+        Ok(loaded_asset)
+    }
+
+    /// Loads the asset at the given `path` directly from the provided `reader`. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset, and that value comes from your [`Reader`].
+    /// For example, if you are deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// If the settings type `S` does not match the settings expected by `A`'s asset loader, an error will be printed to the log
+    /// and the asset load will fail.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_with_reader_and_settings<'b, A: Asset, S: Settings + Default>(
+        &mut self,
+        reader: &mut Reader<'_>,
+        path: impl Into<AssetPath<'b>>,
+        settings: impl Fn(&mut S) + Send + Sync + 'static,
+    ) -> Result<LoadedAsset<A>, LoadDirectError> {
+        let path = path.into().into_owned();
+
+        let loader = self
+            .asset_server
+            .get_asset_loader_with_asset_type::<A>()
+            .await
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error: error.into(),
+            })?;
+
+        let mut meta = loader.default_meta();
+        meta_transform_settings(&mut *meta, &settings);
+
+        let loaded_asset = self
+            .asset_server
+            .load_with_meta_loader_and_reader(
+                &path,
+                meta,
+                &*loader,
+                reader,
+                false,
+                self.populate_hashes,
+            )
+            .await
+            .and_then(|asset| asset.downcast()
+                .map_err(|_| AssetLoadError::RequestedHandleTypeMismatch {
+                    path: path.clone(),
+                    requested: TypeId::of::<A>(),
+                    actual_asset_name: loader.asset_type_name(),
+                    loader_name: loader.type_name(),
+                }))
+            .map_err(|error| LoadDirectError {
+                dependency: path.clone(),
+                error,
+            })?;
+
+        let info = loaded_asset
+            .meta
+            .as_ref()
+            .and_then(|m| m.processed_info().as_ref());
+
+        let hash = info.map(|i| i.full_hash).unwrap_or_default();
+        self.loader_dependencies.insert(path, hash);
+        Ok(loaded_asset)
+    }
+
+    /// Loads the asset at the given `path` directly from the provided `reader`. This is an async function that will wait until the asset is fully loaded before
+    /// returning. Use this if you need the _value_ of another asset in order to load the current asset, and that value comes from your [`Reader`].
+    /// For example, if you are deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
+    /// "load dependency".
+    ///
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
+    /// changing a "load dependency" will result in re-processing of the asset.
+    ///
+    /// [`Process`]: crate::processor::Process
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
+    pub async fn load_direct_untyped_with_reader<'b>(
         &mut self,
         reader: &mut Reader<'_>,
         path: impl Into<AssetPath<'b>>,

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -606,7 +606,7 @@ impl<'a> LoadContext<'a> {
         loader: &dyn ErasedAssetLoader,
         reader: &mut Reader<'_>,
     ) -> Result<LoadedAsset<A>, LoadDirectError> {
-        self.load_direct_untyped_internal(path.clone(), meta, &*loader, &mut *reader)
+        self.load_direct_untyped_internal(path.clone(), meta, loader, &mut *reader)
             .await
             .and_then(move |untyped_asset| {
                 untyped_asset.downcast::<A>().map_err(|_| LoadDirectError {
@@ -694,7 +694,7 @@ impl<'a> LoadContext<'a> {
         settings: impl Fn(&mut S) + Send + Sync + 'static,
     ) -> Result<LoadedAsset<A>, LoadDirectError> {
         self.load_direct_with_transform(path.into().into_owned(), move |meta| {
-            meta_transform_settings(meta, &settings)
+            meta_transform_settings(meta, &settings);
         })
         .await
     }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,8 +1,8 @@
 use crate::{
     io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
     meta::{
-        loader_settings_meta_transform, meta_transform_settings, AssetHash, AssetMeta, AssetMetaDyn,
-        ProcessedInfoMinimal, Settings,
+        loader_settings_meta_transform, meta_transform_settings, AssetHash, AssetMeta,
+        AssetMetaDyn, ProcessedInfoMinimal, Settings,
     },
     path::AssetPath,
     Asset, AssetLoadError, AssetServer, AssetServerMode, Assets, Handle, LoadedUntypedAsset,
@@ -186,7 +186,7 @@ impl<A: Asset> LoadedAsset<A> {
     }
 
     /// Iterate over all labels for "labeled assets" in the loaded asset
-    pub fn iter_labels(&self) -> impl Iterator<Item=&str> {
+    pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
         self.labeled_assets.keys().map(|s| &**s)
     }
 }
@@ -257,15 +257,13 @@ impl ErasedLoadedAsset {
     /// the original type-erased asset is returned.
     pub fn downcast<A: Asset>(mut self) -> Result<LoadedAsset<A>, ErasedLoadedAsset> {
         match self.value.downcast::<A>() {
-            Ok(value) => {
-                Ok(LoadedAsset {
-                    value: *value,
-                    dependencies: self.dependencies,
-                    loader_dependencies: self.loader_dependencies,
-                    labeled_assets: self.labeled_assets,
-                    meta: self.meta,
-                })
-            }
+            Ok(value) => Ok(LoadedAsset {
+                value: *value,
+                dependencies: self.dependencies,
+                loader_dependencies: self.loader_dependencies,
+                labeled_assets: self.labeled_assets,
+                meta: self.meta,
+            }),
             Err(value) => {
                 self.value = value;
                 Err(self)
@@ -596,7 +594,8 @@ impl<'a> LoadContext<'a> {
                 .get_meta_loader_and_reader(&path, Some(TypeId::of::<A>()))
                 .await
                 .map_err(to_error)?;
-            let untyped_asset = self.asset_server
+            let untyped_asset = self
+                .asset_server
                 .load_with_meta_loader_and_reader(
                     &path,
                     meta,
@@ -607,13 +606,14 @@ impl<'a> LoadContext<'a> {
                 )
                 .await
                 .map_err(to_error)?;
-            untyped_asset.downcast::<A>()
-                .map_err(|_| to_error(AssetLoadError::RequestedHandleTypeMismatch {
+            untyped_asset.downcast::<A>().map_err(|_| {
+                to_error(AssetLoadError::RequestedHandleTypeMismatch {
                     path: path.clone(),
                     requested: TypeId::of::<A>(),
                     actual_asset_name: loader.asset_type_name(),
                     loader_name: loader.type_name(),
-                }))?
+                })
+            })?
         };
         let info = loaded_asset
             .meta
@@ -656,7 +656,8 @@ impl<'a> LoadContext<'a> {
                 .await
                 .map_err(to_error)?;
             meta_transform_settings(&mut *meta, &settings);
-            let untyped_asset = self.asset_server
+            let untyped_asset = self
+                .asset_server
                 .load_with_meta_loader_and_reader(
                     &path,
                     meta,
@@ -667,13 +668,14 @@ impl<'a> LoadContext<'a> {
                 )
                 .await
                 .map_err(to_error)?;
-            untyped_asset.downcast::<A>()
-                .map_err(|_| to_error(AssetLoadError::RequestedHandleTypeMismatch {
+            untyped_asset.downcast::<A>().map_err(|_| {
+                to_error(AssetLoadError::RequestedHandleTypeMismatch {
                     path: path.clone(),
                     requested: TypeId::of::<A>(),
                     actual_asset_name: loader.asset_type_name(),
                     loader_name: loader.type_name(),
-                }))?
+                })
+            })?
         };
         let info = loaded_asset
             .meta
@@ -771,13 +773,16 @@ impl<'a> LoadContext<'a> {
                 self.populate_hashes,
             )
             .await
-            .and_then(|asset| asset.downcast()
-                .map_err(|_| AssetLoadError::RequestedHandleTypeMismatch {
-                    path: path.clone(),
-                    requested: TypeId::of::<A>(),
-                    actual_asset_name: loader.asset_type_name(),
-                    loader_name: loader.type_name(),
-                }))
+            .and_then(|asset| {
+                asset
+                    .downcast()
+                    .map_err(|_| AssetLoadError::RequestedHandleTypeMismatch {
+                        path: path.clone(),
+                        requested: TypeId::of::<A>(),
+                        actual_asset_name: loader.asset_type_name(),
+                        loader_name: loader.type_name(),
+                    })
+            })
             .map_err(|error| LoadDirectError {
                 dependency: path.clone(),
                 error,
@@ -839,13 +844,16 @@ impl<'a> LoadContext<'a> {
                 self.populate_hashes,
             )
             .await
-            .and_then(|asset| asset.downcast()
-                .map_err(|_| AssetLoadError::RequestedHandleTypeMismatch {
-                    path: path.clone(),
-                    requested: TypeId::of::<A>(),
-                    actual_asset_name: loader.asset_type_name(),
-                    loader_name: loader.type_name(),
-                }))
+            .and_then(|asset| {
+                asset
+                    .downcast()
+                    .map_err(|_| AssetLoadError::RequestedHandleTypeMismatch {
+                        path: path.clone(),
+                        requested: TypeId::of::<A>(),
+                        actual_asset_name: loader.asset_type_name(),
+                        loader_name: loader.type_name(),
+                    })
+            })
             .map_err(|error| LoadDirectError {
                 dependency: path.clone(),
                 error,

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -166,13 +166,12 @@ impl<A: Asset> LoadedAsset<A> {
         }
     }
 
-    /// Cast (and take ownership) of the [`Asset`] value of the given type. This will return [`Some`] if
-    /// the stored type matches `A` and [`None`] if it does not.
+    /// Cast (and take ownership) of the [`Asset`] value of the given type.
     pub fn take(self) -> A {
         self.value
     }
 
-    /// Retrieves a reference to the internal [`Asset`] type, if it matches the type `A`. Otherwise returns [`None`].
+    /// Retrieves a reference to the internal [`Asset`] type.
     pub fn get(&self) -> &A {
         &self.value
     }

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -255,6 +255,7 @@ impl ErasedLoadedAsset {
 
     /// Cast this loaded asset as the given type. If the type does not match,
     /// the original type-erased asset is returned.
+    #[allow(clippy::result_large_err)]
     pub fn downcast<A: Asset>(mut self) -> Result<LoadedAsset<A>, ErasedLoadedAsset> {
         match self.value.downcast::<A>() {
             Ok(value) => Ok(LoadedAsset {

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -208,21 +208,26 @@ impl AssetLoader for () {
     }
 }
 
+pub(crate) fn meta_transform_settings<S: Settings>(
+    meta: &mut dyn AssetMetaDyn,
+    settings: &(impl Fn(&mut S) + Send + Sync + 'static),
+) {
+    if let Some(loader_settings) = meta.loader_settings_mut() {
+        if let Some(loader_settings) = loader_settings.downcast_mut::<S>() {
+            settings(loader_settings);
+        } else {
+            error!(
+                "Configured settings type {} does not match AssetLoader settings type",
+                std::any::type_name::<S>(),
+            );
+        }
+    }
+}
+
 pub(crate) fn loader_settings_meta_transform<S: Settings>(
     settings: impl Fn(&mut S) + Send + Sync + 'static,
 ) -> MetaTransform {
-    Box::new(move |meta| {
-        if let Some(loader_settings) = meta.loader_settings_mut() {
-            if let Some(loader_settings) = loader_settings.downcast_mut::<S>() {
-                settings(loader_settings);
-            } else {
-                error!(
-                    "Configured settings type {} does not match AssetLoader settings type",
-                    std::any::type_name::<S>(),
-                );
-            }
-        }
-    })
+    Box::new(move |meta| meta_transform_settings(meta, &settings))
 }
 
 pub type AssetHash = [u8; 32];

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -72,7 +72,7 @@ impl AssetLoader for GzAssetLoader {
         let mut reader = VecReader::new(bytes_uncompressed);
 
         let uncompressed = load_context
-            .load_direct_with_reader(&mut reader, contained_path)
+            .load_direct_untyped_with_reader(&mut reader, contained_path)
             .await?;
 
         Ok(GzAsset { uncompressed })

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -72,9 +72,7 @@ impl AssetLoader for GzAssetLoader {
         let mut reader = VecReader::new(bytes_uncompressed);
 
         let uncompressed = load_context
-            .load_direct(contained_path)
-            .with_reader(&mut reader)
-            .load_untyped()
+            .load_direct_untyped_with_reader(&mut reader, contained_path)
             .await?;
 
         Ok(GzAsset { uncompressed })

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -72,7 +72,9 @@ impl AssetLoader for GzAssetLoader {
         let mut reader = VecReader::new(bytes_uncompressed);
 
         let uncompressed = load_context
-            .load_direct_untyped_with_reader(&mut reader, contained_path)
+            .load_direct(contained_path)
+            .with_reader(&mut reader)
+            .load_untyped()
             .await?;
 
         Ok(GzAsset { uncompressed })

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -146,14 +146,16 @@ impl AssetLoader for CoolTextLoader {
         let ron: CoolTextRon = ron::de::from_bytes(&bytes)?;
         let mut base_text = ron.text;
         for embedded in ron.embedded_dependencies {
-            let loaded = load_context.load_direct::<Text>(&embedded).await?;
+            let loaded = load_context.load_direct(&embedded).load::<Text>().await?;
             base_text.push_str(&loaded.get().0);
         }
         for (path, settings_override) in ron.dependencies_with_settings {
             let loaded = load_context
-                .load_direct_with_settings::<Text, _>(&path, move |settings| {
+                .load_direct(&path)
+                .with_settings(move |settings| {
                     *settings = settings_override.clone();
                 })
+                .load::<Text>()
                 .await?;
             base_text.push_str(&loaded.get().0);
         }

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -145,9 +145,8 @@ impl AssetLoader for CoolTextLoader {
         let ron: CoolTextRon = ron::de::from_bytes(&bytes)?;
         let mut base_text = ron.text;
         for embedded in ron.embedded_dependencies {
-            let loaded = load_context.load_direct(&embedded).await?;
-            let text = loaded.get::<Text>().unwrap();
-            base_text.push_str(&text.0);
+            let loaded = load_context.load_direct::<Text>(&embedded).await?;
+            base_text.push_str(&loaded.get().0);
         }
         Ok(CoolText {
             text: base_text,

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -150,9 +150,11 @@ impl AssetLoader for CoolTextLoader {
             base_text.push_str(&loaded.get().0);
         }
         for (path, settings_override) in ron.dependencies_with_settings {
-            let loaded = load_context.load_direct_with_settings::<Text, _>(&path, move |settings| {
-                *settings = settings_override.clone();
-            }).await?;
+            let loaded = load_context
+                .load_direct_with_settings::<Text, _>(&path, move |settings| {
+                    *settings = settings_override.clone();
+                })
+                .await?;
             base_text.push_str(&loaded.get().0);
         }
         Ok(CoolText {

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -146,16 +146,14 @@ impl AssetLoader for CoolTextLoader {
         let ron: CoolTextRon = ron::de::from_bytes(&bytes)?;
         let mut base_text = ron.text;
         for embedded in ron.embedded_dependencies {
-            let loaded = load_context.load_direct(&embedded).load::<Text>().await?;
+            let loaded = load_context.load_direct::<Text>(&embedded).await?;
             base_text.push_str(&loaded.get().0);
         }
         for (path, settings_override) in ron.dependencies_with_settings {
             let loaded = load_context
-                .load_direct(&path)
-                .with_settings(move |settings| {
+                .load_direct_with_settings::<Text, _>(&path, move |settings| {
                     *settings = settings_override.clone();
                 })
-                .load::<Text>()
                 .await?;
             base_text.push_str(&loaded.get().0);
         }

--- a/examples/asset/processing/assets/a.cool.ron
+++ b/examples/asset/processing/assets/a.cool.ron
@@ -5,4 +5,5 @@
         "foo/c.cool.ron",
     ],
     embedded_dependencies: [],
+    dependencies_with_settings: [],
 )

--- a/examples/asset/processing/assets/d.cool.ron
+++ b/examples/asset/processing/assets/d.cool.ron
@@ -6,4 +6,7 @@
         "foo/c.cool.ron",
         "embedded://asset_processing/e.txt"
     ],
+    dependencies_with_settings: [
+        ("embedded://asset_processing/e.txt", (text_override: Some("E"))),
+    ],
 )

--- a/examples/asset/processing/assets/foo/b.cool.ron
+++ b/examples/asset/processing/assets/foo/b.cool.ron
@@ -2,4 +2,5 @@
     text: "b",
     dependencies: [],
     embedded_dependencies: [],
+    dependencies_with_settings: [],
 )

--- a/examples/asset/processing/assets/foo/c.cool.ron
+++ b/examples/asset/processing/assets/foo/c.cool.ron
@@ -2,4 +2,5 @@
     text: "c",
     dependencies: [],
     embedded_dependencies: ["a.cool.ron", "foo/b.cool.ron"],
+    dependencies_with_settings: [],
 )


### PR DESCRIPTION
# Objective
- Introduce variants of `LoadContext::load_direct` which allow picking asset type & configuring settings.
- Fixes #12963.

## Solution
- Implements `ErasedLoadedAsset::downcast` and adds some accessors to `LoadedAsset<A>`.
- Changes `load_direct`/`load_direct_with_reader` to be typed, and introduces `load_direct_untyped`/`load_direct_untyped_with_reader`.
- Introduces `load_direct_with_settings` and `load_direct_with_reader_and_settings`.

## Testing
- I've run cargo test and played with the examples which use `load_direct`.
- I also extended the `asset_processing` example to use the new typed version of `load_direct` and use `load_direct_with_settings`.

---

## Changelog
- Introduced new `load_direct` methods in `LoadContext` to allow specifying type & settings

## Migration Guide
- `LoadContext::load_direct` has been renamed to `LoadContext::load_direct_untyped`. You may find the new `load_direct` is more appropriate for your use case (and the migration may only be moving one type parameter).
- `LoadContext::load_direct_with_reader` has been renamed to `LoadContext::load_direct_untyped_with_reader`.

---

This might not be an obvious win as a solution because it introduces quite a few new `load_direct` alternatives - but it does follow the existing pattern pretty well. I'm very open to alternatives. :sweat_smile: 