### PR TITLE
feat: add insert_after and insert_startup_before

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -195,6 +195,16 @@ impl MainScheduleOrder {
         self.labels.insert(index + 1, schedule.intern());
     }
 
+    /// Adds the given `schedule` before the `before` schedule in the main list of schedules.
+    pub fn insert_before(&mut self, before: impl ScheduleLabel, schedule: impl ScheduleLabel) {
+        let index = self
+            .labels
+            .iter()
+            .position(|current| (**current).eq(&before))
+            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
+        self.labels.insert(index, schedule.intern());
+    }
+
     /// Adds the given `schedule` after the `after` schedule in the list of startup schedules.
     pub fn insert_startup_after(
         &mut self,
@@ -207,6 +217,20 @@ impl MainScheduleOrder {
             .position(|current| (**current).eq(&after))
             .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
         self.startup_labels.insert(index + 1, schedule.intern());
+    }
+
+    /// Adds the given `schedule` before the `before` schedule in the list of startup schedules.
+    pub fn insert_startup_before(
+        &mut self,
+        before: impl ScheduleLabel,
+        schedule: impl ScheduleLabel,
+    ) {
+        let index = self
+            .startup_labels
+            .iter()
+            .position(|current| (**current).eq(&before))
+            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
+        self.startup_labels.insert(index, schedule.intern());
     }
 }
 
@@ -290,6 +314,16 @@ impl FixedMainScheduleOrder {
             .position(|current| (**current).eq(&after))
             .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
         self.labels.insert(index + 1, schedule.intern());
+    }
+
+    /// Adds the given `schedule` before the `before` schedule
+    pub fn insert_before(&mut self, before: impl ScheduleLabel, schedule: impl ScheduleLabel) {
+        let index = self
+            .labels
+            .iter()
+            .position(|current| (**current).eq(&before))
+            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
+        self.labels.insert(index, schedule.intern());
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #13866 

## Solution

Add `insert_before` in **FixedMainScheduleOrder** and **MainScheduleOrder**, add `insert_startup_before` in **MainScheduleOrder**, applying the same logic as `insert_after`, except for parameters naming and insertion index. 
