### PR TITLE
Use correct minimal version of meshopt

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1", features = ["derive", "rc"], optional = true }
 bincode = { version = "1", optional = true }
 thiserror = { version = "1", optional = true }
 range-alloc = { version = "0.1", optional = true }
-meshopt = { version = "0.2", optional = true }
+meshopt = { version = "0.2.1", optional = true }
 metis = { version = "0.2", optional = true }
 itertools = { version = "0.13", optional = true }
 # direct dependency required for derive macro


### PR DESCRIPTION
# Objective

- The current version of the `meshopt` dependency is incorrect, as `bevy_pbr` uses features introduced in `meshopt` `0.2.1`
- This causes errors like this when only `meshopt` `0.2` is present in `Cargo.lock`:
    ```
	error[E0432]: unresolved imports `meshopt::ffi::meshopt_optimizeMeshlet`, `meshopt::simplify_scale`
	  --> crates\bevy_pbr\src\meshlet\from_mesh.rs:10:27
	   |
	10 |     ffi::{meshopt_Bounds, meshopt_optimizeMeshlet},
	   |                           ^^^^^^^^^^^^^^^^^^^^^^^
	   |                           no `meshopt_optimizeMeshlet` in `ffi`
	   |                           help: a similar name exists in the module: `meshopt_optimizeOverdraw`
	11 |     simplify, simplify_scale, Meshlets, SimplifyOptions, VertexDataAdapter,
	   |               ^^^^^^^^^^^^^^ no `simplify_scale` in the root
    ```

## Solution

- Specify the actual minimum version of `meshopt` that `bevy_pbr` requires
