### PR TITLE
Allow bevy_color use without bevy_reflect support

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -22,7 +22,6 @@ encase = { version = "0.8", default-features = false }
 
 [features]
 default = []
-bevy = ["dep:bevy_reflect"]
 serialize = ["serde"]
 
 [lints]

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -21,7 +21,7 @@ wgpu-types = { version = "0.20", default-features = false, optional = true }
 encase = { version = "0.8", default-features = false }
 
 [features]
-default = []
+default = ["bevy_reflect"]
 serialize = ["serde"]
 
 [lints]

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -10,10 +10,10 @@ keywords = ["bevy", "color"]
 rust-version = "1.76.0"
 
 [dependencies]
-bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.14.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
-] }
+], optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
@@ -21,6 +21,8 @@ wgpu-types = { version = "0.20", default-features = false, optional = true }
 encase = { version = "0.8", default-features = false }
 
 [features]
+bevy-support = ["dep:bevy_reflect"]
+default = ["bevy-support"]
 serialize = ["serde"]
 
 [lints]

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -21,8 +21,8 @@ wgpu-types = { version = "0.20", default-features = false, optional = true }
 encase = { version = "0.8", default-features = false }
 
 [features]
-bevy-support = ["dep:bevy_reflect"]
-default = ["bevy-support"]
+default = []
+bevy = ["dep:bevy_reflect"]
 serialize = ["serde"]
 
 [lints]

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -2,7 +2,7 @@ use crate::{
     color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hue, Hwba, Laba, Lcha, LinearRgba,
     Luminance, Mix, Oklaba, Oklcha, Srgba, StandardColor, Xyza,
 };
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// An enumerated type that can represent any of the color types in this crate.
@@ -41,10 +41,10 @@ use bevy_reflect::prelude::*;
 /// To avoid the cost of repeated conversion, and ensure consistent results where that is desired,
 /// first convert this [`Color`] into your desired color space.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub enum Color {

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -2,6 +2,7 @@ use crate::{
     color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hue, Hwba, Laba, Lcha, LinearRgba,
     Luminance, Mix, Oklaba, Oklcha, Srgba, StandardColor, Xyza,
 };
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// An enumerated type that can represent any of the color types in this crate.
@@ -39,11 +40,11 @@ use bevy_reflect::prelude::*;
 /// due to its perceptual uniformity and broad support for Bevy's color operations.
 /// To avoid the cost of repeated conversion, and ensure consistent results where that is desired,
 /// first convert this [`Color`] into your desired color space.
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub enum Color {

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -2,7 +2,7 @@ use crate::{
     color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hue, Hwba, Laba, Lcha, LinearRgba,
     Luminance, Mix, Oklaba, Oklcha, Srgba, StandardColor, Xyza,
 };
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// An enumerated type that can represent any of the color types in this crate.
@@ -41,10 +41,10 @@ use bevy_reflect::prelude::*;
 /// To avoid the cost of repeated conversion, and ensure consistent results where that is desired,
 /// first convert this [`Color`] into your desired color space.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub enum Color {

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -3,7 +3,7 @@ use crate::{
     StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Saturation-Lightness (HSL) color space with alpha.
@@ -13,10 +13,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hsla {

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -3,6 +3,7 @@ use crate::{
     StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Saturation-Lightness (HSL) color space with alpha.
@@ -11,11 +12,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hsla {

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -3,7 +3,7 @@ use crate::{
     StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Saturation-Lightness (HSL) color space with alpha.
@@ -13,10 +13,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hsla {

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -2,7 +2,7 @@ use crate::{
     Alpha, ColorToComponents, Gray, Hue, Hwba, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Saturation-Value (HSV) color space with alpha.
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hsva {

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -2,7 +2,7 @@ use crate::{
     Alpha, ColorToComponents, Gray, Hue, Hwba, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Saturation-Value (HSV) color space with alpha.
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hsva {

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -2,6 +2,7 @@ use crate::{
     Alpha, ColorToComponents, Gray, Hue, Hwba, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Saturation-Value (HSV) color space with alpha.
@@ -10,11 +11,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hsva {

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -6,7 +6,7 @@ use crate::{
     Alpha, ColorToComponents, Gray, Hue, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Whiteness-Blackness (HWB) color space with alpha.
@@ -16,10 +16,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hwba {

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -6,7 +6,7 @@ use crate::{
     Alpha, ColorToComponents, Gray, Hue, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Whiteness-Blackness (HWB) color space with alpha.
@@ -16,10 +16,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hwba {

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -6,6 +6,7 @@ use crate::{
     Alpha, ColorToComponents, Gray, Hue, Lcha, LinearRgba, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in Hue-Whiteness-Blackness (HWB) color space with alpha.
@@ -14,11 +15,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Hwba {

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -3,7 +3,7 @@ use crate::{
     Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in LAB color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Laba {

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -3,6 +3,7 @@ use crate::{
     Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in LAB color space, with alpha
@@ -10,11 +11,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Laba {

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -3,7 +3,7 @@ use crate::{
     Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in LAB color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Laba {

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -3,7 +3,7 @@ use crate::{
     Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in LCH color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Lcha {

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -3,7 +3,7 @@ use crate::{
     Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in LCH color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Lcha {

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -3,6 +3,7 @@ use crate::{
     Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in LCH color space, with alpha
@@ -10,11 +11,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Lcha {

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -147,7 +147,6 @@ where
     Self: core::fmt::Debug,
     Self: Clone + Copy,
     Self: PartialEq,
-    Self: bevy_reflect::Reflect,
     Self: Default,
     Self: From<Color> + Into<Color>,
     Self: From<Srgba> + Into<Srgba>,

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -3,6 +3,7 @@ use crate::{
     ColorToPacked, Gray, Luminance, Mix, StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
 
@@ -11,11 +12,11 @@ use bytemuck::{Pod, Zeroable};
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, Pod, Zeroable)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 #[repr(C)]

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -3,7 +3,7 @@ use crate::{
     ColorToPacked, Gray, Luminance, Mix, StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
 
@@ -13,10 +13,10 @@ use bytemuck::{Pod, Zeroable};
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 #[repr(C)]

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -3,7 +3,7 @@ use crate::{
     ColorToPacked, Gray, Luminance, Mix, StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
 
@@ -13,10 +13,10 @@ use bytemuck::{Pod, Zeroable};
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq, Pod, Zeroable)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 #[repr(C)]

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -3,7 +3,7 @@ use crate::{
     Gray, Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in Oklab color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Oklaba {

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -3,6 +3,7 @@ use crate::{
     Gray, Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in Oklab color space, with alpha
@@ -10,11 +11,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Oklaba {

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -3,7 +3,7 @@ use crate::{
     Gray, Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in Oklab color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Oklaba {

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -3,7 +3,7 @@ use crate::{
     Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// Color in Oklch color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Oklcha {

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -3,6 +3,7 @@ use crate::{
     Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// Color in Oklch color space, with alpha
@@ -10,11 +11,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Oklcha {

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -3,7 +3,7 @@ use crate::{
     Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// Color in Oklch color space, with alpha
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Oklcha {

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -4,6 +4,7 @@ use crate::{
     Luminance, Mix, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 use thiserror::Error;
 
@@ -12,11 +13,11 @@ use thiserror::Error;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Srgba {

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -4,7 +4,7 @@ use crate::{
     Luminance, Mix, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 use thiserror::Error;
 
@@ -14,10 +14,10 @@ use thiserror::Error;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Srgba {

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -4,7 +4,7 @@ use crate::{
     Luminance, Mix, StandardColor, Xyza,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 use thiserror::Error;
 
@@ -14,10 +14,10 @@ use thiserror::Error;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Srgba {

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -3,7 +3,7 @@ use crate::{
     StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy-support")]
+#[cfg(feature = "bevy")]
 use bevy_reflect::prelude::*;
 
 /// [CIE 1931](https://en.wikipedia.org/wiki/CIE_1931_color_space) color space, also known as XYZ, with an alpha channel.
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy-support"),
+    all(feature = "serialize", feature = "bevy"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Xyza {

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -3,6 +3,7 @@ use crate::{
     StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
+#[cfg(feature = "bevy-support")]
 use bevy_reflect::prelude::*;
 
 /// [CIE 1931](https://en.wikipedia.org/wiki/CIE_1931_color_space) color space, also known as XYZ, with an alpha channel.
@@ -10,11 +11,11 @@ use bevy_reflect::prelude::*;
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
-#[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy-support", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
+    all(feature = "serialize", feature = "bevy-support"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Xyza {

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -3,7 +3,7 @@ use crate::{
     StandardColor,
 };
 use bevy_math::{Vec3, Vec4};
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 
 /// [CIE 1931](https://en.wikipedia.org/wiki/CIE_1931_color_space) color space, also known as XYZ, with an alpha channel.
@@ -12,10 +12,10 @@ use bevy_reflect::prelude::*;
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]
 /// </div>
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(Reflect), reflect(PartialEq, Default))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(PartialEq, Default))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
-    all(feature = "serialize", feature = "bevy"),
+    all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
 pub struct Xyza {

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -42,7 +42,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.14.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.14.0-dev", features = [
   "serialize",
   "wgpu-types",
-  "bevy",
+  "bevy_reflect",
 ] }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -42,7 +42,6 @@ bevy_asset = { path = "../bevy_asset", version = "0.14.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.14.0-dev", features = [
   "serialize",
   "wgpu-types",
-  "bevy_reflect",
 ] }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -42,6 +42,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.14.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.14.0-dev", features = [
   "serialize",
   "wgpu-types",
+  "bevy",
 ] }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }


### PR DESCRIPTION
# Objective

Allow the use of color definitions from Bevy in other contexts than pure Bevy apps, e.g. outside ECS use.
In those cases it's nice to not have more dependencies than you need.

## Solution

Hide use of reflection behind a feature flag.
Defaults to on.

## Points to consider

1. This was straightforward _except_ for the `crates/bevy_color/src/lib.rs` change where I removed `Reflect` as a bound. That is awkward to have feature gated since features should be additive. If the bound was added as part of the feature flag, the result would be _more_ restrictive, and _disable_ impls which did not have the impl. On the other hand having the reflect bound there unconditionally would defeat the purpose of the PR. I opted to remove the bound since it seems overly restrictive anyway.
2. It's possible to hide `encase` and `bytemuck` behind the new feature flag too (or a separate one). I'm thinking if `bevy-support` is not desired then it's unlikely that the user has need of those.
