### PR TITLE
Add `binding()` helper function to `BufferVec`

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -59,11 +59,13 @@ impl<T: NoUninit> RawBufferVec<T> {
         }
     }
 
+    /// Returns a handle to the buffer, if the data has been uploaded.
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
     }
 
+    /// Returns the binding for the buffer if the data has been uploaded.
     #[inline]
     pub fn binding(&self) -> Option<BindingResource> {
         Some(BindingResource::Buffer(
@@ -71,21 +73,25 @@ impl<T: NoUninit> RawBufferVec<T> {
         ))
     }
 
+    /// Returns the amount of space that the GPU will use before reallocating.
     #[inline]
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
+    /// Returns the number of items that have been pushed to this buffer.
     #[inline]
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
+    /// Returns true if the buffer is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
 
+    /// Adds a new value and returns its index.
     pub fn push(&mut self, value: T) -> usize {
         let index = self.values.len();
         self.values.push(value);
@@ -96,6 +102,10 @@ impl<T: NoUninit> RawBufferVec<T> {
         self.values.append(&mut other.values);
     }
 
+    /// Changes the debugging label of the buffer.
+    ///
+    /// The next time the buffer is updated (via [`reserve`]), Bevy will inform
+    /// the driver of the new label.
     pub fn set_label(&mut self, label: Option<&str>) {
         let label = label.map(str::to_string);
 
@@ -106,6 +116,7 @@ impl<T: NoUninit> RawBufferVec<T> {
         self.label = label;
     }
 
+    /// Returns the label
     pub fn get_label(&self) -> Option<&str> {
         self.label.as_deref()
     }
@@ -152,10 +163,12 @@ impl<T: NoUninit> RawBufferVec<T> {
         }
     }
 
+    /// Reduces the length of the buffer.
     pub fn truncate(&mut self, len: usize) {
         self.values.truncate(len);
     }
 
+    /// Removes all elements from the buffer.
     pub fn clear(&mut self) {
         self.values.clear();
     }
@@ -224,7 +237,7 @@ where
         self.buffer.as_ref()
     }
 
-    /// Returns the binding for the buffer if the data has been updloaded.
+    /// Returns the binding for the buffer if the data has been uploaded.
     #[inline]
     pub fn binding(&self) -> Option<BindingResource> {
         Some(BindingResource::Buffer(

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -9,7 +9,7 @@ use encase::{
     internal::{WriteInto, Writer},
     ShaderType,
 };
-use wgpu::{BufferAddress, BufferUsages};
+use wgpu::{BindingResource, BufferAddress, BufferUsages};
 
 use super::GpuArrayBufferable;
 
@@ -62,6 +62,13 @@ impl<T: NoUninit> RawBufferVec<T> {
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
+    }
+
+    #[inline]
+    pub fn binding(&self) -> Option<BindingResource> {
+        Some(BindingResource::Buffer(
+            self.buffer()?.as_entire_buffer_binding(),
+        ))
     }
 
     #[inline]
@@ -215,6 +222,14 @@ where
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
+    }
+
+    /// Returns the binding for the buffer if the data has been updloaded.
+    #[inline]
+    pub fn binding(&self) -> Option<BindingResource> {
+        Some(BindingResource::Buffer(
+            self.buffer()?.as_entire_buffer_binding(),
+        ))
     }
 
     /// Returns the amount of space that the GPU will use before reallocating.

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -47,6 +47,7 @@ pub struct RawBufferVec<T: NoUninit> {
 }
 
 impl<T: NoUninit> RawBufferVec<T> {
+    /// Creates a new [`RawBufferVec`] with the given [`BufferUsages`].
     pub const fn new(buffer_usage: BufferUsages) -> Self {
         Self {
             values: Vec::new(),
@@ -398,6 +399,14 @@ where
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
+    }
+
+    /// Returns the binding for the buffer if the data has been uploaded.
+    #[inline]
+    pub fn binding(&self) -> Option<BindingResource> {
+        Some(BindingResource::Buffer(
+            self.buffer()?.as_entire_buffer_binding(),
+        ))
     }
 
     /// Reserves space for one more element in the buffer and returns its index.

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -91,9 +91,7 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
     pub fn binding(&self) -> Option<BindingResource> {
         match self {
             GpuArrayBuffer::Uniform(buffer) => buffer.binding(),
-            GpuArrayBuffer::Storage(buffer) => {
-                buffer.buffer().map(|buffer| buffer.as_entire_binding())
-            }
+            GpuArrayBuffer::Storage(buffer) => buffer.binding(),
         }
     }
 


### PR DESCRIPTION
# Objective

- Other render resources have a convenient `.binding()` helper function to get the binding to the resource

## Solution

- Add the same thing to `BufferVec`, `RawBufferVec`, and `UninitBufferVec`
