### PR TITLE
Fix typo in CPU adapter warning

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -190,7 +190,7 @@ pub async fn initialize_renderer(
 
     if adapter_info.device_type == DeviceType::Cpu {
         warn!(
-            "The selected adapter is using the a driver that only supports software rendering. \
+            "The selected adapter is using a driver that only supports software rendering. \
              This is likely to be very slow. See https://bevyengine.org/learn/errors/b0006/"
         );
     }


### PR DESCRIPTION
An annoying typo slipped through in #13780