### PR TITLE
Add Hash for Tick

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -837,7 +837,7 @@ impl Components {
 ///
 /// *Note* that a system that hasn't been run yet has a `Tick` of 0.
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, Hash, PartialEq))]
 pub struct Tick {
     tick: u32,
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -837,7 +837,11 @@ impl Components {
 ///
 /// *Note* that a system that hasn't been run yet has a `Tick` of 0.
 #[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, Hash, PartialEq))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, Hash, PartialEq)
+)]
 pub struct Tick {
     tick: u32,
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -836,7 +836,7 @@ impl Components {
 /// This is used to power change detection.
 ///
 /// *Note* that a system that hasn't been run yet has a `Tick` of 0.
-#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
 pub struct Tick {
     tick: u32,


### PR DESCRIPTION
# Objective

- There are some situations (networking) where storing `Tick` as a key in a hashmap is useful

