### PR TITLE
make `App` implement `Send` again

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -196,7 +196,7 @@ impl App {
     /// App::new()
     ///     .set_runner(my_runner);
     /// ```
-    pub fn set_runner(&mut self, f: impl FnOnce(App) -> AppExit + 'static) -> &mut Self {
+    pub fn set_runner(&mut self, f: impl FnOnce(App) -> AppExit + 'static + Send) -> &mut Self {
         self.runner = Box::new(f);
         self
     }
@@ -830,7 +830,7 @@ impl App {
     }
 }
 
-type RunnerFn = Box<dyn FnOnce(App) -> AppExit>;
+type RunnerFn = Box<dyn FnOnce(App) -> AppExit + Send>;
 
 fn run_once(mut app: App) -> AppExit {
     while app.plugins_state() == PluginsState::Adding {
@@ -1177,5 +1177,11 @@ mod tests {
         // There wont be many of them so the size isn't a issue but
         // it's nice they're so small let's keep it that way.
         assert_eq!(mem::size_of::<AppExit>(), mem::size_of::<u8>());
+    }
+
+    #[test]
+    fn test_app_send() {
+        fn g<T: Send>() {}
+        g::<App>();
     }
 }


### PR DESCRIPTION
# Objective

- `App` used to be `Send` but it was removed by this change: https://github.com/bevyengine/bevy/pull/9202/files#diff-b2fba3a0c86e496085ce7f0e3f1de5960cb754c7d215ed0f087aa556e529f97fL74

<img width="1300" alt="image" src="https://github.com/bevyengine/bevy/assets/8112632/8c46337d-1ca5-4b4b-afdf-0129f0f2f08d">

(the new `RunnerFn` type is lacking the `Send` bound that was present before)

## Solution

- Add back the `Send` bound to make sure that `App` is `Send`

## Testing

- Added a unit test
