### PR TITLE
Generalize component reflection to operate on `FilteredEntityRef` and `FilteredEntityMut`, not `EntityRef` and `EntityMut`.

### DIFF
--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -62,7 +62,10 @@ use crate::{
     change_detection::Mut,
     component::Component,
     entity::Entity,
-    world::{unsafe_world_cell::UnsafeEntityCell, EntityMut, EntityRef, EntityWorldMut, World},
+    world::{
+        unsafe_world_cell::UnsafeEntityCell, EntityMut, EntityRef, EntityWorldMut,
+        FilteredEntityMut, FilteredEntityRef, World,
+    },
 };
 use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
 
@@ -106,9 +109,9 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::contains()`].
     pub contains: fn(EntityRef) -> bool,
     /// Function pointer implementing [`ReflectComponent::reflect()`].
-    pub reflect: fn(EntityRef) -> Option<&dyn Reflect>,
+    pub reflect: fn(FilteredEntityRef) -> Option<&dyn Reflect>,
     /// Function pointer implementing [`ReflectComponent::reflect_mut()`].
-    pub reflect_mut: fn(EntityMut) -> Option<Mut<dyn Reflect>>,
+    pub reflect_mut: fn(FilteredEntityMut) -> Option<Mut<dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::reflect_unchecked_mut()`].
     ///
     /// # Safety
@@ -170,14 +173,14 @@ impl ReflectComponent {
     }
 
     /// Gets the value of this [`Component`] type from the entity as a reflected reference.
-    pub fn reflect<'a>(&self, entity: EntityRef<'a>) -> Option<&'a dyn Reflect> {
-        (self.0.reflect)(entity)
+    pub fn reflect<'a>(&self, entity: impl Into<FilteredEntityRef<'a>>) -> Option<&'a dyn Reflect> {
+        (self.0.reflect)(entity.into())
     }
 
     /// Gets the value of this [`Component`] type from the entity as a mutable reflected reference.
     pub fn reflect_mut<'a>(
         &self,
-        entity: impl Into<EntityMut<'a>>,
+        entity: impl Into<FilteredEntityMut<'a>>,
     ) -> Option<Mut<'a, dyn Reflect>> {
         (self.0.reflect_mut)(entity.into())
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2098,6 +2098,18 @@ impl<'w> FilteredEntityMut<'w> {
             .then(|| unsafe { self.entity.get_mut().debug_checked_unwrap() })
     }
 
+    /// Consumes self and gets mutable access to the component of type `T`
+    /// with the world `'w` lifetime for the current entity.
+    /// Returns `None` if the entity does not have a component of type `T`.
+    #[inline]
+    pub fn into_mut<T: Component>(self) -> Option<Mut<'w, T>> {
+        let id = self.entity.world().components().get_id(TypeId::of::<T>())?;
+        self.access
+            .has_write(id)
+            // SAFETY: We have write access so we must have the component
+            .then(|| unsafe { self.entity.get_mut().debug_checked_unwrap() })
+    }
+
     /// Retrieves the change ticks for the given component. This can be useful for implementing change
     /// detection in custom runtimes.
     #[inline]


### PR DESCRIPTION
Currently, either an `EntityRef` or `EntityMut` is required in order to reflect a component on an entity. This can, however, be generalized to `FilteredEntityRef` and `FilteredEntityMut`, which are versions of `EntityRef` and `EntityMut` that restrict the components that can be accessed. This is useful because dynamic queries yield `FilteredEntityRef` and `FilteredEntityMut` rows when iterated over.

This commit changes `ReflectComponent::reflect()` and `ReflectComponent::reflect_mut()` to take an `Into<FilteredEntityRef>` and `Into<FilteredEntityMut>` respectively. Fortunately, `EntityRef` and `EntityMut` already implement the corresponding trait, so nothing else has to be done to the public API. Note that in order to implement `ReflectComponent::reflect_mut()` properly, an additional method `FilteredEntityMut::into_mut()` was required, to match the one on `EntityMut`.

I ran into this when attempting to implement `QUERY` in the Bevy Remote Protocol. There were other potential ways to work around this problem, but they required either reimplementing the query logic myself instead of using regular Bevy queries or storing entity IDs and then issuing another query to fetch the associated `EntityRef`. Both of these seemed worse than just improving the `reflect()` function.

## Migration Guide

* `ReflectComponent::reflect` and `ReflectComponent::reflect_mut` now take `FilteredEntityRef` and `FilteredEntityMut` parameters respectively. `FilteredEntityRef` and `FilteredEntityMut` have very similar APIs to `EntityRef` and `EntityMut` respectively, but optionally restrict the components that can be accessed.