### PR TITLE
Clear messed up feature flag on AppExitStates impl

### DIFF
--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -177,7 +177,6 @@ impl AppExtStates for App {
         self
     }
 
-    #[cfg(feature = "bevy_hierarchy")]
     fn enable_state_scoped_entities<S: States>(&mut self) -> &mut Self {
         self.main_mut().enable_state_scoped_entities::<S>();
         self


### PR DESCRIPTION
# Objective

- In #13649 additional method had been added to AppExitStates, but there feature gate left for method in implementation for App at refactoring stage.
- Fixes #13733 .

## Solution

- Removed the feature gate.

## Testing

- Ran reproducing example from #13733 with no compilation errors
