### PR TITLE
Make volumetric fog and screen space reflections compatible.

### DIFF
--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -73,6 +73,7 @@ use bevy_utils::prelude::default;
 use crate::{
     graph::NodePbr, MeshPipelineViewLayoutKey, MeshPipelineViewLayouts, MeshViewBindGroup,
     ViewFogUniformOffset, ViewLightProbesUniformOffset, ViewLightsUniformOffset,
+    ViewScreenSpaceReflectionsUniformOffset,
 };
 
 /// The volumetric fog shader.
@@ -395,6 +396,7 @@ impl ViewNode for VolumetricFogNode {
         Read<ViewLightsUniformOffset>,
         Read<ViewFogUniformOffset>,
         Read<ViewLightProbesUniformOffset>,
+        Read<ViewScreenSpaceReflectionsUniformOffset>,
         Read<ViewVolumetricFogUniformOffset>,
         Read<MeshViewBindGroup>,
     );
@@ -411,6 +413,7 @@ impl ViewNode for VolumetricFogNode {
             view_lights_offset,
             view_fog_offset,
             view_light_probes_offset,
+            view_ssr_offset,
             view_volumetric_lighting_uniform_buffer_offset,
             view_bind_group,
         ): QueryItem<'w, Self::ViewQuery>,
@@ -474,6 +477,7 @@ impl ViewNode for VolumetricFogNode {
                 view_lights_offset.offset,
                 view_fog_offset.offset,
                 **view_light_probes_offset,
+                **view_ssr_offset,
             ],
         );
         render_pass.set_bind_group(


### PR DESCRIPTION
SSR requires render nodes to set the dynamic uniform stored in the `ViewScreenSpaceSpaceReflectionsUniformOffset`. The SSR pull request was submitted before the introduction of volumetric fog, so it didn't update the volumetric fog render node to include that dynamic offset. This caused a crash when volumetric fog and SSR were simultaneously enabled. This patch fixes that issue.