### PR TITLE
Document use of `NO_COLOR` in `LogPlugin`

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -89,6 +89,7 @@ pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
 ///             custom_layer: |_| None,
+///             ansi: true,
 ///         }))
 ///         .run();
 /// }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -137,6 +137,13 @@ pub struct LogPlugin {
     ///
     /// Please see the `examples/log_layers.rs` for a complete example.
     pub custom_layer: fn(app: &mut App) -> Option<BoxedLayer>,
+
+    /// Corresponds to [`tracing_subscriber::fmt::Layer::set_ansi`].
+    /// This is by default `true`
+    ///
+    /// When `true`, adds ANSI color codes to the formatted logs.
+    /// Setting to `false` is useful when using a terminal that does not support ANSI color codes.
+    pub ansi: bool,
 }
 
 /// A boxed [`Layer`] that can be used with [`LogPlugin`].
@@ -148,6 +155,7 @@ impl Default for LogPlugin {
             filter: "wgpu=error,naga=warn".to_string(),
             level: Level::INFO,
             custom_layer: |_| None,
+            ansi: true,
         }
     }
 }
@@ -218,7 +226,9 @@ impl Plugin for LogPlugin {
             #[cfg(feature = "tracing-tracy")]
             let tracy_layer = tracing_tracy::TracyLayer::default();
 
-            let fmt_layer = tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
+            let mut fmt_layer =
+                tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
+            fmt_layer.set_ansi(self.ansi);
 
             // bevy_render::renderer logs a `tracy.frame_mark` event every frame
             // at Level::INFO. Formatted logs should omit it.

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -139,8 +139,8 @@ pub struct LogPlugin {
     /// Please see the `examples/log_layers.rs` for a complete example.
     pub custom_layer: fn(app: &mut App) -> Option<BoxedLayer>,
 
-    /// Corresponds to [`tracing_subscriber::fmt::Layer::set_ansi`].
-    /// This is by default `true`
+    /// Corresponds to [`tracing_subscriber::fmt::Layer::with_ansi`].
+    /// This is by default `true`.
     ///
     /// When `true`, adds ANSI color codes to the formatted logs.
     /// Setting to `false` is useful when using a terminal that does not support ANSI color codes.
@@ -227,9 +227,8 @@ impl Plugin for LogPlugin {
             #[cfg(feature = "tracing-tracy")]
             let tracy_layer = tracing_tracy::TracyLayer::default();
 
-            let mut fmt_layer =
-                tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
-            fmt_layer.set_ansi(self.ansi);
+            let fmt_layer =
+                tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr).with_ansi(self.ansi);
 
             // bevy_render::renderer logs a `tracy.frame_mark` event every frame
             // at Level::INFO. Formatted logs should omit it.


### PR DESCRIPTION
# Objective
Fixes #13982

## Solution
~~Adds a new field to `bevy_log::LogPlugin`: `ansi: bool`~~
Documents the use of `std::env::set_var("NO_COLOR", "1");` to disable colour output in terminals.

## Testing
Yes, all tests passed when I ran `cargo run -p ci -- test` and `cargo run -p ci -- lints`

I have only tested the code on my Mac, though I doubt this change would have any affect on other platforms.

---