### PR TITLE
add PartialEq to Outline

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1736,7 +1736,7 @@ impl Default for BorderColor {
     }
 }
 
-#[derive(Component, Copy, Clone, Default, Debug, Reflect)]
+#[derive(Component, Copy, Clone, Default, Debug, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 #[cfg_attr(
     feature = "serialize",


### PR DESCRIPTION
# Objective

`sickle_ui` needs `PartialEq` on components to turn them into animatable style attributes.

## Solution

All properties of Outline is already `PartialEq`, add derive on `Outline` as well.

## Testing

- used `sickle_ui` to test if it can be made animatable
