### PR TITLE
Adds `serde` derives to `CubicCurve` behind feature flag

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -810,6 +810,11 @@ impl CubicSegment<Vec2> {
 /// [`CubicBezier`].
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub struct CubicCurve<P: VectorSpace> {
     /// Segments of the curve
     pub segments: Vec<CubicSegment<P>>,


### PR DESCRIPTION
# Objective

- Fixes #13852

## Solution

- Added `Serialize` and `Deserialize` derives to `CubicCurve` gated behind the "serialize" feature flag.