### PR TITLE
Include AutoExposurePlugin in CorePipelinePlugin

### DIFF
--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -49,6 +49,7 @@ pub mod prelude {
 }
 
 use crate::{
+    auto_exposure::AutoExposurePlugin,
     blit::BlitPlugin,
     bloom::BloomPlugin,
     contrast_adaptive_sharpening::CASPlugin,
@@ -91,6 +92,7 @@ impl Plugin for CorePipelinePlugin {
                 CopyDeferredLightingIdPlugin,
                 BlitPlugin,
                 MsaaWritebackPlugin,
+                AutoExposurePlugin,
                 TonemappingPlugin,
                 UpscalingPlugin,
                 BloomPlugin,

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -13,7 +13,7 @@
 
 use bevy::{
     core_pipeline::{
-        auto_exposure::{AutoExposureCompensationCurve, AutoExposurePlugin, AutoExposureSettings},
+        auto_exposure::{AutoExposureCompensationCurve, AutoExposureSettings},
         Skybox,
     },
     math::{cubic_splines::LinearSpline, primitives::Plane3d, vec2},
@@ -23,7 +23,6 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(AutoExposurePlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, example_control_system)
         .run();


### PR DESCRIPTION
This commit includes the `AutoExposurePlugin` with the `CorePipelinePlugin`, so that behaviour is more consistent with the rest of the core pipeline plugins.

## Migration Guide

* Any manual additions of `AutoExposurePlugin` have to be removed when `DefaultPlugins` is added as well.