### PR TITLE
Allow creation of random `Rotation2d`

### DIFF
--- a/crates/bevy_math/src/sampling/standard.rs
+++ b/crates/bevy_math/src/sampling/standard.rs
@@ -7,7 +7,7 @@
 //! ```
 //! # use rand::{random, Rng, SeedableRng, rngs::StdRng, distributions::Standard};
 //! # use bevy_math::{Dir3, sampling::FromRng};
-//! let mut rng = StdRng::from_entropy();
+//! let mut rng = StdRng::seed_from_u64(7313429298);
 //! // Random direction using thread-local rng
 //! let random_direction1: Dir3 = random();
 //!
@@ -21,9 +21,11 @@
 //! let many_random_directions: Vec<Dir3> = rng.sample_iter(Standard).take(5).collect();
 //! ```
 
+use std::f32::consts::TAU;
+
 use crate::{
     primitives::{Circle, Sphere},
-    Dir2, Dir3, Dir3A, Quat, ShapeSample, Vec3A,
+    Dir2, Dir3, Dir3A, Quat, Rotation2d, ShapeSample, Vec3A,
 };
 use rand::{
     distributions::{Distribution, Standard},
@@ -37,7 +39,7 @@ use rand::{
 /// ```
 /// # use rand::{Rng, SeedableRng, rngs::StdRng};
 /// # use bevy_math::{Dir3, sampling::FromRng};
-/// let mut rng = StdRng::from_entropy();
+/// let mut rng = StdRng::seed_from_u64(451);
 /// let random_dir = Dir3::from_rng(&mut rng);
 /// ```
 pub trait FromRng
@@ -80,5 +82,14 @@ impl Distribution<Dir3A> for Standard {
 }
 
 impl FromRng for Dir3A {}
+
+impl Distribution<Rotation2d> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Rotation2d {
+        let angle = rng.gen_range(0.0..TAU);
+        Rotation2d::radians(angle)
+    }
+}
+
+impl FromRng for Rotation2d {}
 
 impl FromRng for Quat {}

--- a/crates/bevy_math/src/sampling/standard.rs
+++ b/crates/bevy_math/src/sampling/standard.rs
@@ -54,6 +54,7 @@ where
 }
 
 impl Distribution<Dir2> for Standard {
+    #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Dir2 {
         let circle = Circle::new(1.0);
         let vector = circle.sample_boundary(rng);
@@ -64,6 +65,7 @@ impl Distribution<Dir2> for Standard {
 impl FromRng for Dir2 {}
 
 impl Distribution<Dir3> for Standard {
+    #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Dir3 {
         let sphere = Sphere::new(1.0);
         let vector = sphere.sample_boundary(rng);
@@ -74,6 +76,7 @@ impl Distribution<Dir3> for Standard {
 impl FromRng for Dir3 {}
 
 impl Distribution<Dir3A> for Standard {
+    #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Dir3A {
         let sphere = Sphere::new(1.0);
         let vector: Vec3A = sphere.sample_boundary(rng).into();
@@ -84,6 +87,7 @@ impl Distribution<Dir3A> for Standard {
 impl FromRng for Dir3A {}
 
 impl Distribution<Rotation2d> for Standard {
+    #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Rotation2d {
         let angle = rng.gen_range(0.0..TAU);
         Rotation2d::radians(angle)


### PR DESCRIPTION
# Objective

Fill the gap in this functionality by implementing it for `Rotation2d`. We have this already for `Quat` in addition to the direction types.

## Solution

`bevy_math::sampling` now contains an implementation of `Distribution<Rotation2d>` for `Standard`, along with the associated convenience implementation `Rotation2d: FromRng`, which allows syntax like this for creating a random rotation:
```rust
// With `FromRng`:
let rotation = Rotation2d::from_rng(rng);
// With `rand::random`:
let another_rotation: Rotation2d = random();
// With `Rng::gen`:
let yet_another_rotation: Rotation2d = rng.gen();
```

I also cleaned up the documentation a little bit, seeding the `Rng`s instead of building them from entropy, along with adding a handful of inline directives.
