### PR TITLE
Refactor check_light_mesh_visibility for performance 

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -368,7 +368,7 @@ impl Plugin for PbrPlugin {
                         .after(TransformSystem::TransformPropagate)
                         .after(SimulationLightSystems::AssignLightsToClusters),
                     check_visibility::<WithLight>.in_set(VisibilitySystems::CheckVisibility),
-                    check_light_mesh_visibility
+                    (check_dir_light_mesh_visibility, check_light_mesh_visibility)
                         .in_set(SimulationLightSystems::CheckLightVisibility)
                         .after(VisibilitySystems::CalculateBounds)
                         .after(TransformSystem::TransformPropagate)

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -368,7 +368,10 @@ impl Plugin for PbrPlugin {
                         .after(TransformSystem::TransformPropagate)
                         .after(SimulationLightSystems::AssignLightsToClusters),
                     check_visibility::<WithLight>.in_set(VisibilitySystems::CheckVisibility),
-                    (check_dir_light_mesh_visibility, check_point_light_mesh_visibility)
+                    (
+                        check_dir_light_mesh_visibility,
+                        check_point_light_mesh_visibility,
+                    )
                         .in_set(SimulationLightSystems::CheckLightVisibility)
                         .after(VisibilitySystems::CalculateBounds)
                         .after(TransformSystem::TransformPropagate)

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -368,7 +368,7 @@ impl Plugin for PbrPlugin {
                         .after(TransformSystem::TransformPropagate)
                         .after(SimulationLightSystems::AssignLightsToClusters),
                     check_visibility::<WithLight>.in_set(VisibilitySystems::CheckVisibility),
-                    (check_dir_light_mesh_visibility, check_light_mesh_visibility)
+                    (check_dir_light_mesh_visibility, check_point_light_mesh_visibility)
                         .in_set(SimulationLightSystems::CheckLightVisibility)
                         .after(VisibilitySystems::CalculateBounds)
                         .after(TransformSystem::TransformPropagate)

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -979,7 +979,7 @@ pub fn check_dir_light_mesh_visibility(
                                 frustum_visible_entities.push(entity);
                             }
                             if visible {
-                                queue0.push(entity)
+                                queue0.push(entity);
                             }
                         } else {
                             queue0.push(entity);
@@ -999,7 +999,7 @@ pub fn check_dir_light_mesh_visibility(
                         .zip(entities.iter_mut())
                         .for_each(|(dst, source)| {
                             dst.append(source);
-                        })
+                        });
                 }
             }
         },
@@ -1015,10 +1015,10 @@ pub fn check_dir_light_mesh_visibility(
     }
 
     let mut defer_queue = std::mem::take(visible_entities_queue.deref_mut());
-    commands.add(move |mut world: &mut World| {
+    commands.add(move |world: &mut World| {
         let mut query = world.query::<&mut ViewVisibility>();
         for entities in defer_queue.iter_mut() {
-            let mut iter = query.iter_many_mut(&mut world, entities.iter());
+            let mut iter = query.iter_many_mut(world, entities.iter());
             while let Some(mut t) = iter.fetch_next() {
                 t.set();
             }

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -1015,7 +1015,7 @@ pub fn check_dir_light_mesh_visibility(
         }
     }
 
-    // TODO: use resource to avoid unnessary memory alloc
+    // TODO: use resource to avoid unnecessary memory alloc
     let mut defer_queue = std::mem::take(visible_entities_queue.deref_mut());
     commands.add(move |world: &mut World| {
         let mut query = world.query::<&mut ViewVisibility>();

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::DerefMut;
 
-use bevy_ecs::entity::EntityHashMap;
+use bevy_ecs::entity::{EntityHashMap, EntityHashSet};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Vec3A, Vec4};
 use bevy_reflect::prelude::*;
@@ -10,6 +10,7 @@ use bevy_render::{
     extract_resource::ExtractResource,
     mesh::Mesh,
     primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, Sphere},
+    render_resource::Buffer,
     view::{
         InheritedVisibility, RenderLayers, ViewVisibility, VisibilityRange, VisibleEntities,
         VisibleEntityRanges, WithMesh,
@@ -853,6 +854,7 @@ pub fn check_dir_light_mesh_visibility(
     mut commands: Commands,
     mut directional_lights: Query<
         (
+            Entity,
             &DirectionalLight,
             &CascadesFrusta,
             &mut CascadesVisibleEntities,
@@ -878,11 +880,16 @@ pub fn check_dir_light_mesh_visibility(
     >,
     visible_entity_ranges: Option<Res<VisibleEntityRanges>>,
     mut visible_entities_queue: Local<Parallel<Vec<Entity>>>,
-    mut view_light_visbile_entities: Local<Parallel<EntityHashMap<Vec<Vec<Entity>>>>>,
+    mut view_light_visbile_entities: Local<
+        Parallel<EntityHashMap<EntityHashMap<Vec<Vec<Entity>>>>>,
+    >,
 ) {
     let visible_entity_ranges = visible_entity_ranges.as_deref();
 
-    for (_, frusta, mut cascades_visible_entities, _, _) in &mut directional_lights {
+    // let mut lights_to_remove = EntityHashSet::default();
+    view_light_visbile_entities.clear();
+
+    for (light_entity, _, frusta, mut cascades_visible_entities, _, _) in &mut directional_lights {
         let mut views_to_remove = Vec::new();
         for (view, cascade_view_entities) in &mut cascades_visible_entities.entities {
             match frusta.frusta.get(view) {
@@ -903,93 +910,143 @@ pub fn check_dir_light_mesh_visibility(
                 .or_insert_with(|| vec![VisibleEntities::default(); frusta.len()]);
         }
 
-        for v in views_to_remove {
-            cascades_visible_entities.entities.remove(&v);
-        }
+        // for light_entities in view_light_visbile_entities.iter_mut() {
+        //     match light_entities.get_mut(&light_entity) {
+        //         Some(entities) => {
+        //             for v in views_to_remove.iter() {
+        //                 entities.remove(v);
+        //             }
+        //         }
+        //         None => {
+        //             lights_to_remove.insert(light_entity);
+        //         }
+        //     }
+        // }
     }
 
-    visible_entity_query.par_iter().for_each_init(
-        || {
-            (
-                visible_entities_queue.borrow_local_mut(),
-                view_light_visbile_entities.borrow_local_mut(),
-            )
-        },
-        |(queue0, queue1),
-         (
-            entity,
-            inherited_visibility,
-            maybe_entity_mask,
-            maybe_aabb,
-            maybe_transform,
-            has_visibility_range,
-        )| {
-            if !inherited_visibility.get() {
-                return;
-            }
-            let mut visible = false;
+    // for light_entities in view_light_visbile_entities.iter_mut() {
+    //     for e in &lights_to_remove {
+    //         light_entities.remove(e);
+    //     }
+    // }
 
-            for (directional_light, frusta, _, maybe_view_mask, light_view_visibility) in
-                &directional_lights
-            {
-                // NOTE: If shadow mapping is disabled for the light then it must have no visible entities
-                if !directional_light.shadows_enabled || !light_view_visibility.get() {
-                    continue;
+    visible_entity_query
+        .par_iter()
+        .batching_strategy(bevy_ecs::batching::BatchingStrategy {
+            batches_per_thread: 2,
+            ..Default::default()
+        })
+        .for_each_init(
+            || {
+                (
+                    visible_entities_queue.borrow_local_mut(),
+                    view_light_visbile_entities.borrow_local_mut(),
+                )
+            },
+            |(queue0, queue1),
+             (
+                entity,
+                inherited_visibility,
+                maybe_entity_mask,
+                maybe_aabb,
+                maybe_transform,
+                has_visibility_range,
+            )| {
+                if !inherited_visibility.get() {
+                    return;
                 }
+                let mut visible = false;
 
-                let view_mask = maybe_view_mask.unwrap_or_default();
-                let entity_mask = maybe_entity_mask.unwrap_or_default();
-                if !view_mask.intersects(entity_mask) {
-                    continue;
-                }
+                for (
+                    light_entity,
+                    directional_light,
+                    frusta,
+                    _,
+                    maybe_view_mask,
+                    light_view_visibility,
+                ) in &directional_lights
+                {
+                    // NOTE: If shadow mapping is disabled for the light then it must have no visible entities
+                    if !directional_light.shadows_enabled || !light_view_visibility.get() {
+                        continue;
+                    }
 
-                if let (Some(aabb), Some(transform)) = (maybe_aabb, maybe_transform) {
-                    for (view, view_frusta) in &frusta.frusta {
-                        let view_visible_entities =
-                            queue1
+                    let view_mask = maybe_view_mask.unwrap_or_default();
+                    let entity_mask = maybe_entity_mask.unwrap_or_default();
+                    if !view_mask.intersects(entity_mask) {
+                        continue;
+                    }
+
+                    let light_cascades_visible_entities = queue1.entry(light_entity).or_default();
+
+                    if let (Some(aabb), Some(transform)) = (maybe_aabb, maybe_transform) {
+                        for (view, view_frusta) in &frusta.frusta {
+                            let view_visible_entities = light_cascades_visible_entities
                                 .entry(*view)
                                 .or_insert(vec![Vec::default(); view_frusta.len()]);
+                            view_visible_entities.resize(view_frusta.len(), Vec::default());
 
-                        // Check visibility ranges.
-                        if has_visibility_range
-                            && visible_entity_ranges.is_some_and(|visible_entity_ranges| {
-                                !visible_entity_ranges.entity_is_in_range_of_view(entity, *view)
-                            })
-                        {
-                            continue;
-                        }
-
-                        for (frustum, frustum_visible_entities) in
-                            view_frusta.iter().zip(view_visible_entities)
-                        {
-                            // Disable near-plane culling, as a shadow caster could lie before the near plane.
-                            if !frustum.intersects_obb(aabb, &transform.affine(), false, true) {
+                            // Check visibility ranges.
+                            if has_visibility_range
+                                && visible_entity_ranges.is_some_and(|visible_entity_ranges| {
+                                    !visible_entity_ranges.entity_is_in_range_of_view(entity, *view)
+                                })
+                            {
                                 continue;
                             }
 
-                            visible = true;
-                            frustum_visible_entities.push(entity);
-                        }
-                    }
-                } else {
-                    visible = true;
-                    for view in frusta.frusta.keys() {
-                        let view_visible_entities = queue1.entry(*view).or_default();
+                            for (frustum, frustum_visible_entities) in
+                                view_frusta.iter().zip(view_visible_entities)
+                            {
+                                // Disable near-plane culling, as a shadow caster could lie before the near plane.
+                                if !frustum.intersects_obb(aabb, &transform.affine(), false, true) {
+                                    continue;
+                                }
 
-                        for frustum_visible_entities in view_visible_entities {
-                            frustum_visible_entities.push(entity);
+                                visible = true;
+                                frustum_visible_entities.push(entity);
+                            }
+                        }
+                    } else {
+                        visible = true;
+                        for (view, frusta) in &frusta.frusta {
+                            let view_visible_entities = light_cascades_visible_entities
+                                .entry(*view)
+                                .or_insert(vec![Vec::default(); frusta.len()]);
+
+                            view_visible_entities.resize(frusta.len(), Vec::default());
+
+                            for frustum_visible_entities in view_visible_entities {
+                                frustum_visible_entities.push(entity);
+                            }
                         }
                     }
                 }
-            }
 
-            if visible {
-                queue0.push(entity)
-            }
-        },
-    );
+                if visible {
+                    queue0.push(entity)
+                }
+            },
+        );
 
-    for (_, _, mut cascades_visible_entities, _, _) in &mut directional_lights {
+    for entities in view_light_visbile_entities.iter_mut() {
+        for (e, visible_entities) in entities.iter_mut() {
+            if let Ok((_, _, _, mut cascades_visible_entities, _, _)) =
+                directional_lights.get_mut(*e)
+            {
+                for (view_entity, cascade_entities) in cascades_visible_entities.entities.iter_mut()
+                {
+                    let values = visible_entities.get_mut(view_entity).unwrap();
+                    cascade_entities
+                        .iter_mut()
+                        .zip(values.iter_mut())
+                        .for_each(|(des, source)| des.get_mut::<WithMesh>().append(source))
+                }
+            };
+        }
+    }
+
+    for (entity, _, _, mut cascades_visible_entities, _, _) in &mut directional_lights {
         for (_, cascade_view_entities) in &mut cascades_visible_entities.entities {
             cascade_view_entities
                 .iter_mut()

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -682,11 +682,11 @@ pub fn check_light_mesh_visibility(
     >,
     visible_entity_ranges: Option<Res<VisibleEntityRanges>>,
 ) {
-    fn shrink_entities(visible_entities: &mut VisibleEntities) {
+    fn shrink_entities(visible_entities: &mut Vec<Entity>) {
         // Check that visible entities capacity() is no more than two times greater than len()
-        let capacity = visible_entities.entities.capacity();
+        let capacity = visible_entities.capacity();
         let reserved = capacity
-            .checked_div(visible_entities.entities.len())
+            .checked_div(visible_entities.len())
             .map_or(0, |reserve| {
                 if reserve > 2 {
                     capacity / (reserve / 2)
@@ -695,7 +695,7 @@ pub fn check_light_mesh_visibility(
                 }
             });
 
-        visible_entities.entities.shrink_to(reserved);
+        visible_entities.shrink_to(reserved);
     }
 
     let visible_entity_ranges = visible_entity_ranges.as_deref();
@@ -712,7 +712,7 @@ pub fn check_light_mesh_visibility(
                     cascade_view_entities.resize(view_frusta.len(), Default::default());
                     cascade_view_entities
                         .iter_mut()
-                        .for_each(|x| x.entities.clear());
+                        .for_each(|x| x.clear::<WithMesh>());
                 }
                 None => views_to_remove.push(*view),
             };
@@ -798,7 +798,10 @@ pub fn check_light_mesh_visibility(
         }
 
         for (_, cascade_view_entities) in &mut visible_entities.entities {
-            cascade_view_entities.iter_mut().for_each(shrink_entities);
+            cascade_view_entities
+                .iter_mut()
+                .map(|x| x.get_mut::<WithMesh>())
+                .for_each(shrink_entities);
         }
     }
 
@@ -814,7 +817,7 @@ pub fn check_light_mesh_visibility(
             )) = point_lights.get_mut(light_entity)
             {
                 for visible_entities in cubemap_visible_entities.iter_mut() {
-                    visible_entities.entities.clear();
+                    visible_entities.clear::<WithMesh>();
                 }
 
                 // NOTE: If shadow mapping is disabled for the light then it must have no visible entities
@@ -882,7 +885,7 @@ pub fn check_light_mesh_visibility(
                 }
 
                 for visible_entities in cubemap_visible_entities.iter_mut() {
-                    shrink_entities(visible_entities);
+                    shrink_entities(visible_entities.get_mut::<WithMesh>());
                 }
             }
 
@@ -890,7 +893,7 @@ pub fn check_light_mesh_visibility(
             if let Ok((point_light, transform, frustum, mut visible_entities, maybe_view_mask)) =
                 spot_lights.get_mut(light_entity)
             {
-                visible_entities.entities.clear();
+                visible_entities.clear::<WithMesh>();
 
                 // NOTE: If shadow mapping is disabled for the light then it must have no visible entities
                 if !point_light.shadows_enabled {
@@ -949,7 +952,7 @@ pub fn check_light_mesh_visibility(
                     }
                 }
 
-                shrink_entities(&mut visible_entities);
+                shrink_entities(visible_entities.get_mut::<WithMesh>());
             }
         }
     }


### PR DESCRIPTION
# Objective

- The current `check_light_mesh_visibility ` system has unsatisfactory performance, as it involves multiple hash lookups for every mesh entity and lacks parallelization

## Solution

- split `check_light_mesh_visibility` to `check_dir_light_mesh_visibility` and `check_point_light_mesh_visibility`

- `check_dir_light_mesh_visibility `defers setting the entity's viewVisibility so that Bevy can schedule it to run in parallel with `check_point_light_mesh_visibility`.

- Reduce HashMap lookups for directional light checking as much as possible

- Use par_iter to parallelize the checking process within each system.

## Testing
cargo run --release --example many_cubes --features bevy/trace_tracy -- --shadows    

![image](https://github.com/bevyengine/bevy/assets/45868716/c51d6a8b-ad35-40ff-8e0e-693234066999)

command apply:
![image](https://github.com/bevyengine/bevy/assets/45868716/f5f8cdf1-1759-4953-a93f-a916276adc94)

reduce from 4.88ms to 972+ 303 =1.2ms ,~4x speed up.


 cargo run --release --example many_foxes --features bevy/trace_tracy -- --count 10000 

![image](https://github.com/bevyengine/bevy/assets/45868716/45c72eee-1cd3-47ef-a5f8-598d4eb67868)

command apply:
![image](https://github.com/bevyengine/bevy/assets/45868716/31c4ec7a-016f-4ea7-9edb-20c39281e597)

reduce from 646us to 142+ 97 =239us  ,~3x speed up.

In the most common scenarios, there is usually one directional light and multiple point lights, and this PR should provide more advantages as direction light checking can run in parallel with point light checking.