### PR TITLE
feat(bevy_app): expose an API to perform updates for a specific sub-app.

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -663,6 +663,11 @@ impl App {
         self.sub_apps.sub_apps.remove(&label.intern())
     }
 
+    /// Extract data from main world into app's world and perform an update.
+    pub fn update_sub_app_by_label(&mut self, label: impl AppLabel) {
+        self.sub_apps.update_subapp_by_label(label);
+    }
+
     /// Inserts a new `schedule` under the provided `label`, overwriting any existing
     /// schedule with the same label.
     pub fn add_schedule(&mut self, schedule: Schedule) -> &mut Self {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -663,7 +663,7 @@ impl App {
         self.sub_apps.sub_apps.remove(&label.intern())
     }
 
-    /// Extract data from main world into app's world and perform an update.
+    /// Extract data from the main world into the [`SubApp`] with the given label and perform an update if it exists.
     pub fn update_sub_app_by_label(&mut self, label: impl AppLabel) {
         self.sub_apps.update_subapp_by_label(label);
     }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -450,7 +450,7 @@ impl SubApps {
         std::iter::once(&mut self.main).chain(self.sub_apps.values_mut())
     }
 
-    /// Extract data from the main world into the sub-app with the given label and perform an update if it exists.
+    /// Extract data from the main world into the [`SubApp`] with the given label and perform an update if it exists.
     pub fn update_subapp_by_label(&mut self, label: impl AppLabel) {
         if let Some(sub_app) = self.sub_apps.get_mut(&label.intern()) {
             sub_app.extract(&mut self.main.world);

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -1,4 +1,4 @@
-use crate::{App, InternedAppLabel, Plugin, Plugins, PluginsState};
+use crate::{App, AppLabel, InternedAppLabel, Plugin, Plugins, PluginsState};
 use bevy_ecs::{
     event::EventRegistry,
     prelude::*,
@@ -448,5 +448,13 @@ impl SubApps {
     /// Returns a mutable iterator over the sub-apps (starting with the main one).
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut SubApp> + '_ {
         std::iter::once(&mut self.main).chain(self.sub_apps.values_mut())
+    }
+
+    /// Extract data from main world into app's world and perform an update.
+    pub fn update_subapp_by_label(&mut self, label: impl AppLabel) {
+        if let Some(sub_app) = self.sub_apps.get_mut(&label.intern()) {
+            sub_app.extract(&mut self.main.world);
+            sub_app.update();
+        }
     }
 }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -450,7 +450,7 @@ impl SubApps {
         std::iter::once(&mut self.main).chain(self.sub_apps.values_mut())
     }
 
-    /// Extract data from main world into app's world and perform an update.
+    /// Extract data from the main world into the sub-app with the given label and perform an update if it exists.
     pub fn update_subapp_by_label(&mut self, label: impl AppLabel) {
         if let Some(sub_app) = self.sub_apps.get_mut(&label.intern()) {
             sub_app.extract(&mut self.main.world);


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/14003

## Solution

- Expose an API to perform updates for a specific sub-app, so we can avoid mutable borrow the app twice.

## Testing

- I have tested the API by modifying the code in the `many_lights` example with the following changes:
```rust
impl Plugin for LogVisibleLights {
    fn build(&self, app: &mut App) {
        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
            return;
        };

        render_app.add_systems(Render, print_visible_light_count.in_set(RenderSet::Prepare));
    }

    fn finish(&self, app: &mut App) {
        app.update_sub_app_by_label(RenderApp);
    }
}
```

---

## Changelog
- add the `update_sub_app_by_label` API to `App` and `SubApps`.
