### PR TITLE
Poll system information in separate tasks

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -20,6 +20,7 @@ bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 
 const-fnv1a-hash = "1.1.0"
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -24,9 +24,7 @@ pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 #[cfg(feature = "sysinfo_plugin")]
-pub use system_information_diagnostics_plugin::{
-    SystemInfo, SystemInformationDiagnosticsPlugin, EXPECTED_SYSTEM_INFORMATION_INTERVAL,
-};
+pub use system_information_diagnostics_plugin::{SystemInfo, SystemInformationDiagnosticsPlugin};
 
 use bevy_app::prelude::*;
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -24,7 +24,9 @@ pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 #[cfg(feature = "sysinfo_plugin")]
-pub use system_information_diagnostics_plugin::{SystemInfo, SystemInformationDiagnosticsPlugin};
+pub use system_information_diagnostics_plugin::{
+    SystemInfo, SystemInformationDiagnosticsPlugin, EXPECTED_SYSTEM_INFORMATION_INTERVAL,
+};
 
 use bevy_app::prelude::*;
 

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -4,7 +4,7 @@ use bevy_ecs::system::Resource;
 
 /// Adds a System Information Diagnostic, specifically `cpu_usage` (in %) and `mem_usage` (in %)
 ///
-/// Note that gather system information is a time intensive task and therefore can't be done on every frame.
+/// Note that gathering system information is a time intensive task and therefore can't be done on every frame.
 /// Any system diagnostics gathered by this plugin may not be current when you access them.
 ///
 /// Supported targets:


### PR DESCRIPTION
# Objective

Reading system information severely slows down the update loop.
Fixes #12848.

## Solution

Read system info in a separate thread.

## Testing

- Open the scene 3d example
-  Add `FrameTimeDiagnosticsPlugin`, `SystemInformationDiagnosticsPlugin` and `LogDiagnosticsPlugin` to the app.
- Add this system to the update schedule to disable Vsync on the main window
```rust
fn change_window_mode(mut windows: Query<&mut Window, Added<Window>>) {
    for mut window in &mut windows {
        window.present_mode = PresentMode::AutoNoVsync;
    }
}
```
- Read the fps values in the console before and after this PR.

On my PC I went from around 50 fps to around 1150 fps.

---

## Changelog

### Changed

- The `SystemInformationDiagnosticsPlugin` now reads system data separate of the update cycle.

### Added 

-  The `EXPECTED_SYSTEM_INFORMATION_INTERVAL` constant which defines how often we read system diagnostic data.