### PR TITLE
Tetrahedron mesh

### DIFF
--- a/crates/bevy_render/src/mesh/primitives/dim3/mod.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/mod.rs
@@ -4,6 +4,7 @@ mod cuboid;
 mod cylinder;
 mod plane;
 mod sphere;
+mod tetrahedron;
 mod torus;
 pub(crate) mod triangle3d;
 

--- a/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
@@ -28,7 +28,7 @@ impl Meshable for Tetrahedron {
         for face in faces {
             positions.extend(face.vertices);
 
-            let face_normal: Vec3 = face.normal().map_or(Vec3::ZERO, |n| n.into());
+            let face_normal = triangle3d::normal_vec(&face);
             normals.extend(vec![face_normal; 3]);
 
             let face_uvs = triangle3d::uv_coords(&face);

--- a/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
@@ -14,7 +14,7 @@ impl Meshable for Tetrahedron {
 
         // If the tetrahedron has negative orientation, reverse all the triangles so that
         // they still face outward.
-        if self.signed_volume() < 0.0 {
+        if self.signed_volume().is_sign_negative() {
             faces.iter_mut().for_each(Triangle3d::reverse);
         }
 

--- a/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
@@ -1,0 +1,56 @@
+use super::triangle3d;
+use crate::{
+    mesh::{Indices, Mesh, Meshable},
+    render_asset::RenderAssetUsages,
+};
+use bevy_math::primitives::{Tetrahedron, Triangle3d};
+use bevy_math::Vec3;
+use wgpu::PrimitiveTopology;
+
+impl Meshable for Tetrahedron {
+    type Output = Mesh;
+
+    fn mesh(&self) -> Self::Output {
+        let mut faces: Vec<_> = self.faces().into();
+
+        // If the tetrahedron has negative orientation, reverse all the triangles so that
+        // they still face outward.
+        if self.signed_volume() < 0.0 {
+            faces.iter_mut().for_each(Triangle3d::reverse);
+        }
+
+        let mut positions = vec![];
+        let mut normals = vec![];
+        let mut uvs = vec![];
+
+        // Each face is meshed as a `Triangle3d`, and we just shove the data into the
+        // vertex attributes sequentially.
+        for face in faces {
+            positions.extend(face.vertices);
+
+            let face_normal: Vec3 = face.normal().map_or(Vec3::ZERO, |n| n.into());
+            normals.extend(vec![face_normal; 3]);
+
+            let face_uvs = triangle3d::uv_coords(&face);
+            uvs.extend(face_uvs);
+        }
+
+        // There are four faces and none of them share vertices.
+        let indices = Indices::U32(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        )
+        .with_inserted_indices(indices)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
+    }
+}
+
+impl From<Tetrahedron> for Mesh {
+    fn from(tetrahedron: Tetrahedron) -> Self {
+        tetrahedron.mesh()
+    }
+}

--- a/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/tetrahedron.rs
@@ -4,7 +4,6 @@ use crate::{
     render_asset::RenderAssetUsages,
 };
 use bevy_math::primitives::{Tetrahedron, Triangle3d};
-use bevy_math::Vec3;
 use wgpu::PrimitiveTopology;
 
 impl Meshable for Tetrahedron {

--- a/crates/bevy_render/src/mesh/primitives/dim3/triangle3d.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/triangle3d.rs
@@ -14,7 +14,7 @@ impl Meshable for Triangle3d {
         let uvs: Vec<_> = uv_coords(self).into();
 
         // Every vertex has the normal of the face of the triangle (or zero if the triangle is degenerate).
-        let normal: Vec3 = self.normal().map_or(Vec3::ZERO, |n| n.into());
+        let normal: Vec3 = normal_vec(self);
         let normals = vec![normal; 3];
 
         let indices = Indices::U32(vec![0, 1, 2]);
@@ -28,6 +28,12 @@ impl Meshable for Triangle3d {
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
         .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
     }
+}
+
+/// The normal of a [`Triangle3d`] with zeroing so that a [`Vec3`] is always obtained for meshing.
+#[inline]
+pub(crate) fn normal_vec(triangle: &Triangle3d) -> Vec3 {
+    triangle.normal().map_or(Vec3::ZERO, |n| n.into())
 }
 
 /// Unskewed uv-coordinates for a [`Triangle3d`].

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -39,6 +39,7 @@ fn setup(
 
     let shapes = [
         meshes.add(Cuboid::default()),
+        meshes.add(Tetrahedron::default()),
         meshes.add(Capsule3d::default()),
         meshes.add(Torus::default()),
         meshes.add(Cylinder::default()),


### PR DESCRIPTION
# Objective

Allow the `Tetrahedron` primitive to be used for mesh generation. This is part of ongoing work to bring unify the capabilities of `bevy_math` primitives.

## Solution

`Tetrahedron` implements `Meshable`. Essentially, each face is just meshed as a `Triangle3d`, but first there is an inversion step when the signed volume of the tetrahedron is negative to ensure that the faces all actually point outward.

## Testing

I loaded up some examples and hackily exchanged existing meshes with the new one to see that it works as expected.
