### PR TITLE
use ssr dynamic offset in volumetric fog bind group

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -73,6 +73,7 @@ use bevy_utils::prelude::default;
 use crate::{
     graph::NodePbr, MeshPipelineViewLayoutKey, MeshPipelineViewLayouts, MeshViewBindGroup,
     ViewFogUniformOffset, ViewLightProbesUniformOffset, ViewLightsUniformOffset,
+    ViewScreenSpaceReflectionsUniformOffset,
 };
 
 /// The volumetric fog shader.
@@ -397,6 +398,7 @@ impl ViewNode for VolumetricFogNode {
         Read<ViewLightProbesUniformOffset>,
         Read<ViewVolumetricFogUniformOffset>,
         Read<MeshViewBindGroup>,
+        Read<ViewScreenSpaceReflectionsUniformOffset>,
     );
 
     fn run<'w>(
@@ -413,6 +415,7 @@ impl ViewNode for VolumetricFogNode {
             view_light_probes_offset,
             view_volumetric_lighting_uniform_buffer_offset,
             view_bind_group,
+            view_ssr_offset,
         ): QueryItem<'w, Self::ViewQuery>,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
@@ -474,6 +477,7 @@ impl ViewNode for VolumetricFogNode {
                 view_lights_offset.offset,
                 view_fog_offset.offset,
                 **view_light_probes_offset,
+                **view_ssr_offset,
             ],
         );
         render_pass.set_bind_group(


### PR DESCRIPTION
# Objective

- #13418 broke volumetric fog

```
wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(2, 4, Metal)>`
    In a set_bind_group command
      note: bind group = `mesh_view_bind_group`
    Bind group 0 expects 5 dynamic offsets. However 4 dynamic offsets were provided.
```

## Solution

- add ssr offset to volumetric fog bind group
