### PR TITLE
text position: use size instead of bounds

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -87,7 +87,11 @@ impl TextPipeline {
 
         let size = compute_text_bounds(&section_glyphs, |index| scaled_fonts[index]).size();
 
-        let h_limit = bounds.x.is_finite().then_some(bounds.x).unwrap_or(size.x);
+        let h_limit = if bounds.x.is_finite() {
+            bounds.x
+        } else {
+            size.x
+        };
 
         let h_anchor = match text_alignment {
             JustifyText::Left => 0.0,

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -89,8 +89,8 @@ impl TextPipeline {
 
         let h_anchor = match text_alignment {
             JustifyText::Left => 0.0,
-            JustifyText::Center => bounds.x * 0.5,
-            JustifyText::Right => bounds.x * 1.0,
+            JustifyText::Center => size.x * 0.5,
+            JustifyText::Right => size.x * 1.0,
         }
         .floor();
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -87,10 +87,12 @@ impl TextPipeline {
 
         let size = compute_text_bounds(&section_glyphs, |index| scaled_fonts[index]).size();
 
+        let h_limit = bounds.x.is_finite().then_some(bounds.x).unwrap_or(size.x);
+
         let h_anchor = match text_alignment {
             JustifyText::Left => 0.0,
-            JustifyText::Center => size.x * 0.5,
-            JustifyText::Right => size.x * 1.0,
+            JustifyText::Center => h_limit * 0.5,
+            JustifyText::Right => h_limit * 1.0,
         }
         .floor();
 


### PR DESCRIPTION
# Objective

- #13846 introduced a bug where text not bound was not displayed

## Solution

- bounds are infinite
- use computed size instead, that already should be using the available bounds
