### PR TITLE
Fix UI in WebGPU: call `textureSample` from outside the if

### DIFF
--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -126,9 +126,7 @@ fn antialias(distance: f32) -> f32 {
     return clamp(0.0, 1.0, 0.5 - distance);
 }
 
-fn draw(in: VertexOutput) -> vec4<f32> {
-    let texture_color = textureSample(sprite_texture, sprite_sampler, in.uv);
-
+fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // Only use the color sampled from the texture if the `TEXTURED` flag is enabled. 
     // This allows us to draw both textured and untextured shapes together in the same batch.
     let color = select(in.color, in.color * texture_color, enabled(in.flags, TEXTURED));
@@ -161,8 +159,7 @@ fn draw(in: VertexOutput) -> vec4<f32> {
     return vec4(color.rgb, saturate(color.a * t));
 }
 
-fn draw_background(in: VertexOutput) -> vec4<f32> {
-    let texture_color = textureSample(sprite_texture, sprite_sampler, in.uv);
+fn draw_background(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     let color = select(in.color, in.color * texture_color, enabled(in.flags, TEXTURED));
 
     // When drawing the background only draw the internal area and not the border.
@@ -173,9 +170,11 @@ fn draw_background(in: VertexOutput) -> vec4<f32> {
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let texture_color = textureSample(sprite_texture, sprite_sampler, in.uv);
+
     if enabled(in.flags, BORDER) {
-        return draw(in);    
+        return draw(in, texture_color);    
     } else {
-        return draw_background(in);
+        return draw_background(in, texture_color);
     }
 }


### PR DESCRIPTION
# Objective

- since #13523, UI is broken in WebGPU

```
Compilation log for [Invalid ShaderModule (unlabeled)]:
1 error(s) generated while compiling the shader:
:108:27 error: 'textureSample' must only be called from uniform control flow
    let texture_color_1 = textureSample(sprite_texture, sprite_sampler, in_2.uv);
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

:151:19 note: called by 'draw_background' from 'fragment'
        let _e5 = draw_background(in);
                  ^^^^^^^^^^^^^^^^^^^

:147:5 note: control flow depends on possibly non-uniform value
    if _e3 {
    ^^

:146:23 note: parameter 'in' of 'fragment' may be non-uniform
    let _e3 = enabled(in.flags, BORDER);
```


## Solution

- call `textureSample` from outside the if. both branches are using the same parameters
