### PR TITLE
Use default window and font sizes in sprite_slice example

### DIFF
--- a/examples/2d/sprite_slice.rs
+++ b/examples/2d/sprite_slice.rs
@@ -4,13 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                resolution: (1350.0, 700.0).into(),
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .run();
 }
@@ -25,17 +19,12 @@ fn spawn_sprites(
 ) {
     let cases = [
         // Reference sprite
-        ("Original texture", style.clone(), Vec2::splat(100.0), None),
+        ("Original", style.clone(), Vec2::splat(100.0), None),
         // Scaled regular sprite
-        (
-            "Stretched texture",
-            style.clone(),
-            Vec2::new(100.0, 200.0),
-            None,
-        ),
+        ("Stretched", style.clone(), Vec2::new(100.0, 200.0), None),
         // Stretched Scaled sliced sprite
         (
-            "Stretched and sliced",
+            "With Slicing",
             style.clone(),
             Vec2::new(100.0, 200.0),
             Some(ImageScaleMode::Sliced(TextureSlicer {
@@ -46,7 +35,7 @@ fn spawn_sprites(
         ),
         // Scaled sliced sprite
         (
-            "Sliced and Tiled",
+            "With Tiling",
             style.clone(),
             Vec2::new(100.0, 200.0),
             Some(ImageScaleMode::Sliced(TextureSlicer {
@@ -58,7 +47,7 @@ fn spawn_sprites(
         ),
         // Scaled sliced sprite horizontally
         (
-            "Sliced and Tiled",
+            "With Tiling",
             style.clone(),
             Vec2::new(300.0, 200.0),
             Some(ImageScaleMode::Sliced(TextureSlicer {
@@ -70,7 +59,7 @@ fn spawn_sprites(
         ),
         // Scaled sliced sprite horizontally with max scale
         (
-            "Sliced and Tiled with corner constraint",
+            "With Corners Constrained",
             style,
             Vec2::new(300.0, 200.0),
             Some(ImageScaleMode::Sliced(TextureSlicer {
@@ -113,7 +102,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
     let style = TextStyle {
         font: font.clone(),
-        font_size: 16.0,
         ..default()
     };
 
@@ -127,7 +115,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Vec3::new(-600.0, 200.0, 0.0),
         200.0,
         style.clone(),
-        50.,
+        40.,
     );
 
     spawn_sprites(
@@ -136,6 +124,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Vec3::new(-600.0, -200.0, 0.0),
         80.0,
         style,
-        50.,
+        40.,
     );
 }


### PR DESCRIPTION
# Objective

A couple issues with this example are evident from this screenshot of the example showcase:

<img width="319" alt="image" src="https://github.com/bevyengine/bevy/assets/200550/5325bb29-9576-4989-a5a3-a972c8bbf1af">

- The images are misaligned, closer to the right edge of the screen
- The example uses a custom window resolution with a different aspect ratio from the default, which results in black bars

## Solution

- Use the default window size
- Adjust positions so that things are centered

This isn't really fixing a problem, but I also:

- Used the default font size and adjusted the text labels and gaps so that everything still fits

Which is how I got here in the first place (one less font size to adjust for the cosmic text PR).

## Before

<img width="1350" alt="Screenshot 2024-06-20 at 12 23 10 PM" src="https://github.com/bevyengine/bevy/assets/200550/1c7cfcfe-7edc-4561-a4e7-9b3bc8f87f75">

## After

<img width="1280" alt="Screenshot 2024-06-20 at 12 23 30 PM" src="https://github.com/bevyengine/bevy/assets/200550/abab8a46-4e11-4ee6-a407-ae3b8bf31975">
