### PR TITLE
Add `from_color` to `StandardMaterial` and `ColorMaterial`

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -747,6 +747,11 @@ impl StandardMaterial {
         self.flip(horizontal, vertical);
         self
     }
+
+    /// Creates a new material from a given color
+    pub fn from_color(color: impl Into<Color>) -> Self {
+        Self::from(color.into())
+    }
 }
 
 impl Default for StandardMaterial {

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -51,6 +51,13 @@ pub struct ColorMaterial {
     pub texture: Option<Handle<Image>>,
 }
 
+impl ColorMaterial {
+    /// Creates a new material from a given color
+    pub fn from_color(color: impl Into<Color>) -> Self {
+        Self::from(color.into())
+    }
+}
+
 impl Default for ColorMaterial {
     fn default() -> Self {
         ColorMaterial {


### PR DESCRIPTION
# Objective

Closes #13738

## Solution

Added `from_color` to materials that would support it. Didn't add `from_color` to `WireframeMaterial` as it doesn't seem we expect users to be constructing them themselves.

## Testing

None

---

## Changelog

### Added

- `from_color` to `StandardMaterial` so you can construct this material from any color type.
- `from_color` to `ColorMaterial` so you can construct this material from any color type.

