### PR TITLE
Don't show `.to_bits` in `Display` impl for `Entity`

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -125,7 +125,7 @@ impl<'a> std::fmt::Display for DebugNameItem<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {
             Some(name) => std::fmt::Display::fmt(name, f),
-            None => write!(f, "{}v{}", self.entity.index(), self.entity.generation()),
+            None => std::fmt::Display::fmt(&self.entity, f),
         }
     }
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -392,7 +392,7 @@ impl<'de> Deserialize<'de> for Entity {
 
 impl fmt::Display for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}v{}", self.index(), self.generation(),)
+        write!(f, "{}v{}", self.index(), self.generation())
     }
 }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -392,13 +392,7 @@ impl<'de> Deserialize<'de> for Entity {
 
 impl fmt::Display for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}v{}|{}",
-            self.index(),
-            self.generation(),
-            self.to_bits()
-        )
+        write!(f, "{}v{}", self.index(), self.generation(),)
     }
 }
 
@@ -1162,9 +1156,7 @@ mod tests {
     fn entity_display() {
         let entity = Entity::from_raw(42);
         let string = format!("{}", entity);
-        let bits = entity.to_bits().to_string();
         assert!(string.contains("42"));
         assert!(string.contains("v1"));
-        assert!(string.contains(&bits));
     }
 }


### PR DESCRIPTION
# Objective

#12469 changed the `Debug` impl for `Entity`, making sure it's actually accurate for debugging. To ensure that its can still be readily logged in error messages and inspectors, this PR added a more concise and human-friendly `Display` impl.

However, users found this form too verbose: the `to_bits` information was unhelpful and too long. Fixes #13980. 

## Solution

- Don't include `Entity::to_bits` in the `Display` implementation for `Entity`. This information can readily be accessed and logged for users who need it.
- Also clean up the implementation of `Display` for `DebugName`, introduced in https://github.com/bevyengine/bevy/pull/13760, to simply use the new `Display` impl (since this was the desired format there).

## Testing

I've updated an existing test to verify the output of `Entity::display`.