### PR TITLE
Combine transition systems of `Substates`

### DIFF
--- a/crates/bevy_state/macros/src/states.rs
+++ b/crates/bevy_state/macros/src/states.rs
@@ -117,12 +117,8 @@ pub fn derive_substates(input: TokenStream) -> TokenStream {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
             type SourceStates = #source_state_type;
 
-            fn should_exist(sources: #source_state_type) -> Option<Self> {
-                if matches!(sources, #source_state_value) {
-                    Some(Self::default())
-                } else {
-                    None
-                }
+            fn should_exist(sources: #source_state_type) -> bool {
+                matches!(sources, #source_state_value)
             }
         }
 

--- a/crates/bevy_state/macros/src/states.rs
+++ b/crates/bevy_state/macros/src/states.rs
@@ -117,8 +117,8 @@ pub fn derive_substates(input: TokenStream) -> TokenStream {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
             type SourceStates = #source_state_type;
 
-            fn should_exist(sources: #source_state_type) -> bool {
-                matches!(sources, #source_state_value)
+            fn should_exist(sources: #source_state_type) -> Option<Self> {
+                matches!(sources, #source_state_value).then_some(Self::default())
             }
         }
 

--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -38,7 +38,7 @@ pub mod prelude {
     pub use crate::condition::*;
     #[doc(hidden)]
     pub use crate::state::{
-        apply_state_transition, ComputedStates, NextState, OnEnter, OnExit, OnTransition, State,
-        StateSet, StateTransition, StateTransitionEvent, States, SubStates,
+        ComputedStates, NextState, OnEnter, OnExit, OnTransition, State, StateSet, StateTransition,
+        StateTransitionEvent, States, SubStates,
     };
 }

--- a/crates/bevy_state/src/state/resources.rs
+++ b/crates/bevy_state/src/state/resources.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 
 use bevy_ecs::{
+    change_detection::DetectChangesMut,
     system::{ResMut, Resource},
     world::{FromWorld, World},
 };
@@ -138,10 +139,10 @@ pub(crate) fn take_next_state<S: FreelyMutableState>(
 ) -> Option<S> {
     let mut next_state = next_state?;
 
-    match next_state.clone() {
-        NextState::Pending(new_state) => {
-            *next_state.as_mut() = NextState::<S>::Unchanged;
-            Some(new_state)
+    match std::mem::take(next_state.bypass_change_detection()) {
+        NextState::Pending(x) => {
+            next_state.set_changed();
+            Some(x)
         }
         NextState::Unchanged => None,
     }

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -183,24 +183,9 @@ impl<S: InnerStateSet> StateSet for S {
                     false => current_state.clone(),
                 };
 
-                match should_exist {
-                    Some(initial_state) => {
-                        let new_state = match (current_state, next_state) {
-                            (_, Some(next_state)) => next_state,
-                            (Some(current_state), None) => current_state,
-                            (None, None) => initial_state,
-                        };
-                        internal_apply_state_transition(
-                            event,
-                            commands,
-                            current_state_res,
-                            Some(new_state),
-                        );
-                    }
-                    None => {
-                        internal_apply_state_transition(event, commands, current_state_res, None);
-                    }
-                };
+                let new_state = should_exist
+                    .map(|initial_state| next_state.or(current_state).unwrap_or(initial_state));
+                internal_apply_state_transition(event, commands, current_state_res, new_state);
             };
 
         schedule

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -177,18 +177,18 @@ impl<S: InnerStateSet> StateSet for S {
                         if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
                             T::should_exist(state_set)
                         } else {
-                            false
+                            None
                         }
                     }
-                    false => current_state.is_some(),
+                    false => current_state.clone(),
                 };
 
                 match should_exist {
-                    true => {
+                    Some(initial_state) => {
                         let new_state = match (current_state, next_state) {
                             (_, Some(next_state)) => next_state,
                             (Some(current_state), None) => current_state,
-                            (None, None) => T::default(),
+                            (None, None) => initial_state,
                         };
                         internal_apply_state_transition(
                             event,
@@ -197,7 +197,7 @@ impl<S: InnerStateSet> StateSet for S {
                             Some(new_state),
                         );
                     }
-                    false => {
+                    None => {
                         internal_apply_state_transition(event, commands, current_state_res, None);
                     }
                 };
@@ -285,18 +285,18 @@ macro_rules! impl_state_set_sealed_tuples {
                             if let ($(Some($val)),*,) = ($($param::convert_to_usable_state($val.as_deref())),*,) {
                                 T::should_exist(($($val),*, ))
                             } else {
-                                false
+                                None
                             }
                         }
-                        false => current_state.is_some(),
+                        false => current_state.clone(),
                     };
 
                     match should_exist {
-                        true => {
+                        Some(initial_state) => {
                             let new_state = match (current_state, next_state) {
                                 (_, Some(next_state)) => next_state,
                                 (Some(current_state), None) => current_state,
-                                (None, None) => T::default(),
+                                (None, None) => initial_state,
                             };
                             internal_apply_state_transition(
                                 event,
@@ -305,7 +305,7 @@ macro_rules! impl_state_set_sealed_tuples {
                                 Some(new_state),
                             );
                         }
-                        false => {
+                        None => {
                             internal_apply_state_transition(event, commands, current_state_res, None);
                         }
                     };

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -8,9 +8,9 @@ use bevy_utils::all_tuples;
 use self::sealed::StateSetSealed;
 
 use super::{
-    apply_state_transition, computed_states::ComputedStates, internal_apply_state_transition,
-    last_transition, run_enter, run_exit, run_transition, sub_states::SubStates,
-    ApplyStateTransition, State, StateTransitionEvent, StateTransitionSteps, States,
+    computed_states::ComputedStates, internal_apply_state_transition, last_transition, run_enter,
+    run_exit, run_transition, sub_states::SubStates, take_next_state, ApplyStateTransition,
+    NextState, State, StateTransitionEvent, StateTransitionSteps, States,
 };
 
 mod sealed {
@@ -93,28 +93,29 @@ impl<S: InnerStateSet> StateSet for S {
     fn register_computed_state_systems_in_schedule<T: ComputedStates<SourceStates = Self>>(
         schedule: &mut Schedule,
     ) {
-        let system = |mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
-                      event: EventWriter<StateTransitionEvent<T>>,
-                      commands: Commands,
-                      current_state: Option<ResMut<State<T>>>,
-                      state_set: Option<Res<State<S::RawState>>>| {
-            if parent_changed.is_empty() {
-                return;
-            }
-            parent_changed.clear();
+        let apply_state_transition =
+            |mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
+             event: EventWriter<StateTransitionEvent<T>>,
+             commands: Commands,
+             current_state: Option<ResMut<State<T>>>,
+             state_set: Option<Res<State<S::RawState>>>| {
+                if parent_changed.is_empty() {
+                    return;
+                }
+                parent_changed.clear();
 
-            let new_state =
-                if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
-                    T::compute(state_set)
-                } else {
-                    None
-                };
+                let new_state =
+                    if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
+                        T::compute(state_set)
+                    } else {
+                        None
+                    };
 
-            internal_apply_state_transition(event, commands, current_state, new_state);
-        };
+                internal_apply_state_transition(event, commands, current_state, new_state);
+            };
 
         schedule
-            .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
+            .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
             .add_systems(
                 last_transition::<T>
                     .pipe(run_enter::<T>)
@@ -140,45 +141,70 @@ impl<S: InnerStateSet> StateSet for S {
     fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
         schedule: &mut Schedule,
     ) {
-        let system = |mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
-                      event: EventWriter<StateTransitionEvent<T>>,
-                      commands: Commands,
-                      current_state: Option<ResMut<State<T>>>,
-                      state_set: Option<Res<State<S::RawState>>>| {
-            if parent_changed.is_empty() {
-                return;
-            }
-            parent_changed.clear();
+        // | parent changed | next state | already exists | should exist | what happens                     |
+        // | -------------- | ---------- | -------------- | ------------ | -------------------------------- |
+        // | false          | false      | false          | -            | -                                |
+        // | false          | false      | true           | -            | -                                |
+        // | false          | true       | false          | false        | -                                |
+        // | true           | false      | false          | false        | -                                |
+        // | true           | true       | false          | false        | -                                |
+        // | true           | false      | true           | false        | Some(current) -> None            |
+        // | true           | true       | true           | false        | Some(current) -> None            |
+        // | true           | false      | false          | true         | None -> Some(default)            |
+        // | true           | true       | false          | true         | None -> Some(next)               |
+        // | true           | true       | true           | true         | Some(current) -> Some(next)      |
+        // | false          | true       | true           | true         | Some(current) -> Some(next)      |
+        // | true           | false      | true           | true         | Some(current) -> Some(current)   |
 
-            let new_state =
-                if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
-                    T::should_exist(state_set)
-                } else {
-                    None
+        let apply_state_transition =
+            |mut parent_changed: EventReader<StateTransitionEvent<S::RawState>>,
+             event: EventWriter<StateTransitionEvent<T>>,
+             commands: Commands,
+             current_state_res: Option<ResMut<State<T>>>,
+             next_state_res: Option<ResMut<NextState<T>>>,
+             state_set: Option<Res<State<S::RawState>>>| {
+                let parent_changed = parent_changed.read().last().is_some();
+                let next_state = take_next_state(next_state_res);
+
+                if !parent_changed && next_state.is_none() {
+                    return;
+                }
+
+                let current_state = current_state_res.as_ref().map(|s| s.get()).cloned();
+
+                let should_exist = match parent_changed {
+                    true => {
+                        if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
+                            T::should_exist(state_set)
+                        } else {
+                            false
+                        }
+                    }
+                    false => current_state.is_some(),
                 };
 
-            match new_state {
-                Some(value) => {
-                    if current_state.is_none() {
+                match should_exist {
+                    true => {
+                        let new_state = match (current_state, next_state) {
+                            (_, Some(next_state)) => next_state,
+                            (Some(current_state), None) => current_state,
+                            (None, None) => T::default(),
+                        };
                         internal_apply_state_transition(
                             event,
                             commands,
-                            current_state,
-                            Some(value),
+                            current_state_res,
+                            Some(new_state),
                         );
                     }
-                }
-                None => {
-                    internal_apply_state_transition(event, commands, current_state, None);
-                }
+                    false => {
+                        internal_apply_state_transition(event, commands, current_state_res, None);
+                    }
+                };
             };
-        };
 
         schedule
-            .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
-            .add_systems(
-                apply_state_transition::<T>.in_set(StateTransitionSteps::ManualTransitions),
-            )
+            .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
             .add_systems(
                 last_transition::<T>
                     .pipe(run_enter::<T>)
@@ -214,7 +240,7 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_computed_state_systems_in_schedule<T: ComputedStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let system = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,), event: EventWriter<StateTransitionEvent<T>>, commands: Commands, current_state: Option<ResMut<State<T>>>, ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
+                let apply_state_transition = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,), event: EventWriter<StateTransitionEvent<T>>, commands: Commands, current_state: Option<ResMut<State<T>>>, ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
                     if ($($evt.is_empty())&&*) {
                         return;
                     }
@@ -230,7 +256,7 @@ macro_rules! impl_state_set_sealed_tuples {
                 };
 
                 schedule
-                    .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
+                    .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
                     .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
                     .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
                     .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
@@ -244,32 +270,49 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let system = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,), event: EventWriter<StateTransitionEvent<T>>, commands: Commands, current_state: Option<ResMut<State<T>>>, ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                    if ($($evt.is_empty())&&*) {
+                let apply_state_transition = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,), event: EventWriter<StateTransitionEvent<T>>, commands: Commands, current_state_res: Option<ResMut<State<T>>>, next_state_res: Option<ResMut<NextState<T>>>, ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
+                    let parent_changed = ($($evt.read().last().is_some())&&*);
+                    let next_state = take_next_state(next_state_res);
+
+                    if !parent_changed && next_state.is_none() {
                         return;
                     }
-                    $($evt.clear();)*
 
-                    let new_state = if let ($(Some($val)),*,) = ($($param::convert_to_usable_state($val.as_deref())),*,) {
-                        T::should_exist(($($val),*, ))
-                    } else {
-                        None
-                    };
-                    match new_state {
-                        Some(value) => {
-                            if current_state.is_none() {
-                                internal_apply_state_transition(event, commands, current_state, Some(value));
+                    let current_state = current_state_res.as_ref().map(|s| s.get()).cloned();
+
+                    let should_exist = match parent_changed {
+                        true => {
+                            if let ($(Some($val)),*,) = ($($param::convert_to_usable_state($val.as_deref())),*,) {
+                                T::should_exist(($($val),*, ))
+                            } else {
+                                false
                             }
                         }
-                        None => {
-                            internal_apply_state_transition(event, commands, current_state, None);
-                        },
+                        false => current_state.is_some(),
+                    };
+
+                    match should_exist {
+                        true => {
+                            let new_state = match (current_state, next_state) {
+                                (_, Some(next_state)) => next_state,
+                                (Some(current_state), None) => current_state,
+                                (None, None) => T::default(),
+                            };
+                            internal_apply_state_transition(
+                                event,
+                                commands,
+                                current_state_res,
+                                Some(new_state),
+                            );
+                        }
+                        false => {
+                            internal_apply_state_transition(event, commands, current_state_res, None);
+                        }
                     };
                 };
 
                 schedule
-                    .add_systems(system.in_set(ApplyStateTransition::<T>::apply()))
-                    .add_systems(apply_state_transition::<T>.in_set(StateTransitionSteps::ManualTransitions))
+                    .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
                     .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
                     .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
                     .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -96,13 +96,11 @@ pub use bevy_state_macros::SubStates;
 /// ```
 ///
 /// However, you can also manually implement them. If you do so, you'll also need to manually implement the `States` & `FreelyMutableState` traits.
-/// Unlike the derive, this does not require an implementation of [`Default`], since you are providing the `exists` function
-/// directly.
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// # use bevy_state::prelude::*;
-/// # use bevy_state::state::FreelyMutableState;
+/// # use bevy_state::state::{FreelyMutableState, NextState};
 ///
 /// /// Computed States require some state to derive from
 /// #[derive(States, Clone, PartialEq, Eq, Hash, Debug, Default)]
@@ -128,11 +126,11 @@ pub use bevy_state_macros::SubStates;
 ///     /// We then define the compute function, which takes in the [`Self::SourceStates`]
 ///     fn should_exist(sources: Option<AppState>) -> bool {
 ///         match sources {
-///             /// When we are in game, so we want a GamePhase state to exist, and the default is
-///             /// GamePhase::Setup
+///             /// When we are in game, so we want a GamePhase state to exist.
+///             /// If available, the initial state will be taken from [`NextState`]
+///             /// otherwise [`Default::default()`] will be used.
 ///             Some(AppState::InGame { .. }) => true,
-///             /// Otherwise, we don't want the `State<GamePhase>` resource to exist,
-///             /// so we return `false`.
+///             /// If we don't want the `State<GamePhase>` resource to exist we return `false`.
 ///             _ => false
 ///         }
 ///     }
@@ -156,7 +154,7 @@ pub trait SubStates: States + FreelyMutableState + Default {
     /// The result is used to determine the existence of [`State<Self>`](crate::state::State).
     ///
     /// If the result is `false`, the [`State<Self>`](crate::state::State) resource will be removed from the world, otherwise
-    /// if the [`State<Self>`](crate::state::State) resource doesn't exist it will be created.
+    /// if the [`State<Self>`](crate::state::State) resource doesn't exist it will be created from [`NextState`](crate::state::NextState) or [`Default::default()`].
     fn should_exist(sources: Self::SourceStates) -> bool;
 
     /// This function sets up systems that compute the state whenever one of the [`SourceStates`](Self::SourceStates)

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -125,7 +125,7 @@ pub use bevy_state_macros::SubStates;
 ///     /// We then define the compute function, which takes in the [`Self::SourceStates`]
 ///     fn should_exist(sources: Option<AppState>) -> Option<Self> {
 ///         match sources {
-///             /// When we are in game, so we want a GamePhase state to exist.
+///             /// When we are in game, we want a GamePhase state to exist.
 ///             /// We can set the initial value here or overwrite it through [`NextState`].
 ///             Some(AppState::InGame { .. }) => Some(Self::Setup),
 ///             /// If we don't want the `State<GamePhase>` resource to exist we return [`None`].

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -112,8 +112,9 @@ pub use bevy_state_macros::SubStates;
 ///     InGame { paused: bool }
 /// }
 ///
-/// #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+/// #[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
 /// enum GamePhase {
+///     #[default]
 ///     Setup,
 ///     Battle,
 ///     Conclusion
@@ -125,14 +126,14 @@ pub use bevy_state_macros::SubStates;
 ///     type SourceStates = Option<AppState>;
 ///
 ///     /// We then define the compute function, which takes in the [`Self::SourceStates`]
-///     fn should_exist(sources: Option<AppState>) -> Option<Self> {
+///     fn should_exist(sources: Option<AppState>) -> bool {
 ///         match sources {
 ///             /// When we are in game, so we want a GamePhase state to exist, and the default is
 ///             /// GamePhase::Setup
-///             Some(AppState::InGame { .. }) => Some(GamePhase::Setup),
+///             Some(AppState::InGame { .. }) => true,
 ///             /// Otherwise, we don't want the `State<GamePhase>` resource to exist,
-///             /// so we return None.
-///             _ => None
+///             /// so we return `false`.
+///             _ => false
 ///         }
 ///     }
 /// }

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -143,7 +143,7 @@ pub use bevy_state_macros::SubStates;
 ///
 /// impl FreelyMutableState for GamePhase {}
 /// ```
-pub trait SubStates: States + FreelyMutableState {
+pub trait SubStates: States + FreelyMutableState + Default {
     /// The set of states from which the [`Self`] is derived.
     ///
     /// This can either be a single type that implements [`States`], or a tuple
@@ -154,9 +154,9 @@ pub trait SubStates: States + FreelyMutableState {
     /// This function gets called whenever one of the [`SourceStates`](Self::SourceStates) changes.
     /// The result is used to determine the existence of [`State<Self>`](crate::state::State).
     ///
-    /// If the result is [`None`], the [`State<Self>`](crate::state::State) resource will be removed from the world, otherwise
-    /// if the [`State<Self>`](crate::state::State) resource doesn't exist - it will be created with the [`Some`] value.
-    fn should_exist(sources: Self::SourceStates) -> Option<Self>;
+    /// If the result is `false`, the [`State<Self>`](crate::state::State) resource will be removed from the world, otherwise
+    /// if the [`State<Self>`](crate::state::State) resource doesn't exist it will be created.
+    fn should_exist(sources: Self::SourceStates) -> bool;
 
     /// This function sets up systems that compute the state whenever one of the [`SourceStates`](Self::SourceStates)
     /// change. It is called by `App::add_computed_state`, but can be called manually if `App` is not


### PR DESCRIPTION
# Objective

Prerequisite to #13579.
Combine separate `Substates` transition systems to centralize transition logic and exert more control over it.

## Solution

Originally the transition happened in 2 stages:
- `apply_state_transition` in `ManualTransitions` handled `NextState`,
- closure system in `DependentTransitions` handled parent-related changes, insertion and deletion of the substate.

Now:
- Both transitions are processed in a single closure system during `DependentTransitions`.
- Since `Substates` no longer use `ManualTransitions`, it's been renamed to `RootTransitions`. Only root states use it.
- When `Substates` state comes into existence, it will try to initialize from `NextState` and fallback to `should_exist` result.
- Remove `apply_state_transition` from public API.

Consequentially, removed the possibility of multiple `StateTransitionEvent`s when both transition systems fire in a single frame.

## Changelog

- Renamed `ManualTransitions` to `RootTransitions`.
- `Substates` will initialize their value with `NextState` if available and fallback to `should_exist` result.

## Migration Guide

- `apply_state_transition` is no longer publicly available, run the `StateTransition` schedule instead.