### PR TITLE
Sysinfo plugin compilation has been fixed for disabled multi_threaded feature

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["bevy"]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
 sysinfo_plugin = ["sysinfo"]
+multi_threaded = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -86,6 +86,7 @@ multi_threaded = [
   "bevy_ecs/multi_threaded",
   "bevy_render?/multi_threaded",
   "bevy_tasks/multi_threaded",
+  "bevy_diagnostic/multi_threaded",
 ]
 async-io = ["bevy_tasks/async-io"]
 


### PR DESCRIPTION
# Objective

- Fixes #13957 .
- Sysinfo fails compilation of `multi_threaded` feature disabled, because [single_threaded_task_pool::TaskPool::spawn](https://github.com/bevyengine/bevy/blob/68db79862227885bb5d4794c2636e1749e36e574/crates/bevy_tasks/src/single_threaded_task_pool.rs#L153) returns `FakeTask` which can't contain future result, because [it's just empty struct](https://github.com/bevyengine/bevy/blob/68db79862227885bb5d4794c2636e1749e36e574/crates/bevy_tasks/src/single_threaded_task_pool.rs#L205), but actualy for non wasm (for `wasm32` it indeed can't do better, because uses [wasm spawn method which allows only futures which outputs only empty tuple](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/fn.spawn_local.html)) it [spawns future, gets it's task](https://github.com/bevyengine/bevy/blob/68db79862227885bb5d4794c2636e1749e36e574/crates/bevy_tasks/src/single_threaded_task_pool.rs#L165), waits [while executor finishes](https://github.com/bevyengine/bevy/blob/68db79862227885bb5d4794c2636e1749e36e574/crates/bevy_tasks/src/single_threaded_task_pool.rs#L167), and return nothing (FakeTask), throwing away _task with result!

## Solution

- For non wasm builds FakeTask contains result, which is used by Sysinfo.

## Testing

- Built project with and without feature `multi_threaded`