### PR TITLE
Add more granular system sets for state transition schedule ordering

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -47,8 +47,9 @@ pub mod prelude {
     pub use crate::condition::*;
     #[doc(hidden)]
     pub use crate::state::{
-        last_transition, ComputedStates, NextState, OnEnter, OnExit, OnTransition, State, StateSet,
-        StateTransition, StateTransitionEvent, StateTransitionSteps, States, SubStates,
+        last_transition, ComputedStates, EnterSchedules, ExitSchedules, NextState, OnEnter, OnExit,
+        OnTransition, State, StateSet, StateTransition, StateTransitionEvent, States, SubStates,
+        TransitionSchedules,
     };
     #[doc(hidden)]
     pub use crate::state_scoped::StateScoped;

--- a/crates/bevy_state/src/state/mod.rs
+++ b/crates/bevy_state/src/state/mod.rs
@@ -664,10 +664,10 @@ mod tests {
         world.init_resource::<State<SubState>>();
         world.insert_resource(State(TransitionTestingComputedState::IsA));
         let mut schedules = world.remove_resource::<Schedules>().unwrap();
-        let mut apply_changes = schedules.get_mut(StateTransition).unwrap();
-        SimpleState::register_state(&mut apply_changes);
-        SubState::register_sub_state_systems(&mut apply_changes);
-        TransitionTestingComputedState::register_computed_state_systems(&mut apply_changes);
+        let apply_changes = schedules.get_mut(StateTransition).unwrap();
+        SimpleState::register_state(apply_changes);
+        SubState::register_sub_state_systems(apply_changes);
+        TransitionTestingComputedState::register_computed_state_systems(apply_changes);
 
         world.init_resource::<TransitionTracker>();
         fn register_transition(string: &'static str) -> impl Fn(ResMut<TransitionTracker>) {

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -10,7 +10,8 @@ use self::sealed::StateSetSealed;
 use super::{
     computed_states::ComputedStates, internal_apply_state_transition, last_transition, run_enter,
     run_exit, run_transition, sub_states::SubStates, take_next_state, ApplyStateTransition,
-    NextState, State, StateTransitionEvent, StateTransitionSteps, States,
+    EnterSchedules, ExitSchedules, NextState, State, StateTransitionEvent, StateTransitionSteps,
+    States, TransitionSchedules,
 };
 
 mod sealed {
@@ -114,27 +115,35 @@ impl<S: InnerStateSet> StateSet for S {
                 internal_apply_state_transition(event, commands, current_state, new_state);
             };
 
+        schedule.configure_sets((
+            ApplyStateTransition::<T>::default()
+                .in_set(StateTransitionSteps::DependentTransitions)
+                .after(ApplyStateTransition::<S::RawState>::default()),
+            ExitSchedules::<T>::default()
+                .in_set(StateTransitionSteps::ExitSchedules)
+                .before(ExitSchedules::<S::RawState>::default()),
+            TransitionSchedules::<T>::default().in_set(StateTransitionSteps::TransitionSchedules),
+            EnterSchedules::<T>::default()
+                .in_set(StateTransitionSteps::EnterSchedules)
+                .after(EnterSchedules::<S::RawState>::default()),
+        ));
+
         schedule
-            .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
-            .add_systems(
-                last_transition::<T>
-                    .pipe(run_enter::<T>)
-                    .in_set(StateTransitionSteps::EnterSchedules),
-            )
+            .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::default()))
             .add_systems(
                 last_transition::<T>
                     .pipe(run_exit::<T>)
-                    .in_set(StateTransitionSteps::ExitSchedules),
+                    .in_set(ExitSchedules::<T>::default()),
             )
             .add_systems(
                 last_transition::<T>
                     .pipe(run_transition::<T>)
-                    .in_set(StateTransitionSteps::TransitionSchedules),
+                    .in_set(TransitionSchedules::<T>::default()),
             )
-            .configure_sets(
-                ApplyStateTransition::<T>::apply()
-                    .in_set(StateTransitionSteps::DependentTransitions)
-                    .after(ApplyStateTransition::<S::RawState>::apply()),
+            .add_systems(
+                last_transition::<T>
+                    .pipe(run_enter::<T>)
+                    .in_set(EnterSchedules::<T>::default()),
             );
     }
 
@@ -186,27 +195,35 @@ impl<S: InnerStateSet> StateSet for S {
                 internal_apply_state_transition(event, commands, current_state_res, new_state);
             };
 
+        schedule.configure_sets((
+            ApplyStateTransition::<T>::default()
+                .in_set(StateTransitionSteps::DependentTransitions)
+                .after(ApplyStateTransition::<S::RawState>::default()),
+            ExitSchedules::<T>::default()
+                .in_set(StateTransitionSteps::ExitSchedules)
+                .before(ExitSchedules::<S::RawState>::default()),
+            TransitionSchedules::<T>::default().in_set(StateTransitionSteps::TransitionSchedules),
+            EnterSchedules::<T>::default()
+                .in_set(StateTransitionSteps::EnterSchedules)
+                .after(EnterSchedules::<S::RawState>::default()),
+        ));
+
         schedule
-            .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
-            .add_systems(
-                last_transition::<T>
-                    .pipe(run_enter::<T>)
-                    .in_set(StateTransitionSteps::EnterSchedules),
-            )
+            .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::default()))
             .add_systems(
                 last_transition::<T>
                     .pipe(run_exit::<T>)
-                    .in_set(StateTransitionSteps::ExitSchedules),
+                    .in_set(ExitSchedules::<T>::default()),
             )
             .add_systems(
                 last_transition::<T>
                     .pipe(run_transition::<T>)
-                    .in_set(StateTransitionSteps::TransitionSchedules),
+                    .in_set(TransitionSchedules::<T>::default()),
             )
-            .configure_sets(
-                ApplyStateTransition::<T>::apply()
-                    .in_set(StateTransitionSteps::DependentTransitions)
-                    .after(ApplyStateTransition::<S::RawState>::apply()),
+            .add_systems(
+                last_transition::<T>
+                    .pipe(run_enter::<T>)
+                    .in_set(EnterSchedules::<T>::default()),
             );
     }
 }
@@ -243,16 +260,25 @@ macro_rules! impl_state_set_sealed_tuples {
                         internal_apply_state_transition(event, commands, current_state, new_state);
                     };
 
-                schedule
-                    .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
-                    .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
-                    .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
-                    .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
-                    .configure_sets(
-                        ApplyStateTransition::<T>::apply()
+                schedule.configure_sets((
+                    ApplyStateTransition::<T>::default()
                         .in_set(StateTransitionSteps::DependentTransitions)
-                        $(.after(ApplyStateTransition::<$param::RawState>::apply()))*
-                    );
+                        $(.after(ApplyStateTransition::<$param::RawState>::default()))*,
+                    ExitSchedules::<T>::default()
+                        .in_set(StateTransitionSteps::ExitSchedules)
+                        $(.before(ExitSchedules::<$param::RawState>::default()))*,
+                    TransitionSchedules::<T>::default()
+                        .in_set(StateTransitionSteps::TransitionSchedules),
+                    EnterSchedules::<T>::default()
+                        .in_set(StateTransitionSteps::EnterSchedules)
+                        $(.after(EnterSchedules::<$param::RawState>::default()))*,
+                ));
+
+                schedule
+                    .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::default()))
+                    .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(ExitSchedules::<T>::default()))
+                    .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(TransitionSchedules::<T>::default()))
+                    .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(EnterSchedules::<T>::default()));
             }
 
             fn register_sub_state_systems_in_schedule<T: SubStates<SourceStates = Self>>(
@@ -288,16 +314,25 @@ macro_rules! impl_state_set_sealed_tuples {
                         internal_apply_state_transition(event, commands, current_state_res, new_state);
                     };
 
-                schedule
-                    .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::apply()))
-                    .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(StateTransitionSteps::EnterSchedules))
-                    .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(StateTransitionSteps::ExitSchedules))
-                    .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(StateTransitionSteps::TransitionSchedules))
-                    .configure_sets(
-                        ApplyStateTransition::<T>::apply()
+                schedule.configure_sets((
+                    ApplyStateTransition::<T>::default()
                         .in_set(StateTransitionSteps::DependentTransitions)
-                        $(.after(ApplyStateTransition::<$param::RawState>::apply()))*
-                    );
+                        $(.after(ApplyStateTransition::<$param::RawState>::default()))*,
+                    ExitSchedules::<T>::default()
+                        .in_set(StateTransitionSteps::ExitSchedules)
+                        $(.before(ExitSchedules::<$param::RawState>::default()))*,
+                    TransitionSchedules::<T>::default()
+                        .in_set(StateTransitionSteps::TransitionSchedules),
+                    EnterSchedules::<T>::default()
+                        .in_set(StateTransitionSteps::EnterSchedules)
+                        $(.after(EnterSchedules::<$param::RawState>::default()))*,
+                ));
+
+                schedule
+                    .add_systems(apply_state_transition.in_set(ApplyStateTransition::<T>::default()))
+                    .add_systems(last_transition::<T>.pipe(run_exit::<T>).in_set(ExitSchedules::<T>::default()))
+                    .add_systems(last_transition::<T>.pipe(run_transition::<T>).in_set(TransitionSchedules::<T>::default()))
+                    .add_systems(last_transition::<T>.pipe(run_enter::<T>).in_set(EnterSchedules::<T>::default()));
             }
         }
     };

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -150,7 +150,7 @@ pub trait SubStates: States + FreelyMutableState {
     ///
     /// This can either be a single type that implements [`States`], or a tuple
     /// containing multiple types that implement [`States`], or any combination of
-    /// types implementing [`States`] and Options of types implementing [`States`]
+    /// types implementing [`States`] and Options of types implementing [`States`].
     type SourceStates: StateSet;
 
     /// This function gets called whenever one of the [`SourceStates`](Self::SourceStates) changes.

--- a/crates/bevy_state/src/state/transitions.rs
+++ b/crates/bevy_state/src/state/transitions.rs
@@ -53,25 +53,23 @@ pub struct StateTransitionEvent<S: States> {
     pub entered: Option<S>,
 }
 
-/// Applies manual state transitions using [`NextState<S>`].
+/// Applies state transitions and runs transitions schedules in order.
 ///
 /// These system sets are run sequentially, in the order of the enum variants.
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum StateTransitionSteps {
-    /// Parentless states apply their [`NextState<S>`].
-    RootTransitions,
-    /// States with parents apply their computation and [`NextState<S>`].
+    /// States apply their transitions from [`NextState`] and compute functions based on their parent states.
     DependentTransitions,
-    /// Exit schedules are executed in leaf-root order
+    /// Exit schedules are executed in leaf to root order
     ExitSchedules,
     /// Transition schedules are executed in arbitrary order.
     TransitionSchedules,
-    /// Enter schedules are executed in root-leaf order.
+    /// Enter schedules are executed in root to leaf order.
     EnterSchedules,
 }
 
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
-/// Exit schedules are executed.
+/// System set that runs exit schedule(s) for state `S`.
 pub struct ExitSchedules<S: States>(PhantomData<S>);
 
 impl<S: States> Default for ExitSchedules<S> {
@@ -81,7 +79,7 @@ impl<S: States> Default for ExitSchedules<S> {
 }
 
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
-/// Transition schedules are executed.
+/// System set that runs transition schedule(s) for state `S`.
 pub struct TransitionSchedules<S: States>(PhantomData<S>);
 
 impl<S: States> Default for TransitionSchedules<S> {
@@ -91,7 +89,7 @@ impl<S: States> Default for TransitionSchedules<S> {
 }
 
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
-/// Enter schedules are executed.
+/// System set that runs enter schedule(s) for state `S`.
 pub struct EnterSchedules<S: States>(PhantomData<S>);
 
 impl<S: States> Default for EnterSchedules<S> {
@@ -100,7 +98,7 @@ impl<S: States> Default for EnterSchedules<S> {
     }
 }
 
-/// Defines a system set to aid with dependent state ordering.
+/// System set that applies transitions for state `S`.
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct ApplyStateTransition<S: States>(PhantomData<S>);
 
@@ -181,7 +179,6 @@ pub fn setup_state_transitions_in_world(
     let mut schedule = Schedule::new(StateTransition);
     schedule.configure_sets(
         (
-            StateTransitionSteps::RootTransitions,
             StateTransitionSteps::DependentTransitions,
             StateTransitionSteps::ExitSchedules,
             StateTransitionSteps::TransitionSchedules,

--- a/crates/bevy_state/src/state/transitions.rs
+++ b/crates/bevy_state/src/state/transitions.rs
@@ -57,26 +57,56 @@ pub struct StateTransitionEvent<S: States> {
 ///
 /// These system sets are run sequentially, in the order of the enum variants.
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum StateTransitionSteps {
+pub(crate) enum StateTransitionSteps {
     /// Parentless states apply their [`NextState<S>`].
     RootTransitions,
     /// States with parents apply their computation and [`NextState<S>`].
     DependentTransitions,
-    /// Exit schedules are executed.
+    /// Exit schedules are executed in leaf-root order
     ExitSchedules,
-    /// Transition schedules are executed.
+    /// Transition schedules are executed in arbitrary order.
     TransitionSchedules,
-    /// Enter schedules are executed.
+    /// Enter schedules are executed in root-leaf order.
     EnterSchedules,
 }
 
-/// Defines a system set to aid with dependent state ordering
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ApplyStateTransition<S: States>(PhantomData<S>);
+/// Exit schedules are executed.
+pub struct ExitSchedules<S: States>(PhantomData<S>);
 
-impl<S: States> ApplyStateTransition<S> {
-    pub(crate) fn apply() -> Self {
-        Self(PhantomData)
+impl<S: States> Default for ExitSchedules<S> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
+/// Transition schedules are executed.
+pub struct TransitionSchedules<S: States>(PhantomData<S>);
+
+impl<S: States> Default for TransitionSchedules<S> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
+/// Enter schedules are executed.
+pub struct EnterSchedules<S: States>(PhantomData<S>);
+
+impl<S: States> Default for EnterSchedules<S> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+/// Defines a system set to aid with dependent state ordering.
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ApplyStateTransition<S: States>(PhantomData<S>);
+
+impl<S: States> Default for ApplyStateTransition<S> {
+    fn default() -> Self {
+        Self(Default::default())
     }
 }
 

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -72,13 +72,13 @@ mod custom_transitions {
                     // - [`ExitSchedules`] - Ran from leaf-states to root-states,
                     // - [`TransitionSchedules`] - Ran in arbitrary order,
                     // - [`EnterSchedules`] - Ran from root-states to leaf-states.
-                    .in_set(EnterSchedules<S>::default()),
+                    .in_set(EnterSchedules::<S>::default()),
             )
             .add_systems(
                 StateTransition,
                 last_transition::<S>
                     .pipe(run_reexit::<S>)
-                    .in_set(ExitSchedules<S>::default()),
+                    .in_set(ExitSchedules::<S>::default()),
             );
         }
     }

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -13,10 +13,7 @@
 
 use std::marker::PhantomData;
 
-use bevy::{
-    dev_tools::states::*, ecs::schedule::ScheduleLabel, prelude::*,
-    state::state::StateTransitionSteps,
-};
+use bevy::{dev_tools::states::*, ecs::schedule::ScheduleLabel, prelude::*};
 
 use custom_transitions::*;
 
@@ -72,16 +69,16 @@ mod custom_transitions {
                     // State transitions are handled in three ordered steps, exposed as system sets.
                     // We can add our systems to them, which will run the corresponding schedules when they're evaluated.
                     // These are:
-                    // - [`StateTransitionSteps::ExitSchedules`]
-                    // - [`StateTransitionSteps::TransitionSchedules`]
-                    // - [`StateTransitionSteps::EnterSchedules`]
-                    .in_set(StateTransitionSteps::EnterSchedules),
+                    // - [`ExitSchedules`] - Ran from leaf-states to root-states,
+                    // - [`TransitionSchedules`] - Ran in arbitrary order,
+                    // - [`EnterSchedules`] - Ran from root-states to leaf-states.
+                    .in_set(EnterSchedules<S>::default()),
             )
             .add_systems(
                 StateTransition,
                 last_transition::<S>
                     .pipe(run_reexit::<S>)
-                    .in_set(StateTransitionSteps::ExitSchedules),
+                    .in_set(ExitSchedules<S>::default()),
             );
         }
     }


### PR DESCRIPTION
# Objective

Fixes #13711 

## Solution

Introduce smaller, generic system sets for each schedule variant, which are ordered against other generic variants:
- `ExitSchedules<S>` - For `OnExit` schedules, runs from leaf states to root states.
- `TransitionSchedules<S>` - For `OnTransition` schedules, runs in arbitrary order.
- `EnterSchedules<S>` - For `OnEnter` schedules, runs from root states to leaf states.

Also unified `ApplyStateTransition<S>` schedule which works in basically the same way, just for internals.

## Testing

- One test that tests schedule execution order
