### PR TITLE
SystemParam `QueryRecursive` for safe recursive iteration.

### DIFF
--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -70,10 +70,15 @@ pub use valid_parent_check_plugin::*;
 mod query_extension;
 pub use query_extension::*;
 
+mod recursive;
+pub use recursive::QueryRecursive;
+
 #[doc(hidden)]
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{child_builder::*, components::*, hierarchy::*, query_extension::*};
+    pub use crate::{
+        child_builder::*, components::*, hierarchy::*, query_extension::*, QueryRecursive,
+    };
 
     #[doc(hidden)]
     #[cfg(feature = "bevy_app")]

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -464,13 +464,6 @@ mod test {
                 assert_eq!(a.0, 0);
             });
 
-        world
-            .query::<(&GlobalTransform, &ShouldBe)>()
-            .iter(&world)
-            .for_each(|(a, b)| {
-                assert_eq!(a.0, b.0);
-            });
-
         let mut world = test_world();
         world.run_system_once(
             |mut query: QueryRecursive<

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -1,0 +1,259 @@
+use bevy_ecs::{
+    entity::Entity,
+    query::{QueryData, QueryFilter, With, WorldQuery},
+    system::{Query, SystemParam},
+};
+
+use crate::{Children, Parent};
+
+/// [`SystemParam`] that provide mutable hierarchical access to data stored in the world.
+///
+/// When queried, we recursively look for entities from parent to child, along the queries defined by the user.
+///
+/// [`QueryRecursive`] is a generic data structure that accepts `5` type parameters:
+///
+/// * `QShared` is present in all entities, a read only version of this item is passed down from parent to child during iteration.
+/// * `QRoot` is present on root entities only.
+/// * `QChild` is present on child entities only.
+/// * `FRoot` is a [`QueryFilter`] for root entities.
+/// * `FChild` is a [`QueryFilter`] for child entities, [`With<Parent>`] is automatically added.
+///
+/// The user is responsible for excluding the all child entities in `FRoot` (for example use `Without<Parent>`).
+/// 
+/// # Example
+///
+/// A naive transform pipeline implementation.
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_hierarchy::prelude::*;
+/// # #[derive(Clone, Copy, Component)] pub struct Transform;
+/// # #[derive(Clone, Copy, Component)] pub struct GlobalTransform;
+///
+/// # impl Transform {
+/// #    fn into(self) -> GlobalTransform {
+/// #        GlobalTransform
+/// #    }
+/// # }
+///
+/// # impl GlobalTransform {
+/// #    fn mul_transform(self, global: Transform) -> GlobalTransform {
+/// #        GlobalTransform
+/// #    }
+/// # }
+/// fn propagate_transforms(mut query: QueryRecursive<
+///     (&Transform, &mut GlobalTransform),
+///     (),
+///     (),
+///     Without<Parent>,
+///     ()
+/// >) {
+///     query.for_each_mut(
+///         |(transform, mut global_transform), ()|
+///             *global_transform = (*transform).into(),
+///         |(_, parent), (transform, mut global_transform), ()|
+///             *global_transform = parent.mul_transform(*transform),
+///     );
+/// }
+/// ```
+///
+/// # Panics
+///
+/// If hierarchy is malformed, for example if a parent child mismatch is found.
+#[derive(SystemParam)]
+pub struct QueryRecursive<
+    'w,
+    's,
+    QShared: QueryData + 'static,
+    QRoot: QueryData + 'static,
+    QChild: QueryData + 'static,
+    FRoot: QueryFilter + 'static,
+    FChild: QueryFilter + 'static,
+> {
+    root: Query<'w, 's, (QShared, QRoot, Option<&'static Children>), FRoot>,
+    children: Query<'w, 's, (QShared, QChild, Option<&'static Children>), (FChild, With<Parent>)>,
+    parent: Query<'w, 's, (Entity, &'static Parent)>,
+}
+
+type Item<'t, T> = <T as WorldQuery>::Item<'t>;
+type ReadItem<'t, T> = <<T as QueryData>::ReadOnly as WorldQuery>::Item<'t>;
+
+impl<
+        QShared: QueryData + 'static,
+        QRoot: QueryData + 'static,
+        QChild: QueryData + 'static,
+        FRoot: QueryFilter + 'static,
+        FChild: QueryFilter + 'static,
+    > QueryRecursive<'_, '_, QShared, QRoot, QChild, FRoot, FChild>
+{
+    /// Iterate through the [`QueryRecursive`] hierarchy.
+    /// Children receives a readonly reference to their parent's `QShared` [`QueryData`] as the first argument.
+    pub fn for_each(
+        &self,
+        root_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QRoot>),
+        mut child_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QShared>, ReadItem<QChild>),
+    ) {
+        self.for_each_with(root_fn, |a, _, b, c| child_fn(a, b, c));
+    }
+
+    /// Iterate through the [`QueryRecursive`] hierarchy.
+    /// Children receives a readonly reference to their parent's `QShared` [`QueryData`] as the first argument.
+    pub fn for_each_mut(
+        &mut self,
+        root_fn: impl FnMut(Item<QShared>, Item<QRoot>),
+        mut child_fn: impl FnMut(&ReadItem<QShared>, Item<QShared>, Item<QChild>),
+    ) {
+        self.for_each_mut_with(root_fn, |a, _, b, c| child_fn(a, b, c));
+    }
+
+    /// Iterate through a the [`QueryRecursive`] hierarchy while passing down an evaluation result from parent to child.
+    /// Children receives a readonly reference to their parent's `QShared` [`QueryData`] as the first argument.
+    #[allow(unsafe_code)]
+    pub fn for_each_with<T: 'static>(
+        &self,
+        mut root_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QRoot>) -> T,
+        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, ReadItem<QShared>, ReadItem<QChild>) -> T,
+    ) {
+        for (shared, owned, children) in self.root.iter() {
+            let info = root_fn(&shared, owned);
+            let Some(children) = children else {
+                continue;
+            };
+            for entity in children {
+                // Safety: `self.children` is not fetched while this is running.
+                unsafe {
+                    propagate(
+                        &shared,
+                        &info,
+                        &self.children.to_readonly(),
+                        &self.parent,
+                        *entity,
+                        &mut child_fn,
+                    );
+                };
+            }
+        }
+    }
+
+    /// Iterate through a the [`QueryRecursive`] hierarchy while passing down an evaluation result from parent to child.
+    /// Children receives a readonly reference to their parent's `QShared` [`QueryData`] as the first argument.
+    #[allow(unsafe_code)]
+    pub fn for_each_mut_with<T: 'static>(
+        &mut self,
+        mut root_fn: impl FnMut(Item<QShared>, Item<QRoot>) -> T,
+        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, Item<QShared>, Item<QChild>) -> T,
+    ) {
+        let infos: Vec<_> = self
+            .root
+            .iter_mut()
+            .map(|(shared, root, _)| root_fn(shared, root))
+            .collect();
+        for ((shared, _, children), info) in self.root.iter().zip(infos) {
+            let Some(children) = children else {
+                continue;
+            };
+            for entity in children {
+                // Safety: `self.children` is not fetched while this is running.
+                unsafe {
+                    propagate(
+                        &shared,
+                        &info,
+                        &self.children,
+                        &self.parent,
+                        *entity,
+                        &mut child_fn,
+                    );
+                };
+            }
+        }
+    }
+}
+
+/// Recursively run a function on descendants, passing immutable references of parent to child.
+///
+/// # Panics
+///
+/// If `entity`'s descendants have a malformed hierarchy, this function will panic.
+///
+/// # Safety
+///
+/// - While this function is running, `main_query` must not have any fetches for `entity`,
+/// nor any of its descendants.
+/// - The caller must ensure that the hierarchy leading to `entity`
+/// is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
+#[allow(unsafe_code)]
+unsafe fn propagate<
+    QShared: QueryData + 'static,
+    QMain: QueryData + 'static,
+    Filter: QueryFilter + 'static,
+    Info: 'static,
+>(
+    parent: &ReadItem<QShared>,
+    parent_info: &Info,
+    main_query: &Query<(QShared, QMain, Option<&'static Children>), (Filter, With<Parent>)>,
+    parent_query: &Query<(Entity, &Parent)>,
+    entity: Entity,
+    mut function: impl FnMut(&ReadItem<QShared>, &Info, Item<QShared>, Item<QMain>) -> Info,
+) {
+    // SAFETY: This call cannot create aliased mutable references.
+    //   - The top level iteration parallelizes on the roots of the hierarchy.
+    //   - The caller ensures that each child has one and only one unique parent throughout the entire
+    //     hierarchy.
+    //
+    // For example, consider the following malformed hierarchy:
+    //
+    //     A
+    //   /   \
+    //  B     C
+    //   \   /
+    //     D
+    //
+    // D has two parents, B and C. If the propagation passes through C, but the Parent component on D points to B,
+    // the above check will panic as the origin parent does match the recorded parent.
+    //
+    // Also consider the following case, where A and B are roots:
+    //
+    //  A       B
+    //   \     /
+    //    C   D
+    //     \ /
+    //      E
+    //
+    // Even if these A and B start two separate tasks running in parallel, one of them will panic before attempting
+    // to mutably access E.
+    let info = {
+        let Ok((shared, owned, _)) =
+            // Safety: see above.
+            (unsafe { main_query.get_unchecked(entity) }) else {
+                return;
+            };
+
+        function(parent, parent_info, shared, owned)
+    };
+
+    let Ok((shared, _, children)) = main_query.get(entity) else {
+        return;
+    };
+
+    let Some(children) = children else { return };
+    for (child, actual_parent) in parent_query.iter_many(children) {
+        assert_eq!(
+            actual_parent.get(), entity,
+            "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
+        );
+        // SAFETY: The caller guarantees that `main_query` will not be fetched
+        // for any descendants of `entity`, so it is safe to call `propagate_recursive` for each child.
+        //
+        // The above assertion ensures that each child has one and only one unique parent throughout the
+        // entire hierarchy.
+        unsafe {
+            propagate(
+                &shared,
+                &info,
+                main_query,
+                parent_query,
+                child,
+                &mut function,
+            );
+        }
+    }
+}

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -19,7 +19,7 @@ use crate::{Children, Parent};
 /// * `FChild` is a [`QueryFilter`] for child entities, [`With<Parent>`] is automatically added.
 ///
 /// The user is responsible for excluding the all child entities in `FRoot` (for example use `Without<Parent>`).
-/// 
+///
 /// # Example
 ///
 /// A naive transform pipeline implementation.

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -48,10 +48,10 @@ use crate::{Children, Parent};
 ///     ()
 /// >) {
 ///     query.for_each_mut(
-///         |(transform, mut global_transform), ()|
-///             *global_transform = (*transform).into(),
-///         |(_, parent), (transform, mut global_transform), ()|
-///             *global_transform = parent.mul_transform(*transform),
+///         |(transform, global_transform), ()|
+///             **global_transform = (**transform).into(),
+///         |(_, parent), (transform, global_transform), ()|
+///             **global_transform = parent.mul_transform(**transform),
 ///     );
 /// }
 /// ```

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -413,12 +413,82 @@ mod test {
                 &mut GlobalTransform,
                 &Transform,
                 &Transform,
+                Without<Parent>,
+                (),
+            >| {
+                query.for_each_mut_with(
+                    |global, transform| {
+                        global.0 = transform.0;
+                        global.0
+                    },
+                    |_, parent, global, transform| {
+                        global.0 = transform.0 + *parent;
+                        global.0
+                    },
+                );
+            },
+        );
+
+        world
+            .query::<(&GlobalTransform, &ShouldBe)>()
+            .iter(&world)
+            .for_each(|(a, b)| {
+                assert_eq!(a.0, b.0);
+            });
+
+        let mut world = test_world();
+        world.run_system_once(
+            |mut query: QueryRecursive<
+                &mut GlobalTransform,
+                &Transform,
+                &Transform,
                 (Without<Parent>, Without<Trim>),
                 Without<Trim>,
             >| {
                 query.for_each_mut(
                     |global, transform| global.0 = transform.0,
                     |parent, global, transform| global.0 = transform.0 + parent.0,
+                );
+            },
+        );
+        world
+            .query_filtered::<(&GlobalTransform, &ShouldBe), Without<Trimmed>>()
+            .iter(&world)
+            .for_each(|(a, b)| {
+                assert_eq!(a.0, b.0);
+            });
+        world
+            .query_filtered::<&GlobalTransform, With<Trimmed>>()
+            .iter(&world)
+            .for_each(|a| {
+                assert_eq!(a.0, 0);
+            });
+
+        world
+            .query::<(&GlobalTransform, &ShouldBe)>()
+            .iter(&world)
+            .for_each(|(a, b)| {
+                assert_eq!(a.0, b.0);
+            });
+
+        let mut world = test_world();
+        world.run_system_once(
+            |mut query: QueryRecursive<
+                &mut GlobalTransform,
+                &Transform,
+                &Transform,
+                (Without<Parent>, Without<Trim>),
+                Without<Trim>,
+            >| {
+                query.for_each_mut_with(
+                    |global, transform| {
+                        global.0 = transform.0;
+                        global.0
+                    },
+                    |_, parent, global, transform| {
+                        global.0 = transform.0 + *parent;
+                        global.0
+                    },
                 );
             },
         );

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -93,8 +93,8 @@ impl<
     /// If hierarchy is malformed, for example if a parent child mismatch or a cycle is found.
     pub fn for_each(
         &self,
-        root_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QRoot>),
-        mut child_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QShared>, ReadItem<QChild>),
+        root_fn: impl FnMut(&ReadItem<QShared>, &ReadItem<QRoot>),
+        mut child_fn: impl FnMut(&ReadItem<QShared>, &ReadItem<QShared>, &ReadItem<QChild>),
     ) {
         self.for_each_with(root_fn, |a, _, b, c| child_fn(a, b, c));
     }
@@ -107,8 +107,8 @@ impl<
     /// If hierarchy is malformed, for example if a parent child mismatch or a cycle is found.
     pub fn for_each_mut(
         &mut self,
-        root_fn: impl FnMut(Item<QShared>, Item<QRoot>),
-        mut child_fn: impl FnMut(&ReadItem<QShared>, Item<QShared>, Item<QChild>),
+        root_fn: impl FnMut(&mut Item<QShared>, &mut Item<QRoot>),
+        mut child_fn: impl FnMut(&Item<QShared>, &mut Item<QShared>, &mut Item<QChild>),
     ) {
         self.for_each_mut_with(root_fn, |a, _, b, c| child_fn(a, b, c));
     }
@@ -122,11 +122,11 @@ impl<
     #[allow(unsafe_code)]
     pub fn for_each_with<T: 'static>(
         &self,
-        mut root_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QRoot>) -> T,
-        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, ReadItem<QShared>, ReadItem<QChild>) -> T,
+        mut root_fn: impl FnMut(&ReadItem<QShared>, &ReadItem<QRoot>) -> T,
+        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, &ReadItem<QShared>, &ReadItem<QChild>) -> T,
     ) {
         for (shared, owned, children) in self.root.iter() {
-            let info = root_fn(&shared, owned);
+            let info = root_fn(&shared, &owned);
             let Some(children) = children else {
                 continue;
             };
@@ -140,7 +140,7 @@ impl<
                         &self.children.to_readonly(),
                         &self.parent,
                         *entity,
-                        &mut child_fn,
+                        |a, b, c, d| child_fn(a, b, c, d),
                     );
                 };
             }
@@ -156,15 +156,11 @@ impl<
     #[allow(unsafe_code)]
     pub fn for_each_mut_with<T: 'static>(
         &mut self,
-        mut root_fn: impl FnMut(Item<QShared>, Item<QRoot>) -> T,
-        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, Item<QShared>, Item<QChild>) -> T,
+        mut root_fn: impl FnMut(&mut Item<QShared>, &mut Item<QRoot>) -> T,
+        mut child_fn: impl FnMut(&Item<QShared>, &T, &mut Item<QShared>, &mut Item<QChild>) -> T,
     ) {
-        let infos: Vec<_> = self
-            .root
-            .iter_mut()
-            .map(|(shared, root, _)| root_fn(shared, root))
-            .collect();
-        for ((shared, _, children), info) in self.root.iter().zip(infos) {
+        for (mut shared, mut root, children) in self.root.iter_mut() {
+            let info = root_fn(&mut shared, &mut root);
             let Some(children) = children else {
                 continue;
             };
@@ -206,12 +202,12 @@ unsafe fn propagate<
     Info: 'static,
 >(
     actual_root: Entity,
-    parent: &ReadItem<QShared>,
+    parent: &Item<QShared>,
     parent_info: &Info,
     main_query: &Query<(QShared, QMain, Option<&'static Children>), (Filter, With<Parent>)>,
     parent_query: &Query<(Entity, &Parent)>,
     entity: Entity,
-    mut function: impl FnMut(&ReadItem<QShared>, &Info, Item<QShared>, Item<QMain>) -> Info,
+    mut function: impl FnMut(&Item<QShared>, &Info, &mut Item<QShared>, &mut Item<QMain>) -> Info,
 ) {
     // SAFETY: This call cannot create aliased mutable references.
     //   - The top level iteration parallelizes on the roots of the hierarchy.
@@ -239,19 +235,12 @@ unsafe fn propagate<
     //
     // Even if these A and B start two separate tasks running in parallel, one of them will panic before attempting
     // to mutably access E.
-    let info = {
-        let Ok((shared, owned, _)) =
-            // Safety: see above.
-            (unsafe { main_query.get_unchecked(entity) }) else {
-                return;
-            };
-
-        function(parent, parent_info, shared, owned)
-    };
-
-    let Ok((shared, _, children)) = main_query.get(entity) else {
+    let Ok((mut shared, mut owned, children)) = (unsafe { main_query.get_unchecked(entity) })
+    else {
         return;
     };
+
+    let info = function(parent, parent_info, &mut shared, &mut owned);
 
     let Some(children) = children else { return };
     for (child, actual_parent) in parent_query.iter_many(children) {
@@ -264,7 +253,7 @@ unsafe fn propagate<
         // This was not needed in `propagate_transform` since the root node did not have parents.
         assert_ne!(
             actual_root, entity,
-            "Malformed hierarchy. Your hierarchy contains a cycle"
+            "Malformed hierarchy. The hierarchy contains a cycle"
         );
         // SAFETY: The caller guarantees that `main_query` will not be fetched
         // for any descendants of `entity`, so it is safe to call `propagate_recursive` for each child.

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -133,7 +133,6 @@ impl<
                 continue;
             };
             for entity in children {
-                // Self referencing root node is checked by `propagate`.
                 assert_eq!(
                     self.parent.get(*entity).map(|(_, p)| p.get()).ok(), Some(actual_root),
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained."
@@ -173,7 +172,6 @@ impl<
                 continue;
             };
             for entity in children {
-                // Self referencing root node is checked by `propagate`.
                 assert_eq!(
                     self.parent.get(*entity).map(|(_, p)| p.get()).ok(), Some(actual_root),
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained."

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -93,8 +93,8 @@ impl<
     /// If hierarchy is malformed, for example if a parent child mismatch or a cycle is found.
     pub fn for_each(
         &self,
-        root_fn: impl FnMut(ReadItem<QShared>, ReadItem<QRoot>),
-        mut child_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QShared>, ReadItem<QChild>),
+        root_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QRoot>),
+        mut child_fn: impl FnMut(&ReadItem<QShared>, &ReadItem<QShared>, ReadItem<QChild>),
     ) {
         self.for_each_with(root_fn, |a, _, b, c| child_fn(a, b, c));
     }
@@ -107,8 +107,8 @@ impl<
     /// If hierarchy is malformed, for example if a parent child mismatch or a cycle is found.
     pub fn for_each_mut(
         &mut self,
-        root_fn: impl FnMut(Item<QShared>, Item<QRoot>),
-        mut child_fn: impl FnMut(&ReadItem<QShared>, Item<QShared>, Item<QChild>),
+        root_fn: impl FnMut(&mut Item<QShared>, Item<QRoot>),
+        mut child_fn: impl FnMut(&Item<QShared>, &mut Item<QShared>, Item<QChild>),
     ) {
         self.for_each_mut_with(root_fn, |a, _, b, c| child_fn(a, b, c));
     }
@@ -122,15 +122,11 @@ impl<
     #[allow(unsafe_code)]
     pub fn for_each_with<T: 'static>(
         &self,
-        mut root_fn: impl FnMut(ReadItem<QShared>, ReadItem<QRoot>) -> T,
-        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, ReadItem<QShared>, ReadItem<QChild>) -> T,
+        mut root_fn: impl FnMut(&ReadItem<QShared>, ReadItem<QRoot>) -> T,
+        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, &ReadItem<QShared>, ReadItem<QChild>) -> T,
     ) {
-        let infos: Vec<_> = self
-            .root
-            .iter()
-            .map(|(shared, root, _)| root_fn(shared, root))
-            .collect();
-        for ((shared, _, children), info) in self.root.iter().zip(infos) {
+        for (shared, owned, children) in self.root.iter() {
+            let info = root_fn(&shared, owned);
             let Some(children) = children else {
                 continue;
             };
@@ -144,7 +140,7 @@ impl<
                         &self.children.to_readonly(),
                         &self.parent,
                         *entity,
-                        &mut child_fn,
+                        |a, b, c, d| child_fn(a, b, c, d),
                     );
                 };
             }
@@ -160,15 +156,11 @@ impl<
     #[allow(unsafe_code)]
     pub fn for_each_mut_with<T: 'static>(
         &mut self,
-        mut root_fn: impl FnMut(Item<QShared>, Item<QRoot>) -> T,
-        mut child_fn: impl FnMut(&ReadItem<QShared>, &T, Item<QShared>, Item<QChild>) -> T,
+        mut root_fn: impl FnMut(&mut Item<QShared>, Item<QRoot>) -> T,
+        mut child_fn: impl FnMut(&Item<QShared>, &T, &mut Item<QShared>, Item<QChild>) -> T,
     ) {
-        let infos: Vec<_> = self
-            .root
-            .iter_mut()
-            .map(|(shared, root, _)| root_fn(shared, root))
-            .collect();
-        for ((shared, _, children), info) in self.root.iter().zip(infos) {
+        for (mut shared, owned, children) in self.root.iter_mut() {
+            let info = root_fn(&mut shared, owned);
             let Some(children) = children else {
                 continue;
             };
@@ -210,12 +202,12 @@ unsafe fn propagate<
     Info: 'static,
 >(
     actual_root: Entity,
-    parent: &ReadItem<QShared>,
+    parent: &Item<QShared>,
     parent_info: &Info,
     main_query: &Query<(QShared, QMain, Option<&'static Children>), (Filter, With<Parent>)>,
     parent_query: &Query<(Entity, &Parent)>,
     entity: Entity,
-    mut function: impl FnMut(&ReadItem<QShared>, &Info, Item<QShared>, Item<QMain>) -> Info,
+    mut function: impl FnMut(&Item<QShared>, &Info, &mut Item<QShared>, Item<QMain>) -> Info,
 ) {
     // SAFETY: This call cannot create aliased mutable references.
     //   - The top level iteration parallelizes on the roots of the hierarchy.
@@ -243,19 +235,11 @@ unsafe fn propagate<
     //
     // Even if these A and B start two separate tasks running in parallel, one of them will panic before attempting
     // to mutably access E.
-    let info = {
-        let Ok((shared, owned, _)) =
-            // Safety: see above.
-            (unsafe { main_query.get_unchecked(entity) }) else {
-                return;
-            };
-
-        function(parent, parent_info, shared, owned)
-    };
-
-    let Ok((shared, _, children)) = main_query.get(entity) else {
+    let Ok((mut shared, owned, children)) = (unsafe { main_query.get_unchecked(entity) }) else {
         return;
     };
+
+    let info = function(parent, parent_info, &mut shared, owned);
 
     let Some(children) = children else { return };
     for (child, actual_parent) in parent_query.iter_many(children) {

--- a/crates/bevy_hierarchy/src/recursive.rs
+++ b/crates/bevy_hierarchy/src/recursive.rs
@@ -133,7 +133,16 @@ impl<
                 continue;
             };
             for entity in children {
+                assert_ne!(
+                    *entity, actual_root,
+                    "Malformed hierarchy. Self-referencing entity detected."
+                );
+                assert_eq!(
+                    self.parent.get(*entity).map(|(_, p)| p.get()).ok(), Some(actual_root),
+                    "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained."
+                );
                 // Safety: `self.children` is not fetched while this is running.
+                // actual root is the parent of entity and is not self referencing.
                 unsafe {
                     propagate(
                         actual_root,
@@ -167,6 +176,14 @@ impl<
                 continue;
             };
             for entity in children {
+                assert_ne!(
+                    *entity, actual_root,
+                    "Malformed hierarchy. Self-referencing entity detected."
+                );
+                assert_eq!(
+                    self.parent.get(*entity).map(|(_, p)| p.get()).ok(), Some(actual_root),
+                    "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained."
+                );
                 // Safety: `self.children` is not fetched while this is running.
                 unsafe {
                     propagate(
@@ -201,6 +218,8 @@ impl<
 /// nor any of its descendants.
 /// - The caller must ensure that the hierarchy leading to `entity`
 /// is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
+/// - When called externally, `actual_root` must be the parent of `entity` and not self referencing,
+/// when called recursively, `actual_root` must be the ancestor of `entity`.
 #[allow(unsafe_code)]
 unsafe fn propagate<
     QShared: QueryData + 'static,


### PR DESCRIPTION
# Objective

Recursive iterating through the hierarchy while keeping a reference to parent requires `unsafe`, as seen in `propagate_transform` in `bevy_transform`. This PR alleviates this issue by generalizing recursive iteration into a safe interface.

## Solution 

Added `QueryRecursive` that contains 2 queries from 5 generic parameters.

```rust
root: Query<(Shared, Root), RootFilter>
child: Query<(Shared, Child), ChildFilter>
```

`QueryData` `Shared` gets passed from parent to children as a reference during iteration. 

Additionally we support passing evaluation results from parent to children in `iter_mut_with`.

### Example: transform pipeline (naive implementation)

```rust
fn propagate_transforms(mut query: QueryRecursive<
    (&Transform, &mut GlobalTransform),
    (),
    (),
    Without<Parent>,
    ()
>) {
    query.for_each_mut(
        |(transform, global_transform), ()|
            **global_transform = (**transform).into(),
        |(_, parent), (transform, global_transform), ()|
            **global_transform = parent.mul_transform(**transform),
    );
}
```


## Testing

Added some tests.

---

## Changelog

Added `QueryRecursive`.
