### PR TITLE
Audio sink seek

### DIFF
--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
 use bevy_ecs::component::Component;
 use bevy_math::Vec3;
 use bevy_transform::prelude::Transform;
 use rodio::{Sink, SpatialSink};
+use rodio::source::SeekError;
 
 /// Common interactions with an audio sink.
 pub trait AudioSinkPlayback {
@@ -71,6 +73,9 @@ pub trait AudioSinkPlayback {
 
     /// Returns true if this sink has no more sounds to play.
     fn empty(&self) -> bool;
+
+    /// Seeks to a specific position in the audio.
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError>;
 }
 
 /// Used to control audio during playback.
@@ -124,6 +129,10 @@ impl AudioSinkPlayback for AudioSink {
     fn empty(&self) -> bool {
         self.sink.empty()
     }
+
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
+        self.sink.try_seek(pos)
+    }
 }
 
 /// Used to control spatial audio during playback.
@@ -176,6 +185,10 @@ impl AudioSinkPlayback for SpatialAudioSink {
 
     fn empty(&self) -> bool {
         self.sink.empty()
+    }
+
+    fn try_seek(&self, pos: Duration) -> Result<(), SeekError> {
+        self.sink.try_seek(pos)
     }
 }
 

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_speed, pause, volume))
+        .add_systems(Update, (update_speed, pause, volume, seek))
         .run();
 }
 
@@ -49,6 +49,17 @@ fn volume(
             sink.set_volume(sink.volume() + 0.1);
         } else if keyboard_input.just_pressed(KeyCode::Minus) {
             sink.set_volume(sink.volume() - 0.1);
+        }
+    }
+}
+
+fn seek(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    music_controller: Query<&AudioSink, With<MyMusic>>,
+) {
+    if let Ok(sink) = music_controller.get_single() {
+        if keyboard_input.just_pressed(KeyCode::Digit0) {
+            sink.try_seek(std::time::Duration::from_secs_f64(0.0)).unwrap();
         }
     }
 }


### PR DESCRIPTION
# Objective

- Seeking in audio sink to specific location

## Solution

- Using new method [`fn try_seek(&mut self, pos: Duration) -> Result<(), SeekNotSupported>`](https://github.com/RustAudio/rodio/pull/513) from `rodio`.

Related issue: https://github.com/bevyengine/bevy/issues/9076

## Testing

- It is not working, help needed.

  ```shell
  /home/i/.cargo/bin/cargo +nightly run --color=always --package bevy --example audio_control --release
  ```

```plaintext
    Finished `release` profile [optimized] target(s) in 0.30s
     Running `target/release/examples/audio_control`
2024-06-16T07:42:04.325210Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "Linux 40 Fedora Linux", kernel: "6.8.11-300.fc40.x86_64", cpu: "AMD Ryzen 7 5800U with Radeon Graphics", core_count: "8", memory: "14.5 GiB" }
2024-06-16T07:42:04.451561Z  INFO bevy_render::renderer: AdapterInfo { name: "AMD Radeon Graphics (RADV RENOIR)", vendor: 4098, device: 5688, device_type: IntegratedGpu, driver: "radv", driver_info: "Mesa 24.1.1", backend: Vulkan }
2024-06-16T07:42:04.852471Z  INFO bevy_winit::system: Creating new window "App" (Entity { index: 0, generation: 1 })
2024-06-16T07:42:04.853166Z  INFO winit::platform_impl::platform::x11::window: Guessed window scale factor: 2
thread 'Compute Task Pool (1)' panicked at examples/audio/audio_control.rs:62:68:
called `Result::unwrap()` on an `Err` value: NotSupported { underlying_source: "rodio::decoder::vorbis::VorbisDecoder<std::io::cursor::Cursor<bevy_audio::audio_source::AudioSource>>" }
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
   4: <bevy_ecs::system::function_system::FunctionSystem<Marker,F> as bevy_ecs::system::system::System>::run_unsafe
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Encountered a panic in system `audio_control::seek`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!

Process finished with exit code 101
``` 

---

## Changelog

### Added

- Seeking to specific location in audio sink.