### PR TITLE
Add compass direction constants to `Dir2`

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -105,6 +105,23 @@ impl Dir2 {
     /// The directional axes.
     pub const AXES: [Self; 2] = [Self::X, Self::Y];
 
+    /// The "north" direction, equivalent to [`Dir2::Y`].
+    pub const NORTH: Self = Self::Y;
+    /// The "south" direction, equivalent to [`Dir2::NEG_Y`].
+    pub const SOUTH: Self = Self::NEG_Y;
+    /// The "east" direction, equivalent to [`Dir2::X`].
+    pub const EAST: Self = Self::X;
+    /// The "west" direction, equivalent to [`Dir2::NEG_X`].
+    pub const WEST: Self = Self::NEG_X;
+    /// The "north-east" direction, between [`Dir2::NORTH`] and [`Dir2::EAST`].
+    pub const NORTH_EAST: Self = Self(Vec2::new(0.70710677, 0.70710677));
+    /// The "north-west" direction, between [`Dir2::NORTH`] and [`Dir2::WEST`].
+    pub const NORTH_WEST: Self = Self(Vec2::new(-0.70710677, 0.70710677));
+    /// The "south-east" direction, between [`Dir2::SOUTH`] and [`Dir2::EAST`].
+    pub const SOUTH_EAST: Self = Self(Vec2::new(0.70710677, -0.70710677));
+    /// The "south-west" direction, between [`Dir2::SOUTH`] and [`Dir2::WEST`].
+    pub const SOUTH_WEST: Self = Self(Vec2::new(-0.70710677, -0.70710677));
+
     /// Create a direction from a finite, nonzero [`Vec2`], normalizing it.
     ///
     /// Returns [`Err(InvalidDirectionError)`](InvalidDirectionError) if the length

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -3,6 +3,8 @@ use crate::{
     Quat, Rotation2d, Vec2, Vec3, Vec3A,
 };
 
+use core::f32::consts::FRAC_1_SQRT_2;
+
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
@@ -106,21 +108,21 @@ impl Dir2 {
     pub const AXES: [Self; 2] = [Self::X, Self::Y];
 
     /// The "north" direction, equivalent to [`Dir2::Y`].
-    pub const NORTH: Self = Self::Y;
+    pub const NORTH: Self = Self(Vec2::Y);
     /// The "south" direction, equivalent to [`Dir2::NEG_Y`].
-    pub const SOUTH: Self = Self::NEG_Y;
+    pub const SOUTH: Self = Self(Vec2::NEG_Y);
     /// The "east" direction, equivalent to [`Dir2::X`].
-    pub const EAST: Self = Self::X;
+    pub const EAST: Self = Self(Vec2::X);
     /// The "west" direction, equivalent to [`Dir2::NEG_X`].
-    pub const WEST: Self = Self::NEG_X;
+    pub const WEST: Self = Self(Vec2::NEG_X);
     /// The "north-east" direction, between [`Dir2::NORTH`] and [`Dir2::EAST`].
-    pub const NORTH_EAST: Self = Self(Vec2::new(0.70710677, 0.70710677));
+    pub const NORTH_EAST: Self = Self(Vec2::new(FRAC_1_SQRT_2, FRAC_1_SQRT_2));
     /// The "north-west" direction, between [`Dir2::NORTH`] and [`Dir2::WEST`].
-    pub const NORTH_WEST: Self = Self(Vec2::new(-0.70710677, 0.70710677));
+    pub const NORTH_WEST: Self = Self(Vec2::new(-FRAC_1_SQRT_2, FRAC_1_SQRT_2));
     /// The "south-east" direction, between [`Dir2::SOUTH`] and [`Dir2::EAST`].
-    pub const SOUTH_EAST: Self = Self(Vec2::new(0.70710677, -0.70710677));
+    pub const SOUTH_EAST: Self = Self(Vec2::new(FRAC_1_SQRT_2, -FRAC_1_SQRT_2));
     /// The "south-west" direction, between [`Dir2::SOUTH`] and [`Dir2::WEST`].
-    pub const SOUTH_WEST: Self = Self(Vec2::new(-0.70710677, -0.70710677));
+    pub const SOUTH_WEST: Self = Self(Vec2::new(-FRAC_1_SQRT_2, -FRAC_1_SQRT_2));
 
     /// Create a direction from a finite, nonzero [`Vec2`], normalizing it.
     ///

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -1,3 +1,5 @@
+use core::f32::consts::FRAC_1_SQRT_2;
+
 use glam::FloatExt;
 
 use crate::prelude::{Mat2, Vec2};
@@ -81,8 +83,8 @@ impl Rotation2d {
 
     /// A counterclockwise rotation of π/4 radians.
     pub const FRAC_PI_4: Self = Self {
-        cos: std::f32::consts::FRAC_1_SQRT_2,
-        sin: std::f32::consts::FRAC_1_SQRT_2,
+        cos: FRAC_1_SQRT_2,
+        sin: FRAC_1_SQRT_2,
     };
 
     /// A counterclockwise rotation of π/6 radians.
@@ -95,6 +97,41 @@ impl Rotation2d {
     pub const FRAC_PI_8: Self = Self {
         cos: 0.923_879_5,
         sin: 0.382_683_43,
+    };
+
+    /// The "north" direction, equivalent to a counterclockwise rotation of π/2 radians.
+    pub const NORTH: Self = Self { cos: 0.0, sin: 1.0 };
+    /// The "south" direction, equivalent to a counterclockwise rotation of -π/2 radians.
+    pub const SOUTH: Self = Self {
+        cos: 0.0,
+        sin: -1.0,
+    };
+    /// The "east" direction, equivalent to a counterclockwise rotation of 0 radians.
+    pub const EAST: Self = Self { cos: 1.0, sin: 0.0 };
+    /// The "west" direction, equivalent to a counterclockwise rotation of π radians.
+    pub const WEST: Self = Self {
+        cos: -1.0,
+        sin: 0.0,
+    };
+    /// The "north-east" direction, equivalent to a counterclockwise rotation of π/4 radians.
+    pub const NORTH_EAST: Self = Self {
+        cos: FRAC_1_SQRT_2,
+        sin: FRAC_1_SQRT_2,
+    };
+    /// The "north-west" direction, equivalent to a counterclockwise rotation of 3π/4 radians.
+    pub const NORTH_WEST: Self = Self {
+        cos: -FRAC_1_SQRT_2,
+        sin: FRAC_1_SQRT_2,
+    };
+    /// The "south-east" direction, equivalent to a counterclockwise rotation of -π/4 radians.
+    pub const SOUTH_EAST: Self = Self {
+        cos: FRAC_1_SQRT_2,
+        sin: -FRAC_1_SQRT_2,
+    };
+    /// The "south-west" direction, equivalent to a counterclockwise rotation of -3π/4 radians.
+    pub const SOUTH_WEST: Self = Self {
+        cos: -FRAC_1_SQRT_2,
+        sin: -FRAC_1_SQRT_2,
     };
 
     /// Creates a [`Rotation2d`] from a counterclockwise angle in radians.

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -2,8 +2,6 @@ use glam::FloatExt;
 
 use crate::prelude::{Mat2, Vec2};
 
-use core::f32::consts::FRAC_1_SQRT_2;
-
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
@@ -83,8 +81,8 @@ impl Rotation2d {
 
     /// A counterclockwise rotation of π/4 radians.
     pub const FRAC_PI_4: Self = Self {
-        cos: FRAC_1_SQRT_2,
-        sin: FRAC_1_SQRT_2,
+        cos: core::f32::consts::FRAC_1_SQRT_2,
+        sin: core::f32::consts::FRAC_1_SQRT_2,
     };
 
     /// A counterclockwise rotation of π/6 radians.

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -1,8 +1,8 @@
-use core::f32::consts::FRAC_1_SQRT_2;
-
 use glam::FloatExt;
 
 use crate::prelude::{Mat2, Vec2};
+
+use core::f32::consts::FRAC_1_SQRT_2;
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -99,41 +99,6 @@ impl Rotation2d {
         sin: 0.382_683_43,
     };
 
-    /// The "north" direction, equivalent to a counterclockwise rotation of π/2 radians.
-    pub const NORTH: Self = Self { cos: 0.0, sin: 1.0 };
-    /// The "south" direction, equivalent to a counterclockwise rotation of -π/2 radians.
-    pub const SOUTH: Self = Self {
-        cos: 0.0,
-        sin: -1.0,
-    };
-    /// The "east" direction, equivalent to a counterclockwise rotation of 0 radians.
-    pub const EAST: Self = Self { cos: 1.0, sin: 0.0 };
-    /// The "west" direction, equivalent to a counterclockwise rotation of π radians.
-    pub const WEST: Self = Self {
-        cos: -1.0,
-        sin: 0.0,
-    };
-    /// The "north-east" direction, equivalent to a counterclockwise rotation of π/4 radians.
-    pub const NORTH_EAST: Self = Self {
-        cos: FRAC_1_SQRT_2,
-        sin: FRAC_1_SQRT_2,
-    };
-    /// The "north-west" direction, equivalent to a counterclockwise rotation of 3π/4 radians.
-    pub const NORTH_WEST: Self = Self {
-        cos: -FRAC_1_SQRT_2,
-        sin: FRAC_1_SQRT_2,
-    };
-    /// The "south-east" direction, equivalent to a counterclockwise rotation of -π/4 radians.
-    pub const SOUTH_EAST: Self = Self {
-        cos: FRAC_1_SQRT_2,
-        sin: -FRAC_1_SQRT_2,
-    };
-    /// The "south-west" direction, equivalent to a counterclockwise rotation of -3π/4 radians.
-    pub const SOUTH_WEST: Self = Self {
-        cos: -FRAC_1_SQRT_2,
-        sin: -FRAC_1_SQRT_2,
-    };
-
     /// Creates a [`Rotation2d`] from a counterclockwise angle in radians.
     #[inline]
     pub fn radians(radians: f32) -> Self {


### PR DESCRIPTION
# Objective

When working on `leafwing-input-manager` and in my games, I've found these compass directions to be both clear and useful when attempting to describe angles in 2 dimensions.

This was directly used when mapping gamepad inputs into 4-way movement as a virtual dpad, and I expect other uses are common in games.

## Solution

- Add constants corresponding to the 4 cardinal and 4 semi-cardinal directions.

## Testing

- I've validated the quadrants of each of the directions through self-review.