### PR TITLE
Add docs to bevy_gltf about loading parts of a Gltf asset

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -22,7 +22,8 @@
 //!
 //! fn spawn_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
 //!     commands.spawn(SceneBundle {
-//!         // The `#Scene0` label here is very important. Keep reading for more details
+//!         // The `#Scene0` label here is very important because it tells bevy to load the first scene in the gLTF file.
+//!         // If this isn't specified bevy doesn't know which part of the gLTF file to load.
 //!         scene: asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"),
 //!         // You can use the transform to give it a position
 //!         transform: Transform::from_xyz(2.0, 0.0, -5.0),

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! # Quick Start
 //!
-//! Here's how to spawn a simple gltf scene
+//! Here's how to spawn a simple glTF scene
 //!
 //! ```
 //! # use bevy_ecs::prelude::*;
@@ -22,8 +22,8 @@
 //!
 //! fn spawn_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
 //!     commands.spawn(SceneBundle {
-//!         // The `#Scene0` label here is very important because it tells bevy to load the first scene in the gLTF file.
-//!         // If this isn't specified bevy doesn't know which part of the gLTF file to load.
+//!         // The `#Scene0` label here is very important because it tells bevy to load the first scene in the glTF file.
+//!         // If this isn't specified bevy doesn't know which part of the glTF file to load.
 //!         scene: asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"),
 //!         // You can use the transform to give it a position
 //!         transform: Transform::from_xyz(2.0, 0.0, -5.0),
@@ -31,7 +31,7 @@
 //!     });
 //! }
 //! ```
-//! # Loading parts of a gLTF asset
+//! # Loading parts of a glTF asset
 //!
 //! ## Using `Gltf`
 //!
@@ -87,22 +87,22 @@
 //!
 //! ## Asset Labels
 //!
-//! The gLTF loader let's you specify labels that let you target specific parts of the gLTF.
+//! The glTF loader let's you specify labels that let you target specific parts of the glTF.
 //!
 //! Be careful when using this feature, if you misspell a label it will simply ignore it without warning.
 //!
 //! Here's the list of supported labels (`{}` is the index in the file):
 //!
-//! - `Scene{}`: gLTF Scene as a Bevy `Scene`
-//! - `Node{}`: gLTF Node as a `GltfNode`
-//! - `Mesh{}`: gLTF Mesh as a `GltfMesh`
-//! - `Mesh{}/Primitive{}`: gLTF Primitive as a Bevy `Mesh`
-//! - `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a gLTF Primitive
-//! - `Texture{}`: gLTF Texture as a Bevy `Image`
-//! - `Material{}`: gLTF Material as a Bevy `StandardMaterial`
-//! - `DefaultMaterial`: as above, if the gLTF file contains a default material with no index
-//! - `Animation{}`: gLTF Animation as Bevy `AnimationClip`
-//! - `Skin{}`: gLTF mesh skin as Bevy `SkinnedMeshInverseBindposes`
+//! - `Scene{}`: glTF Scene as a Bevy `Scene`
+//! - `Node{}`: glTF Node as a `GltfNode`
+//! - `Mesh{}`: glTF Mesh as a `GltfMesh`
+//! - `Mesh{}/Primitive{}`: glTF Primitive as a Bevy `Mesh`
+//! - `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a glTF Primitive
+//! - `Texture{}`: glTF Texture as a Bevy `Image`
+//! - `Material{}`: glTF Material as a Bevy `StandardMaterial`
+//! - `DefaultMaterial`: as above, if the glTF file contains a default material with no index
+//! - `Animation{}`: glTF Animation as Bevy `AnimationClip`
+//! - `Skin{}`: glTF mesh skin as Bevy `SkinnedMeshInverseBindposes`
 
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::AnimationClip;

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -20,7 +20,7 @@
 //!     commands.spawn(SceneBundle {
 //!         // The `#Scene0` label here is very important. Keep reading for more details
 //!         scene: asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"),
-//!         // You can use the Tranform to give it a position
+//!         // You can use the transform to give it a position
 //!         transform: Transform::from_xyz(2.0, 0.0, -5.0),
 //!         ..Default::default()
 //!     });
@@ -83,7 +83,7 @@
 //! ## Asset Labels
 //! The GLTF loader let's you specify labels that let you target specific parts of the GLTF.
 //!
-//! Be careful when using this feature, if you mispell a label it will simply ignore it wihtout warning.
+//! Be careful when using this feature, if you misspell a label it will simply ignore it without warning.
 //!
 //! Here's the list of supported labels (`{}` is the index in the file):
 //!

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -9,6 +9,94 @@
 //! for loading glTF 2.0 (a standard 3D scene definition format) files in Bevy.
 //!
 //! The [glTF 2.0 specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html) defines the format of the glTF files.
+//!
+//! # Quick Start
+//!
+//! Here's how to spawn a simple gltf scene
+//!
+//! ```
+//! # use bevy::prelude*;
+//! fn spawn_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
+//!     commands.spawn(SceneBundle {
+//!         // The `#Scene0` label here is very important. Keep reading for more details
+//!         scene: asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0"),
+//!         // You can use the Tranform to give it a position
+//!         transform: Transform::from_xyz(2.0, 0.0, -5.0),
+//!         ..Default::default()
+//!     });
+//! }
+//! ```
+//!
+//! # Loading parts of a GLTF asset
+//!
+//! ## Using `Gltf`
+//!
+//! If you want to access part of the asset, you can load the entire `Gltf` using the `AssetServer`.
+//! Once the `Handle<Gltf>` is loaded you can then use it to access named parts of it.
+//!
+//! ```
+//! # use bevy_ecs::prelude::*;
+//! # use bevy_asset::prelude::*;
+//! # use bevy_scene::prelude::*;
+//! # use bevy_transform::prelude::*;
+//!
+//! // Holds the scene handle
+//! #[derive(Resource)]
+//! struct HelmetScene(Handle<Gltf>);
+//!
+//! fn load_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
+//!     let gltf = asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0");
+//!     commands.insert_resource(HelmetScene(gltf));
+//! }
+//!
+//! fn spawn_gltf_objects(
+//!     mut commands: Commands,
+//!     helmet_scene: Res<HelmetScene>,
+//!     gltf_assets: Res<Assets<Gltf>>,
+//!     mut loaded: Local<bool>,
+//! ) {
+//!     // Only do this once
+//!     if *loaded {
+//!         return;
+//!     }
+//!     // Wait until the scene is loaded
+//!     let Some(gltf) = gltf_assets.get(&helmet_scene.0) else {
+//!         return;
+//!     };
+//!     *loaded = true;
+//!
+//!     commands.spawn(SceneBundle {
+//!         // Gets the first scene in the file
+//!         scene: gltf.scenes[0].clone(),
+//!         ..Default::default()
+//!     });
+//!
+//!     commands.spawn(SceneBundle {
+//!         // Gets the scene named "Lenses_low"
+//!         scene: gltf.named_scenes["Lenses_low"].clone(),
+//!         transform: Transform::from_xyz(1.0, 2.0, 3.0),
+//!         ..Default::default()
+//!     });
+//! }
+//! ```
+//!
+//! ## Asset Labels
+//! The GLTF loader let's you specify labels that let you target specific parts of the GLTF.
+//!
+//! Be careful when using this feature, if you mispell a label it will simply ignore it wihtout warning.
+//!
+//! Here's the list of supported labels (`{}` is the index in the file):
+//!
+//! - `Scene{}`: GLTF Scene as a Bevy `Scene`
+//! - `Node{}`: GLTF Node as a `GltfNode`
+//! - `Mesh{}`: GLTF Mesh as a `GltfMesh`
+//! - `Mesh{}/Primitive{}`: GLTF Primitive as a Bevy `Mesh`
+//! - `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a GLTF Primitive
+//! - `Texture{}`: GLTF Texture as a Bevy `Image`
+//! - `Material{}`: GLTF Material as a Bevy `StandardMaterial`
+//! - `DefaultMaterial`: as above, if the GLTF file contains a default material with no index
+//! - `Animation{}`: GLTF Animation as Bevy `AnimationClip`
+//! - `Skin{}`: GLTF mesh skin as Bevy `SkinnedMeshInverseBindposes`
 
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::AnimationClip;

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -50,7 +50,7 @@
 //! struct HelmetScene(Handle<Gltf>);
 //!
 //! fn load_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
-//!     let gltf = asset_server.load("models/FlightHelmet/FlightHelmet.gltf#Scene0");
+//!     let gltf = asset_server.load("models/FlightHelmet/FlightHelmet.gltf");
 //!     commands.insert_resource(HelmetScene(gltf));
 //! }
 //!

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -15,7 +15,11 @@
 //! Here's how to spawn a simple gltf scene
 //!
 //! ```
-//! # use bevy::prelude*;
+//! # use bevy_ecs::prelude::*;
+//! # use bevy_asset::prelude::*;
+//! # use bevy_scene::prelude::*;
+//! # use bevy_transform::prelude::*;
+//!
 //! fn spawn_gltf(mut commands: Commands, asset_server: Res<AssetServer>) {
 //!     commands.spawn(SceneBundle {
 //!         // The `#Scene0` label here is very important. Keep reading for more details
@@ -26,7 +30,6 @@
 //!     });
 //! }
 //! ```
-//!
 //! # Loading parts of a gLTF asset
 //!
 //! ## Using `Gltf`

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -27,7 +27,7 @@
 //! }
 //! ```
 //!
-//! # Loading parts of a GLTF asset
+//! # Loading parts of a gLTF asset
 //!
 //! ## Using `Gltf`
 //!
@@ -82,22 +82,22 @@
 //!
 //! ## Asset Labels
 //!
-//! The GLTF loader let's you specify labels that let you target specific parts of the GLTF.
+//! The gLTF loader let's you specify labels that let you target specific parts of the gLTF.
 //!
 //! Be careful when using this feature, if you misspell a label it will simply ignore it without warning.
 //!
 //! Here's the list of supported labels (`{}` is the index in the file):
 //!
-//! - `Scene{}`: GLTF Scene as a Bevy `Scene`
-//! - `Node{}`: GLTF Node as a `GltfNode`
-//! - `Mesh{}`: GLTF Mesh as a `GltfMesh`
-//! - `Mesh{}/Primitive{}`: GLTF Primitive as a Bevy `Mesh`
-//! - `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a GLTF Primitive
-//! - `Texture{}`: GLTF Texture as a Bevy `Image`
-//! - `Material{}`: GLTF Material as a Bevy `StandardMaterial`
-//! - `DefaultMaterial`: as above, if the GLTF file contains a default material with no index
-//! - `Animation{}`: GLTF Animation as Bevy `AnimationClip`
-//! - `Skin{}`: GLTF mesh skin as Bevy `SkinnedMeshInverseBindposes`
+//! - `Scene{}`: gLTF Scene as a Bevy `Scene`
+//! - `Node{}`: gLTF Node as a `GltfNode`
+//! - `Mesh{}`: gLTF Mesh as a `GltfMesh`
+//! - `Mesh{}/Primitive{}`: gLTF Primitive as a Bevy `Mesh`
+//! - `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a gLTF Primitive
+//! - `Texture{}`: gLTF Texture as a Bevy `Image`
+//! - `Material{}`: gLTF Material as a Bevy `StandardMaterial`
+//! - `DefaultMaterial`: as above, if the gLTF file contains a default material with no index
+//! - `Animation{}`: gLTF Animation as Bevy `AnimationClip`
+//! - `Skin{}`: gLTF mesh skin as Bevy `SkinnedMeshInverseBindposes`
 
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::AnimationClip;

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -42,6 +42,7 @@
 //! # use bevy_asset::prelude::*;
 //! # use bevy_scene::prelude::*;
 //! # use bevy_transform::prelude::*;
+//! # use bevy_gltf::Gltf;
 //!
 //! // Holds the scene handle
 //! #[derive(Resource)]

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -81,6 +81,7 @@
 //! ```
 //!
 //! ## Asset Labels
+//!
 //! The GLTF loader let's you specify labels that let you target specific parts of the GLTF.
 //!
 //! Be careful when using this feature, if you misspell a label it will simply ignore it without warning.


### PR DESCRIPTION
# Objective

- The Gltf loader has a ton of features to load parts of an asset that are essentially undocumented.

## Solution

- Add some docs to explain some of those features
- The docs is definitely inspired by the bevy cheatbook page on the subject but it goes in a lot less details
