### PR TITLE
Fix meshlet vertex attribute interpolation

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -55,11 +55,11 @@ fn mesh_normal_local_to_world(vertex_normal: vec3<f32>, instance_index: u32) -> 
 
 // Calculates the sign of the determinant of the 3x3 model matrix based on a
 // mesh flag
-fn sign_determinant_model_3x3m(instance_index: u32) -> f32 {
+fn sign_determinant_model_3x3m(mesh_flags: u32) -> f32 {
     // bool(u32) is false if 0u else true
     // f32(bool) is 1.0 if true else 0.0
     // * 2.0 - 1.0 remaps 0.0 or 1.0 to -1.0 or 1.0 respectively
-    return f32(bool(mesh[instance_index].flags & MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT)) * 2.0 - 1.0;
+    return f32(bool(mesh_flags & MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT)) * 2.0 - 1.0;
 }
 
 fn mesh_tangent_local_to_world(world_from_local: mat4x4<f32>, vertex_tangent: vec4<f32>, instance_index: u32) -> vec4<f32> {
@@ -76,12 +76,12 @@ fn mesh_tangent_local_to_world(world_from_local: mat4x4<f32>, vertex_tangent: ve
                 mat3x3<f32>(
                     world_from_local[0].xyz,
                     world_from_local[1].xyz,
-                    world_from_local[2].xyz
+                    world_from_local[2].xyz,
                 ) * vertex_tangent.xyz
             ),
             // NOTE: Multiplying by the sign of the determinant of the 3x3 model matrix accounts for
             // situations such as negative scaling.
-            vertex_tangent.w * sign_determinant_model_3x3m(instance_index)
+            vertex_tangent.w * sign_determinant_model_3x3m(mesh[instance_index].flags)
         );
     } else {
         return vertex_tangent;


### PR DESCRIPTION
# Objective

- Mikktspace requires that we normalize world normals/tangents _before_ interpolation across vertices, and then do _not_ normalize after. I had it backwards. 
- We do not (am not supposed to?) need a second set of barycentrics for motion vectors. If you think about the typical raster pipeline, in the vertex shader we calculate previous_world_position, and then it gets interpolated using the current triangle's barycentrics.

## Solution

- Fix normal/tangent processing 
- Reuse barycentrics for motion vector calculations
- Not implementing this for 0.14, but long term I aim to remove explicit vertex tangents and calculate them in the shader on the fly.

## Testing

- I tested out some of the normal maps we have in repo. Didn't seem to make a difference, but mikktspace is all about correctness across various baking tools. I probably just didn't have any of the ones that would cause it to break.
- Didn't test motion vectors as there's a known bug with the depth buffer and meshlets that I'm waiting on the render graph rewrite to fix.