### PR TITLE
Use a unstable sort to sort component ids in `bevy_ecs`

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -310,7 +310,7 @@ impl BundleInfo {
         id: BundleId,
     ) -> BundleInfo {
         let mut deduped = component_ids.clone();
-        deduped.sort();
+        deduped.sort_unstable();
         deduped.dedup();
 
         if deduped.len() != component_ids.len() {
@@ -475,7 +475,7 @@ impl BundleInfo {
                 } else {
                     new_table_components.extend(current_archetype.table_components());
                     // sort to ignore order while hashing
-                    new_table_components.sort();
+                    new_table_components.sort_unstable();
                     // SAFETY: all component ids in `new_table_components` exist
                     table_id = unsafe {
                         storages
@@ -491,7 +491,7 @@ impl BundleInfo {
                 } else {
                     new_sparse_set_components.extend(current_archetype.sparse_set_components());
                     // sort to ignore order while hashing
-                    new_sparse_set_components.sort();
+                    new_sparse_set_components.sort_unstable();
                     new_sparse_set_components
                 };
             };

--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -320,8 +320,7 @@ where
                     // unblock this node's ancestors
                     while let Some(n) = unblock_stack.pop() {
                         if blocked.remove(&n) {
-                            let unblock_predecessors =
-                                unblock_together.entry(n).or_insert_with(HashSet::new);
+                            let unblock_predecessors = unblock_together.entry(n).or_default();
                             unblock_stack.extend(unblock_predecessors.iter());
                             unblock_predecessors.clear();
                         }
@@ -329,10 +328,7 @@ where
                 } else {
                     // if its descendants can be unblocked later, this node will be too
                     for successor in subgraph.neighbors(*node) {
-                        unblock_together
-                            .entry(successor)
-                            .or_insert_with(HashSet::new)
-                            .insert(*node);
+                        unblock_together.entry(successor).or_default().insert(*node);
                     }
                 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2338,8 +2338,8 @@ unsafe fn remove_bundle_from_archetype(
 
             // sort removed components so we can do an efficient "sorted remove". archetype
             // components are already sorted
-            removed_table_components.sort();
-            removed_sparse_set_components.sort();
+            removed_table_components.sort_unstable();
+            removed_sparse_set_components.sort_unstable();
             next_table_components = current_archetype.table_components().collect();
             next_sparse_set_components = current_archetype.sparse_set_components().collect();
             sorted_remove(&mut next_table_components, &removed_table_components);


### PR DESCRIPTION
# Objective

While writing code for the `bevy_ecs` I noticed we were using a unnecessarily stable sort to sort component ids

## Solution

- Sort component ids with a unstable sort
- Comb the bevy_ecs crate for any other obvious inefficiencies.
- Don't clone component vectors when inserting an archetype.

## Testing

I ran `cargo test -p bevy_ecs`. Everything else I leave to CI.

## Profiling

I measured about a 1% speed increase when spawning entities directly into a world. Since the difference is so small (and might just be noise) I didn't bother to figure out which of change if any made the biggest difference. 
<details>
<summary> Tracy data </summary>
Yellow is this PR. Red is the commit I branched from.

![image](https://github.com/bevyengine/bevy/assets/59848927/f1a5c95d-a882-4dfb-ac07-dd2922273b91)

</details>

<details>
<summary>Methodology</summary>
I created a system that spawn a 1000 entities each with the same 30 components each frame, and then I measured it's run time. The unusually high number of components was chosen because the standard library [will use a insertion sort for slices under 20 elements](https://github.com/rust-lang/rust/blob/0de24a5177b1d49d6304f76f3ab159faaec134f9/library/core/src/slice/sort.rs#L1048-L1049). This holds for both stable and unstable sorts.
</details>


