### PR TITLE
Add Commands.register_system

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -7,9 +7,11 @@ use thiserror::Error;
 
 /// A small wrapper for [`BoxedSystem`] that also keeps track whether or not the system has been initialized.
 #[derive(Component)]
-struct RegisteredSystem<I, O> {
-    initialized: bool,
-    system: BoxedSystem<I, O>,
+pub struct RegisteredSystem<I, O> {
+    /// Set to true if system is initialized.
+    pub initialized: bool,
+    /// Boxed system that will store our system.
+    pub system: BoxedSystem<I, O>,
 }
 
 /// A system that has been removed from the registry.


### PR DESCRIPTION
`register_system`, `register_boxed_system` and `remove_system` were added for Commands. This is very useful for adding systems inside entities to make the code flexible. It's needed specially for the UI.

# Objective

For the proposal posted here 
https://github.com/bevyengine/bevy/issues/13986

I just started rust 3 weeks ago so i'm not sure if this is good.

## Solution

Register Entity owned systems (we would add the system id's entity as a child and then we will have resource management + caching. We also won't need to make our systems exclusive.

## Testing

https://github.com/darthLeviN/commands_register_system_example
Works.

## Further suggestions

I'm not sure whether we want this in `ChildBuilder` as well or not.

The example usage is basic. but this will be used to create flexible automated node tree builder systems that are still cached efficiently and can be called with `Commands` instead of a exclusive `&mut World` query in the entire system. So there will be an opportunity for parallelization if we're loading something heavy (even though the parallelization might not be happening in the current implementation).

At the moment `run_system` command is ran with 
```
impl<I: 'static + Send> Command for RunSystemWithInput<I> {
    #[inline]
    fn apply(self, world: &mut World) {
        let _ = world.run_system_with_input(self.system_id, self.input);
    }
}
```

My idea is that if two `RunSystemWithInput` need to run at the end of two queues, it might be possible to run them at the same time.