### PR TITLE
Align `Scene::write_to_world_with` to match `DynamicScene::write_to_world_with`

### DIFF
--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,6 +1,6 @@
-use crate::{DynamicScene, InstanceInfo, SceneSpawnError};
+use crate::{DynamicScene, SceneSpawnError};
 use bevy_asset::Asset;
-use bevy_ecs::entity::EntityHashMap;
+use bevy_ecs::entity::{Entity, EntityHashMap};
 use bevy_ecs::{
     reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
     world::World,
@@ -43,7 +43,8 @@ impl Scene {
     /// provided [`AppTypeRegistry`] or doesn't reflect the [`Component`](bevy_ecs::component::Component) trait.
     pub fn clone_with(&self, type_registry: &AppTypeRegistry) -> Result<Scene, SceneSpawnError> {
         let mut new_world = World::new();
-        self.write_to_world_with(&mut new_world, type_registry)?;
+        let mut entity_map = EntityHashMap::default();
+        self.write_to_world_with(&mut new_world, &mut entity_map, type_registry)?;
         Ok(Self { world: new_world })
     }
 
@@ -54,12 +55,9 @@ impl Scene {
     pub fn write_to_world_with(
         &self,
         world: &mut World,
+        entity_map: &mut EntityHashMap<Entity>,
         type_registry: &AppTypeRegistry,
-    ) -> Result<InstanceInfo, SceneSpawnError> {
-        let mut instance_info = InstanceInfo {
-            entity_map: EntityHashMap::default(),
-        };
-
+    ) -> Result<(), SceneSpawnError> {
         let type_registry = type_registry.read();
 
         // Resources archetype
@@ -94,8 +92,7 @@ impl Scene {
 
         for archetype in self.world.archetypes().iter() {
             for scene_entity in archetype.entities() {
-                let entity = *instance_info
-                    .entity_map
+                let entity = entity_map
                     .entry(scene_entity.id())
                     .or_insert_with(|| world.spawn_empty().id());
                 for component_id in archetype.components() {
@@ -121,7 +118,7 @@ impl Scene {
                         &self.world,
                         world,
                         scene_entity.id(),
-                        entity,
+                        *entity,
                         &type_registry,
                     );
                 }
@@ -130,10 +127,10 @@ impl Scene {
 
         for registration in type_registry.iter() {
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
-                map_entities_reflect.map_all_entities(world, &mut instance_info.entity_map);
+                map_entities_reflect.map_all_entities(world, entity_map);
             }
         }
 
-        Ok(instance_info)
+        Ok(())
     }
 }

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -221,6 +221,7 @@ impl SceneSpawner {
             let scene = scenes
                 .get(id)
                 .ok_or(SceneSpawnError::NonExistentScene { id })?;
+
             scene.write_to_world(world, entity_map)
         })
     }
@@ -231,25 +232,31 @@ impl SceneSpawner {
         world: &mut World,
         id: AssetId<Scene>,
     ) -> Result<InstanceId, SceneSpawnError> {
-        self.spawn_sync_internal(world, id, InstanceId::new())
+        let mut entity_map = EntityHashMap::default();
+        let id = id.into();
+        Self::spawn_sync_internal(world, id, &mut entity_map)?;
+        let instance_id = InstanceId::new();
+        self.spawned_instances
+            .insert(instance_id, InstanceInfo { entity_map });
+        Ok(instance_id)
     }
 
     fn spawn_sync_internal(
-        &mut self,
+        // &mut self,
         world: &mut World,
         id: AssetId<Scene>,
-        instance_id: InstanceId,
-    ) -> Result<InstanceId, SceneSpawnError> {
+        entity_map: &mut EntityHashMap<Entity>,
+    ) -> Result<(), SceneSpawnError> {
         world.resource_scope(|world, scenes: Mut<Assets<Scene>>| {
             let scene = scenes
                 .get(id)
                 .ok_or(SceneSpawnError::NonExistentRealScene { id })?;
 
-            let instance_info =
-                scene.write_to_world_with(world, &world.resource::<AppTypeRegistry>().clone())?;
-
-            self.spawned_instances.insert(instance_id, instance_info);
-            Ok(instance_id)
+            scene.write_to_world_with(
+                world,
+                entity_map,
+                &world.resource::<AppTypeRegistry>().clone(),
+            )
         })
     }
 
@@ -319,7 +326,9 @@ impl SceneSpawner {
         let scenes_to_spawn = std::mem::take(&mut self.scenes_to_spawn);
 
         for (scene_handle, instance_id) in scenes_to_spawn {
-            match self.spawn_sync_internal(world, scene_handle.id(), instance_id) {
+            let mut entity_map = EntityHashMap::default();
+
+            match Self::spawn_sync_internal(world, scene_handle.id(), &mut entity_map) {
                 Ok(_) => {}
                 Err(SceneSpawnError::NonExistentRealScene { .. }) => {
                     self.scenes_to_spawn.push((scene_handle, instance_id));


### PR DESCRIPTION
# Objective

`Scene` and `DynamicScene` work with `InstanceInfo` at different levels of abstraction
- `Scene::write_to_world_with` returns an `InstanceInfo` whereas `DynamicScene::write_to_world_with` returns `()`. Instances are created one level higher at the `SceneSpawner` API level.
- `DynamicScene::write_to_world_with` takes the `entity_map` as an argument whereas the `Scene` version is less flexible and creates a new one for you. No reason this needs to be the case.

## Solution

I propose changing `Scene::write_to_world_with` to match the API we have for `DynamicScene`. Returning the `InstanceInfo` as we do today just seems like a leaky abstraction - it's only used in `spawn_sync_internal`. Being able to pass in an entity_map gives you more flexibility with how you write entities to a world. 

This also moves `InstanceInfo` out of `Scene` which is cleaner conceptually. If someone wants to work with instances then they should work with `SceneSpawner` - I see `write_to_world_with` as a lower-level API to be used with exclusive world access. 

## Testing

Code is just shifting things around.

## Changelog

Changed `Scene::write_to_world_with to take `entity_map` as an argument and no longer return an `InstanceInfo`
