### PR TITLE
Additional options to mesh primitives

### DIFF
--- a/crates/bevy_render/src/mesh/primitives/dim3/cone.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/cone.rs
@@ -63,7 +63,7 @@ impl ConeMeshBuilder {
 
     /// Sets a custom anchor point for the mesh
     #[inline]
-    pub const fn with_anchor(mut self, anchor: ConeAnchor) -> Self {
+    pub const fn anchor(mut self, anchor: ConeAnchor) -> Self {
         self.anchor = anchor;
         self
     }

--- a/crates/bevy_render/src/mesh/primitives/dim3/cone.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/cone.rs
@@ -6,6 +6,18 @@ use crate::{
     render_asset::RenderAssetUsages,
 };
 
+/// Anchoring options for [`ConeMeshBuilder`]
+#[derive(Debug, Copy, Clone, Default)]
+pub enum ConeAnchor {
+    #[default]
+    /// Midpoint between the tip of the cone and the center of its base.
+    MidPoint,
+    /// The Tip of the triangle
+    Tip,
+    /// The center of the base circle
+    Base,
+}
+
 /// A builder used for creating a [`Mesh`] with a [`Cone`] shape.
 #[derive(Clone, Copy, Debug)]
 pub struct ConeMeshBuilder {
@@ -15,6 +27,9 @@ pub struct ConeMeshBuilder {
     ///
     /// The default is `32`.
     pub resolution: u32,
+    /// The anchor point for the cone mesh, defaults to the midpoint between
+    /// the tip of the cone and the center of its base
+    pub anchor: ConeAnchor,
 }
 
 impl Default for ConeMeshBuilder {
@@ -22,6 +37,7 @@ impl Default for ConeMeshBuilder {
         Self {
             cone: Cone::default(),
             resolution: 32,
+            anchor: ConeAnchor::default(),
         }
     }
 }
@@ -34,6 +50,7 @@ impl ConeMeshBuilder {
         Self {
             cone: Cone { radius, height },
             resolution,
+            anchor: ConeAnchor::MidPoint,
         }
     }
 
@@ -41,6 +58,13 @@ impl ConeMeshBuilder {
     #[inline]
     pub const fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
+        self
+    }
+
+    /// Sets a custom anchor point for the mesh
+    #[inline]
+    pub const fn with_anchor(mut self, anchor: ConeAnchor) -> Self {
+        self.anchor = anchor;
         self
     }
 }
@@ -129,6 +153,13 @@ impl MeshBuilder for ConeMeshBuilder {
         for i in 1..(self.resolution - 1) {
             indices.extend_from_slice(&[index_offset, index_offset + i, index_offset + i + 1]);
         }
+
+        // Offset the vertex positions Y axis to match the anchor
+        match self.anchor {
+            ConeAnchor::Tip => positions.iter_mut().for_each(|p| p[1] -= half_height),
+            ConeAnchor::Base => positions.iter_mut().for_each(|p| p[1] += half_height),
+            ConeAnchor::MidPoint => (),
+        };
 
         Mesh::new(
             PrimitiveTopology::TriangleList,

--- a/crates/bevy_render/src/mesh/primitives/dim3/cylinder.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/cylinder.rs
@@ -6,6 +6,18 @@ use crate::{
     render_asset::RenderAssetUsages,
 };
 
+/// Anchoring options for [`CylinderMeshBuilder`]
+#[derive(Debug, Copy, Clone, Default)]
+pub enum CylinderAnchor {
+    #[default]
+    /// Midpoint between the top and bottom caps of the cylinder
+    MidPoint,
+    /// The center of the top circle cap
+    Top,
+    /// The center of the bottom circle cap
+    Bottom,
+}
+
 /// A builder used for creating a [`Mesh`] with a [`Cylinder`] shape.
 #[derive(Clone, Copy, Debug)]
 pub struct CylinderMeshBuilder {
@@ -20,6 +32,12 @@ pub struct CylinderMeshBuilder {
     ///
     /// The default is `1`.
     pub segments: u32,
+    /// If set to `true`, the cylinder caps (flat circle faces) are built,
+    /// otherwise the mesh will be a shallow tube
+    pub caps: bool,
+    /// The anchor point for the cylinder mesh, defaults to the midpoint between
+    /// the top and bottom caps
+    pub anchor: CylinderAnchor,
 }
 
 impl Default for CylinderMeshBuilder {
@@ -28,6 +46,8 @@ impl Default for CylinderMeshBuilder {
             cylinder: Cylinder::default(),
             resolution: 32,
             segments: 1,
+            caps: true,
+            anchor: CylinderAnchor::default(),
         }
     }
 }
@@ -56,6 +76,20 @@ impl CylinderMeshBuilder {
     #[inline]
     pub const fn segments(mut self, segments: u32) -> Self {
         self.segments = segments;
+        self
+    }
+
+    /// Ignore the cylinder caps, making the mesh a shallow tube instead
+    #[inline]
+    pub const fn without_caps(mut self) -> Self {
+        self.caps = false;
+        self
+    }
+
+    /// Sets a custom anchor point for the mesh
+    #[inline]
+    pub const fn with_anchor(mut self, anchor: CylinderAnchor) -> Self {
+        self.anchor = anchor;
         self
     }
 }
@@ -118,35 +152,47 @@ impl MeshBuilder for CylinderMeshBuilder {
         }
 
         // caps
+        if self.caps {
+            let mut build_cap = |top: bool| {
+                let offset = positions.len() as u32;
+                let (y, normal_y, winding) = if top {
+                    (self.cylinder.half_height, 1., (1, 0))
+                } else {
+                    (-self.cylinder.half_height, -1., (0, 1))
+                };
 
-        let mut build_cap = |top: bool| {
-            let offset = positions.len() as u32;
-            let (y, normal_y, winding) = if top {
-                (self.cylinder.half_height, 1., (1, 0))
-            } else {
-                (-self.cylinder.half_height, -1., (0, 1))
+                for i in 0..self.resolution {
+                    let theta = i as f32 * step_theta;
+                    let (sin, cos) = theta.sin_cos();
+
+                    positions.push([cos * self.cylinder.radius, y, sin * self.cylinder.radius]);
+                    normals.push([0.0, normal_y, 0.0]);
+                    uvs.push([0.5 * (cos + 1.0), 1.0 - 0.5 * (sin + 1.0)]);
+                }
+
+                for i in 1..(self.resolution - 1) {
+                    indices.extend_from_slice(&[
+                        offset,
+                        offset + i + winding.0,
+                        offset + i + winding.1,
+                    ]);
+                }
             };
 
-            for i in 0..self.resolution {
-                let theta = i as f32 * step_theta;
-                let (sin, cos) = theta.sin_cos();
+            build_cap(true);
+            build_cap(false);
+        }
 
-                positions.push([cos * self.cylinder.radius, y, sin * self.cylinder.radius]);
-                normals.push([0.0, normal_y, 0.0]);
-                uvs.push([0.5 * (cos + 1.0), 1.0 - 0.5 * (sin + 1.0)]);
-            }
-
-            for i in 1..(self.resolution - 1) {
-                indices.extend_from_slice(&[
-                    offset,
-                    offset + i + winding.0,
-                    offset + i + winding.1,
-                ]);
-            }
+        // Offset the vertex positions Y axis to match the anchor
+        match self.anchor {
+            CylinderAnchor::Top => positions
+                .iter_mut()
+                .for_each(|p| p[1] -= self.cylinder.half_height),
+            CylinderAnchor::Bottom => positions
+                .iter_mut()
+                .for_each(|p| p[1] += self.cylinder.half_height),
+            CylinderAnchor::MidPoint => (),
         };
-
-        build_cap(true);
-        build_cap(false);
 
         Mesh::new(
             PrimitiveTopology::TriangleList,

--- a/crates/bevy_render/src/mesh/primitives/dim3/cylinder.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/cylinder.rs
@@ -88,7 +88,7 @@ impl CylinderMeshBuilder {
 
     /// Sets a custom anchor point for the mesh
     #[inline]
-    pub const fn with_anchor(mut self, anchor: CylinderAnchor) -> Self {
+    pub const fn anchor(mut self, anchor: CylinderAnchor) -> Self {
         self.anchor = anchor;
         self
     }


### PR DESCRIPTION
# Objective

Add new options to some primitives, like anchoring for Cones and cylinders and custom angle ranges for Torus.
I think these kind of options are useful, but I would understand that these addition feel overkill

## Solution

Add 

## Testing

- Did you test these changes? If so, how?

> I used the new options in the `3d_shapes` example with various parameters and got the expected results

## Changelog

- Added `caps` bool option to toggle cylinder circle caps
- Added `angle_range` f32 range option non full torus shapes
- Added `anchor` enum option for cylinders,  with either `Top`, `Midpoint` or `Bottom`
- Added `anchor` enum option for cones, with either `Tip`, `Midpoint` or `Base`
- **BREAKING** `TorusMeshBuilder` is no longer `Copy` due to `RangeInclusive`, we can use a `(f32, f32)` if we want it to be `Copy`