### PR TITLE
Use CameraController in 3d_gizmos example

### DIFF
--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -1,15 +1,17 @@
 //! This example demonstrates Bevy's immediate mode drawing API intended for visual debugging.
 
-use std::f32::consts::PI;
+#[path = "../helpers/camera_controller.rs"]
+mod camera_controller;
 
 use bevy::{color::palettes::css::*, prelude::*};
+use camera_controller::{CameraController, CameraControllerPlugin};
+use std::f32::consts::PI;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, CameraControllerPlugin))
         .init_gizmo_group::<MyRoundGizmos>()
         .add_systems(Startup, setup)
-        .add_systems(Update, rotate_camera)
         .add_systems(Update, (draw_example_collection, update_config))
         .run();
 }
@@ -23,10 +25,13 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 1.5, 6.).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(0., 1.5, 6.).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        CameraController::default(),
+    ));
     // plane
     commands.spawn(PbrBundle {
         mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
@@ -70,12 +75,6 @@ fn setup(
             ..default()
         }),
     );
-}
-
-fn rotate_camera(mut query: Query<&mut Transform, With<Camera>>, time: Res<Time>) {
-    let mut transform = query.single_mut();
-
-    transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(time.delta_seconds() / 2.));
 }
 
 fn draw_example_collection(


### PR DESCRIPTION
# Objective

- Make it easier to see how the 3d gizmos work by letting the viewer control the camera.
- This was suggested by someone in Discord or in a GitHub comment but I couldn't find the original source. I thought it was a good idea too so decided to make a PR.

## Solution

- Use the camera controller helper instead of the automatic rotation system.

## Testing

```
cargo run --example 3d_gizmos
```

And confirmed the freecam controls work.

### Screenshots

Initial view:

<img width="1920" alt="image" src="https://github.com/bevyengine/bevy/assets/135186256/98672539-de4a-4eb7-98e6-c7bd03cd8d66">

Above:

<img width="1920" alt="image" src="https://github.com/bevyengine/bevy/assets/135186256/10eabc4a-bded-44b7-a1de-6130754c7f0e">

Below:

<img width="1920" alt="image" src="https://github.com/bevyengine/bevy/assets/135186256/b9ba9eb7-d1e8-4ad7-a9cd-aeb499ea7f9a">
