### PR TITLE
fix emissive value in StandardMaterial after swith to LinearRgba

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -977,7 +977,7 @@ impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
 
         StandardMaterialUniform {
             base_color: LinearRgba::from(self.base_color).to_vec4(),
-            emissive: self.emissive.to_vec4(),
+            emissive,
             roughness: self.perceptual_roughness,
             metallic: self.metallic,
             reflectance: self.reflectance,


### PR DESCRIPTION
# Objective

- #13352 broke bloom in 3d

## Solution

- Use the correct value for `emissive` in `StandardMaterial`. It's computed just above but unused
https://github.com/bevyengine/bevy/blob/d87505899fc6adcb1a26550e921b0f5b0c351c57/crates/bevy_pbr/src/pbr_material.rs#L975-L976

## Testing

- Run example `bloom_3d`
