### PR TITLE
Unify transition names to `exited` and `entered`

### DIFF
--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -337,13 +337,13 @@ fn log_transitions(
     for transition in transitions.read() {
         info!(
             "transition: {:?} => {:?}",
-            transition.before, transition.after
+            transition.exited, transition.entered
         );
     }
     for transition in tutorial_transitions.read() {
         info!(
             "tutorial transition: {:?} => {:?}",
-            transition.before, transition.after
+            transition.exited, transition.entered
         );
     }
 }

--- a/examples/state/state.rs
+++ b/examples/state/state.rs
@@ -170,7 +170,7 @@ fn log_transitions(mut transitions: EventReader<StateTransitionEvent<AppState>>)
     for transition in transitions.read() {
         info!(
             "transition: {:?} => {:?}",
-            transition.before, transition.after
+            transition.exited, transition.entered
         );
     }
 }

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -162,7 +162,7 @@ fn log_transitions(mut transitions: EventReader<StateTransitionEvent<AppState>>)
     for transition in transitions.read() {
         info!(
             "transition: {:?} => {:?}",
-            transition.before, transition.after
+            transition.exited, transition.entered
         );
     }
 }


### PR DESCRIPTION
# Objective

Unifies the naming convention between `StateTransitionEvent<S>` and transition schedules.

## Migration Guide

- `StateTransitionEvent<S>` and `OnTransition<S>` schedule had their fields renamed to `exited`  and `entered` to match schedules.
