### PR TITLE
Allow custom prepass without normal attribute

### DIFF
--- a/assets/shaders/extended_material.wgsl
+++ b/assets/shaders/extended_material.wgsl
@@ -6,7 +6,7 @@
 #ifdef PREPASS_PIPELINE
 #import bevy_pbr::{
     prepass_io::{VertexOutput, FragmentOutput},
-    pbr_deferred_functions::deferred_output,
+    prepass_utils::prepass_output,
 }
 #else
 #import bevy_pbr::{
@@ -38,7 +38,7 @@ fn fragment(
 
 #ifdef PREPASS_PIPELINE
     // in deferred mode we can't modify anything after that, as lighting is run in a separate fullscreen shader.
-    let out = deferred_output(in, pbr_input);
+    let out = prepass_output(in, pbr_input);
 #else
     var out: FragmentOutput;
     // apply lighting

--- a/assets/shaders/water_material.wgsl
+++ b/assets/shaders/water_material.wgsl
@@ -4,7 +4,7 @@
 // This is used in the `ssr` example. It only supports deferred rendering.
 
 #import bevy_pbr::{
-    pbr_deferred_functions::deferred_output,
+    prepass_utils::prepass_output,
     pbr_fragment::pbr_input_from_standard_material,
     prepass_io::{VertexOutput, FragmentOutput},
 }
@@ -55,5 +55,5 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     // Bump the normal.
     pbr_input.N = sample_noise(in.uv, globals.time);
     // Send the rest to the deferred shader.
-    return deferred_output(in, pbr_input);
+    return prepass_output(in, pbr_input);
 }

--- a/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
+++ b/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
@@ -107,28 +107,3 @@ fn pbr_input_from_deferred_gbuffer(frag_coord: vec4<f32>, gbuffer: vec4<u32>) ->
 
     return pbr;
 }
-
-#ifdef PREPASS_PIPELINE
-fn deferred_output(in: VertexOutput, pbr_input: PbrInput) -> FragmentOutput {
-    var out: FragmentOutput;
-
-    // gbuffer
-    out.deferred = deferred_gbuffer_from_pbr_input(pbr_input);
-    // lighting pass id (used to determine which lighting shader to run for the fragment)
-    out.deferred_lighting_pass_id = pbr_input.material.deferred_lighting_pass_id;
-    // normal if required
-#ifdef NORMAL_PREPASS
-    out.normal = vec4(in.world_normal * 0.5 + vec3(0.5), 1.0);
-#endif
-    // motion vectors if required
-#ifdef MOTION_VECTOR_PREPASS
-#ifdef MESHLET_MESH_MATERIAL_PASS
-    out.motion_vector = in.motion_vector;
-#else
-    out.motion_vector = calculate_motion_vector(in.world_position, in.previous_world_position);
-#endif
-#endif
-
-    return out;
-}
-#endif

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -27,7 +27,7 @@ use bevy_render::{
     Extract,
 };
 use bevy_transform::prelude::GlobalTransform;
-use bevy_utils::tracing::error;
+use bevy_utils::tracing::{error, warn};
 
 #[cfg(feature = "meshlet")]
 use crate::meshlet::{
@@ -412,8 +412,15 @@ where
             .mesh_key
             .intersects(MeshPipelineKey::NORMAL_PREPASS | MeshPipelineKey::DEFERRED_PREPASS)
         {
-            vertex_attributes.push(Mesh::ATTRIBUTE_NORMAL.at_shader_location(3));
             shader_defs.push("NORMAL_PREPASS_OR_DEFERRED_PREPASS".into());
+            if layout.0.contains(Mesh::ATTRIBUTE_NORMAL) {
+                shader_defs.push("VERTEX_NORMALS".into());
+                vertex_attributes.push(Mesh::ATTRIBUTE_NORMAL.at_shader_location(3));
+            } else if matches!(M::prepass_fragment_shader(), ShaderRef::Default) {
+                warn!(
+                    "The default normal prepass expects the mesh to have vertex normal attributes. Either use a custom prepass shader or add vertex normal attributes."
+                );
+            }
             if layout.0.contains(Mesh::ATTRIBUTE_TANGENT) {
                 shader_defs.push("VERTEX_TANGENTS".into());
                 vertex_attributes.push(Mesh::ATTRIBUTE_TANGENT.at_shader_location(4));

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -67,11 +67,18 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif // VERTEX_UVS_B
 
 #ifdef NORMAL_PREPASS_OR_DEFERRED_PREPASS
+
+#ifdef VERTEX_NORMALS
+var normal_in = vertex.normal;
+#else
+var normal_in = vec3(0.0);
+#endif
+
 #ifdef SKINNED
-    out.world_normal = skinning::skin_normals(model, vertex.normal);
+    out.world_normal = skinning::skin_normals(model, normal_in);
 #else // SKINNED
     out.world_normal = mesh_functions::mesh_normal_local_to_world(
-        vertex.normal,
+        normal_in,
         // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
         // See https://github.com/gfx-rs/naga/issues/2416
         vertex_no_morph.instance_index

--- a/crates/bevy_pbr/src/prepass/prepass_io.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_io.wgsl
@@ -15,7 +15,9 @@ struct Vertex {
 #endif
 
 #ifdef NORMAL_PREPASS_OR_DEFERRED_PREPASS
+#ifdef VERTEX_NORMALS
     @location(3) normal: vec3<f32>,
+#endif
 #ifdef VERTEX_TANGENTS
     @location(4) tangent: vec4<f32>,
 #endif

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -6,7 +6,7 @@
 #ifdef PREPASS_PIPELINE
 #import bevy_pbr::{
     prepass_io::{VertexOutput, FragmentOutput},
-    pbr_deferred_functions::deferred_output,
+    prepass_utils::prepass_output,
 }
 #else
 #import bevy_pbr::{
@@ -49,7 +49,7 @@ fn fragment(
 
 #ifdef PREPASS_PIPELINE
     // write the gbuffer, lighting pass id, and optionally normal and motion_vector textures
-    let out = deferred_output(in, pbr_input);
+    let out = prepass_output(in, pbr_input);
 #else
     // in forward mode, we calculate the lit color immediately, and then apply some post-lighting effects here.
     // in deferred mode the lit color and these effects will be calculated in the deferred lighting shader


### PR DESCRIPTION
# Objective

There are a couple of problems when trying to use CustomMaterials in cobination with a prepass:

1. Right now when you try to run a custom prepass material that doesn't have a normal attribute (e.g. because you manually pack your mesh data, or generate it on the fly) bevy refuses to use it and logs the following:
`Mesh is missing requested attribute: Vertex_Normal (MeshVertexAttributeId(1), pipeline type: Some("bevy_pbr::prepass::PrepassPipeline<bevy_voxel::voxel_engine::rendering::CustomMaterialA>"))`

This PR should also fix #13054.

2. Fixing the first problem revealed a second problem: the shader function `deferred_output` is used across the engine both for generic prepasses and deferred repasses. However, it lacked necessary checks to ensure the deferred data is only written if the prepass actually uses deferred rendering.

## Solution

1. I added an if check to make sure the normal attribute is actually used.
2. The old `deferred_output` method was replaced with `prepass_output`, which works both when deferred rendering is disabled and enabled.

## Testing

- Did you test these changes? If so, how?
Yes, I ran my experimental game project and bevy no longer complained about the missing attribute.
- Are there any parts that need more testing?
Not that I am aware of.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Try to use a prepass material that doesn't have a normal attribute.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
I tested this on linux/vulkan, but I don't see why that would have any impact on this particular bug.

## Migration Guide

The shader function `pbr_deferred_functions::deferred_output` was replaced with `prepass_utils::prepass_output`. The new function should behave identical to the old one, with the added benefit of no longer crashing when running in a prepass without deferred lighting.