### PR TITLE
Set ambient_intensity to 0.0 in volumetric_fog example, correct doc comment

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -102,18 +102,19 @@ pub struct VolumetricFogSettings {
 
     /// Color of the ambient light.
     ///
-    /// This is separate from Bevy's [`crate::light::AmbientLight`] because an
-    /// [`crate::environment_map::EnvironmentMapLight`] is still considered an ambient light for the
-    /// purposes of volumetric fog. If you're using a
-    /// [`crate::environment_map::EnvironmentMapLight`], for best results, this should be a good
-    /// approximation of the average color of the environment map.
+    /// This is separate from Bevy's [`AmbientLight`](crate::light::AmbientLight) because an
+    /// [`EnvironmentMapLight`](crate::environment_map::EnvironmentMapLight) is
+    /// still considered an ambient light for the purposes of volumetric fog. If you're using a
+    /// [`EnvironmentMapLight`](crate::environment_map::EnvironmentMapLight), for best results,
+    /// this should be a good approximation of the average color of the environment map.
     ///
     /// Defaults to white.
     pub ambient_color: Color,
 
     /// The brightness of the ambient light.
     ///
-    /// If there's no [`crate::environment_map::EnvironmentMapLight`], set this to 0.
+    /// If there's no [`EnvironmentMapLight`](crate::environment_map::EnvironmentMapLight),
+    /// set this to 0.
     ///
     /// Defaults to 0.1.
     pub ambient_intensity: f32,

--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -103,9 +103,9 @@ pub struct VolumetricFogSettings {
     /// Color of the ambient light.
     ///
     /// This is separate from Bevy's [`crate::light::AmbientLight`] because an
-    /// [`EnvironmentMapLight`] is still considered an ambient light for the
+    /// [`crate::environment_map::EnvironmentMapLight`] is still considered an ambient light for the
     /// purposes of volumetric fog. If you're using a
-    /// [`crate::EnvironmentMapLight`], for best results, this should be a good
+    /// [`crate::environment_map::EnvironmentMapLight`], for best results, this should be a good
     /// approximation of the average color of the environment map.
     ///
     /// Defaults to white.
@@ -113,7 +113,7 @@ pub struct VolumetricFogSettings {
 
     /// The brightness of the ambient light.
     ///
-    /// If there's no environment map light, set this to 0.
+    /// If there's no [`crate::environment_map::EnvironmentMapLight`], set this to 0.
     ///
     /// Defaults to 0.1.
     pub ambient_intensity: f32,

--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -113,7 +113,7 @@ pub struct VolumetricFogSettings {
 
     /// The brightness of the ambient light.
     ///
-    /// If there's no ambient light, set this to 0.
+    /// If there's no environment map light, set this to 0.
     ///
     /// Defaults to 0.1.
     pub ambient_intensity: f32,

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -50,7 +50,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 1000.0,
         })
-        .insert(VolumetricFogSettings::default());
+        .insert(VolumetricFogSettings {
+            ambient_intensity: 0.0,
+            ..default()
+        });
 
     // Add the help text.
     commands.spawn(

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -51,6 +51,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             brightness: 1000.0,
         })
         .insert(VolumetricFogSettings {
+            // This value is explicitly set to 0 since we have no environment map light
             ambient_intensity: 0.0,
             ..default()
         });


### PR DESCRIPTION
# Objective

- Fixes #13521

## Solution

Set `ambient_intensity` to 0.0 in volumetric_fog example.

I chose setting it explicitly over changing the default in order to make it clear that this needs to be set depending on whether you have an `EnvironmentMapLight`. See documentation for `ambient_intensity` and related members.

## Testing

- Run the volumetric_fog example and notice how the light shown in #13521 is not there anymore, as expected.