### PR TITLE
hashing error in bevy_reflect now includes the type (bevyengine#13646)

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -756,7 +756,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "the given key does not support hashing")]
+    #[should_panic(
+        expected = "the given key bevy_reflect::tests::Foo does not support hashing"
+    )]
     fn reflect_map_no_hash() {
         #[derive(Reflect)]
         struct Foo {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -756,9 +756,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "the given key bevy_reflect::tests::Foo does not support hashing"
-    )]
+    #[should_panic(expected = "the given key bevy_reflect::tests::Foo does not support hashing")]
     fn reflect_map_no_hash() {
         #[derive(Reflect)]
         struct Foo {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -194,13 +194,12 @@ impl MapInfo {
     }
 }
 
-
 #[macro_export]
 macro_rules! hash_error {
     ( $key:expr ) => {{
-        let type_name = match (*$key).get_represented_type_info(){
-            None=>"Unknown",
-            Some(s)=>s.type_path(),
+        let type_name = match (*$key).get_represented_type_info() {
+            None => "Unknown",
+            Some(s) => s.type_path(),
         };
         format!("the given key {} does not support hashing", type_name).as_str()
     }};
@@ -295,7 +294,10 @@ impl Map for DynamicMap {
         key: Box<dyn Reflect>,
         mut value: Box<dyn Reflect>,
     ) -> Option<Box<dyn Reflect>> {
-        match self.indices.entry(key.reflect_hash().expect(hash_error!(key))) {
+        match self
+            .indices
+            .entry(key.reflect_hash().expect(hash_error!(key)))
+        {
             Entry::Occupied(entry) => {
                 let (_old_key, old_value) = self.values.get_mut(*entry.get()).unwrap();
                 std::mem::swap(old_value, &mut value);


### PR DESCRIPTION
# Objective
If you try to add an object to the hashmap that is not capable of hashing, the program panics. For easier debugging, the type for that object should be included in the error message.

Fixes #13646.

## Solution
initially i tried calling std::any::type_name_of_val. this had the problem that it would print something like dyn Box<dyn Reflect>, not helpful. But since these objects all implement Reflect, i used Reflect::type_path() instead. Previously, the error message was part of a constant called HASH_ERROR. i changed that to a macro called hash_error to print the type of that object more easily

## Testing
i adapted the unit test reflect_map_no_hash to expect the type in that panic aswell

since this is my first contribution, please let me know if i have done everything properly