### PR TITLE
Simplify state transitions

### DIFF
--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -306,10 +306,10 @@ impl SubApp {
             self.init_resource::<State<S>>()
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
-            let initial = self.world.resource::<State<S>>().get().clone();
+            let state = self.world.resource::<State<S>>().get().clone();
             self.world.send_event(StateTransitionEvent {
                 exited: None,
-                entered: Some(initial),
+                entered: Some(state),
             });
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_state(schedule);

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -306,13 +306,13 @@ impl SubApp {
             self.init_resource::<State<S>>()
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
+            let schedule = self.get_schedule_mut(StateTransition).unwrap();
+            S::register_state(schedule);
             let state = self.world.resource::<State<S>>().get().clone();
             self.world.send_event(StateTransitionEvent {
                 exited: None,
                 entered: Some(state),
             });
-            let schedule = self.get_schedule_mut(StateTransition).unwrap();
-            S::register_state(schedule);
         }
 
         self
@@ -326,12 +326,12 @@ impl SubApp {
             self.insert_resource::<State<S>>(State::new(state.clone()))
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
+            let schedule = self.get_schedule_mut(StateTransition).unwrap();
+            S::register_state(schedule);
             self.world.send_event(StateTransitionEvent {
                 exited: None,
                 entered: Some(state),
             });
-            let schedule = self.get_schedule_mut(StateTransition).unwrap();
-            S::register_state(schedule);
         }
 
         self
@@ -348,6 +348,11 @@ impl SubApp {
             self.add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_computed_state_systems(schedule);
+            let state = self.world.resource::<State<S>>().get().clone();
+            self.world.send_event(StateTransitionEvent {
+                exited: None,
+                entered: Some(state),
+            });
         }
 
         self
@@ -365,6 +370,11 @@ impl SubApp {
             self.add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_sub_state_systems(schedule);
+            let state = self.world.resource::<State<S>>().get().clone();
+            self.world.send_event(StateTransitionEvent {
+                exited: None,
+                entered: Some(state),
+            });
         }
 
         self

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -306,6 +306,11 @@ impl SubApp {
             self.init_resource::<State<S>>()
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
+            let initial = self.world.resource::<State<S>>().get().clone();
+            self.world.send_event(StateTransitionEvent {
+                exited: None,
+                entered: Some(initial),
+            });
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_state(schedule);
         }
@@ -318,10 +323,13 @@ impl SubApp {
     pub fn insert_state<S: FreelyMutableState>(&mut self, state: S) -> &mut Self {
         if !self.world.contains_resource::<State<S>>() {
             setup_state_transitions_in_world(&mut self.world, Some(Startup.intern()));
-            self.insert_resource::<State<S>>(State::new(state))
+            self.insert_resource::<State<S>>(State::new(state.clone()))
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
-
+            self.world.send_event(StateTransitionEvent {
+                exited: None,
+                entered: Some(state),
+            });
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_state(schedule);
         }

--- a/crates/bevy_state/src/state/freely_mutable_state.rs
+++ b/crates/bevy_state/src/state/freely_mutable_state.rs
@@ -17,17 +17,17 @@ pub trait FreelyMutableState: States {
                 apply_state_transition::<Self>.in_set(ApplyStateTransition::<Self>::apply()),
             )
             .add_systems(
-                last_event::<Self>
+                last_transition::<Self>
                     .pipe(run_enter::<Self>)
                     .in_set(StateTransitionSteps::EnterSchedules),
             )
             .add_systems(
-                last_event::<Self>
+                last_transition::<Self>
                     .pipe(run_exit::<Self>)
                     .in_set(StateTransitionSteps::ExitSchedules),
             )
             .add_systems(
-                last_event::<Self>
+                last_transition::<Self>
                     .pipe(run_transition::<Self>)
                     .in_set(StateTransitionSteps::TransitionSchedules),
             )

--- a/crates/bevy_state/src/state/freely_mutable_state.rs
+++ b/crates/bevy_state/src/state/freely_mutable_state.rs
@@ -17,17 +17,17 @@ pub trait FreelyMutableState: States {
                 apply_state_transition::<Self>.in_set(ApplyStateTransition::<Self>::apply()),
             )
             .add_systems(
-                should_run_transition::<Self, OnEnter<Self>>
+                last_event::<Self>
                     .pipe(run_enter::<Self>)
                     .in_set(StateTransitionSteps::EnterSchedules),
             )
             .add_systems(
-                should_run_transition::<Self, OnExit<Self>>
+                last_event::<Self>
                     .pipe(run_exit::<Self>)
                     .in_set(StateTransitionSteps::ExitSchedules),
             )
             .add_systems(
-                should_run_transition::<Self, OnTransition<Self>>
+                last_event::<Self>
                     .pipe(run_transition::<Self>)
                     .in_set(StateTransitionSteps::TransitionSchedules),
             )

--- a/crates/bevy_state/src/state/mod.rs
+++ b/crates/bevy_state/src/state/mod.rs
@@ -497,36 +497,4 @@ mod tests {
             "Should Only Exit Twice"
         );
     }
-
-    #[test]
-    fn all_state_events_fire_during_startup() {
-        let mut world = World::new();
-        setup_state_transitions_in_world(&mut world, Some(Startup.intern()));
-        EventRegistry::register_event::<StateTransitionEvent<SimpleState>>(&mut world);
-        EventRegistry::register_event::<StateTransitionEvent<TestComputedState>>(&mut world);
-        EventRegistry::register_event::<StateTransitionEvent<SubState>>(&mut world);
-        world.init_resource::<State<SimpleState>>();
-        let mut schedules = world.resource_mut::<Schedules>();
-        let apply_changes = schedules
-            .get_mut(StateTransition)
-            .expect("State Transition Schedule Doesn't Exist");
-        SimpleState::register_state(apply_changes);
-        TestComputedState::register_computed_state_systems(apply_changes);
-        SubState::register_sub_state_systems(apply_changes);
-        world.send_event(StateTransitionEvent {
-            exited: None,
-            entered: Some(SimpleState::A),
-        });
-
-        world.run_schedule(Startup);
-        assert!(!world
-            .resource::<Events<StateTransitionEvent<SimpleState>>>()
-            .is_empty());
-        assert!(!world
-            .resource::<Events<StateTransitionEvent<SubState>>>()
-            .is_empty());
-        assert!(!world
-            .resource::<Events<StateTransitionEvent<TestComputedState>>>()
-            .is_empty());
-    }
 }

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -9,9 +9,8 @@ use self::sealed::StateSetSealed;
 
 use super::{
     apply_state_transition, computed_states::ComputedStates, internal_apply_state_transition,
-    run_enter, run_exit, run_transition, should_run_transition, sub_states::SubStates,
-    ApplyStateTransition, OnEnter, OnExit, OnTransition, State, StateTransitionEvent,
-    StateTransitionSteps, States,
+    last_event, run_enter, run_exit, run_transition, sub_states::SubStates, ApplyStateTransition,
+    State, StateTransitionEvent, StateTransitionSteps, States,
 };
 
 mod sealed {
@@ -117,17 +116,17 @@ impl<S: InnerStateSet> StateSet for S {
         schedule
             .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
             .add_systems(
-                should_run_transition::<T, OnEnter<T>>
+                last_event::<T>
                     .pipe(run_enter::<T>)
                     .in_set(StateTransitionSteps::EnterSchedules),
             )
             .add_systems(
-                should_run_transition::<T, OnExit<T>>
+                last_event::<T>
                     .pipe(run_exit::<T>)
                     .in_set(StateTransitionSteps::ExitSchedules),
             )
             .add_systems(
-                should_run_transition::<T, OnTransition<T>>
+                last_event::<T>
                     .pipe(run_transition::<T>)
                     .in_set(StateTransitionSteps::TransitionSchedules),
             )
@@ -181,17 +180,17 @@ impl<S: InnerStateSet> StateSet for S {
                 apply_state_transition::<T>.in_set(StateTransitionSteps::ManualTransitions),
             )
             .add_systems(
-                should_run_transition::<T, OnEnter<T>>
+                last_event::<T>
                     .pipe(run_enter::<T>)
                     .in_set(StateTransitionSteps::EnterSchedules),
             )
             .add_systems(
-                should_run_transition::<T, OnExit<T>>
+                last_event::<T>
                     .pipe(run_exit::<T>)
                     .in_set(StateTransitionSteps::ExitSchedules),
             )
             .add_systems(
-                should_run_transition::<T, OnTransition<T>>
+                last_event::<T>
                     .pipe(run_transition::<T>)
                     .in_set(StateTransitionSteps::TransitionSchedules),
             )
@@ -232,9 +231,9 @@ macro_rules! impl_state_set_sealed_tuples {
 
                 schedule
                     .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
-                    .add_systems(should_run_transition::<T, OnEnter<T>>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
-                    .add_systems(should_run_transition::<T, OnExit<T>>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
-                    .add_systems(should_run_transition::<T, OnTransition<T>>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
+                    .add_systems(last_event::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
+                    .add_systems(last_event::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
+                    .add_systems(last_event::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
                     .configure_sets(
                         ApplyStateTransition::<T>::apply()
                         .in_set(StateTransitionSteps::DependentTransitions)
@@ -271,9 +270,9 @@ macro_rules! impl_state_set_sealed_tuples {
                 schedule
                     .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
                     .add_systems(apply_state_transition::<T>.in_set(StateTransitionSteps::ManualTransitions))
-                    .add_systems(should_run_transition::<T, OnEnter<T>>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
-                    .add_systems(should_run_transition::<T, OnExit<T>>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
-                    .add_systems(should_run_transition::<T, OnTransition<T>>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
+                    .add_systems(last_event::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
+                    .add_systems(last_event::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
+                    .add_systems(last_event::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
                     .configure_sets(
                         ApplyStateTransition::<T>::apply()
                         .in_set(StateTransitionSteps::DependentTransitions)

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -9,8 +9,8 @@ use self::sealed::StateSetSealed;
 
 use super::{
     apply_state_transition, computed_states::ComputedStates, internal_apply_state_transition,
-    last_event, run_enter, run_exit, run_transition, sub_states::SubStates, ApplyStateTransition,
-    State, StateTransitionEvent, StateTransitionSteps, States,
+    last_transition, run_enter, run_exit, run_transition, sub_states::SubStates,
+    ApplyStateTransition, State, StateTransitionEvent, StateTransitionSteps, States,
 };
 
 mod sealed {
@@ -116,17 +116,17 @@ impl<S: InnerStateSet> StateSet for S {
         schedule
             .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
             .add_systems(
-                last_event::<T>
+                last_transition::<T>
                     .pipe(run_enter::<T>)
                     .in_set(StateTransitionSteps::EnterSchedules),
             )
             .add_systems(
-                last_event::<T>
+                last_transition::<T>
                     .pipe(run_exit::<T>)
                     .in_set(StateTransitionSteps::ExitSchedules),
             )
             .add_systems(
-                last_event::<T>
+                last_transition::<T>
                     .pipe(run_transition::<T>)
                     .in_set(StateTransitionSteps::TransitionSchedules),
             )
@@ -180,17 +180,17 @@ impl<S: InnerStateSet> StateSet for S {
                 apply_state_transition::<T>.in_set(StateTransitionSteps::ManualTransitions),
             )
             .add_systems(
-                last_event::<T>
+                last_transition::<T>
                     .pipe(run_enter::<T>)
                     .in_set(StateTransitionSteps::EnterSchedules),
             )
             .add_systems(
-                last_event::<T>
+                last_transition::<T>
                     .pipe(run_exit::<T>)
                     .in_set(StateTransitionSteps::ExitSchedules),
             )
             .add_systems(
-                last_event::<T>
+                last_transition::<T>
                     .pipe(run_transition::<T>)
                     .in_set(StateTransitionSteps::TransitionSchedules),
             )
@@ -231,9 +231,9 @@ macro_rules! impl_state_set_sealed_tuples {
 
                 schedule
                     .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
-                    .add_systems(last_event::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
-                    .add_systems(last_event::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
-                    .add_systems(last_event::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
+                    .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
+                    .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
+                    .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
                     .configure_sets(
                         ApplyStateTransition::<T>::apply()
                         .in_set(StateTransitionSteps::DependentTransitions)
@@ -270,9 +270,9 @@ macro_rules! impl_state_set_sealed_tuples {
                 schedule
                     .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
                     .add_systems(apply_state_transition::<T>.in_set(StateTransitionSteps::ManualTransitions))
-                    .add_systems(last_event::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
-                    .add_systems(last_event::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
-                    .add_systems(last_event::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
+                    .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
+                    .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
+                    .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
                     .configure_sets(
                         ApplyStateTransition::<T>::apply()
                         .in_set(StateTransitionSteps::DependentTransitions)

--- a/crates/bevy_state/src/state/transitions.rs
+++ b/crates/bevy_state/src/state/transitions.rs
@@ -202,7 +202,8 @@ pub fn apply_state_transition<S: FreelyMutableState>(
     *next_state_resource.as_mut() = NextState::<S>::Unchanged;
 }
 
-pub(crate) fn last_event<S: States>(
+/// Returns the latest state transition event, if any are available.
+pub fn last_transition<S: States>(
     mut reader: EventReader<StateTransitionEvent<S>>,
 ) -> Option<StateTransitionEvent<S>> {
     reader.read().last().cloned()

--- a/crates/bevy_state/src/state/transitions.rs
+++ b/crates/bevy_state/src/state/transitions.rs
@@ -202,7 +202,7 @@ pub fn apply_state_transition<S: FreelyMutableState>(
     *next_state_resource.as_mut() = NextState::<S>::Unchanged;
 }
 
-/// Returns the latest state transition event, if any are available.
+/// Returns the latest state transition event of type `S`, if any are available.
 pub fn last_transition<S: States>(
     mut reader: EventReader<StateTransitionEvent<S>>,
 ) -> Option<StateTransitionEvent<S>> {


### PR DESCRIPTION
# Objective

Prerequisite to #13579.
Make state transition schedule running simpler.

## Solution

- Remove `should_run_transition` which read the latest event and fake-fire an event for the startup transitions (e.g. startup `OnEnter()`).
- Account for startup event, by actually emitting an event when adding states to `App`.
- Replace `should_run_transition` with `last_transition`, which is a light wrapper over `EventReader::read().last()`.