### PR TITLE
Set the default target exposure to the minimum value, not 0

### DIFF
--- a/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
+++ b/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
@@ -155,11 +155,14 @@ fn compute_average(@builtin(local_invocation_index) local_index: u32) {
         count += bin_count;
     }
 
-    // This is the default exposure value.
+
+    // Target exposure controls how much we should brighten or darken the scene.
+    // Higher values will brighten the scene, while lower values will darken it.
     //
     // If all values are below the threshold,
-    // we should set it to the minimal value to avoid suddenly darkening the scene.
-    var target_exposure = compensation_curve.min_compensation;
+    // we should set it to the maximum value.
+    // Since no pixels are overexposed, we should correct the exposure as much as possible.
+    var target_exposure = compensation_curve.min_compensation + compensation_curve.compensation_range;
 
     if count > 0u {
         // The average luminance of the included histogram samples.

--- a/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
+++ b/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
@@ -155,7 +155,25 @@ fn compute_average(@builtin(local_invocation_index) local_index: u32) {
         count += bin_count;
     }
 
+    var avg_lum = settings.min_log_lum;
 
+    if count > 0u {
+        // The average luminance of the included histogram samples.
+        avg_lum = sum / (f32(count) * 63.0)
+            * settings.log_lum_range
+            + settings.min_log_lum;
+    }
+
+    // The position in the compensation curve texture to sample for avg_lum.
+    let u = (avg_lum - compensation_curve.min_log_lum) * compensation_curve.inv_log_lum_range;
+
+    // The target exposure is the negative of the average log luminance.
+    // The compensation value is added to the target exposure to adjust the exposure for
+    // artistic purposes.
+    let target_exposure = textureLoad(tex_compensation, i32(saturate(u) * 255.0), 0).r
+        * compensation_curve.compensation_range
+        + compensation_curve.min_compensation
+        - avg_lum;
     // Target exposure controls how much we should brighten or darken the scene.
     // Higher values will brighten the scene, while lower values will darken it.
     //

--- a/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
+++ b/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
@@ -155,7 +155,11 @@ fn compute_average(@builtin(local_invocation_index) local_index: u32) {
         count += bin_count;
     }
 
-    var target_exposure = 0.0;
+    // This is the default exposure value.
+    //
+    // If all values are below the threshold,
+    // we should set it to the minimal value to avoid suddenly darkening the scene.
+    var target_exposure = settings.min_log_lum;
 
     if count > 0u {
         // The average luminance of the included histogram samples.

--- a/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
+++ b/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
@@ -159,7 +159,7 @@ fn compute_average(@builtin(local_invocation_index) local_index: u32) {
     //
     // If all values are below the threshold,
     // we should set it to the minimal value to avoid suddenly darkening the scene.
-    var target_exposure = settings.min_log_lum;
+    var target_exposure = compensation_curve.min_compensation;
 
     if count > 0u {
         // The average luminance of the included histogram samples.

--- a/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
+++ b/crates/bevy_core_pipeline/src/auto_exposure/auto_exposure.wgsl
@@ -174,31 +174,6 @@ fn compute_average(@builtin(local_invocation_index) local_index: u32) {
         * compensation_curve.compensation_range
         + compensation_curve.min_compensation
         - avg_lum;
-    // Target exposure controls how much we should brighten or darken the scene.
-    // Higher values will brighten the scene, while lower values will darken it.
-    //
-    // If all values are below the threshold,
-    // we should set it to the maximum value.
-    // Since no pixels are overexposed, we should correct the exposure as much as possible.
-    var target_exposure = compensation_curve.min_compensation + compensation_curve.compensation_range;
-
-    if count > 0u {
-        // The average luminance of the included histogram samples.
-        let avg_lum = sum / (f32(count) * 63.0)
-            * settings.log_lum_range
-            + settings.min_log_lum;
-
-        // The position in the compensation curve texture to sample for avg_lum.
-        let u = (avg_lum - compensation_curve.min_log_lum) * compensation_curve.inv_log_lum_range;
-
-        // The target exposure is the negative of the average log luminance.
-        // The compensation value is added to the target exposure to adjust the exposure for
-        // artistic purposes.
-        target_exposure = textureLoad(tex_compensation, i32(saturate(u) * 255.0), 0).r
-            * compensation_curve.compensation_range
-            + compensation_curve.min_compensation
-            - avg_lum;
-    }
 
     // Smoothly adjust the `exposure` towards the `target_exposure`
     let delta = target_exposure - exposure;

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -111,7 +111,7 @@ fn setup(
 
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 5000.0,
+            intensity: 2000.0,
             ..default()
         },
         transform: Transform::from_xyz(0.0, 0.0, 0.0),


### PR DESCRIPTION
# Objective

- In particularly dark scenes, auto-exposure would lead to an unexpected darkening of the view.
- Fixes #13446.

## Solution

The average luminance should default to something else than 0.0 instead, when there are no samples. We set it to `settings.min_log_lum`.

## Testing

I was able to reproduce the problem on the `auto_exposure` example by setting the point light intensity to 2000 and looking into the right-hand corner. There was a sudden darkening.

Now, the discontinuity is gone.