### PR TITLE
Mention updating Bevy book code validation for release candidates

### DIFF
--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -85,3 +85,5 @@
     1. Discord: Bevy, #dev-announcements
 
 ### RC Post-Release
+
+1. Update Bevy version used for Bevy book code validation to latest release.


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy-website/pull/1404 updates `code-validation` on the website to use the latest release candidate.
- It also adds instructions to update this version for each new release candidate.
- @alice-i-cecile asked [that this is added to the release checklist](https://github.com/bevyengine/bevy-website/pull/1404#issuecomment-2168453165).

## Solution

- Add a note to the post-release section for release candidates.

## Testing

- No testing needed :)
