### PR TITLE
Fix  error in AnyOf

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1864,16 +1864,13 @@ macro_rules! impl_anytuple_fetch {
             fn update_component_access(state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {
                 let mut _new_access = _access.clone();
 
-                // update the access (add the read/writes)
-                <($(Option<$name>,)*)>::update_component_access(state, _access);
-
                 // update the filters (Or<(With<$name>,)>)
                 let ($($name,)*) = state;
                 let mut _not_first = false;
                 $(
                     if _not_first {
-                        // we use an intermediate access because we only want to update the filters, not the access
-                        let mut intermediate = FilteredAccess::default();
+                        // we use an intermediate access because we only want to update the filter_sets, not the access
+                        let mut intermediate = _access.clone();
                         $name::update_component_access($name, &mut intermediate);
                         _new_access.append_or(&intermediate);
                     } else {
@@ -1884,6 +1881,11 @@ macro_rules! impl_anytuple_fetch {
                 )*
 
                 _access.filter_sets = _new_access.filter_sets;
+
+                // update the access (add the read/writes)
+                // Option<T> updates the access but not the filter_sets
+                <($(Option<$name>,)*)>::update_component_access(state, _access);
+
             }
             #[allow(unused_variables)]
             fn init_state(world: &mut World) -> Self::State {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -564,6 +564,13 @@ mod tests {
     }
 
     #[test]
+    fn any_of_with_and_without_common() {
+        fn sys(_: Query<(&mut D, &C, AnyOf<(&A, &B)>)>, _: Query<&mut D, Without<C>>) {}
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
     #[should_panic = "&bevy_ecs::system::tests::A conflicts with a previous access in this query."]
     fn any_of_with_mut_and_ref() {
         fn sys(_: Query<AnyOf<(&mut A, &A)>>) {}


### PR DESCRIPTION
# Objective

- Fixes a correctness error introduced in https://github.com/bevyengine/bevy/pull/14013 ...

## Solution

I've been playing around a lot of with the access code and I realized that I introduced a soundness error when trying to simplify the code. When we have a `Or<(With<A>, With<B>)>` filter, we cannot call
```
  let mut intermediate = FilteredAccess::default();
  $name::update_component_access($name, &mut intermediate);
  _new_access.append_or(&intermediate);
```
because that's just equivalent to adding the new components as `Or` clauses.
For example if the existing `filter_sets` was `vec![With<C>]`, we would then get `vec![With<C>, With<A>, With<B>]` which translates to `C or A or B`.
Instead what we want is `(C and A) or (C and B)`, so we need to have each new OR clause compose with the existing access like so:
```
let mut intermediate = _access.clone();
// if we previously had a With<C> in the filter_set, this will become `With<C> AND With<A>`
$name::update_component_access($name, &mut intermediate);
_new_access.append_or(&intermediate);
```

## Testing

- Added a unit test that is broken in main, but passes in this PR