### PR TITLE
feat: Reflection implementations on Identifier

### DIFF
--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -3,6 +3,8 @@
 //! or other IDs that can be packed and expressed within a `u64` sized type.
 //! [`Identifier`]s cannot be created directly, only able to be converted from other
 //! compatible IDs.
+use bevy_reflect::Reflect;
+
 use self::{error::IdentifierError, kinds::IdKind, masks::IdentifierMask};
 use std::{hash::Hash, num::NonZeroU32};
 
@@ -15,6 +17,8 @@ pub(crate) mod masks;
 /// segment, a 31-bit high segment, and the significant bit reserved as type flags to denote
 /// entity kinds.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect_value(Hash, PartialEq))]
 // Alignment repr necessary to allow LLVM to better output
 // optimised codegen for `to_bits`, `PartialEq` and `Ord`.
 #[repr(C, align(8))]

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -3,6 +3,7 @@
 //! or other IDs that can be packed and expressed within a `u64` sized type.
 //! [`Identifier`]s cannot be created directly, only able to be converted from other
 //! compatible IDs.
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 
 use self::{error::IdentifierError, kinds::IdKind, masks::IdentifierMask};

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod masks;
 /// entity kinds.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-#[cfg_attr(feature = "bevy_reflect", reflect_value(Hash, PartialEq))]
+#[cfg_attr(feature = "bevy_reflect", reflect_value(Debug, Hash, PartialEq))]
 // Alignment repr necessary to allow LLVM to better output
 // optimised codegen for `to_bits`, `PartialEq` and `Ord`.
 #[repr(C, align(8))]


### PR DESCRIPTION
# Objective

- Follow-up on some changes in #11498
- Unblock using `Identifier` to replace `ComponentId` internals.

## Solution

- Implement the same `Reflect` impls from `Entity` onto `Identifier` as they share same/similar purposes, 

## Testing

- No compile errors. Currently `Identifier` has no serialization impls, so there's no need to test a serialization/deserialization roundtrip to ensure correctness.

---

## Changelog

### Added

- Reflection implementations on `Identifier`.
