### PR TITLE
Made `Mesh::merge` take a reference of `Mesh`.

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -741,7 +741,7 @@ impl Mesh {
     /// Panics if the vertex attribute values of `other` are incompatible with `self`.
     /// For example, [`VertexAttributeValues::Float32`] is incompatible with [`VertexAttributeValues::Float32x3`].
     #[allow(clippy::match_same_arms)]
-    pub fn merge(&mut self, other: Mesh) {
+    pub fn merge(&mut self, other: &Mesh) {
         use VertexAttributeValues::*;
 
         // The indices of `other` should start after the last vertex of `self`.

--- a/crates/bevy_render/src/mesh/primitives/extrusion.rs
+++ b/crates/bevy_render/src/mesh/primitives/extrusion.rs
@@ -207,7 +207,7 @@ where
 
         // An extrusion of depth 0 does not need a mantel
         if self.half_depth == 0. {
-            front_face.merge(back_face);
+            front_face.merge(&back_face);
             return front_face;
         }
 
@@ -374,8 +374,8 @@ where
             .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
         };
 
-        front_face.merge(back_face);
-        front_face.merge(mantel);
+        front_face.merge(&back_face);
+        front_face.merge(&mantel);
         front_face
     }
 }


### PR DESCRIPTION
# Objective

`Mesh::merge` does not need ownership of the right hand side mesh.

## Solution

Made `Mesh::merge` take a reference.

## Testing

Modified existing tests.

---

## Changelog

Made `Mesh::merge` take a reference.


## Migration Guide

* `Mesh::merge` now take a reference of a mesh instead of an owned mesh.
