### PR TITLE
Correctly check physical size when updating winit

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -223,7 +223,10 @@ pub(crate) fn changed_windows(
         }
 
         if window.resolution != cache.window.resolution {
-            let mut physical_size = winit_window.inner_size();
+            let mut physical_size = PhysicalSize::new(
+                window.resolution.physical_width(),
+                window.resolution.physical_height(),
+            );
 
             let cached_physical_size = PhysicalSize::new(
                 cache.window.physical_width(),


### PR DESCRIPTION
Fixes #13701

After `winit` upgrade to `0.31`, windows were no longer correctly resizing. This appears to just have been a simple mistake, where the new physical size was being sourced from the `winit` window rather than on the incoming `Window` component.

## Testing

Tested on macOS, but I'm curious whether this was also broken on other platforms.