### PR TITLE
impl `BuildChildrenTransformExt` for `EntityWorldMut`

### DIFF
--- a/crates/bevy_transform/src/commands.rs
+++ b/crates/bevy_transform/src/commands.rs
@@ -2,7 +2,11 @@
 //! while preserving [`GlobalTransform`].
 
 use crate::prelude::{GlobalTransform, Transform};
-use bevy_ecs::{prelude::Entity, system::EntityCommands, world::Command, world::World};
+use bevy_ecs::{
+    prelude::Entity,
+    system::EntityCommands,
+    world::{Command, EntityWorldMut, World},
+};
 use bevy_hierarchy::{PushChild, RemoveParent};
 
 /// Command similar to [`PushChild`], but updating the child transform to keep
@@ -94,6 +98,20 @@ impl BuildChildrenTransformExt for EntityCommands<'_> {
     fn remove_parent_in_place(&mut self) -> &mut Self {
         let child = self.id();
         self.commands().add(RemoveParentInPlace { child });
+        self
+    }
+}
+
+impl BuildChildrenTransformExt for EntityWorldMut<'_> {
+    fn set_parent_in_place(&mut self, parent: Entity) -> &mut Self {
+        let child = self.id();
+        self.world_scope(|world| PushChildInPlace { child, parent }.apply(world));
+        self
+    }
+
+    fn remove_parent_in_place(&mut self) -> &mut Self {
+        let child = self.id();
+        self.world_scope(|world| RemoveParentInPlace { child }.apply(world));
         self
     }
 }


### PR DESCRIPTION
# Objective

Implement `BuildChildrenTransformExt` for `EntityWorldMut`, which is useful when working directly with a mutable `World` ref.

## Solution

I realize this isn't the most optimal implementation in that it doesn't reuse the existing entity location for the child, but it is terse and reuses the existing code. I can address that if needed.

## Testing

I only tested locally. There are no tests for `set_parent_in_place` and `remove_parent_in_place` currently, but I can add some.

---

## Changelog

`BuildChildrenTransformExt` implemented for `EntityWorldMut`.
