### PR TITLE
Regenerate light cluster patch file

### DIFF
--- a/tools/example-showcase/reduce-light-cluster-config.patch
+++ b/tools/example-showcase/reduce-light-cluster-config.patch
@@ -1,8 +1,8 @@
-diff --git a/crates/bevy_pbr/src/light/mod.rs b/crates/bevy_pbr/src/light/mod.rs
-index 5d6be4fcf..fe20a5dc5 100644
---- a/crates/bevy_pbr/src/light/mod.rs
-+++ b/crates/bevy_pbr/src/light/mod.rs
-@@ -759,8 +759,8 @@ impl Default for ClusterConfig {
+diff --git a/crates/bevy_pbr/src/cluster/mod.rs b/crates/bevy_pbr/src/cluster/mod.rs
+index a8c218b44..13cc9f9c6 100644
+--- a/crates/bevy_pbr/src/cluster/mod.rs
++++ b/crates/bevy_pbr/src/cluster/mod.rs
+@@ -239,8 +239,8 @@ impl Default for ClusterConfig {
          // 24 depth slices, square clusters with at most 4096 total clusters
          // use max light distance as clusters max `Z`-depth, first slice extends to 5.0
          Self::FixedZ {


### PR DESCRIPTION
# Objective

- CI on main has been failing since #13640 was merged.
  - Here's the [offending run](https://github.com/bevyengine/bevy/actions/runs/9352635857/job/25741242787).
- One of the patch files is out of date, so it failed in the validation check.

## Solution

- Regenerate the patch file. (The location has been moved to `cluster/mod.rs`.)

## Testing

- Run `git apply tools/example-showcase/reduce-light-cluster-config.patch`
  - It should change `bevy_pbr/src/cluster/mod.rs` on line 239, decreasing `total` and `z_slices`.
- CI's validation checks should also verify that this works, though only after it gets merged.
