### PR TITLE
Add segments to `ExtrusionBuilder`

### DIFF
--- a/crates/bevy_render/src/mesh/primitives/extrusion.rs
+++ b/crates/bevy_render/src/mesh/primitives/extrusion.rs
@@ -228,6 +228,8 @@ where
                 panic!("The base mesh did not have vertex positions");
             };
 
+            debug_assert!(self.segments > 0);
+
             let layers = self.segments + 1;
             let layer_depth_delta = self.half_depth * 2.0 / self.segments as f32;
 


### PR DESCRIPTION
# Objective

- Add support for `segments` for extrusion-meshes, akin to what is possible with cylinders

## Solution

- Added a `.segments(segments: usize)` function to `ExtrusionBuilder`.
- Implemented support for segments in the meshing algorithm.
- If you set `.segments(0)`, the meshing will fail, just like it does with cylinders.

## Additional information

Here is a wireframe of some extrusions with 1, 2, 3, etc. segments:
![image_2024-06-06_233205114](https://github.com/bevyengine/bevy/assets/62256001/358081e2-172d-407b-8bdb-9cda88eb4664)
