### PR TITLE
Checking points when creating CubicBezier (#13726)

### DIFF
--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -31,6 +31,7 @@ pub trait VectorSpace:
     + Debug
     + Clone
     + Copy
+    + PartialEq
 {
     /// The zero vector, which is the identity of addition for the vector space type.
     const ZERO: Self;

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -40,7 +40,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 ///     vec2(5.0, 3.0),
 ///     vec2(9.0, 8.0),
 /// ]];
-/// let bezier = CubicBezier::new(points).to_curve();
+/// let bezier = CubicBezier::new(points).unwrap().to_curve();
 /// let positions: Vec<_> = bezier.iter_positions(100).collect();
 /// ```
 #[derive(Clone, Debug)]
@@ -52,12 +52,32 @@ pub struct CubicBezier<P: VectorSpace> {
 
 impl<P: VectorSpace> CubicBezier<P> {
     /// Create a new cubic Bezier curve from sets of control points.
-    pub fn new(control_points: impl Into<Vec<[P; 4]>>) -> Self {
-        Self {
-            control_points: control_points.into(),
+    pub fn new(control_points: impl Into<Vec<[P; 4]>>) -> Option<Self> {
+        let control_points = control_points.into();
+        
+        // check the vertecies are connected
+        let mut index = 1;
+        while index < control_points.len() {
+            let prev: &P = &(&control_points[index - 1])[4];
+            let next: &P = &(&control_points[index])[0];
+            if prev != next {
+                return None;
+            }
+            index += 1;
         }
+
+        Some(Self { control_points })
     }
 }
+
+// impl<P: VectorSpace> CubicBezier<P> {
+//     /// Create a new cubic Bezier curve from sets of control points.
+//     pub fn new(control_points: impl Into<Vec<[P; 4]>>) -> Self {
+//         Self {
+//             control_points: control_points.into(),
+//         }
+//     }
+// }
 impl<P: VectorSpace> CubicGenerator<P> for CubicBezier<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
@@ -710,7 +730,7 @@ impl CubicSegment<Vec2> {
     /// example, the ubiquitous "ease-in-out" is defined as `(0.25, 0.1), (0.25, 1.0)`.
     pub fn new_bezier(p1: impl Into<Vec2>, p2: impl Into<Vec2>) -> Self {
         let (p0, p3) = (Vec2::ZERO, Vec2::ONE);
-        let bezier = CubicBezier::new([[p0, p1.into(), p2.into(), p3]]).to_curve();
+        let bezier = CubicBezier::new([[p0, p1.into(), p2.into(), p3]]).unwrap().to_curve();
         bezier.segments[0]
     }
 
@@ -1253,11 +1273,23 @@ mod tests {
             vec2(5.0, 3.0),
             vec2(9.0, 8.0),
         ]];
-        let bezier = CubicBezier::new(points).to_curve();
+        let bezier = CubicBezier::new(points).unwrap().to_curve();
         for i in 0..=N_SAMPLES {
             let t = i as f32 / N_SAMPLES as f32; // Check along entire length
             assert!(bezier.position(t).distance(cubic_manual(t, points[0])) <= FLOAT_EQ);
         }
+    }
+
+    /// No Bezier can be constructed,
+    #[test]
+    fn cubic_fail(){
+
+    }
+
+    #[TEST]
+    fn cubic_empty(){
+        let points = [[]];
+        let bezier = CubicBezier::new(points).unwrap();
     }
 
     /// Manual, hardcoded function for computing the position along a cubic bezier.

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1285,9 +1285,7 @@ mod tests {
     fn cubic_empty() {
         let points: [[glam::Vec4; 4]; 0] = [];
         let bezier = CubicBezier::new(points);
-        if let Some(_) = bezier {
-            assert!(false);
-        }
+        assert!(bezier.is_none());
     }
 
     #[test]
@@ -1313,11 +1311,9 @@ mod tests {
                 glam::Vec4::new(0., 1., 0., 1.),
             ],
         ];
-        assert!(&(&points[0])[3] != &(&points[1])[0]);
+        assert!((&points[0])[3] != (&points[1])[0]);
         let bezier = CubicBezier::new(points);
-        if let Some(_) = bezier {
-            assert!(false);
-        }
+        assert!(bezier.is_none());
     }
 
     /// Manual, hardcoded function for computing the position along a cubic bezier.


### PR DESCRIPTION
when calling CubicBezier::new, we both check if the points provided are empty,
or if the points are discontinuous.
in both cases, we now return None.

keep in mind that I added PartialEq to the VectorSpace (so i will have to modify the documentation later).
I dont think its the best solution, and its more something of a conversation starter.

Fixes #13726