### PR TITLE
Add missing StaticSystemParam::queue implementation.

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1609,6 +1609,10 @@ unsafe impl<P: SystemParam + 'static> SystemParam for StaticSystemParam<'_, '_, 
         P::apply(state, system_meta, world);
     }
 
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        P::queue(state, system_meta, world);
+    }
+
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         system_meta: &SystemMeta,


### PR DESCRIPTION
# Objective

`StaticSystemParam` should delegate all `SystemParam` methods to the inner param, but it looks like it was missed when the new `queue()` method was added in #10839.  

## Solution

Implement `StaticSystemParam::queue()` to delegate to the inner param.  
