### PR TITLE
Add first person view model example with different FOVs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3119,6 +3119,17 @@ description = "A 2D top-down camera smoothly following player movements"
 category = "Camera"
 wasm = true
 
+[[example]]
+name = "first_person_view_model"
+path = "examples/camera/first_person_view_model.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.first_person_view_model]
+name = "First person view model"
+description = "TODO"
+category = "Camera"
+wasm = true
+
 [package.metadata.example.fps_overlay]
 name = "FPS overlay"
 description = "Demonstrates FPS overlay"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3126,7 +3126,7 @@ doc-scrape-examples = true
 
 [package.metadata.example.first_person_view_model]
 name = "First person view model"
-description = "TODO"
+description = "A first-person camera that uses a world model and a view model with different FOVs"
 category = "Camera"
 wasm = true
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -246,6 +246,7 @@ Example | Description
 Example | Description
 --- | ---
 [2D top-down camera](../examples/camera/2d_top_down_camera.rs) | A 2D top-down camera smoothly following player movements
+[First person view model](../examples/camera/first_person_view_model.rs) | TODO
 
 ## Dev tools
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -246,7 +246,7 @@ Example | Description
 Example | Description
 --- | ---
 [2D top-down camera](../examples/camera/2d_top_down_camera.rs) | A 2D top-down camera smoothly following player movements
-[First person view model](../examples/camera/first_person_view_model.rs) | TODO
+[First person view model](../examples/camera/first_person_view_model.rs) | A first-person camera that uses a world model and a view model with different FOVs
 
 ## Dev tools
 

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -1,17 +1,28 @@
+use bevy::color::palettes::tailwind;
 use bevy::input::mouse::MouseMotion;
+use bevy::pbr::NotShadowCaster;
 use bevy::prelude::*;
 use bevy::render::view::RenderLayers;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Startup, (spawn_view_model, spawn_world_model, spawn_text))
+        .add_systems(
+            Startup,
+            (
+                spawn_view_model,
+                spawn_world_model,
+                spawn_lights,
+                spawn_text,
+            ),
+        )
         .add_systems(Update, (move_player, change_fov))
         .run();
 }
 
 #[derive(Debug, Component)]
 struct Player;
+
 #[derive(Debug, Component)]
 struct WorldModelCamera;
 
@@ -23,7 +34,7 @@ fn spawn_view_model(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let arm = meshes.add(Cuboid::new(0.1, 0.1, 0.5));
-    let arm_material = materials.add(Color::srgb(0.5, 0.5, 1.0));
+    let arm_material = materials.add(Color::from(tailwind::TEAL_200));
 
     commands
         .spawn((
@@ -73,6 +84,7 @@ fn spawn_view_model(
                     ..default()
                 },
                 RenderLayers::layer(1),
+                NotShadowCaster,
             ));
         });
 }
@@ -83,8 +95,8 @@ fn spawn_world_model(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let floor = meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(10.0)));
-    let cube = meshes.add(Cuboid::new(1.0, 1.0, 1.0));
-    let material = materials.add(Color::srgb(1.0, 0.5, 0.5));
+    let cube = meshes.add(Cuboid::new(2.0, 0.5, 1.0));
+    let material = materials.add(Color::WHITE);
 
     commands.spawn(
         (MaterialMeshBundle {
@@ -98,18 +110,21 @@ fn spawn_world_model(
         (MaterialMeshBundle {
             mesh: cube,
             material,
-            transform: Transform::from_xyz(0.0, 0.0, -3.0),
+            transform: Transform::from_xyz(0.0, 0.25, -3.0),
             ..default()
         }),
     );
+}
 
+fn spawn_lights(mut commands: Commands) {
     commands.spawn((
         PointLightBundle {
             point_light: PointLight {
+                color: Color::from(tailwind::ROSE_300),
                 shadows_enabled: true,
                 ..default()
             },
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
+            transform: Transform::from_xyz(-3.0, 3.0, -0.75),
             ..default()
         },
         RenderLayers::from_layers(&[0, 1]),

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -1,0 +1,99 @@
+use bevy::input::mouse::MouseMotion;
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, (spawn_view_model, spawn_world_model))
+        .add_systems(Update, move_player)
+        .run();
+}
+
+#[derive(Debug, Component)]
+struct Player;
+
+fn spawn_view_model(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let arm = meshes.add(Cuboid::new(0.1, 0.1, 0.8));
+    let arm_material = materials.add(Color::srgb(0.5, 0.5, 1.0));
+
+    commands
+        .spawn((
+            Name::new("Player"),
+            SpatialBundle {
+                transform: Transform::from_xyz(0.0, 1.0, 0.0),
+                ..default()
+            },
+            Player,
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                Name::new("View Model Camera"),
+                Camera3dBundle { ..default() },
+            ));
+
+            parent.spawn((
+                Name::new("Arm"),
+                MaterialMeshBundle {
+                    mesh: arm,
+                    material: arm_material,
+                    transform: Transform::from_xyz(0.2, -0.1, -0.4),
+                    ..default()
+                },
+            ));
+        });
+}
+
+fn spawn_world_model(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let floor = meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(10.0)));
+    let cube = meshes.add(Cuboid::new(1.0, 1.0, 1.0));
+    let material = materials.add(Color::srgb(1.0, 0.5, 0.5));
+
+    commands.spawn(
+        (MaterialMeshBundle {
+            mesh: floor,
+            material: material.clone(),
+            ..default()
+        }),
+    );
+
+    commands.spawn(
+        (MaterialMeshBundle {
+            mesh: cube,
+            material,
+            transform: Transform::from_xyz(0.0, 0.0, -3.0),
+            ..default()
+        }),
+    );
+
+    commands.spawn(
+        (PointLightBundle {
+            point_light: PointLight {
+                shadows_enabled: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(4.0, 8.0, 4.0),
+            ..default()
+        }),
+    );
+}
+
+fn move_player(
+    mut mouse_motion: EventReader<MouseMotion>,
+    mut player: Query<&mut Transform, With<Player>>,
+) {
+    let mut transform = player.single_mut();
+    for motion in mouse_motion.read() {
+        let yaw = -motion.delta.x * 0.002;
+        let pitch = -motion.delta.y * 0.002;
+        transform.rotate_y(yaw);
+        transform.rotate_local_x(pitch);
+    }
+}

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -5,7 +5,7 @@ use bevy::render::view::RenderLayers;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Startup, (spawn_view_model, spawn_world_model))
+        .add_systems(Startup, (spawn_view_model, spawn_world_model, spawn_text))
         .add_systems(Update, (move_player, change_fov))
         .run();
 }
@@ -14,6 +14,8 @@ fn main() {
 struct Player;
 #[derive(Debug, Component)]
 struct WorldModelCamera;
+
+// Setup systems
 
 fn spawn_view_model(
     mut commands: Commands,
@@ -43,7 +45,7 @@ fn spawn_view_model(
                     .into(),
                     ..default()
                 },
-                WorldModelCamera
+                WorldModelCamera,
             ));
             parent.spawn((
                 Name::new("View Model Camera"),
@@ -114,6 +116,34 @@ fn spawn_world_model(
     ));
 }
 
+fn spawn_text(mut commands: Commands) {
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(12.0),
+                left: Val::Px(12.0),
+                ..default()
+            },
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn(TextBundle::from_section(
+                concat!(
+                    "Move the camera with your mouse.\n",
+                    "Press arrow up to decrease the FOV of the world model.\n",
+                    "Press arrow down to increase the FOV of the world model."
+                ),
+                TextStyle {
+                    font_size: 25.0,
+                    ..default()
+                },
+            ));
+        });
+}
+
+// Functional systems
+
 fn move_player(
     mut mouse_motion: EventReader<MouseMotion>,
     mut player: Query<&mut Transform, With<Player>>,
@@ -129,15 +159,10 @@ fn move_player(
 
 fn change_fov(
     input: Res<ButtonInput<KeyCode>>,
-    mut world_model_projection: Query<
-        &mut Projection,
-        With<WorldModelCamera>,
-    >,
+    mut world_model_projection: Query<&mut Projection, With<WorldModelCamera>>,
 ) {
     let mut projection = world_model_projection.single_mut();
-    let Projection::Perspective(ref mut projection) =
-        projection.as_mut()
-    else {
+    let Projection::Perspective(ref mut projection) = projection.as_mut() else {
         unreachable!();
     };
 


### PR DESCRIPTION
# Objective

An extremely common way to organize a first-person view is to split it into two kinds of models:

 - The *view model* is the model that represents the player's body.
 - The *world model* is everything else.

 The reason for this distinction is that these two models should be rendered with different FOVs.
 The view model is typically designed and animated with a very specific FOV in mind, so it is
 generally *fixed* and cannot be changed by a player. The world model, on the other hand, should
 be able to change its FOV to accommodate the player's preferences for the following reasons:
 - *Accessibility*: How prone is the player to motion sickness? A wider FOV can help.
 - *Tactical preference*: Does the player want to see more of the battlefield?
 Or have a more zoomed-in view for precision aiming?
 - *Physical considerations*: How well does the in-game FOV match the player's real-world FOV?
 Are they sitting in front of a monitor or playing on a TV in the living room? How big is the screen?

## Solution

I've added an example implementing the described setup as follows.

 The `Player` is an entity holding two cameras, one for each model. The view model camera has a fixed
 FOV of 70 degrees, while the world model camera has a variable FOV that can be changed by the player.

 We use different `RenderLayers` to select what to render.

 - The world model camera has no explicit `RenderLayers` component, so it uses the layer 0.
 All static objects in the scene are also on layer 0 for the same reason.
 - The view model camera has a `RenderLayers` component with layer 1, so it only renders objects
 explicitly assigned to layer 1. The arm of the player is one such object.
 The order of the view model camera is additionally bumped to 1 to ensure it renders on top of the world model.
 - The light source in the scene must illuminate both the view model and the world model, so it is
 assigned to both layers 0 and 1.

## Testing

Default FOV:
<img width="1392" alt="image" src="https://github.com/bevyengine/bevy/assets/9047632/40e2feab-1898-4407-908b-9c448b36b23e">
Decreased FOV:
<img width="1392" alt="image" src="https://github.com/bevyengine/bevy/assets/9047632/9e2fc04d-665e-4c2e-b6c6-269812975ee6">
Increased FOV:
<img width="1392" alt="image" src="https://github.com/bevyengine/bevy/assets/9047632/d465aefd-4033-43bd-b295-6935aef075b1">

Note that the white bar on the right represents the player's arm, which is more obvious in-game because you can move the camera around.

---

## Changelog

I don't think new examples go in here, do they?
