### PR TITLE
Fix UI elements randomly not appearing after #13277.

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -101,8 +101,7 @@ pub fn build_ui_render(app: &mut App) {
         .add_systems(
             ExtractSchedule,
             (
-                extract_default_ui_camera_view::<Camera2d>,
-                extract_default_ui_camera_view::<Camera3d>,
+                extract_default_ui_camera_view,
                 extract_uinode_background_colors.in_set(RenderUiSystem::ExtractBackgrounds),
                 extract_uinode_images.in_set(RenderUiSystem::ExtractImages),
                 extract_uinode_borders.in_set(RenderUiSystem::ExtractBorders),
@@ -657,11 +656,12 @@ const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 #[derive(Component)]
 pub struct DefaultCameraView(pub Entity);
 
-pub fn extract_default_ui_camera_view<T: Component>(
+/// Extracts all UI elements associated with a camera into the render world.
+pub fn extract_default_ui_camera_view(
     mut commands: Commands,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
     ui_scale: Extract<Res<UiScale>>,
-    query: Extract<Query<(Entity, &Camera), With<T>>>,
+    query: Extract<Query<(Entity, &Camera), Or<(With<Camera2d>, With<Camera3d>)>>>,
     mut live_entities: Local<EntityHashSet>,
 ) {
     live_entities.clear();


### PR DESCRIPTION
We invoked the `extract_default_ui_camera_view` system twice: once for 2D cameras and once for 3D cameras. This was fine before moving to resources for render phases, but, after the move to resources, the first thing such systems do is to clear out all the entities-to-be-rendered from the previous frame. So, if the scheduler happened to run `extract_default_ui_camera_view::<Camera2d>` first, then all the UI elements that it queued would be overwritten by the `extract_default_ui_camera_view::<Camera3d>` system, or vice versa. The ordering dependence is the reason why this problem was intermittent.

This commit fixes the problem by merging the two systems into one systems, using an `Or` query filter.

## Migration Guide

* The `bevy_ui::render::extract_default_ui_camera_view` system is no longer parameterized over the specific type of camera and is hard-wired to either `Camera2d` or `Camera3d` components.