### PR TITLE
Add `Triangle3d` / `Tetrahedron` to render_primitives example

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -6,7 +6,7 @@ use std::f32::consts::TAU;
 use bevy_color::Color;
 use bevy_math::primitives::{
     BoxedPolyline3d, Capsule3d, Cone, ConicalFrustum, Cuboid, Cylinder, Line3d, Plane3d,
-    Polyline3d, Primitive3d, Segment3d, Sphere, Tetrahedron, Torus,
+    Polyline3d, Primitive3d, Segment3d, Sphere, Tetrahedron, Torus, Triangle3d,
 };
 use bevy_math::{Dir3, Quat, Vec3};
 
@@ -400,6 +400,34 @@ where
                 .iter()
                 .copied()
                 .map(rotate_then_translate_3d(rotation, position)),
+            color,
+        );
+    }
+}
+
+// triangle 3d
+
+impl<'w, 's, Config, Clear> GizmoPrimitive3d<Triangle3d> for Gizmos<'w, 's, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
+    type Output<'a> = () where Self: 'a;
+
+    fn primitive_3d(
+        &mut self,
+        primitive: Triangle3d,
+        position: Vec3,
+        rotation: Quat,
+        color: impl Into<Color>,
+    ) -> Self::Output<'_> {
+        if !self.enabled {
+            return;
+        }
+
+        let [a, b, c] = primitive.vertices;
+        self.linestrip(
+            [a, b, c, a].map(rotate_then_translate_3d(rotation, position)),
             color,
         );
     }

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -84,6 +84,7 @@ enum PrimitiveSelected {
     Cone,
     ConicalFrustum,
     Torus,
+    Tetrahedron,
 }
 
 impl std::fmt::Display for PrimitiveSelected {
@@ -98,7 +99,7 @@ impl std::fmt::Display for PrimitiveSelected {
 }
 
 impl PrimitiveSelected {
-    const ALL: [Self; 15] = [
+    const ALL: [Self; 16] = [
         Self::RectangleAndCuboid,
         Self::CircleAndSphere,
         Self::Ellipse,
@@ -114,6 +115,7 @@ impl PrimitiveSelected {
         Self::Cone,
         Self::ConicalFrustum,
         Self::Torus,
+        Self::Tetrahedron,
     ];
 
     fn next(self) -> Self {
@@ -157,11 +159,19 @@ const ELLIPSE: Ellipse = Ellipse {
     half_size: Vec2::new(BIG_2D, SMALL_2D),
 };
 
-const TRIANGLE: Triangle2d = Triangle2d {
+const TRIANGLE_2D: Triangle2d = Triangle2d {
     vertices: [
-        Vec2::new(SMALL_2D, 0.0),
-        Vec2::new(0.0, SMALL_2D),
-        Vec2::new(-SMALL_2D, 0.0),
+        Vec2::new(BIG_2D, 0.0),
+        Vec2::new(0.0, BIG_2D),
+        Vec2::new(-BIG_2D, 0.0),
+    ],
+};
+
+const TRIANGLE_3D: Triangle3d = Triangle3d {
+    vertices: [
+        Vec3::new(BIG_3D, 0.0, 0.0),
+        Vec3::new(0.0, BIG_3D, 0.0),
+        Vec3::new(-BIG_3D, 0.0, 0.0),
     ],
 };
 
@@ -248,6 +258,15 @@ const ANNULUS: Annulus = Annulus {
 const TORUS: Torus = Torus {
     minor_radius: SMALL_3D / 2.0,
     major_radius: SMALL_3D * 1.5,
+};
+
+const TETRAHEDRON: Tetrahedron = Tetrahedron {
+    vertices: [
+        Vec3::new(-BIG_3D, 0.0, 0.0),
+        Vec3::new(BIG_3D, 0.0, 0.0),
+        Vec3::new(0.0, 0.0, -BIG_3D * 1.67),
+        Vec3::new(0.0, BIG_3D * 1.67, -BIG_3D * 0.5),
+    ],
 };
 
 fn setup_cameras(mut commands: Commands) {
@@ -420,7 +439,7 @@ fn draw_gizmos_2d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         }
         PrimitiveSelected::CircleAndSphere => gizmos.primitive_2d(CIRCLE, POSITION, angle, color),
         PrimitiveSelected::Ellipse => gizmos.primitive_2d(ELLIPSE, POSITION, angle, color),
-        PrimitiveSelected::Triangle => gizmos.primitive_2d(TRIANGLE, POSITION, angle, color),
+        PrimitiveSelected::Triangle => gizmos.primitive_2d(TRIANGLE_2D, POSITION, angle, color),
         PrimitiveSelected::Plane => gizmos.primitive_2d(PLANE_2D, POSITION, angle, color),
         PrimitiveSelected::Line => drop(gizmos.primitive_2d(LINE2D, POSITION, angle, color)),
         PrimitiveSelected::Segment => drop(gizmos.primitive_2d(SEGMENT_2D, POSITION, angle, color)),
@@ -434,6 +453,7 @@ fn draw_gizmos_2d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
         PrimitiveSelected::Cone => {}
         PrimitiveSelected::ConicalFrustum => {}
         PrimitiveSelected::Torus => gizmos.primitive_2d(ANNULUS, POSITION, angle, color),
+        PrimitiveSelected::Tetrahedron => {}
     }
 }
 
@@ -464,7 +484,7 @@ fn spawn_primitive_2d(
         Some(RECTANGLE.mesh()),
         Some(CIRCLE.mesh().build()),
         Some(ELLIPSE.mesh().build()),
-        Some(TRIANGLE.mesh()),
+        Some(TRIANGLE_2D.mesh()),
         None, // plane
         None, // line
         None, // segment
@@ -476,6 +496,7 @@ fn spawn_primitive_2d(
         None, // cone
         None, // conical frustum
         Some(ANNULUS.mesh().build()),
+        None, // tetrahedron
     ]
     .into_iter()
     .zip(PrimitiveSelected::ALL)
@@ -510,7 +531,7 @@ fn spawn_primitive_3d(
         Some(CUBOID.mesh()),
         Some(SPHERE.mesh().build()),
         None, // ellipse
-        None, // triangle
+        Some(TRIANGLE_3D.mesh()),
         Some(PLANE_3D.mesh().build()),
         None, // line
         None, // segment
@@ -522,6 +543,7 @@ fn spawn_primitive_3d(
         None, // cone
         None, // conical frustum
         Some(TORUS.mesh().build()),
+        Some(TETRAHEDRON.mesh()),
     ]
     .into_iter()
     .zip(PrimitiveSelected::ALL)
@@ -626,7 +648,7 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
                 .resolution(resolution),
         ),
         PrimitiveSelected::Ellipse => {}
-        PrimitiveSelected::Triangle => {}
+        PrimitiveSelected::Triangle => gizmos.primitive_3d(TRIANGLE_3D, POSITION, rotation, color),
         PrimitiveSelected::Plane => drop(gizmos.primitive_3d(PLANE_3D, POSITION, rotation, color)),
         PrimitiveSelected::Line => gizmos.primitive_3d(LINE3D, POSITION, rotation, color),
         PrimitiveSelected::Segment => gizmos.primitive_3d(SEGMENT_3D, POSITION, rotation, color),
@@ -658,5 +680,8 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
                 .minor_resolution(resolution)
                 .major_resolution(resolution),
         ),
+        PrimitiveSelected::Tetrahedron => {
+            gizmos.primitive_3d(TETRAHEDRON, POSITION, rotation, color);
+        }
     }
 }


### PR DESCRIPTION
# Objective

This is just cleanup; we've got some more renderable gizmos and primitives now that hadn't been added to this example, so let's add them.

## Solution

In the `render_primitives` example:
- Added `Triangle3d` mesh
- Wrote `primitive_3d` gizmo impl for `Triangle3d` and added the gizmo
- Added `Tetrahedron` mesh and gizmo

I also made the 2d triangle bigger, since it was really small.

## Testing

You can just run the example to see that everything turned out all right.

## Other

Feel free to let me know if there are other primitives that I missed; I'm happy to tack them onto this PR.