### PR TITLE
Fix: Motion blur should sample onscreen fragments with no depth

### DIFF
--- a/crates/bevy_core_pipeline/src/motion_blur/motion_blur.wgsl
+++ b/crates/bevy_core_pipeline/src/motion_blur/motion_blur.wgsl
@@ -79,6 +79,12 @@ fn fragment(
         // The current sample step vector, from in.uv
         let step_vector = 0.5 * exposure_vector * (f32(i) + noise) / f32(n_samples);
         var sample_uv = in.uv + step_vector;
+
+        // If the sample is off screen, skip it.
+        if sample_uv.x < 0.0 || sample_uv.x > 1.0 || sample_uv.y < 0.0 || sample_uv.y > 1.0 {
+            continue;
+        }
+
         let sample_coords = vec2<i32>(sample_uv * texture_size);
 
     #ifdef MULTISAMPLED
@@ -103,7 +109,10 @@ fn fragment(
 
         var weight = 1.0;
         let is_sample_in_fg = !(depth_supported && sample_depth < this_depth && sample_depth > 0.0);
-        if is_sample_in_fg {
+        // If the depth is 0.0, this fragment has no depth written to it and we assume it is in the
+        // background. This ensures that things like skyboxes, which do not write to depth, are
+        // correctly sampled in motion blur.
+        if sample_depth != 0.0 && is_sample_in_fg {
             // The following weight calculation is used to eliminate ghosting artifacts that are
             // common in motion-vector-based motion blur implementations. While some resources
             // recommend using depth, I've found that sampling the velocity results in significantly


### PR DESCRIPTION
# Objective

- Motion blur does not currently work with skyboxes or anything else that does not write to depth.

## Solution

- When computing blur, include fragments with no depth, as long as they are onscreen.

## Testing

- Tested with the examples - the motion_blur example uncovered a bug with this fix, where offscreen pixels where now being sampled and causing artifacts.
- Attached example showing the skybox being sampled in the blur (note the feathering on edges):


https://github.com/bevyengine/bevy/assets/2632925/fc14b0c1-2394-46a5-a2b9-a859efcd23ef


