### PR TITLE
Add Display implementation to DebugName.

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -100,9 +100,9 @@ impl std::fmt::Debug for Name {
 ///     for (name, mut score) in &mut scores {
 ///         score.0 += 1.0;
 ///         if score.0.is_nan() {
-///             // use the Display impl to return either the Name,
-///             // or Entity's Display impl for entities which don't
-///             // have one.
+///             // use the Display impl to return either the Name
+///             // where there is one, or {index}v{generation} 
+///             // for entities which don't have a Name.
 ///             // You can still use the Debug impl it is just quite verbose.
 ///             bevy_utils::tracing::error!("Score for {} is invalid", name);
 ///         }
@@ -124,7 +124,7 @@ impl<'a> std::fmt::Display for DebugNameItem<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {
             Some(name) => std::fmt::Display::fmt(name, f),
-            None => std::fmt::Display::fmt(&self.entity, f),
+            None => write!(f, "{}v{}", self.entity.index(), self.entity.generation()),
         }
     }
 }
@@ -218,8 +218,8 @@ mod tests {
         let mut query = world.query::<DebugName>();
         let d1 = query.get(&world, e1).unwrap();
         let d2 = query.get(&world, e2).unwrap();
-        // DebugName Display for entities without a Name should be Display impl of the Entity
-        assert_eq!(d1.to_string(), format!("{e1}"));
+        // DebugName Display for entities without a Name should be {index}v{generation}
+        assert_eq!(d1.to_string(), "0v1");
         // DebugName Display for entiites with a Name should be the Name
         assert_eq!(d2.to_string(), "MyName");
     }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -100,16 +100,17 @@ impl std::fmt::Debug for Name {
 ///     for (name, mut score) in &mut scores {
 ///         score.0 += 1.0;
 ///         if score.0.is_nan() {
-///             // use the Display impl to return either the Name
-///             // where there is one, or {index}v{generation}
-///             // for entities which don't have a Name.
-///             // You can still use the Debug impl it is just quite verbose.
 ///             bevy_utils::tracing::error!("Score for {name} is invalid");
 ///         }
 ///     }
 /// }
 /// # bevy_ecs::system::assert_is_system(increment_score);
 /// ```
+///
+/// # Implementation
+///
+/// The `Display` impl for `DebugName` returns the `Name` where there is one
+/// or {index}v{generation} for entities without one.
 #[derive(QueryData)]
 #[query_data(derive(Debug))]
 pub struct DebugName {

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -104,7 +104,7 @@ impl std::fmt::Debug for Name {
 ///             // where there is one, or {index}v{generation}
 ///             // for entities which don't have a Name.
 ///             // You can still use the Debug impl it is just quite verbose.
-///             bevy_utils::tracing::error!("Score for {} is invalid", name);
+///             bevy_utils::tracing::error!("Score for {name} is invalid");
 ///         }
 ///     }
 /// }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -220,7 +220,7 @@ mod tests {
         let d2 = query.get(&world, e2).unwrap();
         // DebugName Display for entities without a Name should be {index}v{generation}
         assert_eq!(d1.to_string(), "0v1");
-        // DebugName Display for entiites with a Name should be the Name
+        // DebugName Display for entities with a Name should be the Name
         assert_eq!(d2.to_string(), "MyName");
     }
 }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -101,7 +101,7 @@ impl std::fmt::Debug for Name {
 ///         score.0 += 1.0;
 ///         if score.0.is_nan() {
 ///             // use the Display impl to return either the Name
-///             // where there is one, or {index}v{generation} 
+///             // where there is one, or {index}v{generation}
 ///             // for entities which don't have a Name.
 ///             // You can still use the Debug impl it is just quite verbose.
 ///             bevy_utils::tracing::error!("Score for {} is invalid", name);

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -392,13 +392,7 @@ impl<'de> Deserialize<'de> for Entity {
 
 impl fmt::Display for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}v{}|{}",
-            self.index(),
-            self.generation(),
-            self.to_bits()
-        )
+        write!(f, "{}v{}", self.index(), self.generation())
     }
 }
 
@@ -1162,9 +1156,7 @@ mod tests {
     fn entity_display() {
         let entity = Entity::from_raw(42);
         let string = format!("{}", entity);
-        let bits = entity.to_bits().to_string();
         assert!(string.contains("42"));
         assert!(string.contains("v1"));
-        assert!(string.contains(&bits));
     }
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -392,7 +392,13 @@ impl<'de> Deserialize<'de> for Entity {
 
 impl fmt::Display for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}v{}", self.index(), self.generation())
+        write!(
+            f,
+            "{}v{}|{}",
+            self.index(),
+            self.generation(),
+            self.to_bits()
+        )
     }
 }
 
@@ -1156,7 +1162,9 @@ mod tests {
     fn entity_display() {
         let entity = Entity::from_raw(42);
         let string = format!("{}", entity);
+        let bits = entity.to_bits().to_string();
         assert!(string.contains("42"));
         assert!(string.contains("v1"));
+        assert!(string.contains(&bits));
     }
 }


### PR DESCRIPTION
# Objective

- When writing "in game" debugging tools, quite often you need the name of an entity (for example an entity tree). DebugName is the usual way of doing that.
- A recent change to Entity's Debug implementation meant it was no longer a minimal {index}v{generation} but instead a more verbose auto generated Debug.
- This made DebugName's Debug implementation also verbose

## Solution

- I changed DebugName to derive Debug automatically and added a new (preferred) Display implementation for it which is the preferred name for an entity. If the entity has a Name component its the contents of that, otherwise it is {index}v{generation} (though this does not use Display of the Entity as that is more verbose than this).

## Testing

- I've added a new test in name.rs which tests the Display implementation for DebugName by using to_string.

---

## Migration Guide

- In code which uses DebugName you should now use the Display implementation rather than the Debug implementation (ie {} instead of {:?} if you were printing it out).
