### PR TITLE
Add a test asserting that reflected cloning a Handle increments strong count

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -620,7 +620,7 @@ mod tests {
         assert_eq!(UntypedHandle::from(typed.clone()), untyped);
     }
 
-    /// Reflect::clone_value should increase the strong count of a strong handle
+    /// `Reflect::clone_value` should increase the strong count of a strong handle
     #[test]
     fn strong_handle_reflect_clone() {
         use crate::{AssetApp, AssetPlugin, Assets, VisitAssetDependencies};


### PR DESCRIPTION
# Objective

Closes #5943. Seems like Assets v2 solved this one.

## Solution

Added a test to confirm that using `Reflect::clone_value` and then `FromReflect::from_reflect` on a `Handle<T>` both increment the strong count.

## Testing

A new test was added to confirm behavior.