### PR TITLE
bug: Don't panic. Warn on missing file_watcher path. (new branch)

### DIFF
--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -471,8 +471,10 @@ impl AssetSource {
         return "Web does not currently support watching assets.";
         #[cfg(target_os = "android")]
         return "Android does not currently support watching assets.";
-        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android"), not(feature = "file_watcher")))]
         return "Consider enabling the `file_watcher` feature.";
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android"), feature = "file_watcher"))]
+        return "Consider adding an `assets` directory.";
     }
 
     /// Returns a builder function for this platform's default [`AssetWatcher`]. `path` is the relative path to

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -471,9 +471,17 @@ impl AssetSource {
         return "Web does not currently support watching assets.";
         #[cfg(target_os = "android")]
         return "Android does not currently support watching assets.";
-        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android"), not(feature = "file_watcher")))]
+        #[cfg(all(
+            not(target_arch = "wasm32"),
+            not(target_os = "android"),
+            not(feature = "file_watcher")
+        ))]
         return "Consider enabling the `file_watcher` feature.";
-        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android"), feature = "file_watcher"))]
+        #[cfg(all(
+            not(target_arch = "wasm32"),
+            not(target_os = "android"),
+            feature = "file_watcher"
+        ))]
         return "Consider adding an `assets` directory.";
     }
 

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -496,7 +496,7 @@ impl AssetSource {
             {
                 let path = std::path::PathBuf::from(path.clone());
                 if path.exists() {
-                    return Some(Box::new(
+                    Some(Box::new(
                         super::file::FileWatcher::new(
                             path.clone(),
                             sender,
@@ -505,10 +505,10 @@ impl AssetSource {
                         .unwrap_or_else(|e| {
                             panic!("Failed to create file watcher from path {path:?}, {e:?}")
                         }),
-                    ));
+                    ))
                 } else {
                     warn!("Skip creating file watcher because path {path:?} does not exist.");
-                    return None;
+                    None
                 }
             }
             #[cfg(any(

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -493,16 +493,24 @@ impl AssetSource {
                 not(target_arch = "wasm32"),
                 not(target_os = "android")
             ))]
-            return Some(Box::new(
-                super::file::FileWatcher::new(
-                    std::path::PathBuf::from(path.clone()),
-                    sender,
-                    file_debounce_wait_time,
-                )
-                .unwrap_or_else(|e| {
-                    panic!("Failed to create file watcher from path {path:?}, {e:?}")
-                }),
-            ));
+            {
+                let path = std::path::PathBuf::from(path.clone());
+                if path.exists() {
+                    return Some(Box::new(
+                        super::file::FileWatcher::new(
+                            path.clone(),
+                            sender,
+                            file_debounce_wait_time,
+                        )
+                        .unwrap_or_else(|e| {
+                            panic!("Failed to create file watcher from path {path:?}, {e:?}")
+                        }),
+                    ));
+                } else {
+                    warn!("Skip creating file watcher because path {path:?} does not exist.");
+                    return None;
+                }
+            }
             #[cfg(any(
                 not(feature = "file_watcher"),
                 target_arch = "wasm32",

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -482,7 +482,7 @@ impl AssetSource {
             not(target_os = "android"),
             feature = "file_watcher"
         ))]
-        return "Consider adding an `assets` directory.";
+        return "Consider adding an \"assets\" directory.";
     }
 
     /// Returns a builder function for this platform's default [`AssetWatcher`]. `path` is the relative path to


### PR DESCRIPTION
I updated my 'main' branch, which accidentally closed the original PR #13747. I'm reopening the this from an actual branch on my repo like I should have done in the first place. Here's the original info from the first PR:

* * *

# Problem

The `file_watcher` feature panics if the file_watcher's path "assets" is not present. I stumbled upon this behavior when I was actually testing against `embedded_watcher`. I had no "assets" directory and didn't need one for [my project](https://github.com/shanecelis/bevy_plane_cut).

```text
$ cargo run --example simple; # Runs fine.
$ cargo run --example simple --feature embedded_watcher; # Panics
thread 'main' panicked at /Users/shane/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_asset-0.14.0-rc.2/src/io/source.rs:503:21:
Failed to create file watcher from path "assets", Error { kind: PathNotFound, paths: ["/Users/shane/Projects/bevy_plane_cut/assets"] }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# Opinion

If a project runs without panicing, then adding the `file_watcher` feature shouldn't cause it to panic.

# Suggested Solution

This PR suggests if the "assets" path does not exist, emit a warning stating that the file watcher could not be created and why. All other errors will be treated as before with a panic and a message.

```text
$ cargo run --example simple --feature embedded_watcher; # Panics
2024-06-08T08:55:11.385249Z  WARN bevy_asset::io::source: Skip creating file watcher because path "assets" does not exist.
2024-06-08T08:55:11.385291Z  WARN bevy_asset::io::source: AssetSourceId::Default does not have an AssetWatcher configured. Consider enabling the `file_watcher` feature.
```

The second warning is new and I'd prefer it didn't emit under this condition, but I'll wait to see whether this is actually regarded as a bug.

# Testing

No tests added. Compiled against my project and it demonstrated the suggested behavior.

* * *

I changed the second warning to the following when the `file_watcher` feature is present. When it's not present, it uses the same warning as before.

```
024-06-09T01:22:16.880619Z  WARN bevy_asset::io::source: Skip creating file watcher because path "assets" does not exist.
2024-06-09T01:22:16.880660Z  WARN bevy_asset::io::source: AssetSourceId::Default does not have an AssetWatcher configured. Consider adding an "assets" directory.
```