### PR TITLE
Fix lighting example following emissive material changes in #13350

### DIFF
--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -146,8 +146,7 @@ fn setup(
                 mesh: meshes.add(Sphere::new(0.1).mesh().uv(32, 18)),
                 material: materials.add(StandardMaterial {
                     base_color: RED.into(),
-                    emissive: Color::linear_rgba(713.0, 0.0, 0.0, 0.0),
-                    emissive_exposure_weight: 1.0,
+                    emissive: Color::linear_rgba(4.0, 0.0, 0.0, 0.0),
                     ..default()
                 }),
                 ..default()
@@ -175,8 +174,7 @@ fn setup(
                 mesh: meshes.add(Capsule3d::new(0.1, 0.125)),
                 material: materials.add(StandardMaterial {
                     base_color: LIME.into(),
-                    emissive: Color::linear_rgba(0.0, 713.0, 0.0, 0.0),
-                    emissive_exposure_weight: 1.0,
+                    emissive: Color::linear_rgba(0.0, 4.0, 0.0, 0.0),
                     ..default()
                 }),
                 ..default()

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -147,6 +147,7 @@ fn setup(
                 material: materials.add(StandardMaterial {
                     base_color: RED.into(),
                     emissive: Color::linear_rgba(713.0, 0.0, 0.0, 0.0),
+                    emissive_exposure_weight: 1.0,
                     ..default()
                 }),
                 ..default()
@@ -175,6 +176,7 @@ fn setup(
                 material: materials.add(StandardMaterial {
                     base_color: LIME.into(),
                     emissive: Color::linear_rgba(0.0, 713.0, 0.0, 0.0),
+                    emissive_exposure_weight: 1.0,
                     ..default()
                 }),
                 ..default()


### PR DESCRIPTION
# Objective

After the emissive material changes in #13350, the red and green point lights in the `lighting` example turned white.

## Solution

This PR gives the point lights the `emissive_exposure_weight` property in order for them to appear with correct color again.

## Testing

The `lighting` example before this fix:

![image](https://github.com/bevyengine/bevy/assets/143610747/be31d422-f616-4651-ab63-18ddfdba3773)

After this fix (looks the same as before #13350):

![image](https://github.com/bevyengine/bevy/assets/143610747/e5b5eab3-0588-4f30-bf74-2b52db7345ad)