### PR TITLE
Improve MeshletMesh::from_mesh performance further

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1", features = ["derive", "rc"], optional = true }
 bincode = { version = "1", optional = true }
 thiserror = { version = "1", optional = true }
 range-alloc = { version = "0.1", optional = true }
-meshopt = { version = "0.2.1", optional = true }
+meshopt = { version = "0.3.0", optional = true }
 metis = { version = "0.2", optional = true }
 itertools = { version = "0.13", optional = true }
 # direct dependency required for derive macro

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -290,8 +290,8 @@ fn simplify_meshlet_groups(
 
     // Allow more deformation for high LOD levels (1% at LOD 1, 10% at LOD 20+)
     let t = (lod_level - 1) as f32 / 19.0;
-    let target_error_rel = 0.1 * t + 0.01 * (1.0 - t);
-    let target_error = target_error_rel * mesh_scale;
+    let target_error_relative = 0.1 * t + 0.01 * (1.0 - t);
+    let target_error = target_error_relative * mesh_scale;
 
     // Simplify the group to ~50% triangle count
     // TODO: Use simplify_with_locks()


### PR DESCRIPTION
This change updates meshopt-rs to 0.3 to take advantage of the newly added sparse simplification mode: by default, simplifier assumes that the entire mesh is simplified and runs a set of calculations that are O(vertex count), but in our case we simplify many small mesh subsets which is inefficient.

Sparse mode instead assumes that the simplified subset is only using a portion of the vertex buffer, and optimizes accordingly. This changes the meaning of the error (as it becomes relative to the subset, in our case a meshlet group); to ensure consistent error selection, we also use the ErrorAbsolute mode which allows us to operate in mesh coordinate space.

Additionally, meshopt 0.3 runs optimizeMeshlet automatically as part of `build_meshlets` so we no longer need to call it ourselves.

This reduces the time to build meshlet representation for Stanford Bunny mesh from ~1.65s to ~0.45s (3.7x) in optimized builds.