### PR TITLE
Fix EntityCommands::despawn docs

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1017,6 +1017,7 @@ impl EntityCommands<'_> {
     }
 
     /// Despawns the entity.
+    /// This will emit a warning if the entity does not exist.
     ///
     /// See [`World::despawn`] for more details.
     ///
@@ -1024,10 +1025,6 @@ impl EntityCommands<'_> {
     ///
     /// This won't clean up external references to the entity (such as parent-child relationships
     /// if you're using `bevy_hierarchy`), which may leave the world in an invalid state.
-    ///
-    /// # Panics
-    ///
-    /// The command will panic when applied if the associated entity does not exist.
     ///
     /// # Example
     ///

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -91,6 +91,7 @@ pub trait DespawnRecursiveExt {
 
 impl DespawnRecursiveExt for EntityCommands<'_> {
     /// Despawns the provided entity and its children.
+    /// This will emit warnings for any entity that does not exist.
     fn despawn_recursive(mut self) {
         let entity = self.id();
         self.commands().add(DespawnRecursive { entity });
@@ -105,6 +106,7 @@ impl DespawnRecursiveExt for EntityCommands<'_> {
 
 impl<'w> DespawnRecursiveExt for EntityWorldMut<'w> {
     /// Despawns the provided entity and its children.
+    /// This will emit warnings for any entity that does not exist.
     fn despawn_recursive(self) {
         let entity = self.id();
 


### PR DESCRIPTION
# Objective

The `EntityCommands::despawn` method was previously changed from panicking behavior to a warning, but the docs continue to state that it panics.

## Solution

- Removed panic section, copied warning blurb from `World::despawn`
- Adds a similar warning blurb to `DespawnRecursiveExt::despawn_recursive` and `DespawnRecursiveExt::despawn_descendants`