### PR TITLE
derive(SystemParam) better lifetime param (#10331)

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -275,11 +275,11 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
 }
 
 // replace 'world with 'w and 'state with 's
-fn replace_lifetimes(stream: TokenStream, f: &dyn Fn(&str) -> &str) -> TokenStream {
-    struct LifetimeReplacer<'a> {
-        f: Box<&'a dyn Fn(&str) -> &str>,
+fn replace_lifetimes(stream: TokenStream, f: Box<dyn Fn(&str) -> &str>) -> TokenStream {
+    struct LifetimeReplacer {
+        f: Box<dyn Fn(&str) -> &str>,
     }
-    impl VisitMut for LifetimeReplacer<'_> {
+    impl VisitMut for LifetimeReplacer {
         fn visit_lifetime_mut(&mut self, lifetime: &mut syn::Lifetime) {
             lifetime.ident = syn::Ident::new(
                 (self.f)(lifetime.ident.to_string().as_str()),
@@ -289,7 +289,7 @@ fn replace_lifetimes(stream: TokenStream, f: &dyn Fn(&str) -> &str) -> TokenStre
     }
 
     let mut ast = parse_macro_input!(stream as DeriveInput);
-    LifetimeReplacer { f: Box::new(f) }.visit_derive_input_mut(&mut ast);
+    LifetimeReplacer { f }.visit_derive_input_mut(&mut ast);
 
     quote! {#ast}.into()
 }
@@ -297,11 +297,14 @@ fn replace_lifetimes(stream: TokenStream, f: &dyn Fn(&str) -> &str) -> TokenStre
 /// Implement `SystemParam` to use a struct as a parameter in a system
 #[proc_macro_derive(SystemParam, attributes(system_param))]
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
-    let input = replace_lifetimes(input, &|s| match s {
-        "world" => "w",
-        "state" => "s",
-        other => other,
-    });
+    let input = replace_lifetimes(
+        input,
+        Box::new(|s| match s {
+            "world" => "w",
+            "state" => "s",
+            other => other,
+        }),
+    );
     let token_stream = input.clone();
     let ast = parse_macro_input!(input as DeriveInput);
     let syn::Data::Struct(syn::DataStruct {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -141,7 +141,7 @@ use std::{
 /// #    query: Query<'world, 'state, Entity>,
 /// #    res: Res<'world, SomeResource>,
 /// #    res_mut: ResMut<'world, SomeOtherResource>,
-/// #    local: Local<'state, u8>,
+/// #    world: Local<'state, u8>,
 /// #    commands: Commands<'world, 'state>,
 /// #    eventreader: EventReader<'world, 'state, SomeEvent>,
 /// #    eventwriter: EventWriter<'world, SomeEvent>

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -37,7 +37,7 @@ use std::{
 /// Derived `SystemParam` structs may have two lifetimes: `'w` for data stored in the [`World`],
 /// and `'s` for data stored in the parameter's state.
 /// instead of `'w` and `'s`, you are permitted to use `'world` and `'state`
-/// 
+///
 /// The following list shows the most common [`SystemParam`]s and which lifetime they require
 ///
 /// ```
@@ -125,7 +125,7 @@ use std::{
 ///   by [`SystemParam::get_param`] with the provided [`system_meta`](SystemMeta).
 /// - None of the world accesses may conflict with any prior accesses registered
 ///   on `system_meta`.
-/// 
+///
 /// Doc test to ensure that 'world and 'state are permitted aswell
 /// ```
 /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -36,7 +36,8 @@ use std::{
 ///
 /// Derived `SystemParam` structs may have two lifetimes: `'w` for data stored in the [`World`],
 /// and `'s` for data stored in the parameter's state.
-///
+/// instead of `'w` and `'s`, you are permitted to use `'world` and `'state`
+/// 
 /// The following list shows the most common [`SystemParam`]s and which lifetime they require
 ///
 /// ```
@@ -124,6 +125,28 @@ use std::{
 ///   by [`SystemParam::get_param`] with the provided [`system_meta`](SystemMeta).
 /// - None of the world accesses may conflict with any prior accesses registered
 ///   on `system_meta`.
+/// 
+/// Doc test to ensure that 'world and 'state are permitted aswell
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # #[derive(Resource)]
+/// # struct SomeResource;
+/// # #[derive(Event)]
+/// # struct SomeEvent;
+/// # #[derive(Resource)]
+/// # struct SomeOtherResource;
+/// # use bevy_ecs::system::SystemParam;
+/// # #[derive(SystemParam)]
+/// # struct ParamsExample<'world, 'state> {
+/// #    query: Query<'world, 'state, Entity>,
+/// #    res: Res<'world, SomeResource>,
+/// #    res_mut: ResMut<'world, SomeOtherResource>,
+/// #    local: Local<'state, u8>,
+/// #    commands: Commands<'world, 'state>,
+/// #    eventreader: EventReader<'world, 'state, SomeEvent>,
+/// #    eventwriter: EventWriter<'world, SomeEvent>
+/// # }
+/// ```
 pub unsafe trait SystemParam: Sized {
     /// Used to store data which persists across invocations of a system.
     type State: Send + Sync + 'static;

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 toml_edit = { version = "0.22.7", default-features = false, features = [
   "parse",
 ] }
-syn = "2.0"
+syn = {version = "2.0", features = ["visit-mut"]}
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 toml_edit = { version = "0.22.7", default-features = false, features = [
   "parse",
 ] }
-syn = {version = "2.0", features = ["visit-mut"]}
+syn = { version = "2.0", features = ["visit-mut"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
previously, only 'w and 's lifetime parameters were permitted. now, 'world and 'state are permitted aswell.
this is achieved by replacing every occurrence of 'world with 'w, and 'state with 's.
I also updated the documentation to inform the user that they may use these new lifetimes now.
That is, in the compiler error message, and in the description of the trait (idk if there are more places that i should have updated).

it seems like a hack, and I am not confident if this is the perfect and best way to solve the issue. Especially since I modified the Cargo.toml in bevy_macro_utils
And it took me way longer than id like to admit bc I thought I was smarter than ChatGpt lol

## Testing
I wrote some boilerplate code in the trait documentation in such a way that its hidden to the user. It seems like a hack aswell, but idk how else to unit test if code compiles

fixes #10331