### PR TITLE
Omit font size where it closely matches the default in examples

### DIFF
--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -78,14 +78,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
         ..default()
     });
 
-    spawn_text(&mut commands, &asset_server, &app_status);
+    spawn_text(&mut commands, &app_status);
 }
 
 /// Spawns the help text.
-fn spawn_text(commands: &mut Commands, asset_server: &AssetServer, app_status: &AppStatus) {
+fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
     commands.spawn(
         TextBundle {
-            text: app_status.create_help_text(asset_server),
+            text: app_status.create_help_text(),
             ..default()
         }
         .with_style(Style {
@@ -223,13 +223,9 @@ fn handle_input(
 }
 
 /// A system that updates the help text based on the current app status.
-fn update_help_text(
-    mut text_query: Query<&mut Text>,
-    app_status: Res<AppStatus>,
-    asset_server: Res<AssetServer>,
-) {
+fn update_help_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
     for mut text in text_query.iter_mut() {
-        *text = app_status.create_help_text(&asset_server);
+        *text = app_status.create_help_text();
     }
 }
 
@@ -278,7 +274,7 @@ fn spawn_point_light(commands: &mut Commands) {
 
 impl AppStatus {
     /// Creates the help text as appropriate for the current app status.
-    fn create_help_text(&self, asset_server: &AssetServer) -> Text {
+    fn create_help_text(&self) -> Text {
         // Choose the appropriate help text for the anisotropy toggle.
         let material_variant_help_text = if self.anisotropy_enabled {
             "Press Enter to disable anisotropy"
@@ -296,11 +292,7 @@ impl AppStatus {
         // Build the `Text` object.
         Text::from_section(
             format!("{}\n{}", material_variant_help_text, light_help_text),
-            TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                font_size: 24.0,
-                ..default()
-            },
+            TextStyle::default(),
         )
     }
 }

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -179,15 +179,19 @@ fn setup(
     });
 
     // Controls Text
+
+    // We need the full version of this font so we can use box drawing characters.
+    let font = asset_server.load("fonts/FiraMono-Medium.ttf");
+
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+        font: font.clone(),
         ..default()
     };
 
     let label_text_style = TextStyle {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-        font_size: 25.0,
+        font,
         color: ORANGE.into(),
+        ..default()
     };
 
     commands.spawn(

--- a/examples/ecs/one_shot_systems.rs
+++ b/examples/ecs/one_shot_systems.rs
@@ -97,10 +97,7 @@ fn setup_ui(mut commands: Commands) {
         TextBundle::from_sections([
             TextSection::new(
                 "Press A or B to trigger a one-shot system\n",
-                TextStyle {
-                    font_size: 25.0,
-                    ..default()
-                },
+                TextStyle::default(),
             ),
             TextSection::new("Last Triggered: ", TextStyle::default()),
             TextSection::new(

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -78,7 +78,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-        font_size: 24.0,
         ..default()
     };
 

--- a/examples/ui/flex_layout.rs
+++ b/examples/ui/flex_layout.rs
@@ -177,8 +177,8 @@ fn spawn_nested_text_bundle(
                 text,
                 TextStyle {
                     font,
-                    font_size: 24.0,
                     color: Color::BLACK,
+                    ..default()
                 },
             ));
         });

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -140,7 +140,6 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "Sidebar",
                         TextStyle {
                             font: font.clone(),
-                            font_size: 24.0,
                             ..default()
                         },
                     ));
@@ -215,8 +214,8 @@ fn spawn_nested_text_bundle(builder: &mut ChildBuilder, font: Handle<Font>, text
         text,
         TextStyle {
             font,
-            font_size: 24.0,
             color: Color::BLACK,
+            ..default()
         },
     ));
 }


### PR DESCRIPTION
# Objective

In a few examples, we're specifying a font or font size that is the same as the current default value. Might as well use the default. That'll be one less thing to worry about if we ever need to change the default font size. (wink)

In a few others, we were using a value of `25.0` and it didn't seem like it was different for an important reason, so I switched to the default there too.

(There are a bunch of examples that use non-default font sizes for various reasons. Not trying address them all here.)