### PR TITLE
Use a well defined type for sides in RegularPolygon

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -852,7 +852,13 @@ where
         }
 
         let points = (0..=primitive.sides)
-            .map(|p| single_circle_coordinate(primitive.circumcircle.radius, primitive.sides, p))
+            .map(|p| {
+                single_circle_coordinate(
+                    primitive.circumcircle.radius,
+                    primitive.sides as usize,
+                    p as usize,
+                )
+            })
             .map(rotate_then_translate_2d(angle, position));
         self.linestrip_2d(points, color);
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1642,7 +1642,7 @@ pub struct RegularPolygon {
     /// The circumcircle on which all vertices lie
     pub circumcircle: Circle,
     /// The number of sides
-    pub sides: usize,
+    pub sides: u32,
 }
 impl Primitive2d for RegularPolygon {}
 
@@ -1664,7 +1664,7 @@ impl RegularPolygon {
     ///
     /// Panics if `circumradius` is negative
     #[inline(always)]
-    pub fn new(circumradius: f32, sides: usize) -> Self {
+    pub fn new(circumradius: f32, sides: u32) -> Self {
         assert!(
             circumradius.is_sign_positive(),
             "polygon has a negative radius"

--- a/crates/bevy_render/src/mesh/primitives/dim2.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim2.rs
@@ -56,8 +56,9 @@ impl CircleMeshBuilder {
 
 impl MeshBuilder for CircleMeshBuilder {
     fn build(&self) -> Mesh {
-        RegularPolygon::new(self.circle.radius, self.resolution)
+        Ellipse::new(self.circle.radius, self.circle.radius)
             .mesh()
+            .resolution(self.resolution)
             .build()
     }
 }
@@ -401,7 +402,7 @@ impl From<CircularSegment> for Mesh {
 /// A builder used for creating a [`Mesh`] with a [`RegularPolygon`] shape.
 pub struct RegularPolygonMeshBuilder {
     circumradius: f32,
-    sides: usize,
+    sides: u32,
 }
 impl Meshable for RegularPolygon {
     type Output = RegularPolygonMeshBuilder;
@@ -419,7 +420,7 @@ impl MeshBuilder for RegularPolygonMeshBuilder {
         // The ellipse mesh is just a regular polygon with two radii
         Ellipse::new(self.circumradius, self.circumradius)
             .mesh()
-            .resolution(self.sides)
+            .resolution(self.sides as usize)
             .build()
     }
 }

--- a/crates/bevy_render/src/mesh/primitives/dim2.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim2.rs
@@ -428,7 +428,7 @@ impl MeshBuilder for RegularPolygonMeshBuilder {
 impl Extrudable for RegularPolygonMeshBuilder {
     fn perimeter(&self) -> Vec<PerimeterSegment> {
         vec![PerimeterSegment::Flat {
-            indices: (0..self.sides as u32).chain([0]).collect(),
+            indices: (0..self.sides).chain([0]).collect(),
         }]
     }
 }


### PR DESCRIPTION
# Objective

- Primitives should not use poorly defined types like `usize`, especially since they are serializable

## Solution

- Use `u32` instead of `usize`
- The generic array types do not need to be changed because this size is not actually stored or serialized anywhere

---

## Migration Guide

- `RegularPolygon` now uses `u32` instead of `usize` for the number of sides