### PR TITLE
Made Material2dBindGroupId instantiable

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -463,7 +463,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
 }
 
 #[derive(Component, Clone, Copy, Default, PartialEq, Eq, Deref, DerefMut)]
-pub struct Material2dBindGroupId(Option<BindGroupId>);
+pub struct Material2dBindGroupId(pub Option<BindGroupId>);
 
 /// Data prepared for a [`Material2d`] instance.
 pub struct PreparedMaterial2d<T: Material2d> {


### PR DESCRIPTION
# Objective / Solution

Make it possible to construct `Material2dBindGroupId` for custom 2D material pipelines by making the inner field public.

---

The 3D variant (`MaterialBindGroupId`) had this done in https://github.com/bevyengine/bevy/commit/e79b9b62ce0d6f10f77a0c026aa7d424abe26bb0