### PR TITLE
Use u32 for all resolution/subdivision fields in bevy_gizmos

### DIFF
--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -79,7 +79,7 @@ where
     arc_angle: f32,
     radius: f32,
     color: Color,
-    resolution: Option<usize>,
+    resolution: Option<u32>,
 }
 
 impl<Config, Clear> Arc2dBuilder<'_, '_, '_, Config, Clear>
@@ -88,7 +88,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines used to approximate the geometry of this arc.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution.replace(resolution);
         self
     }
@@ -123,7 +123,7 @@ fn arc_2d_inner(
     direction_angle: f32,
     arc_angle: f32,
     radius: f32,
-    resolution: usize,
+    resolution: u32,
 ) -> impl Iterator<Item = Vec2> {
     (0..resolution + 1).map(move |i| {
         let start = direction_angle - arc_angle / 2.;
@@ -368,7 +368,7 @@ where
     angle: f32,
     radius: f32,
     color: Color,
-    resolution: Option<usize>,
+    resolution: Option<u32>,
 }
 
 impl<Config, Clear> Arc3dBuilder<'_, '_, '_, Config, Clear>
@@ -377,7 +377,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines for this arc.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution.replace(resolution);
         self
     }
@@ -415,7 +415,7 @@ fn arc_3d_inner(
     rotation: Quat,
     angle: f32,
     radius: f32,
-    resolution: usize,
+    resolution: u32,
 ) -> impl Iterator<Item = Vec3> {
     // drawing arcs bigger than TAU degrees or smaller than -TAU degrees makes no sense since
     // we won't see the overlap and we would just decrease the level of details since the resolution
@@ -429,6 +429,6 @@ fn arc_3d_inner(
 }
 
 // helper function for getting a default value for the resolution parameter
-fn resolution_from_angle(angle: f32) -> usize {
-    ((angle.abs() / TAU) * DEFAULT_CIRCLE_RESOLUTION as f32).ceil() as usize
+fn resolution_from_angle(angle: f32) -> u32 {
+    ((angle.abs() / TAU) * DEFAULT_CIRCLE_RESOLUTION as f32).ceil() as u32
 }

--- a/crates/bevy_gizmos/src/circles.rs
+++ b/crates/bevy_gizmos/src/circles.rs
@@ -9,9 +9,9 @@ use bevy_math::Mat2;
 use bevy_math::{Dir3, Quat, Vec2, Vec3};
 use std::f32::consts::TAU;
 
-pub(crate) const DEFAULT_CIRCLE_RESOLUTION: usize = 32;
+pub(crate) const DEFAULT_CIRCLE_RESOLUTION: u32 = 32;
 
-fn ellipse_inner(half_size: Vec2, resolution: usize) -> impl Iterator<Item = Vec2> {
+fn ellipse_inner(half_size: Vec2, resolution: u32) -> impl Iterator<Item = Vec2> {
     (0..resolution + 1).map(move |i| {
         let angle = i as f32 * TAU / resolution as f32;
         let (x, y) = angle.sin_cos();
@@ -230,7 +230,7 @@ where
     rotation: Quat,
     half_size: Vec2,
     color: Color,
-    resolution: usize,
+    resolution: u32,
 }
 
 impl<Config, Clear> EllipseBuilder<'_, '_, '_, Config, Clear>
@@ -239,7 +239,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines used to approximate the geometry of this ellipse.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
         self
     }
@@ -273,7 +273,7 @@ where
     rotation: Mat2,
     half_size: Vec2,
     color: Color,
-    resolution: usize,
+    resolution: u32,
 }
 
 impl<Config, Clear> Ellipse2dBuilder<'_, '_, '_, Config, Clear>
@@ -282,7 +282,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of line-segments used to approximate the geometry of this ellipse.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
         self
     }
@@ -325,7 +325,7 @@ where
     color: Color,
 
     // Number of line-segments used to approximate the sphere geometry
-    resolution: usize,
+    resolution: u32,
 }
 
 impl<Config, Clear> SphereBuilder<'_, '_, '_, Config, Clear>
@@ -334,7 +334,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of line-segments used to approximate the sphere geometry.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
         self
     }

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -227,8 +227,8 @@ where
     inner_radius: f32,
     outer_radius: f32,
     color: Color,
-    inner_resolution: usize,
-    outer_resolution: usize,
+    inner_resolution: u32,
+    outer_resolution: u32,
 }
 
 impl<Config, Clear> Annulus2dBuilder<'_, '_, '_, Config, Clear>
@@ -237,20 +237,20 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of line-segments for each circle of the annulus.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.outer_resolution = resolution;
         self.inner_resolution = resolution;
         self
     }
 
     /// Set the number of line-segments for the outer circle of the annulus.
-    pub fn outer_resolution(mut self, resolution: usize) -> Self {
+    pub fn outer_resolution(mut self, resolution: u32) -> Self {
         self.outer_resolution = resolution;
         self
     }
 
     /// Set the number of line-segments for the inner circle of the annulus.
-    pub fn inner_resolution(mut self, resolution: usize) -> Self {
+    pub fn inner_resolution(mut self, resolution: u32) -> Self {
         self.inner_resolution = resolution;
         self
     }
@@ -852,13 +852,7 @@ where
         }
 
         let points = (0..=primitive.sides)
-            .map(|p| {
-                single_circle_coordinate(
-                    primitive.circumcircle.radius,
-                    primitive.sides as usize,
-                    p as usize,
-                )
-            })
+            .map(|p| single_circle_coordinate(primitive.circumcircle.radius, primitive.sides, p))
             .map(rotate_then_translate_2d(angle, position));
         self.linestrip_2d(points, color);
     }

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -13,7 +13,7 @@ use bevy_math::{Dir3, Quat, Vec3};
 use crate::circles::SphereBuilder;
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 
-const DEFAULT_RESOLUTION: usize = 5;
+const DEFAULT_RESOLUTION: u32 = 5;
 // length used to simulate infinite lines
 const INFINITE_LEN: f32 = 10_000.0;
 
@@ -95,9 +95,9 @@ where
     color: Color,
 
     // Number of axis to hint the plane
-    axis_count: usize,
+    axis_count: u32,
     // Number of segments used to hint the plane
-    segment_count: usize,
+    segment_count: u32,
     // Length of segments used to hint the plane
     segment_length: f32,
 }
@@ -108,7 +108,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of segments used to hint the plane.
-    pub fn segment_count(mut self, count: usize) -> Self {
+    pub fn segment_count(mut self, count: u32) -> Self {
         self.segment_count = count;
         self
     }
@@ -120,7 +120,7 @@ where
     }
 
     /// Set the number of axis used to hint the plane.
-    pub fn axis_count(mut self, count: usize) -> Self {
+    pub fn axis_count(mut self, count: u32) -> Self {
         self.axis_count = count;
         self
     }
@@ -183,7 +183,7 @@ where
                     .filter(|i| i % 2 != 0)
                     .map(|percent| (percent as f32 + 0.5) * self.segment_length * axis_direction)
                     .map(|position| position + self.position)
-                    .take(self.segment_count)
+                    .take(self.segment_count as usize)
                     .for_each(|position| {
                         self.gizmos.primitive_3d(
                             &Segment3d {
@@ -431,7 +431,7 @@ where
     color: Color,
 
     // Number of lines used to approximate the cylinder geometry
-    resolution: usize,
+    resolution: u32,
 }
 
 impl<Config, Clear> Cylinder3dBuilder<'_, '_, '_, Config, Clear>
@@ -440,7 +440,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines used to approximate the top an bottom of the cylinder geometry.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
         self
     }
@@ -541,7 +541,7 @@ where
     color: Color,
 
     // Number of lines used to approximate the capsule geometry
-    resolution: usize,
+    resolution: u32,
 }
 
 impl<Config, Clear> Capsule3dBuilder<'_, '_, '_, Config, Clear>
@@ -550,7 +550,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines used to approximate the capsule geometry.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
         self
     }
@@ -681,10 +681,10 @@ where
     color: Color,
 
     // Number of lines used to approximate the cone base geometry
-    base_resolution: usize,
+    base_resolution: u32,
 
     // Number of lines used to approximate the cone height geometry
-    height_resolution: usize,
+    height_resolution: u32,
 }
 
 impl<Config, Clear> Cone3dBuilder<'_, '_, '_, Config, Clear>
@@ -693,7 +693,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines used to approximate the cone geometry for its base and height.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.base_resolution = resolution;
         self.height_resolution = resolution;
         self
@@ -703,7 +703,7 @@ where
     ///
     /// `resolution` should be a multiple of the value passed to [`Self::height_resolution`]
     /// for the height to connect properly with the base.
-    pub fn base_resolution(mut self, resolution: usize) -> Self {
+    pub fn base_resolution(mut self, resolution: u32) -> Self {
         self.base_resolution = resolution;
         self
     }
@@ -712,7 +712,7 @@ where
     ///
     /// `resolution` should be a divisor of the value passed to [`Self::base_resolution`]
     /// for the height to connect properly with the base.
-    pub fn height_resolution(mut self, resolution: usize) -> Self {
+    pub fn height_resolution(mut self, resolution: u32) -> Self {
         self.height_resolution = resolution;
         self
     }
@@ -817,7 +817,7 @@ where
     color: Color,
 
     // Number of lines used to approximate the curved surfaces
-    resolution: usize,
+    resolution: u32,
 }
 
 impl<Config, Clear> ConicalFrustum3dBuilder<'_, '_, '_, Config, Clear>
@@ -826,7 +826,7 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines used to approximate the curved surfaces.
-    pub fn resolution(mut self, resolution: usize) -> Self {
+    pub fn resolution(mut self, resolution: u32) -> Self {
         self.resolution = resolution;
         self
     }
@@ -937,9 +937,9 @@ where
     color: Color,
 
     // Number of lines in the minor (tube) direction
-    minor_resolution: usize,
+    minor_resolution: u32,
     // Number of lines in the major (ring) direction
-    major_resolution: usize,
+    major_resolution: u32,
 }
 
 impl<Config, Clear> Torus3dBuilder<'_, '_, '_, Config, Clear>
@@ -948,13 +948,13 @@ where
     Clear: 'static + Send + Sync,
 {
     /// Set the number of lines in the minor (tube) direction.
-    pub fn minor_resolution(mut self, minor_resolution: usize) -> Self {
+    pub fn minor_resolution(mut self, minor_resolution: u32) -> Self {
         self.minor_resolution = minor_resolution;
         self
     }
 
     /// Set the number of lines in the major (ring) direction.
-    pub fn major_resolution(mut self, major_resolution: usize) -> Self {
+    pub fn major_resolution(mut self, major_resolution: u32) -> Self {
         self.major_resolution = major_resolution;
         self
     }

--- a/crates/bevy_gizmos/src/primitives/helpers.rs
+++ b/crates/bevy_gizmos/src/primitives/helpers.rs
@@ -29,7 +29,7 @@ pub(crate) fn rotate_then_translate_3d(rotation: Quat, translation: Vec3) -> imp
 /// Given a circle's radiu and its resolution, this function computes the position
 /// of the `nth` point along the circumference of the circle. The rotation starts at `(0.0, radius)`
 /// and proceeds counter-clockwise.
-pub(crate) fn single_circle_coordinate(radius: f32, resolution: usize, nth_point: usize) -> Vec2 {
+pub(crate) fn single_circle_coordinate(radius: f32, resolution: u32, nth_point: u32) -> Vec2 {
     let angle = nth_point as f32 * TAU / resolution as f32;
     let (x, y) = angle.sin_cos();
     Vec2::new(x, y) * radius
@@ -40,10 +40,10 @@ pub(crate) fn single_circle_coordinate(radius: f32, resolution: usize, nth_point
 /// This function creates an iterator that yields the positions of points approximating a
 /// circle with the given radius, divided into linear segments. The iterator produces `resolution`
 /// number of points.
-pub(crate) fn circle_coordinates(radius: f32, resolution: usize) -> impl Iterator<Item = Vec2> {
+pub(crate) fn circle_coordinates(radius: f32, resolution: u32) -> impl Iterator<Item = Vec2> {
     (0..)
         .map(move |p| single_circle_coordinate(radius, resolution, p))
-        .take(resolution)
+        .take(resolution as usize)
 }
 
 /// Draws a circle in 3D space.
@@ -54,7 +54,7 @@ pub(crate) fn circle_coordinates(radius: f32, resolution: usize) -> impl Iterato
 pub(crate) fn draw_circle_3d<Config, Clear>(
     gizmos: &mut Gizmos<'_, '_, Config, Clear>,
     radius: f32,
-    resolution: usize,
+    resolution: u32,
     rotation: Quat,
     translation: Vec3,
     color: Color,

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -27,7 +27,7 @@ struct RoundedBoxConfig {
     rotation: Quat,
     color: Color,
     corner_radius: f32,
-    arc_resolution: usize,
+    arc_resolution: u32,
 }
 
 impl<T: GizmoConfigGroup> RoundedRectBuilder<'_, '_, '_, T> {
@@ -40,7 +40,7 @@ impl<T: GizmoConfigGroup> RoundedRectBuilder<'_, '_, '_, T> {
 
     /// Change the resolution of the arcs at the corners of the rectangle.
     /// The default value is 8
-    pub fn arc_resolution(mut self, arc_resolution: usize) -> Self {
+    pub fn arc_resolution(mut self, arc_resolution: u32) -> Self {
         self.config.arc_resolution = arc_resolution;
         self
     }
@@ -55,7 +55,7 @@ impl<T: GizmoConfigGroup> RoundedCuboidBuilder<'_, '_, '_, T> {
 
     /// Change the resolution of the arcs at the edges of the cuboid.
     /// The default value is 8
-    pub fn arc_resolution(mut self, arc_resolution: usize) -> Self {
+    pub fn arc_resolution(mut self, arc_resolution: u32) -> Self {
         self.config.arc_resolution = arc_resolution;
         self
     }
@@ -376,5 +376,5 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     }
 }
 
-const DEFAULT_ARC_RESOLUTION: usize = 8;
+const DEFAULT_ARC_RESOLUTION: u32 = 8;
 const DEFAULT_CORNER_RADIUS: f32 = 0.1;


### PR DESCRIPTION
# Objective

- Make gizmos behavior consistent across platforms

## Solution

- Use `u32` instead of `usize` for resolution/subdivisions/segments/etc fields

---

## Changelog

- Change resolutions in gizmos from `usize` to  `u32`

## Migration Guide

- All gizmos now take `u32` instead of `usize` for their resolution/subdivision/segment counts
