### PR TITLE
Have WindowPosition::Centered take scale_factor_override into account

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -379,9 +379,12 @@ pub fn winit_window_position(
             if let Some(monitor) = maybe_monitor {
                 let screen_size = monitor.size();
 
-                // We use the monitors scale factor here since `WindowResolution.scale_factor` is
-                // not yet populated when windows are created during plugin setup.
-                let scale_factor = monitor.scale_factor();
+                let scale_factor = match resolution.scale_factor_override() {
+                    Some(scale_factor_override) => scale_factor_override as f64,
+                    // We use the monitors scale factor here since `WindowResolution.scale_factor` is
+                    // not yet populated when windows are created during plugin setup.
+                    None => monitor.scale_factor(),
+                };
 
                 // Logical to physical window size
                 let (width, height): (u32, u32) =


### PR DESCRIPTION
# Objective

Fixes #8916 

My game has a low resolution pixel art style, and I use `.with_scale_factor_override()` to make the window larger. `WindowPosition::Centered` doesn't work for me.

## Solution

If `scale_factor_override` is set, use that over `monitor.scale_factor`

## Testing

Tested on Windows 11 with an Nvidia GPU:

### Main
![image](https://github.com/bevyengine/bevy/assets/3324533/5f9ae90e-b65a-48d9-b601-117df8f08a28)

### This PR
![image](https://github.com/bevyengine/bevy/assets/3324533/cd860611-7b6a-4ae5-b690-28d9ba8ea6ad)

