### PR TITLE
Warn on missing gamepad mapping

### DIFF
--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -14,7 +14,7 @@ use bevy_input::gamepad::{GamepadEvent, GamepadInfo};
 use bevy_input::prelude::{GamepadAxis, GamepadButton};
 use bevy_input::Axis;
 use bevy_utils::tracing::warn;
-use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter};
+use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter, MappingSource};
 
 pub fn gilrs_event_startup_system(
     #[cfg(target_arch = "wasm32")] mut gilrs: NonSendMut<Gilrs>,
@@ -56,9 +56,9 @@ pub fn gilrs_event_system(
                     name: pad.name().into(),
                 };
 
-                if pad.map_name().is_none() {
+                if pad.mapping_source() == MappingSource::Driver {
                     warn!(
-                        "No game controller mapping found for gamepad \"{}\". \
+                        "No game controller mapping found for gamepad \"{}\", using the driver default instead. \
                         This may cause the gamepad to behave unexpectedly. \
                         Please contribute your device's mapping to https://github.com/mdqinc/SDL_GameControllerDB",
                         pad.name()

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -13,6 +13,7 @@ use bevy_input::gamepad::{
 use bevy_input::gamepad::{GamepadEvent, GamepadInfo};
 use bevy_input::prelude::{GamepadAxis, GamepadButton};
 use bevy_input::Axis;
+use bevy_utils::tracing::warn;
 use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter};
 
 pub fn gilrs_event_startup_system(
@@ -54,6 +55,15 @@ pub fn gilrs_event_system(
                 let info = GamepadInfo {
                     name: pad.name().into(),
                 };
+
+                if pad.map_name().is_none() {
+                    warn!(
+                        "No game controller mapping found for gamepad \"{}\". \
+                        This may cause the gamepad to behave unexpectedly. \
+                        Please contribute your device's mapping to https://github.com/mdqinc/SDL_GameControllerDB",
+                        pad.name()
+                    );
+                }
 
                 events.send(
                     GamepadConnectionEvent::new(gamepad, GamepadConnection::Connected(info)).into(),


### PR DESCRIPTION
# Objective

It is possible for a gamepad device to be found and connected without there being a known mapping for it. This will cause the controller to behave erratically and is confusing (e.g. #13625).

## Solution

We should warn the user when this happens so that they are aware and can help fix it for themselves and for others. Bevy depends transitively on https://github.com/mdqinc/SDL_GameControllerDB via gilrs, which contains all of the known gamepad mappings. Ideally users will see this warning and add their controller there, which eventually finds its way upstream to Bevy.

## Testing

I tested the changes with my unrecognized Xbox controller and it displays an appropriate warning.