### PR TITLE
fix examples color_grading and mobile after BackgroundColor changes

### DIFF
--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -567,7 +567,11 @@ fn handle_button_presses(
 
 /// Updates the state of the UI based on the current state.
 fn update_ui_state(
-    mut buttons: Query<(&mut UiImage, &mut BorderColor, &ColorGradingOptionWidget)>,
+    mut buttons: Query<(
+        &mut BackgroundColor,
+        &mut BorderColor,
+        &ColorGradingOptionWidget,
+    )>,
     mut button_text: Query<(&mut Text, &ColorGradingOptionWidget), Without<HelpText>>,
     mut help_text: Query<&mut Text, With<HelpText>>,
     cameras: Query<Ref<ColorGrading>>,
@@ -579,12 +583,12 @@ fn update_ui_state(
     }
 
     // The currently-selected option is drawn with inverted colors.
-    for (mut image, mut border_color, widget) in buttons.iter_mut() {
+    for (mut background, mut border_color, widget) in buttons.iter_mut() {
         if *currently_selected_option == widget.option {
-            image.color = Color::WHITE;
+            *background = Color::WHITE.into();
             *border_color = Color::BLACK.into();
         } else {
-            image.color = Color::BLACK;
+            *background = Color::BLACK.into();
             *border_color = Color::WHITE.into();
         }
     }

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -114,21 +114,18 @@ fn setup_scene(
 
     // Test ui
     commands
-        .spawn((
-            ButtonBundle {
-                style: Style {
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    position_type: PositionType::Absolute,
-                    left: Val::Px(50.0),
-                    right: Val::Px(50.0),
-                    bottom: Val::Px(50.0),
-                    ..default()
-                },
+        .spawn(ButtonBundle {
+            style: Style {
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                position_type: PositionType::Absolute,
+                left: Val::Px(50.0),
+                right: Val::Px(50.0),
+                bottom: Val::Px(50.0),
                 ..default()
             },
-            BackgroundColor(Color::WHITE),
-        ))
+            ..default()
+        })
         .with_children(|b| {
             b.spawn(
                 TextBundle::from_section(


### PR DESCRIPTION
# Objective

- #14017 changed how `UiImage` and `BackgroundColor` work
- one change was missed in example `color_grading`, another in the mobile example

## Solution

- Change it in the examples
