### PR TITLE
Make meshlet processing deterministic

### DIFF
--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -256,7 +256,7 @@ fn find_connected_meshlets(
 
 fn group_meshlets(
     simplification_queue: Range<usize>,
-    connected_meshlets_per_meshlet: &Vec<Vec<(usize, usize)>>,
+    connected_meshlets_per_meshlet: &[Vec<(usize, usize)>],
 ) -> Vec<Vec<usize>> {
     let mut xadj = Vec::with_capacity(simplification_queue.len() + 1);
     let mut adjncy = Vec::new();


### PR DESCRIPTION
This is a followup to https://github.com/bevyengine/bevy/pull/13904 based on the discussion there, and switches two HashMaps that used meshlet ids as keys to Vec.

In addition to a small further performance boost for `from_mesh` (1.66s => 1.60s), this makes processing deterministic modulo threading issues wrt CRT rand described in the linked PR. This is valuable for debugging, as you can visually or programmatically inspect the meshlet distribution before/after making changes that should not change the output, whereas previously every asset rebuild would change the meshlet structure.

Tested with https://github.com/bevyengine/bevy/pull/13431; after this change, the visual output of meshlets is consistent between asset rebuilds, and the MD5 of the output GLB file does not change either, which was not the case before.