### PR TITLE
Dont hang on window drop

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -119,6 +119,7 @@ fn extract_windows(
     screenshot_manager: Extract<Res<ScreenshotManager>>,
     mut closing: Extract<EventReader<WindowClosing>>,
     windows: Extract<Query<(Entity, &Window, &RawHandleWrapper, Option<&PrimaryWindow>)>>,
+    mut removed: Extract<RemovedComponents<RawHandleWrapper>>,
     mut window_surfaces: ResMut<WindowSurfaces>,
 ) {
     for (entity, window, handle, primary) in windows.iter() {
@@ -179,6 +180,10 @@ fn extract_windows(
     for closing_window in closing.read() {
         extracted_windows.remove(&closing_window.window);
         window_surfaces.remove(&closing_window.window);
+    }
+    for removed_window in removed.read() {
+        extracted_windows.remove(&removed_window);
+        window_surfaces.remove(&removed_window);
     }
     // This lock will never block because `callbacks` is `pub(crate)` and this is the singular callsite where it's locked.
     // Even if a user had multiple copies of this system, since the system has a mutable resource access the two systems would never run

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -119,7 +119,6 @@ fn extract_windows(
     screenshot_manager: Extract<Res<ScreenshotManager>>,
     mut closing: Extract<EventReader<WindowClosing>>,
     windows: Extract<Query<(Entity, &Window, &RawHandleWrapper, Option<&PrimaryWindow>)>>,
-    mut removed: Extract<RemovedComponents<RawHandleWrapper>>,
     mut window_surfaces: ResMut<WindowSurfaces>,
 ) {
     for (entity, window, handle, primary) in windows.iter() {
@@ -180,10 +179,6 @@ fn extract_windows(
     for closing_window in closing.read() {
         extracted_windows.remove(&closing_window.window);
         window_surfaces.remove(&closing_window.window);
-    }
-    for removed_window in removed.read() {
-        extracted_windows.remove(&removed_window);
-        window_surfaces.remove(&removed_window);
     }
     // This lock will never block because `callbacks` is `pub(crate)` and this is the singular callsite where it's locked.
     // Even if a user had multiple copies of this system, since the system has a mutable resource access the two systems would never run


### PR DESCRIPTION
Same as #13686, but attempts to consolidate the logic such that we only ever respond to the `WindowClosing` event in the render world, rather than also dropping on removed components in the render world. While this makes the `despawn_windows` system a bit more complex, I think it makes sense to only respond to `RemovedComponents<Window>` in a single place.