### PR TITLE
Inconsistent segments/resolution naming

### DIFF
--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -42,7 +42,7 @@ where
     ///     // You may want to increase this for larger arcs.
     ///     gizmos
     ///         .arc_2d(Vec2::ZERO, 0., PI / 4., 5., RED)
-    ///         .segments(64);
+    ///         .resolution(64);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -62,7 +62,7 @@ where
             arc_angle,
             radius,
             color: color.into(),
-            segments: None,
+            resolution: None,
         }
     }
 }
@@ -79,7 +79,7 @@ where
     arc_angle: f32,
     radius: f32,
     color: Color,
-    segments: Option<usize>,
+    resolution: Option<usize>,
 }
 
 impl<Config, Clear> Arc2dBuilder<'_, '_, '_, Config, Clear>
@@ -87,9 +87,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of line-segments for this arc.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments.replace(segments);
+    /// Set the number of lines used to approximate the geometry of this arc.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution.replace(resolution);
         self
     }
 }
@@ -104,12 +104,17 @@ where
             return;
         }
 
-        let segments = self
-            .segments
-            .unwrap_or_else(|| segments_from_angle(self.arc_angle));
+        let resolution = self
+            .resolution
+            .unwrap_or_else(|| resolution_from_angle(self.arc_angle));
 
-        let positions = arc_2d_inner(self.direction_angle, self.arc_angle, self.radius, segments)
-            .map(|vec2| (vec2 + self.position));
+        let positions = arc_2d_inner(
+            self.direction_angle,
+            self.arc_angle,
+            self.radius,
+            resolution,
+        )
+        .map(|vec2| (vec2 + self.position));
         self.gizmos.linestrip_2d(positions, self.color);
     }
 }
@@ -118,12 +123,12 @@ fn arc_2d_inner(
     direction_angle: f32,
     arc_angle: f32,
     radius: f32,
-    segments: usize,
+    resolution: usize,
 ) -> impl Iterator<Item = Vec2> {
-    (0..segments + 1).map(move |i| {
+    (0..resolution + 1).map(move |i| {
         let start = direction_angle - arc_angle / 2.;
 
-        let angle = start + (i as f32 * (arc_angle / segments as f32));
+        let angle = start + (i as f32 * (arc_angle / resolution as f32));
         Vec2::from(angle.sin_cos()) * radius
     })
 }
@@ -155,8 +160,8 @@ where
     /// - `color`: color of the arc
     ///
     /// # Builder methods
-    /// The number of segments of the arc (i.e. the level of detail) can be adjusted with the
-    /// `.segments(...)` method.
+    /// The resolution of the arc (i.e. the level of detail) can be adjusted with the
+    /// `.resolution(...)` method.
     ///
     /// # Example
     /// ```
@@ -177,7 +182,7 @@ where
     ///          rotation,
     ///          ORANGE
     ///          )
-    ///          .segments(100);
+    ///          .resolution(100);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -198,7 +203,7 @@ where
             angle,
             radius,
             color: color.into(),
-            segments: None,
+            resolution: None,
         }
     }
 
@@ -212,8 +217,8 @@ where
     /// - `color`: color of the arc
     ///
     /// # Builder methods
-    /// The number of segments of the arc (i.e. the level of detail) can be adjusted with the
-    /// `.segments(...)` method.
+    /// The resolution of the arc (i.e. the level of detail) can be adjusted with the
+    /// `.resolution(...)` method.
     ///
     /// # Examples
     /// ```
@@ -228,7 +233,7 @@ where
     ///        Vec3::ZERO,
     ///        ORANGE
     ///        )
-    ///        .segments(100);
+    ///        .resolution(100);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -259,8 +264,8 @@ where
     /// - `color`: color of the arc
     ///
     /// # Builder methods
-    /// The number of segments of the arc (i.e. the level of detail) can be adjusted with the
-    /// `.segments(...)` method.
+    /// The resolution of the arc (i.e. the level of detail) can be adjusted with the
+    /// `.resolution(...)` method.
     ///
     /// # Examples
     /// ```
@@ -275,7 +280,7 @@ where
     ///        Vec3::ZERO,
     ///        ORANGE
     ///        )
-    ///        .segments(100);
+    ///        .resolution(100);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -334,7 +339,7 @@ where
             angle,
             radius,
             color: color.into(),
-            segments: None,
+            resolution: None,
         }
     }
 }
@@ -361,7 +366,7 @@ where
     angle: f32,
     radius: f32,
     color: Color,
-    segments: Option<usize>,
+    resolution: Option<usize>,
 }
 
 impl<Config, Clear> Arc3dBuilder<'_, '_, '_, Config, Clear>
@@ -369,9 +374,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of line-segments for this arc.
+    /// Set the number of lines for this arc.
     pub fn resolution(mut self, resolution: usize) -> Self {
-        self.segments.replace(resolution);
+        self.resolution.replace(resolution);
         self
     }
 }
@@ -386,9 +391,9 @@ where
             return;
         }
 
-        let segments = self
-            .segments
-            .unwrap_or_else(|| segments_from_angle(self.angle));
+        let resolution = self
+            .resolution
+            .unwrap_or_else(|| resolution_from_angle(self.angle));
 
         let positions = arc_3d_inner(
             self.start_vertex,
@@ -396,7 +401,7 @@ where
             self.rotation,
             self.angle,
             self.radius,
-            segments,
+            resolution,
         );
         self.gizmos.linestrip(positions, self.color);
     }
@@ -408,20 +413,20 @@ fn arc_3d_inner(
     rotation: Quat,
     angle: f32,
     radius: f32,
-    segments: usize,
+    resolution: usize,
 ) -> impl Iterator<Item = Vec3> {
     // drawing arcs bigger than TAU degrees or smaller than -TAU degrees makes no sense since
-    // we won't see the overlap and we would just decrease the level of details since the segments
+    // we won't see the overlap and we would just decrease the level of details since the resolution
     // would be larger
     let angle = angle.clamp(-TAU, TAU);
-    (0..=segments)
-        .map(move |frac| frac as f32 / segments as f32)
+    (0..=resolution)
+        .map(move |frac| frac as f32 / resolution as f32)
         .map(move |percentage| angle * percentage)
         .map(move |frac_angle| Quat::from_axis_angle(Vec3::Y, frac_angle) * start_vertex)
         .map(move |p| rotation * (p * radius) + center)
 }
 
-// helper function for getting a default value for the segments parameter
-fn segments_from_angle(angle: f32) -> usize {
+// helper function for getting a default value for the resolution parameter
+fn resolution_from_angle(angle: f32) -> usize {
     ((angle.abs() / TAU) * DEFAULT_CIRCLE_SEGMENTS as f32).ceil() as usize
 }

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -3,7 +3,7 @@
 //! Includes the implementation of [`Gizmos::arc_2d`],
 //! and assorted support items.
 
-use crate::circles::DEFAULT_CIRCLE_SEGMENTS;
+use crate::circles::DEFAULT_CIRCLE_RESOLUTION;
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 use bevy_color::Color;
 use bevy_math::{Quat, Vec2, Vec3};
@@ -428,5 +428,5 @@ fn arc_3d_inner(
 
 // helper function for getting a default value for the resolution parameter
 fn resolution_from_angle(angle: f32) -> usize {
-    ((angle.abs() / TAU) * DEFAULT_CIRCLE_SEGMENTS as f32).ceil() as usize
+    ((angle.abs() / TAU) * DEFAULT_CIRCLE_RESOLUTION as f32).ceil() as usize
 }

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -370,8 +370,8 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of line-segments for this arc.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments.replace(segments);
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.segments.replace(resolution);
         self
     }
 }

--- a/crates/bevy_gizmos/src/circles.rs
+++ b/crates/bevy_gizmos/src/circles.rs
@@ -9,11 +9,11 @@ use bevy_math::Mat2;
 use bevy_math::{Dir3, Quat, Vec2, Vec3};
 use std::f32::consts::TAU;
 
-pub(crate) const DEFAULT_CIRCLE_SEGMENTS: usize = 32;
+pub(crate) const DEFAULT_CIRCLE_RESOLUTION: usize = 32;
 
-fn ellipse_inner(half_size: Vec2, segments: usize) -> impl Iterator<Item = Vec2> {
-    (0..segments + 1).map(move |i| {
-        let angle = i as f32 * TAU / segments as f32;
+fn ellipse_inner(half_size: Vec2, resolution: usize) -> impl Iterator<Item = Vec2> {
+    (0..resolution + 1).map(move |i| {
+        let angle = i as f32 * TAU / resolution as f32;
         let (x, y) = angle.sin_cos();
         Vec2::new(x, y) * half_size
     })
@@ -41,7 +41,7 @@ where
     ///     // You may want to increase this for larger ellipses.
     ///     gizmos
     ///         .ellipse(Vec3::ZERO, Quat::IDENTITY, Vec2::new(5., 1.), RED)
-    ///         .segments(64);
+    ///         .resolution(64);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -59,7 +59,7 @@ where
             rotation,
             half_size,
             color: color.into(),
-            segments: DEFAULT_CIRCLE_SEGMENTS,
+            resolution: DEFAULT_CIRCLE_RESOLUTION,
         }
     }
 
@@ -80,7 +80,7 @@ where
     ///     // You may want to increase this for larger ellipses.
     ///     gizmos
     ///         .ellipse_2d(Vec2::ZERO, 180.0_f32.to_radians(), Vec2::new(5., 1.), RED)
-    ///         .segments(64);
+    ///         .resolution(64);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -98,7 +98,7 @@ where
             rotation: Mat2::from_angle(angle),
             half_size,
             color: color.into(),
-            segments: DEFAULT_CIRCLE_SEGMENTS,
+            resolution: DEFAULT_CIRCLE_RESOLUTION,
         }
     }
 
@@ -119,7 +119,7 @@ where
     ///     // You may want to increase this for larger circles.
     ///     gizmos
     ///         .circle(Vec3::ZERO, Dir3::Z, 5., RED)
-    ///         .segments(64);
+    ///         .resolution(64);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -137,7 +137,7 @@ where
             rotation: Quat::from_rotation_arc(Vec3::Z, *normal),
             half_size: Vec2::splat(radius),
             color: color.into(),
-            segments: DEFAULT_CIRCLE_SEGMENTS,
+            resolution: DEFAULT_CIRCLE_RESOLUTION,
         }
     }
 
@@ -158,7 +158,7 @@ where
     ///     // You may want to increase this for larger circles.
     ///     gizmos
     ///         .circle_2d(Vec2::ZERO, 5., RED)
-    ///         .segments(64);
+    ///         .resolution(64);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -175,7 +175,7 @@ where
             rotation: Mat2::IDENTITY,
             half_size: Vec2::splat(radius),
             color: color.into(),
-            segments: DEFAULT_CIRCLE_SEGMENTS,
+            resolution: DEFAULT_CIRCLE_RESOLUTION,
         }
     }
 }
@@ -191,7 +191,7 @@ where
     rotation: Quat,
     half_size: Vec2,
     color: Color,
-    segments: usize,
+    resolution: usize,
 }
 
 impl<Config, Clear> EllipseBuilder<'_, '_, '_, Config, Clear>
@@ -199,9 +199,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of line-segments for this ellipse.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+    /// Set the number of lines used to approximate the geometry of this ellipse.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -216,7 +216,7 @@ where
             return;
         }
 
-        let positions = ellipse_inner(self.half_size, self.segments)
+        let positions = ellipse_inner(self.half_size, self.resolution)
             .map(|vec2| self.rotation * vec2.extend(0.))
             .map(|vec3| vec3 + self.position);
         self.gizmos.linestrip(positions, self.color);
@@ -234,7 +234,7 @@ where
     rotation: Mat2,
     half_size: Vec2,
     color: Color,
-    segments: usize,
+    resolution: usize,
 }
 
 impl<Config, Clear> Ellipse2dBuilder<'_, '_, '_, Config, Clear>
@@ -242,9 +242,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of line-segments for this ellipse.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+    /// Set the number of line-segments used to approximate the geometry of this ellipse.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -260,7 +260,7 @@ where
             return;
         };
 
-        let positions = ellipse_inner(self.half_size, self.segments)
+        let positions = ellipse_inner(self.half_size, self.resolution)
             .map(|vec2| self.rotation * vec2)
             .map(|vec2| vec2 + self.position);
         self.gizmos.linestrip_2d(positions, self.color);

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -2,7 +2,7 @@
 
 use std::{iter, marker::PhantomData, mem};
 
-use crate::circles::DEFAULT_CIRCLE_SEGMENTS;
+use crate::circles::DEFAULT_CIRCLE_RESOLUTION;
 use bevy_color::{Color, LinearRgba};
 use bevy_ecs::{
     component::Tick,
@@ -494,7 +494,7 @@ where
             rotation: rotation.normalize(),
             radius,
             color: color.into(),
-            circle_segments: DEFAULT_CIRCLE_SEGMENTS,
+            circle_segments: DEFAULT_CIRCLE_RESOLUTION,
         }
     }
 
@@ -828,7 +828,7 @@ where
         for axis in Dir3::AXES {
             self.gizmos
                 .circle(self.position, self.rotation * axis, self.radius, self.color)
-                .segments(self.circle_segments);
+                .resolution(self.circle_segments);
         }
     }
 }

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -476,7 +476,7 @@ where
     ///     // You may want to increase this for larger spheres.
     ///     gizmos
     ///         .sphere(Vec3::ZERO, Quat::IDENTITY, 5., Color::BLACK)
-    ///         .circle_segments(64);
+    ///         .resolution(64);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -494,7 +494,7 @@ where
             rotation: rotation.normalize(),
             radius,
             color: color.into(),
-            circle_segments: DEFAULT_CIRCLE_RESOLUTION,
+            resolution: DEFAULT_CIRCLE_RESOLUTION,
         }
     }
 
@@ -801,7 +801,7 @@ where
     rotation: Quat,
     radius: f32,
     color: Color,
-    circle_segments: usize,
+    resolution: usize,
 }
 
 impl<Config, Clear> SphereBuilder<'_, '_, '_, Config, Clear>
@@ -810,8 +810,8 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of line-segments per circle for this sphere.
-    pub fn circle_segments(mut self, segments: usize) -> Self {
-        self.circle_segments = segments;
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -828,7 +828,7 @@ where
         for axis in Dir3::AXES {
             self.gizmos
                 .circle(self.position, self.rotation * axis, self.radius, self.color)
-                .resolution(self.circle_segments);
+                .resolution(self.resolution);
         }
     }
 }

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -51,7 +51,7 @@ fn point_light_gizmo(
         .resolution(16);
     gizmos
         .sphere(position, Quat::IDENTITY, point_light.range, color)
-        .circle_segments(32);
+        .resolution(32);
 }
 
 /// Draws a sphere for the radius, two cones for the inner and outer angles, plus two 3d arcs crossing the

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -48,7 +48,7 @@ fn point_light_gizmo(
             Quat::IDENTITY,
             color,
         )
-        .segments(16);
+        .resolution(16);
     gizmos
         .sphere(position, Quat::IDENTITY, point_light.range, color)
         .circle_segments(32);
@@ -72,7 +72,7 @@ fn spot_light_gizmo(
             Quat::IDENTITY,
             color,
         )
-        .segments(16);
+        .resolution(16);
 
     // Offset the tip of the cone to the light position.
     for angle in [spot_light.inner_angle, spot_light.outer_angle] {
@@ -88,8 +88,8 @@ fn spot_light_gizmo(
                 rotation * Quat::from_rotation_x(PI / 2.0),
                 color,
             )
-            .height_segments(4)
-            .base_segments(32);
+            .height_resolution(4)
+            .base_resolution(32);
     }
 
     for arc_rotation in [
@@ -109,7 +109,7 @@ fn spot_light_gizmo(
                 rotation * arc_rotation,
                 color,
             )
-            .segments(16);
+            .resolution(16);
     }
 }
 

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -149,7 +149,14 @@ where
         });
 
         // draws one great circle of the sphere
-        draw_circle_3d(self.gizmos, *radius, *resolution, *rotation, *center, *color);
+        draw_circle_3d(
+            self.gizmos,
+            *radius,
+            *resolution,
+            *rotation,
+            *center,
+            *color,
+        );
     }
 }
 

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -12,7 +12,7 @@ use bevy_math::{Dir3, Quat, Vec3};
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 
-const DEFAULT_NUMBER_SEGMENTS: usize = 5;
+const DEFAULT_RESOLUTION: usize = 5;
 // length used to simulate infinite lines
 const INFINITE_LEN: f32 = 10_000.0;
 
@@ -110,7 +110,7 @@ where
             position,
             rotation,
             color: color.into(),
-            resolution: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_RESOLUTION,
         }
     }
 }
@@ -525,7 +525,7 @@ where
             position,
             rotation,
             color: color.into(),
-            resolution: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_RESOLUTION,
         }
     }
 }
@@ -638,7 +638,7 @@ where
             position,
             rotation,
             color: color.into(),
-            resolution: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_RESOLUTION,
         }
     }
 }
@@ -769,8 +769,8 @@ where
             position,
             rotation,
             color: color.into(),
-            base_resolution: DEFAULT_NUMBER_SEGMENTS,
-            height_resolution: DEFAULT_NUMBER_SEGMENTS,
+            base_resolution: DEFAULT_RESOLUTION,
+            height_resolution: DEFAULT_RESOLUTION,
         }
     }
 }
@@ -884,7 +884,7 @@ where
             position,
             rotation,
             color: color.into(),
-            resolution: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_RESOLUTION,
         }
     }
 }
@@ -1011,8 +1011,8 @@ where
             position,
             rotation,
             color: color.into(),
-            minor_resolution: DEFAULT_NUMBER_SEGMENTS,
-            major_resolution: DEFAULT_NUMBER_SEGMENTS,
+            minor_resolution: DEFAULT_RESOLUTION,
+            major_resolution: DEFAULT_RESOLUTION,
         }
     }
 }

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -73,8 +73,9 @@ where
     // Color of the sphere
     color: Color,
 
-    // Number of segments used to approximate the sphere geometry
-    segments: usize,
+    // Resolution of the gizmos used to approximate the sphere geometry
+    // The number of vertices used to approximate the sphere geometry.
+    resolution: usize,
 }
 
 impl<Config, Clear> SphereBuilder<'_, '_, '_, Config, Clear>
@@ -82,9 +83,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of segments used to approximate the sphere geometry.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+    /// Set the number of lines used to approximate the sphere geometry.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -109,7 +110,7 @@ where
             position,
             rotation,
             color: color.into(),
-            segments: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -129,7 +130,7 @@ where
             position: center,
             rotation,
             color,
-            segments,
+            resolution,
             ..
         } = self;
 
@@ -139,7 +140,7 @@ where
             draw_semi_sphere(
                 self.gizmos,
                 *radius,
-                *segments,
+                *resolution,
                 *rotation,
                 *center,
                 top,
@@ -148,7 +149,7 @@ where
         });
 
         // draws one great circle of the sphere
-        draw_circle_3d(self.gizmos, *radius, *segments, *rotation, *center, *color);
+        draw_circle_3d(self.gizmos, *radius, *resolution, *rotation, *center, *color);
     }
 }
 
@@ -480,8 +481,8 @@ where
     // Color of the cylinder
     color: Color,
 
-    // Number of segments used to approximate the cylinder geometry
-    segments: usize,
+    // Number of lines used to approximate the cylinder geometry
+    resolution: usize,
 }
 
 impl<Config, Clear> Cylinder3dBuilder<'_, '_, '_, Config, Clear>
@@ -489,9 +490,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of segments used to approximate the cylinder geometry.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+    /// Set the number of lines used to approximate the top an bottom of the cylinder geometry.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -517,7 +518,7 @@ where
             position,
             rotation,
             color: color.into(),
-            segments: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -539,7 +540,7 @@ where
             position,
             rotation,
             color,
-            segments,
+            resolution,
         } = self;
 
         let normal = *rotation * Vec3::Y;
@@ -549,7 +550,7 @@ where
             draw_circle_3d(
                 gizmos,
                 *radius,
-                *segments,
+                *resolution,
                 *rotation,
                 *position + sign * *half_height * normal,
                 *color,
@@ -560,7 +561,7 @@ where
         draw_cylinder_vertical_lines(
             gizmos,
             *radius,
-            *segments,
+            *resolution,
             *half_height,
             *rotation,
             *position,
@@ -593,8 +594,8 @@ where
     // Color of the capsule
     color: Color,
 
-    // Number of segments used to approximate the capsule geometry
-    segments: usize,
+    // Number of lines used to approximate the capsule geometry
+    resolution: usize,
 }
 
 impl<Config, Clear> Capsule3dBuilder<'_, '_, '_, Config, Clear>
@@ -602,9 +603,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of segments used to approximate the capsule geometry.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+    /// Set the number of lines used to approximate the capsule geometry.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -630,7 +631,7 @@ where
             position,
             rotation,
             color: color.into(),
-            segments: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -652,7 +653,7 @@ where
             position,
             rotation,
             color,
-            segments,
+            resolution,
         } = self;
 
         let normal = *rotation * Vec3::Y;
@@ -661,15 +662,15 @@ where
         [1.0, -1.0].into_iter().for_each(|sign| {
             let center = *position + sign * *half_length * normal;
             let top = center + sign * *radius * normal;
-            draw_semi_sphere(gizmos, *radius, *segments, *rotation, center, top, *color);
-            draw_circle_3d(gizmos, *radius, *segments, *rotation, center, *color);
+            draw_semi_sphere(gizmos, *radius, *resolution, *rotation, center, top, *color);
+            draw_circle_3d(gizmos, *radius, *resolution, *rotation, center, *color);
         });
 
         // connect the two semi spheres with lines
         draw_cylinder_vertical_lines(
             gizmos,
             *radius,
-            *segments,
+            *resolution,
             *half_length,
             *rotation,
             *position,
@@ -702,11 +703,11 @@ where
     // Color of the cone
     color: Color,
 
-    // Number of segments used to approximate the cone base geometry
-    base_segments: usize,
+    // Number of lines used to approximate the cone base geometry
+    base_resolution: usize,
 
-    // Number of segments used to approximate the cone height geometry
-    height_segments: usize,
+    // Number of lines used to approximate the cone height geometry
+    height_resolution: usize,
 }
 
 impl<Config, Clear> Cone3dBuilder<'_, '_, '_, Config, Clear>
@@ -714,28 +715,28 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of segments used to approximate the cone geometry for its base and height.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.base_segments = segments;
-        self.height_segments = segments;
+    /// Set the number of lines used to approximate the cone geometry for its base and height.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.base_resolution = resolution;
+        self.height_resolution = resolution;
         self
     }
 
-    /// Set the number of segments to approximate the height of the cone geometry.
+    /// Set the number of lines used to approximate the height of the cone geometry.
     ///
-    /// `segments` should be a multiple of the value passed to [`Self::height_segments`]
+    /// `resolution` should be a multiple of the value passed to [`Self::height_resolution`]
     /// for the height to connect properly with the base.
-    pub fn base_segments(mut self, segments: usize) -> Self {
-        self.base_segments = segments;
+    pub fn base_resolution(mut self, resolution: usize) -> Self {
+        self.base_resolution = resolution;
         self
     }
 
-    /// Set the number of segments to approximate the height of the cone geometry.
+    /// Set the number of lines used to approximate the height of the cone geometry.
     ///
-    /// `segments` should be a divisor of the value passed to [`Self::base_segments`]
+    /// `resolution` should be a divisor of the value passed to [`Self::base_resolution`]
     /// for the height to connect properly with the base.
-    pub fn height_segments(mut self, segments: usize) -> Self {
-        self.height_segments = segments;
+    pub fn height_resolution(mut self, resolution: usize) -> Self {
+        self.height_resolution = resolution;
         self
     }
 }
@@ -761,8 +762,8 @@ where
             position,
             rotation,
             color: color.into(),
-            base_segments: DEFAULT_NUMBER_SEGMENTS,
-            height_segments: DEFAULT_NUMBER_SEGMENTS,
+            base_resolution: DEFAULT_NUMBER_SEGMENTS,
+            height_resolution: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -784,8 +785,8 @@ where
             position,
             rotation,
             color,
-            base_segments,
-            height_segments,
+            base_resolution,
+            height_resolution,
         } = self;
 
         let half_height = *height * 0.5;
@@ -794,7 +795,7 @@ where
         draw_circle_3d(
             gizmos,
             *radius,
-            *base_segments,
+            *base_resolution,
             *rotation,
             *position - *rotation * Vec3::Y * half_height,
             *color,
@@ -802,7 +803,7 @@ where
 
         // connect the base circle with the tip of the cone
         let end = Vec3::Y * half_height;
-        circle_coordinates(*radius, *height_segments)
+        circle_coordinates(*radius, *height_resolution)
             .map(|p| Vec3::new(p.x, -half_height, p.y))
             .map(move |p| [p, end])
             .map(|ps| ps.map(rotate_then_translate_3d(*rotation, *position)))
@@ -838,8 +839,8 @@ where
     // Color of the conical frustum
     color: Color,
 
-    // Number of segments used to approximate the curved surfaces
-    segments: usize,
+    // Number of lines used to approximate the curved surfaces
+    resolution: usize,
 }
 
 impl<Config, Clear> ConicalFrustum3dBuilder<'_, '_, '_, Config, Clear>
@@ -847,9 +848,9 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of segments used to approximate the curved surfaces.
-    pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+    /// Set the number of lines used to approximate the curved surfaces.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = resolution;
         self
     }
 }
@@ -876,7 +877,7 @@ where
             position,
             rotation,
             color: color.into(),
-            segments: DEFAULT_NUMBER_SEGMENTS,
+            resolution: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -899,7 +900,7 @@ where
             position,
             rotation,
             color,
-            segments,
+            resolution,
         } = self;
 
         let half_height = *height * 0.5;
@@ -912,7 +913,7 @@ where
                 draw_circle_3d(
                     gizmos,
                     radius,
-                    *segments,
+                    *resolution,
                     *rotation,
                     *position + height * normal,
                     *color,
@@ -920,10 +921,10 @@ where
             });
 
         // connect the two circles of the conical frustum
-        circle_coordinates(*radius_top, *segments)
+        circle_coordinates(*radius_top, *resolution)
             .map(move |p| Vec3::new(p.x, half_height, p.y))
             .zip(
-                circle_coordinates(*radius_bottom, *segments)
+                circle_coordinates(*radius_bottom, *resolution)
                     .map(|p| Vec3::new(p.x, -half_height, p.y)),
             )
             .map(|(start, end)| [start, end])
@@ -958,10 +959,10 @@ where
     // Color of the torus
     color: Color,
 
-    // Number of segments in the minor (tube) direction
-    minor_segments: usize,
-    // Number of segments in the major (ring) direction
-    major_segments: usize,
+    // Number of lines in the minor (tube) direction
+    minor_resolution: usize,
+    // Number of lines in the major (ring) direction
+    major_resolution: usize,
 }
 
 impl<Config, Clear> Torus3dBuilder<'_, '_, '_, Config, Clear>
@@ -969,15 +970,15 @@ where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    /// Set the number of segments in the minor (tube) direction.
-    pub fn minor_segments(mut self, minor_segments: usize) -> Self {
-        self.minor_segments = minor_segments;
+    /// Set the number of lines in the minor (tube) direction.
+    pub fn minor_resolution(mut self, minor_resolution: usize) -> Self {
+        self.minor_resolution = minor_resolution;
         self
     }
 
-    /// Set the number of segments in the major (ring) direction.
-    pub fn major_segments(mut self, major_segments: usize) -> Self {
-        self.major_segments = major_segments;
+    /// Set the number of lines in the major (ring) direction.
+    pub fn major_resolution(mut self, major_resolution: usize) -> Self {
+        self.major_resolution = major_resolution;
         self
     }
 }
@@ -1003,8 +1004,8 @@ where
             position,
             rotation,
             color: color.into(),
-            minor_segments: DEFAULT_NUMBER_SEGMENTS,
-            major_segments: DEFAULT_NUMBER_SEGMENTS,
+            minor_resolution: DEFAULT_NUMBER_SEGMENTS,
+            major_resolution: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -1026,8 +1027,8 @@ where
             position,
             rotation,
             color,
-            minor_segments,
-            major_segments,
+            minor_resolution,
+            major_resolution,
         } = self;
 
         let normal = *rotation * Vec3::Y;
@@ -1044,7 +1045,7 @@ where
             draw_circle_3d(
                 gizmos,
                 radius,
-                *major_segments,
+                *major_resolution,
                 *rotation,
                 *position + height * normal,
                 *color,
@@ -1053,7 +1054,7 @@ where
 
         // along the major circle draw orthogonal minor circles
         let affine = rotate_then_translate_3d(*rotation, *position);
-        circle_coordinates(*major_radius, *major_segments)
+        circle_coordinates(*major_radius, *major_resolution)
             .map(|p| Vec3::new(p.x, 0.0, p.y))
             .flat_map(|major_circle_point| {
                 let minor_center = affine(major_circle_point);
@@ -1074,7 +1075,7 @@ where
             .for_each(|(center, from, to)| {
                 gizmos
                     .short_arc_3d_between(center, from, to, *color)
-                    .segments(*minor_segments);
+                    .resolution(*minor_resolution);
             });
     }
 }

--- a/crates/bevy_gizmos/src/primitives/helpers.rs
+++ b/crates/bevy_gizmos/src/primitives/helpers.rs
@@ -24,37 +24,37 @@ pub(crate) fn rotate_then_translate_3d(rotation: Quat, translation: Vec3) -> imp
     move |v| rotation * v + translation
 }
 
-/// Calculates the `nth` coordinate of a circle segment.
+/// Calculates the `nth` coordinate of a circle.
 ///
-/// Given a circle's radiu and the number of segments, this function computes the position
+/// Given a circle's radiu and its resolution, this function computes the position
 /// of the `nth` point along the circumference of the circle. The rotation starts at `(0.0, radius)`
 /// and proceeds counter-clockwise.
-pub(crate) fn single_circle_coordinate(radius: f32, segments: usize, nth_point: usize) -> Vec2 {
-    let angle = nth_point as f32 * TAU / segments as f32;
+pub(crate) fn single_circle_coordinate(radius: f32, resolution: usize, nth_point: usize) -> Vec2 {
+    let angle = nth_point as f32 * TAU / resolution as f32;
     let (x, y) = angle.sin_cos();
     Vec2::new(x, y) * radius
 }
 
-/// Generates an iterator over the coordinates of a circle segment.
+/// Generates an iterator over the coordinates of a circle.
 ///
 /// This function creates an iterator that yields the positions of points approximating a
-/// circle with the given radius, divided into linear segments. The iterator produces `segments`
+/// circle with the given radius, divided into linear segments. The iterator produces `resolution`
 /// number of points.
-pub(crate) fn circle_coordinates(radius: f32, segments: usize) -> impl Iterator<Item = Vec2> {
+pub(crate) fn circle_coordinates(radius: f32, resolution: usize) -> impl Iterator<Item = Vec2> {
     (0..)
-        .map(move |p| single_circle_coordinate(radius, segments, p))
-        .take(segments)
+        .map(move |p| single_circle_coordinate(radius, resolution, p))
+        .take(resolution)
 }
 
 /// Draws a semi-sphere.
 ///
 /// This function draws a semi-sphere at the specified `center` point with the given `rotation`,
-/// `radius`, and `color`. The `segments` parameter determines the level of detail, and the `top`
+/// `radius`, and `color`. The `resolution` parameter determines the level of detail, and the `top`
 /// argument specifies the shape of the semi-sphere's tip.
 pub(crate) fn draw_semi_sphere<Config, Clear>(
     gizmos: &mut Gizmos<'_, '_, Config, Clear>,
     radius: f32,
-    segments: usize,
+    resolution: usize,
     rotation: Quat,
     center: Vec3,
     top: Vec3,
@@ -63,13 +63,13 @@ pub(crate) fn draw_semi_sphere<Config, Clear>(
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    circle_coordinates(radius, segments)
+    circle_coordinates(radius, resolution)
         .map(|p| Vec3::new(p.x, 0.0, p.y))
         .map(rotate_then_translate_3d(rotation, center))
         .for_each(|from| {
             gizmos
                 .short_arc_3d_between(center, from, top, color)
-                .resolution(segments / 2);
+                .resolution(resolution / 2);
         });
 }
 
@@ -81,7 +81,7 @@ pub(crate) fn draw_semi_sphere<Config, Clear>(
 pub(crate) fn draw_circle_3d<Config, Clear>(
     gizmos: &mut Gizmos<'_, '_, Config, Clear>,
     radius: f32,
-    segments: usize,
+    resolution: usize,
     rotation: Quat,
     translation: Vec3,
     color: Color,
@@ -89,8 +89,8 @@ pub(crate) fn draw_circle_3d<Config, Clear>(
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    let positions = (0..=segments)
-        .map(|frac| frac as f32 / segments as f32)
+    let positions = (0..=resolution)
+        .map(|frac| frac as f32 / resolution as f32)
         .map(|percentage| percentage * TAU)
         .map(|angle| Vec2::from(angle.sin_cos()) * radius)
         .map(|p| Vec3::new(p.x, 0.0, p.y))
@@ -102,7 +102,7 @@ pub(crate) fn draw_circle_3d<Config, Clear>(
 pub(crate) fn draw_cylinder_vertical_lines<Config, Clear>(
     gizmos: &mut Gizmos<'_, '_, Config, Clear>,
     radius: f32,
-    segments: usize,
+    resolution: usize,
     half_height: f32,
     rotation: Quat,
     center: Vec3,
@@ -111,7 +111,7 @@ pub(crate) fn draw_cylinder_vertical_lines<Config, Clear>(
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
 {
-    circle_coordinates(radius, segments)
+    circle_coordinates(radius, resolution)
         .map(move |point_2d| {
             [1.0, -1.0]
                 .map(|sign| sign * half_height)

--- a/crates/bevy_gizmos/src/primitives/helpers.rs
+++ b/crates/bevy_gizmos/src/primitives/helpers.rs
@@ -69,7 +69,7 @@ pub(crate) fn draw_semi_sphere<Config, Clear>(
         .for_each(|from| {
             gizmos
                 .short_arc_3d_between(center, from, top, color)
-                .segments(segments / 2);
+                .resolution(segments / 2);
         });
 }
 

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -117,7 +117,7 @@ impl<T: GizmoConfigGroup> Drop for RoundedRectBuilder<'_, '_, '_, T> {
         for chunk in vertices.chunks_exact(3) {
             self.gizmos
                 .short_arc_3d_between(chunk[1], chunk[0], chunk[2], config.color)
-                .segments(config.arc_segments);
+                .resolution(config.arc_segments);
         }
 
         let edges = if config.corner_radius > 0. {

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -5,7 +5,7 @@
 
 use std::f32::consts::FRAC_PI_2;
 
-use crate::prelude::{GizmoConfigGroup, Gizmos};
+use crate::{circles::DEFAULT_CIRCLE_RESOLUTION, prelude::{GizmoConfigGroup, Gizmos}};
 use bevy_color::Color;
 use bevy_math::{Quat, Vec2, Vec3};
 use bevy_transform::components::Transform;
@@ -27,7 +27,7 @@ struct RoundedBoxConfig {
     rotation: Quat,
     color: Color,
     corner_radius: f32,
-    arc_segments: usize,
+    arc_resolution: usize,
 }
 
 impl<T: GizmoConfigGroup> RoundedRectBuilder<'_, '_, '_, T> {
@@ -38,10 +38,10 @@ impl<T: GizmoConfigGroup> RoundedRectBuilder<'_, '_, '_, T> {
         self
     }
 
-    /// Change the segments of the arcs at the corners of the rectangle.
+    /// Change the resolution of the arcs at the corners of the rectangle.
     /// The default value is 8
-    pub fn arc_segments(mut self, arc_segments: usize) -> Self {
-        self.config.arc_segments = arc_segments;
+    pub fn arc_resolution(mut self, arc_resolution: usize) -> Self {
+        self.config.arc_resolution = arc_resolution;
         self
     }
 }
@@ -53,10 +53,10 @@ impl<T: GizmoConfigGroup> RoundedCuboidBuilder<'_, '_, '_, T> {
         self
     }
 
-    /// Change the segments of the arcs at the edges of the cuboid.
+    /// Change the resolution of the arcs at the edges of the cuboid.
     /// The default value is 8
-    pub fn arc_segments(mut self, arc_segments: usize) -> Self {
-        self.config.arc_segments = arc_segments;
+    pub fn arc_resolution(mut self, arc_resolution: usize) -> Self {
+        self.config.arc_resolution = arc_resolution;
         self
     }
 }
@@ -117,7 +117,7 @@ impl<T: GizmoConfigGroup> Drop for RoundedRectBuilder<'_, '_, '_, T> {
         for chunk in vertices.chunks_exact(3) {
             self.gizmos
                 .short_arc_3d_between(chunk[1], chunk[0], chunk[2], config.color)
-                .resolution(config.arc_segments);
+                .resolution(config.arc_resolution);
         }
 
         let edges = if config.corner_radius > 0. {
@@ -190,7 +190,7 @@ impl<T: GizmoConfigGroup> Drop for RoundedCuboidBuilder<'_, '_, '_, T> {
                     size,
                     config.color,
                 )
-                .arc_segments(config.arc_segments)
+                .arc_resolution(config.arc_resolution)
                 .corner_radius(edge_radius);
 
             self.gizmos
@@ -200,7 +200,7 @@ impl<T: GizmoConfigGroup> Drop for RoundedCuboidBuilder<'_, '_, '_, T> {
                     size,
                     config.color,
                 )
-                .arc_segments(config.arc_segments)
+                .arc_resolution(config.arc_resolution)
                 .corner_radius(edge_radius);
         }
     }
@@ -221,8 +221,8 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// # Builder methods
     ///
     /// - The corner radius can be adjusted with the `.corner_radius(...)` method.
-    /// - The number of segments of the arcs at each corner (i.e. the level of detail) can be adjusted with the
-    /// `.arc_segments(...)` method.
+    /// - The resolution of the arcs at each corner (i.e. the level of detail) can be adjusted with the
+    /// `.arc_resolution(...)` method.
     ///
     /// # Example
     /// ```
@@ -238,7 +238,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     ///         GREEN
     ///         )
     ///         .corner_radius(0.25)
-    ///         .arc_segments(10);
+    ///         .arc_resolution(10);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -257,7 +257,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
                 rotation,
                 color: color.into(),
                 corner_radius,
-                arc_segments: DEFAULT_ARC_SEGMENTS,
+                arc_resolution: DEFAULT_ARC_RESOLUTION,
             },
             size,
         }
@@ -277,8 +277,8 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// # Builder methods
     ///
     /// - The corner radius can be adjusted with the `.corner_radius(...)` method.
-    /// - The number of segments of the arcs at each corner (i.e. the level of detail) can be adjusted with the
-    /// `.arc_segments(...)` method.
+    /// - The resolution of the arcs at each corner (i.e. the level of detail) can be adjusted with the
+    /// `.arc_resolution(...)` method.
     ///
     /// # Example
     /// ```
@@ -294,7 +294,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     ///         GREEN
     ///         )
     ///         .corner_radius(0.25)
-    ///         .arc_segments(10);
+    ///         .arc_resolution(10);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -313,7 +313,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
                 rotation: Quat::from_rotation_z(rotation),
                 color: color.into(),
                 corner_radius,
-                arc_segments: DEFAULT_ARC_SEGMENTS,
+                arc_resolution: DEFAULT_ARC_RESOLUTION,
             },
             size,
         }
@@ -333,8 +333,8 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// # Builder methods
     ///
     /// - The edge radius can be adjusted with the `.edge_radius(...)` method.
-    /// - The number of segments of the arcs at each edge (i.e. the level of detail) can be adjusted with the
-    /// `.arc_segments(...)` method.
+    /// - The resolution of the arcs at each edge (i.e. the level of detail) can be adjusted with the
+    /// `.arc_resolution(...)` method.
     ///
     /// # Example
     /// ```
@@ -350,7 +350,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     ///         GREEN
     ///         )
     ///         .edge_radius(0.25)
-    ///         .arc_segments(10);
+    ///         .arc_resolution(10);
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
@@ -369,12 +369,12 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
                 rotation,
                 color: color.into(),
                 corner_radius,
-                arc_segments: DEFAULT_ARC_SEGMENTS,
+                arc_resolution: DEFAULT_ARC_RESOLUTION,
             },
             size,
         }
     }
 }
 
-const DEFAULT_ARC_SEGMENTS: usize = 8;
+const DEFAULT_ARC_RESOLUTION: usize = DEFAULT_CIRCLE_RESOLUTION / 4;
 const DEFAULT_CORNER_RADIUS: f32 = 0.1;

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -5,7 +5,7 @@
 
 use std::f32::consts::FRAC_PI_2;
 
-use crate::{circles::DEFAULT_CIRCLE_RESOLUTION, prelude::{GizmoConfigGroup, Gizmos}};
+use crate::prelude::{GizmoConfigGroup, Gizmos};
 use bevy_color::Color;
 use bevy_math::{Quat, Vec2, Vec3};
 use bevy_transform::components::Transform;
@@ -376,5 +376,5 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     }
 }
 
-const DEFAULT_ARC_RESOLUTION: usize = DEFAULT_CIRCLE_RESOLUTION / 4;
+const DEFAULT_ARC_RESOLUTION: usize = 8;
 const DEFAULT_CORNER_RADIUS: f32 = 0.1;

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -78,7 +78,7 @@ fn draw_example_collection(
 
     // Circles have 32 line-segments by default.
     // You may want to increase this for larger circles.
-    my_gizmos.circle_2d(Vec2::ZERO, 300., NAVY).segments(64);
+    my_gizmos.circle_2d(Vec2::ZERO, 300., NAVY).resolution(64);
 
     my_gizmos.ellipse_2d(
         Vec2::ZERO,

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -87,7 +87,7 @@ fn draw_example_collection(
         YELLOW_GREEN,
     );
 
-    // Arcs default amount of segments is linearly interpolated between
+    // Arcs default resolution is linearly interpolated between
     // 1 and 32, using the arc length as scalar.
     my_gizmos.arc_2d(Vec2::ZERO, sin / 10., PI / 2., 310., ORANGE_RED);
 

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -116,7 +116,7 @@ fn draw_example_collection(
             TURQUOISE,
         )
         .edge_radius(0.1)
-        .arc_segments(4);
+        .arc_resolution(4);
 
     for y in [0., 0.5, 1.] {
         gizmos.ray(
@@ -144,7 +144,7 @@ fn draw_example_collection(
         .resolution(64);
     my_gizmos
         .sphere(Vec3::ZERO, Quat::IDENTITY, 3.2, BLACK)
-        .circle_segments(64);
+        .resolution(64);
 
     gizmos.arrow(Vec3::ZERO, Vec3::ONE * 1.5, YELLOW);
 

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -141,7 +141,7 @@ fn draw_example_collection(
     // You may want to increase this for larger circles or spheres.
     my_gizmos
         .circle(Vec3::ZERO, Dir3::Y, 3.1, NAVY)
-        .segments(64);
+        .resolution(64);
     my_gizmos
         .sphere(Vec3::ZERO, Quat::IDENTITY, 3.2, BLACK)
         .circle_segments(64);

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -134,7 +134,7 @@ fn draw_example_collection(
             Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()),
             ORANGE,
         )
-        .segments(10);
+        .resolution(10);
 
     // Circles have 32 line-segments by default.
     my_gizmos.circle(Vec3::ZERO, Dir3::Y, 3., BLACK);

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -614,7 +614,7 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         .unwrap_or(Vec3::Z),
     );
     let color = Color::WHITE;
-    let segments = 10;
+    let resolution = 10;
 
     match state.get() {
         PrimitiveSelected::RectangleAndCuboid => {
@@ -623,7 +623,7 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::CircleAndSphere => drop(
             gizmos
                 .primitive_3d(SPHERE, POSITION, rotation, color)
-                .resolution(segments),
+                .resolution(resolution),
         ),
         PrimitiveSelected::Ellipse => {}
         PrimitiveSelected::Triangle => {}
@@ -636,17 +636,17 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Capsule => drop(
             gizmos
                 .primitive_3d(CAPSULE_3D, POSITION, rotation, color)
-                .resolution(segments),
+                .resolution(resolution),
         ),
         PrimitiveSelected::Cylinder => drop(
             gizmos
                 .primitive_3d(CYLINDER, POSITION, rotation, color)
-                .resolution(segments),
+                .resolution(resolution),
         ),
         PrimitiveSelected::Cone => drop(
             gizmos
                 .primitive_3d(CONE, POSITION, rotation, color)
-                .resolution(segments),
+                .resolution(resolution),
         ),
         PrimitiveSelected::ConicalFrustum => {
             gizmos.primitive_3d(CONICAL_FRUSTUM, POSITION, rotation, color);
@@ -655,8 +655,8 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Torus => drop(
             gizmos
                 .primitive_3d(TORUS, POSITION, rotation, color)
-                .minor_resolution(segments)
-                .major_resolution(segments),
+                .minor_resolution(resolution)
+                .major_resolution(resolution),
         ),
     }
 }

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -623,7 +623,7 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::CircleAndSphere => drop(
             gizmos
                 .primitive_3d(SPHERE, POSITION, rotation, color)
-                .segments(segments),
+                .resolution(segments),
         ),
         PrimitiveSelected::Ellipse => {}
         PrimitiveSelected::Triangle => {}
@@ -636,17 +636,17 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Capsule => drop(
             gizmos
                 .primitive_3d(CAPSULE_3D, POSITION, rotation, color)
-                .segments(segments),
+                .resolution(segments),
         ),
         PrimitiveSelected::Cylinder => drop(
             gizmos
                 .primitive_3d(CYLINDER, POSITION, rotation, color)
-                .segments(segments),
+                .resolution(segments),
         ),
         PrimitiveSelected::Cone => drop(
             gizmos
                 .primitive_3d(CONE, POSITION, rotation, color)
-                .segments(segments),
+                .resolution(segments),
         ),
         PrimitiveSelected::ConicalFrustum => {
             gizmos.primitive_3d(CONICAL_FRUSTUM, POSITION, rotation, color);
@@ -655,8 +655,8 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Torus => drop(
             gizmos
                 .primitive_3d(TORUS, POSITION, rotation, color)
-                .minor_segments(segments)
-                .major_segments(segments),
+                .minor_resolution(segments)
+                .major_resolution(segments),
         ),
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #13412

## Solution

- Renamed `segments` in `bevy_gizmos` to `resolution` and adjusted examples

## Migration Guide

- When working with gizmos, replace all calls to `.segments(...)` with `.resolution(...)`
