### PR TITLE
Remove extra allocation in AccessFilters

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -416,7 +416,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
     /// we can simply append to the array.
     pub fn append_or(&mut self, other: &FilteredAccess<T>) {
         let mut other_filter_sets = if other.filter_sets.is_empty() {
-            // we want to explicit append with an empty filter set
+            // we want to explicit append with an empty filter set, for example in Or<((), With<A>)>
             vec![AccessFilters::default()]
         } else {
             other.filter_sets.clone()

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -416,7 +416,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
     /// we can simply append to the array.
     pub fn append_or(&mut self, other: &FilteredAccess<T>) {
         let mut other_filter_sets = if other.filter_sets.is_empty() {
-            // we want to explicit append with an empty filter set, for example in Or<((), With<A>)>
+            // we want to explicitly append_or with an empty filter set, for example in Or<((), With<A>)>
             vec![AccessFilters::default()]
         } else {
             other.filter_sets.clone()

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -474,7 +474,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
             return;
         }
         if self.filter_sets.is_empty() {
-            self.filter_sets = other.filter_sets.clone();
+            self.filter_sets.clone_from(&other.filter_sets);
             return;
         }
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -416,6 +416,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
     /// we can simply append to the array.
     pub fn append_or(&mut self, other: &FilteredAccess<T>) {
         let mut other_filter_sets = if other.filter_sets.is_empty() {
+            // we want to explicit append with an empty filter set
             vec![AccessFilters::default()]
         } else {
             other.filter_sets.clone()

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -442,12 +442,13 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
         //
         // For example, `Query<&mut C, Or<(With<A>, Without<B>)>>` is compatible `Query<&mut C, (With<B>, Without<A>)>`,
         // but `Query<&mut C, Or<(Without<A>, Without<B>)>>` isn't compatible with `Query<&mut C, Or<(With<A>, With<B>)>>`.
-        self.filter_sets.iter().all(|filter| {
-            other
-                .filter_sets
-                .iter()
-                .all(|other_filter| filter.is_ruled_out_by(other_filter))
-        })
+        !self.filter_sets.is_empty()
+            && self.filter_sets.iter().all(|filter| {
+                other
+                    .filter_sets
+                    .iter()
+                    .all(|other_filter| filter.is_ruled_out_by(other_filter))
+            })
     }
 
     /// Returns a vector of elements that this and `other` cannot access at the same time.
@@ -474,7 +475,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
         }
         if self.filter_sets.is_empty() {
             self.filter_sets = other.filter_sets.clone();
-            return
+            return;
         }
 
         // We can avoid allocating a new array of bitsets if `other` contains just a single set of filters:
@@ -599,7 +600,7 @@ impl<T: SparseSetIndex> FilteredAccessSet<T> {
     ///    mutually exclusive. The fine grained phase iterates over all filters in
     ///    the `self` set and compares it to all the filters in the `other` set,
     ///    making sure they are all mutually compatible.
-     pub fn is_compatible(&self, other: &FilteredAccessSet<T>) -> bool {
+    pub fn is_compatible(&self, other: &FilteredAccessSet<T>) -> bool {
         if self.combined_access.is_compatible(other.combined_access()) {
             return true;
         }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1865,18 +1865,11 @@ macro_rules! impl_anytuple_fetch {
                 let ($($name,)*) = state;
 
                 let mut _new_access = _access.clone();
-                let mut _not_first = false;
                 $(
-                    if _not_first {
-                        let mut intermediate = _access.clone();
-                        $name::update_component_access($name, &mut intermediate);
-                        _new_access.append_or(&intermediate);
-                        _new_access.extend_access(&intermediate);
-                    } else {
-                        $name::update_component_access($name, &mut _new_access);
-                        _new_access.required = _access.required.clone();
-                        _not_first = true;
-                    }
+                    let mut intermediate = _access.clone();
+                    $name::update_component_access($name, &mut intermediate);
+                    _new_access.append_or(&intermediate);
+                    _new_access.extend_access(&intermediate);
                 )*
 
                 *_access = _new_access;

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1862,17 +1862,18 @@ macro_rules! impl_anytuple_fetch {
             }
 
             fn update_component_access(state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {
-                // update the access (add the read/writes)
-                <($(Option<$name>,)*)>::update_component_access(state, _access);
-
                 // update the filters (Or<(With<$name>,)>)
                 let ($($name,)*) = state;
+                let mut _new_access = FilteredAccess::default();
                 $(
                     // we use an intermediate empty access because we only want to update the filters, not the access
-                    let mut intermediate = FilteredAccess::default();
+                    let mut intermediate = _access.clone();
                     $name::update_component_access($name, &mut intermediate);
-                    _access.append_or(&intermediate);
+                    _new_access.append_or(&intermediate);
                 )*
+                _access.filter_sets = _new_access.filter_sets;
+
+                <($(Option<$name>,)*)>::update_component_access(state, _access);
             }
             #[allow(unused_variables)]
             fn init_state(world: &mut World) -> Self::State {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1871,10 +1871,8 @@ macro_rules! impl_anytuple_fetch {
                     // we use an intermediate empty access because we only want to update the filters, not the access
                     let mut intermediate = FilteredAccess::default();
                     $name::update_component_access($name, &mut intermediate);
-                    _new_access.append_or(&intermediate);
+                    _access.append_or(&intermediate);
                 )*
-
-                _access.filter_sets = _new_access.filter_sets;
             }
             #[allow(unused_variables)]
             fn init_state(world: &mut World) -> Self::State {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -443,7 +443,7 @@ macro_rules! impl_or_query_filter {
             fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
                 let ($($filter,)*) = state;
 
-                let mut _new_access = access.clone();
+                let mut _new_access = FilteredAccess::default();
                 $(
                     let mut intermediate = access.clone();
                     $filter::update_component_access($filter, &mut intermediate);

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -444,18 +444,11 @@ macro_rules! impl_or_query_filter {
                 let ($($filter,)*) = state;
 
                 let mut _new_access = access.clone();
-                let mut _not_first = false;
                 $(
-                    if _not_first {
-                        let mut intermediate = access.clone();
-                        $filter::update_component_access($filter, &mut intermediate);
-                        _new_access.append_or(&intermediate);
-                        _new_access.extend_access(&intermediate);
-                    } else {
-                        $filter::update_component_access($filter, &mut _new_access);
-                        _new_access.required = access.required.clone();
-                        _not_first = true;
-                    }
+                    let mut intermediate = access.clone();
+                    $filter::update_component_access($filter, &mut intermediate);
+                    _new_access.append_or(&intermediate);
+                    _new_access.extend_access(&intermediate);
                 )*
 
                 *access = _new_access;

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -448,7 +448,6 @@ macro_rules! impl_or_query_filter {
                     let mut intermediate = access.clone();
                     $filter::update_component_access($filter, &mut intermediate);
                     _new_access.append_or(&intermediate);
-                    _new_access.extend_access(&intermediate);
                 )*
 
                 *access = _new_access;

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -434,15 +434,16 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
 
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
     pub fn matches_component_set(&self, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
-        self.component_access.filter_sets.is_empty() || self.component_access.filter_sets.iter().any(|set| {
-            set.with
-                .ones()
-                .all(|index| set_contains_id(ComponentId::get_sparse_set_index(index)))
-                && set
-                    .without
+        self.component_access.filter_sets.is_empty()
+            || self.component_access.filter_sets.iter().any(|set| {
+                set.with
                     .ones()
-                    .all(|index| !set_contains_id(ComponentId::get_sparse_set_index(index)))
-        })
+                    .all(|index| set_contains_id(ComponentId::get_sparse_set_index(index)))
+                    && set
+                        .without
+                        .ones()
+                        .all(|index| !set_contains_id(ComponentId::get_sparse_set_index(index)))
+            })
     }
 
     /// For the given `archetype`, adds any component accessed used by this query's underlying [`FilteredAccess`] to `access`.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -434,7 +434,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
 
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
     pub fn matches_component_set(&self, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
-        self.component_access.filter_sets.iter().any(|set| {
+        self.component_access.filter_sets.is_empty() || self.component_access.filter_sets.iter().any(|set| {
             set.with
                 .ones()
                 .all(|index| set_contains_id(ComponentId::get_sparse_set_index(index)))


### PR DESCRIPTION
# Objective


Some parts of the AccessFilter code is currently pretty hard to understand. For example take a filter like `Or<(With<A>, With<B>)>`. 
Instead of having code like:
```
_access.append_or(component_a);
_access.append_or(component_b);
```
we have some strange-looking code that does something different for the first component in the `Or` filter:
```
A::update_component_access(state_a, &mut _access);
_access.append_or(component_b);
```

The reason is that if we just called `append_or` for all components, we would get a `filter_sets` in the form of `vec![(), With<A>, With<B>]`, because the default value for `filter_sets` is `vec![AccessFilters::default()]`.
This is incorrect because then systems such as `q1: Query<Entity, Or<(With<A>)>, q2: Query<Entity, Without<A>` would fail because the two queries would not be disjoint anymore (since the first query `q1`'s filter would effectively be `Or<((), With<A>>`). 
Instead what we want is a `filter_set` in the form of `vec![With<A>, With<B>]`. The special logic for the first tuple element ensures that the existing filter_set is first replaced by the filter_set value of the first component A (to remove the empty `AccessFilters::default()`) and then we call `append_or` as per usual.


I'm not entirely sure why the default `FilteredAccess` contains a `filter_sets` in the form of `vec![AccessFilters::default()]`.
Maybe to guarantee that `append_and` is correct (`filter_sets` is in disjunctive normal form so adding 'and' terms requires at least one element in `filter_sets`).


## Solution

- Make the default `filter_sets` `vec![]` instead of `vec![AccessFilters::default()]`, which removes an allocation whenever we create a filter. (and whenever we clone a `FilteredAccess`, which is quite frequent)
- The `AnyOf` and `Or` `WorldQuery` logic becomes simplified as there is no need to have special logic for the first element of the tuple anymore
- Some of the other access-related code needs to be adapted to handle empty filter_sets correctly

## Testing

- Via unit tests