### PR TITLE
improved error message when forgetting to call system apply function …

### DIFF
--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -312,7 +312,7 @@ impl RawCommandQueue {
 impl Drop for CommandQueue {
     fn drop(&mut self) {
         if !self.bytes.is_empty() {
-            warn!("CommandQueue has un-applied commands being dropped.");
+            warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?");
         }
         // SAFETY: A reference is always a valid pointer
         unsafe { self.get_raw().apply_or_drop_queued(None) };


### PR DESCRIPTION
fixes #13944
I literally just added `Did you forget to call SystemState::apply?` to the error message. I tested it with the code snipped from the Issue and yeah it works