### PR TITLE
apply window scale to window size when creating it

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -817,6 +817,18 @@ impl WindowResolution {
         self.scale_factor = scale_factor;
     }
 
+    /// Set the window's scale factor, and apply it to the currently known physical size.
+    /// This may get overridden by the backend. This is mostly useful on window creation,
+    /// so that the window is created with the expected size instead of waiting for a resize
+    /// event after its creation.
+    #[inline]
+    #[doc(hidden)]
+    pub fn set_scale_factor_and_apply_to_physical_size(&mut self, scale_factor: f32) {
+        self.scale_factor = scale_factor;
+        self.physical_width = (self.physical_width as f32 * scale_factor) as u32;
+        self.physical_height = (self.physical_height as f32 * scale_factor) as u32;
+    }
+
     /// Set the window's scale factor, this will be used over what the backend decides.
     ///
     /// This can change the logical and physical sizes if the resulting physical

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -76,7 +76,7 @@ pub fn create_windows<F: QueryFilter + 'static>(
 
         window
             .resolution
-            .set_scale_factor(winit_window.scale_factor() as f32);
+            .set_scale_factor_and_apply_to_physical_size(winit_window.scale_factor() as f32);
 
         commands.entity(entity).insert(CachedWindow {
             window: window.clone(),


### PR DESCRIPTION
# Objective

- Fixes #13702
- When creating a new window, its scale was changed to match the one returned by winit, but its size was not which resulted in an incorrect size until the event with the correct size was received, at least 1 frame later

## Solution

- Apply the window scale to its size when creating it
