### PR TITLE
Highlight dependency on shader files in examples

### DIFF
--- a/examples/2d/custom_gltf_vertex_attribute.rs
+++ b/examples/2d/custom_gltf_vertex_attribute.rs
@@ -11,6 +11,9 @@ use bevy::{
     sprite::{Material2d, Material2dKey, Material2dPlugin, MaterialMesh2dBundle, Mesh2dHandle},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/custom_gltf_2d.wgsl";
+
 /// This vertex attribute supplies barycentric coordinates for each triangle.
 /// Each component of the vector corresponds to one corner of a triangle. It's
 /// equal to 1.0 in that corner and 0.0 in the other two. Hence, its value in
@@ -68,10 +71,10 @@ struct CustomMaterial {}
 
 impl Material2d for CustomMaterial {
     fn vertex_shader() -> ShaderRef {
-        "shaders/custom_gltf_2d.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_gltf_2d.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 
     fn specialize(

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -22,6 +22,9 @@ use bevy::prelude::*;
 use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
 use bevy::window::PrimaryWindow;
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/irradiance_volume_voxel_visualization.wgsl";
+
 // Rotation speed in radians per frame.
 const ROTATION_SPEED: f32 = 0.2;
 
@@ -650,6 +653,6 @@ fn toggle_voxel_visibility(
 
 impl MaterialExtension for VoxelVisualizationExtension {
     fn fragment_shader() -> ShaderRef {
-        "shaders/irradiance_volume_voxel_visualization.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -14,6 +14,9 @@ use bevy::{
     },
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/line_material.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<LineMaterial>::default()))
@@ -72,7 +75,7 @@ struct LineMaterial {
 
 impl Material for LineMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/line_material.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 
     fn specialize(

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -21,6 +21,9 @@ use bevy::{
     },
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/water_material.wgsl";
+
 // The speed of camera movement.
 const CAMERA_KEYBOARD_ZOOM_SPEED: f32 = 0.1;
 const CAMERA_KEYBOARD_ORBIT_SPEED: f32 = 0.02;
@@ -286,7 +289,7 @@ fn create_text(app_settings: &AppSettings) -> Text {
 
 impl MaterialExtension for Water {
     fn deferred_fragment_shader() -> ShaderRef {
-        "shaders/water_material.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }
 

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -13,6 +13,9 @@ use bevy::{
 };
 use std::f32::consts::PI;
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/tonemapping_test_patterns.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -600,7 +603,7 @@ impl Default for PerMethodSettings {
 
 impl Material for ColorGradientMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/tonemapping_test_patterns.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }
 

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -7,6 +7,9 @@ use bevy::{
     render::render_resource::{AsBindGroup, ShaderRef},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/animate_shader.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
@@ -39,6 +42,6 @@ struct CustomMaterial {}
 
 impl Material for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/animate_shader.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -8,6 +8,9 @@ use bevy::{
     render::render_resource::{AsBindGroup, ShaderRef},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/array_texture.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -89,6 +92,6 @@ struct ArrayTextureMaterial {
 
 impl Material for ArrayTextureMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/array_texture.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -13,6 +13,9 @@ use bevy::{
     },
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/custom_vertex_attribute.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
@@ -65,10 +68,10 @@ struct CustomMaterial {
 
 impl Material for CustomMaterial {
     fn vertex_shader() -> ShaderRef {
-        "shaders/custom_vertex_attribute.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_vertex_attribute.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 
     fn specialize(

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -7,6 +7,9 @@ use bevy::{
     render::render_resource::*,
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/extended_material.wgsl";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -79,10 +82,10 @@ struct MyExtension {
 
 impl MaterialExtension for MyExtension {
     fn fragment_shader() -> ShaderRef {
-        "shaders/extended_material.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 
     fn deferred_fragment_shader() -> ShaderRef {
-        "shaders/extended_material.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/fallback_image.rs
+++ b/examples/shader/fallback_image.rs
@@ -11,6 +11,9 @@ use bevy::{
     render::render_resource::{AsBindGroup, ShaderRef},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/fallback_image_test.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -73,6 +76,6 @@ struct FallbackTestMaterial {
 
 impl Material for FallbackTestMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/fallback_image_test.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -18,6 +18,9 @@ use bevy::{
 };
 use crossbeam_channel::{Receiver, Sender};
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/gpu_readback.wgsl";
+
 // The length of the buffer sent to the gpu
 const BUFFER_LEN: usize = 16;
 
@@ -177,7 +180,7 @@ impl FromWorld for ComputePipeline {
                 storage_buffer::<Vec<u32>>(false),
             ),
         );
-        let shader = world.load_asset("shaders/gpu_readback.wgsl");
+        let shader = world.load_asset(SHADER_ASSET_PATH);
         let pipeline_cache = world.resource::<PipelineCache>();
         let pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some("GPU readback compute shader".into()),

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -31,6 +31,9 @@ use bevy::{
     },
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/post_processing.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, PostProcessPlugin))
@@ -249,7 +252,7 @@ impl FromWorld for PostProcessPipeline {
         let sampler = render_device.create_sampler(&SamplerDescriptor::default());
 
         // Get the shader handle
-        let shader = world.load_asset("shaders/post_processing.wgsl");
+        let shader = world.load_asset(SHADER_ASSET_PATH);
 
         let pipeline_id = world
             .resource_mut::<PipelineCache>()

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -12,6 +12,9 @@ use bevy::{
     },
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/shader_defs.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
@@ -56,7 +59,7 @@ fn setup(
 
 impl Material for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/shader_defs.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 
     fn specialize(

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -26,6 +26,9 @@ use bevy::{
 };
 use bytemuck::{Pod, Zeroable};
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/instancing.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, CustomMaterialPlugin))
@@ -190,7 +193,7 @@ impl FromWorld for CustomPipeline {
         let mesh_pipeline = world.resource::<MeshPipeline>();
 
         CustomPipeline {
-            shader: world.load_asset("shaders/instancing.wgsl"),
+            shader: world.load_asset(SHADER_ASSET_PATH),
             mesh_pipeline: mesh_pipeline.clone(),
         }
     }

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -6,6 +6,9 @@ use bevy::{
     render::render_resource::{AsBindGroup, ShaderRef},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/custom_material.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
@@ -54,7 +57,7 @@ struct CustomMaterial {
 /// You only need to implement functions for features that need non-default behavior. See the Material api docs for details!
 impl Material for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_material.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 
     fn alpha_mode(&self) -> AlphaMode {

--- a/examples/shader/shader_material_2d.rs
+++ b/examples/shader/shader_material_2d.rs
@@ -7,6 +7,9 @@ use bevy::{
     sprite::{Material2d, Material2dPlugin, MaterialMesh2dBundle},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/custom_material_2d.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -53,6 +56,6 @@ struct CustomMaterial {
 /// You only need to implement functions for features that need non-default behavior. See the Material2d api docs for details!
 impl Material2d for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_material_2d.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -12,6 +12,10 @@ use bevy::{
     },
 };
 
+/// This example uses shader source files from the assets subdirectory
+const VERTEX_SHADER_ASSET_PATH: &str = "shaders/custom_material.vert";
+const FRAGMENT_SHADER_ASSET_PATH: &str = "shaders/custom_material.frag";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
@@ -61,11 +65,11 @@ struct CustomMaterial {
 /// When using the GLSL shading language for your shader, the specialize method must be overridden.
 impl Material for CustomMaterial {
     fn vertex_shader() -> ShaderRef {
-        "shaders/custom_material.vert".into()
+        VERTEX_SHADER_ASSET_PATH.into()
     }
 
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_material.frag".into()
+        FRAGMENT_SHADER_ASSET_PATH.into()
     }
 
     fn alpha_mode(&self) -> AlphaMode {

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -6,6 +6,9 @@ use bevy::{
     render::render_resource::{AsBindGroup, ShaderRef},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/custom_material_screenspace_texture.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, MaterialPlugin::<CustomMaterial>::default()))
@@ -74,6 +77,6 @@ struct CustomMaterial {
 
 impl Material for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_material_screenspace_texture.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -10,6 +10,10 @@ use bevy::{
     render::render_resource::{AsBindGroup, ShaderRef, ShaderType},
 };
 
+/// This example uses a shader source file from the assets subdirectory
+const PREPASS_SHADER_ASSET_PATH: &str = "shaders/show_prepass.wgsl";
+const MATERIAL_SHADER_ASSET_PATH: &str = "shaders/custom_material.wgsl";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -166,7 +170,7 @@ struct CustomMaterial {
 /// function will also be used by the prepass
 impl Material for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/custom_material.wgsl".into()
+        MATERIAL_SHADER_ASSET_PATH.into()
     }
 
     fn alpha_mode(&self) -> AlphaMode {
@@ -208,7 +212,7 @@ struct PrepassOutputMaterial {
 
 impl Material for PrepassOutputMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/show_prepass.wgsl".into()
+        PREPASS_SHADER_ASSET_PATH.into()
     }
 
     // This needs to be transparent in order to show the scene behind the mesh

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -17,6 +17,9 @@ use bevy::{
 };
 use std::{num::NonZeroU32, process::exit};
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/texture_binding_array.wgsl";
+
 fn main() {
     let mut app = App::new();
     app.add_plugins((
@@ -186,6 +189,6 @@ impl AsBindGroup for BindlessMaterial {
 
 impl Material for BindlessMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/texture_binding_array.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/ui/ui_material.rs
+++ b/examples/ui/ui_material.rs
@@ -4,6 +4,9 @@ use bevy::prelude::*;
 use bevy::reflect::TypePath;
 use bevy::render::render_resource::*;
 
+/// This example uses a shader source file from the assets subdirectory
+const SHADER_ASSET_PATH: &str = "shaders/circle_shader.wgsl";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -60,6 +63,6 @@ struct CustomUiMaterial {
 
 impl UiMaterial for CustomUiMaterial {
     fn fragment_shader() -> ShaderRef {
-        "shaders/circle_shader.wgsl".into()
+        SHADER_ASSET_PATH.into()
     }
 }


### PR DESCRIPTION
The examples won't work when copy-pasted to another project, without also copying their shader files. This change adds constants at the top of the files to bring attention to the dependencies.

Follow up to [#13624](https://github.com/bevyengine/bevy/pull/13624#issuecomment-2143872791)
