### PR TITLE
run windows ci on rust 1.78

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -132,7 +132,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.78
       - name: Build bevy
         shell: bash
         # this uses the same command as when running the example to ensure build is reused


### PR DESCRIPTION
# Objective

- temporary fix for CI 
- Rust 1.79 seems to have broken bevy on DX12 on some configuration

## Solution

- Keep using Rust 1.78
