### PR TITLE
add Debug for ptr types

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -7,7 +7,7 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
-use core::fmt::{self, Debug, Formatter, Pointer};
+use core::fmt::{self, Formatter, Pointer};
 use core::{
     cell::UnsafeCell, marker::PhantomData, mem::ManuallyDrop, num::NonZeroUsize, ptr::NonNull,
 };
@@ -155,7 +155,7 @@ impl<'a, T: ?Sized> From<&'a mut T> for ConstNonNull<T> {
 ///
 /// It may be helpful to think of this type as similar to `&'a dyn Any` but without
 /// the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
 pub struct Ptr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a u8, A)>);
 
@@ -170,6 +170,7 @@ pub struct Ptr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a u8, A)>
 ///
 /// It may be helpful to think of this type as similar to `&'a mut dyn Any` but without
 /// the metadata and able to point to data that does not correspond to a Rust type.
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct PtrMut<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut u8, A)>);
 
@@ -188,6 +189,7 @@ pub struct PtrMut<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut 
 ///
 /// It may be helpful to think of this type as similar to `&'a mut ManuallyDrop<dyn Any>` but
 /// without the metadata and able to point to data that does not correspond to a Rust type.
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct OwningPtr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut u8, A)>);
 
@@ -256,12 +258,6 @@ macro_rules! impl_ptr {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 Pointer::fmt(&self.0, f)
-            }
-        }
-
-        impl<A: IsAligned> Debug for $ptr<'_, A> {
-            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                Debug::fmt(&self.0, f)
             }
         }
     };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -7,7 +7,7 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
-use core::fmt::{self, Formatter, Pointer};
+use core::fmt::{self, Debug, Formatter, Pointer};
 use core::{
     cell::UnsafeCell, marker::PhantomData, mem::ManuallyDrop, num::NonZeroUsize, ptr::NonNull,
 };
@@ -256,6 +256,12 @@ macro_rules! impl_ptr {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 Pointer::fmt(&self.0, f)
+            }
+        }
+
+        impl<A: IsAligned> Debug for $ptr<'_, A> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                Debug::fmt(&self.0, f)
             }
         }
     };


### PR DESCRIPTION
# Objective

- I wanted to store a Ptr in a struct of mine that has a `#[derive(Debug)]` and I noticed that the Ptrs don't implement Debug, even though the underlying `NonNull<u8>` does

## Solution

- Add `#[derive(Debug)]`
