### PR TITLE
Tetrahedron sampling

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -538,7 +538,7 @@ impl Triangle2d {
     #[inline(always)]
     #[must_use]
     pub fn reversed(mut self) -> Self {
-        self.reverse;
+        self.reverse();
         self
     }
 }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -528,10 +528,18 @@ impl Triangle2d {
     }
 
     /// Reverse the [`WindingOrder`] of the triangle
-    /// by swapping the first and last vertices
+    /// by swapping the first and last vertices.
     #[inline(always)]
     pub fn reverse(&mut self) {
         self.vertices.swap(0, 2);
+    }
+
+    /// This triangle but reversed.
+    #[inline(always)]
+    #[must_use]
+    pub fn reversed(mut self) -> Self {
+        self.reverse;
+        self
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -786,6 +786,14 @@ impl Triangle3d {
         self.vertices.swap(0, 2);
     }
 
+    /// This triangle but reversed.
+    #[inline(always)]
+    #[must_use]
+    pub fn reversed(mut self) -> Triangle3d {
+        self.reverse();
+        self
+    }
+
     /// Get the centroid of the triangle.
     ///
     /// This function finds the geometric center of the triangle by averaging the vertices:
@@ -914,6 +922,22 @@ impl Tetrahedron {
     #[inline(always)]
     pub fn centroid(&self) -> Vec3 {
         (self.vertices[0] + self.vertices[1] + self.vertices[2] + self.vertices[3]) / 4.0
+    }
+
+    /// Get the triangles that form the faces of this tetrahedron.
+    ///
+    /// Note that the orientations of the faces are determined by that of the tetrahedron; if the
+    /// signed volume of this tetrahedron is positive, then the triangles' normals will point
+    /// outward, and if the signed volume is negative they will point inward.
+    #[inline(always)]
+    pub fn faces(&self) -> [Triangle3d; 4] {
+        let [a, b, c, d] = self.vertices;
+        [
+            Triangle3d::new(b, c, d),
+            Triangle3d::new(a, c, d).reversed(),
+            Triangle3d::new(a, b, d),
+            Triangle3d::new(a, b, c).reversed(),
+        ]
     }
 }
 

--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -245,6 +245,7 @@ impl ShapeSample for Tetrahedron {
             1. - coords[2],
         );
 
+        // This is also a linear mapping, so probability density is still preserved.
         v0 * a + v1 * b + v2 * c + v3 * d
     }
 
@@ -262,7 +263,7 @@ impl ShapeSample for Tetrahedron {
             let idx = dist.sample(rng);
             triangles[idx].sample_interior(rng)
         } else {
-            // In this branch the triangle has zero surface area; just return a point that's on
+            // In this branch the tetrahedron has zero surface area; just return a point that's on
             // the tetrahedron.
             self.vertices[0]
         }

--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -236,8 +236,12 @@ impl ShapeSample for Tetrahedron {
 
         // Now, convert a point from the fundamental tetrahedron into barycentric coordinates by
         // taking the four successive differences of coordinates; note that these telescope to sum
-        // to 1, and this transformation is linear, hence has constant Jacobian, hence preserves
-        // relative probability density.
+        // to 1, and this transformation is linear, hence preserves the probability density, since
+        // the latter comes from the Lebesgue measure.
+        //
+        // (See https://en.wikipedia.org/wiki/Lebesgue_measure#Properties — specifically, that
+        // Lebesgue measure of a linearly transformed set is its original measure times the
+        // determinant.)
         let (a, b, c, d) = (
             coords[0],
             coords[1] - coords[0],

--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -215,6 +215,58 @@ impl ShapeSample for Triangle3d {
     }
 }
 
+impl ShapeSample for Tetrahedron {
+    type Output = Vec3;
+
+    fn sample_interior<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::Output {
+        // See: https://vcg.isti.cnr.it/activities/OLD/geometryegraphics/pointintetraedro.html
+
+        let [v0, v1, v2, v3] = self.vertices;
+
+        // Form a cube in parameter space to make barycentric coordinates later:
+        let mut u = rng.gen_range(0.0..=1.0);
+        let mut v = rng.gen_range(0.0..=1.0);
+        let mut w = rng.gen_range(0.0..=1.0);
+
+        // Reflect into lower triangular prism inside of cube in parameter space:
+        if u + v > 1. {
+            (u, v) = (1. - u, 1. - v);
+        }
+
+        // Now, cut that prism into three tetrahedra, folding in the two cut out by the planes
+        // v + w = 1 and u + v + w = 1 (note both branches satisfy u + v + w > 1)
+        if v + w > 1. {
+            (v, w) = (1. - w, 1. - u - v);
+        } else if u + v + w > 1. {
+            (u, w) = (1. - v - w, u + v + w - 1.);
+        }
+
+        // Complete this to barycentric coordinates:
+        let a = 1. - u - v - w;
+        v0 * a + v1 * u + v2 * v + v3 * w
+    }
+
+    fn sample_boundary<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::Output {
+        // Filter out degenerate faces, since there are many ways a tetrahedron can degenerate.
+        let triangles: Vec<Triangle3d> = self
+            .faces()
+            .into_iter()
+            .filter(|t| !t.is_degenerate())
+            .collect();
+
+        if !triangles.is_empty() {
+            // Nondegenerate triangles have nonzero area, so this unwrap never fails.
+            let dist = WeightedIndex::new(triangles.iter().map(|t| t.area())).unwrap();
+            let idx = dist.sample(rng);
+            triangles[idx].sample_interior(rng)
+        } else {
+            // In this branch the triangle has zero surface area; just return a point that's on
+            // the tetrahedron.
+            self.vertices[0]
+        }
+    }
+}
+
 impl ShapeSample for Cylinder {
     type Output = Vec3;
 

--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -235,7 +235,7 @@ impl ShapeSample for Tetrahedron {
         coords.sort_by(|x, y| x.partial_cmp(y).unwrap());
 
         // Now, convert a point from the fundamental tetrahedron into barycentric coordinates by
-        // taking the four succesive differences of coordinates; note that these telescope to sum
+        // taking the four successive differences of coordinates; note that these telescope to sum
         // to 1, and this transformation is linear, hence has constant Jacobian, hence preserves
         // relative probability density.
         let (a, b, c, d) = (


### PR DESCRIPTION
# Objective

Add interior and boundary sampling for the `Tetrahedron` primitive. This is part of ongoing work to bring the primitives to parity with each other in terms of their capabilities.

## Solution

`Tetrahedron` implements the `ShapeSample` trait. To support this, there is a new public method `Tetrahedron::faces` which gets the faces of a tetrahedron as `Triangle3d`s. There are more sophisticated ideas for getting the faces we might want to consider in the future (e.g. adjusting according to the orientation), but this method gives the most mathematically straightforward answer, giving the faces the orientation induced by the tetrahedron itself. 