### PR TITLE
Add App and SubApp resource methods

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -501,6 +501,7 @@ impl App {
     ///
     /// let mut app = App::new();
     /// app.insert_resource(MyCounter { counter: 0 });
+    ///
     /// assert!(app.remove_resource::<MyCounter>().is_some());
     /// ```
     #[inline]
@@ -532,6 +533,7 @@ impl App {
     ///
     /// let mut app = App::new();
     /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    ///
     /// assert!(app.remove_non_send_resource::<MyCounter>().is_some());
     /// ```
     #[inline]
@@ -606,15 +608,15 @@ impl App {
     /// # use bevy_app::prelude::*;
     /// # use bevy_ecs::prelude::*;
     /// #
+    /// #[derive(Resource)]
     /// struct MyCounter {
     ///     counter: usize,
     /// }
     ///
     /// let mut app = App::new();
-    /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    /// app.insert_resource(MyCounter { counter: 0 });
     ///
-    /// assert!(app.contains_non_send_resource::<MyCounter>());
-    /// ```
+    /// assert_eq!(app.resource::<MyCounter>().counter, 0);
     pub fn resource<R: Resource>(&self) -> &R {
         self.main().resource()
     }
@@ -628,6 +630,22 @@ impl App {
     ///
     /// If you want to instead insert a value if the resource does not exist,
     /// use [`get_resource_or_insert_with`](App::get_resource_or_insert_with).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Resource)]
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_resource(MyCounter { counter: 0 });
+    ///
+    /// assert_eq!(app.resource_ref::<MyCounter>().counter, 0);
     pub fn resource_ref<R: Resource>(&self) -> Res<R> {
         self.main().resource_ref()
     }
@@ -641,27 +659,109 @@ impl App {
     ///
     /// If you want to instead insert a value if the resource does not exist,
     /// use [`get_resource_or_insert_with`](App::get_resource_or_insert_with).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Resource)]
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_resource(MyCounter { counter: 0 });
+    /// app.resource_mut::<MyCounter>().counter = 1;
+    ///
+    /// assert_eq!(app.resource::<MyCounter>().counter, 1);
     pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
         self.main_mut().resource_mut()
     }
 
     /// Gets a reference to the resource of the given type if it exists
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Resource)]
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_resource(MyCounter { counter: 0 });
+    ///
+    /// assert!(app.get_resource::<MyCounter>().is_some());
     pub fn get_resource<R: Resource>(&self) -> Option<&R> {
         self.main().get_resource()
     }
 
     /// Gets a reference including change detection to the resource of the given type if it exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Resource)]
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_resource(MyCounter { counter: 0 });
+    ///
+    /// assert!(app.get_resource_ref::<MyCounter>().is_some());
     pub fn get_resource_ref<R: Resource>(&self) -> Option<Res<R>> {
         self.main().get_resource_ref()
     }
 
     /// Gets a mutable reference to the resource of the given type if it exists
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Resource)]
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_resource(MyCounter { counter: 0 });
+    /// app.get_resource_mut::<MyCounter>().unwrap().counter = 1;
+    ///
+    /// assert_eq!(app.resource::<MyCounter>().counter, 1);
     pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
         self.main_mut().get_resource_mut()
     }
 
     /// Gets a mutable reference to the resource of type `T` if it exists,
     /// otherwise inserts the resource using the result of calling `func`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Resource)]
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.get_resource_or_insert_with(|| MyCounter { counter: 0 });
+    ///
+    /// assert!(app.get_resource::<MyCounter>().is_some());
     pub fn get_resource_or_insert_with<R: Resource>(
         &mut self,
         func: impl FnOnce() -> R,
@@ -677,6 +777,20 @@ impl App {
     /// Use [`get_non_send_resource`](App::get_non_send_resource) instead if you want to handle this case.
     ///
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// #
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    ///
+    /// assert_eq!(app.non_send_resource::<MyCounter>().counter, 0);
     pub fn non_send_resource<R: 'static>(&self) -> &R {
         self.main().non_send_resource()
     }
@@ -689,6 +803,21 @@ impl App {
     /// Use [`get_non_send_resource_mut`](App::get_non_send_resource_mut) instead if you want to handle this case.
     ///
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// #
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    /// app.non_send_resource_mut::<MyCounter>().counter = 1;
+    ///
+    /// assert_eq!(app.non_send_resource::<MyCounter>().counter, 1);
     pub fn non_send_resource_mut<R: 'static>(&mut self) -> Mut<'_, R> {
         self.main_mut().non_send_resource_mut()
     }
@@ -698,6 +827,20 @@ impl App {
     ///
     /// # Panics
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// #
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    ///
+    /// assert!(app.get_non_send_resource::<MyCounter>().is_some());
     pub fn get_non_send_resource<R: 'static>(&self) -> Option<&R> {
         self.main().get_non_send_resource()
     }
@@ -707,6 +850,21 @@ impl App {
     ///
     /// # Panics
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// #
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    /// app.get_non_send_resource_mut::<MyCounter>().unwrap().counter = 1;
+    ///
+    /// assert_eq!(app.non_send_resource::<MyCounter>().counter, 1);
     pub fn get_non_send_resource_mut<R: 'static>(&mut self) -> Option<Mut<'_, R>> {
         self.main_mut().get_non_send_resource_mut()
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1306,7 +1306,7 @@ mod tests {
 
         fn my_runner(mut app: App) -> AppExit {
             let my_state = MyState {};
-            app.world_mut().insert_resource(my_state);
+            app.insert_resource(my_state);
 
             for _ in 0..5 {
                 app.update();

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -501,7 +501,7 @@ impl App {
     ///
     /// let mut app = App::new();
     /// app.insert_resource(MyCounter { counter: 0 });
-    /// app.remove_resource::<MyCounter>();
+    /// assert!(app.remove_resource::<MyCounter>().is_some());
     /// ```
     #[inline]
     pub fn remove_resource<R: Resource>(&mut self) -> Option<R> {
@@ -532,7 +532,7 @@ impl App {
     ///
     /// let mut app = App::new();
     /// app.insert_non_send_resource(MyCounter { counter: 0 });
-    /// app.remove_non_send_resource::<MyCounter>();
+    /// assert!(app.remove_non_send_resource::<MyCounter>().is_some());
     /// ```
     #[inline]
     pub fn remove_non_send_resource<R: 'static>(&mut self) -> Option<R> {
@@ -588,6 +588,127 @@ impl App {
     /// ```
     pub fn contains_non_send_resource<R: 'static>(&self) -> bool {
         self.main().contains_non_send_resource::<R>()
+    }
+
+    /// Gets a reference to the resource of the given type
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resource does not exist.
+    /// Use [`get_resource`](App::get_resource) instead if you want to handle this case.
+    ///
+    /// If you want to instead insert a value if the resource does not exist,
+    /// use [`get_resource_or_insert_with`](App::get_resource_or_insert_with).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// let mut app = App::new();
+    /// app.insert_non_send_resource(MyCounter { counter: 0 });
+    ///
+    /// assert!(app.contains_non_send_resource::<MyCounter>());
+    /// ```
+    pub fn resource<R: Resource>(&self) -> &R {
+        self.main().resource()
+    }
+
+    /// Gets a reference to the resource of the given type
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resource does not exist.
+    /// Use [`get_resource_ref`](App::get_resource_ref) instead if you want to handle this case.
+    ///
+    /// If you want to instead insert a value if the resource does not exist,
+    /// use [`get_resource_or_insert_with`](App::get_resource_or_insert_with).
+    pub fn resource_ref<R: Resource>(&self) -> Res<R> {
+        self.main().resource_ref()
+    }
+
+    /// Gets a mutable reference to the resource of the given type
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resource does not exist.
+    /// Use [`get_resource_mut`](App::get_resource_mut) instead if you want to handle this case.
+    ///
+    /// If you want to instead insert a value if the resource does not exist,
+    /// use [`get_resource_or_insert_with`](App::get_resource_or_insert_with).
+    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+        self.main_mut().resource_mut()
+    }
+
+    /// Gets a reference to the resource of the given type if it exists
+    pub fn get_resource<R: Resource>(&self) -> Option<&R> {
+        self.main().get_resource()
+    }
+
+    /// Gets a reference including change detection to the resource of the given type if it exists.
+    pub fn get_resource_ref<R: Resource>(&self) -> Option<Res<R>> {
+        self.main().get_resource_ref()
+    }
+
+    /// Gets a mutable reference to the resource of the given type if it exists
+    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+        self.main_mut().get_resource_mut()
+    }
+
+    /// Gets a mutable reference to the resource of type `T` if it exists,
+    /// otherwise inserts the resource using the result of calling `func`.
+    pub fn get_resource_or_insert_with<R: Resource>(
+        &mut self,
+        func: impl FnOnce() -> R,
+    ) -> Mut<'_, R> {
+        self.main_mut().get_resource_or_insert_with(func)
+    }
+
+    /// Gets an immutable reference to the non-send resource of the given type, if it exists.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resource does not exist.
+    /// Use [`get_non_send_resource`](App::get_non_send_resource) instead if you want to handle this case.
+    ///
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    pub fn non_send_resource<R: 'static>(&self) -> &R {
+        self.main().non_send_resource()
+    }
+
+    /// Gets a mutable reference to the non-send resource of the given type, if it exists.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resource does not exist.
+    /// Use [`get_non_send_resource_mut`](App::get_non_send_resource_mut) instead if you want to handle this case.
+    ///
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    pub fn non_send_resource_mut<R: 'static>(&mut self) -> Mut<'_, R> {
+        self.main_mut().non_send_resource_mut()
+    }
+
+    /// Gets a reference to the non-send resource of the given type, if it exists.
+    /// Otherwise, returns `None`.
+    ///
+    /// # Panics
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    pub fn get_non_send_resource<R: 'static>(&self) -> Option<&R> {
+        self.main().get_non_send_resource()
+    }
+
+    /// Gets a mutable reference to the non-send resource of the given type, if it exists.
+    /// Otherwise, returns `None`.
+    ///
+    /// # Panics
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    pub fn get_non_send_resource_mut<R: 'static>(&mut self) -> Option<Mut<'_, R>> {
+        self.main_mut().get_non_send_resource_mut()
     }
 
     pub(crate) fn add_boxed_plugin(

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -203,7 +203,7 @@ impl SubApp {
 
     /// See [`App::contains_non_send_resource`].
     pub fn contains_non_send_resource<R: 'static>(&self) -> bool {
-        self.world.contains_non_send::<R>()
+        self.world.contains_non_send_resource::<R>()
     }
 
     /// See [`App::add_systems`].

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -174,6 +174,38 @@ impl SubApp {
         self
     }
 
+    /// See [`App::insert_non_resource`].
+    pub fn insert_non_send_resource<R: 'static>(&mut self, resource: R) -> &mut Self {
+        self.world.insert_non_send_resource(resource);
+        self
+    }
+
+    /// See [`App::init_non_send_resource`].
+    pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) -> &mut Self {
+        self.world.init_non_send_resource::<R>();
+        self
+    }
+
+    /// See [`App::remove_resource`].
+    pub fn remove_resource<R: Resource>(&mut self) -> Option<R> {
+        self.world.remove_resource::<R>()
+    }
+
+    /// See [`App::remove_non_send_resource`].
+    pub fn remove_non_send_resource<R: 'static>(&mut self) -> Option<R> {
+        self.world.remove_non_send_resource::<R>()
+    }
+
+    /// See [`App::contains_resource`].
+    pub fn contains_resource<R: Resource>(&self) -> bool {
+        self.world.contains_resource::<R>()
+    }
+
+    /// See [`App::contains_non_send_resource`].
+    pub fn contains_non_send_resource<R: 'static>(&self) -> bool {
+        self.world.contains_non_send::<R>()
+    }
+
     /// See [`App::add_systems`].
     pub fn add_systems<M>(
         &mut self,

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -206,6 +206,64 @@ impl SubApp {
         self.world.contains_non_send_resource::<R>()
     }
 
+    /// See [`App::resource`].
+    pub fn resource<R: Resource>(&self) -> &R {
+        self.world.resource()
+    }
+
+    /// See [`App::resource_ref`].
+    pub fn resource_ref<R: Resource>(&self) -> Res<R> {
+        self.world.resource_ref()
+    }
+
+    /// See [`App::resource_mut`].
+    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+        self.world.resource_mut()
+    }
+
+    /// See [`App::get_resource`].
+    pub fn get_resource<R: Resource>(&self) -> Option<&R> {
+        self.world.get_resource()
+    }
+
+    /// See [`App::get_resource_ref`].
+    pub fn get_resource_ref<R: Resource>(&self) -> Option<Res<R>> {
+        self.world.get_resource_ref()
+    }
+
+    /// See [`App::get_resource_mut`].
+    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+        self.world.get_resource_mut()
+    }
+
+    /// See [`App::get_resource_or_insert_with`].
+    pub fn get_resource_or_insert_with<R: Resource>(
+        &mut self,
+        func: impl FnOnce() -> R,
+    ) -> Mut<'_, R> {
+        self.world.get_resource_or_insert_with(func)
+    }
+
+    /// See [`App::non_send_resource`].
+    pub fn non_send_resource<R: 'static>(&self) -> &R {
+        self.world.non_send_resource()
+    }
+
+    /// See [`App::non_send_resource_mut`].
+    pub fn non_send_resource_mut<R: 'static>(&mut self) -> Mut<'_, R> {
+        self.world.non_send_resource_mut()
+    }
+
+    /// See [`App::get_non_send_resource`].
+    pub fn get_non_send_resource<R: 'static>(&self) -> Option<&R> {
+        self.world.get_non_send_resource()
+    }
+
+    /// See [`App::get_non_send_resource_mut`].
+    pub fn get_non_send_resource_mut<R: 'static>(&mut self) -> Option<Mut<'_, R>> {
+        self.world.get_non_send_resource_mut()
+    }
+
     /// See [`App::add_systems`].
     pub fn add_systems<M>(
         &mut self,

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -253,7 +253,7 @@ pub fn watched_path(_source_file_path: &'static str, _asset_path: &'static str) 
 #[macro_export]
 macro_rules! load_internal_asset {
     ($app: ident, $handle: expr, $path_str: expr, $loader: expr) => {{
-        let mut assets = $app.world_mut().resource_mut::<$crate::Assets<_>>();
+        let mut assets = $app.resource_mut::<$crate::Assets<_>>();
         assets.insert($handle.id(), ($loader)(
             include_str!($path_str),
             std::path::Path::new(file!())
@@ -265,7 +265,7 @@ macro_rules! load_internal_asset {
     }};
     // we can't support params without variadic arguments, so internal assets with additional params can't be hot-reloaded
     ($app: ident, $handle: ident, $path_str: expr, $loader: expr $(, $param:expr)+) => {{
-        let mut assets = $app.world_mut().resource_mut::<$crate::Assets<_>>();
+        let mut assets = $app.resource_mut::<$crate::Assets<_>>();
         assets.insert($handle.id(), ($loader)(
             include_str!($path_str),
             std::path::Path::new(file!())
@@ -282,7 +282,7 @@ macro_rules! load_internal_asset {
 #[macro_export]
 macro_rules! load_internal_binary_asset {
     ($app: ident, $handle: expr, $path_str: expr, $loader: expr) => {{
-        let mut assets = $app.world_mut().resource_mut::<$crate::Assets<_>>();
+        let mut assets = $app.resource_mut::<$crate::Assets<_>>();
         assets.insert(
             $handle.id(),
             ($loader)(

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -364,7 +364,7 @@ impl AssetApp for App {
         self.world()
             .resource::<AssetServer>()
             .register_asset(&assets);
-        if self.world().contains_resource::<AssetProcessor>() {
+        if self.contains_resource::<AssetProcessor>() {
             let processor = self.world().resource::<AssetProcessor>();
             // The processor should have its own handle provider separate from the Asset storage
             // to ensure the id spaces are entirely separate. Not _strictly_ necessary, but

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -925,8 +925,8 @@ mod tests {
             0,
             "SubText asset entities should be despawned when no more handles exist"
         );
-        let events = app.world_mut().remove_resource::<StoredEvents>().unwrap();
-        let id_results = app.world_mut().remove_resource::<IdResults>().unwrap();
+        let events = app.remove_resource::<StoredEvents>().unwrap();
+        let id_results = app.remove_resource::<IdResults>().unwrap();
         let expected_events = vec![
             AssetEvent::Added { id: a_id },
             AssetEvent::LoadedWithDependencies {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -170,7 +170,7 @@ impl Plugin for AssetPlugin {
             }
             match self.mode {
                 AssetMode::Unprocessed => {
-                    let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
+                    let mut builders = app.resource_mut::<AssetSourceBuilders>();
                     let sources = builders.build_sources(watch, false);
 
                     app.insert_resource(AssetServer::new_with_meta_check(
@@ -183,7 +183,7 @@ impl Plugin for AssetPlugin {
                 AssetMode::Processed => {
                     #[cfg(feature = "asset_processor")]
                     {
-                        let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
+                        let mut builders = app.resource_mut::<AssetSourceBuilders>();
                         let processor = AssetProcessor::new(&mut builders);
                         let mut sources = builders.build_sources(false, watch);
                         sources.gate_on_processor(processor.data.clone());
@@ -200,7 +200,7 @@ impl Plugin for AssetPlugin {
                     }
                     #[cfg(not(feature = "asset_processor"))]
                     {
-                        let mut builders = app.world_mut().resource_mut::<AssetSourceBuilders>();
+                        let mut builders = app.resource_mut::<AssetSourceBuilders>();
                         let sources = builders.build_sources(false, watch);
                         app.insert_resource(AssetServer::new_with_meta_check(
                             sources,
@@ -906,7 +906,7 @@ mod tests {
         });
 
         {
-            let mut texts = app.world_mut().resource_mut::<Assets<CoolText>>();
+            let mut texts = app.resource_mut::<Assets<CoolText>>();
             let a = texts.get_mut(a_id).unwrap();
             a.text = "Changed".to_string();
         }
@@ -1190,7 +1190,7 @@ mod tests {
         );
         // remove event is emitted
         app.update();
-        let events = std::mem::take(&mut app.world_mut().resource_mut::<StoredEvents>().0);
+        let events = std::mem::take(&mut app.resource_mut::<StoredEvents>().0);
         let expected_events = vec![
             AssetEvent::Added { id },
             AssetEvent::Unused { id },
@@ -1211,14 +1211,14 @@ mod tests {
         // TODO: ideally it doesn't take two updates for the added event to emit
         app.update();
 
-        let events = std::mem::take(&mut app.world_mut().resource_mut::<StoredEvents>().0);
+        let events = std::mem::take(&mut app.resource_mut::<StoredEvents>().0);
         let expected_events = vec![AssetEvent::Added { id: a_handle.id() }];
         assert_eq!(events, expected_events);
 
         gate_opener.open(dep_path);
         loop {
             app.update();
-            let events = std::mem::take(&mut app.world_mut().resource_mut::<StoredEvents>().0);
+            let events = std::mem::take(&mut app.resource_mut::<StoredEvents>().0);
             if events.is_empty() {
                 continue;
             }
@@ -1232,7 +1232,7 @@ mod tests {
             break;
         }
         app.update();
-        let events = std::mem::take(&mut app.world_mut().resource_mut::<StoredEvents>().0);
+        let events = std::mem::take(&mut app.resource_mut::<StoredEvents>().0);
         let expected_events = vec![AssetEvent::Added {
             id: dep_handle.id(),
         }];

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1189,7 +1189,7 @@ impl World {
         });
     }
 
-    /// Removes the resource of a given type and returns it, if it exists. Otherwise returns `None`.
+    /// Removes the resource of a given type and returns it, if it exists. Otherwise, returns `None`.
     #[inline]
     pub fn remove_resource<R: Resource>(&mut self) -> Option<R> {
         let component_id = self.components.get_resource_id(TypeId::of::<R>())?;
@@ -1221,7 +1221,7 @@ impl World {
         unsafe { Some(ptr.read::<R>()) }
     }
 
-    /// Returns `true` if a resource of type `R` exists. Otherwise returns `false`.
+    /// Returns `true` if a resource of type `R` exists. Otherwise, returns `false`.
     #[inline]
     pub fn contains_resource<R: Resource>(&self) -> bool {
         self.components
@@ -1231,7 +1231,7 @@ impl World {
             .unwrap_or(false)
     }
 
-    /// Returns `true` if a resource of type `R` exists. Otherwise returns `false`.
+    /// Returns `true` if a resource of type `R` exists. Otherwise, returns `false`.
     #[inline]
     pub fn contains_non_send<R: 'static>(&self) -> bool {
         self.components
@@ -1501,7 +1501,7 @@ impl World {
     }
 
     /// Gets a reference to the non-send resource of the given type, if it exists.
-    /// Otherwise returns `None`.
+    /// Otherwise, returns `None`.
     ///
     /// # Panics
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
@@ -1514,7 +1514,7 @@ impl World {
     }
 
     /// Gets a mutable reference to the non-send resource of the given type, if it exists.
-    /// Otherwise returns `None`.
+    /// Otherwise, returns `None`.
     ///
     /// # Panics
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
@@ -2379,7 +2379,7 @@ impl World {
         }
     }
 
-    /// Removes the resource of a given type, if it exists. Otherwise returns `None`.
+    /// Removes the resource of a given type, if it exists. Otherwise, returns `None`.
     ///
     /// **You should prefer to use the typed API [`World::remove_resource`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**
@@ -2391,7 +2391,7 @@ impl World {
         Some(())
     }
 
-    /// Removes the resource of a given type, if it exists. Otherwise returns `None`.
+    /// Removes the resource of a given type, if it exists. Otherwise, returns `None`.
     ///
     /// **You should prefer to use the typed API [`World::remove_resource`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1233,7 +1233,14 @@ impl World {
 
     /// Returns `true` if a resource of type `R` exists. Otherwise, returns `false`.
     #[inline]
+    #[deprecated = "Use `World::contains_non_send_resource` instead"]
     pub fn contains_non_send<R: 'static>(&self) -> bool {
+        self.contains_non_send_resource()
+    }
+
+    /// Returns `true` if a resource of type `R` exists. Otherwise, returns `false`.
+    #[inline]
+    pub fn contains_non_send_resource<R: 'static>(&self) -> bool {
         self.components
             .get_resource_id(TypeId::of::<R>())
             .and_then(|component_id| self.storages.non_send_resources.get(component_id))

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1235,7 +1235,7 @@ impl World {
     #[inline]
     #[deprecated = "Use `World::contains_non_send_resource` instead"]
     pub fn contains_non_send<R: 'static>(&self) -> bool {
-        self.contains_non_send_resource()
+        self.contains_non_send_resource::<R>()
     }
 
     /// Returns `true` if a resource of type `R` exists. Otherwise, returns `false`.

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -206,7 +206,7 @@ pub trait AppGizmoBuilder {
 
 impl AppGizmoBuilder for App {
     fn init_gizmo_group<Config: GizmoConfigGroup>(&mut self) -> &mut Self {
-        if self.world().contains_resource::<GizmoStorage<Config, ()>>() {
+        if self.contains_resource::<GizmoStorage<Config, ()>>() {
             return self;
         }
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -401,7 +401,7 @@ impl Plugin for PbrPlugin {
             .init_resource::<LightMeta>();
 
         let shadow_pass_node = ShadowPassNode::new(render_app.world_mut());
-        let mut graph = render_app.world_mut().resource_mut::<RenderGraph>();
+        let mut graph = render_app.resource_mut::<RenderGraph>();
         let draw_3d_graph = graph.get_sub_graph_mut(Core3d).unwrap();
         draw_3d_graph.add_node(NodePbr::ShadowPass, shadow_pass_node);
         draw_3d_graph.add_node_edge(NodePbr::ShadowPass, Node3d::StartMainPass);

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -47,7 +47,7 @@ impl Plugin for CameraPlugin {
                 .add_systems(ExtractSchedule, extract_cameras)
                 .add_systems(Render, sort_cameras.in_set(RenderSet::ManageViews));
             let camera_driver_node = CameraDriverNode::new(render_app.world_mut());
-            let mut render_graph = render_app.world_mut().resource_mut::<RenderGraph>();
+            let mut render_graph = render_app.resource_mut::<RenderGraph>();
             render_graph.add_node(crate::graph::CameraDriverLabel, camera_driver_node);
         }
     }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -368,7 +368,7 @@ impl Plugin for RenderPlugin {
             Shader::from_wgsl
         );
         if let Some(future_renderer_resources) =
-            app.world_mut().remove_resource::<FutureRendererResources>()
+            app.remove_resource::<FutureRendererResources>()
         {
             let (device, queue, adapter_info, render_adapter, instance) =
                 future_renderer_resources.0.lock().unwrap().take().unwrap();

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -132,7 +132,7 @@ impl Plugin for PipelinedRenderingPlugin {
 
         // clone main thread executor to render world
         let executor = app.world().get_resource::<MainThreadExecutor>().unwrap();
-        render_app.world_mut().insert_resource(executor.clone());
+        render_app.insert_resource(executor.clone());
 
         render_to_app_sender.send_blocking(render_app).unwrap();
 

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -89,8 +89,7 @@ impl Plugin for ImagePlugin {
             .init_asset::<Image>()
             .register_asset_reflect::<Image>();
 
-        app.world_mut()
-            .resource_mut::<Assets<Image>>()
+        app.resource_mut::<Assets<Image>>()
             .insert(&Handle::default(), Image::default());
         #[cfg(feature = "basis-universal")]
         if let Some(processor) = app

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -166,7 +166,7 @@ mod tests {
         );
 
         // let's try to delete the scene
-        let mut scene_spawner = app.world_mut().resource_mut::<SceneSpawner>();
+        let mut scene_spawner = app.resource_mut::<SceneSpawner>();
         scene_spawner.despawn(&scene_handle);
 
         // run the scene spawner system to despawn the scene

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -28,8 +28,7 @@ impl Plugin for ColorMaterialPlugin {
         app.add_plugins(Material2dPlugin::<ColorMaterial>::default())
             .register_asset_reflect::<ColorMaterial>();
 
-        app.world_mut()
-            .resource_mut::<Assets<ColorMaterial>>()
+        app.resource_mut::<Assets<ColorMaterial>>()
             .insert(
                 &Handle::<ColorMaterial>::default(),
                 ColorMaterial {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -121,7 +121,7 @@ pub fn build_ui_render(app: &mut App) {
     // Render graph
     let ui_graph_2d = get_ui_graph(render_app);
     let ui_graph_3d = get_ui_graph(render_app);
-    let mut graph = render_app.world_mut().resource_mut::<RenderGraph>();
+    let mut graph = render_app.resource_mut::<RenderGraph>();
 
     if let Some(graph_2d) = graph.get_sub_graph_mut(Core2d) {
         graph_2d.add_sub_graph(SubGraphUi, ui_graph_2d);

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -114,7 +114,7 @@ impl Plugin for WindowPlugin {
                 .spawn(primary_window.clone())
                 .insert(PrimaryWindow)
                 .id();
-            if let Some(mut focus) = app.world_mut().get_resource_mut::<Focus>() {
+            if let Some(mut focus) = app.get_resource_mut::<Focus>() {
                 **focus = Some(initial_focus);
             }
         }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -276,8 +276,7 @@ pub fn winit_runner(mut app: App) -> AppExit {
         .remove_non_send_resource::<EventLoop<UserEvent>>()
         .unwrap();
 
-    app.world_mut()
-        .insert_non_send_resource(event_loop.create_proxy());
+    app.insert_non_send_resource(event_loop.create_proxy());
 
     let mut runner_state = WinitAppRunnerState::default();
 

--- a/crates/bevy_winit/src/winit_event.rs
+++ b/crates/bevy_winit/src/winit_event.rs
@@ -274,7 +274,6 @@ pub(crate) fn forward_winit_events(buffered_events: &mut Vec<WinitEvent>, app: &
             }
         }
     }
-    app.world_mut()
-        .resource_mut::<Events<WinitEvent>>()
+    app.resource_mut::<Events<WinitEvent>>()
         .send_batch(buffered_events.drain(..));
 }


### PR DESCRIPTION
# Objective

Add helper methods to `App` and `SubApp` to ease plugin maintainers and less verbose code. It also adds examples to show how to use these methods.

It also deprecates the `World::contains_non_send` in favor of the more consistent `World::contains_non_send_resource`.
