### PR TITLE
bevy_reflect: `enum_utility` cleanup

### DIFF
--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -4,7 +4,7 @@ use crate::{derive_data::ReflectEnum, utility::ident_or_index};
 use bevy_macro_utils::fq_std::{FQDefault, FQOption};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use syn::{Member, Path};
+use syn::Member;
 
 pub(crate) struct EnumVariantOutputData {
     /// The names of each variant as a string.
@@ -14,11 +14,11 @@ pub(crate) struct EnumVariantOutputData {
     /// The constructor portion of each variant.
     ///
     /// For example, `Option::Some { 0: value }` and `Option::None {}` for the `Option` enum.
-    pub variant_constructors: Vec<proc_macro2::TokenStream>,
+    pub variant_constructors: Vec<TokenStream>,
 }
 
 #[derive(Copy, Clone)]
-struct VariantField<'a, 'b> {
+pub(crate) struct VariantField<'a, 'b> {
     /// The pre-computed member for the field.
     pub member: &'a Member,
     /// The name of the variant that contains the field.
@@ -28,7 +28,10 @@ struct VariantField<'a, 'b> {
 }
 
 /// Trait used to control how enum variants are built.
-trait VariantBuilder: Sized {
+pub(crate) trait VariantBuilder: Sized {
+    /// Returns the enum data.
+    fn reflect_enum(&self) -> &ReflectEnum;
+
     /// Returns a token stream that accesses a field of a variant as an `Option<dyn Reflect>`.
     ///
     /// The default implementation of this method will return a token stream
@@ -37,7 +40,7 @@ trait VariantBuilder: Sized {
     /// # Parameters
     /// * `ident`: The identifier of the enum
     /// * `field`: The field to access
-    fn access_field(&self, ident: &Ident, field: VariantField) -> proc_macro2::TokenStream {
+    fn access_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
         match &field.field.data.ident {
             Some(field_ident) => {
                 let name = field_ident.to_string();
@@ -61,7 +64,7 @@ trait VariantBuilder: Sized {
     /// # Parameters
     /// * `ident`: The identifier of the enum
     /// * `field`: The field to access
-    fn unwrap_field(&self, ident: &Ident, field: VariantField) -> proc_macro2::TokenStream;
+    fn unwrap_field(&self, ident: &Ident, field: VariantField) -> TokenStream;
 
     /// Returns a token stream that constructs a field of a variant as a concrete type
     /// (from a `&dyn Reflect`).
@@ -69,29 +72,62 @@ trait VariantBuilder: Sized {
     /// # Parameters
     /// * `ident`: The identifier of the enum
     /// * `field`: The field to access
-    fn construct_field(&self, ident: &Ident, field: VariantField) -> proc_macro2::TokenStream;
-}
+    fn construct_field(&self, ident: &Ident, field: VariantField) -> TokenStream;
 
-struct EnumVariantOutputBuilder<'a, V: VariantBuilder> {
-    /// A reference to the enum that is being reflected (e.g. `self`).
-    this: &'a Ident,
-    /// The reflect enum data.
-    reflect_enum: &'a ReflectEnum<'a>,
-    /// The variant builder.
-    variant_builder: V,
-}
+    /// Returns a token stream that constructs an instance of an active field.
+    ///
+    /// # Parameters
+    /// * `ident`: The identifier of the enum
+    /// * `field`: The field to access
+    fn on_active_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
+        let field_accessor = self.access_field(ident, field);
 
-impl<'a, V: VariantBuilder> EnumVariantOutputBuilder<'a, V> {
-    pub fn new(this: &'a Ident, reflect_enum: &'a ReflectEnum<'a>, variant_builder: V) -> Self {
-        Self {
-            this,
-            reflect_enum,
-            variant_builder,
+        let field_ident = format_ident!("__field");
+        let field_constructor = self.construct_field(&field_ident, field);
+
+        match &field.field.attrs.default {
+            DefaultBehavior::Func(path) => quote! {
+                if let #FQOption::Some(#field_ident) = #field_accessor {
+                    #field_constructor
+                } else {
+                    #path()
+                }
+            },
+            DefaultBehavior::Default => quote! {
+                if let #FQOption::Some(#field_ident) = #field_accessor {
+                    #field_constructor
+                } else {
+                    #FQDefault::default()
+                }
+            },
+            DefaultBehavior::Required => {
+                let field_unwrapper = self.unwrap_field(&field_ident, field);
+
+                quote! {{
+                    // `#field_ident` is used by both the unwrapper and constructor
+                    let #field_ident = #field_accessor;
+                    let #field_ident = #field_unwrapper;
+                    #field_constructor
+                }}
+            }
         }
     }
 
-    pub fn build(self) -> EnumVariantOutputData {
-        let variants = self.reflect_enum.variants();
+    /// Returns a token stream that constructs an instance of an ignored field.
+    ///
+    /// # Parameters
+    /// * `ident`: The identifier of the enum
+    /// * `field`: The field to access
+    fn on_ignored_field(&self, field: VariantField) -> TokenStream {
+        match &field.field.attrs.default {
+            DefaultBehavior::Func(path) => quote! { #path() },
+            _ => quote! { #FQDefault::default() },
+        }
+    }
+
+    /// Builds the enum variant output data.
+    fn build(&self, this: &Ident) -> EnumVariantOutputData {
+        let variants = self.reflect_enum().variants();
 
         let mut variant_names = Vec::with_capacity(variants.len());
         let mut variant_constructors = Vec::with_capacity(variants.len());
@@ -99,18 +135,24 @@ impl<'a, V: VariantBuilder> EnumVariantOutputBuilder<'a, V> {
         for variant in variants {
             let variant_ident = &variant.data.ident;
             let variant_name = variant_ident.to_string();
-            let variant_path = self.reflect_enum.get_unit(variant_ident);
+            let variant_path = self.reflect_enum().get_unit(variant_ident);
 
             let fields = variant.fields();
 
             let field_constructors = fields.iter().map(|field| {
                 let member = ident_or_index(field.data.ident.as_ref(), field.declaration_index);
 
-                let value = self.construct_field(VariantField {
+                let variant_field = VariantField {
                     member: &member,
                     variant_name: &variant_name,
                     field,
-                });
+                };
+
+                let value = if field.attrs.ignore.is_ignored() {
+                    self.on_ignored_field(variant_field)
+                } else {
+                    self.on_active_field(this, variant_field)
+                };
 
                 let constructor = quote! {
                     #member: #value
@@ -134,144 +176,88 @@ impl<'a, V: VariantBuilder> EnumVariantOutputBuilder<'a, V> {
             variant_constructors,
         }
     }
-
-    fn construct_field(&self, variant_field: VariantField) -> proc_macro2::TokenStream {
-        let VariantField { field, .. } = variant_field;
-
-        // Ignored fields (fall back to default value)
-        if field.attrs.ignore.is_ignored() {
-            return match &field.attrs.default {
-                DefaultBehavior::Func(path) => quote! { #path() },
-                _ => quote! { #FQDefault::default() },
-            };
-        }
-
-        let field_accessor = self.variant_builder.access_field(self.this, variant_field);
-
-        let field_ident = format_ident!("__field");
-        let field_constructor = self
-            .variant_builder
-            .construct_field(&field_ident, variant_field);
-
-        match &field.attrs.default {
-            DefaultBehavior::Func(path) => quote! {
-                if let #FQOption::Some(#field_ident) = #field_accessor {
-                    #field_constructor
-                } else {
-                    #path()
-                }
-            },
-            DefaultBehavior::Default => quote! {
-                if let #FQOption::Some(#field_ident) = #field_accessor {
-                    #field_constructor
-                } else {
-                    #FQDefault::default()
-                }
-            },
-            DefaultBehavior::Required => {
-                let field_unwrapper = self
-                    .variant_builder
-                    .unwrap_field(&field_ident, variant_field);
-
-                quote! {{
-                    // `#field_ident` is used by both the unwrapper and constructor
-                    let #field_ident = #field_accessor;
-                    let #field_ident = #field_unwrapper;
-                    #field_constructor
-                }}
-            }
-        }
-    }
 }
 
 /// Generates the enum variant output data needed to build the `FromReflect::from_reflect` implementation.
-pub(crate) fn generate_from_reflect_variants(
-    reflect_enum: &ReflectEnum,
-    this: &Ident,
-) -> EnumVariantOutputData {
-    struct FromReflectVariantBuilder<'a> {
-        bevy_reflect_path: &'a Path,
+pub(crate) struct FromReflectVariantBuilder<'a> {
+    reflect_enum: &'a ReflectEnum<'a>,
+}
+
+impl<'a> FromReflectVariantBuilder<'a> {
+    pub fn new(reflect_enum: &'a ReflectEnum) -> Self {
+        Self { reflect_enum }
+    }
+}
+
+impl<'a> VariantBuilder for FromReflectVariantBuilder<'a> {
+    fn reflect_enum(&self) -> &ReflectEnum {
+        self.reflect_enum
     }
 
-    impl<'a> VariantBuilder for FromReflectVariantBuilder<'a> {
-        fn unwrap_field(&self, ident: &Ident, _field: VariantField) -> TokenStream {
-            quote!(#ident?)
-        }
-
-        fn construct_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
-            let bevy_reflect_path = self.bevy_reflect_path;
-            let field_ty = &field.field.data.ty;
-
-            quote! {
-                <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#ident)?
-            }
-        }
+    fn unwrap_field(&self, ident: &Ident, _field: VariantField) -> TokenStream {
+        quote!(#ident?)
     }
 
-    EnumVariantOutputBuilder::new(
-        this,
-        reflect_enum,
-        FromReflectVariantBuilder {
-            bevy_reflect_path: reflect_enum.meta().bevy_reflect_path(),
-        },
-    )
-    .build()
+    fn construct_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
+        let bevy_reflect_path = self.reflect_enum.meta().bevy_reflect_path();
+        let field_ty = &field.field.data.ty;
+
+        quote! {
+            <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#ident)?
+        }
+    }
 }
 
 /// Generates the enum variant output data needed to build the `Reflect::try_apply` implementation.
-pub(crate) fn generate_try_apply_variants(
-    reflect_enum: &ReflectEnum,
-    this: &Ident,
-) -> EnumVariantOutputData {
-    struct TryApplyVariantBuilder<'a> {
-        bevy_reflect_path: &'a Path,
+pub(crate) struct TryApplyVariantBuilder<'a> {
+    reflect_enum: &'a ReflectEnum<'a>,
+}
+
+impl<'a> TryApplyVariantBuilder<'a> {
+    pub fn new(reflect_enum: &'a ReflectEnum) -> Self {
+        Self { reflect_enum }
+    }
+}
+
+impl<'a> VariantBuilder for TryApplyVariantBuilder<'a> {
+    fn reflect_enum(&self) -> &ReflectEnum {
+        self.reflect_enum
     }
 
-    impl<'a> VariantBuilder for TryApplyVariantBuilder<'a> {
-        fn unwrap_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
-            let VariantField {
-                member,
-                variant_name,
-                ..
-            } = field;
+    fn unwrap_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
+        let VariantField {
+            member,
+            variant_name,
+            ..
+        } = field;
 
-            let bevy_reflect_path = self.bevy_reflect_path;
+        let bevy_reflect_path = self.reflect_enum.meta().bevy_reflect_path();
 
-            let field_name = match member {
-                Member::Named(member_ident) => format!("{member_ident}"),
-                Member::Unnamed(member_index) => format!(".{}", member_index.index),
-            };
+        let field_name = match member {
+            Member::Named(member_ident) => format!("{member_ident}"),
+            Member::Unnamed(member_index) => format!(".{}", member_index.index),
+        };
 
-            quote! {
-                #ident.ok_or(#bevy_reflect_path::ApplyError::MissingEnumField {
-                    variant_name: ::core::convert::Into::into(#variant_name),
-                    field_name: ::core::convert::Into::into(#field_name)
+        quote! {
+            #ident.ok_or(#bevy_reflect_path::ApplyError::MissingEnumField {
+                variant_name: ::core::convert::Into::into(#variant_name),
+                field_name: ::core::convert::Into::into(#field_name)
+            })?
+        }
+    }
+
+    fn construct_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
+        let bevy_reflect_path = self.reflect_enum.meta().bevy_reflect_path();
+        let field_ty = &field.field.data.ty;
+
+        quote! {
+            <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#ident)
+                .ok_or(#bevy_reflect_path::ApplyError::MismatchedTypes {
+                    from_type: ::core::convert::Into::into(
+                        #bevy_reflect_path::DynamicTypePath::reflect_type_path(#ident)
+                    ),
+                    to_type: ::core::convert::Into::into(<#field_ty as #bevy_reflect_path::TypePath>::type_path())
                 })?
-            }
-        }
-
-        fn construct_field(&self, ident: &Ident, field: VariantField) -> TokenStream {
-            let bevy_reflect_path = self.bevy_reflect_path;
-            let field_ty = &field.field.data.ty;
-
-            quote! {
-                <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#ident)
-                    .ok_or(#bevy_reflect_path::ApplyError::MismatchedTypes {
-                        from_type: ::core::convert::Into::into(
-                            #bevy_reflect_path::DynamicTypePath::reflect_type_path(#ident)
-                        ),
-                        to_type: ::core::convert::Into::into(<#field_ty as #bevy_reflect_path::TypePath>::type_path())
-                    })?
-            }
         }
     }
-
-    EnumVariantOutputBuilder::new(
-        this,
-        reflect_enum,
-        TryApplyVariantBuilder {
-            bevy_reflect_path: reflect_enum.meta().bevy_reflect_path(),
-        },
-    )
-    .build()
 }

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -1,122 +1,277 @@
 use crate::derive_data::StructField;
 use crate::field_attributes::DefaultBehavior;
-use crate::{
-    derive_data::{EnumVariantFields, ReflectEnum},
-    utility::ident_or_index,
-};
+use crate::{derive_data::ReflectEnum, utility::ident_or_index};
 use bevy_macro_utils::fq_std::{FQDefault, FQOption};
 use proc_macro2::Ident;
-use quote::{quote, ToTokens};
+use quote::{format_ident, quote};
 use syn::Member;
 
-/// Contains all data needed to construct all variants within an enum.
-pub(crate) struct EnumVariantConstructors {
+pub(crate) struct EnumVariantOutputData {
     /// The names of each variant as a string.
+    ///
+    /// For example, `Some` and `None` for the `Option` enum.
     pub variant_names: Vec<String>,
-    /// The stream of tokens that will construct each variant.
+    /// The pattern matching portion of each variant.
+    ///
+    /// For example, `Option::Some { 0: _0 }` and `Option::None {}` for the `Option` enum.
+    #[allow(dead_code)]
+    pub variant_patterns: Vec<proc_macro2::TokenStream>,
+    /// The constructor portion of each variant.
+    ///
+    /// For example, `Option::Some { 0: value }` and `Option::None {}` for the `Option` enum.
     pub variant_constructors: Vec<proc_macro2::TokenStream>,
 }
 
-/// Gets the constructors for all variants in the given enum.
-pub(crate) fn get_variant_constructors(
-    reflect_enum: &ReflectEnum,
-    ref_value: &Ident,
-    return_apply_error: bool,
-) -> EnumVariantConstructors {
-    let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
-    let variant_count = reflect_enum.variants().len();
-    let mut variant_names = Vec::with_capacity(variant_count);
-    let mut variant_constructors = Vec::with_capacity(variant_count);
+#[derive(Copy, Clone)]
+struct VariantField<'a, 'b> {
+    /// The pre-computed member for the field.
+    pub member: &'a Member,
+    /// The name of the variant that contains the field.
+    pub variant_name: &'a str,
+    /// The field data.
+    pub field: &'a StructField<'b>,
+}
 
-    for variant in reflect_enum.variants() {
-        let ident = &variant.data.ident;
-        let name = ident.to_string();
-        let variant_constructor = reflect_enum.get_unit(ident);
+/// A builder for constructing [`EnumVariantOutputData`].
+///
+/// When a variant field needs to be constructed, the builder will:
+/// 1. Use `field_accessor` to access the field as an `Option<&dyn Reflect>`.
+/// 2. Use `field_unwrapper` to unwrap the field into a `&dyn Reflect`.
+/// 3. Use `field_constructor` to construct the field into a concrete value.
+struct EnumVariantOutputDataBuilder<'a> {
+    /// A reference to the enum that is being reflected (e.g. `self`).
+    this: &'a Ident,
+    /// The reflect enum data.
+    reflect_enum: &'a ReflectEnum<'a>,
+    /// A function to generate tokens that will extract the field value from the enum
+    /// as an `Option<&dyn Reflect>`.
+    field_accessor: Box<dyn Fn(&Ident, VariantField) -> proc_macro2::TokenStream + 'a>,
+    /// A function to generate tokens that will unwrap the accessed field value into a
+    /// `&dyn Reflect`.
+    field_unwrapper: Box<dyn Fn(&Ident, VariantField) -> proc_macro2::TokenStream + 'a>,
+    /// A function to generate tokens that will construct a new concrete value from the accessed field.
+    field_constructor: Box<dyn Fn(&Ident, VariantField) -> proc_macro2::TokenStream + 'a>,
+}
 
-        let fields: &[StructField] = match &variant.fields {
-            EnumVariantFields::Unit => &[],
-            EnumVariantFields::Named(fields) | EnumVariantFields::Unnamed(fields) => {
-                fields.as_slice()
-            }
-        };
-        let mut reflect_index: usize = 0;
-        let constructor_fields = fields.iter().enumerate().map(|(declare_index, field)| {
-            let field_ident = ident_or_index(field.data.ident.as_ref(), declare_index);
-            let field_ty = &field.data.ty;
+impl<'a> EnumVariantOutputDataBuilder<'a> {
+    pub fn new(this: &'a Ident, reflect_enum: &'a ReflectEnum<'a>) -> Self {
+        Self {
+            this,
+            reflect_enum,
+            field_accessor: Box::new(Self::generate_dynamic_field_accessor),
+            field_unwrapper: Box::new(
+                |_, _| quote! {::core::compile_error!("internal bevy_reflect error: failed to define field unwrapper")},
+            ),
+            field_constructor: Box::new(
+                |_, _| quote! {::core::compile_error!("internal bevy_reflect error: failed to define field constructor")},
+            ),
+        }
+    }
 
-            let field_value = if field.attrs.ignore.is_ignored() {
-                match &field.attrs.default {
-                    DefaultBehavior::Func(path) => quote! { #path() },
-                    _ => quote! { #FQDefault::default() }
-                }
-            } else {
-                let field_accessor = match &field.data.ident {
-                    Some(ident) => {
-                        let name = ident.to_string();
-                        quote!(#ref_value.field(#name))
-                    }
-                    None => quote!(#ref_value.field_at(#reflect_index)),
-                };
-                reflect_index += 1;
+    pub fn with_field_unwrapper(
+        mut self,
+        unwrapper: impl Fn(&Ident, VariantField) -> proc_macro2::TokenStream + 'a,
+    ) -> Self {
+        self.field_unwrapper = Box::new(unwrapper);
+        self
+    }
 
-                let (resolve_error, resolve_missing) = if return_apply_error {
-                    let field_ref_str = match &field_ident {
-                        Member::Named(ident) => format!("{ident}"),
-                        Member::Unnamed(index) => format!(".{}", index.index)
+    pub fn with_field_constructor(
+        mut self,
+        constructor: impl Fn(&Ident, VariantField) -> proc_macro2::TokenStream + 'a,
+    ) -> Self {
+        self.field_constructor = Box::new(constructor);
+        self
+    }
+
+    pub fn build(self) -> EnumVariantOutputData {
+        let variants = self.reflect_enum.variants();
+
+        let mut variant_names = Vec::with_capacity(variants.len());
+        let mut variant_patterns = Vec::with_capacity(variants.len());
+        let mut variant_constructors = Vec::with_capacity(variants.len());
+
+        for variant in variants {
+            let variant_ident = &variant.data.ident;
+            let variant_name = variant_ident.to_string();
+            let variant_path = self.reflect_enum.get_unit(variant_ident);
+
+            let fields = variant.fields();
+
+            let (field_patterns, field_constructors): (Vec<_>, Vec<_>) = fields
+                .iter()
+                .map(|field| {
+                    let member = ident_or_index(field.data.ident.as_ref(), field.declaration_index);
+                    let alias = format_ident!("_{}", member);
+
+                    let value = self.construct_field(VariantField {
+                        member: &member,
+                        variant_name: &variant_name,
+                        field,
+                    });
+
+                    let pattern = quote! {
+                        #member: #alias
                     };
-                    let ty = field.data.ty.to_token_stream();
 
-                    (
-                        quote!(.ok_or(#bevy_reflect_path::ApplyError::MismatchedTypes {
-                            // The unwrap won't panic. By this point the #field_accessor would have been invoked once and any failure to
-                            // access the given field handled by the `resolve_missing` code bellow.
-                            from_type: ::core::convert::Into::into(
-                                #bevy_reflect_path::DynamicTypePath::reflect_type_path(#FQOption::unwrap(#field_accessor))
-                            ),
-                            to_type: ::core::convert::Into::into(<#ty as #bevy_reflect_path::TypePath>::type_path())
-                        })?),
-                        quote!(.ok_or(#bevy_reflect_path::ApplyError::MissingEnumField {
-                                variant_name: ::core::convert::Into::into(#name),
-                                field_name: ::core::convert::Into::into(#field_ref_str)
-                        })?)
-                    )
-                } else {
-                    (quote!(?), quote!(?))
-                };
+                    let constructor = quote! {
+                        #member: #value
+                    };
 
-                match &field.attrs.default {
-                    DefaultBehavior::Func(path) => quote! {
-                        if let #FQOption::Some(field) = #field_accessor {
-                            <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
-                            #resolve_error
-                        } else {
-                            #path()
-                        }
-                    },
-                    DefaultBehavior::Default => quote! {
-                        if let #FQOption::Some(field) = #field_accessor {
-                            <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
-                            #resolve_error
-                        } else {
-                            #FQDefault::default()
-                        }
-                    },
-                    DefaultBehavior::Required => quote! {
-                        <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#field_accessor #resolve_missing)
-                        #resolve_error
-                    },
+                    (pattern, constructor)
+                })
+                .unzip();
+
+            let pattern = quote! {
+                #variant_path { #( #field_patterns ),* }
+            };
+
+            let constructor = quote! {
+                #variant_path {
+                    #( #field_constructors ),*
                 }
             };
-            quote! { #field_ident : #field_value }
-        });
-        variant_constructors.push(quote! {
-            #variant_constructor { #( #constructor_fields ),* }
-        });
-        variant_names.push(name);
+
+            variant_names.push(variant_name);
+            variant_patterns.push(pattern);
+            variant_constructors.push(constructor);
+        }
+
+        EnumVariantOutputData {
+            variant_names,
+            variant_patterns,
+            variant_constructors,
+        }
     }
 
-    EnumVariantConstructors {
-        variant_names,
-        variant_constructors,
+    fn construct_field(&self, variant_field: VariantField) -> proc_macro2::TokenStream {
+        let VariantField { field, .. } = variant_field;
+
+        // Ignored fields (fall back to default value)
+        if field.attrs.ignore.is_ignored() {
+            return match &field.attrs.default {
+                DefaultBehavior::Func(path) => quote! { #path() },
+                _ => quote! { #FQDefault::default() },
+            };
+        }
+
+        let field_accessor = (self.field_accessor)(self.this, variant_field);
+
+        let field_ident = format_ident!("__field");
+        let field_constructor = (self.field_constructor)(&field_ident, variant_field);
+
+        match &field.attrs.default {
+            DefaultBehavior::Func(path) => quote! {
+                if let #FQOption::Some(#field_ident) = #field_accessor {
+                    #field_constructor
+                } else {
+                    #path()
+                }
+            },
+            DefaultBehavior::Default => quote! {
+                if let #FQOption::Some(#field_ident) = #field_accessor {
+                    #field_constructor
+                } else {
+                    #FQDefault::default()
+                }
+            },
+            DefaultBehavior::Required => {
+                let field_unwrapper = (self.field_unwrapper)(&field_ident, variant_field);
+
+                quote! {{
+                    let #field_ident = #field_accessor;
+                    let #field_ident = #field_unwrapper;
+                    #field_constructor
+                }}
+            }
+        }
     }
+
+    /// Generates a dynamic field accessor for the given variant field.
+    ///
+    /// This will result in either `this.field("field_name")` or `this.field_at(index)`
+    /// depending on whether the field is named or unnamed.
+    ///
+    /// By using this accessor, we can extract the field dynamically from a `dyn Enum`
+    /// without having to know what it's concrete type is.
+    fn generate_dynamic_field_accessor(
+        this: &Ident,
+        variant_field: VariantField,
+    ) -> proc_macro2::TokenStream {
+        match variant_field.member {
+            Member::Named(ident) => {
+                let name = ident.to_string();
+                quote!(#this.field(#name))
+            }
+            Member::Unnamed(reflect_index) => {
+                quote!(#this.field_at(#reflect_index))
+            }
+        }
+    }
+}
+
+/// Generates the enum variant output data needed to build the `FromReflect::from_reflect` implementation.
+pub(crate) fn generate_from_reflect_variants(
+    reflect_enum: &ReflectEnum,
+    this: &Ident,
+) -> EnumVariantOutputData {
+    let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
+
+    EnumVariantOutputDataBuilder::new(this, reflect_enum)
+        .with_field_unwrapper(|ident, _| {
+            quote! {
+                #ident?
+            }
+        })
+        .with_field_constructor(|ident, variant_field| {
+            let field_ty = &variant_field.field.data.ty;
+
+            quote! {
+                <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#ident)?
+            }
+        })
+        .build()
+}
+
+/// Generates the enum variant output data needed to build the `Reflect::try_apply` implementation.
+pub(crate) fn generate_try_apply_variants(
+    reflect_enum: &ReflectEnum,
+    this: &Ident,
+) -> EnumVariantOutputData {
+    let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
+
+    EnumVariantOutputDataBuilder::new(this, reflect_enum)
+        .with_field_unwrapper(|ident, variant_field| {
+            let VariantField {
+                member,
+                variant_name,
+                ..
+            } = variant_field;
+
+            let field_name = match member {
+                Member::Named(member_ident) => format!("{member_ident}"),
+                Member::Unnamed(member_index) => format!(".{}", member_index.index),
+            };
+
+            quote! {
+                #ident.ok_or(#bevy_reflect_path::ApplyError::MissingEnumField {
+                    variant_name: ::core::convert::Into::into(#variant_name),
+                    field_name: ::core::convert::Into::into(#field_name)
+                })?
+            }
+        })
+        .with_field_constructor(|ident, variant_field| {
+            let field_ty = &variant_field.field.data.ty;
+
+            quote! {
+                <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#ident)
+                    .ok_or(#bevy_reflect_path::ApplyError::MismatchedTypes {
+                        from_type: ::core::convert::Into::into(
+                            #bevy_reflect_path::DynamicTypePath::reflect_type_path(#ident)
+                        ),
+                        to_type: ::core::convert::Into::into(<#field_ty as #bevy_reflect_path::TypePath>::type_path())
+                    })?
+            }
+        })
+        .build()
 }

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -178,13 +178,19 @@ impl<'a> EnumVariantOutputDataBuilder<'a> {
         this: &Ident,
         variant_field: VariantField,
     ) -> proc_macro2::TokenStream {
-        match variant_field.member {
-            Member::Named(ident) => {
+        match &variant_field.field.data.ident {
+            Some(ident) => {
                 let name = ident.to_string();
                 quote!(#this.field(#name))
             }
-            Member::Unnamed(reflect_index) => {
-                quote!(#this.field_at(#reflect_index))
+            None => {
+                if let Some(index) = variant_field.field.reflection_index {
+                    quote!(#this.field_at(#index))
+                } else {
+                    quote!(::core::compile_error!(
+                        "internal bevy_reflect error: field should be active"
+                    ))
+                }
             }
         }
     }

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -1,6 +1,6 @@
 use crate::container_attributes::REFLECT_DEFAULT;
 use crate::derive_data::ReflectEnum;
-use crate::enum_utility::{generate_from_reflect_variants, EnumVariantOutputData};
+use crate::enum_utility::{EnumVariantOutputData, FromReflectVariantBuilder, VariantBuilder};
 use crate::field_attributes::DefaultBehavior;
 use crate::utility::{ident_or_index, WhereClauseOptions};
 use crate::{ReflectMeta, ReflectStruct};
@@ -41,11 +41,12 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
 
     let ref_value = Ident::new("__param0", Span::call_site());
+
     let EnumVariantOutputData {
         variant_names,
         variant_constructors,
         ..
-    } = generate_from_reflect_variants(reflect_enum, &ref_value);
+    } = FromReflectVariantBuilder::new(reflect_enum).build(&ref_value);
 
     let (impl_generics, ty_generics, where_clause) = enum_path.generics().split_for_impl();
 

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -1,6 +1,6 @@
 use crate::container_attributes::REFLECT_DEFAULT;
 use crate::derive_data::ReflectEnum;
-use crate::enum_utility::{get_variant_constructors, EnumVariantConstructors};
+use crate::enum_utility::{generate_from_reflect_variants, EnumVariantOutputData};
 use crate::field_attributes::DefaultBehavior;
 use crate::utility::{ident_or_index, WhereClauseOptions};
 use crate::{ReflectMeta, ReflectStruct};
@@ -41,10 +41,11 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
 
     let ref_value = Ident::new("__param0", Span::call_site());
-    let EnumVariantConstructors {
+    let EnumVariantOutputData {
         variant_names,
         variant_constructors,
-    } = get_variant_constructors(reflect_enum, &ref_value, false);
+        ..
+    } = generate_from_reflect_variants(reflect_enum, &ref_value);
 
     let (impl_generics, ty_generics, where_clause) = enum_path.generics().split_for_impl();
 

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -1,5 +1,5 @@
 use crate::derive_data::{EnumVariantFields, ReflectEnum, StructField};
-use crate::enum_utility::{get_variant_constructors, EnumVariantConstructors};
+use crate::enum_utility::{generate_try_apply_variants, EnumVariantOutputData};
 use crate::impls::{impl_type_path, impl_typed};
 use bevy_macro_utils::fq_std::{FQAny, FQBox, FQOption, FQResult};
 use proc_macro2::{Ident, Span};
@@ -27,10 +27,11 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         enum_variant_type,
     } = generate_impls(reflect_enum, &ref_index, &ref_name);
 
-    let EnumVariantConstructors {
+    let EnumVariantOutputData {
         variant_names,
         variant_constructors,
-    } = get_variant_constructors(reflect_enum, &ref_value, true);
+        ..
+    } = generate_try_apply_variants(reflect_enum, &ref_value);
 
     let hash_fn = reflect_enum
         .meta()

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -1,5 +1,5 @@
 use crate::derive_data::{EnumVariantFields, ReflectEnum, StructField};
-use crate::enum_utility::{generate_try_apply_variants, EnumVariantOutputData};
+use crate::enum_utility::{EnumVariantOutputData, TryApplyVariantBuilder, VariantBuilder};
 use crate::impls::{impl_type_path, impl_typed};
 use bevy_macro_utils::fq_std::{FQAny, FQBox, FQOption, FQResult};
 use proc_macro2::{Ident, Span};
@@ -31,7 +31,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         variant_names,
         variant_constructors,
         ..
-    } = generate_try_apply_variants(reflect_enum, &ref_value);
+    } = TryApplyVariantBuilder::new(reflect_enum).build(&ref_value);
 
     let hash_fn = reflect_enum
         .meta()


### PR DESCRIPTION
# Objective

The `enum_utility` module contains the `get_variant_constructors` function, which is used to generate token streams for constructing enums. It's used for the `FromReflect::from_reflect` implementation and the `Reflect::try_apply` implementation.

Due to the complexity of enums, this function is understandably a little messy and difficult to extend.

## Solution

Clean up the `enum_utility` module.

Now "clean" is a bit subjective. I believe my solution is "cleaner" in that the logic to generate the tokens are strictly coupled with the intended usage. Because of this, `try_apply` is also no longer strictly coupled with `from_reflect`. 

This makes it easier to extend with new functionality, which is something I'm doing in a future unrelated PR that I have based off this one.

## Testing

There shouldn't be any testing required other than ensuring that the project still builds and that CI passes.