### PR TITLE
Sample `Transform` from an `AnimationClip`

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -18,14 +18,12 @@ use std::hash::{Hash, Hasher};
 use std::iter;
 use std::ops::{Add, Mul};
 
-use animatable::Animatable;
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_asset::{Asset, AssetApp, Assets, Handle};
 use bevy_core::Name;
 use bevy_ecs::entity::MapEntities;
 use bevy_ecs::prelude::*;
 use bevy_ecs::reflect::ReflectMapEntities;
-use bevy_ecs::system::QueryLens;
 use bevy_hierarchy::Parent;
 use bevy_math::{FloatExt, Quat, Vec3};
 use bevy_reflect::Reflect;

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -157,7 +157,7 @@ impl VariableCurve {
         Some(step_start)
     }
 
-    /// Write the output of this [`VariableCurve`] at `seek_time` to a [`Transform`] component, with influence, `influence`.
+    /// Write the output of this [`VariableCurve`] at `seek_time` to a [`Transform`] component with influence `influence`.
     pub fn write_to_transform(&self, seek_time: f32, influence: f32, transform: &mut Transform) {
         let Some((idx, fac, step_duration)) = (match self.find_current_keyframe(seek_time) {
             Some(idx) => (|| {


### PR DESCRIPTION
# Objective

Allow users to obtain transform information from an animation without animating.

## Solution

Added the ability to sample `Transform` from an `AnimationClip` at a given time.

## Testing

TODO

## Changelog

* Added `sample_transform_at` to `AnimationClip`.
* Added `write_to_transform` to `VariableCurve`.
