### PR TITLE
Use standard instruction text / position in various examples

### DIFF
--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -61,14 +61,14 @@ fn setup(
         TextBundle::from_section(
             "Press space to toggle wireframes",
             TextStyle {
-                font_size: 24.0,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -69,15 +69,14 @@ fn setup(
         TextBundle::from_section(
             "",
             TextStyle {
-                font_size: 18.0,
-                color: Color::WHITE,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/2d/bounding_2d.rs
+++ b/examples/2d/bounding_2d.rs
@@ -83,7 +83,7 @@ fn update_text(mut text: Query<&mut Text>, cur_state: Res<State<Test>>) {
         let s = if **cur_state == test { "*" } else { " " };
         text.push_str(&format!(" {s} {test:?} {s}\n"));
     }
-    text.push_str("\npress Space to cycle");
+    text.push_str("\nPress space to cycle");
 }
 
 #[derive(Component)]
@@ -195,7 +195,7 @@ struct Intersects(bool);
 const OFFSET_X: f32 = 125.;
 const OFFSET_Y: f32 = 75.;
 
-fn setup(mut commands: Commands, loader: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn((
         SpatialBundle {
@@ -270,15 +270,14 @@ fn setup(mut commands: Commands, loader: Res<AssetServer>) {
         TextBundle::from_section(
             "",
             TextStyle {
-                font: loader.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 26.0,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -99,10 +99,17 @@ fn setup(
 
     // Text used to show controls
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_section(
+            "",
+            TextStyle {
+                font_size: 20.,
+                ..default()
+            },
+        )
+        .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -116,8 +123,7 @@ fn update_colors(
     mut text: Query<&mut Text>,
 ) {
     text.single_mut().sections[0].value = format!(
-        "
-Controls
+        "Controls
 ---------------
 Z - Toggle global
 X - Change global color
@@ -126,8 +132,7 @@ C - Change color of the circle wireframe
 Wireframe2dConfig
 -------------
 Global: {}
-Color: {:?}
-",
+Color: {:?}",
         config.global, config.default_color,
     );
 

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -100,14 +100,14 @@ fn setup(
         TextBundle::from_section(
             "Press space to toggle wireframes",
             TextStyle {
-                font_size: 24.0,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -132,20 +132,19 @@ fn setup(
     });
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-        font_size: 18.0,
+        font_size: 20.0,
         ..default()
     };
 
     commands.spawn(
         TextBundle::from_section(
-            "Left / Right — Rotate Camera\nC — Toggle Compensation Curve\nM — Toggle Metering Mask\nV — Visualize Metering Mask",
+            "Left / Right - Rotate Camera\nC - Toggle Compensation Curve\nM - Toggle Metering Mask\nV - Visualize Metering Mask",
             text_style.clone(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -181,7 +181,7 @@ fn setup(
     // Controls Text
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-        font_size: 18.0,
+        font_size: 20.0,
         ..default()
     };
 
@@ -198,8 +198,8 @@ fn setup(
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -207,8 +207,8 @@ fn setup(
     commands.spawn((
         TextBundle::from_section("", text_style).with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            right: Val::Px(10.0),
+            top: Val::Px(12.0),
+            right: Val::Px(12.0),
             ..default()
         }),
         ExampleDisplay,

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -93,7 +93,6 @@ fn setup_scene(
             "",
             TextStyle {
                 font_size: 20.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -74,7 +74,7 @@ fn setup(
 
     spawn_light(&mut commands);
     spawn_camera(&mut commands, &asset_server);
-    spawn_text(&mut commands, &asset_server, &light_mode);
+    spawn_text(&mut commands, &light_mode);
 }
 
 /// Generates a sphere.
@@ -232,16 +232,16 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 }
 
 /// Spawns the help text.
-fn spawn_text(commands: &mut Commands, asset_server: &AssetServer, light_mode: &LightMode) {
+fn spawn_text(commands: &mut Commands, light_mode: &LightMode) {
     commands.spawn(
         TextBundle {
-            text: light_mode.create_help_text(asset_server),
+            text: light_mode.create_help_text(),
             ..TextBundle::default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -304,13 +304,9 @@ fn handle_input(
 }
 
 /// Updates the help text at the bottom of the screen.
-fn update_help_text(
-    mut text_query: Query<&mut Text>,
-    light_mode: Res<LightMode>,
-    asset_server: Res<AssetServer>,
-) {
+fn update_help_text(mut text_query: Query<&mut Text>, light_mode: Res<LightMode>) {
     for mut text in text_query.iter_mut() {
-        *text = light_mode.create_help_text(&asset_server);
+        *text = light_mode.create_help_text();
     }
 }
 
@@ -334,7 +330,7 @@ fn create_directional_light() -> DirectionalLight {
 
 impl LightMode {
     /// Creates the help text at the bottom of the screen.
-    fn create_help_text(&self, asset_server: &AssetServer) -> Text {
+    fn create_help_text(&self) -> Text {
         let help_text = match *self {
             LightMode::Point => "Press Space to switch to a directional light",
             LightMode::Directional => "Press Space to switch to a point light",
@@ -343,8 +339,7 @@ impl LightMode {
         Text::from_section(
             help_text,
             TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 24.0,
+                font_size: 20.0,
                 ..default()
             },
         )

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -95,13 +95,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     // Spawn the help text.
     commands.spawn(
         TextBundle {
-            text: create_text(&asset_server, &app_settings),
+            text: create_text(&app_settings),
             ..TextBundle::default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -212,23 +212,18 @@ fn tweak_scene(
 }
 
 /// Update the help text entity per the current app settings.
-fn update_text(
-    mut texts: Query<&mut Text>,
-    asset_server: Res<AssetServer>,
-    app_settings: Res<AppSettings>,
-) {
+fn update_text(mut texts: Query<&mut Text>, app_settings: Res<AppSettings>) {
     for mut text in texts.iter_mut() {
-        *text = create_text(&asset_server, &app_settings);
+        *text = create_text(&app_settings);
     }
 }
 
 /// Regenerates the app text component per the current app settings.
-fn create_text(asset_server: &AssetServer, app_settings: &AppSettings) -> Text {
+fn create_text(app_settings: &AppSettings) -> Text {
     Text::from_section(
         app_settings.help_text(),
         TextStyle {
-            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-            font_size: 24.0,
+            font_size: 20.0,
             ..default()
         },
     )

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -209,12 +209,7 @@ fn main() {
 }
 
 // Spawns all the scene objects.
-fn setup(
-    mut commands: Commands,
-    assets: Res<ExampleAssets>,
-    app_status: Res<AppStatus>,
-    asset_server: Res<AssetServer>,
-) {
+fn setup(mut commands: Commands, assets: Res<ExampleAssets>, app_status: Res<AppStatus>) {
     spawn_main_scene(&mut commands, &assets);
     spawn_camera(&mut commands, &assets);
     spawn_irradiance_volume(&mut commands, &assets);
@@ -222,7 +217,7 @@ fn setup(
     spawn_sphere(&mut commands, &assets);
     spawn_voxel_cube_parent(&mut commands);
     spawn_fox(&mut commands, &assets);
-    spawn_text(&mut commands, &app_status, &asset_server);
+    spawn_text(&mut commands, &app_status);
 }
 
 fn spawn_main_scene(commands: &mut Commands, assets: &ExampleAssets) {
@@ -301,36 +296,32 @@ fn spawn_fox(commands: &mut Commands, assets: &ExampleAssets) {
         .insert(MainObject);
 }
 
-fn spawn_text(commands: &mut Commands, app_status: &AppStatus, asset_server: &AssetServer) {
+fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
     commands.spawn(
         TextBundle {
-            text: app_status.create_text(asset_server),
-            ..TextBundle::default()
+            text: app_status.create_text(),
+            ..default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
 }
 
 // A system that updates the help text.
-fn update_text(
-    mut text_query: Query<&mut Text>,
-    app_status: Res<AppStatus>,
-    asset_server: Res<AssetServer>,
-) {
+fn update_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
     for mut text in text_query.iter_mut() {
-        *text = app_status.create_text(&asset_server);
+        *text = app_status.create_text();
     }
 }
 
 impl AppStatus {
     // Constructs the help text at the bottom of the screen based on the
     // application status.
-    fn create_text(&self, asset_server: &AssetServer) -> Text {
+    fn create_text(&self) -> Text {
         let irradiance_volume_help_text = if self.irradiance_volume_present {
             DISABLE_IRRADIANCE_VOLUME_HELP_TEXT
         } else {
@@ -364,8 +355,7 @@ impl AppStatus {
                 switch_mesh_help_text
             ),
             TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 24.0,
+                font_size: 20.0,
                 ..default()
             },
         )

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -253,7 +253,7 @@ fn spawn_trees(
 
 fn setup_ui(mut commands: Commands) {
     let style = TextStyle {
-        font_size: 24.0,
+        font_size: 20.0,
         ..default()
     };
     commands.spawn(

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -92,7 +92,7 @@ fn setup(
     spawn_camera(&mut commands);
     spawn_sphere(&mut commands, &mut meshes, &mut materials);
     spawn_reflection_probe(&mut commands, &cubemaps);
-    spawn_text(&mut commands, &asset_server, &app_status);
+    spawn_text(&mut commands, &app_status);
 }
 
 // Spawns the cubes, light, and camera.
@@ -156,17 +156,17 @@ fn spawn_reflection_probe(commands: &mut Commands, cubemaps: &Cubemaps) {
 }
 
 // Spawns the help text.
-fn spawn_text(commands: &mut Commands, asset_server: &AssetServer, app_status: &AppStatus) {
+fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
     // Create the text.
     commands.spawn(
         TextBundle {
-            text: app_status.create_text(asset_server),
+            text: app_status.create_text(),
             ..TextBundle::default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -241,13 +241,9 @@ fn toggle_rotation(keyboard: Res<ButtonInput<KeyCode>>, mut app_status: ResMut<A
 }
 
 // A system that updates the help text.
-fn update_text(
-    mut text_query: Query<&mut Text>,
-    app_status: Res<AppStatus>,
-    asset_server: Res<AssetServer>,
-) {
+fn update_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
     for mut text in text_query.iter_mut() {
-        *text = app_status.create_text(&asset_server);
+        *text = app_status.create_text();
     }
 }
 
@@ -278,7 +274,7 @@ impl Display for ReflectionMode {
 impl AppStatus {
     // Constructs the help text at the bottom of the screen based on the
     // application status.
-    fn create_text(&self, asset_server: &AssetServer) -> Text {
+    fn create_text(&self) -> Text {
         let rotation_help_text = if self.rotating {
             STOP_ROTATION_HELP_TEXT
         } else {
@@ -291,8 +287,7 @@ impl AppStatus {
                 self.reflection_mode, rotation_help_text, REFLECTION_MODE_HELP_TEXT
             ),
             TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 24.0,
+                font_size: 20.0,
                 ..default()
             },
         )

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -161,7 +161,7 @@ fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
     commands.spawn(
         TextBundle {
             text: app_status.create_text(),
-            ..TextBundle::default()
+            ..default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -98,14 +98,14 @@ fn setup(
             "",
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 26.0,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -136,7 +136,7 @@ fn setup(
         &mut water_materials,
     );
     spawn_camera(&mut commands, &asset_server);
-    spawn_text(&mut commands, &asset_server, &app_settings);
+    spawn_text(&mut commands, &app_settings);
 }
 
 // Spawns the rotating cube.
@@ -248,23 +248,23 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 }
 
 // Spawns the help text.
-fn spawn_text(commands: &mut Commands, asset_server: &AssetServer, app_settings: &AppSettings) {
+fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
     commands.spawn(
         TextBundle {
-            text: create_text(asset_server, app_settings),
+            text: create_text(app_settings),
             ..TextBundle::default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
 }
 
 // Creates or recreates the help text.
-fn create_text(asset_server: &AssetServer, app_settings: &AppSettings) -> Text {
+fn create_text(app_settings: &AppSettings) -> Text {
     Text::from_section(
         format!(
             "{}\n{}\n{}",
@@ -280,8 +280,7 @@ fn create_text(asset_server: &AssetServer, app_settings: &AppSettings) -> Text {
             MOVE_CAMERA_HELP_TEXT
         ),
         TextStyle {
-            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-            font_size: 24.0,
+            font_size: 20.0,
             ..default()
         },
     )
@@ -350,7 +349,6 @@ fn move_camera(
 #[allow(clippy::too_many_arguments)]
 fn adjust_app_settings(
     mut commands: Commands,
-    asset_server: Res<AssetServer>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut app_settings: ResMut<AppSettings>,
     mut cameras: Query<Entity, With<Camera>>,
@@ -413,7 +411,7 @@ fn adjust_app_settings(
 
     // Update the help text.
     for mut text in text.iter_mut() {
-        *text = create_text(&asset_server, &app_settings);
+        *text = create_text(&app_settings);
     }
 }
 

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -83,14 +83,14 @@ fn setup(
         TextBundle::from_section(
             "",
             TextStyle {
-                font_size: 18.0,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -366,15 +366,15 @@ fn setup(
 
     // Controls Text
     let text_style = TextStyle {
-        font_size: 18.0,
+        font_size: 20.0,
         ..default()
     };
 
     commands.spawn((
         TextBundle::from_section("", text_style).with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
         ExampleDisplay,

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -153,13 +153,13 @@ fn setup(
     // Create the text.
     commands.spawn(
         TextBundle {
-            text: app_status.create_text(&asset_server),
+            text: app_status.create_text(),
             ..TextBundle::default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -290,19 +290,15 @@ fn update_mode(
 }
 
 // A system that updates the help text.
-fn update_help_text(
-    mut text_query: Query<&mut Text>,
-    app_status: Res<AppStatus>,
-    asset_server: Res<AssetServer>,
-) {
+fn update_help_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
     for mut text in text_query.iter_mut() {
-        *text = app_status.create_text(&asset_server);
+        *text = app_status.create_text();
     }
 }
 
 impl AppStatus {
     // Creates and returns help text reflecting the app status.
-    fn create_text(&self, asset_server: &AssetServer) -> Text {
+    fn create_text(&self) -> Text {
         Text::from_section(
             format!(
                 "\
@@ -328,8 +324,7 @@ Press WASD or use the mouse wheel to move the camera",
                 },
             ),
             TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 24.0,
+                font_size: 20.0,
                 ..default()
             },
         )

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -62,8 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text: Text::from_section(
                 "Press WASD or the arrow keys to change the light direction",
                 TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 24.0,
+                    font_size: 20.0,
                     ..default()
                 },
             ),
@@ -71,8 +70,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -113,10 +113,17 @@ fn setup(
 
     // Text used to show controls
     commands.spawn(
-        TextBundle::from_section("", TextStyle::default()).with_style(Style {
+        TextBundle::from_section(
+            "",
+            TextStyle {
+                font_size: 20.0,
+                ..default()
+            },
+        )
+        .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );
@@ -130,8 +137,7 @@ fn update_colors(
     mut text: Query<&mut Text>,
 ) {
     text.single_mut().sections[0].value = format!(
-        "
-Controls
+        "Controls
 ---------------
 Z - Toggle global
 X - Change global color
@@ -140,8 +146,7 @@ C - Change color of the green cube wireframe
 WireframeConfig
 -------------
 Global: {}
-Color: {:?}
-",
+Color: {:?}",
         config.global, config.default_color,
     );
 

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -24,10 +24,16 @@ fn setup(mut commands: Commands) {
         text: Text::from_section(
             "Press P to panic",
             TextStyle {
-                font_size: 60.0,
+                font_size: 20.0,
                 ..default()
             },
         ),
+        style: Style {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
         ..default()
     });
 }

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -133,7 +133,7 @@ fn setup(
     });
 
     let style = TextStyle {
-        font_size: 18.0,
+        font_size: 20.0,
         ..default()
     };
 
@@ -147,8 +147,8 @@ fn setup(
         ])
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -87,13 +87,21 @@ fn setup(mut commands: Commands) {
         ..default()
     });
 
-    commands.spawn(TextBundle::from_section(
-        "",
-        TextStyle {
-            font_size: 30.,
+    commands.spawn(
+        TextBundle::from_section(
+            "",
+            TextStyle {
+                font_size: 20.,
+                ..default()
+            },
+        )
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
-        },
-    ));
+        }),
+    );
 }
 
 fn ui_system(mut query: Query<&mut Text>, config: Res<Config>, diag: Res<DiagnosticsStore>) {

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -16,7 +16,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         font_size: 20.0,
         ..default()
     };

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -65,14 +65,14 @@ fn setup(
         TextBundle::from_section(
             "Press <spacebar> to save a screenshot to disk",
             TextStyle {
-                font_size: 25.0,
+                font_size: 20.0,
                 ..default()
             },
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );


### PR DESCRIPTION
## Objective

Use the "standard" text size / placement for the new text in these examples.

Continuation of an effort started here: https://github.com/bevyengine/bevy/pull/8478

This is definitely not comprehensive. I did the ones that were easy to find and relatively straightforward updates. I meant to just do `3d_shapes` and `2d_shapes`, but one thing lead to another.

## Solution

Use `font_size: 20.0`, the default (built-in) font, `Color::WHITE` (default), and `Val::Px(12.)` from the edges of the screen.

There are a few little drive-by cleanups of defaults not being used, etc.

## Testing

Ran the changed examples, verified that they still look reasonable.
