### PR TITLE
Fix parameter name of all_tuples's document

### DIFF
--- a/crates/bevy_utils/macros/src/lib.rs
+++ b/crates/bevy_utils/macros/src/lib.rs
@@ -67,10 +67,10 @@ impl Parse for AllTuples {
 ///
 /// all_tuples!(impl_wrapped_in_foo, 0, 15, T);
 /// // impl_wrapped_in_foo!();
-/// // impl_wrapped_in_foo!(P0);
-/// // impl_wrapped_in_foo!(P0, P1);
+/// // impl_wrapped_in_foo!(T0);
+/// // impl_wrapped_in_foo!(T0, T1);
 /// // ..
-/// // impl_wrapped_in_foo!(P0 .. P14);
+/// // impl_wrapped_in_foo!(T0 .. T14);
 /// ```
 /// Multiple parameters.
 /// ```


### PR DESCRIPTION
# Objective

I got little confused by the document of `all_tuples!` because type names of the parameter `T` and extracted names `Pn` are difference.

## Solution

I fixed type names of the document.