### PR TITLE
Fix typo in `Query::single_mut` docs

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1150,7 +1150,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// # Panics
     ///
-    /// This method panics if the number of query item is **not** exactly one.
+    /// This method panics if the number of query items is **not** exactly one.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# Objective

- Fix a typo in documentation for `Query::single_mut`

## Solution

- Change `item` to `items`

## Testing

- I built the documentation and it looked fine.
- Since this only affects a doc comment, no further testing should be necessary.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Fixed a typo in the documentation for Query.
