### PR TITLE
Add a helper function for making loading a list of a given type of assets from a folder easier.

### DIFF
--- a/crates/bevy_asset/src/folder.rs
+++ b/crates/bevy_asset/src/folder.rs
@@ -14,25 +14,25 @@ pub struct LoadedFolder {
     pub handles: Vec<UntypedHandle>,
 }
 
-/// loads assets of type T from a given [`LoadedFolder`] handle. Returns None if the folder inaccessible. 
-/// 
+/// loads assets of type T from a given [`LoadedFolder`] handle. Returns None if the folder inaccessible.
+///
 /// [`LoadedFolder`]: crate::LoadedFolder
 pub fn load_assets_in<T: Asset>(
     folders: &Res<Assets<LoadedFolder>>,
-    folder_handle: &Handle<LoadedFolder>
-) -> Option<Vec<Handle<T>>>{
+    folder_handle: &Handle<LoadedFolder>,
+) -> Option<Vec<Handle<T>>> {
     let typeid = TypeId::of::<T>();
 
-     if let Some(folder) = folders.get(folder_handle) {
+    if let Some(folder) = folders.get(folder_handle) {
         let handles: Vec<Handle<T>> = folder
-        .handles
-        .clone()
-        .into_iter()
-        .filter(|handle| handle.type_id() == typeid)
-        .map(|handle| handle.typed::<T>())
-        .collect::<Vec<_>>();
+            .handles
+            .clone()
+            .into_iter()
+            .filter(|handle| handle.type_id() == typeid)
+            .map(|handle| handle.typed::<T>())
+            .collect::<Vec<_>>();
         Some(handles)
-     } else {
-         None
-     }
+    } else {
+        None
+    }
 }

--- a/crates/bevy_asset/src/folder.rs
+++ b/crates/bevy_asset/src/folder.rs
@@ -1,5 +1,8 @@
-use crate as bevy_asset;
+use std::any::TypeId;
+
+use crate::{self as bevy_asset, Assets, Handle};
 use crate::{Asset, UntypedHandle};
+use bevy_ecs::system::Res;
 use bevy_reflect::TypePath;
 
 /// A "loaded folder" containing handles for all assets stored in a given [`AssetPath`].
@@ -9,4 +12,27 @@ use bevy_reflect::TypePath;
 pub struct LoadedFolder {
     #[dependency]
     pub handles: Vec<UntypedHandle>,
+}
+
+/// loads assets of type T from a given [`LoadedFolder`] handle. Returns None if the folder inaccessible. 
+/// 
+/// [`LoadedFolder`]: crate::LoadedFolder
+pub fn load_assets_in<T: Asset>(
+    folders: &Res<Assets<LoadedFolder>>,
+    folder_handle: &Handle<LoadedFolder>
+) -> Option<Vec<Handle<T>>>{
+    let typeid = TypeId::of::<T>();
+
+     if let Some(folder) = folders.get(folder_handle) {
+        let handles: Vec<Handle<T>> = folder
+        .handles
+        .clone()
+        .into_iter()
+        .filter(|handle| handle.type_id() == typeid)
+        .map(|handle| handle.typed::<T>())
+        .collect::<Vec<_>>();
+        Some(handles)
+     } else {
+         None
+     }
 }


### PR DESCRIPTION
# Objective

Currently, loading specific assets from a given folder is difficult and bevy has no way to do it directly through a function call. This pr addresses this issue.


## Solution

This pr adds a function `load_assets_in::<T>` to get a typed vec of handles of a given asset type with the folder assets resource + a handle to the folder being searched.