### PR TITLE
reduce the antialias strength

### DIFF
--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -123,7 +123,8 @@ fn sd_inset_rounded_box(point: vec2<f32>, size: vec2<f32>, radius: vec4<f32>, in
 // get alpha for antialiasing for sdf
 fn antialias(distance: f32) -> f32 {
     // Using the fwidth(distance) was causing artifacts, so just use the distance.
-    return clamp(0.0, 1.0, 0.5 - distance);
+    // This antialiases between the distance values of 0.25 and -0.25
+    return clamp(0.0, 1.0, 0.5 - 2.0 * distance);
 }
 
 fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {


### PR DESCRIPTION
# Objective

- Fixes #13807

## Solution

- Before this pr we antialiased between 0.5 and -0.5. This pr changes things to antialias between 0.25 and -0.25. I tried slightly larger ranges, but the edge between the boxes still showed. I'm not 100% sure this is the correct solution, but from what I could find the range you use is more art than science.

## Testing

- Ran rounded_borders example, the code in the linked issue, and the testing example from #12702. 

---

## Changelog

- reduce antialiasing in ui shader.
