### PR TITLE
rename the crate bevy_state_macros_official back to its original name

### DIFF
--- a/crates/bevy_state/Cargo.toml
+++ b/crates/bevy_state/Cargo.toml
@@ -18,7 +18,7 @@ bevy_hierarchy = ["dep:bevy_hierarchy"]
 
 [dependencies]
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
-bevy_state_macros_official = { path = "macros", version = "0.14.0-dev" }
+bevy_state_macros = { path = "macros", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", optional = true }
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev", optional = true }

--- a/crates/bevy_state/macros/Cargo.toml
+++ b/crates/bevy_state/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bevy_state_macros_official"
+name = "bevy_state_macros"
 version = "0.14.0-dev"
 description = "Macros for bevy_state"
 edition = "2021"

--- a/crates/bevy_state/src/condition.rs
+++ b/crates/bevy_state/src/condition.rs
@@ -180,7 +180,7 @@ mod tests {
     use bevy_ecs::schedule::{Condition, IntoSystemConfigs, Schedule};
 
     use crate::prelude::*;
-    use bevy_state_macros_official::States;
+    use bevy_state_macros::States;
 
     #[derive(States, PartialEq, Eq, Debug, Default, Hash, Clone)]
     enum TestState {

--- a/crates/bevy_state/src/state/mod.rs
+++ b/crates/bevy_state/src/state/mod.rs
@@ -6,7 +6,7 @@ mod states;
 mod sub_states;
 mod transitions;
 
-pub use bevy_state_macros_official::*;
+pub use bevy_state_macros::*;
 pub use computed_states::*;
 pub use freely_mutable_state::*;
 pub use resources::*;
@@ -20,8 +20,8 @@ mod tests {
     use bevy_ecs::event::EventRegistry;
     use bevy_ecs::prelude::*;
     use bevy_ecs::schedule::ScheduleLabel;
-    use bevy_state_macros_official::States;
-    use bevy_state_macros_official::SubStates;
+    use bevy_state_macros::States;
+    use bevy_state_macros::SubStates;
 
     use super::*;
     use crate as bevy_state;

--- a/crates/bevy_state/src/state/resources.rs
+++ b/crates/bevy_state/src/state/resources.rs
@@ -23,7 +23,7 @@ use bevy_ecs::prelude::ReflectResource;
 /// ```
 /// use bevy_state::prelude::*;
 /// use bevy_ecs::prelude::*;
-/// use bevy_state_macros_official::States;
+/// use bevy_state_macros::States;
 ///
 /// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
 /// enum GameState {

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::schedule::Schedule;
 
 use super::{freely_mutable_state::FreelyMutableState, state_set::StateSet, states::States};
-pub use bevy_state_macros_official::SubStates;
+pub use bevy_state_macros::SubStates;
 
 /// A sub-state is a state that exists only when the source state meet certain conditions,
 /// but unlike [`ComputedStates`](crate::state::ComputedStates) - while they exist they can be manually modified.


### PR DESCRIPTION
# Objective

- Thanks to the original author we can now use the original name

## Solution

- Use it
