### PR TITLE
Use TBN in apply_normal_mapping in pbr_prepass

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -74,13 +74,13 @@ fn fragment(
             uv,
             bias,
         ).rgb;
+        let TBN = pbr_functions::calculate_tbn_mikktspace(normal, in.world_tangent);
 
         normal = pbr_functions::apply_normal_mapping(
             material.flags,
-            world_normal,
+            TBN,
             double_sided,
             is_front,
-            in.world_tangent,
             Nt,
             view.mip_bias,
         );


### PR DESCRIPTION
# Objective

- apply_normal_mapping was changed to use TBN but the pbr_prepass was not updated for that change

## Solution

- Update the pbr_prepass to correctly apply normal mapping
