### PR TITLE
Add conversions and convenience methods for `Dir2` and `Rotation2d`

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -167,7 +167,8 @@ impl Dir2 {
         self.0
     }
 
-    /// Validates that a direction is well-formed.
+    /// Validates that a direction is well-formed (but not necessarily normalized).
+    /// See [`InvalidDirectionError`] for the ways that a direction can be invalid.
     ///
     /// Note that directions may be valid but not normalized:
     /// some degree of drift is expected due to floating point error accumulation.
@@ -382,7 +383,8 @@ impl Dir3 {
         self.0
     }
 
-    /// Validates that a direction is well-formed.
+    /// Validates that a direction is well-formed (but not necessarily normalized).
+    /// See [`InvalidDirectionError`] for the ways that a direction can be invalid.
     ///
     /// Note that directions may be valid but not normalized:
     /// some degree of drift is expected due to floating point error accumulation.

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -150,7 +150,7 @@ impl Dir2 {
         Self::new(Vec2::new(x, y))
     }
 
-    /// Creates a new [`Dir2`] from an angle in radians by rotating Dir2::X counterclockwise.
+    /// Creates a new [`Dir2`] from an angle in radians by rotating [`Dir2::X`]` counterclockwise.
     ///
     /// # Example
     ///
@@ -167,7 +167,7 @@ impl Dir2 {
         Dir2::new_unchecked(vec)
     }
 
-    /// Creates a new [`Dir2`] from an angle in degrees by rotating Dir2::X counterclockwise.
+    /// Creates a new [`Dir2`] from an angle in degrees by rotating [`Dir2::X`]` counterclockwise.
     ///
     /// # Example
     ///

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -150,7 +150,7 @@ impl Dir2 {
         Self::new(Vec2::new(x, y))
     }
 
-    /// Creates a new [`Dir2`] from an angle in radians by rotating [`Dir2::X`]` counterclockwise.
+    /// Creates a new [`Dir2`] from an angle in radians by rotating [`Dir2::X`] counterclockwise.
     ///
     /// # Example
     ///
@@ -167,7 +167,7 @@ impl Dir2 {
         Dir2::new_unchecked(vec)
     }
 
-    /// Creates a new [`Dir2`] from an angle in degrees by rotating [`Dir2::X`]` counterclockwise.
+    /// Creates a new [`Dir2`] from an angle in degrees by rotating [`Dir2::X`] counterclockwise.
     ///
     /// # Example
     ///

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -151,6 +151,16 @@ impl Dir2 {
     }
 
     /// Creates a new [`Dir2`] from an angle in radians by rotating Dir2::X counterclockwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bevy_math::Dir2;
+    /// use approx::assert_relative_eq;
+    ///
+    /// assert_relative_eq!(Dir2::radians(0.), Dir2::X, epsilon = 0.000001);
+    /// assert_relative_eq!(Dir2::radians(std::f32::consts::FRAC_PI_2), Dir2::Y, epsilon = 0.000001);
+    /// ```
     pub fn radians(angle: f32) -> Self {
         let vec = Vec2::new(angle.cos(), angle.sin());
 
@@ -158,6 +168,16 @@ impl Dir2 {
     }
 
     /// Creates a new [`Dir2`] from an angle in degrees by rotating Dir2::X counterclockwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bevy_math::Dir2;
+    /// use approx::assert_relative_eq;
+    ///
+    /// assert_relative_eq!(Dir2::degrees(0.), Dir2::X, epsilon = 0.000001);
+    /// assert_relative_eq!(Dir2::degrees(90.), Dir2::Y, epsilon = 0.000001);
+    /// ```
     pub fn degrees(angle: f32) -> Self {
         Self::radians(angle.to_radians())
     }

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -150,6 +150,18 @@ impl Dir2 {
         Self::new(Vec2::new(x, y))
     }
 
+    /// Creates a new [`Dir2`] from an angle in radians.
+    pub fn radians(angle: f32) -> Self {
+        let vec = Vec2::new(angle.cos(), angle.sin());
+
+        Dir2::new_unchecked(vec)
+    }
+
+    /// Creates a new [`Dir2`] from an angle in degrees.
+    pub fn degrees(angle: f32) -> Self {
+        Self::radians(angle.to_radians())
+    }
+
     /// Returns the inner [`Vec2`]
     pub const fn as_vec2(&self) -> Vec2 {
         self.0

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -172,9 +172,9 @@ impl Dir2 {
     /// Note that directions may be valid but not normalized:
     /// some degree of drift is expected due to floating point error accumulation.
     pub fn validate(self) -> Result<Self, InvalidDirectionError> {
-        if self.0.length_squared().abs() < f32::EPSILON {
+        if self.0.length_squared() == 0. {
             Err(InvalidDirectionError::Zero)
-        } else if !self.0.length().is_finite() {
+        } else if self.0.length().is_infinite() {
             Err(InvalidDirectionError::Infinite)
         } else if self.0.length().is_nan() {
             Err(InvalidDirectionError::NaN)

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -155,6 +155,22 @@ impl Dir2 {
         self.0
     }
 
+    /// Validates that a direction is well-formed.
+    ///
+    /// Note that directions may be valid but not normalized:
+    /// some degree of drift is expected due to floating point error accumulation.
+    pub fn validate(&self) -> Result<(), InvalidDirectionError> {
+        if self.0.length_squared().abs() < f32::EPSILON {
+            Err(InvalidDirectionError::Zero)
+        } else if !self.0.length().is_finite() {
+            Err(InvalidDirectionError::Infinite)
+        } else if self.0.length().is_nan() {
+            Err(InvalidDirectionError::NaN)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Performs a spherical linear interpolation between `self` and `rhs`
     /// based on the value `s`.
     ///
@@ -352,6 +368,22 @@ impl Dir3 {
     /// Returns the inner [`Vec3`]
     pub const fn as_vec3(&self) -> Vec3 {
         self.0
+    }
+
+    /// Validates that a direction is well-formed.
+    ///
+    /// Note that directions may be valid but not normalized:
+    /// some degree of drift is expected due to floating point error accumulation.
+    pub fn validate(&self) -> Result<(), InvalidDirectionError> {
+        if self.0.length_squared().abs() < f32::EPSILON {
+            Err(InvalidDirectionError::Zero)
+        } else if !self.0.length().is_finite() {
+            Err(InvalidDirectionError::Infinite)
+        } else if self.0.length().is_nan() {
+            Err(InvalidDirectionError::NaN)
+        } else {
+            Ok(())
+        }
     }
 
     /// Performs a spherical linear interpolation between `self` and `rhs`

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -159,7 +159,7 @@ impl Dir2 {
     ///
     /// Note that directions may be valid but not normalized:
     /// some degree of drift is expected due to floating point error accumulation.
-    pub fn validate(&self) -> Result<(), InvalidDirectionError> {
+    pub fn validate(self) -> Result<Self, InvalidDirectionError> {
         if self.0.length_squared().abs() < f32::EPSILON {
             Err(InvalidDirectionError::Zero)
         } else if !self.0.length().is_finite() {
@@ -167,7 +167,7 @@ impl Dir2 {
         } else if self.0.length().is_nan() {
             Err(InvalidDirectionError::NaN)
         } else {
-            Ok(())
+            Ok(self)
         }
     }
 
@@ -374,7 +374,7 @@ impl Dir3 {
     ///
     /// Note that directions may be valid but not normalized:
     /// some degree of drift is expected due to floating point error accumulation.
-    pub fn validate(&self) -> Result<(), InvalidDirectionError> {
+    pub fn validate(self) -> Result<Self, InvalidDirectionError> {
         if self.0.length_squared().abs() < f32::EPSILON {
             Err(InvalidDirectionError::Zero)
         } else if !self.0.length().is_finite() {
@@ -382,7 +382,7 @@ impl Dir3 {
         } else if self.0.length().is_nan() {
             Err(InvalidDirectionError::NaN)
         } else {
-            Ok(())
+            Ok(self)
         }
     }
 

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -1,5 +1,4 @@
 use glam::FloatExt;
-use libm::atan2;
 
 use crate::{
     prelude::{Dir2, Mat2, Vec2},
@@ -611,5 +610,34 @@ mod tests {
         assert!(rot1.slerp(rot2, 0.0).is_near_identity());
         assert_eq!(rot1.slerp(rot2, 0.5).as_degrees(), 90.0);
         assert_eq!(rot1.slerp(rot2, 1.0).as_degrees().abs(), 180.0);
+    }
+
+    #[test]
+    fn rotation_direction_conversion() {
+        let directions = [
+            Dir2::degrees(0.0),
+            Dir2::degrees(45.0),
+            Dir2::degrees(90.0),
+            Dir2::degrees(135.0),
+            Dir2::degrees(180.0),
+            Dir2::degrees(225.0),
+            Dir2::degrees(270.0),
+            Dir2::degrees(315.0),
+            Dir2::degrees(360.0),
+        ];
+
+        let rotations = [
+            Rotation2d::degrees(0.0),
+            Rotation2d::degrees(45.0),
+            Rotation2d::degrees(90.0),
+            Rotation2d::degrees(135.0),
+            Rotation2d::degrees(180.0),
+            Rotation2d::degrees(225.0),
+        ];
+
+        for (dir, rot) in directions.iter().zip(rotations.iter()) {
+            assert_eq!(Rotation2d::try_from(*dir).unwrap(), *rot);
+            assert_eq!(Dir2::try_from(*rot).unwrap(), *dir);
+        }
     }
 }

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -407,8 +407,13 @@ impl TryFrom<Dir2> for Rotation2d {
     type Error = InvalidDirectionError;
 
     fn try_from(dir: Dir2) -> Result<Rotation2d, InvalidDirectionError> {
-        dir.validate()
-            .map(|dir| Rotation2d::from_sin_cos(dir.y, dir.x))
+        dir.validate().map(|dir| {
+            let dir = dir.normalize();
+            Rotation2d {
+                cos: dir.x,
+                sin: dir.y,
+            }
+        })
     }
 }
 
@@ -416,7 +421,7 @@ impl TryFrom<Rotation2d> for Dir2 {
     type Error = InvalidDirectionError;
 
     fn try_from(rot: Rotation2d) -> Result<Dir2, InvalidDirectionError> {
-        Dir2::from_xy(rot.sin, rot.cos)
+        Dir2::from_xy(rot.cos, rot.sin)
     }
 }
 
@@ -636,6 +641,8 @@ mod tests {
         ];
 
         for (dir, rot) in directions.iter().zip(rotations.iter()) {
+            println!("Checking {:?} {:?}", dir, rot);
+
             let converted_dir = Dir2::try_from(*rot).unwrap();
             assert_relative_eq!(converted_dir.x, dir.x, epsilon = 1e-6);
             assert_relative_eq!(converted_dir.y, dir.y, epsilon = 1e-6);

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -636,8 +636,13 @@ mod tests {
         ];
 
         for (dir, rot) in directions.iter().zip(rotations.iter()) {
-            assert_eq!(Rotation2d::try_from(*dir).unwrap(), *rot);
-            assert_eq!(Dir2::try_from(*rot).unwrap(), *dir);
+            let converted_dir = Dir2::try_from(*rot).unwrap();
+            assert_relative_eq!(converted_dir.x, dir.x, epsilon = 1e-6);
+            assert_relative_eq!(converted_dir.y, dir.y, epsilon = 1e-6);
+
+            let converted_rot = Rotation2d::try_from(*dir).unwrap();
+            assert_relative_eq!(converted_rot.sin, rot.sin, epsilon = 1e-6);
+            assert_relative_eq!(converted_rot.cos, rot.cos, epsilon = 1e-6);
         }
     }
 }

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -408,13 +408,8 @@ impl TryFrom<Dir2> for Rotation2d {
     type Error = InvalidDirectionError;
 
     fn try_from(dir: Dir2) -> Result<Rotation2d, InvalidDirectionError> {
-        match dir.validate() {
-            Ok(()) => Ok(Rotation2d {
-                sin: dir.y,
-                cos: dir.x,
-            }),
-            Err(err) => Err(err),
-        }
+        dir.validate()
+            .map(|dir| Rotation2d::from_sin_cos(dir.y, dir.x))
     }
 }
 

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -1,6 +1,10 @@
 use glam::FloatExt;
+use libm::atan2;
 
-use crate::prelude::{Mat2, Vec2};
+use crate::{
+    prelude::{Dir2, Mat2, Vec2},
+    InvalidDirectionError,
+};
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -397,6 +401,28 @@ impl std::ops::Mul<Vec2> for Rotation2d {
             rhs.x * self.cos - rhs.y * self.sin,
             rhs.x * self.sin + rhs.y * self.cos,
         )
+    }
+}
+
+impl TryFrom<Dir2> for Rotation2d {
+    type Error = InvalidDirectionError;
+
+    fn try_from(dir: Dir2) -> Result<Rotation2d, InvalidDirectionError> {
+        match dir.validate() {
+            Ok(()) => Ok(Rotation2d {
+                sin: dir.y,
+                cos: dir.x,
+            }),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl TryFrom<Rotation2d> for Dir2 {
+    type Error = InvalidDirectionError;
+
+    fn try_from(rot: Rotation2d) -> Result<Dir2, InvalidDirectionError> {
+        Dir2::from_xy(rot.sin, rot.cos)
     }
 }
 


### PR DESCRIPTION
# Objective

As discovered in https://github.com/bevyengine/bevy-website/pull/1281, there's currently no good way to convert between our two representations of 2D rotations: `Dir2` and `Rotation2d`.

## Solution

- added `TryFrom` in both directions
- added `Dir2::validate` as a helper method to make writing the conversions easier
- added `Dir2::degrees` and `Dir2::radians` to make writing tests easier and generally improve the usability of `Dir2`

## Testing

I've added a test to validate that both directions of conversion work correctly.