### PR TITLE
Distribute shapes across -X_EXTENT and X_EXTENT

### DIFF
--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -13,7 +13,7 @@ fn main() {
         .run();
 }
 
-const X_EXTENT: f32 = 900.;
+const X_EXTENT: f32 = 450.;
 
 fn setup(
     mut commands: Commands,
@@ -48,8 +48,8 @@ fn setup(
             mesh: shape,
             material: materials.add(color),
             transform: Transform::from_xyz(
-                // Distribute shapes from -X_EXTENT/2 to +X_EXTENT/2.
-                -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
+                // Distribute shapes from -X_EXTENT to +X_EXTENT.
+                -X_EXTENT + i as f32 / (num_shapes - 1) as f32 * 2. * X_EXTENT,
                 0.0,
                 0.0,
             ),

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -28,7 +28,7 @@ fn main() {
 #[derive(Component)]
 struct Shape;
 
-const SHAPES_X_EXTENT: f32 = 14.0;
+const SHAPES_X_EXTENT: f32 = 7.0;
 const EXTRUSION_X_EXTENT: f32 = 16.0;
 const Z_EXTENT: f32 = 5.0;
 
@@ -73,7 +73,7 @@ fn setup(
                 mesh: shape,
                 material: debug_material.clone(),
                 transform: Transform::from_xyz(
-                    -SHAPES_X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * SHAPES_X_EXTENT,
+                    -SHAPES_X_EXTENT + i as f32 / (num_shapes - 1) as f32 * 2. * SHAPES_X_EXTENT,
                     2.0,
                     Z_EXTENT / 2.,
                 )


### PR DESCRIPTION
# Objective

- In the examples for 2d shapes, the comment (previously, comment fixed in #12865) says it is distributing the shapes from `-X_EXTENT` to `X_EXTENT`, but the code actually distributes it from `-X_EXTENT/2` to `X_EXTENT/2`.
- It makes more sense to distribute it from `X_EXTENT` since that is the meaning of "extent", and the camera will render everything anyways, so there is not need to arbitrarily render to extent/2 instead.


## Solution

- Fix the code to distribute it from  `-X_EXTENT` to `X_EXTENT`.
- Reduce the `X_EXTENT` by half to compensate for the increase in distance between the shapes.
- Did similarly for 3d shapes

## Testing

- Did you test these changes? If so, how?
  - Ran the 2d and 3d shapes examples
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---