### PR TITLE
Emit a warning if the result of `EntityCommand::with_entity` is not used

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -826,7 +826,9 @@ impl<'w, 's> Commands<'w, 's> {
 pub trait EntityCommand<Marker = ()>: Send + 'static {
     /// Executes this command for the given [`Entity`].
     fn apply(self, id: Entity, world: &mut World);
+
     /// Returns a [`Command`] which executes this [`EntityCommand`] for the given [`Entity`].
+    #[must_use = "commands do nothing unless applied to a `World`"]
     fn with_entity(self, id: Entity) -> WithEntity<Marker, Self>
     where
         Self: Sized,


### PR DESCRIPTION
# Objective

When using combinators such as `EntityCommand::with_entity` to build commands, it can be easy to forget to apply that command, leading to dead code. In many cases this doesn't even lead to an unused variable warning, which can make these mistakes difficult to track down

## Solution

Annotate the method with `#[must_use]`
