### PR TITLE
example showcase: keep the order of the shaders imported

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -731,13 +731,17 @@ fn parse_examples() -> Vec<Example> {
                 Regex::new(r"(shaders\/\w+\.wgsl)|(shaders\/\w+\.frag)|(shaders\/\w+\.vert)")
                     .unwrap();
 
-            // Find all instances of references to shader files, collect into set to avoid duplicates, then convert to vec of strings.
-            let shader_paths = Vec::from_iter(
-                shader_regex
-                    .find_iter(&source_code)
-                    .map(|matches| matches.as_str().to_owned())
-                    .collect::<HashSet<String>>(),
-            );
+            // Find all instances of references to shader files, and keep them in an ordered and deduped vec.
+            let mut shader_paths = vec![];
+            for path in shader_regex
+                .find_iter(&source_code)
+                .map(|matches| matches.as_str().to_owned())
+            {
+                if !shader_paths.contains(&path) {
+                    shader_paths.push(path);
+                }
+            }
+
             if metadatas
                 .get(&technical_name)
                 .and_then(|metadata| metadata.get("hidden"))

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -1,7 +1,7 @@
 //! Tool to run all examples or generate a showcase page for the Bevy website.
 
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap, HashSet},
+    collections::{hash_map::DefaultHasher, HashMap},
     fmt::Display,
     fs::{self, File},
     hash::{Hash, Hasher},


### PR DESCRIPTION
# Objective

- After #13908, shaders imported are collected
- this is done with a hashset, so order is random between executions

## Solution

- Don't use a hashset, and keep the order they were found in the example
