### PR TITLE
Add cross gizmos

### DIFF
--- a/crates/bevy_gizmos/src/cross.rs
+++ b/crates/bevy_gizmos/src/cross.rs
@@ -5,7 +5,7 @@
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 use bevy_color::Color;
-use bevy_math::{Mat2, Quat, Vec2, Vec3};
+use bevy_math::{Mat2, Mat3, Quat, Vec2, Vec3};
 
 impl<Config> Gizmos<'_, '_, Config>
 where
@@ -33,9 +33,10 @@ where
         half_size: f32,
         color: impl Into<Color>,
     ) {
-        let local_x = rotation * Vec3::new(half_size, 0.0, 0.0);
-        let local_y = rotation * Vec3::new(0.0, half_size, 0.0);
-        let local_z = rotation * Vec3::new(0.0, 0.0, half_size);
+        let axes = half_size * Mat3::from_quat(rotation);
+        let local_x = axes.col(0);
+        let local_y = axes.col(1);
+        let local_z = axes.col(2);
 
         let color: Color = color.into();
         self.line(position + local_x, position - local_x, color);
@@ -65,9 +66,9 @@ where
         half_size: f32,
         color: impl Into<Color>,
     ) {
-        let rotation = Mat2::from_angle(angle);
-        let local_x = rotation * Vec2::new(half_size, 0.0);
-        let local_y = rotation * Vec2::new(0.0, half_size);
+        let axes = half_size * Mat2::from_angle(angle);
+        let local_x = axes.col(0);
+        let local_y = axes.col(1);
 
         let color: Color = color.into();
         self.line_2d(position + local_x, position - local_x, color);

--- a/crates/bevy_gizmos/src/cross.rs
+++ b/crates/bevy_gizmos/src/cross.rs
@@ -1,0 +1,76 @@
+//! Additional [`Gizmos`] Functions -- Crosses
+//!
+//! Includes the implementation of [`Gizmos::cross`] and [`Gizmos::cross_2d`],
+//! and assorted support items.
+
+use crate::prelude::{GizmoConfigGroup, Gizmos};
+use bevy_color::Color;
+use bevy_math::{Mat2, Quat, Vec2, Vec3};
+
+impl<Config> Gizmos<'_, '_, Config>
+where
+    Config: GizmoConfigGroup,
+{
+    /// Draw a cross in 3D at `position`.
+    ///
+    /// This should be called for each frame the cross needs to be rendered.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_render::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use bevy_color::palettes::basic::WHITE;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.cross(Vec3::ZERO, Quat::IDENTITY, 0.5, WHITE);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    pub fn cross(
+        &mut self,
+        position: Vec3,
+        rotation: Quat,
+        half_size: f32,
+        color: impl Into<Color>,
+    ) {
+        let local_x = rotation * Vec3::new(half_size, 0.0, 0.0);
+        let local_y = rotation * Vec3::new(0.0, half_size, 0.0);
+        let local_z = rotation * Vec3::new(0.0, 0.0, half_size);
+
+        let color: Color = color.into();
+        self.line(position + local_x, position - local_x, color);
+        self.line(position + local_y, position - local_y, color);
+        self.line(position + local_z, position - local_z, color);
+    }
+
+    /// Draw a cross in 2D (on the xy plane) at `position`.
+    ///
+    /// This should be called for each frame the cross needs to be rendered.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_render::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use bevy_color::palettes::basic::WHITE;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.cross_2d(Vec2::ZERO, 0.0, 0.5, WHITE);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    pub fn cross_2d(
+        &mut self,
+        position: Vec2,
+        angle: f32,
+        half_size: f32,
+        color: impl Into<Color>,
+    ) {
+        let rotation = Mat2::from_angle(angle);
+        let local_x = rotation * Vec2::new(half_size, 0.0);
+        let local_y = rotation * Vec2::new(0.0, half_size);
+
+        let color: Color = color.into();
+        self.line_2d(position + local_x, position - local_x, color);
+        self.line_2d(position + local_y, position - local_y, color);
+    }
+}

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -1,6 +1,6 @@
 //! Additional [`Gizmos`] Functions -- Grids
 //!
-//! Includes the implementation of[`Gizmos::grid`] and [`Gizmos::grid_2d`].
+//! Includes the implementation of [`Gizmos::grid`] and [`Gizmos::grid_2d`].
 //! and assorted support items.
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -36,6 +36,7 @@ pub mod arcs;
 pub mod arrows;
 pub mod circles;
 pub mod config;
+pub mod cross;
 pub mod gizmos;
 pub mod grid;
 pub mod primitives;

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -68,6 +68,8 @@ fn draw_example_collection(
 
     gizmos.rect_2d(Vec2::ZERO, 0., Vec2::splat(650.), BLACK);
 
+    gizmos.cross_2d(Vec2::new(-160., 120.), 0., 12., GRAY);
+
     my_gizmos
         .rounded_rect_2d(Vec2::ZERO, 0., Vec2::splat(630.), BLACK)
         .corner_radius((time.elapsed_seconds() / 3.).cos() * 100.);

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -68,7 +68,7 @@ fn draw_example_collection(
 
     gizmos.rect_2d(Vec2::ZERO, 0., Vec2::splat(650.), BLACK);
 
-    gizmos.cross_2d(Vec2::new(-160., 120.), 0., 12., GRAY);
+    gizmos.cross_2d(Vec2::new(-160., 120.), 0., 12., FUCHSIA);
 
     my_gizmos
         .rounded_rect_2d(Vec2::ZERO, 0., Vec2::splat(630.), BLACK)

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -103,6 +103,8 @@ fn draw_example_collection(
         LIME,
     );
 
+    gizmos.cross(Vec3::new(-1., 1., 1.), Quat::IDENTITY, 0.5, FUCHSIA);
+
     my_gizmos.sphere(Vec3::new(1., 0.5, 0.), Quat::IDENTITY, 0.5, RED);
 
     my_gizmos


### PR DESCRIPTION
# Objective

Add `cross` and `cross_2d` gizmos in accordance with #13868.

## Solution

Extend `Gizmos` to provide these functions.

## Testing

Tested in `2d_gizmos` and `3d_gizmos` examples, and external projects.

![image](https://github.com/bevyengine/bevy/assets/29227697/d13067e1-d7eb-46c5-9b73-6c2d70417889)

![image](https://github.com/bevyengine/bevy/assets/29227697/0a8eba48-fbb3-4b3e-abe1-4e250222f94b)

