### PR TITLE
Proof of concept `StateRegistry`

### DIFF
--- a/crates/bevy_state/src/state/freely_mutable_state.rs
+++ b/crates/bevy_state/src/state/freely_mutable_state.rs
@@ -42,7 +42,8 @@ pub trait FreelyMutableState: States {
     }
 }
 
-fn apply_state_transition<S: FreelyMutableState>(
+///
+pub fn apply_state_transition<S: FreelyMutableState>(
     event: EventWriter<StateTransitionEvent<S>>,
     commands: Commands,
     current_state: Option<ResMut<State<S>>>,

--- a/crates/bevy_state/src/state/mod.rs
+++ b/crates/bevy_state/src/state/mod.rs
@@ -1,6 +1,7 @@
 mod computed_states;
 mod freely_mutable_state;
 mod resources;
+mod state_registry;
 mod state_set;
 mod states;
 mod sub_states;
@@ -10,6 +11,7 @@ pub use bevy_state_macros::*;
 pub use computed_states::*;
 pub use freely_mutable_state::*;
 pub use resources::*;
+pub use state_registry::*;
 pub use state_set::*;
 pub use states::*;
 pub use sub_states::*;
@@ -618,5 +620,27 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq, Hash, crate::state::States)]
+    enum MyState {
+        Foo,
+        Bar,
+    }
+
+    #[test]
+    fn first_test() {
+        let mut registry = StateRegistry::default();
+        let mut world = World::new();
+        EventRegistry::register_event::<StateTransitionEvent<MyState>>(&mut world);
+        world.insert_resource(State(MyState::Bar));
+        world.insert_resource(NextState::Pending(MyState::Foo));
+
+        registry.register_root_state::<MyState>(&mut world);
+
+        registry.update(&mut world);
+
+        let events = world.resource::<Events<StateTransitionEvent<MyState>>>();
+        assert_eq!(events.len(), 1);
     }
 }

--- a/crates/bevy_state/src/state/state_registry.rs
+++ b/crates/bevy_state/src/state/state_registry.rs
@@ -1,0 +1,91 @@
+use bevy_ecs::{
+    system::{IntoSystem, SystemId},
+    world::World,
+};
+
+use super::{last_transition, run_enter, run_exit, run_transition, FreelyMutableState};
+
+/// Linearized state graph.
+#[derive(Default)]
+pub struct StateRegistry {
+    states: Vec<StateEntry>,
+}
+
+impl StateRegistry {
+    /// Register a root state
+    pub fn register_root_state<S: FreelyMutableState>(&mut self, world: &mut World) {
+        let depth = S::DEPENDENCY_DEPTH;
+        let update = world.register_system(super::apply_state_transition::<S>);
+        let on_exit = vec![world.register_system(last_transition::<S>.pipe(run_exit::<S>))];
+        let on_transition =
+            vec![world.register_system(last_transition::<S>.pipe(run_transition::<S>))];
+        let on_enter = vec![world.register_system(last_transition::<S>.pipe(run_enter::<S>))];
+
+        let entry = StateEntry {
+            depth,
+            update,
+            on_exit,
+            on_transition,
+            on_enter,
+        };
+        self.insert_entry(entry);
+    }
+
+    //pub fn register_sub_state() {}
+
+    //pub fn register_computed_state() {}
+
+    /// Inserts one type erased state behavior into a depth-sorted vector.
+    fn insert_entry(&mut self, entry: StateEntry) {
+        if let Some((i, _)) = self
+            .states
+            .iter()
+            .enumerate()
+            .find(|s| s.1.depth >= entry.depth)
+        {
+            self.states.insert(i, entry);
+        } else {
+            self.states.push(entry);
+        }
+    }
+
+    /// Runs state update functions and registered transitions.
+    pub fn update(&self, world: &mut World) {
+        // Run updates
+        for state in self.states.iter() {
+            world.run_system(state.update).unwrap();
+        }
+
+        // Run callbacks: exit, transition, enter
+        for state in self.states.iter().rev() {
+            for system in state.on_exit.iter() {
+                world.run_system(*system).unwrap();
+            }
+        }
+        for state in self.states.iter() {
+            for system in state.on_transition.iter() {
+                world.run_system(*system).unwrap();
+            }
+        }
+        for state in self.states.iter() {
+            for system in state.on_enter.iter() {
+                world.run_system(*system).unwrap();
+            }
+        }
+    }
+}
+
+// What about:
+// - related type/component ids
+pub struct StateEntry {
+    /// Depth in the dependency graph
+    depth: usize,
+    /// Function that updates the state based on [`NextState`](crate::state::NextState) and parent states.
+    update: SystemId,
+    /// Systems that run when state is exited, executed in leaf-root graph order
+    on_exit: Vec<SystemId>,
+    /// Systems that run when state is changed, executed in arbitrary order
+    on_transition: Vec<SystemId>,
+    /// Systems that run when state is entered, executed in root-leaf graph order
+    on_enter: Vec<SystemId>,
+}

--- a/crates/bevy_state/src/state/state_registry.rs
+++ b/crates/bevy_state/src/state/state_registry.rs
@@ -115,6 +115,8 @@ impl StateRegistry {
 
 // What about:
 // - related type/component ids
+
+/// Type erased state information, holds ordering, update and transition systems.
 pub struct StateEntry {
     /// Depth in the dependency graph
     depth: usize,


### PR DESCRIPTION
# Objective

Fixes #13711 

## Solution

Introduce `StateRegistry`, similar to `EventRegistry`, which manages state-related system execution
as opposed to the current `StateTransitions` schedule.
The registry holds a linearized DAG of state dependencies.
The `update` method applies all transitions and then runs the schedules in 3 waves:
- exits - From leaf to root
- transitions - Arbitrary (implemented as from root to leaf)
- enters - From root to leaf

### Pros

- Manual state transition triggered through a `StateRegistry::update` rather than running a schedule.
- Cleaner ordering, without a lot of `after` conditions.
- Much simplified custom schedule execution.

### Cons

- Potential performance drop.
  While schedule execution is world-exclusive, updates could run in parallel.

## Testing

- A single test proves the order is correct.
- Before finalization, this needs benchmarking.

## Changelog

TODO

## Migration Guide

TODO
