### PR TITLE
Move `StateTransitionSteps` registration to states plugin

### DIFF
--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -70,7 +70,6 @@ impl AppExtStates for SubApp {
     fn init_state<S: FreelyMutableState + FromWorld>(&mut self) -> &mut Self {
         warn_if_no_states_plugin_installed(self);
         if !self.world().contains_resource::<State<S>>() {
-            setup_state_transitions_in_world(self.world_mut(), Some(Startup.intern()));
             self.init_resource::<State<S>>()
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
@@ -92,7 +91,6 @@ impl AppExtStates for SubApp {
     fn insert_state<S: FreelyMutableState>(&mut self, state: S) -> &mut Self {
         warn_if_no_states_plugin_installed(self);
         if !self.world().contains_resource::<State<S>>() {
-            setup_state_transitions_in_world(self.world_mut(), Some(Startup.intern()));
             self.insert_resource::<State<S>>(State::new(state.clone()))
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
@@ -123,7 +121,6 @@ impl AppExtStates for SubApp {
             .world()
             .contains_resource::<Events<StateTransitionEvent<S>>>()
         {
-            setup_state_transitions_in_world(self.world_mut(), Some(Startup.intern()));
             self.add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
             S::register_computed_state_systems(schedule);
@@ -149,7 +146,6 @@ impl AppExtStates for SubApp {
             .world()
             .contains_resource::<Events<StateTransitionEvent<S>>>()
         {
-            setup_state_transitions_in_world(self.world_mut(), Some(Startup.intern()));
             self.init_resource::<NextState<S>>();
             self.add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).unwrap();
@@ -221,6 +217,7 @@ impl Plugin for StatesPlugin {
     fn build(&self, app: &mut App) {
         let mut schedule = app.world_mut().resource_mut::<MainScheduleOrder>();
         schedule.insert_after(PreUpdate, StateTransition);
+        setup_state_transitions_in_world(app.world_mut(), Some(Startup.intern()));
     }
 }
 

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -225,6 +225,7 @@ impl Plugin for StatesPlugin {
 mod tests {
     use crate::{
         self as bevy_state,
+        app::StatesPlugin,
         state::{State, StateTransition, StateTransitionEvent},
     };
     use bevy_app::App;
@@ -244,6 +245,7 @@ mod tests {
     #[test]
     fn insert_state_can_overwrite_init_state() {
         let mut app = App::new();
+        app.add_plugins(StatesPlugin);
 
         app.init_state::<TestState>();
         app.insert_state(TestState::B);
@@ -263,6 +265,7 @@ mod tests {
     #[test]
     fn insert_state_can_overwrite_insert_state() {
         let mut app = App::new();
+        app.add_plugins(StatesPlugin);
 
         app.insert_state(TestState::B);
         app.insert_state(TestState::C);

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -26,14 +26,17 @@ enum AppState {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        // We insert the custom transitions plugin for `AppState`.
+        .add_plugins((
+            DefaultPlugins,
+            IdentityTransitionsPlugin::<AppState>::default(),
+        ))
         .init_state::<AppState>()
         .add_systems(Startup, setup)
         .add_systems(OnEnter(AppState::Menu), setup_menu)
         .add_systems(Update, menu.run_if(in_state(AppState::Menu)))
         .add_systems(OnExit(AppState::Menu), cleanup_menu)
         // We will restart the game progress every time we re-enter into it.
-        .add_plugins(IdentityTransitionsPlugin::<AppState>::default())
         .add_systems(OnReenter(AppState::InGame), setup_game)
         .add_systems(OnReexit(AppState::InGame), teardown_game)
         // Doing it this way allows us to restart the game without any additional in-between states.

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -228,10 +228,12 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
         texture: asset_server.load("branding/icon.png"),
         ..default()
     });
+    info!("Setup game");
 }
 
 fn teardown_game(mut commands: Commands, player: Query<Entity, With<Sprite>>) {
     commands.entity(player.single()).despawn();
+    info!("Teardown game");
 }
 
 #[derive(Resource)]


### PR DESCRIPTION
# Objective

Fixes #13920

## Solution

As described in the issue.

## Testing

Moved a custom transition plugin in example before any of the app-state methods.
