### PR TITLE
Update to `rodio` 0.18

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -29,7 +29,7 @@ rodio = { version = "0.18", default-features = false }
 cpal = { version = "0.15", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.17", default-features = false, features = [
+rodio = { version = "0.18", default-features = false, features = [
   "wasm-bindgen",
 ] }
 

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -23,7 +23,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 
 # other
-rodio = { version = "0.17", default-features = false }
+rodio = { version = "0.18", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 cpal = { version = "0.15", optional = true }


### PR DESCRIPTION
# Objective

- Adopted from #13528.
- `rodio` released 0.18! While we are working on migrating away from it and towards `kira`, it is still good to keep our dependencies up-to-date.

## Solution

- Update `Cargo.toml` to depend on `rodio` 0.18.
  - #13528 was failing because it didn't update `rodio` for `wasm32-unknown-unknown` too.

## Testing

- The CI should catch any errors here, but you can also run an audio example if you want like `spatial_audio_2d`.

---

## Changelog

- Updated `rodio` to 0.18.