### PR TITLE
Adds bevy_tracing crate

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -25,7 +25,7 @@ trace_chrome = ["bevy_log/tracing-chrome"]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy"]
 trace_tracy_memory = ["bevy_log/trace_tracy_memory"]
 wgpu_trace = ["bevy_render/wgpu_trace"]
-detailed_trace = ["bevy_utils/detailed_trace"]
+detailed_trace = ["bevy_tracing/detailed_trace"]
 
 sysinfo_plugin = ["bevy_diagnostic/sysinfo_plugin"]
 
@@ -203,6 +203,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
 ] }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
+bevy_tracing = { path = "../bevy_tracing", version = "0.14.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -58,6 +58,7 @@ pub use bevy_tasks as tasks;
 #[cfg(feature = "bevy_text")]
 pub use bevy_text as text;
 pub use bevy_time as time;
+pub use bevy_tracing as tracing;
 pub use bevy_transform as transform;
 #[cfg(feature = "bevy_ui")]
 pub use bevy_ui as ui;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,7 +1,7 @@
 #[doc(hidden)]
 pub use crate::{
     app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
-    log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
+    log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*, tracing::prelude::*,
     transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
 };
 

--- a/crates/bevy_tracing/Cargo.toml
+++ b/crates/bevy_tracing/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "bevy_tracing"
+version = "0.14.0-dev"
+edition = "2021"
+description = "A collection of tracing utilities for Bevy Engine"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy"]
+
+[features]
+detailed_trace = []
+
+[dependencies]
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
+all-features = true

--- a/crates/bevy_tracing/README.md
+++ b/crates/bevy_tracing/README.md
@@ -1,0 +1,9 @@
+# Bevy Tracing
+
+[![License](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/bevyengine/bevy#license)
+[![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy_tracing)
+[![Downloads](https://img.shields.io/crates/d/bevy_tracing.svg)](https://crates.io/crates/bevy_tracing)
+[![Docs](https://docs.rs/bevy_tracing/badge.svg)](https://docs.rs/bevy_tracing/latest/bevy_tracing/)
+[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)
+
+A Collection of Tracing Utilities for the [Bevy Engine](https://bevyengine.org/).

--- a/crates/bevy_tracing/src/lib.rs
+++ b/crates/bevy_tracing/src/lib.rs
@@ -1,0 +1,117 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![allow(unsafe_code)]
+#![doc(
+    html_logo_url = "https://bevyengine.org/assets/icon.png",
+    html_favicon_url = "https://bevyengine.org/assets/icon.png"
+)]
+
+//! Tracing utilities for first-party [Bevy] engine crates.
+//!
+//! [Bevy]: https://bevyengine.org/
+//!
+
+#[allow(missing_docs)]
+pub mod prelude {
+    pub use crate::tracing;
+}
+
+pub use tracing;
+
+use std::fmt::Debug;
+
+/// Calls the [`tracing::info!`] macro on a value.
+pub fn info<T: Debug>(data: T) {
+    tracing::info!("{:?}", data);
+}
+
+/// Calls the [`tracing::debug!`] macro on a value.
+pub fn dbg<T: Debug>(data: T) {
+    tracing::debug!("{:?}", data);
+}
+
+/// Processes a [`Result`] by calling the [`tracing::warn!`] macro in case of an [`Err`] value.
+pub fn warn<E: Debug>(result: Result<(), E>) {
+    if let Err(warn) = result {
+        tracing::warn!("{:?}", warn);
+    }
+}
+
+/// Processes a [`Result`] by calling the [`tracing::error!`] macro in case of an [`Err`] value.
+pub fn error<E: Debug>(result: Result<(), E>) {
+    if let Err(error) = result {
+        tracing::error!("{:?}", error);
+    }
+}
+
+/// Call some expression only once per call site.
+#[macro_export]
+macro_rules! once {
+    ($expression:expr) => {{
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static SHOULD_FIRE: AtomicBool = AtomicBool::new(true);
+        if SHOULD_FIRE.swap(false, Ordering::Relaxed) {
+            $expression;
+        }
+    }};
+}
+
+/// Like [`tracing::trace`], but conditional on cargo feature `detailed_trace`.
+#[macro_export]
+macro_rules! detailed_trace {
+    ($($tts:tt)*) => {
+        if cfg!(detailed_trace) {
+            $crate::tracing::trace!($($tts)*);
+        }
+    }
+}
+
+/// Call [`trace!`](crate::tracing::trace) once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! trace_once {
+    ($($arg:tt)+) => ({
+        $crate::once!($crate::tracing::trace!($($arg)+))
+    });
+}
+
+/// Call [`debug!`](crate::tracing::debug) once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! debug_once {
+    ($($arg:tt)+) => ({
+        $crate::once!($crate::tracing::debug!($($arg)+))
+    });
+}
+
+/// Call [`info!`](crate::tracing::info) once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! info_once {
+    ($($arg:tt)+) => ({
+        $crate::once!($crate::tracing::info!($($arg)+))
+    });
+}
+
+/// Call [`warn!`](crate::tracing::warn) once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! warn_once {
+    ($($arg:tt)+) => ({
+        $crate::once!($crate::tracing::warn!($($arg)+))
+    });
+}
+
+/// Call [`error!`](crate::tracing::error) once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! error_once {
+    ($($arg:tt)+) => ({
+        $crate::once!($crate::tracing::error!($($arg)+))
+    });
+}

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -1,5 +1,6 @@
 # if crate A depends on crate B, B must come before A in this list
 crates=(
+    bevy_tracing
     bevy_utils/macros
     bevy_utils
     bevy_ptr


### PR DESCRIPTION
# Objective

- Related to https://github.com/bevyengine/bevy/issues/11478

## Solution

- Added a new crate called `bevy_tracing` with all tracing utilities that were present in `bevy_utils`.

TODO:

We should decide if we:

a) decide to make this a breaking change and remove these utilities from `bevy_utils` in a follow-up or
b) deprecate the utilities in `bevy_utils` and migrate crate by crate to reduce diff footprint in subsequent PRs. We would need to remove the utilities from `bevy_utils` at some point though.

We also need to reserve the crate name in `crates.io`.

---

## Migration Guide

- TBD
