### PR TITLE
Rename `Rect` `inset()` method to `inflate()`

### DIFF
--- a/crates/bevy_math/src/rects/irect.rs
+++ b/crates/bevy_math/src/rects/irect.rs
@@ -19,6 +19,12 @@ pub struct IRect {
 }
 
 impl IRect {
+    /// An empty `IRect`, represented by maximum and minimum corner points
+    /// with all `i32::MAX` values.
+    pub const EMPTY: Self = Self {
+        max: IVec2::MAX,
+        min: IVec2::MAX,
+    };
     /// Create a new rectangle from two corner points.
     ///
     /// The two points do not need to be the minimum and/or maximum corners.

--- a/crates/bevy_math/src/rects/irect.rs
+++ b/crates/bevy_math/src/rects/irect.rs
@@ -300,17 +300,17 @@ impl IRect {
     /// ```
     /// # use bevy_math::{IRect, IVec2};
     /// let r = IRect::new(0, 0, 5, 1); // w=5 h=1
-    /// let r2 = r.inset(3); // w=11 h=7
+    /// let r2 = r.inflate(3); // w=11 h=7
     /// assert_eq!(r2.min, IVec2::splat(-3));
     /// assert_eq!(r2.max, IVec2::new(8, 4));
     ///
     /// let r = IRect::new(0, -1, 4, 3); // w=4 h=4
-    /// let r2 = r.inset(-1); // w=2 h=2
+    /// let r2 = r.inflate(-1); // w=2 h=2
     /// assert_eq!(r2.min, IVec2::new(1, 0));
     /// assert_eq!(r2.max, IVec2::new(3, 2));
     /// ```
     #[inline]
-    pub fn inset(&self, inset: i32) -> Self {
+    pub fn inflate(&self, inset: i32) -> Self {
         let mut r = Self {
             min: self.min - inset,
             max: self.max + inset,
@@ -451,7 +451,7 @@ mod tests {
     fn rect_inset() {
         let r = IRect::from_center_size(IVec2::ZERO, IVec2::splat(4)); // [-2,-2] - [2,2]
 
-        let r2 = r.inset(2);
+        let r2 = r.inflate(2);
         assert_eq!(r2.min, IVec2::new(-4, -4));
         assert_eq!(r2.max, IVec2::new(4, 4));
     }

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -288,17 +288,17 @@ impl Rect {
     /// ```
     /// # use bevy_math::{Rect, Vec2};
     /// let r = Rect::new(0., 0., 5., 1.); // w=5 h=1
-    /// let r2 = r.inset(3.); // w=11 h=7
+    /// let r2 = r.inflate(3.); // w=11 h=7
     /// assert!(r2.min.abs_diff_eq(Vec2::splat(-3.), 1e-5));
     /// assert!(r2.max.abs_diff_eq(Vec2::new(8., 4.), 1e-5));
     ///
     /// let r = Rect::new(0., -1., 6., 7.); // w=6 h=8
-    /// let r2 = r.inset(-2.); // w=11 h=7
+    /// let r2 = r.inflate(-2.); // w=11 h=7
     /// assert!(r2.min.abs_diff_eq(Vec2::new(2., 1.), 1e-5));
     /// assert!(r2.max.abs_diff_eq(Vec2::new(4., 5.), 1e-5));
     /// ```
     #[inline]
-    pub fn inset(&self, inset: f32) -> Self {
+    pub fn inflate(&self, inset: f32) -> Self {
         let mut r = Self {
             min: self.min - inset,
             max: self.max + inset,
@@ -463,7 +463,7 @@ mod tests {
     fn rect_inset() {
         let r = Rect::from_center_size(Vec2::ZERO, Vec2::ONE); // [-0.5,-0.5] - [0.5,0.5]
 
-        let r2 = r.inset(0.3);
+        let r2 = r.inflate(0.3);
         assert!(r2.min.abs_diff_eq(Vec2::new(-0.8, -0.8), 1e-5));
         assert!(r2.max.abs_diff_eq(Vec2::new(0.8, 0.8), 1e-5));
     }

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -19,6 +19,12 @@ pub struct Rect {
 }
 
 impl Rect {
+    /// An empty `Rect`, represented by maximum and minimum corner points
+    /// with all `f32::MAX` values.
+    pub const EMPTY: Self = Self {
+        max: Vec2::MAX,
+        min: Vec2::MAX,
+    };
     /// Create a new rectangle from two corner points.
     ///
     /// The two points do not need to be the minimum and/or maximum corners.

--- a/crates/bevy_math/src/rects/urect.rs
+++ b/crates/bevy_math/src/rects/urect.rs
@@ -297,17 +297,17 @@ impl URect {
     /// ```
     /// # use bevy_math::{URect, UVec2};
     /// let r = URect::new(4, 4, 6, 6); // w=2 h=2
-    /// let r2 = r.inset(1); // w=4 h=4
+    /// let r2 = r.inflate(1); // w=4 h=4
     /// assert_eq!(r2.min, UVec2::splat(3));
     /// assert_eq!(r2.max, UVec2::splat(7));
     ///
     /// let r = URect::new(4, 4, 8, 8); // w=4 h=4
-    /// let r2 = r.inset(-1); // w=2 h=2
+    /// let r2 = r.inflate(-1); // w=2 h=2
     /// assert_eq!(r2.min, UVec2::splat(5));
     /// assert_eq!(r2.max, UVec2::splat(7));
     /// ```
     #[inline]
-    pub fn inset(&self, inset: i32) -> Self {
+    pub fn inflate(&self, inset: i32) -> Self {
         let mut r = Self {
             min: UVec2::new(
                 self.min.x.saturating_add_signed(-inset),
@@ -454,7 +454,7 @@ mod tests {
     fn rect_inset() {
         let r = URect::from_center_size(UVec2::splat(6), UVec2::splat(6)); // [3, 3] - [9, 9]
 
-        let r2 = r.inset(2);
+        let r2 = r.inflate(2);
         assert_eq!(r2.min, UVec2::new(1, 1));
         assert_eq!(r2.max, UVec2::new(11, 11));
     }

--- a/crates/bevy_math/src/rects/urect.rs
+++ b/crates/bevy_math/src/rects/urect.rs
@@ -19,6 +19,12 @@ pub struct URect {
 }
 
 impl URect {
+    /// An empty `URect`, represented by maximum and minimum corner points
+    /// with all `u32::MAX` values.
+    pub const EMPTY: Self = Self {
+        max: UVec2::MAX,
+        min: UVec2::MAX,
+    };
     /// Create a new rectangle from two corner points.
     ///
     /// The two points do not need to be the minimum and/or maximum corners.

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -579,7 +579,7 @@ pub fn extract_uinode_outlines(
 
         // Calculate the outline rects.
         let inner_rect = Rect::from_center_size(Vec2::ZERO, node.size() + 2. * node.outline_offset);
-        let outer_rect = inner_rect.inset(node.outline_width());
+        let outer_rect = inner_rect.inflate(node.outline_width());
         let outline_edges = [
             // Left edge
             Rect::new(


### PR DESCRIPTION
# Objective

- Fixes #13092.

## Solution

- Renamed the `inset()` method in `Rect`, `IRect` and `URect` to `inflate()`.
- Added `EMPTY` constants to all `Rect` variants, represented by corners with the maximum numerical values for each kind.

---

## Migration Guide

- Replace `Rect::inset()`, `IRect::inset()` and `URect::inset()` calls with `inflate()`.