### PR TITLE
Document `inherited_visibility` using internal `include_doc!(...)` macro

### DIFF
--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -12,6 +12,7 @@ use bevy_render::{
     view::{InheritedVisibility, ViewVisibility, Visibility, VisibleEntities},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
+use bevy_utils::include_doc;
 
 /// A component bundle for PBR entities with a [`Mesh`] and a [`StandardMaterial`].
 pub type PbrBundle = MaterialMeshBundle<StandardMaterial>;
@@ -25,7 +26,7 @@ pub struct MaterialMeshBundle<M: Material> {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -88,7 +89,7 @@ pub struct PointLightBundle {
     pub global_transform: GlobalTransform,
     /// Enables or disables the light
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -104,7 +105,7 @@ pub struct SpotLightBundle {
     pub global_transform: GlobalTransform,
     /// Enables or disables the light
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -122,7 +123,7 @@ pub struct DirectionalLightBundle {
     pub global_transform: GlobalTransform,
     /// Enables or disables the light
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -28,7 +28,7 @@ pub struct MaterialMeshBundle<M: Material> {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }
 
@@ -91,7 +91,7 @@ pub struct PointLightBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }
 
@@ -107,7 +107,7 @@ pub struct SpotLightBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }
 
@@ -125,6 +125,6 @@ pub struct DirectionalLightBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -250,7 +250,7 @@ pub struct MaterialMeshletMeshBundle<M: Material> {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }
 

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -248,7 +248,7 @@ pub struct MaterialMeshletMeshBundle<M: Material> {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{prelude::*, query::QueryFilter};
 use bevy_hierarchy::{Children, Parent};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::{components::GlobalTransform, TransformSystem};
-use bevy_utils::{Parallel, TypeIdMap};
+use bevy_utils::{include_doc, Parallel, TypeIdMap};
 
 use crate::{
     camera::{Camera, CameraProjection},
@@ -141,11 +141,11 @@ impl ViewVisibility {
 ///   * You may use the [`VisibilityBundle`] to guarantee this.
 #[derive(Bundle, Debug, Clone, Default)]
 pub struct VisibilityBundle {
-    /// The visibility of the entity.
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
-    // The inherited visibility of the entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    // The computed visibility of the entity.
+		#[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }
 

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -31,7 +31,7 @@ pub struct SpriteBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }
 
@@ -65,6 +65,6 @@ pub struct SpriteSheetBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
 }

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -8,6 +8,7 @@ use bevy_render::{
     view::{InheritedVisibility, ViewVisibility, Visibility},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
+use bevy_utils::include_doc;
 
 /// A [`Bundle`] of components for drawing a single sprite from an image.
 ///
@@ -28,7 +29,7 @@ pub struct SpriteBundle {
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -62,7 +63,7 @@ pub struct SpriteSheetBundle {
     pub atlas: TextureAtlas,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -81,7 +81,7 @@ pub struct Text2dBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Contains the size of the text and its glyph's position and scale data. Generated via [`TextPipeline::queue_text`]
     pub text_layout_info: TextLayoutInfo,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -25,7 +25,7 @@ use bevy_render::{
 };
 use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, SpriteSource, TextureAtlasLayout};
 use bevy_transform::prelude::{GlobalTransform, Transform};
-use bevy_utils::HashSet;
+use bevy_utils::{include_doc, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 
 /// The maximum width and height of text. The text will wrap according to the specified size.
@@ -79,7 +79,7 @@ pub struct Text2dBundle {
     pub global_transform: GlobalTransform,
     /// The visibility properties of the text.
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -51,7 +51,7 @@ pub struct NodeBundle {
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -164,7 +164,7 @@ pub struct AtlasImageBundle {
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -205,7 +205,7 @@ pub struct TextBundle {
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -333,7 +333,7 @@ pub struct ButtonBundle {
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
@@ -389,7 +389,7 @@ pub struct MaterialNodeBundle<M: UiMaterial> {
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -49,7 +49,7 @@ pub struct NodeBundle {
     /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
@@ -112,7 +112,7 @@ pub struct ImageBundle {
     ///
     /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
@@ -162,7 +162,7 @@ pub struct AtlasImageBundle {
     ///
     /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
@@ -203,7 +203,7 @@ pub struct TextBundle {
     ///
     /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
@@ -331,7 +331,7 @@ pub struct ButtonBundle {
     ///
     /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
     pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
@@ -387,7 +387,7 @@ pub struct MaterialNodeBundle<M: UiMaterial> {
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
+    #[doc = include_doc!(visibility)]
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -17,6 +17,7 @@ use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
 use bevy_text::{BreakLineOn, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
+use bevy_utils::include_doc;
 
 /// The basic UI node.
 ///
@@ -113,7 +114,7 @@ pub struct ImageBundle {
     pub global_transform: GlobalTransform,
     /// Describes the visibility properties of the node
     pub visibility: Visibility,
-    /// Inherited visibility of an entity.
+    #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -53,7 +53,7 @@ pub struct NodeBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
@@ -116,7 +116,7 @@ pub struct ImageBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
@@ -166,7 +166,7 @@ pub struct AtlasImageBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
@@ -207,7 +207,7 @@ pub struct TextBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
@@ -335,7 +335,7 @@ pub struct ButtonBundle {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
@@ -391,7 +391,7 @@ pub struct MaterialNodeBundle<M: UiMaterial> {
     pub visibility: Visibility,
     #[doc = include_doc!(inherited_visibility)]
     pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    #[doc = include_doc!(view_visibility)]
     pub view_visibility: ViewVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,

--- a/crates/bevy_utils/src/include_doc.rs
+++ b/crates/bevy_utils/src/include_doc.rs
@@ -26,4 +26,10 @@ macro_rules! include_doc {
             "/../../inline-docs/visibility.md"
         ))
     };
+		(view_visibility) => {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../inline-docs/view_visibility.md"
+        ))
+    };
 }

--- a/crates/bevy_utils/src/include_doc.rs
+++ b/crates/bevy_utils/src/include_doc.rs
@@ -20,4 +20,10 @@ macro_rules! include_doc {
             "/../../inline-docs/inherited_visibility.md"
         ))
     };
+		(visibility) => {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../inline-docs/visibility.md"
+        ))
+    };
 }

--- a/crates/bevy_utils/src/include_doc.rs
+++ b/crates/bevy_utils/src/include_doc.rs
@@ -1,0 +1,20 @@
+/// Allows for compile-time deduplication of documentation for commonly repeated documentation.
+/// Assumes that the crate is compiling under bevy-root-dir/crates/some-crate-name/ ...
+///
+/// ```rust
+/// use bevy_utils::include_doc;
+/// 
+/// struct MyType {
+///   /// Inherited visibility of an entity.
+///   inherited_visibility_duplicated: i32,
+///
+///   #[doc = include_doc!(inherited_visibility)]
+///   inherited_visibility_better_docs: u32,
+/// }
+/// ```
+#[macro_export]
+macro_rules! include_doc {
+    (inherited_visibility) => {
+			include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../inline-docs/inherited_visibility.md"))
+		};
+}

--- a/crates/bevy_utils/src/include_doc.rs
+++ b/crates/bevy_utils/src/include_doc.rs
@@ -3,7 +3,7 @@
 ///
 /// ```rust
 /// use bevy_utils::include_doc;
-/// 
+///
 /// struct MyType {
 ///   /// Inherited visibility of an entity.
 ///   inherited_visibility_duplicated: i32,
@@ -15,6 +15,9 @@
 #[macro_export]
 macro_rules! include_doc {
     (inherited_visibility) => {
-			include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../inline-docs/inherited_visibility.md"))
-		};
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../inline-docs/inherited_visibility.md"
+        ))
+    };
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -25,6 +25,7 @@ mod cow_arc;
 mod default;
 mod once;
 mod parallel_queue;
+mod include_doc;
 
 pub use ahash::{AHasher, RandomState};
 pub use bevy_utils_proc_macros::*;

--- a/inline-docs/inherited_visibility.md
+++ b/inline-docs/inherited_visibility.md
@@ -1,0 +1,5 @@
+Inherited visibility of an entity.
+
+This will not be accurate until [`VisibilityPropagate`](`bevy_render::view::visibility::VisibilitySystems`) runs in the [`PostUpdate`](`bevy_app::PostUpdate`) schedule.
+
+If this is false, then [`ViewVisibility`](`bevy_render::view::visibility::ViewVisibility`) should also be false.

--- a/inline-docs/view_visibility.md
+++ b/inline-docs/view_visibility.md
@@ -1,0 +1,11 @@
+Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+
+Each frame, this will be reset to `false` during [`VisibilityPropagate`] systems in [`PostUpdate`].
+Later in the frame, systems in [`CheckVisibility`] will mark any visible entities using [`ViewVisibility::set`](`bevy_render::view::visibility::ViewVisibility::set`).
+Because of this, values of this type will be marked as changed every frame, even when they do not change.
+
+If you wish to add custom visibility system that sets this value, make sure you add it to the [`CheckVisibility`] set.
+
+[`VisibilityPropagate`]: bevy_render::view::visibility::VisibilitySystems::VisibilityPropagate
+[`CheckVisibility`]: bevy_render::view::visibility::VisibilitySystems::CheckVisibility
+[`PostUpdate`]: bevy_app::PostUpdate

--- a/inline-docs/visibility.md
+++ b/inline-docs/visibility.md
@@ -1,0 +1,6 @@
+Describes the visibility properties of the node.
+A user indication of whether an entity is visible. Propagates down the entity hierarchy.
+
+If an entity is hidden in this way, all [`Children`](`bevy_hierarchy::Children`) (and all of their children and so on) who are set to [`Visibility::Inherited`](`bevy_render::view::visibility::Visibility::Inherited`) will also be hidden.
+
+This is done by the `visibility_propagate_system` which uses the entity hierarchy and [`Visibility`](`bevy_render::view::visibility::Visibility`) to set the values of each entity's [`InheritedVisibility`](`bevy_render::view::visibility::InheritedVisibility`) component.


### PR DESCRIPTION
# Objective

Centralize documentation.
A small but rather useful change I made in a personal project [here](https://github.com/ActuallyHappening/Apple-CLIs/blob/110e594624e17815ae3f77c73e06eb3d6229838c/src/lib.rs#L75) was to extract documentation I commonly repeated into a macro which I called `include_doc!`to mimic an `include_str!` invocation.
This allows you to document fields / structs / items using `#[doc = include_doc!(compile_time_name_here)]` rather than hard coding the documentation (which isn't necessarily a bad option) or doing the manual `#[doc = include_str!(... annoying concat!() stuff here, or even worse a hard coded path)]`.

## Solution

A very simple macro, which allows for easy expansion to document further items in the future:
```rust
/// Assumes that the crate is compiling under bevy-root-dir/crates/some-crate-name/ ...
#[macro_export]
macro_rules! include_doc {
  (inherited_visibility) => {
    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../inline-docs/inherited_visibility.md"))
  };
// new branches can be easily added, I haven't added any more than 1 so far in case this PR is not accepted
// but I would definitely add many more here if accepted
}
```

## Testing

- Did you test these changes? If so, how?
Yes, there is a documentation test on the macro itself and multiple uses. This is purely a compile time documentation features.

- Are there any parts that need more testing?
Uses outside of the root/crates/* might need adjusting, but no need yet.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?
No

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Only macOS I tested it on. This *might* matter because of path prefixes `/` versus `\` although I don't think so. The offending macro used is `include_str!(concat!("path", "/second-path"))` which might fail on windows.

---

## Changelog
### Fixed
Improved documentation organisation.
