### PR TITLE
Ensure that events are updated even when using a bare-bones Bevy App

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -925,7 +925,7 @@ mod tests {
         change_detection::{DetectChanges, ResMut},
         component::Component,
         entity::Entity,
-        event::{signal_event_update_system, Event, EventWriter, Events},
+        event::{Event, EventWriter, Events},
         query::With,
         removal_detection::RemovedComponents,
         schedule::{IntoSystemConfigs, ScheduleLabel},
@@ -933,7 +933,7 @@ mod tests {
         world::{FromWorld, World},
     };
 
-    use crate::{App, AppExit, Last, Plugin, SubApp, Update};
+    use crate::{App, AppExit, Plugin, SubApp, Update};
 
     struct PluginA;
     impl Plugin for PluginA {
@@ -1281,8 +1281,6 @@ mod tests {
         struct TestEvent;
 
         let mut app = App::new();
-        // Without minimal plugins, we need to make sure that this system is added
-        app.add_systems(Last, signal_event_update_system);
         app.add_event::<TestEvent>();
 
         // Starts empty

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -925,7 +925,7 @@ mod tests {
         change_detection::{DetectChanges, ResMut},
         component::Component,
         entity::Entity,
-        event::{signal_event_update_system, Event, EventWriter},
+        event::{signal_event_update_system, Event, EventWriter, Events},
         query::With,
         removal_detection::RemovedComponents,
         schedule::{IntoSystemConfigs, ScheduleLabel},
@@ -1280,39 +1280,37 @@ mod tests {
         #[derive(Event, Clone)]
         struct TestEvent;
 
-        println!("Starting test");
-
         let mut app = App::new();
         // Without minimal plugins, we need to make sure that this system is added
         app.add_systems(Last, signal_event_update_system);
         app.add_event::<TestEvent>();
 
         // Starts empty
-        //let test_events = app.world().resource::<Events<TestEvent>>();
-        //assert_eq!(test_events.len(), 0);
-        //assert_eq!(test_events.iter_current_update_events().count(), 0);
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 0);
+        assert_eq!(test_events.iter_current_update_events().count(), 0);
         app.update();
 
         // Sending one event
         app.world_mut().send_event(TestEvent);
 
-        //let test_events = app.world().resource::<Events<TestEvent>>();
-        //assert_eq!(test_events.len(), 1);
-        //assert_eq!(test_events.iter_current_update_events().count(), 1);
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 1);
+        assert_eq!(test_events.iter_current_update_events().count(), 1);
         app.update();
 
         // Sending two events on the next frame
         app.world_mut().send_event(TestEvent);
         app.world_mut().send_event(TestEvent);
 
-        //let test_events = app.world().resource::<Events<TestEvent>>();
-        //assert_eq!(test_events.len(), 3); // Events are double-buffered, so we see 1 + 2 = 3
-        //assert_eq!(test_events.iter_current_update_events().count(), 2);
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 3); // Events are double-buffered, so we see 1 + 2 = 3
+        assert_eq!(test_events.iter_current_update_events().count(), 2);
         app.update();
 
         // Sending zero events
-        //let test_events = app.world().resource::<Events<TestEvent>>();
-        //assert_eq!(test_events.len(), 2); // Events are double-buffered, so we see 2 + 0 = 2
-        //assert_eq!(test_events.iter_current_update_events().count(), 0);
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 2); // Events are double-buffered, so we see 2 + 0 = 2
+        assert_eq!(test_events.iter_current_update_events().count(), 0);
     }
 }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -925,7 +925,7 @@ mod tests {
         change_detection::{DetectChanges, ResMut},
         component::Component,
         entity::Entity,
-        event::{Event, EventWriter, Events},
+        event::{Event, EventWriter},
         query::With,
         removal_detection::RemovedComponents,
         schedule::{IntoSystemConfigs, ScheduleLabel},
@@ -1280,35 +1280,37 @@ mod tests {
         #[derive(Event, Clone)]
         struct TestEvent;
 
+        println!("Starting test");
+
         let mut app = App::new();
         app.add_event::<TestEvent>();
 
         // Starts empty
-        let test_events = app.world().resource::<Events<TestEvent>>();
-        assert_eq!(test_events.len(), 0);
-        assert_eq!(test_events.iter_current_update_events().count(), 0);
+        //let test_events = app.world().resource::<Events<TestEvent>>();
+        //assert_eq!(test_events.len(), 0);
+        //assert_eq!(test_events.iter_current_update_events().count(), 0);
         app.update();
 
         // Sending one event
         app.world_mut().send_event(TestEvent);
 
-        let test_events = app.world().resource::<Events<TestEvent>>();
-        assert_eq!(test_events.len(), 1);
-        assert_eq!(test_events.iter_current_update_events().count(), 1);
+        //let test_events = app.world().resource::<Events<TestEvent>>();
+        //assert_eq!(test_events.len(), 1);
+        //assert_eq!(test_events.iter_current_update_events().count(), 1);
         app.update();
 
         // Sending two events on the next frame
         app.world_mut().send_event(TestEvent);
         app.world_mut().send_event(TestEvent);
 
-        let test_events = app.world().resource::<Events<TestEvent>>();
-        assert_eq!(test_events.len(), 3); // Events are double-buffered, so we see 1 + 2 = 3
-        assert_eq!(test_events.iter_current_update_events().count(), 2);
+        //let test_events = app.world().resource::<Events<TestEvent>>();
+        //assert_eq!(test_events.len(), 3); // Events are double-buffered, so we see 1 + 2 = 3
+        //assert_eq!(test_events.iter_current_update_events().count(), 2);
         app.update();
 
         // Sending zero events
-        let test_events = app.world().resource::<Events<TestEvent>>();
-        assert_eq!(test_events.len(), 2); // Events are double-buffered, so we see 2 + 0 = 2
-        assert_eq!(test_events.iter_current_update_events().count(), 0);
+        //let test_events = app.world().resource::<Events<TestEvent>>();
+        //assert_eq!(test_events.len(), 2); // Events are double-buffered, so we see 2 + 0 = 2
+        //assert_eq!(test_events.iter_current_update_events().count(), 0);
     }
 }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -925,7 +925,7 @@ mod tests {
         change_detection::{DetectChanges, ResMut},
         component::Component,
         entity::Entity,
-        event::{Event, EventWriter},
+        event::{signal_event_update_system, Event, EventWriter},
         query::With,
         removal_detection::RemovedComponents,
         schedule::{IntoSystemConfigs, ScheduleLabel},
@@ -933,7 +933,7 @@ mod tests {
         world::{FromWorld, World},
     };
 
-    use crate::{App, AppExit, Plugin, SubApp, Update};
+    use crate::{App, AppExit, Last, Plugin, SubApp, Update};
 
     struct PluginA;
     impl Plugin for PluginA {
@@ -1283,6 +1283,8 @@ mod tests {
         println!("Starting test");
 
         let mut app = App::new();
+        // Without minimal plugins, we need to make sure that this system is added
+        app.add_systems(Last, signal_event_update_system);
         app.add_event::<TestEvent>();
 
         // Starts empty

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -925,7 +925,7 @@ mod tests {
         change_detection::{DetectChanges, ResMut},
         component::Component,
         entity::Entity,
-        event::EventWriter,
+        event::{Event, EventWriter, Events},
         query::With,
         removal_detection::RemovedComponents,
         schedule::{IntoSystemConfigs, ScheduleLabel},
@@ -1273,5 +1273,42 @@ mod tests {
         App::new()
             .init_non_send_resource::<NonSendTestResource>()
             .init_resource::<TestResource>();
+    }
+
+    #[test]
+    fn events_should_be_updated_once_per_update() {
+        #[derive(Event, Clone)]
+        struct TestEvent;
+
+        let mut app = App::new();
+        app.add_event::<TestEvent>();
+
+        // Starts empty
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 0);
+        assert_eq!(test_events.iter_current_update_events().count(), 0);
+        app.update();
+
+        // Sending one event
+        app.world_mut().send_event(TestEvent);
+
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 1);
+        assert_eq!(test_events.iter_current_update_events().count(), 1);
+        app.update();
+
+        // Sending two events on the next frame
+        app.world_mut().send_event(TestEvent);
+        app.world_mut().send_event(TestEvent);
+
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 3); // Events are double-buffered, so we see 1 + 2 = 3
+        assert_eq!(test_events.iter_current_update_events().count(), 2);
+        app.update();
+
+        // Sending zero events
+        let test_events = app.world().resource::<Events<TestEvent>>();
+        assert_eq!(test_events.len(), 2); // Events are double-buffered, so we see 2 + 0 = 2
+        assert_eq!(test_events.iter_current_update_events().count(), 0);
     }
 }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -307,6 +307,7 @@ impl SubApp {
     {
         if !self.world.contains_resource::<Events<T>>() {
             EventRegistry::register_event::<T>(self.world_mut());
+            println!("Registered event: {:?}", std::any::type_name::<T>());
         }
 
         self

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -307,7 +307,6 @@ impl SubApp {
     {
         if !self.world.contains_resource::<Events<T>>() {
             EventRegistry::register_event::<T>(self.world_mut());
-            println!("Registered event: {:?}", std::any::type_name::<T>());
         }
 
         self

--- a/crates/bevy_ecs/src/event/collections.rs
+++ b/crates/bevy_ecs/src/event/collections.rs
@@ -172,8 +172,6 @@ impl<E: Event> Events<E> {
     ///
     /// If you need access to the events that were removed, consider using [`Events::update_drain`].
     pub fn update(&mut self) {
-        println!("Updating events!");
-
         std::mem::swap(&mut self.events_a, &mut self.events_b);
         self.events_b.clear();
         self.events_b.start_event_count = self.event_count;

--- a/crates/bevy_ecs/src/event/collections.rs
+++ b/crates/bevy_ecs/src/event/collections.rs
@@ -172,6 +172,8 @@ impl<E: Event> Events<E> {
     ///
     /// If you need access to the events that were removed, consider using [`Events::update_drain`].
     pub fn update(&mut self) {
+        println!("Updating events!");
+
         std::mem::swap(&mut self.events_a, &mut self.events_b);
         self.events_b.clear();
         self.events_b.start_event_count = self.event_count;

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -13,7 +13,7 @@ pub use bevy_ecs_macros::Event;
 pub use collections::{Events, SendBatchIds};
 pub use iterators::{EventIterator, EventIteratorWithId, EventParIter};
 pub use reader::{EventReader, ManualEventReader};
-pub use registry::EventRegistry;
+pub use registry::{EventRegistry, ShouldUpdateEvents};
 pub use update::{
     event_update_condition, event_update_system, signal_event_update_system, EventUpdates,
 };

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -29,7 +29,7 @@ pub struct EventRegistry {
 }
 
 /// Controls whether or not the events in an [`EventRegistry`] should be updated.
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShouldUpdateEvents {
     /// Without any fixed timestep, events should always be updated each frame.
     #[default]

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -8,7 +8,6 @@ use bevy_ecs::{
 };
 
 #[doc(hidden)]
-#[derive(Debug)]
 struct RegisteredEvent {
     component_id: ComponentId,
     // Required to flush the secondary buffer and drop events even if left unchanged.
@@ -20,7 +19,7 @@ struct RegisteredEvent {
 
 /// A registry of all of the [`Events`] in the [`World`], used by [`event_update_system`]
 /// to update all of the events.
-#[derive(Resource, Default, Debug)]
+#[derive(Resource, Default)]
 pub struct EventRegistry {
     pub(super) needs_update: bool,
     event_updates: Vec<RegisteredEvent>,
@@ -47,11 +46,7 @@ impl EventRegistry {
 
     /// Updates all of the registered events in the World.
     pub fn run_updates(&mut self, world: &mut World, last_change_tick: Tick) {
-        println!("Running event updates");
-
         for registered_event in &mut self.event_updates {
-            println!("Checking if we should update an event");
-
             // Bypass the type ID -> Component ID lookup with the cached component ID.
             if let Some(events) = world.get_resource_mut_by_id(registered_event.component_id) {
                 let has_changed = events.has_changed_since(last_change_tick);

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
 };
 
 #[doc(hidden)]
+#[derive(Debug)]
 struct RegisteredEvent {
     component_id: ComponentId,
     // Required to flush the secondary buffer and drop events even if left unchanged.
@@ -19,7 +20,7 @@ struct RegisteredEvent {
 
 /// A registry of all of the [`Events`] in the [`World`], used by [`event_update_system`]
 /// to update all of the events.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Debug)]
 pub struct EventRegistry {
     pub(super) needs_update: bool,
     event_updates: Vec<RegisteredEvent>,
@@ -46,7 +47,11 @@ impl EventRegistry {
 
     /// Updates all of the registered events in the World.
     pub fn run_updates(&mut self, world: &mut World, last_change_tick: Tick) {
+        println!("Running event updates");
+
         for registered_event in &mut self.event_updates {
+            println!("Checking if we should update an event");
+
             // Bypass the type ID -> Component ID lookup with the cached component ID.
             if let Some(events) = world.get_resource_mut_by_id(registered_event.component_id) {
                 let has_changed = events.has_changed_since(last_change_tick);

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -17,17 +17,20 @@ struct RegisteredEvent {
     update: unsafe fn(MutUntyped),
 }
 
-/// A registry of all of the [`Events`] in the [`World`], used by [`event_update_system`]
+/// A registry of all of the [`Events`] in the [`World`], used by [`event_update_system`](crate::event::update::event_update_system)
 /// to update all of the events.
 #[derive(Resource, Default)]
 pub struct EventRegistry {
-    pub(super) needs_update: ShouldUpdateEvents,
+    /// Should the events be updated?
+    ///
+    /// This field is generally automatically updated by the [`signal_event_update_system`](crate::event::update::signal_event_update_system).
+    pub should_update: ShouldUpdateEvents,
     event_updates: Vec<RegisteredEvent>,
 }
 
-/// Controls whether or not the events should be updated.
+/// Controls whether or not the events in an [`EventRegistry`] should be updated.
 #[derive(Default)]
-pub(crate) enum ShouldUpdateEvents {
+pub enum ShouldUpdateEvents {
     /// Without any fixed timestep, events should always be updated each frame.
     #[default]
     Always,

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -21,8 +21,20 @@ struct RegisteredEvent {
 /// to update all of the events.
 #[derive(Resource, Default)]
 pub struct EventRegistry {
-    pub(super) needs_update: bool,
+    pub(super) needs_update: ShouldUpdateEvents,
     event_updates: Vec<RegisteredEvent>,
+}
+
+/// Controls whether or not the events should be updated.
+#[derive(Default)]
+pub(crate) enum ShouldUpdateEvents {
+    /// Without any fixed timestep shenanigans, events should always be updated each frame.
+    #[default]
+    AlwaysUpdate,
+    /// We need to wait until at least one pass of the fixed update schedules to update the events.
+    WaitingToUpdate,
+    /// At least one pass of the fixed update schedules has occurred, and the events are ready to be updated.
+    ReadyToUpdate,
 }
 
 impl EventRegistry {

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -30,11 +30,11 @@ pub struct EventRegistry {
 pub(crate) enum ShouldUpdateEvents {
     /// Without any fixed timestep shenanigans, events should always be updated each frame.
     #[default]
-    AlwaysUpdate,
+    Always,
     /// We need to wait until at least one pass of the fixed update schedules to update the events.
-    WaitingToUpdate,
+    Waiting,
     /// At least one pass of the fixed update schedules has occurred, and the events are ready to be updated.
-    ReadyToUpdate,
+    Ready,
 }
 
 impl EventRegistry {

--- a/crates/bevy_ecs/src/event/update.rs
+++ b/crates/bevy_ecs/src/event/update.rs
@@ -22,7 +22,7 @@ pub struct EventUpdates;
 /// Normally, this will simply run every frame.
 pub fn signal_event_update_system(signal: Option<ResMut<EventRegistry>>) {
     if let Some(mut registry) = signal {
-        registry.needs_update = ShouldUpdateEvents::Ready;
+        registry.should_update = ShouldUpdateEvents::Ready;
     }
 }
 
@@ -32,7 +32,7 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
         world.resource_scope(|world, mut registry: Mut<EventRegistry>| {
             registry.run_updates(world, *last_change_tick);
 
-            registry.needs_update = match registry.needs_update {
+            registry.should_update = match registry.should_update {
                 // If we're always updating, keep doing so.
                 ShouldUpdateEvents::Always => ShouldUpdateEvents::Always,
                 // Disable the system until signal_event_update_system runs again.
@@ -53,7 +53,7 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
 /// Otherwise, we will always update the events.
 pub fn event_update_condition(maybe_signal: Option<Res<EventRegistry>>) -> bool {
     match maybe_signal {
-        Some(signal) => match signal.needs_update {
+        Some(signal) => match signal.should_update {
             ShouldUpdateEvents::Always | ShouldUpdateEvents::Ready => true,
             ShouldUpdateEvents::Waiting => false,
         },

--- a/crates/bevy_ecs/src/event/update.rs
+++ b/crates/bevy_ecs/src/event/update.rs
@@ -10,14 +10,19 @@ use bevy_ecs_macros::SystemSet;
 #[cfg(feature = "bevy_reflect")]
 use std::hash::Hash;
 
+use super::registry::ShouldUpdateEvents;
+
 #[doc(hidden)]
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EventUpdates;
 
 /// Signals the [`event_update_system`] to run after `FixedUpdate` systems.
+///
+/// This will change the behavior of the [`EventRegistry`] to only run after a fixed update cycle has passed.
+/// Normally, this will simply run every frame.
 pub fn signal_event_update_system(signal: Option<ResMut<EventRegistry>>) {
     if let Some(mut registry) = signal {
-        registry.needs_update = true;
+        registry.needs_update = ShouldUpdateEvents::ReadyToUpdate;
     }
 }
 
@@ -26,16 +31,32 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
     if world.contains_resource::<EventRegistry>() {
         world.resource_scope(|world, mut registry: Mut<EventRegistry>| {
             registry.run_updates(world, *last_change_tick);
-            // Disable the system until signal_event_update_system runs again.
-            registry.needs_update = false;
+
+            registry.needs_update = match registry.needs_update {
+                // If we're always updating, keep doing so.
+                ShouldUpdateEvents::AlwaysUpdate => ShouldUpdateEvents::AlwaysUpdate,
+                // Disable the system until signal_event_update_system runs again.
+                ShouldUpdateEvents::WaitingToUpdate | ShouldUpdateEvents::ReadyToUpdate => {
+                    ShouldUpdateEvents::WaitingToUpdate
+                }
+            };
         });
     }
     *last_change_tick = world.change_tick();
 }
 
 /// A run condition for [`event_update_system`].
-pub fn event_update_condition(signal: Option<Res<EventRegistry>>) -> bool {
-    // If we haven't got a signal to update the events, but we *could* get such a signal
-    // return early and update the events later.
-    signal.map_or(false, |signal| signal.needs_update)
+///
+/// If [`signal_event_update_system`] has been run at least once,
+/// we will wait for it to be run again before updating the events.
+///
+/// Otherwise, we will always update the events.
+pub fn event_update_condition(maybe_signal: Option<Res<EventRegistry>>) -> bool {
+    match maybe_signal {
+        Some(signal) => match signal.needs_update {
+            ShouldUpdateEvents::AlwaysUpdate | ShouldUpdateEvents::ReadyToUpdate => true,
+            ShouldUpdateEvents::WaitingToUpdate => false,
+        },
+        None => true,
+    }
 }

--- a/crates/bevy_ecs/src/event/update.rs
+++ b/crates/bevy_ecs/src/event/update.rs
@@ -23,7 +23,6 @@ pub fn signal_event_update_system(signal: Option<ResMut<EventRegistry>>) {
 
 /// A system that calls [`Events::update`] on all registered [`Events`] in the world.
 pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>) {
-    println!("Running event_update_system");
     if world.contains_resource::<EventRegistry>() {
         world.resource_scope(|world, mut registry: Mut<EventRegistry>| {
             registry.run_updates(world, *last_change_tick);
@@ -36,10 +35,6 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
 
 /// A run condition for [`event_update_system`].
 pub fn event_update_condition(signal: Option<Res<EventRegistry>>) -> bool {
-    println!("Checking if we should run event_update_system");
-
-    println!("signal: {:?}", signal);
-
     // If we haven't got a signal to update the events, but we *could* get such a signal
     // return early and update the events later.
     signal.map_or(false, |signal| signal.needs_update)

--- a/crates/bevy_ecs/src/event/update.rs
+++ b/crates/bevy_ecs/src/event/update.rs
@@ -22,7 +22,7 @@ pub struct EventUpdates;
 /// Normally, this will simply run every frame.
 pub fn signal_event_update_system(signal: Option<ResMut<EventRegistry>>) {
     if let Some(mut registry) = signal {
-        registry.needs_update = ShouldUpdateEvents::ReadyToUpdate;
+        registry.needs_update = ShouldUpdateEvents::Ready;
     }
 }
 
@@ -34,10 +34,10 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
 
             registry.needs_update = match registry.needs_update {
                 // If we're always updating, keep doing so.
-                ShouldUpdateEvents::AlwaysUpdate => ShouldUpdateEvents::AlwaysUpdate,
+                ShouldUpdateEvents::Always => ShouldUpdateEvents::Always,
                 // Disable the system until signal_event_update_system runs again.
-                ShouldUpdateEvents::WaitingToUpdate | ShouldUpdateEvents::ReadyToUpdate => {
-                    ShouldUpdateEvents::WaitingToUpdate
+                ShouldUpdateEvents::Waiting | ShouldUpdateEvents::Ready => {
+                    ShouldUpdateEvents::Waiting
                 }
             };
         });
@@ -54,8 +54,8 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
 pub fn event_update_condition(maybe_signal: Option<Res<EventRegistry>>) -> bool {
     match maybe_signal {
         Some(signal) => match signal.needs_update {
-            ShouldUpdateEvents::AlwaysUpdate | ShouldUpdateEvents::ReadyToUpdate => true,
-            ShouldUpdateEvents::WaitingToUpdate => false,
+            ShouldUpdateEvents::Always | ShouldUpdateEvents::Ready => true,
+            ShouldUpdateEvents::Waiting => false,
         },
         None => true,
     }

--- a/crates/bevy_ecs/src/event/update.rs
+++ b/crates/bevy_ecs/src/event/update.rs
@@ -23,6 +23,7 @@ pub fn signal_event_update_system(signal: Option<ResMut<EventRegistry>>) {
 
 /// A system that calls [`Events::update`] on all registered [`Events`] in the world.
 pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>) {
+    println!("Running event_update_system");
     if world.contains_resource::<EventRegistry>() {
         world.resource_scope(|world, mut registry: Mut<EventRegistry>| {
             registry.run_updates(world, *last_change_tick);
@@ -35,6 +36,10 @@ pub fn event_update_system(world: &mut World, mut last_change_tick: Local<Tick>)
 
 /// A run condition for [`event_update_system`].
 pub fn event_update_condition(signal: Option<Res<EventRegistry>>) -> bool {
+    println!("Checking if we should run event_update_system");
+
+    println!("signal: {:?}", signal);
+
     // If we haven't got a signal to update the events, but we *could* get such a signal
     // return early and update the events later.
     signal.map_or(false, |signal| signal.needs_update)

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -190,9 +190,15 @@ mod tests {
             .init_resource::<FixedUpdateCounter>()
             .insert_resource(TimeUpdateStrategy::ManualDuration(time_step));
 
+        let fixed_time = app.world().resource::<Time<Fixed>>();
+        println!("Fixed time on frame 0: {:?}", fixed_time);
+
         // Update the app by a single timestep
         // Fixed update should not have run yet
         app.update();
+        let fixed_time = app.world().resource::<Time<Fixed>>();
+        println!("Fixed time on frame 1: {:?}", fixed_time);
+
         assert!(time_step < fixed_update_timestep);
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 0, "Fixed update should not have run yet");
@@ -200,6 +206,9 @@ mod tests {
         // Update the app by another timestep
         // Fixed update should have run now
         app.update();
+        let fixed_time = app.world().resource::<Time<Fixed>>();
+        println!("Fixed time on frame 2: {:?}", fixed_time);
+
         assert!(2 * time_step > fixed_update_timestep);
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 1, "Fixed update should have run once");
@@ -207,6 +216,9 @@ mod tests {
         // Update the app by another timestep
         // Fixed update should have run exactly once still
         app.update();
+        let fixed_time = app.world().resource::<Time<Fixed>>();
+        println!("Fixed time on frame 3: {:?}", fixed_time);
+
         assert!(3 * time_step < 2 * fixed_update_timestep);
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 1, "Fixed update should have run once");
@@ -214,6 +226,9 @@ mod tests {
         // Update the app by another timestep
         // Fixed update should have run twice now
         app.update();
+        let fixed_time = app.world().resource::<Time<Fixed>>();
+        println!("Fixed time on frame 4: {:?}", fixed_time);
+
         assert!(4 * time_step > 2 * fixed_update_timestep);
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 2, "Fixed update should have run twice");

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -30,7 +30,7 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, RunFixedMainLoop};
-use bevy_ecs::event::signal_event_update_system;
+use bevy_ecs::event::{signal_event_update_system, EventRegistry, ShouldUpdateEvents};
 use bevy_ecs::prelude::*;
 use bevy_utils::{tracing::warn, Duration, Instant};
 pub use crossbeam_channel::TrySendError;
@@ -65,8 +65,11 @@ impl Plugin for TimePlugin {
         app.add_systems(First, time_system.in_set(TimeSystem))
             .add_systems(RunFixedMainLoop, run_fixed_main_schedule);
 
-        // ensure the events are not dropped until `FixedMain` systems can observe them
+        // Ensure the events are not dropped until `FixedMain` systems can observe them
         app.add_systems(FixedPostUpdate, signal_event_update_system);
+        let mut event_registry = app.world_mut().resource_mut::<EventRegistry>();
+        // We need to start in a waiting state so that the events are not updated until the first fixed update
+        event_registry.should_update = ShouldUpdateEvents::Waiting;
     }
 }
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -210,7 +210,15 @@ mod tests {
             .init_resource::<FixedUpdateCounter>()
             .insert_resource(TimeUpdateStrategy::ManualDuration(time_step));
 
-        // Update the app by a single timestep
+        // Frame 0
+        // Fixed update should not have run yet
+        app.update();
+
+        assert!(Duration::ZERO < fixed_update_timestep);
+        let counter = app.world().resource::<FixedUpdateCounter>();
+        assert_eq!(counter.0, 0, "Fixed update should not have run yet");
+
+        // Frame 1
         // Fixed update should not have run yet
         app.update();
 
@@ -218,7 +226,7 @@ mod tests {
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 0, "Fixed update should not have run yet");
 
-        // Update the app by another timestep
+        // Frame 2
         // Fixed update should have run now
         app.update();
 
@@ -226,7 +234,7 @@ mod tests {
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 1, "Fixed update should have run once");
 
-        // Update the app by another timestep
+        // Frame 3
         // Fixed update should have run exactly once still
         app.update();
 
@@ -234,7 +242,7 @@ mod tests {
         let counter = app.world().resource::<FixedUpdateCounter>();
         assert_eq!(counter.0, 1, "Fixed update should have run once");
 
-        // Update the app by another timestep
+        // Frame 4
         // Fixed update should have run twice now
         app.update();
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -325,13 +325,7 @@ mod tests {
             println!("Total events: {n_total_events} | Current events: {n_current_events}",);
 
             match frame {
-                0 => {
-                    assert_eq!(fixed_updates_seen, 0);
-                    assert_eq!(n_total_events, 1);
-                    assert_eq!(n_current_events, 1);
-                    assert_eq!(should_update, ShouldUpdateEvents::Waiting);
-                }
-                1 => {
+                0 | 1 => {
                     assert_eq!(fixed_updates_seen, 0);
                     assert_eq!(n_total_events, 1);
                     assert_eq!(n_current_events, 1);


### PR DESCRIPTION
# Objective

As discovered in https://github.com/Leafwing-Studios/leafwing-input-manager/issues/538, there appears to be some real weirdness going on in how event updates are processed between Bevy 0.13 and Bevy 0.14.

To identify the cause and prevent regression, I've added tests to validate the intended behavior.
My initial suspicion was that this would be fixed by https://github.com/bevyengine/bevy/pull/13762, but that doesn't seem to be the case.

Instead, events appear to never be updated at all when using `bevy_app` by itself. This is part of the problem resolved by https://github.com/bevyengine/bevy/pull/11528, and introduced by https://github.com/bevyengine/bevy/pull/10077.

After some investigation, it appears that `signal_event_update_system` is never added using a bare-bones `App`, and so event updates are always skipped.

This can be worked around by adding your own copy to a later-in-the-frame schedule, but that's not a very good fix.

## Solution

Ensure that if we're not using a `FixedUpdate` schedule, events are always updated every frame.

To do this, I've modified the logic of `event_update_condition` and `event_update_system` to clearly and correctly differentiate between the two cases: where we're waiting for a "you should update now" signal and where we simply don't care.

To encode this, I've added the `ShouldUpdateEvents` enum, replacing a simple `bool` in `EventRegistry`'s `needs_update` field.

Now, both tests pass as expected, without having to manually add a system!

## Testing

I've written two parallel unit tests to cover the intended behavior:

1. Test that `iter_current_update_events` works as expected in `bevy_ecs`.
2. Test that `iter_current_update_events` works as expected in `bevy_app`

I've also added a test to verify that event updating works correctly in the presence of a fixed main schedule, and a second test to verify that fixed updating works at all to help future authors narrow down failures.

## Outstanding

- [x] figure out why the `bevy_app` version of this test fails but the `bevy_ecs` version does not
- [x] figure out why `EventRegistry::run_updates` isn't working properly
- [x] figure out why `EventRegistry::run_updates` is never getting called
- [x] figure out why `event_update_condition` is always returning false
- [x] figure out why `EventRegistry::needs_update` is always false
- [x] verify that the problem is a missing `signal_events_update_system`