### PR TITLE
Updates default Text font size to 24px

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -202,7 +202,7 @@ impl Default for TextStyle {
     fn default() -> Self {
         Self {
             font: Default::default(),
-            font_size: 12.0,
+            font_size: 24.0,
             color: Color::WHITE,
         }
     }

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -58,19 +58,13 @@ fn setup(
     }
 
     commands.spawn(
-        TextBundle::from_section(
-            "Press space to toggle wireframes",
-            TextStyle {
-                font_size: 20.0,
+        TextBundle::from_section("Press space to toggle wireframes", TextStyle::default())
+            .with_style(Style {
+                position_type: PositionType::Absolute,
+                top: Val::Px(12.0),
+                left: Val::Px(12.0),
                 ..default()
-            },
-        )
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
-            ..default()
-        }),
+            }),
     );
 }
 

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -66,14 +66,7 @@ fn setup(
 
     // UI
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/2d/bounding_2d.rs
+++ b/examples/2d/bounding_2d.rs
@@ -267,14 +267,7 @@ fn setup(mut commands: Commands) {
     ));
 
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -142,10 +142,7 @@ fn setup(
     commands.spawn(TextBundle {
         text: Text::from_section(
             "Left Arrow Key: Animate Left Sprite\nRight Arrow Key: Animate Right Sprite",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         ),
         style: Style {
             position_type: PositionType::Absolute,

--- a/examples/2d/sprite_slice.rs
+++ b/examples/2d/sprite_slice.rs
@@ -114,7 +114,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let style = TextStyle {
         font: font.clone(),
         font_size: 16.0,
-        color: Color::WHITE,
+        ..default()
     };
 
     // Load textures

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -124,7 +124,7 @@ fn setup(
     let text_style: TextStyle = TextStyle {
         font: font.clone(),
         font_size: 50.0,
-        color: Color::WHITE,
+        ..default()
     };
 
     // labels to indicate padding
@@ -173,7 +173,7 @@ fn setup(
     let sampling_label_style = TextStyle {
         font,
         font_size: 30.0,
-        color: Color::WHITE,
+        ..default()
     };
 
     let base_y = 170.0; // y position of the sprites

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -99,14 +99,7 @@ fn setup(
 
     // Text used to show controls
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -97,19 +97,13 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section(
-            "Press space to toggle wireframes",
-            TextStyle {
-                font_size: 20.0,
+        TextBundle::from_section("Press space to toggle wireframes", TextStyle::default())
+            .with_style(Style {
+                position_type: PositionType::Absolute,
+                top: Val::Px(12.0),
+                left: Val::Px(12.0),
                 ..default()
-            },
-        )
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
-            ..default()
-        }),
+            }),
     );
 }
 

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -340,14 +340,7 @@ fn setup(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -97,10 +97,7 @@ fn setup_instructions(mut commands: Commands) {
     commands.spawn(
         TextBundle::from_section(
             "Press Spacebar to Toggle Atmospheric Fog.\nPress S to Toggle Directional Light Fog Influence.",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -131,10 +131,7 @@ fn setup(
         ..default()
     });
 
-    let text_style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let text_style = TextStyle::default();
 
     commands.spawn(
         TextBundle::from_section(

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -181,7 +181,6 @@ fn setup(
     // Controls Text
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-        font_size: 20.0,
         ..default()
     };
 

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -89,14 +89,7 @@ fn setup_scene(
 
     // example instructions
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -236,7 +236,7 @@ fn spawn_text(commands: &mut Commands, light_mode: &LightMode) {
     commands.spawn(
         TextBundle {
             text: light_mode.create_help_text(),
-            ..TextBundle::default()
+            ..default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -336,12 +336,6 @@ impl LightMode {
             LightMode::Directional => "Press Space to switch to a point light",
         };
 
-        Text::from_section(
-            help_text,
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
+        Text::from_section(help_text, TextStyle::default())
     }
 }

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -326,8 +326,7 @@ fn add_help_text(
                 create_help_text(currently_selected_option),
                 TextStyle {
                     font: font.clone(),
-                    font_size: 24.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             )
         })

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -204,14 +204,7 @@ fn setup(
 
     // Example instructions
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     commands.spawn(
         TextBundle {
             text: create_text(&app_settings),
-            ..TextBundle::default()
+            ..default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -220,13 +220,7 @@ fn update_text(mut texts: Query<&mut Text>, app_settings: Res<AppSettings>) {
 
 /// Regenerates the app text component per the current app settings.
 fn create_text(app_settings: &AppSettings) -> Text {
-    Text::from_section(
-        app_settings.help_text(),
-        TextStyle {
-            font_size: 20.0,
-            ..default()
-        },
-    )
+    Text::from_section(app_settings.help_text(), TextStyle::default())
 }
 
 impl From<AppSettings> for Option<DepthOfFieldSettings> {

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -124,14 +124,7 @@ fn setup_pyramid_scene(
 
 fn setup_instructions(mut commands: Commands) {
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -66,10 +66,7 @@ fn setup(
     commands.spawn(
         TextBundle::from_section(
             "Controls:\nSpace: Change UVs\nX/Y/Z: Rotate\nR: Reset orientation",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -354,10 +354,7 @@ impl AppStatus {
                 rotation_help_text,
                 switch_mesh_help_text
             ),
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
     }
 }

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -231,10 +231,8 @@ fn setup(
     });
 
     // example instructions
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let style = TextStyle::default();
+
     commands.spawn(
         TextBundle::from_sections(vec![
             TextSection::new(

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -252,10 +252,8 @@ fn spawn_trees(
 }
 
 fn setup_ui(mut commands: Commands) {
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let style = TextStyle::default();
+
     commands.spawn(
         TextBundle::from_sections(vec![
             TextSection::new(String::new(), style.clone()),

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -301,10 +301,7 @@ fn setup(
     commands.spawn(background_cube_bundle(Vec3::new(0., 0., 45.)));
     commands.spawn(background_cube_bundle(Vec3::new(0., 0., -45.)));
 
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let style = TextStyle::default();
 
     // example instructions
     commands.spawn(

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -103,7 +103,6 @@ fn setup(
             "Loading Environment Map...",
             TextStyle {
                 font_size: 36.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -286,10 +286,7 @@ impl AppStatus {
                 "{}\n{}\n{}",
                 self.reflection_mode, rotation_help_text, REFLECTION_MODE_HELP_TEXT
             ),
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
     }
 }

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -113,10 +113,8 @@ fn setup(
         ..default()
     });
 
-    let style = TextStyle {
-        font_size: 20.,
-        ..default()
-    };
+    let style = TextStyle::default();
+
     commands
         .spawn(NodeBundle {
             style: Style {

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -99,13 +99,7 @@ fn setup(
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(
-                    *camera_name,
-                    TextStyle {
-                        font_size: 20.,
-                        ..default()
-                    },
-                ));
+                parent.spawn(TextBundle::from_section(*camera_name, TextStyle::default()));
                 buttons_panel(parent);
             });
     }
@@ -151,13 +145,7 @@ fn setup(
                 },
             ))
             .with_children(|parent| {
-                parent.spawn(TextBundle::from_section(
-                    caption,
-                    TextStyle {
-                        font_size: 20.,
-                        ..default()
-                    },
-                ));
+                parent.spawn(TextBundle::from_section(caption, TextStyle::default()));
             });
     }
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -137,14 +137,7 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section(
-            INSTRUCTIONS,
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section(INSTRUCTIONS, TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -98,7 +98,6 @@ fn setup(
             "",
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 20.0,
                 ..default()
             },
         )

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -27,7 +27,6 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    asset_server: Res<AssetServer>,
 ) {
     commands
         .spawn(Camera3dBundle {
@@ -94,14 +93,7 @@ fn setup(
     });
 
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -279,10 +279,7 @@ fn create_text(app_settings: &AppSettings) -> Text {
             },
             MOVE_CAMERA_HELP_TEXT
         ),
-        TextStyle {
-            font_size: 20.0,
-            ..default()
-        },
+        TextStyle::default(),
     )
 }
 

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -252,7 +252,7 @@ fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
     commands.spawn(
         TextBundle {
             text: create_text(app_settings),
-            ..TextBundle::default()
+            ..default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -80,14 +80,7 @@ fn setup(
 
     // ui
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -365,10 +365,7 @@ fn setup(
     ));
 
     // Controls Text
-    let text_style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let text_style = TextStyle::default();
 
     commands.spawn((
         TextBundle::from_section("", text_style).with_style(Style {

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -323,10 +323,7 @@ Press WASD or use the mouse wheel to move the camera",
                     ' '
                 },
             ),
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
     }
 }

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -154,7 +154,7 @@ fn setup(
     commands.spawn(
         TextBundle {
             text: app_status.create_text(),
-            ..TextBundle::default()
+            ..default()
         }
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -61,10 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         TextBundle {
             text: Text::from_section(
                 "Press WASD or the arrow keys to change the light direction",
-                TextStyle {
-                    font_size: 20.0,
-                    ..default()
-                },
+                TextStyle::default(),
             ),
             ..default()
         }

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -113,14 +113,7 @@ fn setup(
 
     // Text used to show controls
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -254,13 +254,7 @@ fn setup_scene(
 /// Places the help text at the top left of the window.
 fn setup_help_text(commands: &mut Commands) {
     commands.spawn(TextBundle {
-        text: Text::from_section(
-            HELP_TEXT,
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        ),
+        text: Text::from_section(HELP_TEXT, TextStyle::default()),
         style: Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -21,13 +21,7 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle {
-        text: Text::from_section(
-            "Press P to panic",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
-        ),
+        text: Text::from_section("Press P to panic", TextStyle::default()),
         style: Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -54,10 +54,7 @@ fn read_stream(receiver: Res<StreamReceiver>, mut events: EventWriter<StreamEven
 }
 
 fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
-    let text_style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let text_style = TextStyle::default();
 
     for (per_frame, event) in reader.read().enumerate() {
         commands.spawn(Text2dBundle {

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -78,10 +78,7 @@ fn setup(
     commands.spawn(
         TextBundle::from_section(
             "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -68,10 +68,7 @@ fn setup(
     commands.spawn(
         TextBundle::from_section(
             "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/ecs/one_shot_systems.rs
+++ b/examples/ecs/one_shot_systems.rs
@@ -102,17 +102,10 @@ fn setup_ui(mut commands: Commands) {
                     ..default()
                 },
             ),
-            TextSection::new(
-                "Last Triggered: ",
-                TextStyle {
-                    font_size: 20.0,
-                    ..default()
-                },
-            ),
+            TextSection::new("Last Triggered: ", TextStyle::default()),
             TextSection::new(
                 "-",
                 TextStyle {
-                    font_size: 20.0,
                     color: bevy::color::palettes::css::ORANGE.into(),
                     ..default()
                 },

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -111,7 +111,7 @@ fn setup(
     let text_style = TextStyle {
         font: font.clone(),
         font_size: 30.0,
-        color: Color::WHITE,
+        ..default()
     };
     commands.spawn((
         Text2dBundle {

--- a/examples/games/stepping.rs
+++ b/examples/games/stepping.rs
@@ -85,10 +85,8 @@ fn initialized(state: Res<State>) -> bool {
     !state.systems.is_empty()
 }
 
-const FONT_SIZE: f32 = 20.0;
 const FONT_COLOR: Color = Color::srgb(0.2, 0.2, 0.2);
 const FONT_BOLD: &str = "fonts/FiraSans-Bold.ttf";
-const FONT_MEDIUM: &str = "fonts/FiraMono-Medium.ttf";
 
 #[derive(Component)]
 struct SteppingUi;
@@ -120,8 +118,8 @@ fn build_ui(
             format!("{:?}\n", label),
             TextStyle {
                 font: asset_server.load(FONT_BOLD),
-                font_size: FONT_SIZE,
                 color: FONT_COLOR,
+                ..default()
             },
         ));
 
@@ -146,9 +144,8 @@ fn build_ui(
             text_sections.push(TextSection::new(
                 "   ",
                 TextStyle {
-                    font: asset_server.load(FONT_MEDIUM),
-                    font_size: FONT_SIZE,
                     color: FONT_COLOR,
+                    ..default()
                 },
             ));
 
@@ -156,9 +153,8 @@ fn build_ui(
             text_sections.push(TextSection::new(
                 format!("{}\n", system.name()),
                 TextStyle {
-                    font: asset_server.load(FONT_MEDIUM),
-                    font_size: FONT_SIZE,
                     color: FONT_COLOR,
+                    ..default()
                 },
             ));
         }
@@ -186,7 +182,7 @@ fn build_ui(
     ));
 }
 
-fn build_stepping_hint(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn build_stepping_hint(mut commands: Commands) {
     let hint_text = if cfg!(feature = "bevy_debug_stepping") {
         "Press ` to toggle stepping mode (S: step system, Space: step frame)"
     } else {
@@ -197,9 +193,9 @@ fn build_stepping_hint(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((TextBundle::from_sections([TextSection::new(
         hint_text,
         TextStyle {
-            font: asset_server.load(FONT_MEDIUM),
             font_size: 18.0,
             color: FONT_COLOR,
+            ..default()
         },
     )])
     .with_style(Style {

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -29,8 +29,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Press 'J' / 'K' to cycle through line joins",
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 20.,
                 color: Color::WHITE,
+                ..default()
             },
         )
         .with_style(Style {

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -17,7 +17,7 @@ fn main() {
 #[derive(Default, Reflect, GizmoConfigGroup)]
 struct MyRoundGizmos {}
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     // text
     commands.spawn(
@@ -27,11 +27,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Press '1' / '2' to toggle the visibility of straight / round gizmos\n\
         Press 'U' / 'I' to cycle through line styles\n\
         Press 'J' / 'K' to cycle through line joins",
-            TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                color: Color::WHITE,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -61,10 +61,7 @@ fn setup(
             Press 'A' to show all AABB boxes\n\
             Press 'U' or 'I' to cycle through line styles for straight or round gizmos\n\
             Press 'J' or 'K' to cycle through line joins for straight or round gizmos",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -107,10 +107,8 @@ fn setup(
 
     // Example instructions and gizmo config.
     {
-        let text_style = TextStyle {
-            font_size: 20.0,
-            ..default()
-        };
+        let text_style = TextStyle::default();
+
         commands.spawn(
             TextBundle::from_section(
                 "Press 'D' to toggle drawing gizmos on top of everything else in the scene\n\

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -41,7 +41,6 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 value: "IME Enabled: ".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
-                    font_size: 20.0,
                     ..default()
                 },
             },
@@ -57,7 +56,6 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 value: "IME Active: ".to_string(),
                 style: TextStyle {
                     font: font.clone_weak(),
-                    font_size: 20.0,
                     ..default()
                 },
             },

--- a/examples/math/random_sampling.rs
+++ b/examples/math/random_sampling.rs
@@ -120,10 +120,7 @@ fn setup(
             S: Add one random sample.\n\
             D: Add 100 random samples.\n\
             Rotate camera by panning left/right.",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -344,23 +344,13 @@ fn switch_cameras(current: Res<State<CameraActive>>, mut next: ResMut<NextState<
     next.set(next_state);
 }
 
-fn setup_text(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    cameras: Query<(Entity, &Camera)>,
-) {
+fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
     let active_camera = cameras
         .iter()
         .find_map(|(entity, camera)| camera.is_active.then_some(entity))
         .expect("run condition ensures existence");
     let text = format!("{text}", text = PrimitiveSelected::default());
-    let font_size = 24.0;
-    let font: Handle<Font> = asset_server.load("fonts/FiraMono-Medium.ttf");
-    let style = TextStyle {
-        font,
-        font_size,
-        color: Color::WHITE,
-    };
+    let style = TextStyle::default();
     let instructions = "Press 'C' to switch between 2D and 3D mode\n\
         Press 'Up' or 'Down' to switch to the next/previous primitive";
     let text = [

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -387,10 +387,7 @@ fn setup(
             Zoom camera by scrolling via mouse or +/-.\n\
             Move camera by L/R arrow keys.\n\
             Tab: Toggle this text",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -132,10 +132,7 @@ fn setup(
         ..default()
     });
 
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let style = TextStyle::default();
 
     commands.spawn(
         TextBundle::from_sections(vec![

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -88,14 +88,7 @@ fn setup(mut commands: Commands) {
     });
 
     commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        TextBundle::from_section("", TextStyle::default()).with_style(Style {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -416,10 +416,8 @@ fn setup_triggers(
 }
 
 fn setup_connected(mut commands: Commands) {
-    let text_style = TextStyle {
-        font_size: 20.,
-        ..default()
-    };
+    let text_style = TextStyle::default();
+
     commands.spawn((
         TextBundle {
             text: Text::from_sections([

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -232,7 +232,6 @@ fn detect_morphs(
     meshes: Res<Assets<Mesh>>,
     scene_handle: Res<SceneHandle>,
     mut setup: Local<bool>,
-    asset_server: Res<AssetServer>,
 ) {
     let no_morphing = morphs.iter().len() == 0;
     if no_morphing {
@@ -255,7 +254,6 @@ fn detect_morphs(
     }
     detected.truncate(AVAILABLE_KEYS.len());
     let style = TextStyle {
-        font: asset_server.load("assets/fonts/FiraMono-Medium.ttf"),
         font_size: 13.0,
         ..default()
     };

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -108,10 +108,7 @@ fn setup(
             Press 'T' to align the cube to those directions.\n\
             Click and drag the mouse to rotate the camera.\n\
             Press 'H' to hide/show these instructions.",
-            TextStyle {
-                font_size: 20.,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -153,7 +153,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             .with_children(|builder| {
                 let text_style = TextStyle {
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    font_size: 20.0,
                     ..default()
                 };
 

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -15,10 +15,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    let text_style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
+    let text_style = TextStyle::default();
 
     let image = asset_server.load("branding/icon.png");
 

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -79,10 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Instructions
 
-    let text_style = TextStyle {
-        font_size: 20.,
-        ..default()
-    };
+    let text_style = TextStyle::default();
 
     commands.spawn((
         TextBundle::from_sections([

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -36,7 +36,6 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 width: Val::Percent(100.),
                 height: Val::Percent(100.),
                 justify_content: JustifyContent::SpaceBetween,
-
                 ..default()
             },
             ..default()
@@ -83,7 +82,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextStyle {
                     font: font.clone(),
                     font_size: 30.0,
-                    color: WHITE.into(),
+                    ..default()
                 },
             )
             .with_style(Style {
@@ -143,7 +142,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     TextStyle {
                         font: font.clone(),
                         font_size: 25.0,
-                        color: Color::WHITE,
+                        ..default()
                     },
                 ),
                 TextSection::new(

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -93,8 +93,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Press Space to enable debug outlines.",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 20.,
-                                        ..Default::default()
+                                        ..default()
                                     },
                                 ),
                                 Label,
@@ -106,8 +105,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Try enabling feature \"bevy_dev_tools\".",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 20.,
-                                        ..Default::default()
+                                        ..default()
                                     },
                                 ),
                                 Label,
@@ -177,7 +175,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                                 TextStyle {
                                                     font: asset_server
                                                         .load("fonts/FiraSans-Bold.ttf"),
-                                                    font_size: 20.,
                                                     ..default()
                                                 },
                                             ),

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -28,9 +28,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         font_size: 16.,
         color: Color::BLACK,
+        ..default()
     };
 
     commands

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -25,10 +25,7 @@ fn setup(
     // Camera
     commands.spawn(Camera2dBundle::default());
 
-    let text_style = TextStyle {
-        font_size: 20.,
-        ..default()
-    };
+    let text_style = TextStyle::default();
 
     let texture_handle = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
     let texture_atlas = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -64,10 +64,7 @@ fn setup(
     commands.spawn(
         TextBundle::from_section(
             "Press <spacebar> to save a screenshot to disk",
-            TextStyle {
-                font_size: 20.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
         .with_style(Style {
             position_type: PositionType::Absolute,


### PR DESCRIPTION
# Objective

- The default font size is too small to be useful in examples or for debug text.
- Fixes #13587

## Solution

- Updated the default font size value in `TextStyle` from 12px to 24px.
- Resorted to Text defaults in examples to use the default font size in most of them.

## Testing

- WIP

---

## Migration Guide

- The default font size has been increased to 24px from 12px. Make sure you set the font to the appropriate values in places you were using `Default` text style.
