### PR TITLE
fix typo

### DIFF
--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -75,11 +75,11 @@ pub enum UpdateMode {
         /// **Note:** This has no upper limit.
         /// The [`App`](bevy_app::App) will wait indefinitely if you set this to [`Duration::MAX`].
         wait: Duration,
-        /// Reacts to device events, that will wake up the loop if it's in a wait wtate
+        /// Reacts to device events, that will wake up the loop if it's in a wait state
         react_to_device_events: bool,
-        /// Reacts to user events, that will wake up the loop if it's in a wait wtate
+        /// Reacts to user events, that will wake up the loop if it's in a wait state
         react_to_user_events: bool,
-        /// Reacts to window events, that will wake up the loop if it's in a wait wtate
+        /// Reacts to window events, that will wake up the loop if it's in a wait state
         react_to_window_events: bool,
     },
 }


### PR DESCRIPTION
# Objective

"wtate" an off-by-one typo in the winit_config.rs file

## Solution

"state"

