### PR TITLE
Windows CI example runner: back to using rust stable

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -132,9 +132,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.78
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build bevy
         shell: bash
         # this uses the same command as when running the example to ensure build is reused


### PR DESCRIPTION
- Revert #13834 once wgpu released the fix for https://github.com/gfx-rs/wgpu/pull/5812

