### PR TITLE
Add triangle_math tests and fix Triangle3d::bounding_sphere bug

### DIFF
--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -611,12 +611,10 @@ mod tests {
         assert_eq!(bounding_sphere.radius(), 1.5);
     }
 
+    #[test]
     fn triangle3d() {
-        // let bs = zero_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY); // DIVISION BY ZERO
-        // assert_eq!(bs.center, Vec3::ZERO, "incorrect bounding sphere center");
-        // assert_eq!(bs.sphere.radius, 0.0, "incorrect bounding sphere radius");
-
         let zero_degenerate_triangle = Triangle3d::new(Vec3::ZERO, Vec3::ZERO, Vec3::ZERO);
+
         let br = zero_degenerate_triangle.aabb_3d(Vec3::ZERO, Quat::IDENTITY);
         assert_eq!(
             br.center(),
@@ -649,15 +647,15 @@ mod tests {
             "incorrect bounding box half extents"
         );
 
-        let common_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
-        let bs = common_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY);
+        let collinear_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
+        let bs = collinear_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY);
         assert_eq!(
             bs.center,
             Vec3::ZERO.into(),
             "incorrect bounding sphere center"
         );
         assert_eq!(bs.sphere.radius, 1.0, "incorrect bounding sphere radius");
-        let br = common_degenerate_triangle.aabb_3d(Vec3::ZERO, Quat::IDENTITY);
+        let br = collinear_degenerate_triangle.aabb_3d(Vec3::ZERO, Quat::IDENTITY);
         assert_eq!(
             br.center(),
             Vec3::ZERO.into(),
@@ -668,5 +666,18 @@ mod tests {
             Vec3::new(1.0, 0.0, 0.0).into(),
             "incorrect bounding box half extents"
         );
+    }
+
+    #[test]
+    #[should_panic]
+    fn degenerate_bounding_sphere_should_panic() {
+        let zero_degenerate_triangle = Triangle3d::new(Vec3::ZERO, Vec3::ZERO, Vec3::ZERO);
+        let bs = zero_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY); // DIVISION BY ZERO
+        assert_eq!(
+            bs.center,
+            Vec3::ZERO.into(),
+            "incorrect bounding sphere center"
+        );
+        assert_eq!(bs.sphere.radius, 0.0, "incorrect bounding sphere radius");
     }
 }

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -323,7 +323,7 @@ impl Bounded3d for Triangle3d {
     /// The [`Triangle3d`] implements the minimal bounding sphere calculation. For acute triangles, the circumcenter is used as
     /// the center of the sphere. For the others, the bounding sphere is the minimal sphere
     /// that contains the largest side of the triangle.
-    fn bounding_sphere(&self, translation: Vec3, _: Quat) -> BoundingSphere {
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
         if self.is_degenerate() || self.is_obtuse() {
             let (p1, p2) = self.largest_side();
             let mid_point = (p1 + p2) / 2.0;

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1271,9 +1271,8 @@ mod tests {
             epsilon = 10e-9
         );
         assert_eq!(default_triangle.normal(), Ok(Dir3::Z), "incorrect normal");
-        assert_eq!(
+        assert!(
             default_triangle.is_degenerate(),
-            false,
             "incorrect degenerate check"
         );
         assert_eq!(
@@ -1319,9 +1318,8 @@ mod tests {
 
         // Degenerate triangle tests
         let zero_degenerate_triangle = Triangle3d::new(Vec3::ZERO, Vec3::ZERO, Vec3::ZERO);
-        assert_eq!(
+        assert!(
             zero_degenerate_triangle.is_degenerate(),
-            true,
             "incorrect degenerate check"
         );
         assert_eq!(
@@ -1336,9 +1334,8 @@ mod tests {
         );
 
         let dup_degenerate_triangle = Triangle3d::new(Vec3::ZERO, Vec3::X, Vec3::X);
-        assert_eq!(
+        assert!(
             dup_degenerate_triangle.is_degenerate(),
-            true,
             "incorrect degenerate check"
         );
         assert_eq!(
@@ -1353,9 +1350,8 @@ mod tests {
         );
 
         let common_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
-        assert_eq!(
+        assert!(
             common_degenerate_triangle.is_degenerate(),
-            true,
             "incorrect degenerate check"
         );
         assert_eq!(

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1211,33 +1211,6 @@ mod tests {
     }
 
     #[test]
-    fn complex_triangle_math() {
-        let [a, b, c] = [Vec3::ZERO, Vec3::new(1., 1., 0.5), Vec3::new(-3., 2.5, 1.)];
-        let triangle = Triangle3d::new(a, b, c);
-
-        assert!(!triangle.is_degenerate(), "incorrectly found degenerate");
-        assert_eq!(triangle.area(), 3.0233467, "incorrect area");
-        assert_eq!(triangle.perimeter(), 9.832292, "incorrect perimeter");
-        assert_eq!(
-            triangle.circumcenter(),
-            Vec3::new(-1., 1.75, 0.75),
-            "incorrect circumcenter"
-        );
-        assert_eq!(
-            triangle.normal(),
-            Ok(Dir3::new_unchecked(Vec3::new(
-                -0.04134491,
-                -0.4134491,
-                0.90958804
-            ))),
-            "incorrect normal"
-        );
-
-        let degenerate = Triangle3d::new(Vec3::NEG_ONE, Vec3::ZERO, Vec3::ONE);
-        assert!(degenerate.is_degenerate(), "did not find degenerate");
-    }
-
-    #[test]
     fn extrusion_math() {
         let circle = Circle::new(0.75);
         let cylinder = Extrusion::new(circle, 2.5);
@@ -1314,6 +1287,28 @@ mod tests {
             acute_triangle.circumcenter(),
             Vec3::new(0.5, 2.475, 0.0),
             "incorrect circumcenter"
+        );
+
+        // Arbitrary triangle tests
+        let [a, b, c] = [Vec3::ZERO, Vec3::new(1., 1., 0.5), Vec3::new(-3., 2.5, 1.)];
+        let triangle = Triangle3d::new(a, b, c);
+
+        assert!(!triangle.is_degenerate(), "incorrectly found degenerate");
+        assert_eq!(triangle.area(), 3.0233467, "incorrect area");
+        assert_eq!(triangle.perimeter(), 9.832292, "incorrect perimeter");
+        assert_eq!(
+            triangle.circumcenter(),
+            Vec3::new(-1., 1.75, 0.75),
+            "incorrect circumcenter"
+        );
+        assert_eq!(
+            triangle.normal(),
+            Ok(Dir3::new_unchecked(Vec3::new(
+                -0.04134491,
+                -0.4134491,
+                0.90958804
+            ))),
+            "incorrect normal"
         );
 
         // Degenerate triangle tests

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -789,9 +789,13 @@ impl Triangle3d {
         let ca = a - c;
 
         // a^2 + b^2 < c^2 for an acute triangle
-        let mut side_lengths = [ab.length(), bc.length(), ca.length()];
+        let mut side_lengths = [
+            ab.length_squared(),
+            bc.length_squared(),
+            ca.length_squared(),
+        ];
         side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        side_lengths[0].powf(2.) + side_lengths[1].powf(2.) > side_lengths[2].powf(2.)
+        side_lengths[0] + side_lengths[1] > side_lengths[2]
     }
 
     /// Checks if the triangle is obtuse, meaning one angle is greater than 90 degrees
@@ -803,9 +807,13 @@ impl Triangle3d {
         let ca = a - c;
 
         // a^2 + b^2 > c^2 for an obtuse triangle
-        let mut side_lengths = [ab.length(), bc.length(), ca.length()];
+        let mut side_lengths = [
+            ab.length_squared(),
+            bc.length_squared(),
+            ca.length_squared(),
+        ];
         side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        side_lengths[0].powf(2.) + side_lengths[1].powf(2.) < side_lengths[2].powf(2.)
+        side_lengths[0] + side_lengths[1] < side_lengths[2]
     }
 
     /// Reverse the triangle by swapping the first and last vertices.

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1349,18 +1349,18 @@ mod tests {
             "incorrect largest side"
         );
 
-        let common_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
+        let collinear_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
         assert!(
-            common_degenerate_triangle.is_degenerate(),
+            collinear_degenerate_triangle.is_degenerate(),
             "incorrect degenerate check"
         );
         assert_eq!(
-            common_degenerate_triangle.normal(),
+            collinear_degenerate_triangle.normal(),
             Err(InvalidDirectionError::Zero),
             "incorrect normal"
         );
         assert_eq!(
-            common_degenerate_triangle.largest_side(),
+            collinear_degenerate_triangle.largest_side(),
             (Vec3::NEG_X, Vec3::X),
             "incorrect largest side"
         );

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1272,7 +1272,7 @@ mod tests {
         );
         assert_eq!(default_triangle.normal(), Ok(Dir3::Z), "incorrect normal");
         assert!(
-            default_triangle.is_degenerate(),
+            !default_triangle.is_degenerate(),
             "incorrect degenerate check"
         );
         assert_eq!(

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -780,6 +780,34 @@ impl Triangle3d {
         ab.cross(ac).length() < 10e-7
     }
 
+    /// Checks if the triangle is acute, meaning all angles are less than 90 degrees
+    #[inline(always)]
+    pub fn is_acute(&self) -> bool {
+        let [a, b, c] = self.vertices;
+        let ab = b - a;
+        let bc = c - b;
+        let ca = a - c;
+
+        // a^2 + b^2 < c^2 for an acute triangle
+        let mut side_lengths = [ab.length(), bc.length(), ca.length()];
+        side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        side_lengths[0].powf(2.) + side_lengths[1].powf(2.) > side_lengths[2].powf(2.)
+    }
+
+    /// Checks if the triangle is obtuse, meaning one angle is greater than 90 degrees
+    #[inline(always)]
+    pub fn is_obtuse(&self) -> bool {
+        let [a, b, c] = self.vertices;
+        let ab = b - a;
+        let bc = c - b;
+        let ca = a - c;
+
+        // a^2 + b^2 > c^2 for an obtuse triangle
+        let mut side_lengths = [ab.length(), bc.length(), ca.length()];
+        side_lengths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        side_lengths[0].powf(2.) + side_lengths[1].powf(2.) < side_lengths[2].powf(2.)
+    }
+
     /// Reverse the triangle by swapping the first and last vertices.
     #[inline(always)]
     pub fn reverse(&mut self) {
@@ -1288,6 +1316,11 @@ mod tests {
             Vec3::new(0.5, 2.475, 0.0),
             "incorrect circumcenter"
         );
+
+        assert!(acute_triangle.is_acute());
+        assert!(!acute_triangle.is_obtuse());
+        assert!(!obtuse_triangle.is_acute());
+        assert!(obtuse_triangle.is_obtuse());
 
         // Arbitrary triangle tests
         let [a, b, c] = [Vec3::ZERO, Vec3::new(1., 1., 0.5), Vec3::new(-3., 2.5, 1.)];


### PR DESCRIPTION
# Objective

Adopted #12659.

Resolved the merge conflicts on #12659;

* I merged the `triangle_tests` added by this PR and by #13020.
* I moved the [commented out code](https://github.com/bevyengine/bevy/pull/12659#discussion_r1536640427) from the original PR into a separate test with `#[should_panic]`.