### PR TITLE
unload unused images that are RenderAssetUsages::RENDER_WORLD

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -605,10 +605,9 @@ pub fn prepare_sprite_image_bind_groups(
     for event in &events.images {
         match event {
             AssetEvent::Added { .. } |
-            AssetEvent::Unused { .. } |
             // Images don't have dependencies
             AssetEvent::LoadedWithDependencies { .. } => {}
-            AssetEvent::Modified { id } | AssetEvent::Removed { id } => {
+            AssetEvent::Unused { id } | AssetEvent::Modified { id } | AssetEvent::Removed { id } => {
                 image_bind_groups.values.remove(id);
             }
         };


### PR DESCRIPTION
# Objective

- Fixes #13500
- Images that are `RenderAssetUsages::RENDER_WORLD` don't free their memory when they are no longer used

## Solution

- Remove their bind group when the handles are unused
