### PR TITLE
`Dir2` -> `Rotation2d` conversions

### DIFF
--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -7,9 +7,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
-/// A counterclockwise 2D rotation in radians.
-///
-/// The rotation angle is wrapped to be within the `(-pi, pi]` range.
+/// A counterclockwise 2D rotation.
 ///
 /// # Example
 ///


### PR DESCRIPTION
# Objective

Filling a hole in the API: Previously, there was no particularly ergonomic way to go from, e.g., a pair of directions to the rotation that links them. 

## Solution

We introduce a small suite of API methods to `Dir2` to address this:
```rust
/// Get the rotation that rotates this direction to `other`.
pub fn rotation_to(self, other: Self) -> Rotation2d { //... }

/// Get the rotation that rotates `other` to this direction.
pub fn rotation_from(self, other: Self) -> Rotation2d { //... }

/// Get the rotation that rotates the X-axis to this direction.
pub fn rotation_from_x(self) -> Rotation2d { //... }

/// Get the rotation that rotates this direction to the X-axis.
pub fn rotation_to_x(self) -> Rotation2d { //... }

/// Get the rotation that rotates this direction to the Y-axis.
pub fn rotation_from_y(self) -> Rotation2d { //... }

/// Get the rotation that rotates the Y-axis to this direction.
pub fn rotation_to_y(self) -> Rotation2d { //... }
```

I also removed some language from the `Rotation2d` docs that is misleading: the radian and angle conversion functions are already clear about which angles they spit out, and `Rotation2d` itself doesn't have any bounds on angles or anything.
