### PR TITLE
Support Triggering Buffered Events

### DIFF
--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -15,7 +15,8 @@ pub use iterators::{EventIterator, EventIteratorWithId, EventParIter};
 pub use reader::{EventReader, ManualEventReader};
 pub use registry::{EventRegistry, ShouldUpdateEvents};
 pub use update::{
-    event_update_condition, event_update_system, signal_event_update_system, EventUpdates,
+    event_update_condition, event_update_system, signal_event_update_system,
+    trigger_buffered_events, EventUpdates,
 };
 pub use writer::EventWriter;
 

--- a/crates/bevy_ecs/src/event/update.rs
+++ b/crates/bevy_ecs/src/event/update.rs
@@ -1,8 +1,8 @@
-use crate as bevy_ecs;
-use bevy_ecs::{
+use crate::{
+    self as bevy_ecs,
     change_detection::Mut,
     component::Tick,
-    event::EventRegistry,
+    event::{Event, EventRegistry, Events},
     system::{Local, Res, ResMut},
     world::World,
 };
@@ -59,4 +59,11 @@ pub fn event_update_condition(maybe_signal: Option<Res<EventRegistry>>) -> bool 
         },
         None => true,
     }
+}
+
+/// Triggers events in the [`Events`] collection that have not been triggered yet.
+pub fn trigger_buffered_events<E: Event>(world: &mut World) {
+    world.resource_scope(|world, mut events: Mut<Events<E>>| {
+        events.trigger_events(world);
+    });
 }


### PR DESCRIPTION
# Objective

It should be possible to trigger "buffered" events stored in `Events` collections.

## Solution

`Events` collections now store an `Events::triggered_event_cursor` that tracks the last triggered event index. This is used in the new `Events::trigger_events` function, which will trigger untriggered events in the collection and increase the index. 

There is a new public `trigger_buffered_events::<E>`  system that can be inserted at any point (or multiple points) in the schedule to trigger events. _Where_ an event should be triggered in the schedule is context-specific, so this _probably_ isn't something we should do by default.

I also moved the event triggering logic to World and added borrowed variants of trigger methods (as we can't / shouldn't take ownership of events that are triggered).

## Testing

Included a test that exercises the `trigger_buffered_events` system in various scenarios.

---

## Changelog

- Added `Events::trigger_buffered` and a public `trigger_buffered_events` system that calls it, which can be inserted into a point in the schedule to trigger events of a given type that have not been triggered yet
- Moved event triggering logic to a new `World::trigger_unsafe` and added safe `World::trigger_borrowed` and `World::trigger_targets_borrowed` variants.