### PR TITLE
Remove SparseSets in Archetype/Table storage

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -686,7 +686,7 @@ pub struct Archetypes {
     pub(crate) archetypes: Vec<Archetype>,
     archetype_component_count: usize,
     /// find the archetype id by the components
-    by_components: bevy_utils::HashMap<ArchetypeComponents, ArchetypeId>,
+    by_components: HashMap<ArchetypeComponents, ArchetypeId>,
     /// find all the archetypes that contain a component
     by_component: ComponentIndex,
 }

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -796,30 +796,30 @@ impl Archetypes {
 
         let archetypes = &mut self.archetypes;
         let archetype_component_count = &mut self.archetype_component_count;
-            *self
-                .by_components
-                .entry(archetype_identity)
-                .or_insert_with(move || {
-                    let id = ArchetypeId::new(archetypes.len());
-                    let table_start = *archetype_component_count;
-                    *archetype_component_count += table_components.len();
-                    let table_archetype_components =
-                        (table_start..*archetype_component_count).map(ArchetypeComponentId);
-                    let sparse_start = *archetype_component_count;
-                    *archetype_component_count += sparse_set_components.len();
-                    let sparse_set_archetype_components =
-                        (sparse_start..*archetype_component_count).map(ArchetypeComponentId);
-                    archetypes.push(Archetype::new(
-                        components,
-                        id,
-                        table_id,
-                        table_components.into_iter().zip(table_archetype_components),
-                        sparse_set_components
-                            .into_iter()
-                            .zip(sparse_set_archetype_components),
-                    ));
-                    id
-                })
+        *self
+            .by_components
+            .entry(archetype_identity)
+            .or_insert_with(move || {
+                let id = ArchetypeId::new(archetypes.len());
+                let table_start = *archetype_component_count;
+                *archetype_component_count += table_components.len();
+                let table_archetype_components =
+                    (table_start..*archetype_component_count).map(ArchetypeComponentId);
+                let sparse_start = *archetype_component_count;
+                *archetype_component_count += sparse_set_components.len();
+                let sparse_set_archetype_components =
+                    (sparse_start..*archetype_component_count).map(ArchetypeComponentId);
+                archetypes.push(Archetype::new(
+                    components,
+                    id,
+                    table_id,
+                    table_components.into_iter().zip(table_archetype_components),
+                    sparse_set_components
+                        .into_iter()
+                        .zip(sparse_set_archetype_components),
+                ));
+                id
+            })
     }
 
     /// Returns the number of components that are stored in archetypes.

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -546,10 +546,6 @@ impl Archetype {
         self.entities.is_empty()
     }
 
-    // TODO:
-    //  - either do this in O(n) right now (iterate through components)
-    //  - add a map from ComponentId to index in self.components
-    //  - add an extra argument to this function that is the ComponentIndex
     /// Checks if the archetype contains a specific component. This runs in `O(1)` time.
     #[inline]
     pub fn contains(&self, component_id: ComponentId) -> bool {
@@ -800,7 +796,6 @@ impl Archetypes {
 
         let archetypes = &mut self.archetypes;
         let archetype_component_count = &mut self.archetype_component_count;
-        let archetype_id =
             *self
                 .by_components
                 .entry(archetype_identity)
@@ -824,8 +819,7 @@ impl Archetypes {
                             .zip(sparse_set_archetype_components),
                     ));
                     id
-                });
-        archetype_id
+                })
     }
 
     /// Returns the number of components that are stored in archetypes.

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -322,7 +322,6 @@ pub struct SparseSet<I, V: 'static> {
     sparse: SparseArray<I, NonMaxUsize>,
 }
 
-
 macro_rules! impl_sparse_set {
     ($ty:ident) => {
         impl<I: SparseSetIndex, V> $ty<I, V> {

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -15,14 +15,6 @@ pub(crate) struct SparseArray<I, V = I> {
     marker: PhantomData<I>,
 }
 
-/// A space-optimized version of [`SparseArray`] that cannot be changed
-/// after construction.
-#[derive(Debug)]
-pub(crate) struct ImmutableSparseArray<I, V = I> {
-    values: Box<[Option<V>]>,
-    marker: PhantomData<I>,
-}
-
 impl<I: SparseSetIndex, V> Default for SparseArray<I, V> {
     fn default() -> Self {
         Self::new()
@@ -62,7 +54,6 @@ macro_rules! impl_sparse_array {
 }
 
 impl_sparse_array!(SparseArray);
-impl_sparse_array!(ImmutableSparseArray);
 
 impl<I: SparseSetIndex, V> SparseArray<I, V> {
     /// Inserts `value` at `index` in the array.
@@ -101,14 +92,6 @@ impl<I: SparseSetIndex, V> SparseArray<I, V> {
     /// Removes all of the values stored within.
     pub fn clear(&mut self) {
         self.values.clear();
-    }
-
-    /// Converts the [`SparseArray`] into an immutable variant.
-    pub(crate) fn into_immutable(self) -> ImmutableSparseArray<I, V> {
-        ImmutableSparseArray {
-            values: self.values.into_boxed_slice(),
-            marker: PhantomData,
-        }
     }
 }
 
@@ -339,14 +322,6 @@ pub struct SparseSet<I, V: 'static> {
     sparse: SparseArray<I, NonMaxUsize>,
 }
 
-/// A space-optimized version of [`SparseSet`] that cannot be changed
-/// after construction.
-#[derive(Debug)]
-pub(crate) struct ImmutableSparseSet<I, V: 'static> {
-    dense: Box<[V]>,
-    indices: Box<[I]>,
-    sparse: ImmutableSparseArray<I, NonMaxUsize>,
-}
 
 macro_rules! impl_sparse_set {
     ($ty:ident) => {
@@ -413,7 +388,6 @@ macro_rules! impl_sparse_set {
 }
 
 impl_sparse_set!(SparseSet);
-impl_sparse_set!(ImmutableSparseSet);
 
 impl<I: SparseSetIndex, V> Default for SparseSet<I, V> {
     fn default() -> Self {
@@ -511,15 +485,6 @@ impl<I: SparseSetIndex, V> SparseSet<I, V> {
         self.dense.clear();
         self.indices.clear();
         self.sparse.clear();
-    }
-
-    /// Converts the sparse set into its immutable variant.
-    pub(crate) fn into_immutable(self) -> ImmutableSparseSet<I, V> {
-        ImmutableSparseSet {
-            dense: self.dense.into_boxed_slice(),
-            indices: self.indices.into_boxed_slice(),
-            sparse: self.sparse.into_immutable(),
-        }
     }
 }
 

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick, TickCells},
     entity::Entity,
     query::DebugCheckedUnwrap,
-    storage::{blob_vec::BlobVec},
+    storage::blob_vec::BlobVec,
 };
 use bevy_ptr::{OwningPtr, Ptr, PtrMut, UnsafeCellDeref};
 use bevy_utils::HashMap;
@@ -533,9 +533,11 @@ impl TableBuilder {
 
     #[must_use]
     pub fn add_column(mut self, component_info: &ComponentInfo) -> Self {
-        self.columns.push(Column::with_capacity(component_info, self.capacity));
+        self.columns
+            .push(Column::with_capacity(component_info, self.capacity));
         self.index_map.push(component_info.id());
-        self.column_id_map.insert(component_info.id(), self.columns.len() - 1);
+        self.column_id_map
+            .insert(component_info.id(), self.columns.len() - 1);
         self
     }
 
@@ -570,7 +572,7 @@ pub struct Table {
     /// `index_map[i]` is the [`ComponentId`] of the [`Column`] at index `i`
     index_map: Vec<ComponentId>,
     // TODO: can remove this if we use the ComponentIndex in places where it's needed
-    column_id_map: HashMap<ComponentId, usize>
+    column_id_map: HashMap<ComponentId, usize>,
 }
 
 impl Table {
@@ -707,7 +709,9 @@ impl Table {
     /// [`Component`]: crate::component::Component
     #[inline]
     pub fn get_column(&self, component_id: ComponentId) -> Option<&Column> {
-        self.column_id_map.get(&component_id).and_then(|&idx| self.columns.get(idx))
+        self.column_id_map
+            .get(&component_id)
+            .and_then(|&idx| self.columns.get(idx))
     }
 
     /// Fetches a mutable reference to the [`Column`] for a given [`Component`] within the
@@ -718,7 +722,9 @@ impl Table {
     /// [`Component`]: crate::component::Component
     #[inline]
     pub(crate) fn get_column_mut(&mut self, component_id: ComponentId) -> Option<&mut Column> {
-        self.column_id_map.get(&component_id).and_then(|&idx| self.columns.get_mut(idx))
+        self.column_id_map
+            .get(&component_id)
+            .and_then(|&idx| self.columns.get_mut(idx))
     }
 
     // TODO: options

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -980,7 +980,8 @@ mod tests {
             for entity in &query {
                 let location = entities.get(entity).unwrap();
                 let archetype = archetypes.get(location.archetype_id).unwrap();
-                let archetype_components = archetype.components().collect::<Vec<_>>();
+                let mut archetype_components = archetype.components().collect::<Vec<_>>();
+                archetype_components.sort();
                 let bundle_id = bundles
                     .get_id(TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2278,8 +2278,8 @@ unsafe fn remove_bundle_from_archetype(
         // this Bundle removal result is cached. just return that!
         result
     } else {
-        let mut next_table_components;
-        let mut next_sparse_set_components;
+        let mut next_table_components: Vec<ComponentId>;
+        let mut next_sparse_set_components: Vec<ComponentId>;
         let next_table_id;
         {
             let current_archetype = &mut archetypes[archetype_id];
@@ -2304,12 +2304,13 @@ unsafe fn remove_bundle_from_archetype(
                 }
             }
 
-            // sort removed components so we can do an efficient "sorted remove". archetype
-            // components are already sorted
+            // sort removed components so we can do an efficient "sorted remove".
             removed_table_components.sort();
             removed_sparse_set_components.sort();
             next_table_components = current_archetype.table_components().collect();
             next_sparse_set_components = current_archetype.sparse_set_components().collect();
+            next_table_components.sort();
+            next_sparse_set_components.sort();
             sorted_remove(&mut next_table_components, &removed_table_components);
             sorted_remove(
                 &mut next_sparse_set_components,


### PR DESCRIPTION
# Objective

This PR can probably be split up between 2 changes:
As a side-effect of fragmenting relations, the number of components and archetypes will explode
Consequently, we won't be able to use a `ImmutableSparseSet<ComponentId>` to store component data in `Table` and `Archetype` because our max `ComponentId` will be too high and the SparseSet will use too much memory. 

Therefore we need to update the `Table` and `Archetype` internals to use different data structures.



## Testing

- I think some tests seem to be flimsy because the order of iteration of components in an Archetype or Table are not guaranteed anymore.

## Benchmarks

Benchmark results as of https://github.com/bevyengine/bevy/pull/13448/commits/ac46c5f29604b4ca2411c05127ace8375af50b1a (archetype components are not sorted)
```
group                                  main                                   pr
-----                                  ----                                   --
iter_fragmented/base                   1.00   352.3±26.42ns        ? ?/sec    1.74    613.0±6.28ns        ? ?/sec
iter_fragmented/foreach                1.00   161.3±13.23ns        ? ?/sec    1.90   306.1±17.72ns        ? ?/sec
iter_fragmented/foreach_wide           1.00      3.2±0.18µs        ? ?/sec    1.34      4.3±0.15µs        ? ?/sec
iter_fragmented/wide                   1.00      3.1±0.13µs        ? ?/sec    1.39      4.4±0.39µs        ? ?/sec
iter_fragmented_sparse/base            1.00      6.5±0.11ns        ? ?/sec    1.82     11.9±1.31ns        ? ?/sec
iter_fragmented_sparse/foreach         1.00      6.7±0.58ns        ? ?/sec    1.80     12.1±1.38ns        ? ?/sec
iter_fragmented_sparse/foreach_wide    1.00     45.8±0.67ns        ? ?/sec    1.70     77.8±0.86ns        ? ?/sec
iter_fragmented_sparse/wide            1.00     31.2±1.94ns        ? ?/sec    2.24     69.9±3.02ns        ? ?/sec
iter_simple/base                       1.01      8.6±0.84µs        ? ?/sec    1.00      8.5±0.18µs        ? ?/sec
iter_simple/foreach                    1.01      4.1±0.61µs        ? ?/sec    1.00      4.0±0.25µs        ? ?/sec
iter_simple/foreach_sparse_set         1.00     19.5±0.41µs        ? ?/sec    1.03     20.0±1.11µs        ? ?/sec
iter_simple/foreach_wide               1.00     18.2±0.25µs        ? ?/sec    1.04     19.0±3.20µs        ? ?/sec
iter_simple/foreach_wide_sparse_set    1.01    97.4±18.20µs        ? ?/sec    1.00     96.8±9.62µs        ? ?/sec
iter_simple/sparse_set                 1.01     20.1±1.84µs        ? ?/sec    1.00     19.9±0.26µs        ? ?/sec
iter_simple/system                     1.00      8.3±0.51µs        ? ?/sec    1.14      9.5±0.16µs        ? ?/sec
iter_simple/wide                       1.00     36.6±2.34µs        ? ?/sec    1.02     37.2±0.96µs        ? ?/sec
iter_simple/wide_sparse_set            1.00     96.9±4.37µs        ? ?/sec    1.03   100.1±16.73µs        ? ?/sec
par_iter_simple/with_0_fragment        1.00     35.0±4.10µs        ? ?/sec    1.28    44.9±17.52µs        ? ?/sec
par_iter_simple/with_1000_fragment     1.00     50.5±4.11µs        ? ?/sec    1.21     61.2±3.92µs        ? ?/sec
par_iter_simple/with_100_fragment      1.00     39.6±1.54µs        ? ?/sec    1.19     47.0±4.09µs        ? ?/sec
par_iter_simple/with_10_fragment       1.00     33.9±0.65µs        ? ?/sec    1.35    45.9±16.11µs        ? ?/sec
```
