### PR TITLE
Added an illustration to the compass direction docs (issue 13664)

### DIFF
--- a/crates/bevy_math/src/compass.rs
+++ b/crates/bevy_math/src/compass.rs
@@ -5,7 +5,7 @@ use bevy_reflect::Reflect;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// A compass enum with 4 directions.
-/// ``` ignore 
+/// ``` ignore
 ///          N (North)
 ///          ▲
 ///          │
@@ -35,7 +35,7 @@ pub enum CompassQuadrant {
 }
 
 /// A compass enum with 8 directions.
-/// ``` ignore 
+/// ``` ignore
 ///          N (North)
 ///          ▲
 ///     NW   │   NE

--- a/crates/bevy_math/src/compass.rs
+++ b/crates/bevy_math/src/compass.rs
@@ -5,6 +5,17 @@ use bevy_reflect::Reflect;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// A compass enum with 4 directions.
+/// ```
+///          N (North)
+///          ▲
+///          │
+///          │
+/// W (West) ┼─────► E (East)
+///          │
+///          │
+///          ▼
+///          S (South)
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
@@ -24,6 +35,17 @@ pub enum CompassQuadrant {
 }
 
 /// A compass enum with 8 directions.
+/// ```
+///          N (North)
+///          ▲
+///     NW   │   NE
+///        ╲ │ ╱
+/// W (West) ┼─────► E (East)
+///        ╱ │ ╲
+///     SW   │   SE
+///          ▼
+///          S (South)
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]

--- a/crates/bevy_math/src/compass.rs
+++ b/crates/bevy_math/src/compass.rs
@@ -5,7 +5,7 @@ use bevy_reflect::Reflect;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// A compass enum with 4 directions.
-/// ```
+/// ``` ignore 
 ///          N (North)
 ///          ▲
 ///          │
@@ -35,7 +35,7 @@ pub enum CompassQuadrant {
 }
 
 /// A compass enum with 8 directions.
-/// ```
+/// ``` ignore 
 ///          N (North)
 ///          ▲
 ///     NW   │   NE


### PR DESCRIPTION
i based the design on @mgi388 in the discussion about the issue.
i added the illustration in such a way that it shows up when you hover your mouse over the type, i hope this is what was meant by the issue
no unit tests were added bc obviously

Fixes #13664