### PR TITLE
Fix incorrect computation of mips for cluster occlusion lookup

### DIFF
--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
@@ -85,8 +85,7 @@ fn cull_clusters(
     let culling_bounding_sphere_center_view_space = (view.view_from_world * vec4(culling_bounding_sphere_center.xyz, 1.0)).xyz;
 
     let aabb = project_view_space_sphere_to_screen_space_aabb(culling_bounding_sphere_center_view_space, culling_bounding_sphere_radius);
-    // Halve the view-space AABB size as the depth pyramid is half the view size
-    let depth_pyramid_size_mip_0 = vec2<f32>(textureDimensions(depth_pyramid, 0)) * 0.5;
+    let depth_pyramid_size_mip_0 = vec2<f32>(textureDimensions(depth_pyramid, 0));
     let width = (aabb.z - aabb.x) * depth_pyramid_size_mip_0.x;
     let height = (aabb.w - aabb.y) * depth_pyramid_size_mip_0.y;
     let depth_level = max(0, i32(ceil(log2(max(width, height))))); // TODO: Naga doesn't like this being a u32


### PR DESCRIPTION
The comment was incorrect - we are already looking at the pyramid texture so we do not need to transform the size in any way. Doing that resulted in a mip that was too fine to be selected in certain cases, which resulted in a 2x2 pixel footprint not actually fully covering the cluster sphere - sometimes this could lead to a non-conservative depth value being computed which resulted in the cluster being marked as invisible incorrectly.