### PR TITLE
Uncouple `DynamicTextureAtlasBuilder` from assets

### DIFF
--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -1,5 +1,4 @@
 use crate::TextureAtlasLayout;
-use bevy_asset::{Assets, Handle};
 use bevy_math::{URect, UVec2};
 use bevy_render::{
     render_asset::{RenderAsset, RenderAssetUsages},
@@ -38,23 +37,20 @@ impl DynamicTextureAtlasBuilder {
     ///
     /// # Arguments
     ///
-    /// * `altas_layout` - The atlas to add the texture to
-    /// * `textures` - The texture assets container
-    /// * `texture` - The new texture to add to the atlas
-    /// * `atlas_texture_handle` - The atlas texture to edit
+    /// * `altas_layout` - The atlas layout to add the texture to.
+    /// * `texture` - The source texture to add to the atlas.
+    /// * `atlas_texture` - The destination atlas texture to copy the source texture to.
     pub fn add_texture(
         &mut self,
         atlas_layout: &mut TextureAtlasLayout,
-        textures: &mut Assets<Image>,
         texture: &Image,
-        atlas_texture_handle: &Handle<Image>,
+        atlas_texture: &mut Image,
     ) -> Option<usize> {
         let allocation = self.atlas_allocator.allocate(size2(
             (texture.width() + self.padding).try_into().unwrap(),
             (texture.height() + self.padding).try_into().unwrap(),
         ));
         if let Some(allocation) = allocation {
-            let atlas_texture = textures.get_mut(atlas_texture_handle).unwrap();
             assert!(
                 <GpuImage as RenderAsset>::asset_usage(atlas_texture)
                     .contains(RenderAssetUsages::MAIN_WORLD),

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -12,7 +12,7 @@ use glyph_brush_layout::{
 
 use crate::{
     error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasSets, GlyphAtlasInfo, JustifyText,
-    TextSettings, YAxisOrientation,
+    PlacedGlyph, TextSettings, YAxisOrientation,
 };
 
 pub struct GlyphBrush {
@@ -94,8 +94,10 @@ impl GlyphBrush {
                 mut glyph,
                 font_id: _,
             } = sg;
-            let glyph_id = glyph.id;
-            let glyph_position = glyph.position;
+            let placed_glyph = PlacedGlyph {
+                glyph_id: glyph.id,
+                subpixel_offset: glyph.position.into(),
+            };
             let adjust = GlyphPlacementAdjuster::new(&mut glyph);
             let section_data = sections_data[sg.section_index];
             if let Some(outlined_glyph) = section_data.1.font.outline_glyph(glyph) {
@@ -106,7 +108,7 @@ impl GlyphBrush {
                     .or_insert_with(FontAtlasSet::default);
 
                 let atlas_info = font_atlas_set
-                    .get_glyph_atlas_info(section_data.2, glyph_id, glyph_position)
+                    .get_glyph_atlas_info(section_data.2, &placed_glyph)
                     .map(Ok)
                     .unwrap_or_else(|| {
                         font_atlas_set.add_glyph_to_atlas(texture_atlases, textures, outlined_glyph)


### PR DESCRIPTION
# Objective

Remove some unnecessary coupling between `DynamicTextureAtlasBuilder` and `bevy_asset`.

## Solution

Remove the dependency of `DynamicTextureAtlasBuilder::add_texture` to `bevy_asset`, by directly passing the `Image` of the atlas to mutate, instead of passing separate `Assets<Image>` and `Handle<Image>` for the function to do the lookup by itself. The lookup can be done from the caller, and this allows using the builder in contexts where the `Image` is not stored inside `Assets`.

Clean-up a bit the font atlas files by introducing a `PlacedGlyph` type storing the `GlyphId` and its `SubpixelOffset`, which were otherwise always both passed as function parameters and the pair used as key in hash maps.

## Testing

There's no change in behavior.

---

## Changelog

- Added a `PlacedGlyph` type aggregating a `GlyphId` and a `SubpixelOffset`. That type is now used as parameter in a few text atlas APIs, instead of passing individual values.

## Migration Guide

- Replace the `glyph_id` and `subpixel_offset` of a few text atlas APIs by a single `place_glyph: PlacedGlyph` parameter trivially combining the two.