### PR TITLE
Clean up substate code a bit

### DIFF
--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -172,19 +172,17 @@ impl<S: InnerStateSet> StateSet for S {
 
                 let current_state = current_state_res.as_ref().map(|s| s.get()).cloned();
 
-                let should_exist = match parent_changed {
-                    true => {
-                        if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
-                            T::should_exist(state_set)
-                        } else {
-                            None
-                        }
+                let initial_state = if parent_changed {
+                    if let Some(state_set) = S::convert_to_usable_state(state_set.as_deref()) {
+                        T::should_exist(state_set)
+                    } else {
+                        None
                     }
-                    false => current_state.clone(),
+                } else {
+                    current_state.clone()
                 };
+                let new_state = initial_state.map(|x| next_state.or(current_state).unwrap_or(x));
 
-                let new_state = should_exist
-                    .map(|initial_state| next_state.or(current_state).unwrap_or(initial_state));
                 internal_apply_state_transition(event, commands, current_state_res, new_state);
             };
 
@@ -225,20 +223,25 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_computed_state_systems_in_schedule<T: ComputedStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let apply_state_transition = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,), event: EventWriter<StateTransitionEvent<T>>, commands: Commands, current_state: Option<ResMut<State<T>>>, ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                    if ($($evt.is_empty())&&*) {
-                        return;
-                    }
-                    $($evt.clear();)*
+                let apply_state_transition =
+                    |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,),
+                     event: EventWriter<StateTransitionEvent<T>>,
+                     commands: Commands,
+                     current_state: Option<ResMut<State<T>>>,
+                     ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
+                        if ($($evt.is_empty())&&*) {
+                            return;
+                        }
+                        $($evt.clear();)*
 
-                    let new_state = if let ($(Some($val)),*,) = ($($param::convert_to_usable_state($val.as_deref())),*,) {
-                        T::compute(($($val),*, ))
-                    } else {
-                        None
+                        let new_state = if let ($(Some($val)),*,) = ($($param::convert_to_usable_state($val.as_deref())),*,) {
+                            T::compute(($($val),*, ))
+                        } else {
+                            None
+                        };
+
+                        internal_apply_state_transition(event, commands, current_state, new_state);
                     };
-
-                    internal_apply_state_transition(event, commands, current_state, new_state);
-                };
 
                 schedule
                     .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
@@ -255,46 +258,35 @@ macro_rules! impl_state_set_sealed_tuples {
             fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
                 schedule: &mut Schedule,
             ) {
-                let apply_state_transition = |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,), event: EventWriter<StateTransitionEvent<T>>, commands: Commands, current_state_res: Option<ResMut<State<T>>>, next_state_res: Option<ResMut<NextState<T>>>, ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
-                    let parent_changed = ($($evt.read().last().is_some())&&*);
-                    let next_state = take_next_state(next_state_res);
+                let apply_state_transition =
+                    |($(mut $evt),*,): ($(EventReader<StateTransitionEvent<$param::RawState>>),*,),
+                     event: EventWriter<StateTransitionEvent<T>>,
+                     commands: Commands,
+                     current_state_res: Option<ResMut<State<T>>>,
+                     next_state_res: Option<ResMut<NextState<T>>>,
+                     ($($val),*,): ($(Option<Res<State<$param::RawState>>>),*,)| {
+                        let parent_changed = ($($evt.read().last().is_some())&&*);
+                        let next_state = take_next_state(next_state_res);
 
-                    if !parent_changed && next_state.is_none() {
-                        return;
-                    }
+                        if !parent_changed && next_state.is_none() {
+                            return;
+                        }
 
-                    let current_state = current_state_res.as_ref().map(|s| s.get()).cloned();
+                        let current_state = current_state_res.as_ref().map(|s| s.get()).cloned();
 
-                    let should_exist = match parent_changed {
-                        true => {
+                        let initial_state = if parent_changed {
                             if let ($(Some($val)),*,) = ($($param::convert_to_usable_state($val.as_deref())),*,) {
                                 T::should_exist(($($val),*, ))
                             } else {
                                 None
                             }
-                        }
-                        false => current_state.clone(),
-                    };
+                        } else {
+                            current_state.clone()
+                        };
+                        let new_state = initial_state.map(|x| next_state.or(current_state).unwrap_or(x));
 
-                    match should_exist {
-                        Some(initial_state) => {
-                            let new_state = match (current_state, next_state) {
-                                (_, Some(next_state)) => next_state,
-                                (Some(current_state), None) => current_state,
-                                (None, None) => initial_state,
-                            };
-                            internal_apply_state_transition(
-                                event,
-                                commands,
-                                current_state_res,
-                                Some(new_state),
-                            );
-                        }
-                        None => {
-                            internal_apply_state_transition(event, commands, current_state_res, None);
-                        }
+                        internal_apply_state_transition(event, commands, current_state_res, new_state);
                     };
-                };
 
                 schedule
                     .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))


### PR DESCRIPTION
# Objective

Small substate code cleanup.

1. Format closure arguments inside macros.
2. Replace `match bool` blocks with `if-else` blocks.
3. Replace `match` block in substate macro with the same one-liner as in the non-macro version.