### PR TITLE
Implement motion vectors and TAA for skinned meshes and meshes with morph targets.

### DIFF
--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -124,8 +124,6 @@ pub struct TemporalAntiAliasBundle {
 ///
 /// [Currently](https://github.com/bevyengine/bevy/issues/8423) cannot be used with [`bevy_render::camera::OrthographicProjection`].
 ///
-/// Currently does not support skinned meshes and morph targets.
-/// There will probably be ghosting artifacts if used with them.
 /// Does not work well with alpha-blended meshes as it requires depth writing to determine motion.
 ///
 /// It is very important that correct motion vectors are written for everything on screen.

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -317,12 +317,12 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
             shader_defs.push("SCREEN_SPACE_REFLECTIONS".into());
         }
 
-        if key.contains(MeshPipelineKey::HAVE_PREVIOUS_SKIN) {
-            shader_defs.push("HAVE_PREVIOUS_SKIN".into());
+        if key.contains(MeshPipelineKey::HAS_PREVIOUS_SKIN) {
+            shader_defs.push("HAS_PREVIOUS_SKIN".into());
         }
 
-        if key.contains(MeshPipelineKey::HAVE_PREVIOUS_MORPH) {
-            shader_defs.push("HAVE_PREVIOUS_MORPH".into());
+        if key.contains(MeshPipelineKey::HAS_PREVIOUS_MORPH) {
+            shader_defs.push("HAS_PREVIOUS_MORPH".into());
         }
 
         // Always true, since we're in the deferred lighting pipeline

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -317,6 +317,14 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
             shader_defs.push("SCREEN_SPACE_REFLECTIONS".into());
         }
 
+        if key.contains(MeshPipelineKey::HAVE_PREVIOUS_SKIN) {
+            shader_defs.push("HAVE_PREVIOUS_SKIN".into());
+        }
+
+        if key.contains(MeshPipelineKey::HAVE_PREVIOUS_MORPH) {
+            shader_defs.push("HAVE_PREVIOUS_MORPH".into());
+        }
+
         // Always true, since we're in the deferred lighting pipeline
         shader_defs.push("DEFERRED_PREPASS".into());
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -701,6 +701,20 @@ pub fn queue_material_meshes<M: Material>(
                 mesh_key |= MeshPipelineKey::VISIBILITY_RANGE_DITHER;
             }
 
+            // If the previous frame have skins or morph targets, note that.
+            if mesh_instance
+                .flags
+                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_SKIN)
+            {
+                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_SKIN;
+            }
+            if mesh_instance
+                .flags
+                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_MORPH)
+            {
+                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_MORPH;
+            }
+
             let pipeline_id = pipelines.specialize(
                 &pipeline_cache,
                 &material_pipeline,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -704,15 +704,15 @@ pub fn queue_material_meshes<M: Material>(
             // If the previous frame have skins or morph targets, note that.
             if mesh_instance
                 .flags
-                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_SKIN)
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
             {
-                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_SKIN;
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
             }
             if mesh_instance
                 .flags
-                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_MORPH)
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
             {
-                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_MORPH;
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
             }
 
             let pipeline_id = pipelines.specialize(

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -701,18 +701,20 @@ pub fn queue_material_meshes<M: Material>(
                 mesh_key |= MeshPipelineKey::VISIBILITY_RANGE_DITHER;
             }
 
-            // If the previous frame have skins or morph targets, note that.
-            if mesh_instance
-                .flags
-                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
-            {
-                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
-            }
-            if mesh_instance
-                .flags
-                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
-            {
-                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
+            if motion_vector_prepass {
+                // If the previous frame have skins or morph targets, note that.
+                if mesh_instance
+                    .flags
+                    .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
+                {
+                    mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
+                }
+                if mesh_instance
+                    .flags
+                    .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
+                {
+                    mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
+                }
             }
 
             let pipeline_id = pipelines.specialize(

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -443,6 +443,14 @@ where
             shader_defs.push("MOTION_VECTOR_PREPASS".into());
         }
 
+        if key.mesh_key.contains(MeshPipelineKey::HAVE_PREVIOUS_SKIN) {
+            shader_defs.push("HAVE_PREVIOUS_SKIN".into());
+        }
+
+        if key.mesh_key.contains(MeshPipelineKey::HAVE_PREVIOUS_MORPH) {
+            shader_defs.push("HAVE_PREVIOUS_MORPH".into());
+        }
+
         if key.mesh_key.intersects(
             MeshPipelineKey::NORMAL_PREPASS
                 | MeshPipelineKey::MOTION_VECTOR_PREPASS
@@ -851,6 +859,20 @@ pub fn queue_prepass_material_meshes<M: Material>(
                 .contains_key(visible_entity)
             {
                 mesh_key |= MeshPipelineKey::LIGHTMAPPED;
+            }
+
+            // If the previous frame have skins or morph targets, note that.
+            if mesh_instance
+                .flags
+                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_SKIN)
+            {
+                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_SKIN;
+            }
+            if mesh_instance
+                .flags
+                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_MORPH)
+            {
+                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_MORPH;
             }
 
             let pipeline_id = pipelines.specialize(

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -861,18 +861,20 @@ pub fn queue_prepass_material_meshes<M: Material>(
                 mesh_key |= MeshPipelineKey::LIGHTMAPPED;
             }
 
-            // If the previous frame have skins or morph targets, note that.
-            if mesh_instance
-                .flags
-                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
-            {
-                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
-            }
-            if mesh_instance
-                .flags
-                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
-            {
-                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
+            // If the previous frame has skins or morph targets, note that.
+            if motion_vector_prepass.is_some() {
+                if mesh_instance
+                    .flags
+                    .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
+                {
+                    mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
+                }
+                if mesh_instance
+                    .flags
+                    .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
+                {
+                    mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
+                }
             }
 
             let pipeline_id = pipelines.specialize(

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -443,12 +443,12 @@ where
             shader_defs.push("MOTION_VECTOR_PREPASS".into());
         }
 
-        if key.mesh_key.contains(MeshPipelineKey::HAVE_PREVIOUS_SKIN) {
-            shader_defs.push("HAVE_PREVIOUS_SKIN".into());
+        if key.mesh_key.contains(MeshPipelineKey::HAS_PREVIOUS_SKIN) {
+            shader_defs.push("HAS_PREVIOUS_SKIN".into());
         }
 
-        if key.mesh_key.contains(MeshPipelineKey::HAVE_PREVIOUS_MORPH) {
-            shader_defs.push("HAVE_PREVIOUS_MORPH".into());
+        if key.mesh_key.contains(MeshPipelineKey::HAS_PREVIOUS_MORPH) {
+            shader_defs.push("HAS_PREVIOUS_MORPH".into());
         }
 
         if key.mesh_key.intersects(
@@ -864,15 +864,15 @@ pub fn queue_prepass_material_meshes<M: Material>(
             // If the previous frame have skins or morph targets, note that.
             if mesh_instance
                 .flags
-                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_SKIN)
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
             {
-                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_SKIN;
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
             }
             if mesh_instance
                 .flags
-                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_MORPH)
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
             {
-                mesh_key |= MeshPipelineKey::HAVE_PREVIOUS_MORPH;
+                mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
             }
 
             let pipeline_id = pipelines.specialize(

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -31,7 +31,26 @@ fn morph_vertex(vertex_in: Vertex) -> Vertex {
     }
     return vertex;
 }
-#endif
+
+// Returns the morphed position of the given vertex from the previous frame.
+//
+// This function is used for motion vector calculation, and, as such, it doesn't
+// bother morphing the normals and tangents.
+fn morph_prev_vertex(vertex_in: Vertex) -> Vertex {
+    var vertex = vertex_in;
+    let weight_count = morph::layer_count();
+    for (var i: u32 = 0u; i < weight_count; i ++) {
+        let weight = morph::prev_weight_at(i);
+        if weight == 0.0 {
+            continue;
+        }
+        vertex.position += weight * morph::morph(vertex.index, morph::position_offset, i);
+        // Don't bother morphing normals and tangents; we don't need them for
+        // motion vector calculation.
+    }
+    return vertex;
+}
+#endif  // MORPH_TARGETS
 
 @vertex
 fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
@@ -93,12 +112,42 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.color = vertex.color;
 #endif
 
+    // Compute the motion vector, for TAA. For this we need to know where the
+    // vertex was last frame.
 #ifdef MOTION_VECTOR_PREPASS
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-    // See https://github.com/gfx-rs/naga/issues/2416
+
+    // Take morph targets into account.
+#ifdef MORPH_TARGETS
+
+#ifdef HAVE_PREVIOUS_MORPH
+    let prev_vertex = morph_prev_vertex(vertex_no_morph);
+#else   // HAVE_PREVIOUS_MORPH
+    let prev_vertex = vertex_no_morph;
+#endif  // HAVE_PREVIOUS_MORPH
+
+#else   // MORPH_TARGETS
+    let prev_vertex = vertex_no_morph;
+#endif  // MORPH_TARGETS
+
+    // Take skinning into account.
+#ifdef SKINNED
+
+#ifdef HAVE_PREVIOUS_SKIN
+    let prev_model = skinning::skin_prev_model(
+        prev_vertex.joint_indices,
+        prev_vertex.joint_weights,
+    );
+#else   // HAVE_PREVIOUS_SKIN
+    let prev_model = mesh_functions::get_previous_model_matrix(prev_vertex.instance_index);
+#endif  // HAVE_PREVIOUS_SKIN
+
+#else   // SKINNED
+    let prev_model = mesh_functions::get_previous_model_matrix(prev_vertex.instance_index);
+#endif  // SKINNED
+
     out.previous_world_position = mesh_functions::mesh_position_local_to_world(
-        mesh_functions::get_previous_model_matrix(vertex_no_morph.instance_index),
-        vec4<f32>(vertex.position, 1.0)
+        prev_model,
+        vec4<f32>(prev_vertex.position, 1.0)
     );
 #endif // MOTION_VECTOR_PREPASS
 

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -112,18 +112,18 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.color = vertex.color;
 #endif
 
-    // Compute the motion vector, for TAA. For this we need to know where the
-    // vertex was last frame.
+    // Compute the motion vector for TAA among other purposes. For this we need
+    // to know where the vertex was last frame.
 #ifdef MOTION_VECTOR_PREPASS
 
     // Take morph targets into account.
 #ifdef MORPH_TARGETS
 
-#ifdef HAVE_PREVIOUS_MORPH
+#ifdef HAS_PREVIOUS_MORPH
     let prev_vertex = morph_prev_vertex(vertex_no_morph);
-#else   // HAVE_PREVIOUS_MORPH
+#else   // HAS_PREVIOUS_MORPH
     let prev_vertex = vertex_no_morph;
-#endif  // HAVE_PREVIOUS_MORPH
+#endif  // HAS_PREVIOUS_MORPH
 
 #else   // MORPH_TARGETS
     let prev_vertex = vertex_no_morph;
@@ -132,14 +132,14 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     // Take skinning into account.
 #ifdef SKINNED
 
-#ifdef HAVE_PREVIOUS_SKIN
+#ifdef HAS_PREVIOUS_SKIN
     let prev_model = skinning::skin_prev_model(
         prev_vertex.joint_indices,
         prev_vertex.joint_weights,
     );
-#else   // HAVE_PREVIOUS_SKIN
+#else   // HAS_PREVIOUS_SKIN
     let prev_model = mesh_functions::get_previous_model_matrix(prev_vertex.instance_index);
-#endif  // HAVE_PREVIOUS_SKIN
+#endif  // HAS_PREVIOUS_SKIN
 
 #else   // SKINNED
     let prev_model = mesh_functions::get_previous_model_matrix(prev_vertex.instance_index);

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -409,14 +409,15 @@ bitflags::bitflags! {
         const SHADOW_CASTER           = 1 << 0;
         /// The mesh can participate in automatic batching.
         const AUTOMATIC_BATCHING      = 1 << 1;
-        /// The mesh had a transform last frame and so is eligible for TAA.
-        const HAVE_PREVIOUS_TRANSFORM = 1 << 2;
+        /// The mesh had a transform last frame and so is eligible for motion
+        /// vector computation.
+        const HAS_PREVIOUS_TRANSFORM  = 1 << 2;
         /// The mesh had a skin last frame and so that skin should be taken into
-        /// account for TAA.
-        const HAVE_PREVIOUS_SKIN      = 1 << 3;
+        /// account for motion vector computation.
+        const HAS_PREVIOUS_SKIN       = 1 << 3;
         /// The mesh had morph targets last frame and so they should be taken
-        /// into account for TAA.
-        const HAVE_PREVIOUS_MORPH     = 1 << 4;
+        /// into account for motion vector computation.
+        const HAS_PREVIOUS_MORPH      = 1 << 4;
     }
 }
 
@@ -529,7 +530,7 @@ impl RenderMeshInstanceShared {
             !no_automatic_batching,
         );
         mesh_instance_flags.set(
-            RenderMeshInstanceFlags::HAVE_PREVIOUS_TRANSFORM,
+            RenderMeshInstanceFlags::HAS_PREVIOUS_TRANSFORM,
             previous_transform.is_some(),
         );
 
@@ -982,7 +983,7 @@ pub fn extract_meshes_for_gpu_building(
 
             let previous_input_index = if shared
                 .flags
-                .contains(RenderMeshInstanceFlags::HAVE_PREVIOUS_TRANSFORM)
+                .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_TRANSFORM)
             {
                 render_mesh_instances
                     .get(&entity)
@@ -1032,11 +1033,11 @@ fn set_mesh_motion_vector_flags(
 ) {
     for &entity in skin_indices.prev.keys() {
         render_mesh_instances
-            .insert_mesh_instance_flags(entity, RenderMeshInstanceFlags::HAVE_PREVIOUS_SKIN);
+            .insert_mesh_instance_flags(entity, RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN);
     }
     for &entity in morph_indices.prev.keys() {
         render_mesh_instances
-            .insert_mesh_instance_flags(entity, RenderMeshInstanceFlags::HAVE_PREVIOUS_MORPH);
+            .insert_mesh_instance_flags(entity, RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH);
     }
 }
 
@@ -1406,9 +1407,9 @@ bitflags::bitflags! {
         const IRRADIANCE_VOLUME                 = 1 << 14;
         const VISIBILITY_RANGE_DITHER           = 1 << 15;
         const SCREEN_SPACE_REFLECTIONS          = 1 << 16;
-        const HAVE_PREVIOUS_SKIN                = 1 << 17;
-        const HAVE_PREVIOUS_MORPH               = 1 << 18;
-        const LAST_FLAG                         = Self::HAVE_PREVIOUS_MORPH.bits();
+        const HAS_PREVIOUS_SKIN                = 1 << 17;
+        const HAS_PREVIOUS_MORPH               = 1 << 18;
+        const LAST_FLAG                         = Self::HAS_PREVIOUS_MORPH.bits();
 
         // Bitfields
         const MSAA_RESERVED_BITS                = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
@@ -1710,12 +1711,12 @@ impl SpecializedMeshPipeline for MeshPipeline {
             shader_defs.push("MOTION_VECTOR_PREPASS".into());
         }
 
-        if key.contains(MeshPipelineKey::HAVE_PREVIOUS_SKIN) {
-            shader_defs.push("HAVE_PREVIOUS_SKIN".into());
+        if key.contains(MeshPipelineKey::HAS_PREVIOUS_SKIN) {
+            shader_defs.push("HAS_PREVIOUS_SKIN".into());
         }
 
-        if key.contains(MeshPipelineKey::HAVE_PREVIOUS_MORPH) {
-            shader_defs.push("HAVE_PREVIOUS_MORPH".into());
+        if key.contains(MeshPipelineKey::HAS_PREVIOUS_MORPH) {
+            shader_defs.push("HAS_PREVIOUS_MORPH".into());
         }
 
         if key.contains(MeshPipelineKey::DEFERRED_PREPASS) {

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -106,16 +106,29 @@ pub struct MeshLayouts {
     /// Also includes the uniform for skinning
     pub skinned: BindGroupLayout,
 
+    /// Like [`MeshLayouts::skinned`], but includes slots for the previous
+    /// frame's joint matrices, so that we can compute motion vectors.
+    pub skinned_motion: BindGroupLayout,
+
     /// Also includes the uniform and [`MorphAttributes`] for morph targets.
     ///
     /// [`MorphAttributes`]: bevy_render::mesh::morph::MorphAttributes
     pub morphed: BindGroupLayout,
+
+    /// Like [`MeshLayouts::morphed`], but includes a slot for the previous
+    /// frame's morph weights, so that we can compute motion vectors.
+    pub morphed_motion: BindGroupLayout,
 
     /// Also includes both uniforms for skinning and morph targets, also the
     /// morph target [`MorphAttributes`] binding.
     ///
     /// [`MorphAttributes`]: bevy_render::mesh::morph::MorphAttributes
     pub morphed_skinned: BindGroupLayout,
+
+    /// Like [`MeshLayouts::morphed_skinned`], but includes slots for the
+    /// previous frame's joint matrices and morph weights, so that we can
+    /// compute motion vectors.
+    pub morphed_skinned_motion: BindGroupLayout,
 }
 
 impl MeshLayouts {
@@ -127,8 +140,11 @@ impl MeshLayouts {
             model_only: Self::model_only_layout(render_device),
             lightmapped: Self::lightmapped_layout(render_device),
             skinned: Self::skinned_layout(render_device),
+            skinned_motion: Self::skinned_motion_layout(render_device),
             morphed: Self::morphed_layout(render_device),
+            morphed_motion: Self::morphed_motion_layout(render_device),
             morphed_skinned: Self::morphed_skinned_layout(render_device),
+            morphed_skinned_motion: Self::morphed_skinned_motion_layout(render_device),
         }
     }
 
@@ -154,6 +170,22 @@ impl MeshLayouts {
                     (0, layout_entry::model(render_device)),
                     // The current frame's joint matrix buffer.
                     (1, layout_entry::skinning()),
+                ),
+            ),
+        )
+    }
+
+    /// Creates the layout for skinned meshes with the infrastructure to compute
+    /// motion vectors.
+    fn skinned_motion_layout(render_device: &RenderDevice) -> BindGroupLayout {
+        render_device.create_bind_group_layout(
+            "skinned_motion_mesh_layout",
+            &BindGroupLayoutEntries::with_indices(
+                ShaderStages::VERTEX,
+                (
+                    (0, layout_entry::model(render_device)),
+                    // The current frame's joint matrix buffer.
+                    (1, layout_entry::skinning()),
                     // The previous frame's joint matrix buffer.
                     (6, layout_entry::skinning()),
                 ),
@@ -163,6 +195,23 @@ impl MeshLayouts {
 
     /// Creates the layout for meshes with morph targets.
     fn morphed_layout(render_device: &RenderDevice) -> BindGroupLayout {
+        render_device.create_bind_group_layout(
+            "morphed_mesh_layout",
+            &BindGroupLayoutEntries::with_indices(
+                ShaderStages::VERTEX,
+                (
+                    (0, layout_entry::model(render_device)),
+                    // The current frame's morph weight buffer.
+                    (2, layout_entry::weights()),
+                    (3, layout_entry::targets()),
+                ),
+            ),
+        )
+    }
+
+    /// Creates the layout for meshes with morph targets and the infrastructure
+    /// to compute motion vectors.
+    fn morphed_motion_layout(render_device: &RenderDevice) -> BindGroupLayout {
         render_device.create_bind_group_layout(
             "morphed_mesh_layout",
             &BindGroupLayoutEntries::with_indices(
@@ -184,6 +233,29 @@ impl MeshLayouts {
     fn morphed_skinned_layout(render_device: &RenderDevice) -> BindGroupLayout {
         render_device.create_bind_group_layout(
             "morphed_skinned_mesh_layout",
+            &BindGroupLayoutEntries::with_indices(
+                ShaderStages::VERTEX,
+                (
+                    (0, layout_entry::model(render_device)),
+                    // The current frame's joint matrix buffer.
+                    (1, layout_entry::skinning()),
+                    // The current frame's morph weight buffer.
+                    (2, layout_entry::weights()),
+                    (3, layout_entry::targets()),
+                    // The previous frame's joint matrix buffer.
+                    (6, layout_entry::skinning()),
+                    // The previous frame's morph weight buffer.
+                    (7, layout_entry::weights()),
+                ),
+            ),
+        )
+    }
+
+    /// Creates the bind group layout for meshes with both skins and morph
+    /// targets, in addition to the infrastructure to compute motion vectors.
+    fn morphed_skinned_motion_layout(render_device: &RenderDevice) -> BindGroupLayout {
+        render_device.create_bind_group_layout(
+            "morphed_skinned_motion_mesh_layout",
             &BindGroupLayoutEntries::with_indices(
                 ShaderStages::VERTEX,
                 (
@@ -244,12 +316,30 @@ impl MeshLayouts {
     }
 
     /// Creates the bind group for skinned meshes with no morph targets.
+    pub fn skinned(
+        &self,
+        render_device: &RenderDevice,
+        model: &BindingResource,
+        current_skin: &Buffer,
+    ) -> BindGroup {
+        render_device.create_bind_group(
+            "skinned_mesh_bind_group",
+            &self.skinned,
+            &[
+                entry::model(0, model.clone()),
+                entry::skinning(1, current_skin),
+            ],
+        )
+    }
+
+    /// Creates the bind group for skinned meshes with no morph targets, with
+    /// the infrastructure to compute motion vectors.
     ///
     /// `current_skin` is the buffer of joint matrices for this frame;
     /// `prev_skin` is the buffer for the previous frame. The latter is used for
     /// motion vector computation. If there is no such applicable buffer,
     /// `current_skin` and `prev_skin` will reference the same buffer.
-    pub fn skinned(
+    pub fn skinned_motion(
         &self,
         render_device: &RenderDevice,
         model: &BindingResource,
@@ -257,8 +347,8 @@ impl MeshLayouts {
         prev_skin: &Buffer,
     ) -> BindGroup {
         render_device.create_bind_group(
-            "skinned_mesh_bind_group",
-            &self.skinned,
+            "skinned_motion_mesh_bind_group",
+            &self.skinned_motion,
             &[
                 entry::model(0, model.clone()),
                 entry::skinning(1, current_skin),
@@ -268,12 +358,32 @@ impl MeshLayouts {
     }
 
     /// Creates the bind group for meshes with no skins but morph targets.
+    pub fn morphed(
+        &self,
+        render_device: &RenderDevice,
+        model: &BindingResource,
+        current_weights: &Buffer,
+        targets: &TextureView,
+    ) -> BindGroup {
+        render_device.create_bind_group(
+            "morphed_mesh_bind_group",
+            &self.morphed,
+            &[
+                entry::model(0, model.clone()),
+                entry::weights(2, current_weights),
+                entry::targets(3, targets),
+            ],
+        )
+    }
+
+    /// Creates the bind group for meshes with no skins but morph targets, in
+    /// addition to the infrastructure to compute motion vectors.
     ///
     /// `current_weights` is the buffer of morph weights for this frame;
     /// `prev_weights` is the buffer for the previous frame. The latter is used
     /// for motion vector computation. If there is no such applicable buffer,
     /// `current_weights` and `prev_weights` will reference the same buffer.
-    pub fn morphed(
+    pub fn morphed_motion(
         &self,
         render_device: &RenderDevice,
         model: &BindingResource,
@@ -282,8 +392,8 @@ impl MeshLayouts {
         prev_weights: &Buffer,
     ) -> BindGroup {
         render_device.create_bind_group(
-            "morphed_mesh_bind_group",
-            &self.morphed,
+            "morphed_motion_mesh_bind_group",
+            &self.morphed_motion,
             &[
                 entry::model(0, model.clone()),
                 entry::weights(2, current_weights),
@@ -294,12 +404,36 @@ impl MeshLayouts {
     }
 
     /// Creates the bind group for meshes with skins and morph targets.
-    ///
-    /// See the documentation for [`skinned`] and [`morphed`] above for more
-    /// information about the `current_skin`, `prev_skin`, `current_weights`,
-    /// and `prev_weights` buffers.
     #[allow(clippy::too_many_arguments)]
     pub fn morphed_skinned(
+        &self,
+        render_device: &RenderDevice,
+        model: &BindingResource,
+        current_skin: &Buffer,
+        current_weights: &Buffer,
+        targets: &TextureView,
+    ) -> BindGroup {
+        render_device.create_bind_group(
+            "morphed_skinned_mesh_bind_group",
+            &self.morphed_skinned,
+            &[
+                entry::model(0, model.clone()),
+                entry::skinning(1, current_skin),
+                entry::weights(2, current_weights),
+                entry::targets(3, targets),
+            ],
+        )
+    }
+
+    /// Creates the bind group for meshes with skins and morph targets, in
+    /// addition to the infrastructure to compute motion vectors.
+    ///
+    /// See the documentation for [`MeshLayouts::skinned_motion`] and
+    /// [`MeshLayouts::morphed_motion`] above for more information about the
+    /// `current_skin`, `prev_skin`, `current_weights`, and `prev_weights`
+    /// buffers.
+    #[allow(clippy::too_many_arguments)]
+    pub fn morphed_skinned_motion(
         &self,
         render_device: &RenderDevice,
         model: &BindingResource,
@@ -310,8 +444,8 @@ impl MeshLayouts {
         prev_weights: &Buffer,
     ) -> BindGroup {
         render_device.create_bind_group(
-            "morphed_skinned_mesh_bind_group",
-            &self.morphed_skinned,
+            "morphed_skinned_motion_mesh_bind_group",
+            &self.morphed_skinned_motion,
             &[
                 entry::model(0, model.clone()),
                 entry::skinning(1, current_skin),

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -13,4 +13,4 @@ pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
-pub use skin::{extract_skins, prepare_skins, SkinIndex, SkinUniform, MAX_JOINTS};
+pub use skin::{extract_skins, prepare_skins, SkinIndices, SkinUniforms, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -1,6 +1,5 @@
 use std::{iter, mem};
 
-use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::entity::EntityHashMap;
 use bevy_ecs::prelude::*;
 use bevy_render::{
@@ -18,18 +17,41 @@ pub struct MorphIndex {
     pub(super) index: u32,
 }
 
-#[derive(Default, Resource, Deref, DerefMut)]
-pub struct MorphIndices(EntityHashMap<MorphIndex>);
+/// Maps each mesh affected by morph targets to the applicable offset within the
+/// [`MorphUniforms`] buffer.
+///
+/// We store both the current frame's mapping and the previous frame's mapping
+/// for the purposes of motion vector calculation.
+#[derive(Default, Resource)]
+pub struct MorphIndices {
+    /// Maps each entity with a morphed mesh to the appropriate offset within
+    /// [`MorphUniforms::current_buffer`].
+    pub current: EntityHashMap<MorphIndex>,
 
-#[derive(Resource)]
-pub struct MorphUniform {
-    pub buffer: RawBufferVec<f32>,
+    /// Maps each entity with a morphed mesh to the appropriate offset within
+    /// [`MorphUniforms::prev_buffer`].
+    pub prev: EntityHashMap<MorphIndex>,
 }
 
-impl Default for MorphUniform {
+/// The GPU buffers containing morph weights for all meshes with morph targets.
+///
+/// This is double-buffered: we store the weights of the previous frame in
+/// addition to those of the current frame. This is for motion vector
+/// calculation. Every frame, we swap buffers and reuse the morph target weight
+/// buffer from two frames ago for the current frame.
+#[derive(Resource)]
+pub struct MorphUniforms {
+    /// The morph weights for the current frame.
+    pub current_buffer: RawBufferVec<f32>,
+    /// The morph weights for the previous frame.
+    pub prev_buffer: RawBufferVec<f32>,
+}
+
+impl Default for MorphUniforms {
     fn default() -> Self {
         Self {
-            buffer: RawBufferVec::new(BufferUsages::UNIFORM),
+            current_buffer: RawBufferVec::new(BufferUsages::UNIFORM),
+            prev_buffer: RawBufferVec::new(BufferUsages::UNIFORM),
         }
     }
 }
@@ -37,14 +59,19 @@ impl Default for MorphUniform {
 pub fn prepare_morphs(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut uniform: ResMut<MorphUniform>,
+    mut uniform: ResMut<MorphUniforms>,
 ) {
-    if uniform.buffer.is_empty() {
+    if uniform.current_buffer.is_empty() {
         return;
     }
-    let len = uniform.buffer.len();
-    uniform.buffer.reserve(len, &render_device);
-    uniform.buffer.write_buffer(&render_device, &render_queue);
+    let len = uniform.current_buffer.len();
+    uniform.current_buffer.reserve(len, &render_device);
+    uniform
+        .current_buffer
+        .write_buffer(&render_device, &render_queue);
+
+    // We don't need to write `uniform.prev_buffer` because we already wrote it
+    // last frame, and the data should still be on the GPU.
 }
 
 const fn can_align(step: usize, target: usize) -> bool {
@@ -80,25 +107,32 @@ fn add_to_alignment<T: NoUninit + Default>(buffer: &mut RawBufferVec<T>) {
 // Notes on implementation: see comment on top of the extract_skins system in skin module.
 // This works similarly, but for `f32` instead of `Mat4`
 pub fn extract_morphs(
-    mut morph_indices: ResMut<MorphIndices>,
-    mut uniform: ResMut<MorphUniform>,
+    morph_indices: ResMut<MorphIndices>,
+    uniform: ResMut<MorphUniforms>,
     query: Extract<Query<(Entity, &ViewVisibility, &MeshMorphWeights)>>,
 ) {
-    morph_indices.clear();
-    uniform.buffer.clear();
+    // Borrow check workaround.
+    let (morph_indices, uniform) = (morph_indices.into_inner(), uniform.into_inner());
+
+    // Swap buffers. We need to keep the previous frame's buffer around for the
+    // purposes of motion vector computation.
+    mem::swap(&mut morph_indices.current, &mut morph_indices.prev);
+    mem::swap(&mut uniform.current_buffer, &mut uniform.prev_buffer);
+    morph_indices.current.clear();
+    uniform.current_buffer.clear();
 
     for (entity, view_visibility, morph_weights) in &query {
         if !view_visibility.get() {
             continue;
         }
-        let start = uniform.buffer.len();
+        let start = uniform.current_buffer.len();
         let weights = morph_weights.weights();
         let legal_weights = weights.iter().take(MAX_MORPH_WEIGHTS).copied();
-        uniform.buffer.extend(legal_weights);
-        add_to_alignment::<f32>(&mut uniform.buffer);
+        uniform.current_buffer.extend(legal_weights);
+        add_to_alignment::<f32>(&mut uniform.current_buffer);
 
         let index = (start * mem::size_of::<f32>()) as u32;
-        morph_indices.insert(entity, MorphIndex { index });
+        morph_indices.current.insert(entity, MorphIndex { index });
     }
 }
 

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -6,6 +6,7 @@
 
 @group(1) @binding(2) var<uniform> morph_weights: MorphWeights;
 @group(1) @binding(3) var morph_targets: texture_3d<f32>;
+@group(1) @binding(7) var<uniform> prev_morph_weights: MorphWeights;
 
 // NOTE: Those are the "hardcoded" values found in `MorphAttributes` struct
 // in crates/bevy_render/src/mesh/morph/visitors.rs
@@ -28,6 +29,10 @@ fn component_texture_coord(vertex_index: u32, component_offset: u32) -> vec2<u32
 fn weight_at(weight_index: u32) -> f32 {
     let i = weight_index;
     return morph_weights.weights[i / 4u][i % 4u];
+}
+fn prev_weight_at(weight_index: u32) -> f32 {
+    let i = weight_index;
+    return prev_morph_weights.weights[i / 4u][i % 4u];
 }
 fn morph_pixel(vertex: u32, component: u32, weight: u32) -> f32 {
     let coord = component_texture_coord(vertex, component);

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -1,5 +1,6 @@
+use std::mem;
+
 use bevy_asset::Assets;
-use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::entity::EntityHashMap;
 use bevy_ecs::prelude::*;
 use bevy_math::Mat4;
@@ -30,19 +31,44 @@ impl SkinIndex {
     }
 }
 
-#[derive(Default, Resource, Deref, DerefMut)]
-pub struct SkinIndices(EntityHashMap<SkinIndex>);
+/// Maps each skinned mesh to the applicable offset within the [`SkinUniforms`]
+/// buffer.
+///
+/// We store both the current frame's joint matrices and the previous frame's
+/// joint matrices for the purposes of motion vector calculation.
+#[derive(Default, Resource)]
+pub struct SkinIndices {
+    /// Maps each skinned mesh to the applicable offset within
+    /// [`SkinUniforms::current_buffer`].
+    pub current: EntityHashMap<SkinIndex>,
 
-// Notes on implementation: see comment on top of the `extract_skins` system.
-#[derive(Resource)]
-pub struct SkinUniform {
-    pub buffer: RawBufferVec<Mat4>,
+    /// Maps each skinned mesh to the applicable offset within
+    /// [`SkinUniforms::prev_buffer`].
+    pub prev: EntityHashMap<SkinIndex>,
 }
 
-impl Default for SkinUniform {
+/// The GPU buffers containing joint matrices for all skinned meshes.
+///
+/// This is double-buffered: we store the joint matrices of each mesh for the
+/// previous frame in addition to those of each mesh for the current frame. This
+/// is for motion vector calculation. Every frame, we swap buffers and overwrite
+/// the joint matrix buffer from two frames ago with the data for the current
+/// frame.
+///
+/// Notes on implementation: see comment on top of the `extract_skins` system.
+#[derive(Resource)]
+pub struct SkinUniforms {
+    /// Stores all the joint matrices for skinned meshes in the current frame.
+    pub current_buffer: RawBufferVec<Mat4>,
+    /// Stores all the joint matrices for skinned meshes in the previous frame.
+    pub prev_buffer: RawBufferVec<Mat4>,
+}
+
+impl Default for SkinUniforms {
     fn default() -> Self {
         Self {
-            buffer: RawBufferVec::new(BufferUsages::UNIFORM),
+            current_buffer: RawBufferVec::new(BufferUsages::UNIFORM),
+            prev_buffer: RawBufferVec::new(BufferUsages::UNIFORM),
         }
     }
 }
@@ -50,15 +76,20 @@ impl Default for SkinUniform {
 pub fn prepare_skins(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut uniform: ResMut<SkinUniform>,
+    mut uniform: ResMut<SkinUniforms>,
 ) {
-    if uniform.buffer.is_empty() {
+    if uniform.current_buffer.is_empty() {
         return;
     }
 
-    let len = uniform.buffer.len();
-    uniform.buffer.reserve(len, &render_device);
-    uniform.buffer.write_buffer(&render_device, &render_queue);
+    let len = uniform.current_buffer.len();
+    uniform.current_buffer.reserve(len, &render_device);
+    uniform
+        .current_buffer
+        .write_buffer(&render_device, &render_queue);
+
+    // We don't need to write `uniform.prev_buffer` because we already wrote it
+    // last frame, and the data should still be on the GPU.
 }
 
 // Notes on implementation:
@@ -88,14 +119,22 @@ pub fn prepare_skins(
 // which normally only support fixed size arrays. You just have to make sure
 // in the shader that you only read the values that are valid for that binding.
 pub fn extract_skins(
-    mut skin_indices: ResMut<SkinIndices>,
-    mut uniform: ResMut<SkinUniform>,
+    skin_indices: ResMut<SkinIndices>,
+    uniform: ResMut<SkinUniforms>,
     query: Extract<Query<(Entity, &ViewVisibility, &SkinnedMesh)>>,
     inverse_bindposes: Extract<Res<Assets<SkinnedMeshInverseBindposes>>>,
     joints: Extract<Query<&GlobalTransform>>,
 ) {
-    uniform.buffer.clear();
-    skin_indices.clear();
+    // Borrow check workaround.
+    let (skin_indices, uniform) = (skin_indices.into_inner(), uniform.into_inner());
+
+    // Swap buffers. We need to keep the previous frame's buffer around for the
+    // purposes of motion vector computation.
+    mem::swap(&mut skin_indices.current, &mut skin_indices.prev);
+    mem::swap(&mut uniform.current_buffer, &mut uniform.prev_buffer);
+    skin_indices.current.clear();
+    uniform.current_buffer.clear();
+
     let mut last_start = 0;
 
     // PERF: This can be expensive, can we move this to prepare?
@@ -103,7 +142,7 @@ pub fn extract_skins(
         if !view_visibility.get() {
             continue;
         }
-        let buffer = &mut uniform.buffer;
+        let buffer = &mut uniform.current_buffer;
         let Some(inverse_bindposes) = inverse_bindposes.get(&skin.inverse_bindposes) else {
             continue;
         };
@@ -130,12 +169,12 @@ pub fn extract_skins(
             buffer.push(Mat4::ZERO);
         }
 
-        skin_indices.insert(entity, SkinIndex::new(start));
+        skin_indices.current.insert(entity, SkinIndex::new(start));
     }
 
     // Pad out the buffer to ensure that there's enough space for bindings
-    while uniform.buffer.len() - last_start < MAX_JOINTS {
-        uniform.buffer.push(Mat4::ZERO);
+    while uniform.current_buffer.len() - last_start < MAX_JOINTS {
+        uniform.current_buffer.push(Mat4::ZERO);
     }
 }
 

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -6,6 +6,14 @@
 
 @group(1) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
 
+// An array of matrices specifying the joint positions from the previous frame.
+//
+// This is used for motion vector computation.
+//
+// If this is the first frame, or we're otherwise prevented from using data from
+// the previous frame, this is simply the same as `joint_matrices` above.
+@group(1) @binding(6) var<uniform> prev_joint_matrices: SkinnedMesh;
+
 fn skin_model(
     indexes: vec4<u32>,
     weights: vec4<f32>,
@@ -14,6 +22,20 @@ fn skin_model(
         + weights.y * joint_matrices.data[indexes.y]
         + weights.z * joint_matrices.data[indexes.z]
         + weights.w * joint_matrices.data[indexes.w];
+}
+
+// Returns the skinned position of a vertex with the given weights from the
+// previous frame.
+//
+// This is used for motion vector computation.
+fn skin_prev_model(
+    indexes: vec4<u32>,
+    weights: vec4<f32>,
+) -> mat4x4<f32> {
+    return weights.x * prev_joint_matrices.data[indexes.x]
+        + weights.y * prev_joint_matrices.data[indexes.y]
+        + weights.z * prev_joint_matrices.data[indexes.z]
+        + weights.w * prev_joint_matrices.data[indexes.w];
 }
 
 fn inverse_transpose_3x3m(in: mat3x3<f32>) -> mat3x3<f32> {

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use bevy::{
     animation::{animate_targets, RepeatAnimation},
+    core_pipeline::experimental::taa::{TemporalAntiAliasBundle, TemporalAntiAliasPlugin},
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
 };
@@ -15,7 +16,8 @@ fn main() {
             color: Color::WHITE,
             brightness: 2000.,
         })
-        .add_plugins(DefaultPlugins)
+        .insert_resource(Msaa::Off)
+        .add_plugins((DefaultPlugins, TemporalAntiAliasPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, setup_scene_once_loaded.before(animate_targets))
         .add_systems(Update, keyboard_animation_control)
@@ -60,11 +62,13 @@ fn setup(
     });
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(100.0, 100.0, 150.0)
-            .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
-        ..default()
-    });
+    commands
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(100.0, 100.0, 150.0)
+                .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
+            ..default()
+        })
+        .insert(TemporalAntiAliasBundle::default());
 
     // Plane
     commands.spawn(PbrBundle {

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use bevy::{
     animation::{animate_targets, RepeatAnimation},
-    core_pipeline::experimental::taa::{TemporalAntiAliasBundle, TemporalAntiAliasPlugin},
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
 };
@@ -16,8 +15,7 @@ fn main() {
             color: Color::WHITE,
             brightness: 2000.,
         })
-        .insert_resource(Msaa::Off)
-        .add_plugins((DefaultPlugins, TemporalAntiAliasPlugin))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, setup_scene_once_loaded.before(animate_targets))
         .add_systems(Update, keyboard_animation_control)
@@ -62,13 +60,11 @@ fn setup(
     });
 
     // Camera
-    commands
-        .spawn(Camera3dBundle {
-            transform: Transform::from_xyz(100.0, 100.0, 150.0)
-                .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
-            ..default()
-        })
-        .insert(TemporalAntiAliasBundle::default());
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(100.0, 100.0, 150.0)
+            .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
+        ..default()
+    });
 
     // Plane
     commands.spawn(PbrBundle {


### PR DESCRIPTION
This is a revamped equivalent to #9902, though it shares none of the code. It handles all special cases that I've tested correctly.

The overall technique consists of double-buffering the joint matrix and morph weights buffers, as most of the previous attempts to solve this problem did. The process is generally straightforward. Note that, to avoid regressing the ability of mesh extraction, skin extraction, and morph target extraction to run in parallel, I had to add a new system to rendering, `set_mesh_motion_vector_flags`. The comment there explains the details; it generally runs very quickly.

I've tested this with modified versions of the `animated_fox`, `morph_targets`, and `many_foxes` examples that add TAA, and the patch works. To avoid bloating those examples, I didn't add switches for TAA to them.

Addresses points (1) and (2) of #8423.

## Changelog

### Fixed

* Motion vectors, and therefore TAA, are now supported for meshes with skins and/or morph targets.