### PR TITLE
Hide some re-exports by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,6 +338,9 @@ ios_simulator = ["bevy_internal/ios_simulator"]
 # Enable built in global state machines
 bevy_state = ["bevy_internal/bevy_state"]
 
+# Remove `#[doc(hidden)] from re-exports of certain crates.
+unhide_reexports = ["bevy_internal/unhide_reexports"]
+
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.14.0-dev", default-features = false }
 

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -16,6 +16,10 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 
 accesskit = "0.12"
 
+[features]
+# Remove `#[doc(hidden)] from `accesskit` re-export.
+unhide_reexports = []
+
 [lints]
 workspace = true
 

--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -12,6 +12,7 @@ use std::sync::{
     Arc,
 };
 
+#[cfg_attr(not(unhide_reexports), doc(hidden))]
 pub use accesskit;
 use accesskit::NodeBuilder;
 use bevy_app::Plugin;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -185,6 +185,13 @@ ios_simulator = ["bevy_pbr?/ios_simulator", "bevy_render?/ios_simulator"]
 # Enable built in global state machines
 bevy_state = ["dep:bevy_state", "bevy_app/bevy_state"]
 
+# Remove `#[doc(hidden)] from re-exports of certain crates.
+unhide_reexports = [
+  "bevy_log/unhide_reexports",
+  "bevy_a11y/unhide_reexports",
+  "bevy_utils/unhide_reexports",
+]
+
 [dependencies]
 # bevy
 bevy_a11y = { path = "../bevy_a11y", version = "0.14.0-dev" }

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["bevy"]
 [features]
 trace = ["tracing-error"]
 trace_tracy_memory = ["dep:tracy-client"]
+# Remove `#[doc(hidden)] from `tracing_subscriber` re-export.
+unhide_reexports = []
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -46,6 +46,8 @@ pub use bevy_utils::{
     },
     warn_once,
 };
+
+#[cfg_attr(not(unhide_reexports), doc(hidden))]
 pub use tracing_subscriber;
 
 use bevy_app::{App, Plugin};

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["bevy"]
 
 [features]
 detailed_trace = []
+# Remove `#[doc(hidden)] from various re-exports.
+unhide_reexports = []
 
 [dependencies]
 ahash = "0.8.7"

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -30,8 +30,10 @@ pub use ahash::{AHasher, RandomState};
 pub use bevy_utils_proc_macros::*;
 pub use cow_arc::*;
 pub use default::default;
+#[cfg_attr(not(unhide_reexports), doc(hidden))]
 pub use hashbrown;
 pub use parallel_queue::*;
+#[cfg_attr(not(unhide_reexports), doc(hidden))]
 pub use tracing;
 pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 


### PR DESCRIPTION
# Objective
Re-exports of `accesskit`, `tracing`, `tracingsubscriber` and `hashbrown` are very annoying when using auto-complete.

## Solution

Apply `#[doc(hidden)]` to re-exports of `accesskit`, `tracing`, `tracingsubscriber` and `hashbrown`, that causes issues when using editors. Added feature `unhide_reexports` to un-hide them.

## Testing

Tested with with VSCode.
