### PR TITLE
fix panic: invalid SlotMap key used

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -190,9 +190,6 @@ pub fn ui_layout_system(
     }
     scale_factor_events.clear();
 
-    // clean up removed nodes
-    ui_surface.remove_entities(removed_components.removed_nodes.read());
-
     // clean up removed cameras
     ui_surface.remove_camera_entities(removed_components.removed_cameras.read());
 
@@ -216,6 +213,9 @@ pub fn ui_layout_system(
             ui_surface.update_children(entity, &children);
         }
     }
+
+    // clean up removed nodes after syncing children to avoid potential panic (invalid SlotMap key used)
+    ui_surface.remove_entities(removed_components.removed_nodes.read());
 
     for (camera_id, camera) in &camera_layout_info {
         let inverse_target_scale_factor = camera.scale_factor.recip();


### PR DESCRIPTION
# Objective

Tight, in-frame generation, re-parenting, despawning, etc., UI operations could sometime lead taffy to panic (invalid SlotMap key used) when an entity with an invalid state later despawned.

Fixes #12403 

## Solution

Move the `remove_entities` call after children updates.

## Testing

`sickle_ui` had a case that always caused the panic. Tested before this change, after this change, and before the change again to make sure the error is there without the fix. The fix worked. Test steps and used commit described in issue #12403.

I have also ran every bevy UI example, though none of them deal with entity re-parenting or removal. No regression detected on them.

Tested on Windows only.

