### PR TITLE
Make time_system public

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -110,7 +110,7 @@ pub fn create_time_channels() -> (TimeSender, TimeReceiver) {
 
 /// The system used to update the [`Time`] used by app logic. If there is a render world the time is
 /// sent from there to this system through channels. Otherwise the time is updated in this system.
-fn time_system(
+pub fn time_system(
     mut real_time: ResMut<Time<Real>>,
     mut virtual_time: ResMut<Time<Virtual>>,
     mut time: ResMut<Time>,


### PR DESCRIPTION
# Objective

If `time_system` isn't public you cannot order systems relative to it in the `TimeSystem` set.

## Solution

Make it public