### PR TITLE
Make the component types of the new animation players clonable.

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -236,7 +236,7 @@ impl Hash for AnimationTargetId {
 /// Note that each entity can only be animated by one animation player at a
 /// time. However, you can change [`AnimationTarget`]'s `player` property at
 /// runtime to change which player is responsible for animating the entity.
-#[derive(Clone, Component, Reflect)]
+#[derive(Clone, Copy, Component, Reflect)]
 #[reflect(Component, MapEntities)]
 pub struct AnimationTarget {
     /// The ID of this animation target.
@@ -506,13 +506,28 @@ impl ActiveAnimation {
 }
 
 /// Animation controls
-#[derive(Component, Clone, Default, Reflect)]
+#[derive(Component, Default, Reflect)]
 #[reflect(Component)]
 pub struct AnimationPlayer {
     /// We use a `BTreeMap` instead of a `HashMap` here to ensure a consistent
     /// ordering when applying the animations.
     active_animations: BTreeMap<AnimationNodeIndex, ActiveAnimation>,
     blend_weights: HashMap<AnimationNodeIndex, f32>,
+}
+
+// This is needed since `#[derive(Clone)]` does not generate optimized `clone_from`.
+impl Clone for AnimationPlayer {
+    fn clone(&self) -> Self {
+        Self {
+            active_animations: self.active_animations.clone(),
+            blend_weights: self.blend_weights.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.active_animations.clone_from(&source.active_animations);
+        self.blend_weights.clone_from(&source.blend_weights);
+    }
 }
 
 /// The components that we might need to read or write during animation of each

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -326,7 +326,7 @@ pub enum RepeatAnimation {
 /// playing, but is presently paused.
 ///
 /// An stopped animation is considered no longer active.
-#[derive(Debug, Reflect)]
+#[derive(Debug, Clone, Copy, Reflect)]
 pub struct ActiveAnimation {
     /// The factor by which the weight from the [`AnimationGraph`] is multiplied.
     weight: f32,
@@ -506,7 +506,7 @@ impl ActiveAnimation {
 }
 
 /// Animation controls
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Clone, Default, Reflect)]
 #[reflect(Component)]
 pub struct AnimationPlayer {
     /// We use a `BTreeMap` instead of a `HashMap` here to ensure a consistent

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -27,14 +27,14 @@ use crate::{graph::AnimationNodeIndex, ActiveAnimation, AnimationPlayer};
 /// the [`AnimationPlayer`] directly will cause the [`AnimationTransitions`]
 /// component to get confused about which animation is the "main" animation, and
 /// transitions will usually be incorrect as a result.
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Clone, Default, Reflect)]
 pub struct AnimationTransitions {
     main_animation: Option<AnimationNodeIndex>,
     transitions: Vec<AnimationTransition>,
 }
 
 /// An animation that is being faded out as part of a transition
-#[derive(Debug, Reflect)]
+#[derive(Debug, Clone, Copy, Reflect)]
 pub struct AnimationTransition {
     /// The current weight. Starts at 1.0 and goes to 0.0 during the fade-out.
     current_weight: f32,

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -33,6 +33,7 @@ pub struct AnimationTransitions {
     transitions: Vec<AnimationTransition>,
 }
 
+// This is needed since `#[derive(Clone)]` does not generate optimized `clone_from`.
 impl Clone for AnimationTransitions {
     fn clone(&self) -> Self {
         Self {

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -27,10 +27,24 @@ use crate::{graph::AnimationNodeIndex, ActiveAnimation, AnimationPlayer};
 /// the [`AnimationPlayer`] directly will cause the [`AnimationTransitions`]
 /// component to get confused about which animation is the "main" animation, and
 /// transitions will usually be incorrect as a result.
-#[derive(Component, Clone, Default, Reflect)]
+#[derive(Component, Default, Reflect)]
 pub struct AnimationTransitions {
     main_animation: Option<AnimationNodeIndex>,
     transitions: Vec<AnimationTransition>,
+}
+
+impl Clone for AnimationTransitions {
+    fn clone(&self) -> Self {
+        Self {
+            main_animation: self.main_animation,
+            transitions: self.transitions.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.main_animation = source.main_animation;
+        self.transitions.clone_from(&source.transitions);
+    }
 }
 
 /// An animation that is being faded out as part of a transition


### PR DESCRIPTION
# Objective

Some use cases might require holding onto the previous state of the animation player for change detection.

## Solution

Added `clone` and `copy` implementation to most animation types. 
Added optimized `clone_from` implementations for the specific use case of holding a `PreviousAnimationPlayer` component.
