### PR TITLE
Mouse input accumulation

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -138,7 +138,9 @@ impl Plugin for InputPlugin {
             .register_type::<TouchInput>()
             .register_type::<GamepadEvent>()
             .register_type::<GamepadButtonInput>()
-            .register_type::<GamepadSettings>();
+            .register_type::<GamepadSettings>()
+            .register_type::<AccumulatedMouseMotion>()
+            .register_type::<AccumulatedMouseScroll>();
     }
 }
 

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -43,7 +43,10 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use gestures::*;
 use keyboard::{keyboard_input_system, KeyCode, KeyboardFocusLost, KeyboardInput};
-use mouse::{mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
+use mouse::{
+    accumulate_mouse_input_system, mouse_button_input_system, AccumulatedMouseMotion,
+    AccumulatedMouseScroll, MouseButton, MouseButtonInput, MouseMotion, MouseWheel,
+};
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
 use gamepad::{
@@ -77,7 +80,10 @@ impl Plugin for InputPlugin {
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()
             .init_resource::<ButtonInput<MouseButton>>()
-            .add_systems(PreUpdate, mouse_button_input_system.in_set(InputSystem))
+            .add_systems(
+                PreUpdate,
+                (mouse_button_input_system, accumulate_mouse_input_system).in_set(InputSystem),
+            )
             .add_event::<PinchGesture>()
             .add_event::<RotationGesture>()
             .add_event::<DoubleTapGesture>()
@@ -94,6 +100,8 @@ impl Plugin for InputPlugin {
             .init_resource::<ButtonInput<GamepadButton>>()
             .init_resource::<Axis<GamepadAxis>>()
             .init_resource::<Axis<GamepadButton>>()
+            .init_resource::<AccumulatedMouseMotion>()
+            .init_resource::<AccumulatedMouseScroll>()
             .add_systems(
                 PreUpdate,
                 (

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -44,8 +44,9 @@ use bevy_reflect::Reflect;
 use gestures::*;
 use keyboard::{keyboard_input_system, KeyCode, KeyboardFocusLost, KeyboardInput};
 use mouse::{
-    accumulate_mouse_input_system, mouse_button_input_system, AccumulatedMouseMotion,
-    AccumulatedMouseScroll, MouseButton, MouseButtonInput, MouseMotion, MouseWheel,
+    accumulate_mouse_motion_system, accumulate_mouse_scroll_system, mouse_button_input_system,
+    AccumulatedMouseMotion, AccumulatedMouseScroll, MouseButton, MouseButtonInput, MouseMotion,
+    MouseWheel,
 };
 use touch::{touch_screen_input_system, TouchInput, Touches};
 
@@ -82,7 +83,12 @@ impl Plugin for InputPlugin {
             .init_resource::<ButtonInput<MouseButton>>()
             .add_systems(
                 PreUpdate,
-                (mouse_button_input_system, accumulate_mouse_input_system).in_set(InputSystem),
+                (
+                    mouse_button_input_system,
+                    accumulate_mouse_motion_system,
+                    accumulate_mouse_scroll_system,
+                )
+                    .in_set(InputSystem),
             )
             .add_event::<PinchGesture>()
             .add_event::<RotationGesture>()

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -158,6 +158,7 @@ pub fn mouse_button_input_system(
 }
 
 /// Tracks how much the mouse has moved every frame
+/// This resource is reset to zero every frame
 ///
 /// This resource sums the total [`MouseMotion`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect, Default)]
@@ -173,6 +174,7 @@ pub struct AccumulatedMouseMotion {
 }
 
 /// Tracks how much the mouse has scrolled every frame
+/// This resource is reset to zero every frame
 ///
 /// This resource sums the total [`MouseMotion`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect)]
@@ -198,20 +200,25 @@ impl Default for AccumulatedMouseScroll {
     }
 }
 
-/// Updates the `AccumulatedMouseMotion` and `AccumulatedMouseScroll` resources
-/// using the `MouseMotion` and `MouseWheel` events.
-pub fn accumulate_mouse_input_system(
+/// Updates the [`AccumulatedMouseMotion`] resource using the [`MouseMotion`] event.
+/// The value of [`AccumulatedMouseMotion`] is reset to zero every frame
+pub fn accumulate_mouse_motion_system(
     mut mouse_motion_event: EventReader<MouseMotion>,
-    mut mouse_scroll_event: EventReader<MouseWheel>,
     mut accumulated_mouse_motion: ResMut<AccumulatedMouseMotion>,
-    mut accumulated_mouse_scroll: ResMut<AccumulatedMouseScroll>,
 ) {
     let mut delta = Vec2::ZERO;
     for event in mouse_motion_event.read() {
         delta += event.delta;
     }
     accumulated_mouse_motion.delta = delta;
+}
 
+/// Updates the [`AccumulatedMouseScroll`] resource using the [`MouseWheel`] event.
+/// The value of [`AccumulatedMouseScroll`] is reset to zero every frame
+pub fn accumulate_mouse_scroll_system(
+    mut mouse_scroll_event: EventReader<MouseWheel>,
+    mut accumulated_mouse_scroll: ResMut<AccumulatedMouseScroll>,
+) {
     let mut delta = Vec2::ZERO;
     let mut unit = MouseScrollUnit::Line;
     for event in mouse_scroll_event.read() {

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -159,7 +159,7 @@ pub fn mouse_button_input_system(
 
 /// Tracks how much the mouse has moved every frame
 ///
-/// This event tracks the `MouseMotion` event for calculations.
+/// This resource sums the total [`MouseMotion`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect, Default)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -174,7 +174,7 @@ pub struct AccumulatedMouseMotion {
 
 /// Tracks how much the mouse has scrolled every frame
 ///
-/// This event tracks the `MouseWheel` event for calculations.
+/// This resource sums the total [`MouseMotion`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -174,8 +174,9 @@ pub struct AccumulatedMouseMotion {
     pub delta: Vec2,
 }
 
-/// Tracks how much the mouse has scrolled every frame
-/// This resource is reset to zero every frame
+/// Tracks how much the mouse has scrolled every frame.
+///
+/// This resource is reset to zero every frame.
 ///
 /// This resource sums the total [`MouseWheel`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect)]

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -2,6 +2,7 @@
 
 use crate::{ButtonInput, ButtonState};
 use bevy_ecs::entity::Entity;
+use bevy_ecs::reflect::ReflectResource;
 use bevy_ecs::system::Resource;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
@@ -9,7 +10,7 @@ use bevy_ecs::{
     system::ResMut,
 };
 use bevy_math::Vec2;
-use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -162,7 +163,7 @@ pub fn mouse_button_input_system(
 ///
 /// This resource sums the total [`MouseMotion`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect, Default)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug, Default, Resource, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -178,7 +179,7 @@ pub struct AccumulatedMouseMotion {
 ///
 /// This resource sums the total [`MouseWheel`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug, Default, Resource, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -186,6 +186,8 @@ pub struct AccumulatedMouseMotion {
 )]
 pub struct AccumulatedMouseScroll {
     /// The mouse scroll unit.
+    /// If this value changes while scrolling, then the
+    /// result of the accumulation could be incorrect
     pub unit: MouseScrollUnit,
     /// The change in scroll position.
     pub delta: Vec2,

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -158,8 +158,9 @@ pub fn mouse_button_input_system(
     }
 }
 
-/// Tracks how much the mouse has moved every frame
-/// This resource is reset to zero every frame
+/// Tracks how much the mouse has moved every frame.
+///
+/// This resource is reset to zero every frame.
 ///
 /// This resource sums the total [`MouseMotion`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect, Default)]

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -176,7 +176,7 @@ pub struct AccumulatedMouseMotion {
 /// Tracks how much the mouse has scrolled every frame
 /// This resource is reset to zero every frame
 ///
-/// This resource sums the total [`MouseMotion`] events received this frame.
+/// This resource sums the total [`MouseWheel`] events received this frame.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/examples/input/mouse_input.rs
+++ b/examples/input/mouse_input.rs
@@ -1,12 +1,27 @@
 //! Prints mouse button events.
 
-use bevy::prelude::*;
+use bevy::{
+    input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll},
+    prelude::*,
+};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Update, mouse_click_system)
+        .init_resource::<CurrentMouseMotion>()
+        .init_resource::<CurrentMouseScroll>()
+        .add_systems(Update, (mouse_click_system, mouse_move_system))
         .run();
+}
+
+#[derive(Resource, Default)]
+struct CurrentMouseMotion {
+    pub delta: Vec2,
+}
+
+#[derive(Resource, Default)]
+struct CurrentMouseScroll {
+    pub delta: Vec2,
 }
 
 // This system prints messages when you press or release the left mouse button:
@@ -21,5 +36,28 @@ fn mouse_click_system(mouse_button_input: Res<ButtonInput<MouseButton>>) {
 
     if mouse_button_input.just_released(MouseButton::Left) {
         info!("left mouse just released");
+    }
+}
+
+// This system prints messages when you press or release the left mouse button:
+fn mouse_move_system(
+    accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
+    accumulated_mouse_scroll: Res<AccumulatedMouseScroll>,
+    mut current_mouse_motion: ResMut<CurrentMouseMotion>,
+    mut current_mouse_scroll: ResMut<CurrentMouseScroll>,
+) {
+    if accumulated_mouse_motion.delta == Vec2::ZERO && current_mouse_motion.delta != Vec2::ZERO {
+        let delta = current_mouse_motion.delta;
+        info!("mouse moved ({}, {})", delta.x, delta.y);
+        current_mouse_motion.delta = Vec2::ZERO;
+    } else {
+        current_mouse_motion.delta += accumulated_mouse_motion.delta;
+    }
+    if accumulated_mouse_scroll.delta == Vec2::ZERO && current_mouse_scroll.delta != Vec2::ZERO {
+        let delta = current_mouse_scroll.delta;
+        info!("mouse scrolled ({}, {})", delta.x, delta.y);
+        current_mouse_scroll.delta = Vec2::ZERO;
+    } else {
+        current_mouse_scroll.delta += accumulated_mouse_scroll.delta;
     }
 }

--- a/examples/input/mouse_input.rs
+++ b/examples/input/mouse_input.rs
@@ -8,20 +8,8 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .init_resource::<CurrentMouseMotion>()
-        .init_resource::<CurrentMouseScroll>()
         .add_systems(Update, (mouse_click_system, mouse_move_system))
         .run();
-}
-
-#[derive(Resource, Default)]
-struct CurrentMouseMotion {
-    pub delta: Vec2,
-}
-
-#[derive(Resource, Default)]
-struct CurrentMouseScroll {
-    pub delta: Vec2,
 }
 
 // This system prints messages when you press or release the left mouse button:
@@ -39,25 +27,17 @@ fn mouse_click_system(mouse_button_input: Res<ButtonInput<MouseButton>>) {
     }
 }
 
-// This system prints messages when you press or release the left mouse button:
+// This system prints messages when you finish dragging or scrolling with your mouse
 fn mouse_move_system(
     accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     accumulated_mouse_scroll: Res<AccumulatedMouseScroll>,
-    mut current_mouse_motion: ResMut<CurrentMouseMotion>,
-    mut current_mouse_scroll: ResMut<CurrentMouseScroll>,
 ) {
-    if accumulated_mouse_motion.delta == Vec2::ZERO && current_mouse_motion.delta != Vec2::ZERO {
-        let delta = current_mouse_motion.delta;
+    if accumulated_mouse_motion.delta != Vec2::ZERO {
+        let delta = accumulated_mouse_motion.delta;
         info!("mouse moved ({}, {})", delta.x, delta.y);
-        current_mouse_motion.delta = Vec2::ZERO;
-    } else {
-        current_mouse_motion.delta += accumulated_mouse_motion.delta;
     }
-    if accumulated_mouse_scroll.delta == Vec2::ZERO && current_mouse_scroll.delta != Vec2::ZERO {
-        let delta = current_mouse_scroll.delta;
+    if accumulated_mouse_scroll.delta != Vec2::ZERO {
+        let delta = accumulated_mouse_scroll.delta;
         info!("mouse scrolled ({}, {})", delta.x, delta.y);
-        current_mouse_scroll.delta = Vec2::ZERO;
-    } else {
-        current_mouse_scroll.delta += accumulated_mouse_scroll.delta;
     }
 }


### PR DESCRIPTION
# Objective

- Add the `AccumulatedMouseMotion` and `AccumulatedMouseScroll` resources to make it simpler to track mouse motion/scroll changes
- Closes #13915

## Solution

- Created two resources, `AccumulatedMouseMotion` and `AccumulatedMouseScroll`, and a method that tracks the `MouseMotion` and `MouseWheel` events and accumulates their deltas every frame.
- Also modified the mouse input example to show how to use the resources.

## Testing

- Tested the changes by modifying an existing example to use the newly added resources, and moving/scrolling my trackpad around a ton.