### PR TITLE
Implemented `Reflect` for (almost) all `bevy_math` types

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -21,7 +21,7 @@ rand = { version = "0.8", features = [
 smallvec = { version = "1.11" }
 
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
-  "glam"
+  "glam",
 ], optional = true }
 
 [dev-dependencies]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -20,7 +20,9 @@ rand = { version = "0.8", features = [
 ], default-features = false, optional = true }
 smallvec = { version = "1.11" }
 
-bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", optional = true }
+bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
+  "glam"
+], optional = true }
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/bevy_math/src/affine3.rs
+++ b/crates/bevy_math/src/affine3.rs
@@ -1,8 +1,12 @@
 use glam::{Affine3A, Mat3, Vec3, Vec3Swizzles, Vec4};
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// Reduced-size version of `glam::Affine3A` for use when storage has
 /// significant performance impact. Convert to `glam::Affine3A` to do
 /// non-trivial calculations.
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct Affine3 {
     /// Scaling, rotation, shears, and other non-translation affine transforms
     pub matrix3: Mat3,

--- a/crates/bevy_math/src/aspect_ratio.rs
+++ b/crates/bevy_math/src/aspect_ratio.rs
@@ -2,8 +2,12 @@
 
 use crate::Vec2;
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// An `AspectRatio` is the ratio of width to height.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
 pub struct AspectRatio(f32);
 
 impl AspectRatio {

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -3,6 +3,9 @@ mod primitive_impls;
 use super::{BoundingVolume, IntersectsVolume};
 use crate::prelude::{Mat2, Rotation2d, Vec2};
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// Computes the geometric center of the given set of points.
 #[inline(always)]
 fn point_cloud_2d_center(points: &[Vec2]) -> Vec2 {
@@ -29,6 +32,7 @@ pub trait Bounded2d {
 /// A 2D axis-aligned bounding box, or bounding rectangle
 #[doc(alias = "BoundingRectangle")]
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct Aabb2d {
     /// The minimum, conventionally bottom-left, point of the box
     pub min: Vec2,
@@ -449,6 +453,7 @@ use crate::primitives::Circle;
 
 /// A bounding circle
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct BoundingCircle {
     /// The center of the bounding circle
     pub center: Vec2,

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -5,6 +5,9 @@ use glam::Mat3;
 use super::{BoundingVolume, IntersectsVolume};
 use crate::{Quat, Vec3, Vec3A};
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// Computes the geometric center of the given set of points.
 #[inline(always)]
 fn point_cloud_3d_center(points: impl Iterator<Item = impl Into<Vec3A>>) -> Vec3A {
@@ -29,6 +32,7 @@ pub trait Bounded3d {
 
 /// A 3D axis-aligned bounding box
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct Aabb3d {
     /// The minimum point of the box
     pub min: Vec3A,
@@ -448,6 +452,7 @@ use crate::primitives::Sphere;
 
 /// A bounding sphere
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct BoundingSphere {
     /// The center of the bounding sphere
     pub center: Vec3A,

--- a/crates/bevy_math/src/bounding/raycast2d.rs
+++ b/crates/bevy_math/src/bounding/raycast2d.rs
@@ -1,8 +1,12 @@
 use super::{Aabb2d, BoundingCircle, IntersectsVolume};
 use crate::{Dir2, Ray2d, Vec2};
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// A raycast intersection test for 2D bounding volumes
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct RayCast2d {
     /// The ray for the test
     pub ray: Ray2d,
@@ -100,6 +104,7 @@ impl IntersectsVolume<BoundingCircle> for RayCast2d {
 
 /// An intersection test that casts an [`Aabb2d`] along a ray.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct AabbCast2d {
     /// The ray along which to cast the bounding volume
     pub ray: RayCast2d,
@@ -137,6 +142,7 @@ impl IntersectsVolume<Aabb2d> for AabbCast2d {
 
 /// An intersection test that casts a [`BoundingCircle`] along a ray.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct BoundingCircleCast {
     /// The ray along which to cast the bounding volume
     pub ray: RayCast2d,

--- a/crates/bevy_math/src/bounding/raycast3d.rs
+++ b/crates/bevy_math/src/bounding/raycast3d.rs
@@ -1,8 +1,12 @@
 use super::{Aabb3d, BoundingSphere, IntersectsVolume};
 use crate::{Dir3A, Ray3d, Vec3A};
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// A raycast intersection test for 3D bounding volumes
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct RayCast3d {
     /// The origin of the ray.
     pub origin: Vec3A,
@@ -95,6 +99,7 @@ impl IntersectsVolume<BoundingSphere> for RayCast3d {
 
 /// An intersection test that casts an [`Aabb3d`] along a ray.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct AabbCast3d {
     /// The ray along which to cast the bounding volume
     pub ray: RayCast3d,
@@ -137,6 +142,7 @@ impl IntersectsVolume<Aabb3d> for AabbCast3d {
 
 /// An intersection test that casts a [`BoundingSphere`] along a ray.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct BoundingSphereCast {
     /// The ray along which to cast the bounding volume
     pub ray: RayCast3d,

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -607,6 +607,7 @@ impl<P: VectorSpace> RationalGenerator<P> for CubicNurbs<P> {
 /// ### Continuity
 /// The curve is C0 continuous, meaning it has no holes or jumps.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct LinearSpline<P: VectorSpace> {
     /// The control points of the NURBS
     pub points: Vec<P>,

--- a/crates/bevy_math/src/float_ord.rs
+++ b/crates/bevy_math/src/float_ord.rs
@@ -20,7 +20,7 @@ use bevy_reflect::Reflect;
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
-    reflect(Debug, ParialEq, Hash)
+    reflect(Debug, PartialEq, Hash)
 )]
 pub struct FloatOrd(pub f32);
 

--- a/crates/bevy_math/src/float_ord.rs
+++ b/crates/bevy_math/src/float_ord.rs
@@ -4,6 +4,9 @@ use std::{
     ops::Neg,
 };
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+
 /// A wrapper for floats that implements [`Ord`], [`Eq`], and [`Hash`] traits.
 ///
 /// This is a work around for the fact that the IEEE 754-2008 standard,
@@ -14,6 +17,7 @@ use std::{
 /// Wrapping a float with `FloatOrd` breaks conformance with the standard
 /// by sorting `NaN` as less than all other numbers and equal to any other `NaN`.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct FloatOrd(pub f32);
 
 impl PartialOrd for FloatOrd {

--- a/crates/bevy_math/src/float_ord.rs
+++ b/crates/bevy_math/src/float_ord.rs
@@ -17,7 +17,11 @@ use bevy_reflect::Reflect;
 /// Wrapping a float with `FloatOrd` breaks conformance with the standard
 /// by sorting `NaN` as less than all other numbers and equal to any other `NaN`.
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, ParialEq, Hash)
+)]
 pub struct FloatOrd(pub f32);
 
 impl PartialOrd for FloatOrd {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -98,6 +98,15 @@ impl Measured2d for Circle {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[doc(alias("CircularArc", "CircleArc"))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, PartialEq, Default)
+)]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
 pub struct Arc2d {
     /// The radius of the circle
     pub radius: f32,
@@ -256,6 +265,15 @@ impl Arc2d {
 /// We recommend normalizing circular sectors to have an angle in [0, 2π].
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, PartialEq, Default)
+)]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
 pub struct CircularSector {
     /// The arc defining the sector
     #[cfg_attr(feature = "serialize", serde(flatten))]
@@ -386,6 +404,15 @@ impl CircularSector {
 /// We recommend normalizing circular segments to have an angle in [0, 2π].
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, PartialEq, Default)
+)]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
 pub struct CircularSegment {
     /// The arc defining the segment
     #[cfg_attr(feature = "serialize", serde(flatten))]
@@ -1217,6 +1244,10 @@ impl Segment2d {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
 pub struct Polyline2d<const N: usize> {
     /// The vertices of the polyline
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]
@@ -1538,6 +1569,10 @@ impl Measured2d for Rectangle {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
 pub struct Polygon<const N: usize> {
     /// The vertices of the `Polygon`
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -296,6 +296,10 @@ impl Segment3d {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
 pub struct Polyline3d<const N: usize> {
     /// The vertices of the polyline
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -3,9 +3,19 @@ use crate::{
     Dir2, Dir3, Vec2, Vec3,
 };
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
+#[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+
 /// An infinite half-line starting at `origin` and going in `direction` in 2D space.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Deserialize, Serialize)
+)]
 pub struct Ray2d {
     /// The origin of the ray.
     pub origin: Vec2,
@@ -50,6 +60,11 @@ impl Ray2d {
 /// An infinite half-line starting at `origin` and going in `direction` in 3D space.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Deserialize, Serialize)
+)]
 pub struct Ray3d {
     /// The origin of the ray.
     pub origin: Vec3,


### PR DESCRIPTION
# Objective

Fixes #13535.

## Solution

I implemented `Reflect` for close to all math types now, except for some types that it would cause issues (like some boxed types).

## Testing

- Everything seems to still build, will await CI though.
---

## Changelog

- Made close to all math types implement `Reflect`.
