### PR TITLE
Remove WinitEvents that aren't emitted

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -648,9 +648,6 @@ impl<T: Event> WinitAppRunnerState<T> {
                 WinitEvent::RequestRedraw(e) => {
                     world.send_event(e);
                 }
-                WinitEvent::WindowBackendScaleFactorChanged(e) => {
-                    world.send_event(e);
-                }
                 WinitEvent::WindowCloseRequested(e) => {
                     world.send_event(e);
                 }
@@ -667,12 +664,6 @@ impl<T: Event> WinitAppRunnerState<T> {
                     world.send_event(e);
                 }
                 WinitEvent::WindowOccluded(e) => {
-                    world.send_event(e);
-                }
-                WinitEvent::WindowResized(e) => {
-                    world.send_event(e);
-                }
-                WinitEvent::WindowScaleFactorChanged(e) => {
                     world.send_event(e);
                 }
                 WinitEvent::WindowThemeChanged(e) => {

--- a/crates/bevy_winit/src/winit_event.rs
+++ b/crates/bevy_winit/src/winit_event.rs
@@ -14,9 +14,8 @@ use bevy_reflect::Reflect;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_window::{
     AppLifecycle, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime, ReceivedCharacter,
-    RequestRedraw, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowCreated,
-    WindowDestroyed, WindowFocused, WindowMoved, WindowOccluded, WindowResized,
-    WindowScaleFactorChanged, WindowThemeChanged,
+    RequestRedraw, WindowCloseRequested, WindowCreated, WindowDestroyed, WindowFocused,
+    WindowMoved, WindowOccluded, WindowThemeChanged,
 };
 
 /// Wraps all `bevy_window` events in a common enum.
@@ -41,17 +40,18 @@ pub enum WinitEvent {
     Ime(Ime),
     ReceivedCharacter(ReceivedCharacter),
     RequestRedraw(RequestRedraw),
-    WindowBackendScaleFactorChanged(WindowBackendScaleFactorChanged),
     WindowCloseRequested(WindowCloseRequested),
     WindowCreated(WindowCreated),
     WindowDestroyed(WindowDestroyed),
     WindowFocused(WindowFocused),
     WindowMoved(WindowMoved),
     WindowOccluded(WindowOccluded),
-    WindowResized(WindowResized),
-    WindowScaleFactorChanged(WindowScaleFactorChanged),
     WindowThemeChanged(WindowThemeChanged),
 
+    // Events that are emitted separately.
+    //WindowBackendScaleFactorChanged(WindowBackendScaleFactorChanged),
+    //WindowResized(WindowResized),
+    //WindowScaleFactorChanged(WindowScaleFactorChanged),
     MouseButtonInput(MouseButtonInput),
     MouseMotion(MouseMotion),
     MouseWheel(MouseWheel),
@@ -107,11 +107,6 @@ impl From<RequestRedraw> for WinitEvent {
         Self::RequestRedraw(e)
     }
 }
-impl From<WindowBackendScaleFactorChanged> for WinitEvent {
-    fn from(e: WindowBackendScaleFactorChanged) -> Self {
-        Self::WindowBackendScaleFactorChanged(e)
-    }
-}
 impl From<WindowCloseRequested> for WinitEvent {
     fn from(e: WindowCloseRequested) -> Self {
         Self::WindowCloseRequested(e)
@@ -140,16 +135,6 @@ impl From<WindowMoved> for WinitEvent {
 impl From<WindowOccluded> for WinitEvent {
     fn from(e: WindowOccluded) -> Self {
         Self::WindowOccluded(e)
-    }
-}
-impl From<WindowResized> for WinitEvent {
-    fn from(e: WindowResized) -> Self {
-        Self::WindowResized(e)
-    }
-}
-impl From<WindowScaleFactorChanged> for WinitEvent {
-    fn from(e: WindowScaleFactorChanged) -> Self {
-        Self::WindowScaleFactorChanged(e)
     }
 }
 impl From<WindowThemeChanged> for WinitEvent {


### PR DESCRIPTION
# Objective

Don't include events in the `WinitEvent` enum that won't be emitted, because it will be confusing for users.

It's not actually clear to me why these events are emitted separately, but in any case this is the simplest fix.

## Solution

- Remove events that are emitted separately.

## Testing

N/A
