### PR TITLE
Allow bevy_transform to be used as a barebones dependency

### DIFF
--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -10,26 +10,42 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
+bevy_app = { path = "../bevy_app", version = "0.14.0-dev", optional = true }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev", features = [
   "bevy_reflect",
-] }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev" }
-bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
+], optional = true }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev", optional = true }
+bevy_math = { path = "../bevy_math", version = "0.14.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
-] }
+], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
-bevy_math = { path = "../bevy_math", version = "0.14.0-dev", features = [
+bevy_math = { path = "../bevy_math", version = "0.14.0-dev", default-features = false, features = [
   "approx",
 ] }
 approx = "0.5.1"
 
 [features]
+# Adds normal Bevy impls like deriving components, bundles, reflection, as well as adding
+# systems for transform propagation and more.
+# This exists because it allows opting out of all of this, leaving only a bare-bones transform struct,
+# which enables users to depend on that without needing the larger Bevy dependency tree.
+bevy-support = [
+  "dep:bevy_app",
+  "dep:bevy_ecs",
+  "dep:bevy_hierarchy",
+  "dep:bevy_reflect",
+  "bevy_math/bevy_reflect",
+]
+
+# Turning off default features leaves you with a barebones
+# definition of transform.
+default = ["bevy-support"]
+
 serialize = ["dep:serde", "bevy_math/serialize"]
 
 [lints]

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -1,8 +1,10 @@
 use std::ops::Mul;
 
 use super::Transform;
+#[cfg(feature = "bevy-support")]
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Dir3, Mat4, Quat, Vec3, Vec3A};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 /// Describe the position of an entity relative to the reference frame.
@@ -33,9 +35,13 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// - [`transform`]
 ///
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
-#[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(Component, Default, PartialEq)]
+#[cfg_attr(
+    feature = "bevy-support",
+    derive(Component, Reflect),
+    reflect(Component, Default, PartialEq)
+)]
 pub struct GlobalTransform(Affine3A);
 
 macro_rules! impl_local_axis {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -1,8 +1,9 @@
 use super::GlobalTransform;
+#[cfg(feature = "bevy-support")]
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Dir3, Mat3, Mat4, Quat, Vec3};
-use bevy_reflect::prelude::*;
-use bevy_reflect::Reflect;
+#[cfg(feature = "bevy-support")]
+use bevy_reflect::{prelude::*, Reflect};
 use std::ops::Mul;
 
 /// Describe the position of an entity. If the entity has a parent, the position is relative
@@ -32,9 +33,13 @@ use std::ops::Mul;
 /// - [`transform`]
 ///
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
-#[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(Component, Default, PartialEq)]
+#[cfg_attr(
+    feature = "bevy-support",
+    derive(Component, Reflect),
+    reflect(Component, Default, PartialEq)
+)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
     ///

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -5,22 +5,27 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
+#[cfg(feature = "bevy-support")]
 pub mod commands;
 /// The basic components of the transform crate
 pub mod components;
 
 /// Transform related bundles
+#[cfg(feature = "bevy-support")]
 pub mod bundles;
 
 /// Transform related traits
 pub mod traits;
 
 /// Transform related plugins
+#[cfg(feature = "bevy-support")]
 pub mod plugins;
 
 /// Helpers related to computing global transforms
+#[cfg(feature = "bevy-support")]
 pub mod helper;
 /// Systems responsible for transform propagation
+#[cfg(feature = "bevy-support")]
 pub mod systems;
 
 #[doc(hidden)]
@@ -28,6 +33,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::components::*;
 
+    #[cfg(feature = "bevy-support")]
     #[doc(hidden)]
     pub use crate::{
         bundles::TransformBundle, commands::BuildChildrenTransformExt, helper::TransformHelper,
@@ -35,4 +41,5 @@ pub mod prelude {
     };
 }
 
+#[cfg(feature = "bevy-support")]
 pub use prelude::{TransformPlugin, TransformPoint, TransformSystem};


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/13529

Allow using the `bevy_transform` crate for its definitions of `Transform` (and `GlobalTransform`) which are re-usable in many contexts, including ones where other parts of Bevy (ECS, reflection, etc.) are not necessarily needed or wanted due to the big dependency tree.

## Solution

Introduce a feature flag "bevy-support" in the `bevy_transform` crate which makes the dependency tree small when default features are off.

## Testing

Both `cargo b` and `cargo b --no-default-features` builds.

The dependency tree **before**:

```text
bevy_transform v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_transform)
├── bevy_app v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_app)
│   ├── bevy_derive v0.14.0-dev (proc-macro) (/home/togr/repos/bevy/crates/bevy_derive)
│   │   ├── bevy_macro_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_macro_utils)
│   │   │   ├── proc-macro2 v1.0.83
│   │   │   │   └── unicode-ident v1.0.12
│   │   │   ├── quote v1.0.36
│   │   │   │   └── proc-macro2 v1.0.83 (*)
│   │   │   ├── syn v2.0.65
│   │   │   │   ├── proc-macro2 v1.0.83 (*)
│   │   │   │   ├── quote v1.0.36 (*)
│   │   │   │   └── unicode-ident v1.0.12
│   │   │   └── toml_edit v0.22.13
│   │   │       ├── indexmap v2.2.6
│   │   │       │   ├── equivalent v1.0.1
│   │   │       │   └── hashbrown v0.14.5
│   │   │       ├── toml_datetime v0.6.6
│   │   │       └── winnow v0.6.8
│   │   ├── quote v1.0.36 (*)
│   │   └── syn v2.0.65 (*)
│   ├── bevy_ecs v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ecs)
│   │   ├── bevy_ecs_macros v0.14.0-dev (proc-macro) (/home/togr/repos/bevy/crates/bevy_ecs/macros)
│   │   │   ├── bevy_macro_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_macro_utils) (*)
│   │   │   ├── proc-macro2 v1.0.83 (*)
│   │   │   ├── quote v1.0.36 (*)
│   │   │   └── syn v2.0.65 (*)
│   │   ├── bevy_ptr v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ptr)
│   │   ├── bevy_reflect v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_reflect)
│   │   │   ├── bevy_math v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_math)
│   │   │   │   ├── approx v0.5.1
│   │   │   │   │   └── num-traits v0.2.19
│   │   │   │   │       [build-dependencies]
│   │   │   │   │       └── autocfg v1.3.0
│   │   │   │   ├── glam v0.27.0
│   │   │   │   │   ├── approx v0.5.1 (*)
│   │   │   │   │   ├── bytemuck v1.16.0
│   │   │   │   │   ├── rand v0.8.5
│   │   │   │   │   │   └── rand_core v0.6.4
│   │   │   │   │   └── serde v1.0.202
│   │   │   │   │       └── serde_derive v1.0.202 (proc-macro)
│   │   │   │   │           ├── proc-macro2 v1.0.83 (*)
│   │   │   │   │           ├── quote v1.0.36 (*)
│   │   │   │   │           └── syn v2.0.65 (*)
│   │   │   │   ├── rand v0.8.5 (*)
│   │   │   │   ├── serde v1.0.202 (*)
│   │   │   │   ├── smallvec v1.13.2
│   │   │   │   └── thiserror v1.0.61
│   │   │   │       └── thiserror-impl v1.0.61 (proc-macro)
│   │   │   │           ├── proc-macro2 v1.0.83 (*)
│   │   │   │           ├── quote v1.0.36 (*)
│   │   │   │           └── syn v2.0.65 (*)
│   │   │   ├── bevy_ptr v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ptr)
│   │   │   ├── bevy_reflect_derive v0.14.0-dev (proc-macro) (/home/togr/repos/bevy/crates/bevy_reflect/derive)
│   │   │   │   ├── bevy_macro_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_macro_utils) (*)
│   │   │   │   ├── proc-macro2 v1.0.83 (*)
│   │   │   │   ├── quote v1.0.36 (*)
│   │   │   │   ├── syn v2.0.65 (*)
│   │   │   │   └── uuid v1.8.0
│   │   │   │       └── getrandom v0.2.15
│   │   │   │           ├── cfg-if v1.0.0
│   │   │   │           └── libc v0.2.155
│   │   │   ├── bevy_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_utils)
│   │   │   │   ├── ahash v0.8.11
│   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   ├── getrandom v0.2.15 (*)
│   │   │   │   │   ├── once_cell v1.19.0
│   │   │   │   │   └── zerocopy v0.7.34
│   │   │   │   │   [build-dependencies]
│   │   │   │   │   └── version_check v0.9.4
│   │   │   │   ├── bevy_utils_proc_macros v0.14.0-dev (proc-macro) (/home/togr/repos/bevy/crates/bevy_utils/macros)
│   │   │   │   │   ├── proc-macro2 v1.0.83 (*)
│   │   │   │   │   ├── quote v1.0.36 (*)
│   │   │   │   │   └── syn v2.0.65 (*)
│   │   │   │   ├── hashbrown v0.14.5
│   │   │   │   │   ├── ahash v0.8.11 (*)
│   │   │   │   │   ├── allocator-api2 v0.2.18
│   │   │   │   │   └── serde v1.0.202 (*)
│   │   │   │   ├── thread_local v1.1.8
│   │   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   │   └── once_cell v1.19.0
│   │   │   │   ├── tracing v0.1.40
│   │   │   │   │   ├── pin-project-lite v0.2.14
│   │   │   │   │   └── tracing-core v0.1.32
│   │   │   │   │       └── once_cell v1.19.0
│   │   │   │   └── web-time v0.2.4
│   │   │   ├── downcast-rs v1.2.1
│   │   │   ├── erased-serde v0.4.5
│   │   │   │   ├── serde v1.0.202 (*)
│   │   │   │   └── typeid v1.0.0
│   │   │   ├── glam v0.27.0 (*)
│   │   │   ├── serde v1.0.202 (*)
│   │   │   ├── smallvec v1.13.2
│   │   │   ├── smol_str v0.2.2
│   │   │   └── thiserror v1.0.61 (*)
│   │   ├── bevy_tasks v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_tasks)
│   │   │   ├── async-executor v1.11.0
│   │   │   │   ├── async-task v4.7.1
│   │   │   │   ├── concurrent-queue v2.5.0
│   │   │   │   │   └── crossbeam-utils v0.8.20
│   │   │   │   ├── fastrand v2.1.0
│   │   │   │   ├── futures-lite v2.3.0
│   │   │   │   │   ├── fastrand v2.1.0
│   │   │   │   │   ├── futures-core v0.3.30
│   │   │   │   │   ├── futures-io v0.3.30
│   │   │   │   │   ├── parking v2.2.0
│   │   │   │   │   └── pin-project-lite v0.2.14
│   │   │   │   └── slab v0.4.9
│   │   │   │       [build-dependencies]
│   │   │   │       └── autocfg v1.3.0
│   │   │   └── futures-lite v2.3.0 (*)
│   │   ├── bevy_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_utils) (*)
│   │   ├── bitflags v2.5.0
│   │   ├── concurrent-queue v2.5.0 (*)
│   │   ├── fixedbitset v0.5.7
│   │   ├── nonmax v0.5.5
│   │   ├── petgraph v0.6.5
│   │   │   ├── fixedbitset v0.4.2
│   │   │   └── indexmap v2.2.6 (*)
│   │   └── thiserror v1.0.61 (*)
│   ├── bevy_reflect v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_reflect) (*)
│   ├── bevy_state v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_state)
│   │   ├── bevy_ecs v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ecs) (*)
│   │   ├── bevy_reflect v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_reflect) (*)
│   │   ├── bevy_state_macros v0.14.0-dev (proc-macro) (/home/togr/repos/bevy/crates/bevy_state/macros)
│   │   │   ├── bevy_macro_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_macro_utils) (*)
│   │   │   ├── proc-macro2 v1.0.83 (*)
│   │   │   ├── quote v1.0.36 (*)
│   │   │   └── syn v2.0.65 (*)
│   │   └── bevy_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_utils) (*)
│   ├── bevy_tasks v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_tasks) (*)
│   ├── bevy_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_utils) (*)
│   ├── downcast-rs v1.2.1
│   └── thiserror v1.0.61 (*)
├── bevy_ecs v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ecs) (*)
├── bevy_hierarchy v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_hierarchy)
│   ├── bevy_app v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_app) (*)
│   ├── bevy_core v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_core)
│   │   ├── bevy_app v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_app) (*)
│   │   ├── bevy_ecs v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ecs) (*)
│   │   ├── bevy_reflect v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_reflect) (*)
│   │   ├── bevy_tasks v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_tasks) (*)
│   │   ├── bevy_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_utils) (*)
│   │   └── uuid v1.8.0
│   ├── bevy_ecs v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_ecs) (*)
│   ├── bevy_reflect v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_reflect) (*)
│   ├── bevy_utils v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_utils) (*)
│   └── smallvec v1.13.2
├── bevy_math v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_math) (*)
├── bevy_reflect v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_reflect) (*)
└── thiserror v1.0.61 (*)
```

The dependency tree **after** (no default features):

```text
bevy_transform v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_transform)
├── bevy_math v0.14.0-dev (/home/togr/repos/bevy/crates/bevy_math)
│   ├── approx v0.5.1
│   │   └── num-traits v0.2.19
│   │       [build-dependencies]
│   │       └── autocfg v1.3.0
│   ├── glam v0.27.0
│   │   ├── approx v0.5.1 (*)
│   │   ├── bytemuck v1.16.0
│   │   └── rand v0.8.5
│   │       └── rand_core v0.6.4
│   ├── rand v0.8.5 (*)
│   ├── smallvec v1.13.2
│   └── thiserror v1.0.61
│       └── thiserror-impl v1.0.61 (proc-macro)
│           ├── proc-macro2 v1.0.83
│           │   └── unicode-ident v1.0.12
│           ├── quote v1.0.36
│           │   └── proc-macro2 v1.0.83 (*)
│           └── syn v2.0.65
│               ├── proc-macro2 v1.0.83 (*)
│               ├── quote v1.0.36 (*)
│               └── unicode-ident v1.0.12
└── thiserror v1.0.61 (*)
```