### PR TITLE
Fix a few "repeated word" typos

### DIFF
--- a/crates/bevy_audio/CONTRIBUTING.md
+++ b/crates/bevy_audio/CONTRIBUTING.md
@@ -111,7 +111,7 @@ not run in the audio thread, but in the main game loop thread.
 
 ## Communication with the audio thread
 
-To be able to to anything useful with audio, the thread has to be able to
+To be able to do anything useful with audio, the thread has to be able to
 communicate with the rest of the system, ie. update parameters, send/receive
 audio data, etc., and all of that needs to be done within the constraints of
 real-time programming, of course.

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -79,7 +79,7 @@ pub struct BloomSettings {
     /// Somewhat comparable to the Q factor of an equalizer node.
     ///
     /// Valid range:
-    /// * 0.0 - base base intensity and boosted intensity are linearly interpolated
+    /// * 0.0 - base intensity and boosted intensity are linearly interpolated
     /// * 1.0 - all frequencies below maximum are at boosted intensity level
     pub low_frequency_boost_curvature: f32,
 

--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -14,7 +14,7 @@ pub const ON_REMOVE: ComponentId = ComponentId::new(2);
 #[derive(Event)]
 pub struct OnAdd;
 
-/// Trigger emitted when a component is inserted on to to an entity.
+/// Trigger emitted when a component is inserted onto an entity.
 #[derive(Event)]
 pub struct OnInsert;
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -381,7 +381,7 @@ impl<'w> DeferredWorld<'w> {
     /// Gets an [`UnsafeWorldCell`] containing the underlying world.
     ///
     /// # Safety
-    /// - must only be used to to make non-structural ECS changes
+    /// - must only be used to make non-structural ECS changes
     #[inline]
     pub(crate) fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell {
         self.world

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -156,7 +156,7 @@ pub fn keyboard_input_system(
 ///
 /// This enum is primarily used to store raw keycodes when Winit doesn't map a given native
 /// physical key identifier to a meaningful [`KeyCode`] variant. In the presence of identifiers we
-/// haven't mapped for you yet, this lets you use use [`KeyCode`] to:
+/// haven't mapped for you yet, this lets you use [`KeyCode`] to:
 ///
 /// - Correctly match key press and release events.
 /// - On non-web platforms, support assigning keybinds to virtually any key through a UI.

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1190,7 +1190,7 @@ impl<P: VectorSpace> RationalCurve<P> {
         }
     }
 
-    /// Returns the length of of the domain of the parametric curve.
+    /// Returns the length of the domain of the parametric curve.
     #[inline]
     pub fn domain(&self) -> f32 {
         self.segments.iter().map(|segment| segment.knot_span).sum()

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -90,7 +90,7 @@ pub struct PreprocessPipeline {
     pub bind_group_layout: BindGroupLayout,
     /// The pipeline ID for the compute shader.
     ///
-    /// This gets filled in in `prepare_preprocess_pipelines`.
+    /// This gets filled in `prepare_preprocess_pipelines`.
     pub pipeline_id: Option<CachedComputePipelineId>,
 }
 

--- a/crates/bevy_pbr/src/render/parallax_mapping.wgsl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wgsl
@@ -56,7 +56,7 @@ fn parallaxed_uv(
     var texture_depth = sample_depth_map(uv);
 
     // texture_depth > current_layer_depth means the depth map depth is deeper
-    // than the depth the ray would be at at this UV offset so the ray has not
+    // than the depth the ray would be at this UV offset so the ray has not
     // intersected the surface
     for (var i: i32 = 0; texture_depth > current_layer_depth && i <= i32(layer_count); i++) {
         current_layer_depth += layer_depth;

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -142,7 +142,7 @@ fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
 
     // Signed distance from the border's internal edge (the signed distance is negative if the point 
     // is inside the rect but not on the border).
-    // If the border size is set to zero, this is the same as as the external distance.
+    // If the border size is set to zero, this is the same as the external distance.
     let internal_distance = sd_inset_rounded_box(in.point, in.size, in.radius, in.border);
 
     // Signed distance from the border (the intersection of the rect with its border).

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -10,7 +10,8 @@ use bevy::render::{
 };
 
 // Define a "marker" component to mark the custom mesh. Marker components are often used in Bevy for
-// filtering entities in queries with With, they're usually not queried directly since they don't contain information within them.
+// filtering entities in queries with `With`, they're usually not queried directly since they don't
+// contain information within them.
 #[derive(Component)]
 struct CustomUV;
 

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -141,7 +141,7 @@ impl ComputedStates for Tutorial {
     // effective to rely on the already derived states to avoid the logic drifting apart.
     //
     // Notice that you can wrap any of the [`States`] here in [`Option`]s. If you do so,
-    // the the computation will get called even if the state does not exist.
+    // the computation will get called even if the state does not exist.
     type SourceStates = (TutorialState, InGame, Option<IsPaused>);
 
     // Notice that we aren't using InGame - we're just using it as a source state to


### PR DESCRIPTION
# Objective

Stumbled on one of these and went digging for more

## Solution

```diff
- word word
+ word
```
