### PR TITLE
Add missing plugins to doc of DefaultPlugins

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -28,6 +28,8 @@ use bevy_app::{Plugin, PluginGroup, PluginGroupBuilder};
 /// * [`AudioPlugin`](crate::audio::AudioPlugin) - with feature `bevy_audio`
 /// * [`GilrsPlugin`](crate::gilrs::GilrsPlugin) - with feature `bevy_gilrs`
 /// * [`AnimationPlugin`](crate::animation::AnimationPlugin) - with feature `bevy_animation`
+/// * [`GizmoPlugin`](crate::gizmos::GizmoPlugin) - with feature `bevy_gizmos`
+/// * [`StatesPlugin`](crate::app::StatesPlugin) - with feature `bevy_state`
 /// * [`DevToolsPlugin`](crate::dev_tools::DevToolsPlugin) - with feature `bevy_dev_tools`
 /// * [`CiTestingPlugin`](crate::dev_tools::ci_testing::CiTestingPlugin) - with feature `bevy_ci_testing`
 ///


### PR DESCRIPTION
StatesPlugin and GizmoPlugin were missing from the doc comment of DefaultPlugins. I am not sure whether this was for a reason, but i just stumbled over it and it seemed off...

## Testing

I'm not sure how to test these changes?