### PR TITLE
Update observer archetype flags for sparse components

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -370,6 +370,7 @@ impl Archetype {
             // SAFETY: We are creating an archetype that includes this component so it must exist
             let info = unsafe { components.get_info_unchecked(component_id) };
             info.update_archetype_flags(&mut flags);
+            observers.update_archetype_flags(component_id, &mut flags);
             archetype_components.insert(
                 component_id,
                 ArchetypeComponentInfo {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -400,6 +400,10 @@ mod tests {
     #[derive(Component)]
     struct C;
 
+    #[derive(Component)]
+    #[component(storage = "SparseSet")]
+    struct S;
+
     #[derive(Event)]
     struct EventA;
 
@@ -440,6 +444,22 @@ mod tests {
         let mut entity = world.spawn_empty();
         entity.insert(A);
         entity.remove::<A>();
+        entity.flush();
+        assert_eq!(3, world.resource::<R>().0);
+    }
+
+    #[test]
+    fn observer_order_insert_remove_sparse() {
+        let mut world = World::new();
+        world.init_resource::<R>();
+
+        world.observe(|_: Trigger<OnAdd, S>, mut res: ResMut<R>| res.assert_order(0));
+        world.observe(|_: Trigger<OnInsert, S>, mut res: ResMut<R>| res.assert_order(1));
+        world.observe(|_: Trigger<OnRemove, S>, mut res: ResMut<R>| res.assert_order(2));
+
+        let mut entity = world.spawn_empty();
+        entity.insert(S);
+        entity.remove::<S>();
         entity.flush();
         assert_eq!(3, world.resource::<R>().0);
     }


### PR DESCRIPTION
# Objective

- Fixes #13885 

## Solution

- Update the flags correctly on archetype creation

## Testing

- Added `observer_order_insert_remove_sparse` to catch regressions.
