### PR TITLE
view.inverse_clip_from_world should be world_from_clip

### DIFF
--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -74,8 +74,8 @@ fn vertex(vertex: VertexInput) -> VertexOutput {
     let near_clipping_plane_height = length(pos0.xyz - pos1.xyz);
 
     // We can't use vertex.position_X because we may have changed the clip positions with clip_near_plane
-    let position_a = view.inverse_clip_from_world * clip_a;
-    let position_b = view.inverse_clip_from_world * clip_b;
+    let position_a = view.world_from_clip * clip_a;
+    let position_b = view.world_from_clip * clip_b;
     let world_distance = length(position_a.xyz - position_b.xyz);
 
     // Offset to compensate for moved clip positions. If removed dots on lines will slide when position a is ofscreen.


### PR DESCRIPTION
As per the other changes in https://github.com/bevyengine/bevy/pull/13489 `view.inverse_clip_from_world` should be `world_from_clip`.



# Objective

fixes #13749

## Solution

Modified lines.wgsl to use the right name as the current name does not exist.

## Testing

I ran the 3d_gizmos example and pressed "p".

![screenshot-2024-06-08-at-13 21 22@2x](https://github.com/bevyengine/bevy/assets/551247/b8bfd3db-8273-4606-9dae-040764339883)

![screenshot-2024-06-08-at-13 21 26@2x](https://github.com/bevyengine/bevy/assets/551247/2619f1ae-ce83-44d7-a9fc-07e686950887)
