### PR TITLE
`EventReader::last` to clear all events and return the last one

### DIFF
--- a/benches/benches/bevy_ecs/events/last.rs
+++ b/benches/benches/bevy_ecs/events/last.rs
@@ -1,0 +1,44 @@
+use bevy_ecs::prelude::*;
+
+#[derive(Event)]
+struct BenchEvent<const SIZE: usize>([u8; SIZE]);
+
+pub struct ReaderBenchmark<const SIZE: usize>(Events<BenchEvent<SIZE>>);
+
+impl<const SIZE: usize> ReaderBenchmark<SIZE> {
+    pub fn new(count: usize) -> Self {
+        let mut events = Events::default();
+
+        for _ in 0..count {
+            events.send(BenchEvent([0u8; SIZE]));
+        }
+
+        Self(events)
+    }
+
+    pub fn run(&mut self) {
+        let mut reader = self.0.get_reader();
+        let last = reader.last(&self.0);
+        std::hint::black_box(last);
+    }
+}
+
+pub struct IterBenchmark<const SIZE: usize>(Events<BenchEvent<SIZE>>);
+
+impl<const SIZE: usize> IterBenchmark<SIZE> {
+    pub fn new(count: usize) -> Self {
+        let mut events = Events::default();
+
+        for _ in 0..count {
+            events.send(BenchEvent([0u8; SIZE]));
+        }
+
+        Self(events)
+    }
+
+    pub fn run(&mut self) {
+        let mut reader = self.0.get_reader();
+        let last = reader.read(&self.0).last();
+        std::hint::black_box(last);
+    }
+}

--- a/benches/benches/bevy_ecs/events/mod.rs
+++ b/benches/benches/bevy_ecs/events/mod.rs
@@ -1,9 +1,10 @@
 use criterion::*;
 
 mod iter;
+mod last;
 mod send;
 
-criterion_group!(event_benches, send, iter);
+criterion_group!(event_benches, send, iter, last1, last2);
 
 fn send(c: &mut Criterion) {
     let mut group = c.benchmark_group("events_send");
@@ -49,6 +50,56 @@ fn iter(c: &mut Criterion) {
     for count in [100, 1000, 10000, 50000] {
         group.bench_function(format!("size_512_events_{}", count), |b| {
             let mut bench = iter::Benchmark::<512>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    group.finish();
+}
+
+fn last1(c: &mut Criterion) {
+    let mut group = c.benchmark_group("events_last1");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_4_events_{}", count), |b| {
+            let mut bench = last::ReaderBenchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_16_events_{}", count), |b| {
+            let mut bench = last::ReaderBenchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_512_events_{}", count), |b| {
+            let mut bench = last::ReaderBenchmark::<512>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    group.finish();
+}
+
+fn last2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("events_last2");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_4_events_{}", count), |b| {
+            let mut bench = last::IterBenchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_16_events_{}", count), |b| {
+            let mut bench = last::IterBenchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_512_events_{}", count), |b| {
+            let mut bench = last::IterBenchmark::<512>::new(count);
             b.iter(move || bench.run());
         });
     }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -736,7 +736,9 @@ impl<E: Event> ManualEventReader<E> {
         self.last_event_count = events.event_count;
     }
 
-    /// See [`EventReader::last()`]
+    /// Consumes all available events and returns the last one.
+    ///
+    /// This works much like [`ManualEventReader::clear()`] except it returns the last event.
     pub fn last<'a>(&'a mut self, events: &'a Events<E>) -> Option<&'a E> {
         if self.last_event_count < events.event_count {
             self.last_event_count = events.event_count - 1;

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -537,7 +537,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// Consumes all available events and returns the last one.
     ///
     /// This works much like [`EventReader::clear()`] except it returns the last event.
-    pub fn last<'a>(&'a mut self) -> Option<&'a E> {
+    pub fn last(&mut self) -> Option<&E> {
         self.reader.last(&self.events)
     }
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -741,10 +741,10 @@ impl<E: Event> ManualEventReader<E> {
     /// This works much like [`ManualEventReader::clear()`] except it returns the last event.
     pub fn last<'a>(&'a mut self, events: &'a Events<E>) -> Option<&'a E> {
         if self.last_event_count < events.event_count {
-            self.last_event_count = events.event_count - 1;
-            self.read(events).last()
+            self.last_event_count = events.event_count;
+            // SAFETY: We know this event exists, because this reader has not read it yet.
+            Some(events.get_event(events.event_count - 1).unwrap().0)
         } else {
-            self.clear(events);
             None
         }
     }


### PR DESCRIPTION
# Objective

Add a way to retrieve only the last event from an `EventReader`.

## Solution

Implement `EventReader::last` which works much like `EventReader::clear`.

## Changelog

- Added `EventReader::last` to clear pending events and retrieve the last one.
