### PR TITLE
Added visibility bitmask as an alternative SSAO method

### DIFF
--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
@@ -10,7 +10,7 @@
 
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
 #import bevy_pbr::mesh_view_bindings::screen_space_ambient_occlusion_texture
-#import bevy_pbr::gtao_utils::gtao_multibounce
+#import bevy_pbr::ssao_utils::ssao_multibounce
 #endif
 
 struct FullscreenVertexOutput {
@@ -64,7 +64,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
         let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
-        let ssao_multibounce = gtao_multibounce(ssao, pbr_input.material.base_color.rgb);
+        let ssao_multibounce = ssao_multibounce(ssao, pbr_input.material.base_color.rgb);
         pbr_input.diffuse_occlusion = min(pbr_input.diffuse_occlusion, ssao_multibounce);
 
         // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -44,7 +44,7 @@ use crate::{
     },
     prepass, EnvironmentMapUniformBuffer, FogMeta, GlobalClusterableObjectMeta,
     GpuClusterableObjects, GpuFog, GpuLights, LightMeta, LightProbesBuffer, LightProbesUniform,
-    MeshPipeline, MeshPipelineKey, RenderViewLightProbes, ScreenSpaceAmbientOcclusionTextures,
+    MeshPipeline, MeshPipelineKey, RenderViewLightProbes, ScreenSpaceAmbientOcclusionResources,
     ScreenSpaceReflectionsBuffer, ScreenSpaceReflectionsUniform, ShadowSamplers,
     ViewClusterBindings, ViewShadowBindings, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
 };
@@ -462,7 +462,7 @@ pub fn prepare_mesh_view_bind_groups(
         &ViewShadowBindings,
         &ViewClusterBindings,
         &Msaa,
-        Option<&ScreenSpaceAmbientOcclusionTextures>,
+        Option<&ScreenSpaceAmbientOcclusionResources>,
         Option<&ViewPrepassTextures>,
         Option<&ViewTransmissionTexture>,
         &Tonemapping,
@@ -507,7 +507,7 @@ pub fn prepare_mesh_view_bind_groups(
             shadow_bindings,
             cluster_bindings,
             msaa,
-            ssao_textures,
+            ssao_resources,
             prepass_textures,
             transmission_texture,
             tonemapping,
@@ -519,7 +519,7 @@ pub fn prepare_mesh_view_bind_groups(
                 .image_for_samplecount(1, TextureFormat::bevy_default())
                 .texture_view
                 .clone();
-            let ssao_view = ssao_textures
+            let ssao_view = ssao_resources
                 .map(|t| &t.screen_space_ambient_occlusion_texture.default_view)
                 .unwrap_or(&fallback_ssao);
 

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -15,7 +15,7 @@
 
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
 #import bevy_pbr::mesh_view_bindings::screen_space_ambient_occlusion_texture
-#import bevy_pbr::gtao_utils::gtao_multibounce
+#import bevy_pbr::ssao_utils::ssao_multibounce
 #endif
 
 #ifdef MESHLET_MESH_MATERIAL_PASS
@@ -344,7 +344,7 @@ fn pbr_input_from_standard_material(
 #endif
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
         let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
-        let ssao_multibounce = gtao_multibounce(ssao, pbr_input.material.base_color.rgb);
+        let ssao_multibounce = ssao_multibounce(ssao, pbr_input.material.base_color.rgb);
         diffuse_occlusion = min(diffuse_occlusion, ssao_multibounce);
         // Use SSAO to estimate the specular occlusion.
         // Lagarde and Rousiers 2014, "Moving Frostbite to Physically Based Rendering"

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -166,7 +166,7 @@ pub struct ScreenSpaceAmbientOcclusionBundle {
 pub struct ScreenSpaceAmbientOcclusion {
     /// Quality of the SSAO effect.
     pub quality_level: ScreenSpaceAmbientOcclusionQualityLevel,
-    /// The constant thickness of objects use for the SSAO effect.
+    /// A constant estimated thickness of objects.
     ///
     /// This value is used to decide how far behind an object a ray of light needs to be in order
     /// to pass behind it. Any ray closer than that will be occluded.

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
@@ -14,7 +14,8 @@
 @group(0) @binding(4) var preprocessed_depth_mip3: texture_storage_2d<r16float, write>;
 @group(0) @binding(5) var preprocessed_depth_mip4: texture_storage_2d<r16float, write>;
 @group(1) @binding(0) var point_clamp_sampler: sampler;
-@group(1) @binding(1) var<uniform> view: View;
+@group(1) @binding(1) var linear_clamp_sampler: sampler;
+@group(1) @binding(2) var<uniform> view: View;
 
 
 // Using 4 depths from the previous MIP, compute a weighted average for the depth of the current MIP

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
@@ -15,7 +15,8 @@
 @group(0) @binding(1) var depth_differences: texture_2d<u32>;
 @group(0) @binding(2) var ambient_occlusion: texture_storage_2d<r16float, write>;
 @group(1) @binding(0) var point_clamp_sampler: sampler;
-@group(1) @binding(1) var<uniform> view: View;
+@group(1) @binding(1) var linear_clamp_sampler: sampler;
+@group(1) @binding(2) var<uniform> view: View;
 
 @compute
 @workgroup_size(8, 8, 1)

--- a/crates/bevy_pbr/src/ssao/ssao_utils.wgsl
+++ b/crates/bevy_pbr/src/ssao/ssao_utils.wgsl
@@ -1,10 +1,10 @@
-#define_import_path bevy_pbr::gtao_utils
+#define_import_path bevy_pbr::ssao_utils
 
 #import bevy_render::maths::{PI, HALF_PI}
 
 // Approximates single-bounce ambient occlusion to multi-bounce ambient occlusion
 // https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf#page=78
-fn gtao_multibounce(visibility: f32, base_color: vec3<f32>) -> vec3<f32> {
+fn ssao_multibounce(visibility: f32, base_color: vec3<f32>) -> vec3<f32> {
     let a = 2.0404 * base_color - 0.3324;
     let b = -4.7951 * base_color + 0.6417;
     let c = 2.7552 * base_color + 0.6903;

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -109,32 +109,52 @@ fn update(
     sphere.translation.y = ops::sin(time.elapsed_seconds() / 1.7) * 0.7;
 
     let (camera_entity, ssao, temporal_jitter) = camera.single();
+    let current_ssao = ssao.cloned().unwrap_or_default();
 
     let mut commands = commands
         .entity(camera_entity)
         .insert_if(
             ScreenSpaceAmbientOcclusion {
                 quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Low,
+                ..current_ssao
             },
             || keycode.just_pressed(KeyCode::Digit2),
         )
         .insert_if(
             ScreenSpaceAmbientOcclusion {
                 quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Medium,
+                ..current_ssao
             },
             || keycode.just_pressed(KeyCode::Digit3),
         )
         .insert_if(
             ScreenSpaceAmbientOcclusion {
                 quality_level: ScreenSpaceAmbientOcclusionQualityLevel::High,
+                ..current_ssao
             },
             || keycode.just_pressed(KeyCode::Digit4),
         )
         .insert_if(
             ScreenSpaceAmbientOcclusion {
                 quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Ultra,
+                ..current_ssao
             },
             || keycode.just_pressed(KeyCode::Digit5),
+        )
+        .insert_if(
+            ScreenSpaceAmbientOcclusion {
+                constant_object_thickness: (current_ssao.constant_object_thickness * 2.0).min(4.0),
+                ..current_ssao
+            },
+            || keycode.just_pressed(KeyCode::ArrowUp),
+        )
+        .insert_if(
+            ScreenSpaceAmbientOcclusion {
+                constant_object_thickness: (current_ssao.constant_object_thickness * 0.5)
+                    .max(0.0625),
+                ..current_ssao
+            },
+            || keycode.just_pressed(KeyCode::ArrowDown),
         );
     if keycode.just_pressed(KeyCode::Digit1) {
         commands = commands.remove::<ScreenSpaceAmbientOcclusion>();
@@ -159,6 +179,13 @@ fn update(
         Some(ScreenSpaceAmbientOcclusionQualityLevel::Ultra) => ("", "", "", "", "*"),
         _ => unreachable!(),
     };
+
+    if let Some(thickness) = ssao.map(|s| s.constant_object_thickness) {
+        text.push_str(&format!(
+            "Constant object thickness: {} (Up/Down)\n\n",
+            thickness
+        ));
+    }
 
     text.push_str("SSAO Quality:\n");
     text.push_str(&format!("(1) {o}Off{o}\n"));


### PR DESCRIPTION
Early implementation. I still have to fix the documentation and consider writing a small migration guide.

Questions left to answer:

* [x] should thickness be an overridable constant?
* [x] is there a better way to implement `Eq`/`Hash` for `SSAOMethod`?
* [x] do we want to keep the linear sampler for the depth texture?
* [x] is there a better way to separate the logic than preprocessor macros?

![vbao](https://github.com/bevyengine/bevy/assets/4136413/2a8a0389-2add-4c2e-be37-e208e52dcd25)

## Migration guide

SSAO algorithm was changed from GTAO to VBAO (visibility bitmasks). A new field, `constant_object_thickness`, was added to `ScreenSpaceAmbientOcclusion`. `ScreenSpaceAmbientOcclusion` also lost its `Eq` and `Hash` implementations.
