### PR TITLE
add glsl feature for bevy_pbr

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -62,7 +62,10 @@ symphonia-vorbis = ["bevy_audio/symphonia-vorbis"]
 symphonia-wav = ["bevy_audio/symphonia-wav"]
 
 # Shader formats
-shader_format_glsl = ["bevy_render/shader_format_glsl", "bevy_pbr?/shader_format_glsl"]
+shader_format_glsl = [
+  "bevy_render/shader_format_glsl", 
+  "bevy_pbr?/shader_format_glsl"
+]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]
 
 serialize = [

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -64,7 +64,7 @@ symphonia-wav = ["bevy_audio/symphonia-wav"]
 # Shader formats
 shader_format_glsl = [
   "bevy_render/shader_format_glsl", 
-  "bevy_pbr?/shader_format_glsl"
+  "bevy_pbr?/shader_format_glsl",
 ]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -63,7 +63,7 @@ symphonia-wav = ["bevy_audio/symphonia-wav"]
 
 # Shader formats
 shader_format_glsl = [
-  "bevy_render/shader_format_glsl", 
+  "bevy_render/shader_format_glsl",
   "bevy_pbr?/shader_format_glsl",
 ]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -62,7 +62,7 @@ symphonia-vorbis = ["bevy_audio/symphonia-vorbis"]
 symphonia-wav = ["bevy_audio/symphonia-wav"]
 
 # Shader formats
-shader_format_glsl = ["bevy_render/shader_format_glsl"]
+shader_format_glsl = ["bevy_render/shader_format_glsl", "bevy_pbr?/shader_format_glsl"]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]
 
 serialize = [


### PR DESCRIPTION
# Objective

in bevy_pbr we check for `shader_format_glsl` before using binding arrays due to a naga->glsl limitation. but the feature is currently only enabled for the bevy_render crate.

fix #13232

## Solution

enable the feature for bevy_pbr too.