### PR TITLE
Use rust-lld on windows rustdoc in config_fast_builds.toml

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -134,6 +134,7 @@ rustflags = [
 # rustup component add llvm-tools
 # ```
 linker = "rust-lld.exe"
+rustdocflags = ["-Clinker=rust-lld.exe"]
 rustflags = [
   # Nightly
   # "-Zshare-generics=y",


### PR DESCRIPTION
# Objective

- Rustdoc doesn't seem to follow cargo's `linker` setting
- Improves the situation in #12207

## Solution

- Explicitly set the linker in rustdoc flags

## Testing

- I tested this change on Windows and it significantly improves testing performances (can't give an exact estimate since they got stuck before this change)

---

Note: I avoided changing the settings on Linux and MacOS because I can't test on those platforms. It would be nice if someone could test similar changes there and report so they can be done on all major platforms.