### PR TITLE
Move all asset paths in examples to constants at the top of the example

### DIFF
--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -1,8 +1,5 @@
 //! Illustrates bloom post-processing in 2d.
 
-/// This example uses an asset from the assets subdirectory
-const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
-
 use bevy::{
     core_pipeline::{
         bloom::{BloomCompositeMode, BloomSettings},
@@ -11,6 +8,9 @@ use bevy::{
     prelude::*,
     sprite::MaterialMesh2dBundle,
 };
+
+/// This example uses an asset from the assets subdirectory
+const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
 
 fn main() {
     App::new()

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -1,5 +1,8 @@
 //! Illustrates bloom post-processing in 2d.
 
+/// This example uses an asset from the assets subdirectory
+const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
+
 use bevy::{
     core_pipeline::{
         bloom::{BloomCompositeMode, BloomSettings},
@@ -37,7 +40,7 @@ fn setup(
 
     // Sprite
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/bevy_bird_dark.png"),
+        texture: asset_server.load(BEVY_BIRD_ASSET_PATH),
         sprite: Sprite {
             color: Color::srgb(5.0, 5.0, 5.0), // 4. Put something bright in a dark environment to see the effect
             custom_size: Some(Vec2::splat(160.0)),

--- a/examples/2d/custom_gltf_vertex_attribute.rs
+++ b/examples/2d/custom_gltf_vertex_attribute.rs
@@ -13,6 +13,8 @@ use bevy::{
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/custom_gltf_2d.wgsl";
+/// This example uses a GLTF file from the assets subdirectory
+const BARYCENTRIC_PATH: &str = "models/barycentric/barycentric.gltf";
 
 /// This vertex attribute supplies barycentric coordinates for each triangle.
 /// Each component of the vector corresponds to one corner of a triangle. It's
@@ -50,7 +52,7 @@ fn setup(
             mesh: 0,
             primitive: 0,
         }
-        .from_asset("models/barycentric/barycentric.gltf"),
+        .from_asset(BARYCENTRIC_PATH),
     );
     commands.spawn(MaterialMesh2dBundle {
         mesh: Mesh2dHandle(mesh),

--- a/examples/2d/mesh2d_arcs.rs
+++ b/examples/2d/mesh2d_arcs.rs
@@ -2,9 +2,6 @@
 //!
 //! Also draws the bounding boxes and circles of the primitives.
 
-/// This example uses a png from the assets subdirectory
-const ICON_PATH: &str = "branding/icon.png";
-
 use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
@@ -14,6 +11,9 @@ use bevy::{
     render::mesh::{CircularMeshUvMode, CircularSectorMeshBuilder, CircularSegmentMeshBuilder},
     sprite::MaterialMesh2dBundle,
 };
+
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
 
 fn main() {
     App::new()

--- a/examples/2d/mesh2d_arcs.rs
+++ b/examples/2d/mesh2d_arcs.rs
@@ -1,6 +1,10 @@
 //! Demonstrates UV mappings of the [`CircularSector`] and [`CircularSegment`] primitives.
 //!
 //! Also draws the bounding boxes and circles of the primitives.
+
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
@@ -34,7 +38,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    let material = materials.add(asset_server.load("branding/icon.png"));
+    let material = materials.add(asset_server.load(ICON_PATH));
 
     commands.spawn(Camera2dBundle {
         camera: Camera {

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -1,13 +1,13 @@
 //! Shows how to render a polygonal [`Mesh`], generated from a [`Rectangle`] primitive, in a 2D scene.
 //! Adds a texture and colored vertices, giving per-vertex tinting.
 
-/// This example uses a png from the assets subdirectory
-const BANNER_PATH: &str = "branding/banner.png";
-
 use bevy::{
     prelude::*,
     sprite::{MaterialMesh2dBundle, Mesh2dHandle},
 };
+
+/// This example uses a png from the assets subdirectory
+const BANNER_PATH: &str = "branding/banner.png";
 
 fn main() {
     App::new()

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -1,6 +1,9 @@
 //! Shows how to render a polygonal [`Mesh`], generated from a [`Rectangle`] primitive, in a 2D scene.
 //! Adds a texture and colored vertices, giving per-vertex tinting.
 
+/// This example uses a png from the assets subdirectory
+const BANNER_PATH: &str = "branding/banner.png";
+
 use bevy::{
     prelude::*,
     sprite::{MaterialMesh2dBundle, Mesh2dHandle},
@@ -20,7 +23,7 @@ fn setup(
     asset_server: Res<AssetServer>,
 ) {
     // Load the Bevy logo as a texture
-    let texture_handle = asset_server.load("branding/banner.png");
+    let texture_handle = asset_server.load(BANNER_PATH);
     // Build a default quad mesh
     let mut mesh = Mesh::from(Rectangle::default());
     // Build vertex colors for the quad. One entry per vertex (the corners of the quad)

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -1,8 +1,5 @@
 //! Renders a 2D scene containing a single, moving sprite.
 
-/// This example uses a png from the assets subdirectory
-const ICON_PATH: &str = "branding/icon.png";
-
 use bevy::prelude::*;
 
 fn main() {
@@ -12,6 +9,9 @@ fn main() {
         .add_systems(Update, sprite_movement)
         .run();
 }
+
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
 
 #[derive(Component)]
 enum Direction {

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -1,5 +1,8 @@
 //! Renders a 2D scene containing a single, moving sprite.
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 use bevy::prelude::*;
 
 fn main() {
@@ -20,7 +23,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn((
         SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
+            texture: asset_server.load(ICON_PATH),
             transform: Transform::from_xyz(100., 0., 0.),
             ..default()
         },

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -1,5 +1,9 @@
 //! Shows how to create graphics that snap to the pixel grid by rendering to a texture in 2D
 
+/// This example uses two pngs from the assets subdirectory
+const PIXEL_DARK_PATH: &str = "pixel/bevy_pixel_dark.png";
+const PIXEL_LIGHT_PATH: &str = "pixel/bevy_pixel_light.png";
+
 use bevy::{
     prelude::*,
     render::{
@@ -55,7 +59,7 @@ fn setup_sprite(mut commands: Commands, asset_server: Res<AssetServer>) {
     // the sample sprite that will be rendered to the pixel-perfect canvas
     commands.spawn((
         SpriteBundle {
-            texture: asset_server.load("pixel/bevy_pixel_dark.png"),
+            texture: asset_server.load(PIXEL_DARK_PATH),
             transform: Transform::from_xyz(-40., 20., 2.),
             ..default()
         },
@@ -66,7 +70,7 @@ fn setup_sprite(mut commands: Commands, asset_server: Res<AssetServer>) {
     // the sample sprite that will be rendered to the high-res "outer world"
     commands.spawn((
         SpriteBundle {
-            texture: asset_server.load("pixel/bevy_pixel_light.png"),
+            texture: asset_server.load(PIXEL_LIGHT_PATH),
             transform: Transform::from_xyz(-40., -20., 2.),
             ..default()
         },

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -1,9 +1,5 @@
 //! Shows how to create graphics that snap to the pixel grid by rendering to a texture in 2D
 
-/// This example uses two pngs from the assets subdirectory
-const PIXEL_DARK_PATH: &str = "pixel/bevy_pixel_dark.png";
-const PIXEL_LIGHT_PATH: &str = "pixel/bevy_pixel_light.png";
-
 use bevy::{
     prelude::*,
     render::{
@@ -16,6 +12,10 @@ use bevy::{
     sprite::MaterialMesh2dBundle,
     window::WindowResized,
 };
+
+/// This example uses two pngs from the assets subdirectory
+const PIXEL_DARK_PATH: &str = "pixel/bevy_pixel_dark.png";
+const PIXEL_LIGHT_PATH: &str = "pixel/bevy_pixel_light.png";
 
 /// In-game resolution width.
 const RES_WIDTH: u32 = 160;

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -1,5 +1,10 @@
 //! Demonstrates rotating entities in 2D using quaternions.
 
+/// This example uses three pngs from the assets subdirectory
+const SHIP_C_PATH: &str = "textures/simplespace/ship_C.png";
+const ENEMY_A_PATH: &str = "textures/simplespace/enemy_A.png";
+const ENEMY_B_PATH: &str = "textures/simplespace/enemy_B.png";
+
 use bevy::prelude::*;
 
 const BOUNDS: Vec2 = Vec2::new(1200.0, 640.0);
@@ -50,9 +55,9 @@ struct RotateToPlayer {
 ///
 /// The origin is at the center of the screen.
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let ship_handle = asset_server.load("textures/simplespace/ship_C.png");
-    let enemy_a_handle = asset_server.load("textures/simplespace/enemy_A.png");
-    let enemy_b_handle = asset_server.load("textures/simplespace/enemy_B.png");
+    let ship_handle = asset_server.load(SHIP_C_PATH);
+    let enemy_a_handle = asset_server.load(ENEMY_A_PATH);
+    let enemy_b_handle = asset_server.load(ENEMY_B_PATH);
 
     // 2D orthographic camera
     commands.spawn(Camera2dBundle::default());

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -1,11 +1,11 @@
 //! Demonstrates rotating entities in 2D using quaternions.
 
+use bevy::prelude::*;
+
 /// This example uses three pngs from the assets subdirectory
 const SHIP_C_PATH: &str = "textures/simplespace/ship_C.png";
 const ENEMY_A_PATH: &str = "textures/simplespace/enemy_A.png";
 const ENEMY_B_PATH: &str = "textures/simplespace/enemy_B.png";
-
-use bevy::prelude::*;
 
 const BOUNDS: Vec2 = Vec2::new(1200.0, 640.0);
 

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -1,5 +1,8 @@
 //! Displays a single [`Sprite`], created from an image.
 
+/// This example uses a png from the assets subdirectory
+const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
+
 use bevy::prelude::*;
 
 fn main() {
@@ -12,7 +15,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/bevy_bird_dark.png"),
+        texture: asset_server.load(BEVY_BIRD_ASSET_PATH),
         ..default()
     });
 }

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -1,9 +1,9 @@
 //! Displays a single [`Sprite`], created from an image.
 
+use bevy::prelude::*;
+
 /// This example uses a png from the assets subdirectory
 const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
-
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -2,12 +2,13 @@
 //!
 //! See `sprite_sheet.rs` for an example where the sprite animation loops indefinitely.
 
-/// This example uses a png from the assets subdirectory
-const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
 use std::time::Duration;
 
 use bevy::input::common_conditions::input_just_pressed;
 use bevy::prelude::*;
+
+/// This example uses a png from the assets subdirectory
+const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
 
 fn main() {
     App::new()

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -2,6 +2,8 @@
 //!
 //! See `sprite_sheet.rs` for an example where the sprite animation loops indefinitely.
 
+/// This example uses a png from the assets subdirectory
+const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
 use std::time::Duration;
 
 use bevy::input::common_conditions::input_just_pressed;
@@ -94,7 +96,7 @@ fn setup(
     commands.spawn(Camera2dBundle::default());
 
     // load the sprite sheet using the `AssetServer`
-    let texture = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
+    let texture = asset_server.load(IDLE_RUN_PATH);
 
     // the sprite sheet has 7 sprites arranged in a row, and they are all 24px x 24px
     let layout = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -1,5 +1,8 @@
 //! Displays a single [`Sprite`], created from an image, but flipped on one axis.
 
+/// This example uses png from the assets subdirectory
+const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
+
 use bevy::prelude::*;
 
 fn main() {
@@ -12,7 +15,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/bevy_bird_dark.png"),
+        texture: asset_server.load(BEVY_BIRD_ASSET_PATH),
         sprite: Sprite {
             // Flip the logo to the left
             flip_x: true,

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -1,9 +1,9 @@
 //! Displays a single [`Sprite`], created from an image, but flipped on one axis.
 
+use bevy::prelude::*;
+
 /// This example uses png from the assets subdirectory
 const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_bird_dark.png";
-
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -1,10 +1,10 @@
 //! Renders an animated sprite by loading all animation frames from a single image (a sprite sheet)
 //! into a texture atlas, and changing the displayed image periodically.
 
+use bevy::prelude::*;
+
 /// This example uses a png from the assets subdirectory
 const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
-
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -1,6 +1,9 @@
 //! Renders an animated sprite by loading all animation frames from a single image (a sprite sheet)
 //! into a texture atlas, and changing the displayed image periodically.
 
+/// This example uses a png from the assets subdirectory
+const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
+
 use bevy::prelude::*;
 
 fn main() {
@@ -41,7 +44,7 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
 ) {
-    let texture = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
+    let texture = asset_server.load(IDLE_RUN_PATH);
     let layout = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);
     let texture_atlas_layout = texture_atlas_layouts.add(layout);
     // Use only the subset of sprites in the sheet that make up the run animation

--- a/examples/2d/sprite_slice.rs
+++ b/examples/2d/sprite_slice.rs
@@ -2,6 +2,12 @@
 //! sprites in multiple resolutions while keeping it in proportion
 use bevy::prelude::*;
 
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+/// This examples uses two pngs from the assets subdirectory
+const SLICE_SQUARE_PATH: &str = "textures/slice_square.png";
+const SLICE_SQUARE_2_PATH: &str = "textures/slice_square_2.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -99,15 +105,15 @@ fn spawn_sprites(
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
     let style = TextStyle {
         font: font.clone(),
         ..default()
     };
 
     // Load textures
-    let handle_1 = asset_server.load("textures/slice_square.png");
-    let handle_2 = asset_server.load("textures/slice_square_2.png");
+    let handle_1 = asset_server.load(SLICE_SQUARE_PATH);
+    let handle_2 = asset_server.load(SLICE_SQUARE_2_PATH);
 
     spawn_sprites(
         &mut commands,

--- a/examples/2d/sprite_tile.rs
+++ b/examples/2d/sprite_tile.rs
@@ -1,5 +1,8 @@
 //! Displays a single [`Sprite`] tiled in a grid, with a scaling animation
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 use bevy::prelude::*;
 
 fn main() {
@@ -28,7 +31,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     commands.spawn((
         SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
+            texture: asset_server.load(ICON_PATH),
             ..default()
         },
         ImageScaleMode::Tiled {

--- a/examples/2d/sprite_tile.rs
+++ b/examples/2d/sprite_tile.rs
@@ -1,9 +1,9 @@
 //! Displays a single [`Sprite`] tiled in a grid, with a scaling animation
 
+use bevy::prelude::*;
+
 /// This example uses a png from the assets subdirectory
 const ICON_PATH: &str = "branding/icon.png";
-
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -5,15 +5,15 @@
 //! For an example on how to render text as part of a user interface, independent from the world
 //! viewport, you may want to look at `games/contributors.rs` or `ui/text.rs`.
 
-/// This example uses a font from the assets subdirectory
-const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
-
 use bevy::{
     color::palettes::css::*,
     prelude::*,
     sprite::Anchor,
     text::{BreakLineOn, Text2dBounds},
 };
+
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
 
 fn main() {
     App::new()

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -5,6 +5,9 @@
 //! For an example on how to render text as part of a user interface, independent from the world
 //! viewport, you may want to look at `games/contributors.rs` or `ui/text.rs`.
 
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 use bevy::{
     color::palettes::css::*,
     prelude::*,
@@ -33,7 +36,7 @@ struct AnimateRotation;
 struct AnimateScale;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
     let text_style = TextStyle {
         font: font.clone(),
         font_size: 60.0,

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -7,6 +7,13 @@
 //! Only one padded and one unpadded texture atlas are rendered to the screen.
 //! An upscaled sprite from each of the four atlases are rendered to the screen.
 
+/// This example loads a folder from the assets subdirectory
+const RPG_DIRECTORY_PATH: &str = "textures/rpg";
+/// This example loads a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+/// This example uses a png from the assets subdirectory
+const RPG_VENDOR_PATH: &str = "textures/rpg/chars/vendor/generic-rpg-vendor.png";
+
 use bevy::{asset::LoadedFolder, prelude::*, render::texture::ImageSampler};
 
 fn main() {
@@ -31,7 +38,9 @@ struct RpgSpriteFolder(Handle<LoadedFolder>);
 
 fn load_textures(mut commands: Commands, asset_server: Res<AssetServer>) {
     // load multiple, individual sprites from a folder
-    commands.insert_resource(RpgSpriteFolder(asset_server.load_folder("textures/rpg")));
+    commands.insert_resource(RpgSpriteFolder(
+        asset_server.load_folder(RPG_DIRECTORY_PATH),
+    ));
 }
 
 fn check_textures(
@@ -118,7 +127,7 @@ fn setup(
         ..default()
     });
 
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
 
     // padding label text style
     let text_style: TextStyle = TextStyle {
@@ -141,9 +150,7 @@ fn setup(
     create_label(&mut commands, (250.0, 330.0, 0.0), "Padding", text_style);
 
     // get handle to a sprite to render
-    let vendor_handle: Handle<Image> = asset_server
-        .get_handle("textures/rpg/chars/vendor/generic-rpg-vendor.png")
-        .unwrap();
+    let vendor_handle: Handle<Image> = asset_server.get_handle(RPG_VENDOR_PATH).unwrap();
 
     // get index of the sprite in the texture atlas, this is used to render the sprite
     // the index is the same for all the texture atlases, since they are created from the same folder

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -7,14 +7,14 @@
 //! Only one padded and one unpadded texture atlas are rendered to the screen.
 //! An upscaled sprite from each of the four atlases are rendered to the screen.
 
+use bevy::{asset::LoadedFolder, prelude::*, render::texture::ImageSampler};
+
 /// This example loads a folder from the assets subdirectory
 const RPG_DIRECTORY_PATH: &str = "textures/rpg";
 /// This example loads a font from the assets subdirectory
 const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
 /// This example uses a png from the assets subdirectory
 const RPG_VENDOR_PATH: &str = "textures/rpg/chars/vendor/generic-rpg-vendor.png";
-
-use bevy::{asset::LoadedFolder, prelude::*, render::texture::ImageSampler};
 
 fn main() {
     App::new()

--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -1,10 +1,10 @@
 //! Demonstrates how to use transparency in 2D.
 //! Shows 3 bevy logos on top of each other, each with a different amount of transparency.
 
+use bevy::prelude::*;
+
 /// This example uses a png from the assets subdirectory
 const ICON_PATH: &str = "branding/icon.png";
-
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -1,6 +1,9 @@
 //! Demonstrates how to use transparency in 2D.
 //! Shows 3 bevy logos on top of each other, each with a different amount of transparency.
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 use bevy::prelude::*;
 
 fn main() {
@@ -13,7 +16,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    let sprite_handle = asset_server.load("branding/icon.png");
+    let sprite_handle = asset_server.load(ICON_PATH);
 
     commands.spawn(SpriteBundle {
         texture: sprite_handle.clone(),

--- a/examples/3d/animated_material.rs
+++ b/examples/3d/animated_material.rs
@@ -1,5 +1,8 @@
 //! Shows how to animate material properties
 
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 use bevy::prelude::*;
 
 fn main() {
@@ -23,8 +26,8 @@ fn setup(
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 2_000.0,
         },
     ));

--- a/examples/3d/animated_material.rs
+++ b/examples/3d/animated_material.rs
@@ -1,9 +1,10 @@
 //! Shows how to animate material properties
 
+use bevy::prelude::*;
+
 /// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -1,8 +1,8 @@
 //! Demonstrates anisotropy with the glTF sample barn lamp model.
 
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const ANISOTROPY_BARN_LAMP_PATH: &str = "models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0";
-/// This example uses two compressed texture files from the assets directory
+/// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -1,14 +1,14 @@
 //! Demonstrates anisotropy with the glTF sample barn lamp model.
 
+use bevy::{
+    color::palettes::css::WHITE, core_pipeline::Skybox, math::vec3, prelude::*, time::Stopwatch,
+};
+
 /// This example uses a 3d model file from the assets subdirectory
 const ANISOTROPY_BARN_LAMP_PATH: &str = "models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0";
 /// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
-use bevy::{
-    color::palettes::css::WHITE, core_pipeline::Skybox, math::vec3, prelude::*, time::Stopwatch,
-};
 
 /// The initial position of the camera.
 const CAMERA_INITIAL_POSITION: Vec3 = vec3(-0.4, 0.0, 0.0);

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -1,5 +1,11 @@
 //! Demonstrates anisotropy with the glTF sample barn lamp model.
 
+/// This example uses a 3d model file from the assets directory
+const ANISOTROPY_BARN_LAMP_PATH: &str = "models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0";
+/// This example uses two compressed texture files from the assets directory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use bevy::{
     color::palettes::css::WHITE, core_pipeline::Skybox, math::vec3, prelude::*, time::Stopwatch,
 };
@@ -73,7 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
     spawn_directional_light(&mut commands);
 
     commands.spawn(SceneBundle {
-        scene: asset_server.load("models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0"),
+        scene: asset_server.load(ANISOTROPY_BARN_LAMP_PATH),
         transform: Transform::from_xyz(0.0, 0.07, -0.13),
         ..default()
     });
@@ -239,11 +245,11 @@ fn add_skybox_and_environment_map(
         .entity(entity)
         .insert(Skybox {
             brightness: 5000.0,
-            image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            image: asset_server.load(PISA_SPECULAR_PATH),
         })
         .insert(EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 2500.0,
         });
 }

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -1,5 +1,11 @@
 //! This example compares MSAA (Multi-Sample Anti-aliasing), FXAA (Fast Approximate Anti-aliasing), and TAA (Temporal Anti-aliasing).
 
+/// This example uses a 3d model file from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use std::f32::consts::PI;
 use std::fmt::Write;
 
@@ -278,8 +284,7 @@ fn setup(
 
     // Flight Helmet
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
         ..default()
     });
 
@@ -321,8 +326,8 @@ fn setup(
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 150.0,
         },
         FogSettings {

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -1,13 +1,13 @@
 //! This example compares MSAA (Multi-Sample Anti-aliasing), FXAA (Fast Approximate Anti-aliasing), and TAA (Temporal Anti-aliasing).
 
+use std::f32::consts::PI;
+use std::fmt::Write;
+
 /// This example uses a 3d model file from the assets subdirectory
 const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
 /// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
-use std::f32::consts::PI;
-use std::fmt::Write;
 
 use bevy::{
     core_pipeline::{

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -7,7 +7,7 @@
 //! | `Spacebar`         | Toggle Atmospheric Fog                 |
 //! | `S`                | Toggle Directional Light Fog Influence |
 
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const MOUNTAINS_PATH: &str = "models/terrain/Mountains.gltf";
 
 use bevy::{

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -7,6 +7,9 @@
 //! | `Spacebar`         | Toggle Atmospheric Fog                 |
 //! | `S`                | Toggle Directional Light Fog Influence |
 
+/// This example uses a 3d model file from the assets directory
+const MOUNTAINS_PATH: &str = "models/terrain/Mountains.gltf";
+
 use bevy::{
     pbr::{CascadeShadowConfigBuilder, NotShadowCaster},
     prelude::*,
@@ -72,8 +75,7 @@ fn setup_terrain_scene(
 
     // Terrain
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/terrain/Mountains.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(MOUNTAINS_PATH)),
         ..default()
     });
 

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -7,13 +7,13 @@
 //! | `Spacebar`         | Toggle Atmospheric Fog                 |
 //! | `S`                | Toggle Directional Light Fog Influence |
 
-/// This example uses a 3d model file from the assets subdirectory
-const MOUNTAINS_PATH: &str = "models/terrain/Mountains.gltf";
-
 use bevy::{
     pbr::{CascadeShadowConfigBuilder, NotShadowCaster},
     prelude::*,
 };
+
+/// This example uses a 3d model file from the assets subdirectory
+const MOUNTAINS_PATH: &str = "models/terrain/Mountains.gltf";
 
 fn main() {
     App::new()

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -11,11 +11,6 @@
 //! | `M`                | Toggle Metering Mask                   |
 //! | `V`                | Visualize Metering Mask                |
 
-/// This example uses a png from the assets subdirectory
-const BASIC_METERING_MASK_PATH: &str = "textures/basic_metering_mask.png";
-/// This example uses a compressed texture file from the assets subdirectory
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
 use bevy::{
     core_pipeline::{
         auto_exposure::{AutoExposureCompensationCurve, AutoExposurePlugin, AutoExposureSettings},
@@ -24,6 +19,11 @@ use bevy::{
     math::{cubic_splines::LinearSpline, primitives::Plane3d, vec2},
     prelude::*,
 };
+
+/// This example uses a png from the assets subdirectory
+const BASIC_METERING_MASK_PATH: &str = "textures/basic_metering_mask.png";
+/// This example uses a compressed texture file from the assets subdirectory
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 fn main() {
     App::new()

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -11,6 +11,11 @@
 //! | `M`                | Toggle Metering Mask                   |
 //! | `V`                | Visualize Metering Mask                |
 
+/// This example uses a png from the assets subdirectory
+const BASIC_METERING_MASK_PATH: &str = "textures/basic_metering_mask.png";
+/// This example uses a compressed texture file from the assets subdirectory
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use bevy::{
     core_pipeline::{
         auto_exposure::{AutoExposureCompensationCurve, AutoExposurePlugin, AutoExposureSettings},
@@ -36,7 +41,7 @@ fn setup(
     mut compensation_curves: ResMut<Assets<AutoExposureCompensationCurve>>,
     asset_server: Res<AssetServer>,
 ) {
-    let metering_mask = asset_server.load("textures/basic_metering_mask.png");
+    let metering_mask = asset_server.load(BASIC_METERING_MASK_PATH);
 
     commands.spawn((
         Camera3dBundle {
@@ -52,7 +57,7 @@ fn setup(
             ..default()
         },
         Skybox {
-            image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            image: asset_server.load(PISA_SPECULAR_PATH),
             brightness: bevy::pbr::light_consts::lux::DIRECT_SUNLIGHT,
         },
     ));

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -10,11 +10,11 @@
 //! | `Spacebar`         | Toggle Unlit                        |
 //! | `C`                | Randomize Colors                    |
 
-/// This example uses a font from the assets subdirectory
-const FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
-
 use bevy::{color::palettes::css::ORANGE, prelude::*};
 use rand::random;
+
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
 
 fn main() {
     let mut app = App::new();

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -10,6 +10,9 @@
 //! | `Spacebar`         | Toggle Unlit                        |
 //! | `C`                | Randomize Colors                    |
 
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
+
 use bevy::{color::palettes::css::ORANGE, prelude::*};
 use rand::random;
 
@@ -181,7 +184,7 @@ fn setup(
     // Controls Text
 
     // We need the full version of this font so we can use box drawing characters.
-    let font = asset_server.load("fonts/FiraMono-Medium.ttf");
+    let font = asset_server.load(FONT_PATH);
 
     let text_style = TextStyle {
         font: font.clone(),

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -17,6 +17,15 @@
 //!
 //! [3]: https://threejs.org/examples/webgl_materials_physical_clearcoat.html
 
+/// This example uses two pngs from the assets directory
+const BLUE_NOISE_PATH: &str = "textures/BlueNoise-Normal.png";
+const SCRATCHED_GOLD_PATH: &str = "textures/ScratchedGold-Normal.png";
+/// This example uses a 3d model file from the assets directory
+const GOLF_BALL_PATH: &str = "models/GolfBall/GolfBall.glb";
+/// This example uses two compressed texture files from the assets directory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use std::f32::consts::PI;
 
 use bevy::{
@@ -102,10 +111,12 @@ fn spawn_car_paint_sphere(
             material: materials.add(StandardMaterial {
                 clearcoat: 1.0,
                 clearcoat_perceptual_roughness: 0.1,
-                normal_map_texture: Some(asset_server.load_with_settings(
-                    "textures/BlueNoise-Normal.png",
-                    |settings: &mut ImageLoaderSettings| settings.is_srgb = false,
-                )),
+                normal_map_texture: Some(
+                    asset_server.load_with_settings(
+                        BLUE_NOISE_PATH,
+                        |settings: &mut ImageLoaderSettings| settings.is_srgb = false,
+                    ),
+                ),
                 metallic: 0.9,
                 perceptual_roughness: 0.5,
                 base_color: BLUE.into(),
@@ -149,8 +160,7 @@ fn spawn_coated_glass_bubble_sphere(
 fn spawn_golf_ball(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn(SceneBundle {
-            scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/GolfBall/GolfBall.glb")),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(GOLF_BALL_PATH)),
             transform: Transform::from_xyz(1.0, 1.0, 0.0).with_scale(Vec3::splat(SPHERE_SCALE)),
             ..default()
         })
@@ -172,7 +182,7 @@ fn spawn_scratched_gold_ball(
                 clearcoat: 1.0,
                 clearcoat_perceptual_roughness: 0.3,
                 clearcoat_normal_texture: Some(asset_server.load_with_settings(
-                    "textures/ScratchedGold-Normal.png",
+                    SCRATCHED_GOLD_PATH,
                     |settings: &mut ImageLoaderSettings| settings.is_srgb = false,
                 )),
                 metallic: 0.9,
@@ -223,11 +233,11 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         })
         .insert(Skybox {
             brightness: 5000.0,
-            image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            image: asset_server.load(PISA_SPECULAR_PATH),
         })
         .insert(EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 2000.0,
         });
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -17,12 +17,12 @@
 //!
 //! [3]: https://threejs.org/examples/webgl_materials_physical_clearcoat.html
 
-/// This example uses two pngs from the assets directory
+/// This example uses two pngs from the assets subdirectory
 const BLUE_NOISE_PATH: &str = "textures/BlueNoise-Normal.png";
 const SCRATCHED_GOLD_PATH: &str = "textures/ScratchedGold-Normal.png";
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const GOLF_BALL_PATH: &str = "models/GolfBall/GolfBall.glb";
-/// This example uses two compressed texture files from the assets directory
+/// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -17,15 +17,6 @@
 //!
 //! [3]: https://threejs.org/examples/webgl_materials_physical_clearcoat.html
 
-/// This example uses two pngs from the assets subdirectory
-const BLUE_NOISE_PATH: &str = "textures/BlueNoise-Normal.png";
-const SCRATCHED_GOLD_PATH: &str = "textures/ScratchedGold-Normal.png";
-/// This example uses a 3d model file from the assets subdirectory
-const GOLF_BALL_PATH: &str = "models/GolfBall/GolfBall.glb";
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
 use std::f32::consts::PI;
 
 use bevy::{
@@ -36,6 +27,15 @@ use bevy::{
     prelude::*,
     render::{primitives::CascadesFrusta, texture::ImageLoaderSettings},
 };
+
+/// This example uses two pngs from the assets subdirectory
+const BLUE_NOISE_PATH: &str = "textures/BlueNoise-Normal.png";
+const SCRATCHED_GOLD_PATH: &str = "textures/ScratchedGold-Normal.png";
+/// This example uses a 3d model file from the assets subdirectory
+const GOLF_BALL_PATH: &str = "models/GolfBall/GolfBall.glb";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -1,5 +1,14 @@
 //! Demonstrates color grading with an interactive adjustment UI.
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses two 3d model files from the assets subdirectory
+const TONEMAPPING_TEST_PATH: &str = "models/TonemappingTest/TonemappingTest.gltf";
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+
 use std::{
     f32::consts::PI,
     fmt::{self, Formatter},
@@ -12,8 +21,6 @@ use bevy::{
     render::view::{ColorGrading, ColorGradingGlobal, ColorGradingSection},
 };
 use std::fmt::Display;
-
-static FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
 
 /// How quickly the value changes per frame.
 const OPTION_ADJUSTMENT_SPEED: f32 = 0.003;
@@ -371,8 +378,8 @@ fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 2000.0,
         },
     ));
@@ -381,16 +388,13 @@ fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading
 fn add_basic_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
-        ),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(TONEMAPPING_TEST_PATH)),
         ..default()
     });
 
     // Spawn the flight helmet.
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
         transform: Transform::from_xyz(0.5, 0.0, -0.5)
             .with_rotation(Quat::from_rotation_y(-0.15 * PI)),
         ..default()

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -1,5 +1,10 @@
 //! Demonstrates color grading with an interactive adjustment UI.
 
+use std::{
+    f32::consts::PI,
+    fmt::{self, Formatter},
+};
+
 /// This example uses a font file from the assets subdirectory
 const FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
 /// This example uses two compressed texture files from the assets subdirectory
@@ -8,11 +13,6 @@ const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx
 /// This example uses two 3d model files from the assets subdirectory
 const TONEMAPPING_TEST_PATH: &str = "models/TonemappingTest/TonemappingTest.gltf";
 const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
-
-use std::{
-    f32::consts::PI,
-    fmt::{self, Formatter},
-};
 
 use bevy::{
     ecs::system::EntityCommands,

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -1,15 +1,5 @@
 //! This example compares Forward, Forward + Prepass, and Deferred rendering.
 
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-/// This example uses a 3d model file from the assets subdirectory
-const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
-/// This example uses three pngs from the asset subdirectory
-const CUBE_NORMAL_PATH: &str = "textures/parallax_example/cube_normal.png";
-const CUBE_COLOR_PATH: &str = "textures/parallax_example/cube_color.png";
-const CUBE_DEPTH_PATH: &str = "textures/parallax_example/cube_depth.png";
-
 use std::f32::consts::*;
 
 use bevy::{
@@ -24,6 +14,16 @@ use bevy::{
     prelude::*,
     render::texture::ImageLoaderSettings,
 };
+
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a 3d model file from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+/// This example uses three pngs from the asset subdirectory
+const CUBE_NORMAL_PATH: &str = "textures/parallax_example/cube_normal.png";
+const CUBE_COLOR_PATH: &str = "textures/parallax_example/cube_color.png";
+const CUBE_DEPTH_PATH: &str = "textures/parallax_example/cube_depth.png";
 
 fn main() {
     App::new()

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -1,5 +1,15 @@
 //! This example compares Forward, Forward + Prepass, and Deferred rendering.
 
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a 3d model file from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+/// This example uses three pngs from the asset subdirectory
+const CUBE_NORMAL_PATH: &str = "textures/parallax_example/cube_normal.png";
+const CUBE_COLOR_PATH: &str = "textures/parallax_example/cube_color.png";
+const CUBE_DEPTH_PATH: &str = "textures/parallax_example/cube_depth.png";
+
 use std::f32::consts::*;
 
 use bevy::{
@@ -53,8 +63,8 @@ fn setup(
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 2000.0,
         },
         DepthPrepass,
@@ -80,8 +90,7 @@ fn setup(
     });
 
     // FlightHelmet
-    let helmet_scene = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+    let helmet_scene = asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH));
 
     commands.spawn(SceneBundle {
         scene: helmet_scene.clone(),
@@ -240,7 +249,7 @@ fn setup_parallax(
     // open the depth map, and do Filters → Generic → Normal Map
     // You should enable the "flip X" checkbox.
     let normal_handle = asset_server.load_with_settings(
-        "textures/parallax_example/cube_normal.png",
+        CUBE_NORMAL_PATH,
         // The normal map texture is in linear color space. Lighting won't look correct
         // if `is_srgb` is `true`, which is the default.
         |settings: &mut ImageLoaderSettings| settings.is_srgb = false,
@@ -254,11 +263,11 @@ fn setup_parallax(
 
     let parallax_material = materials.add(StandardMaterial {
         perceptual_roughness: 0.4,
-        base_color_texture: Some(asset_server.load("textures/parallax_example/cube_color.png")),
+        base_color_texture: Some(asset_server.load(CUBE_COLOR_PATH)),
         normal_map_texture: Some(normal_handle),
         // The depth map is a greyscale texture where black is the highest level and
         // white the lowest.
-        depth_map: Some(asset_server.load("textures/parallax_example/cube_depth.png")),
+        depth_map: Some(asset_server.load(CUBE_DEPTH_PATH)),
         parallax_depth_scale: 0.09,
         parallax_mapping_method: ParallaxMappingMethod::Relief { max_steps: 4 },
         max_parallax_layer_count: 5.0f32.exp2(),

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -9,6 +9,11 @@
 //!
 //! [a blog post on depth of field in Unity]: https://catlikecoding.com/unity/tutorials/advanced-rendering/depth-of-field/
 
+/// This example uses a 3d model file from the assets subdirectory
+const DEPTH_OF_FIELD_EXAMPLE_PATH: &str = "models/DepthOfFieldExample/DepthOfFieldExample.glb";
+/// This example uses an HDR file from the assets subdirectory
+const CIRCUIT_BOARD_LIGHTMAP_PATH: &str = "models/DepthOfFieldExample/CircuitBoardLightmap.hdr";
+
 use bevy::{
     core_pipeline::{
         bloom::BloomSettings,
@@ -88,10 +93,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
 
     // Spawn the scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0)
-                .from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
-        ),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(DEPTH_OF_FIELD_EXAMPLE_PATH)),
         ..default()
     });
 
@@ -207,7 +209,7 @@ fn tweak_scene(
         if &**name == "CircuitBoard" {
             materials.get_mut(material).unwrap().lightmap_exposure = 10000.0;
             commands.entity(entity).insert(Lightmap {
-                image: asset_server.load("models/DepthOfFieldExample/CircuitBoardLightmap.hdr"),
+                image: asset_server.load(CIRCUIT_BOARD_LIGHTMAP_PATH),
                 ..default()
             });
         }

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -9,11 +9,6 @@
 //!
 //! [a blog post on depth of field in Unity]: https://catlikecoding.com/unity/tutorials/advanced-rendering/depth-of-field/
 
-/// This example uses a 3d model file from the assets subdirectory
-const DEPTH_OF_FIELD_EXAMPLE_PATH: &str = "models/DepthOfFieldExample/DepthOfFieldExample.glb";
-/// This example uses an HDR file from the assets subdirectory
-const CIRCUIT_BOARD_LIGHTMAP_PATH: &str = "models/DepthOfFieldExample/CircuitBoardLightmap.hdr";
-
 use bevy::{
     core_pipeline::{
         bloom::BloomSettings,
@@ -24,6 +19,11 @@ use bevy::{
     prelude::*,
     render::camera::PhysicalCameraParameters,
 };
+
+/// This example uses a 3d model file from the assets subdirectory
+const DEPTH_OF_FIELD_EXAMPLE_PATH: &str = "models/DepthOfFieldExample/DepthOfFieldExample.glb";
+/// This example uses an HDR file from the assets subdirectory
+const CIRCUIT_BOARD_LIGHTMAP_PATH: &str = "models/DepthOfFieldExample/CircuitBoardLightmap.hdr";
 
 /// The increments in which the user can adjust the focal distance, in meters
 /// per frame.

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -2,15 +2,15 @@
 //! assign a custom UV mapping for a custom texture,
 //! and how to change the UV mapping at run-time.
 
-/// This example uses a png from the assets subdirectory
-const ARRAY_TEXTURE_PATH: &str = "textures/array_texture.png";
-
 use bevy::prelude::*;
 use bevy::render::{
     mesh::{Indices, VertexAttributeValues},
     render_asset::RenderAssetUsages,
     render_resource::PrimitiveTopology,
 };
+
+/// This example uses a png from the assets subdirectory
+const ARRAY_TEXTURE_PATH: &str = "textures/array_texture.png";
 
 // Define a "marker" component to mark the custom mesh. Marker components are often used in Bevy for
 // filtering entities in queries with `With`, they're usually not queried directly since they don't

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -2,6 +2,9 @@
 //! assign a custom UV mapping for a custom texture,
 //! and how to change the UV mapping at run-time.
 
+/// This example uses a png from the assets directory
+const ARRAY_TEXTURE_PATH: &str = "textures/array_texture.png";
+
 use bevy::prelude::*;
 use bevy::render::{
     mesh::{Indices, VertexAttributeValues},
@@ -30,7 +33,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     // Import the custom texture.
-    let custom_texture_handle: Handle<Image> = asset_server.load("textures/array_texture.png");
+    let custom_texture_handle: Handle<Image> = asset_server.load(ARRAY_TEXTURE_PATH);
     // Create and save a handle to the mesh.
     let cube_mesh_handle: Handle<Mesh> = meshes.add(create_cube_mesh());
 

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -2,7 +2,7 @@
 //! assign a custom UV mapping for a custom texture,
 //! and how to change the UV mapping at run-time.
 
-/// This example uses a png from the assets directory
+/// This example uses a png from the assets subdirectory
 const ARRAY_TEXTURE_PATH: &str = "textures/array_texture.png";
 
 use bevy::prelude::*;

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -1,9 +1,6 @@
 //! Illustrates different lights of various types and colors, some static, some moving over
 //! a simple scene.
 
-/// This example uses a png from the assets subdirectory
-const BEVY_LOGO_LIGHT_PATH: &str = "branding/bevy_logo_light.png";
-
 use std::f32::consts::PI;
 
 use bevy::{
@@ -12,6 +9,9 @@ use bevy::{
     prelude::*,
     render::camera::{Exposure, PhysicalCameraParameters},
 };
+
+/// This example uses a png from the assets subdirectory
+const BEVY_LOGO_LIGHT_PATH: &str = "branding/bevy_logo_light.png";
 
 fn main() {
     App::new()

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -1,6 +1,9 @@
 //! Illustrates different lights of various types and colors, some static, some moving over
 //! a simple scene.
 
+/// This example uses a png from the assets subdirectory
+const BEVY_LOGO_LIGHT_PATH: &str = "branding/bevy_logo_light.png";
+
 use std::f32::consts::PI;
 
 use bevy::{
@@ -84,7 +87,7 @@ fn setup(
             mesh: meshes.add(Rectangle::new(2.0, 0.5)),
             transform,
             material: materials.add(StandardMaterial {
-                base_color_texture: Some(asset_server.load("branding/bevy_logo_light.png")),
+                base_color_texture: Some(asset_server.load(BEVY_LOGO_LIGHT_PATH)),
                 perceptual_roughness: 1.0,
                 alpha_mode: AlphaMode::Mask(0.5),
                 cull_mode: None,

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -1,8 +1,8 @@
 //! Rendering a scene with baked lightmaps.
 
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const CORNELL_BOX_PATH: &str = "models/CornellBox/CornellBox.glb";
-/// This example uses a compressed texture file from the assets directory
+/// This example uses a compressed texture file from the assets subdirectory
 const CORNELL_BOX_TEXTURE_LARGE_PATH: &str = "lightmaps/CornellBox-Large.zstd.ktx2";
 const CORNELL_BOX_TEXTURE_SMALL_PATH: &str = "lightmaps/CornellBox-Small.zstd.ktx2";
 const CORNELL_BOX_TEXTURE_BOX_PATH: &str = "lightmaps/CornellBox-Box.zstd.ktx2";

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -1,14 +1,14 @@
 //! Rendering a scene with baked lightmaps.
 
+use bevy::pbr::Lightmap;
+use bevy::prelude::*;
+
 /// This example uses a 3d model file from the assets subdirectory
 const CORNELL_BOX_PATH: &str = "models/CornellBox/CornellBox.glb";
 /// This example uses a compressed texture file from the assets subdirectory
 const CORNELL_BOX_TEXTURE_LARGE_PATH: &str = "lightmaps/CornellBox-Large.zstd.ktx2";
 const CORNELL_BOX_TEXTURE_SMALL_PATH: &str = "lightmaps/CornellBox-Small.zstd.ktx2";
 const CORNELL_BOX_TEXTURE_BOX_PATH: &str = "lightmaps/CornellBox-Box.zstd.ktx2";
-
-use bevy::pbr::Lightmap;
-use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -1,5 +1,12 @@
 //! Rendering a scene with baked lightmaps.
 
+/// This example uses a 3d model file from the assets directory
+const CORNELL_BOX_PATH: &str = "models/CornellBox/CornellBox.glb";
+/// This example uses a compressed texture file from the assets directory
+const CORNELL_BOX_TEXTURE_LARGE_PATH: &str = "lightmaps/CornellBox-Large.zstd.ktx2";
+const CORNELL_BOX_TEXTURE_SMALL_PATH: &str = "lightmaps/CornellBox-Small.zstd.ktx2";
+const CORNELL_BOX_TEXTURE_BOX_PATH: &str = "lightmaps/CornellBox-Box.zstd.ktx2";
+
 use bevy::pbr::Lightmap;
 use bevy::prelude::*;
 
@@ -14,8 +21,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/CornellBox/CornellBox.glb")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(CORNELL_BOX_PATH)),
         ..default()
     });
 
@@ -39,7 +45,7 @@ fn add_lightmaps_to_meshes(
         if &**name == "large_box" {
             materials.get_mut(material).unwrap().lightmap_exposure = exposure;
             commands.entity(entity).insert(Lightmap {
-                image: asset_server.load("lightmaps/CornellBox-Large.zstd.ktx2"),
+                image: asset_server.load(CORNELL_BOX_TEXTURE_LARGE_PATH),
                 ..default()
             });
             continue;
@@ -48,7 +54,7 @@ fn add_lightmaps_to_meshes(
         if &**name == "small_box" {
             materials.get_mut(material).unwrap().lightmap_exposure = exposure;
             commands.entity(entity).insert(Lightmap {
-                image: asset_server.load("lightmaps/CornellBox-Small.zstd.ktx2"),
+                image: asset_server.load(CORNELL_BOX_TEXTURE_SMALL_PATH),
                 ..default()
             });
             continue;
@@ -57,7 +63,7 @@ fn add_lightmaps_to_meshes(
         if name.starts_with("cornell_box") {
             materials.get_mut(material).unwrap().lightmap_exposure = exposure;
             commands.entity(entity).insert(Lightmap {
-                image: asset_server.load("lightmaps/CornellBox-Box.zstd.ktx2"),
+                image: asset_server.load(CORNELL_BOX_TEXTURE_BOX_PATH),
                 ..default()
             });
             continue;

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -1,16 +1,16 @@
 //! Loads and renders a glTF file as a scene.
 
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-/// This example uses a 3d model file from the assets subdirectory
-const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
-
 use bevy::{
     pbr::{CascadeShadowConfigBuilder, DirectionalLightShadowMap},
     prelude::*,
 };
 use std::f32::consts::*;
+
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a 3d model file from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
 
 fn main() {
     App::new()

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -1,9 +1,9 @@
 //! Loads and renders a glTF file as a scene.
 
-/// This example uses two compressed texture files from the assets directory
+/// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
 
 use bevy::{

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -1,5 +1,11 @@
 //! Loads and renders a glTF file as a scene.
 
+/// This example uses two compressed texture files from the assets directory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a 3d model file from the assets directory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+
 use bevy::{
     pbr::{CascadeShadowConfigBuilder, DirectionalLightShadowMap},
     prelude::*,
@@ -23,8 +29,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 250.0,
         },
     ));
@@ -47,8 +53,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..default()
     });
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
         ..default()
     });
 }

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -1,12 +1,6 @@
 //! Meshlet rendering for dense high-poly scenes (experimental).
 
 // Note: This example showcases the meshlet API, but is not the type of scene that would benefit from using meshlets.
-
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-/// This example uses a meshlet_mesh file from the assets subdirectory
-const BUNNY_MESHLET_PATH: &str = "models/bunny.meshlet_mesh";
 #[path = "../helpers/camera_controller.rs"]
 mod camera_controller;
 
@@ -20,6 +14,12 @@ use bevy::{
 };
 use camera_controller::{CameraController, CameraControllerPlugin};
 use std::{f32::consts::PI, path::Path, process::ExitCode};
+
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a meshlet_mesh file from the assets subdirectory
+const BUNNY_MESHLET_PATH: &str = "models/bunny.meshlet_mesh";
 
 const ASSET_URL: &str = "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh";
 

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -18,7 +18,7 @@ use std::{f32::consts::PI, path::Path, process::ExitCode};
 /// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-/// This example uses a meshlet_mesh file from the assets subdirectory
+/// This example uses a `meshlet_mesh` file from the assets subdirectory
 const BUNNY_MESHLET_PATH: &str = "models/bunny.meshlet_mesh";
 
 const ASSET_URL: &str = "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh";

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -2,6 +2,11 @@
 
 // Note: This example showcases the meshlet API, but is not the type of scene that would benefit from using meshlets.
 
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a meshlet_mesh file from the assets subdirectory
+const BUNNY_MESHLET_PATH: &str = "models/bunny.meshlet_mesh";
 #[path = "../helpers/camera_controller.rs"]
 mod camera_controller;
 
@@ -52,8 +57,8 @@ fn setup(
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 150.0,
         },
         CameraController::default(),
@@ -84,7 +89,7 @@ fn setup(
     // that has been converted to a [`bevy_pbr::meshlet::MeshletMesh`]
     // using [`bevy_pbr::meshlet::MeshletMesh::from_mesh`], which is
     // a function only available when the `meshlet_processor` cargo feature is enabled.
-    let meshlet_mesh_handle = asset_server.load("models/bunny.meshlet_mesh");
+    let meshlet_mesh_handle = asset_server.load(BUNNY_MESHLET_PATH);
     let debug_material = debug_materials.add(MeshletDebugMaterial::default());
 
     for x in -2..=2 {

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -1,13 +1,13 @@
 //! Demonstrates how to enable per-object motion blur. This rendering feature can be configured per
 //! camera using the [`MotionBlur`] component.z
 
-/// This example uses a png from the assets subdirectory
-const ICON_PATH: &str = "branding/icon.png";
-
 use bevy::{
     core_pipeline::motion_blur::{MotionBlur, MotionBlurBundle},
     prelude::*,
 };
+
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
 
 fn main() {
     let mut app = App::new();

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -1,6 +1,9 @@
 //! Demonstrates how to enable per-object motion blur. This rendering feature can be configured per
 //! camera using the [`MotionBlur`] component.z
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 use bevy::{
     core_pipeline::motion_blur::{MotionBlur, MotionBlurBundle},
     prelude::*,
@@ -117,7 +120,7 @@ fn spawn_cars(
     const N_CARS: usize = 20;
     let box_mesh = meshes.add(Cuboid::new(0.3, 0.15, 0.55));
     let cylinder = meshes.add(Cylinder::default());
-    let logo = asset_server.load("branding/icon.png");
+    let logo = asset_server.load(ICON_PATH);
     let wheel_matl = materials.add(StandardMaterial {
         base_color: Color::WHITE,
         base_color_texture: Some(logo.clone()),

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -1,6 +1,11 @@
 //! A simple 3D scene with a spinning cube with a normal map and depth map to demonstrate parallax mapping.
 //! Press left mouse button to cycle through different views.
 
+/// This example uses three pngs from the assets subdirectory
+const CUBE_NORMAL_PATH: &str = "textures/parallax_example/cube_normal.png";
+const CUBE_COLOR_PATH: &str = "textures/parallax_example/cube_color.png";
+const CUBE_DEPTH_PATH: &str = "textures/parallax_example/cube_depth.png";
+
 use std::fmt;
 
 use bevy::{prelude::*, render::texture::ImageLoaderSettings};
@@ -204,7 +209,7 @@ fn setup(
     // open the depth map, and do Filters → Generic → Normal Map
     // You should enable the "flip X" checkbox.
     let normal_handle = asset_server.load_with_settings(
-        "textures/parallax_example/cube_normal.png",
+        CUBE_NORMAL_PATH,
         // The normal map texture is in linear color space. Lighting won't look correct
         // if `is_srgb` is `true`, which is the default.
         |settings: &mut ImageLoaderSettings| settings.is_srgb = false,
@@ -254,11 +259,11 @@ fn setup(
     let parallax_mapping_method = CurrentMethod::default();
     let parallax_material = materials.add(StandardMaterial {
         perceptual_roughness: 0.4,
-        base_color_texture: Some(asset_server.load("textures/parallax_example/cube_color.png")),
+        base_color_texture: Some(asset_server.load(CUBE_COLOR_PATH)),
         normal_map_texture: Some(normal_handle),
         // The depth map is a greyscale texture where black is the highest level and
         // white the lowest.
-        depth_map: Some(asset_server.load("textures/parallax_example/cube_depth.png")),
+        depth_map: Some(asset_server.load(CUBE_DEPTH_PATH)),
         parallax_depth_scale,
         parallax_mapping_method: parallax_mapping_method.0,
         max_parallax_layer_count,

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -1,14 +1,14 @@
 //! A simple 3D scene with a spinning cube with a normal map and depth map to demonstrate parallax mapping.
 //! Press left mouse button to cycle through different views.
 
+use std::fmt;
+
+use bevy::{prelude::*, render::texture::ImageLoaderSettings};
+
 /// This example uses three pngs from the assets subdirectory
 const CUBE_NORMAL_PATH: &str = "textures/parallax_example/cube_normal.png";
 const CUBE_COLOR_PATH: &str = "textures/parallax_example/cube_color.png";
 const CUBE_DEPTH_PATH: &str = "textures/parallax_example/cube_depth.png";
-
-use std::fmt;
-
-use bevy::{prelude::*, render::texture::ImageLoaderSettings};
 
 fn main() {
     App::new()

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,5 +1,9 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
@@ -127,8 +131,8 @@ fn setup(
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 900.0,
         },
     ));

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,9 +1,5 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
 use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
@@ -13,6 +9,10 @@ fn main() {
         .add_systems(Update, environment_map_load_finish)
         .run();
 }
+
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 /// set up a simple 3D scene
 fn setup(

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -6,6 +6,14 @@
 //!
 //! Reflection probes don't work on WebGL 2 or WebGPU.
 
+/// This example uses a 3d model file from the assets directory
+const CUBES_PATH: &str = "models/cubes/Cubes.glb";
+/// This example uses two compressed texture files from the assets directory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+const CUBES_SPECULAR_PATH: &str =
+    "environment_maps/cubes_reflection_probe_specular_rgb9e5_zstd.ktx2";
+
 use bevy::core_pipeline::Skybox;
 use bevy::prelude::*;
 
@@ -98,7 +106,7 @@ fn setup(
 // Spawns the cubes, light, and camera.
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/cubes/Cubes.glb")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(CUBES_PATH)),
         ..SceneBundle::default()
     });
 }
@@ -326,12 +334,11 @@ impl FromWorld for Cubemaps {
         // Just use the specular map for the skybox since it's not too blurry.
         // In reality you wouldn't do this--you'd use a real skybox texture--but
         // reusing the textures like this saves space in the Bevy repository.
-        let specular_map = world.load_asset("environment_maps/pisa_specular_rgb9e5_zstd.ktx2");
+        let specular_map = world.load_asset(PISA_SPECULAR_PATH);
 
         Cubemaps {
-            diffuse: world.load_asset("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_reflection_probe: world
-                .load_asset("environment_maps/cubes_reflection_probe_specular_rgb9e5_zstd.ktx2"),
+            diffuse: world.load_asset(PISA_DIFFUSE_PATH),
+            specular_reflection_probe: world.load_asset(CUBES_SPECULAR_PATH),
             specular_environment_map: specular_map.clone(),
             skybox: specular_map,
         }

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -6,14 +6,6 @@
 //!
 //! Reflection probes don't work on WebGL 2 or WebGPU.
 
-/// This example uses a 3d model file from the assets subdirectory
-const CUBES_PATH: &str = "models/cubes/Cubes.glb";
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-const CUBES_SPECULAR_PATH: &str =
-    "environment_maps/cubes_reflection_probe_specular_rgb9e5_zstd.ktx2";
-
 use bevy::core_pipeline::Skybox;
 use bevy::prelude::*;
 
@@ -21,6 +13,14 @@ use std::{
     f32::consts::PI,
     fmt::{Display, Formatter, Result as FmtResult},
 };
+
+/// This example uses a 3d model file from the assets subdirectory
+const CUBES_PATH: &str = "models/cubes/Cubes.glb";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+const CUBES_SPECULAR_PATH: &str =
+    "environment_maps/cubes_reflection_probe_specular_rgb9e5_zstd.ktx2";
 
 static STOP_ROTATION_HELP_TEXT: &str = "Press Enter to stop rotation";
 static START_ROTATION_HELP_TEXT: &str = "Press Enter to start rotation";

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -6,9 +6,9 @@
 //!
 //! Reflection probes don't work on WebGL 2 or WebGPU.
 
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const CUBES_PATH: &str = "models/cubes/Cubes.glb";
-/// This example uses two compressed texture files from the assets directory
+/// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 const CUBES_SPECULAR_PATH: &str =
@@ -328,7 +328,7 @@ fn rotate_camera(
     }
 }
 
-// Loads the cubemaps from the assets directory.
+// Loads the cubemaps from the assets subdirectory.
 impl FromWorld for Cubemaps {
     fn from_world(world: &mut World) -> Self {
         // Just use the specular map for the skybox since it's not too blurry.

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -16,6 +16,8 @@ use bevy::{
 use camera_controller::{CameraController, CameraControllerPlugin};
 use std::f32::consts::PI;
 
+/// This example uses a png and three compressed
+/// texture files from the assets subfolder
 const CUBEMAPS: &[(&str, CompressedImageFormats)] = &[
     (
         "textures/Ryfjallet_cubemap.png",

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -1,13 +1,13 @@
 //! Renders two cameras to the same window to accomplish "split screen".
 
-/// This example uses a 3d model file from the assets subdirectory
-const FOX_PATH: &str = "models/animated/Fox.glb";
-
 use std::f32::consts::PI;
 
 use bevy::{
     pbr::CascadeShadowConfigBuilder, prelude::*, render::camera::Viewport, window::WindowResized,
 };
+
+/// This example uses a 3d model file from the assets subdirectory
+const FOX_PATH: &str = "models/animated/Fox.glb";
 
 fn main() {
     App::new()

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -1,5 +1,8 @@
 //! Renders two cameras to the same window to accomplish "split screen".
 
+/// This example uses a 3d model file from the assets subdirectory
+const FOX_PATH: &str = "models/animated/Fox.glb";
+
 use std::f32::consts::PI;
 
 use bevy::{
@@ -29,7 +32,7 @@ fn setup(
     });
 
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH)),
         ..default()
     });
 

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -23,6 +23,14 @@ use bevy::{
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/water_material.wgsl";
+/// This example uses two pngs from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+const WATER_NORMALS_PATH: &str = "textures/water_normals.png";
+/// This example uses a 3d model from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+/// This example uses a compressed texture file from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 // The speed of camera movement.
 const CAMERA_KEYBOARD_ZOOM_SPEED: f32 = 0.1;
@@ -154,7 +162,7 @@ fn spawn_cube(
             mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
             material: standard_materials.add(StandardMaterial {
                 base_color: Color::from(WHITE),
-                base_color_texture: Some(asset_server.load("branding/icon.png")),
+                base_color_texture: Some(asset_server.load(ICON_PATH)),
                 ..default()
             }),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
@@ -167,8 +175,7 @@ fn spawn_cube(
 fn spawn_flight_helmet(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn(SceneBundle {
-            scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
             transform: Transform::from_scale(Vec3::splat(2.5)),
             ..default()
         })
@@ -193,7 +200,7 @@ fn spawn_water(
             },
             extension: Water {
                 normals: asset_server.load_with_settings::<Image, ImageLoaderSettings>(
-                    "textures/water_normals.png",
+                    WATER_NORMALS_PATH,
                     |settings| {
                         settings.is_srgb = false;
                         settings.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
@@ -239,12 +246,12 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
             ..default()
         })
         .insert(EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 5000.0,
         })
         .insert(Skybox {
-            image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            image: asset_server.load(PISA_SPECULAR_PATH),
             brightness: 5000.0,
         })
         .insert(ScreenSpaceReflectionsBundle::default())

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -1,5 +1,8 @@
 //! This example shows various ways to configure texture materials in 3D.
 
+/// This example uses a png from the assets subdirectory
+const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_logo_dark_big.png";
+
 use std::f32::consts::PI;
 
 use bevy::prelude::*;
@@ -19,7 +22,7 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // load a texture and retrieve its aspect ratio
-    let texture_handle = asset_server.load("branding/bevy_logo_dark_big.png");
+    let texture_handle = asset_server.load(BEVY_BIRD_ASSET_PATH);
     let aspect = 0.25;
 
     // create a new quad mesh. this is what we will apply the texture to

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -1,11 +1,10 @@
 //! This example shows various ways to configure texture materials in 3D.
-
-/// This example uses a png from the assets subdirectory
-const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_logo_dark_big.png";
-
 use std::f32::consts::PI;
 
 use bevy::prelude::*;
+
+/// This example uses a png from the assets subdirectory
+const BEVY_BIRD_ASSET_PATH: &str = "branding/bevy_logo_dark_big.png";
 
 fn main() {
     App::new()

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -15,6 +15,12 @@ use std::f32::consts::PI;
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/tonemapping_test_patterns.wgsl";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses two 3d model files from the assets subdirectory
+const TONEMAPPING_TEST_PATH: &str = "models/TonemappingTest/TonemappingTest.gltf";
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
 
 fn main() {
     App::new()
@@ -75,8 +81,8 @@ fn setup(
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 2000.0,
         },
     ));
@@ -96,9 +102,7 @@ fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Main scene
     commands
         .spawn(SceneBundle {
-            scene: asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
-            ),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(TONEMAPPING_TEST_PATH)),
             ..default()
         })
         .insert(SceneNumber(1));
@@ -106,8 +110,7 @@ fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Flight Helmet
     commands.spawn((
         SceneBundle {
-            scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
             transform: Transform::from_xyz(0.5, 0.0, -0.5)
                 .with_rotation(Quat::from_rotation_y(-0.15 * PI)),
             ..default()

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -18,10 +18,6 @@
 //! | `D`                | Toggle Depth Prepass                                 |
 //! | `T`                | Toggle TAA                                           |
 
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
 use std::f32::consts::PI;
 
 use bevy::{
@@ -37,6 +33,10 @@ use bevy::{
         view::{ColorGrading, ColorGradingGlobal},
     },
 };
+
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
 use bevy::core_pipeline::experimental::taa::{

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -18,6 +18,10 @@
 //! | `D`                | Toggle Depth Prepass                                 |
 //! | `T`                | Toggle TAA                                           |
 
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use std::f32::consts::PI;
 
 use bevy::{
@@ -358,8 +362,8 @@ fn setup(
         TemporalAntiAliasBundle::default(),
         EnvironmentMapLight {
             intensity: 25.0,
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
         },
         BloomSettings::default(),
     ));

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -1,6 +1,12 @@
 //! Update a scene from a glTF file, either by spawning the scene as a child of another entity,
 //! or by accessing the entities of the scene.
 
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+/// This example uses a 3d model file from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+
 use bevy::{pbr::DirectionalLightShadowMap, prelude::*};
 
 fn main() {
@@ -31,8 +37,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         },
         EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 150.0,
         },
     ));
@@ -40,16 +46,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn the scene as a child of this entity at the given transform
     commands.spawn(SceneBundle {
         transform: Transform::from_xyz(-1.0, 0.0, 0.0),
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
         ..default()
     });
 
     // Spawn a second scene, and add a tag component to be able to target it later
     commands.spawn((
         SceneBundle {
-            scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
             ..default()
         },
         MovedScene,

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -1,13 +1,13 @@
 //! Update a scene from a glTF file, either by spawning the scene as a child of another entity,
 //! or by accessing the entities of the scene.
 
+use bevy::{pbr::DirectionalLightShadowMap, prelude::*};
+
 /// This example uses two compressed texture files from the assets subdirectory
 const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 /// This example uses a 3d model file from the assets subdirectory
 const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
-
-use bevy::{pbr::DirectionalLightShadowMap, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -1,5 +1,12 @@
 //! Demonstrates visibility ranges, also known as HLODs.
 
+/// This example uses two 3d model files from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+const FLIGHT_HELMET_LOW_POLY_PATH: &str = "models/FlightHelmet/FlightHelmetLowPoly.gltf";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+
 use std::f32::consts::PI;
 
 use bevy::{
@@ -104,18 +111,15 @@ fn setup(
 
     commands
         .spawn(SceneBundle {
-            scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH)),
             ..default()
         })
         .insert(MainModel::HighPoly);
 
     commands
         .spawn(SceneBundle {
-            scene: asset_server.load(
-                GltfAssetLabel::Scene(0)
-                    .from_asset("models/FlightHelmetLowPoly/FlightHelmetLowPoly.gltf"),
-            ),
+            scene: asset_server
+                .load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_LOW_POLY_PATH)),
             ..default()
         })
         .insert(MainModel::LowPoly);
@@ -149,8 +153,8 @@ fn setup(
             ..default()
         })
         .insert(EnvironmentMapLight {
-            diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-            specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+            specular_map: asset_server.load(PISA_SPECULAR_PATH),
             intensity: 150.0,
         });
 

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -1,12 +1,5 @@
 //! Demonstrates visibility ranges, also known as HLODs.
 
-/// This example uses two 3d model files from the assets subdirectory
-const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
-const FLIGHT_HELMET_LOW_POLY_PATH: &str = "models/FlightHelmet/FlightHelmetLowPoly.gltf";
-/// This example uses two compressed texture files from the assets subdirectory
-const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
-
 use std::f32::consts::PI;
 
 use bevy::{
@@ -16,6 +9,13 @@ use bevy::{
     prelude::*,
     render::view::VisibilityRange,
 };
+
+/// This example uses two 3d model files from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
+const FLIGHT_HELMET_LOW_POLY_PATH: &str = "models/FlightHelmetLowPoly/FlightHelmetLowPoly.gltf";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
 
 // Where the camera is focused.
 const CAMERA_FOCAL_POINT: Vec3 = vec3(0.0, 0.3, 0.0);

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -1,16 +1,16 @@
 //! Demonstrates volumetric fog and lighting (light shafts or god rays).
 
-/// This example uses a 3d model file from the assets subdirectory
-const VOLUMETRIC_FOG_PATH: &str = "models/VolumetricFogExample/VolumetricFogExample.glb";
-/// This example uses a compressed texture file from the assets subdirectory
-const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
-
 use bevy::{
     core_pipeline::{bloom::BloomSettings, tonemapping::Tonemapping, Skybox},
     math::vec3,
     pbr::{VolumetricFogSettings, VolumetricLight},
     prelude::*,
 };
+
+/// This example uses a 3d model file from the assets subdirectory
+const VOLUMETRIC_FOG_PATH: &str = "models/VolumetricFogExample/VolumetricFogExample.glb";
+/// This example uses a compressed texture file from the assets subdirectory
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 const DIRECTIONAL_LIGHT_MOVEMENT_SPEED: f32 = 0.02;
 

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -1,8 +1,8 @@
 //! Demonstrates volumetric fog and lighting (light shafts or god rays).
 
-/// This example uses a 3d model file from the assets directory
+/// This example uses a 3d model file from the assets subdirectory
 const VOLUMETRIC_FOG_PATH: &str = "models/VolumetricFogExample/VolumetricFogExample.glb";
-/// This example uses a compressed texture file from the assets directory
+/// This example uses a compressed texture file from the assets subdirectory
 const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
 
 use bevy::{

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -1,5 +1,10 @@
 //! Demonstrates volumetric fog and lighting (light shafts or god rays).
 
+/// This example uses a 3d model file from the assets directory
+const VOLUMETRIC_FOG_PATH: &str = "models/VolumetricFogExample/VolumetricFogExample.glb";
+/// This example uses a compressed texture file from the assets directory
+const PISA_SPECULAR_PATH: &str = "environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 use bevy::{
     core_pipeline::{bloom::BloomSettings, tonemapping::Tonemapping, Skybox},
     math::vec3,
@@ -29,10 +34,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn the glTF scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0)
-                .from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
-        ),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(VOLUMETRIC_FOG_PATH)),
         ..default()
     });
 
@@ -50,7 +52,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Tonemapping::TonyMcMapface)
         .insert(BloomSettings::default())
         .insert(Skybox {
-            image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            image: asset_server.load(PISA_SPECULAR_PATH),
             brightness: 1000.0,
         })
         .insert(VolumetricFogSettings {

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -1,5 +1,8 @@
 //! Plays animations from a skinned glTF.
 
+/// This example uses a 3d model from the assets subdirectory
+const FOX_PATH: &str = "models/animated/Fox.glb";
+
 use std::f32::consts::PI;
 use std::time::Duration;
 
@@ -41,9 +44,9 @@ fn setup(
     let animations = graph
         .add_clips(
             [
-                GltfAssetLabel::Animation(2).from_asset("models/animated/Fox.glb"),
-                GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb"),
-                GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb"),
+                GltfAssetLabel::Animation(2).from_asset(FOX_PATH),
+                GltfAssetLabel::Animation(1).from_asset(FOX_PATH),
+                GltfAssetLabel::Animation(0).from_asset(FOX_PATH),
             ]
             .into_iter()
             .map(|path| asset_server.load(path)),
@@ -91,7 +94,7 @@ fn setup(
 
     // Fox
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH)),
         ..default()
     });
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -1,8 +1,5 @@
 //! Plays animations from a skinned glTF.
 
-/// This example uses a 3d model from the assets subdirectory
-const FOX_PATH: &str = "models/animated/Fox.glb";
-
 use std::f32::consts::PI;
 use std::time::Duration;
 
@@ -11,6 +8,9 @@ use bevy::{
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
 };
+
+/// This example uses a 3d model from the assets subdirectory
+const FOX_PATH: &str = "models/animated/Fox.glb";
 
 fn main() {
     App::new()

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -3,6 +3,9 @@
 //! The animation graph is shown on screen. You can change the weights of the
 //! playing animations by clicking and dragging left or right within the nodes.
 
+/// This example uses an animation graph from the assets subdirectory
+const ANIMATION_GRAPH_PATH: &str = "animation_graphs/Fox.animgraph.ron";
+
 #[cfg(not(target_arch = "wasm32"))]
 use std::{fs::File, path::Path};
 
@@ -23,9 +26,6 @@ use bevy::asset::io::file::FileAssetReader;
 use bevy::tasks::IoTaskPool;
 #[cfg(not(target_arch = "wasm32"))]
 use ron::ser::PrettyConfig;
-
-/// Where to find the serialized animation graph.
-static ANIMATION_GRAPH_PATH: &str = "animation_graphs/Fox.animgraph.ron";
 
 /// The indices of the nodes containing animation clips in the graph.
 static CLIP_NODE_INDICES: [u32; 3] = [2, 3, 4];

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -3,9 +3,6 @@
 //! The animation graph is shown on screen. You can change the weights of the
 //! playing animations by clicking and dragging left or right within the nodes.
 
-/// This example uses an animation graph from the assets subdirectory
-const ANIMATION_GRAPH_PATH: &str = "animation_graphs/Fox.animgraph.ron";
-
 #[cfg(not(target_arch = "wasm32"))]
 use std::{fs::File, path::Path};
 
@@ -26,6 +23,9 @@ use bevy::asset::io::file::FileAssetReader;
 use bevy::tasks::IoTaskPool;
 #[cfg(not(target_arch = "wasm32"))]
 use ron::ser::PrettyConfig;
+
+/// This example uses an animation graph from the assets subdirectory
+const ANIMATION_GRAPH_PATH: &str = "animation_graphs/Fox.animgraph.ron";
 
 /// The indices of the nodes containing animation clips in the graph.
 static CLIP_NODE_INDICES: [u32; 3] = [2, 3, 4];

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -1,12 +1,12 @@
 //! Skinned mesh example with mesh and joints data loaded from a glTF file.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
-/// This example uses a 3d model file from the assets subdirectory
-const SIMPLE_SKIN_PATH: &str = "models/SimpleSkin/SimpleSkin.gltf";
-
 use std::f32::consts::*;
 
 use bevy::{prelude::*, render::mesh::skinning::SkinnedMesh};
+
+/// This example uses a 3d model file from the assets subdirectory
+const SIMPLE_SKIN_PATH: &str = "models/SimpleSkin/SimpleSkin.gltf";
 
 fn main() {
     App::new()

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -1,6 +1,9 @@
 //! Skinned mesh example with mesh and joints data loaded from a glTF file.
 //! Example taken from <https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_019_SimpleSkin.md>
 
+/// This example uses a 3d model file from the assets subdirectory
+const SIMPLE_SKIN_PATH: &str = "models/SimpleSkin/SimpleSkin.gltf";
+
 use std::f32::consts::*;
 
 use bevy::{prelude::*, render::mesh::skinning::SkinnedMesh};
@@ -27,8 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Spawn the first scene in `models/SimpleSkin/SimpleSkin.gltf`
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/SimpleSkin/SimpleSkin.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(SIMPLE_SKIN_PATH)),
         ..default()
     });
 }

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -7,11 +7,11 @@
 //! - How to read morph target names in `name_morphs`.
 //! - How to play morph target animations in `setup_animations`.
 
-/// This example uses a 3d model from the assets subdirectory
-const MORPH_STRESS_TEST_PATH: &str = "models/animated/MorphStressTest.gltf";
-
 use bevy::prelude::*;
 use std::f32::consts::PI;
+
+/// This example uses a 3d model from the assets subdirectory
+const MORPH_STRESS_TEST_PATH: &str = "models/animated/MorphStressTest.gltf";
 
 fn main() {
     App::new()

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -7,6 +7,9 @@
 //! - How to read morph target names in `name_morphs`.
 //! - How to play morph target animations in `setup_animations`.
 
+/// This example uses a 3d model from the assets subdirectory
+const MORPH_STRESS_TEST_PATH: &str = "models/animated/MorphStressTest.gltf";
+
 use bevy::prelude::*;
 use std::f32::consts::PI;
 
@@ -37,18 +40,17 @@ struct MorphData {
 fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
     commands.insert_resource(MorphData {
         the_wave: asset_server
-            .load(GltfAssetLabel::Animation(2).from_asset("models/animated/MorphStressTest.gltf")),
+            .load(GltfAssetLabel::Animation(2).from_asset(MORPH_STRESS_TEST_PATH)),
         mesh: asset_server.load(
             GltfAssetLabel::Primitive {
                 mesh: 0,
                 primitive: 0,
             }
-            .from_asset("models/animated/MorphStressTest.gltf"),
+            .from_asset(MORPH_STRESS_TEST_PATH),
         ),
     });
     commands.spawn(SceneBundle {
-        scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/animated/MorphStressTest.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(MORPH_STRESS_TEST_PATH)),
         ..default()
     });
     commands.spawn(DirectionalLightBundle {

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -1,5 +1,8 @@
 //! Implements loader for a Gzip compressed asset.
 
+/// This example uses a compressed png from the assets subdirectory
+const COMPRESSED_IMAGE_PATH: &str = "data/compressed_image.png.gz";
+
 use bevy::{
     asset::{
         io::{Reader, VecReader},
@@ -108,7 +111,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn((
         Compressed::<Image> {
-            compressed: asset_server.load("data/compressed_image.png.gz"),
+            compressed: asset_server.load(COMPRESSED_IMAGE_PATH),
             ..default()
         },
         Sprite::default(),

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -1,8 +1,5 @@
 //! Implements loader for a Gzip compressed asset.
 
-/// This example uses a compressed png from the assets subdirectory
-const COMPRESSED_IMAGE_PATH: &str = "data/compressed_image.png.gz";
-
 use bevy::{
     asset::{
         io::{Reader, VecReader},
@@ -15,6 +12,9 @@ use flate2::read::GzDecoder;
 use std::io::prelude::*;
 use std::marker::PhantomData;
 use thiserror::Error;
+
+/// This example uses a compressed png from the assets subdirectory
+const COMPRESSED_IMAGE_PATH: &str = "data/compressed_image.png.gz";
 
 #[derive(Asset, TypePath)]
 struct GzAsset {

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -1,13 +1,13 @@
 //! This example illustrates various ways to load assets.
 
+use bevy::{asset::LoadedFolder, prelude::*};
+
 /// This example uses three 3d model files from the assets subdirectory
 const CUBE_PATH: &str = "models/cube/cube.gltf";
 const SPHERE_PATH: &str = "models/sphere/sphere.gltf";
 const TORUS_MODEL_PATH: &str = "models/torus/torus.gltf";
 /// This example loads a folder from the assets subdirectory
 const TORUS_FOLDER_PATH: &str = "models/torus";
-
-use bevy::{asset::LoadedFolder, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -1,5 +1,12 @@
 //! This example illustrates various ways to load assets.
 
+/// This example uses three 3d model files from the assets subdirectory
+const CUBE_PATH: &str = "models/cube/cube.gltf";
+const SPHERE_PATH: &str = "models/sphere/sphere.gltf";
+const TORUS_MODEL_PATH: &str = "models/torus/torus.gltf";
+/// This example loads a folder from the assets subdirectory
+const TORUS_FOLDER_PATH: &str = "models/torus";
+
 use bevy::{asset::LoadedFolder, prelude::*};
 
 fn main() {
@@ -28,14 +35,14 @@ fn setup(
             mesh: 0,
             primitive: 0,
         }
-        .from_asset("models/cube/cube.gltf"),
+        .from_asset(CUBE_PATH),
     );
     let sphere_handle = asset_server.load(
         GltfAssetLabel::Primitive {
             mesh: 0,
             primitive: 0,
         }
-        .from_asset("models/sphere/sphere.gltf"),
+        .from_asset(SPHERE_PATH),
     );
 
     // All assets end up in their Assets<T> collection once they are done loading:
@@ -55,7 +62,7 @@ fn setup(
     // to load.
     // If you want to keep the assets in the folder alive, make sure you store the returned handle
     // somewhere.
-    let _loaded_folder: Handle<LoadedFolder> = asset_server.load_folder("models/torus");
+    let _loaded_folder: Handle<LoadedFolder> = asset_server.load_folder(TORUS_FOLDER_PATH);
 
     // If you want a handle to a specific asset in a loaded folder, the easiest way to get one is to call load.
     // It will _not_ be loaded a second time.
@@ -66,7 +73,7 @@ fn setup(
             mesh: 0,
             primitive: 0,
         }
-        .from_asset("models/torus/torus.gltf"),
+        .from_asset(TORUS_MODEL_PATH),
     );
 
     // You can also add assets directly to their Assets<T> storage:

--- a/examples/asset/asset_settings.rs
+++ b/examples/asset/asset_settings.rs
@@ -1,16 +1,16 @@
 //! This example demonstrates the usage of '.meta' files and [`AssetServer::load_with_settings`] to override the default settings for loading an asset
 
+use bevy::{
+    prelude::*,
+    render::texture::{ImageLoaderSettings, ImageSampler},
+};
+
 /// This example loads the files directory from this example's directory
 const FILES_FOLDER_PATH: &str = "examples/asset/files";
 /// This example loads three pngs from the assets subdirectory
 const BEVY_DARK_PATH: &str = "bevy_pixel_dark.png";
 const BEVY_DARK_META_PATH: &str = "bevy_pixel_dark_with_meta.png";
 const BEVY_DARK_SETTINGS_PATH: &str = "bevy_pixel_dark_with_settings.png";
-
-use bevy::{
-    prelude::*,
-    render::texture::{ImageLoaderSettings, ImageSampler},
-};
 
 fn main() {
     App::new()

--- a/examples/asset/asset_settings.rs
+++ b/examples/asset/asset_settings.rs
@@ -1,5 +1,12 @@
 //! This example demonstrates the usage of '.meta' files and [`AssetServer::load_with_settings`] to override the default settings for loading an asset
 
+/// This example loads the files directory from this example's directory
+const FILES_FOLDER_PATH: &str = "examples/asset/files";
+/// This example loads three pngs from the assets subdirectory
+const BEVY_DARK_PATH: &str = "bevy_pixel_dark.png";
+const BEVY_DARK_META_PATH: &str = "bevy_pixel_dark_with_meta.png";
+const BEVY_DARK_SETTINGS_PATH: &str = "bevy_pixel_dark_with_settings.png";
+
 use bevy::{
     prelude::*,
     render::texture::{ImageLoaderSettings, ImageSampler},
@@ -10,7 +17,7 @@ fn main() {
         .add_plugins(
             // This just tells the asset server to look in the right examples folder
             DefaultPlugins.set(AssetPlugin {
-                file_path: "examples/asset/files".to_string(),
+                file_path: FILES_FOLDER_PATH.to_string(),
                 ..Default::default()
             }),
         )
@@ -24,7 +31,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Useful note: The default sampler specified by the ImagePlugin is *not* the same as the default implementation of sampler. This is why
     // everything uses linear by default but if you look at the default of sampler, it uses nearest.
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("bevy_pixel_dark.png"),
+        texture: asset_server.load(BEVY_DARK_PATH),
         sprite: Sprite {
             custom_size: Some(Vec2 { x: 160.0, y: 120.0 }),
             ..Default::default()
@@ -43,7 +50,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // and follow to the default implementation of each fields type.
     // https://docs.rs/bevy/latest/bevy/render/texture/struct.ImageLoaderSettings.html#
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("bevy_pixel_dark_with_meta.png"),
+        texture: asset_server.load(BEVY_DARK_META_PATH),
         sprite: Sprite {
             custom_size: Some(Vec2 { x: 160.0, y: 120.0 }),
             ..Default::default()
@@ -64,7 +71,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // same one as without a .meta file.
     commands.spawn(SpriteBundle {
         texture: asset_server.load_with_settings(
-            "bevy_pixel_dark_with_settings.png",
+            BEVY_DARK_SETTINGS_PATH,
             |settings: &mut ImageLoaderSettings| {
                 settings.sampler = ImageSampler::nearest();
             },

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -1,5 +1,9 @@
 //! Implements loader for a custom asset type.
 
+/// This example loads two custom files from the assets subdirectory
+const ASSET_CUSTOM_PATH: &str = "data/asset.custom";
+const ASSET_NO_EXTENSION_PATH: &str = "data/asset_no_extension";
+
 use bevy::{
     asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
     prelude::*,
@@ -109,13 +113,13 @@ struct State {
 
 fn setup(mut state: ResMut<State>, asset_server: Res<AssetServer>) {
     // Recommended way to load an asset
-    state.handle = asset_server.load("data/asset.custom");
+    state.handle = asset_server.load(ASSET_CUSTOM_PATH);
 
     // File extensions are optional, but are recommended for project management and last-resort inference
-    state.other_handle = asset_server.load("data/asset_no_extension");
+    state.other_handle = asset_server.load(ASSET_NO_EXTENSION_PATH);
 
     // Will use BlobAssetLoader instead of CustomAssetLoader thanks to type inference
-    state.blob = asset_server.load("data/asset.custom");
+    state.blob = asset_server.load(ASSET_CUSTOM_PATH);
 }
 
 fn print_on_load(

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -1,9 +1,4 @@
 //! Implements loader for a custom asset type.
-
-/// This example loads two custom files from the assets subdirectory
-const ASSET_CUSTOM_PATH: &str = "data/asset.custom";
-const ASSET_NO_EXTENSION_PATH: &str = "data/asset_no_extension";
-
 use bevy::{
     asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
     prelude::*,
@@ -11,6 +6,10 @@ use bevy::{
 };
 use serde::Deserialize;
 use thiserror::Error;
+
+/// This example loads two custom files from the assets subdirectory
+const ASSET_CUSTOM_PATH: &str = "data/asset.custom";
+const ASSET_NO_EXTENSION_PATH: &str = "data/asset_no_extension";
 
 #[derive(Asset, TypePath, Debug, Deserialize)]
 struct CustomAsset {

--- a/examples/asset/custom_asset_reader.rs
+++ b/examples/asset/custom_asset_reader.rs
@@ -2,6 +2,9 @@
 //! An [`AssetReader`] is what the asset server uses to read the raw bytes of assets.
 //! It does not know anything about the asset formats, only how to talk to the underlying storage.
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 use bevy::{
     asset::io::{
         AssetReader, AssetReaderError, AssetSource, AssetSourceId, ErasedAssetReader, PathStream,
@@ -62,7 +65,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load(ICON_PATH),
         ..default()
     });
 }

--- a/examples/asset/custom_asset_reader.rs
+++ b/examples/asset/custom_asset_reader.rs
@@ -2,9 +2,6 @@
 //! An [`AssetReader`] is what the asset server uses to read the raw bytes of assets.
 //! It does not know anything about the asset formats, only how to talk to the underlying storage.
 
-/// This example uses a png from the assets subdirectory
-const ICON_PATH: &str = "branding/icon.png";
-
 use bevy::{
     asset::io::{
         AssetReader, AssetReaderError, AssetSource, AssetSourceId, ErasedAssetReader, PathStream,
@@ -13,6 +10,9 @@ use bevy::{
     prelude::*,
 };
 use std::path::Path;
+
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
 
 /// A custom asset reader implementation that wraps a given asset reader implementation
 struct CustomAssetReader(Box<dyn ErasedAssetReader>);

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -3,6 +3,9 @@
 
 use bevy::prelude::*;
 
+/// This example uses an audio file from the assets subdirectory
+const MUSIC_PATH: &str = "sounds/Windless Slopes.ogg";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -12,7 +15,7 @@ fn main() {
 
 fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
     commands.spawn(AudioBundle {
-        source: asset_server.load("sounds/Windless Slopes.ogg"),
+        source: asset_server.load(MUSIC_PATH),
         ..default()
     });
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -2,6 +2,9 @@
 
 use bevy::prelude::*;
 
+/// This example uses an audio file from the assets subdirectory
+const MUSIC_PATH: &str = "sounds/Windless Slopes.ogg";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -13,7 +16,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         AudioBundle {
-            source: asset_server.load("sounds/Windless Slopes.ogg"),
+            source: asset_server.load(MUSIC_PATH),
             ..default()
         },
         MyMusic,

--- a/examples/audio/soundtrack.rs
+++ b/examples/audio/soundtrack.rs
@@ -3,6 +3,10 @@
 
 use bevy::prelude::*;
 
+/// This example uses two audio files from the assets subdirectory
+const ACOUSTIC_GUITAR_PATH: &str = "sounds/Mysterious acoustic guitar.ogg";
+const ORCHESTRA_MUSIC_PATH: &str = "sounds/Epic orchestra music.ogg";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -53,8 +57,8 @@ fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
     )));
 
     // Create the track list
-    let track_1 = asset_server.load::<AudioSource>("sounds/Mysterious acoustic guitar.ogg");
-    let track_2 = asset_server.load::<AudioSource>("sounds/Epic orchestra music.ogg");
+    let track_1 = asset_server.load::<AudioSource>(ACOUSTIC_GUITAR_PATH);
+    let track_2 = asset_server.load::<AudioSource>(ORCHESTRA_MUSIC_PATH);
     let track_list = vec![track_1, track_2];
     commands.insert_resource(SoundtrackPlayer::new(track_list));
 }

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -6,6 +6,9 @@ use bevy::{
     sprite::MaterialMesh2dBundle,
 };
 
+/// This example uses an audio file from the assets subdirectory
+const MUSIC_PATH: &str = "sounds/Windless Slopes.ogg";
+
 /// Spatial audio uses the distance to attenuate the sound volume. In 2D with the default camera,
 /// 1 pixel is 1 unit of distance, so we use a scale so that 100 pixels is 1 unit of distance for
 /// audio.
@@ -42,7 +45,7 @@ fn setup(
         },
         Emitter::default(),
         AudioBundle {
-            source: asset_server.load("sounds/Windless Slopes.ogg"),
+            source: asset_server.load(MUSIC_PATH),
             settings: PlaybackSettings::LOOP.with_spatial(true),
         },
     ));

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -4,6 +4,9 @@ use bevy::{
     prelude::*,
 };
 
+/// This example uses an audio file from the assets subdirectory
+const MUSIC_PATH: &str = "sounds/Windless Slopes.ogg";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -32,7 +35,7 @@ fn setup(
         },
         Emitter::default(),
         AudioBundle {
-            source: asset_server.load("sounds/Windless Slopes.ogg"),
+            source: asset_server.load(MUSIC_PATH),
             settings: PlaybackSettings::LOOP.with_spatial(true),
         },
     ));

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -5,6 +5,9 @@ use std::f32::consts::*;
 use bevy::color::palettes::css::*;
 use bevy::prelude::*;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -15,7 +18,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    let texture = asset_server.load("branding/icon.png");
+    let texture = asset_server.load(ICON_PATH);
 
     // Spawn a root entity with no parent
     let parent = commands

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -5,12 +5,15 @@ use bevy::prelude::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 #[derive(Component, Deref)]
 struct Velocity(Vec2);
 
 fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    let texture = asset_server.load("branding/icon.png");
+    let texture = asset_server.load(ICON_PATH);
 
     // We're seeding the PRNG here to make this example deterministic for testing purposes.
     // This isn't strictly required in practical use unless you need your app to be deterministic.

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -2,6 +2,9 @@
 
 use bevy::prelude::*;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 fn main() {
     // Information regarding removed `Component`s is discarded at the end of each frame, so you need
     // to react to the removal before the frame is over.
@@ -29,7 +32,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn((
         SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
+            texture: asset_server.load(ICON_PATH),
             ..default()
         },
         // Add the `Component`.

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -6,6 +6,11 @@ use bevy::prelude::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
+/// This example uses three 3d model files from the asset subdirectory
+const TILE_PATH: &str = "models/AlienCake/tile.glb";
+const ALIEN_PATH: &str = "models/AlienCake/alien.glb";
+const CAKE_BIRTHDAY_PATH: &str = "models/AlienCake/cakeBirthday.glb";
+
 #[derive(Clone, Eq, PartialEq, Debug, Hash, Default, States)]
 enum GameState {
     #[default]
@@ -133,8 +138,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     });
 
     // spawn the game board
-    let cell_scene =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/tile.glb"));
+    let cell_scene = asset_server.load(GltfAssetLabel::Scene(0).from_asset(TILE_PATH));
     game.board = (0..BOARD_SIZE_J)
         .map(|j| {
             (0..BOARD_SIZE_I)
@@ -164,16 +168,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                     rotation: Quat::from_rotation_y(-PI / 2.),
                     ..default()
                 },
-                scene: asset_server
-                    .load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/alien.glb")),
+                scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(ALIEN_PATH)),
                 ..default()
             })
             .id(),
     );
 
     // load the scene for the cake
-    game.bonus.handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/cakeBirthday.glb"));
+    game.bonus.handle = asset_server.load(GltfAssetLabel::Scene(0).from_asset(CAKE_BIRTHDAY_PATH));
 
     // scoreboard
     commands.spawn(

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -10,6 +10,9 @@ use bevy::{
 
 mod stepping;
 
+/// This example uses an audio file from the assets subdirectory
+const COLLISION_SOUND_PATH: &str = "sounds/breakout_collision.ogg";
+
 // These constants are defined in `Transform` units.
 // Using the default 2D camera they correspond 1:1 with screen pixels.
 const PADDLE_SIZE: Vec2 = Vec2::new(120.0, 20.0);
@@ -194,7 +197,7 @@ fn setup(
     commands.spawn(Camera2dBundle::default());
 
     // Sound
-    let ball_collision_sound = asset_server.load("sounds/breakout_collision.ogg");
+    let ball_collision_sound = asset_server.load(COLLISION_SOUND_PATH);
     commands.insert_resource(CollisionSound(ball_collision_sound));
 
     // Paddle

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -9,6 +9,11 @@ use std::{
     process::Stdio,
 };
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -76,7 +81,7 @@ fn setup_contributor_selection(mut commands: Commands, asset_server: Res<AssetSe
             .collect()
     });
 
-    let texture_handle = asset_server.load("branding/icon.png");
+    let texture_handle = asset_server.load(ICON_PATH);
 
     let mut contributor_selection = ContributorSelection {
         order: Vec::with_capacity(contribs.len()),
@@ -132,7 +137,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+        font: asset_server.load(FONT_PATH),
         font_size: 60.0,
         ..default()
     };

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -17,6 +17,11 @@ use bevy::{
 #[cfg(target_os = "macos")]
 use bevy::window::CompositeAlphaMode;
 
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -107,7 +112,7 @@ fn setup(
     commands.spawn(Camera2dBundle::default());
 
     // Spawn the text instructions
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
     let text_style = TextStyle {
         font: font.clone(),
         font_size: 30.0,
@@ -137,7 +142,7 @@ fn setup(
     commands
         .spawn((
             SpriteBundle {
-                texture: asset_server.load("branding/icon.png"),
+                texture: asset_server.load(ICON_PATH),
                 ..default()
             },
             BevyLogo,

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -4,6 +4,12 @@
 
 use bevy::prelude::*;
 
+/// This example uses 4 pngs from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+const RIGHT_PATH: &str = "textures/Game Icons/right.png";
+const WRENCH_PATH: &str = "textures/Game Icons/wrench.png";
+const EXIT_RIGHT_PATH: &str = "textures/Game Icons/exitRight.png";
+
 const TEXT_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
 
 // Enum that will be used as a global state for the game
@@ -71,7 +77,7 @@ mod splash {
     struct SplashTimer(Timer);
 
     fn splash_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        let icon = asset_server.load("branding/icon.png");
+        let icon = asset_server.load(ICON_PATH);
         // Display the logo
         commands
             .spawn((
@@ -462,7 +468,7 @@ mod menu {
                                 MenuButtonAction::Play,
                             ))
                             .with_children(|parent| {
-                                let icon = asset_server.load("textures/Game Icons/right.png");
+                                let icon = asset_server.load(RIGHT_PATH);
                                 parent.spawn(ImageBundle {
                                     style: button_icon_style.clone(),
                                     image: UiImage::new(icon),
@@ -483,7 +489,7 @@ mod menu {
                                 MenuButtonAction::Settings,
                             ))
                             .with_children(|parent| {
-                                let icon = asset_server.load("textures/Game Icons/wrench.png");
+                                let icon = asset_server.load(WRENCH_PATH);
                                 parent.spawn(ImageBundle {
                                     style: button_icon_style.clone(),
                                     image: UiImage::new(icon),
@@ -504,7 +510,7 @@ mod menu {
                                 MenuButtonAction::Quit,
                             ))
                             .with_children(|parent| {
-                                let icon = asset_server.load("textures/Game Icons/exitRight.png");
+                                let icon = asset_server.load(EXIT_RIGHT_PATH);
                                 parent.spawn(ImageBundle {
                                     style: button_icon_style,
                                     image: UiImage::new(icon),

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -2,17 +2,9 @@
 use bevy::{ecs::system::SystemId, prelude::*};
 use pipelines_ready::*;
 
-// The way we'll go about doing this in this example is to
-// keep track of all assets that we want to have loaded before
-// we transition to the desired scene.
-//
-// In order to ensure that visual assets are fully rendered
-// before transitioning to the scene, we need to get the
-// current status of cached pipelines.
-//
-// While loading and pipelines compilation is happening, we
-// will show a loading screen. Once loading is complete, we
-// will transition to the scene we just loaded.
+/// This example uses two 3d model files from the assets subdirectory
+const FOX_PATH: &str = "models/animated/Fox.glb";
+const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
 
 fn main() {
     App::new()
@@ -150,7 +142,7 @@ fn load_level_1(
     ));
 
     // Save the asset into the `loading_assets` vector.
-    let fox = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"));
+    let fox = asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH));
     loading_data.loading_assets.push(fox.clone().into());
     // Spawn the fox.
     commands.spawn((
@@ -192,8 +184,7 @@ fn load_level_2(
     ));
 
     // Spawn the helmet.
-    let helmet_scene = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+    let helmet_scene = asset_server.load(GltfAssetLabel::Scene(0).from_asset(FLIGHT_HELMET_PATH));
     loading_data
         .loading_assets
         .push(helmet_scene.clone().into());

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -6,6 +6,18 @@ use pipelines_ready::*;
 const FOX_PATH: &str = "models/animated/Fox.glb";
 const FLIGHT_HELMET_PATH: &str = "models/FlightHelmet/FlightHelmet.gltf";
 
+// The way we'll go about doing this in this example is to
+// keep track of all assets that we want to have loaded before
+// we transition to the desired scene.
+//
+// In order to ensure that visual assets are fully rendered
+// before transitioning to the scene, we need to get the
+// current status of cached pipelines.
+//
+// While loading and pipelines compilation is happening, we
+// will show a loading screen. Once loading is complete, we
+// will transition to the scene we just loaded.
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -14,6 +14,9 @@ use bevy::{
     prelude::*,
 };
 
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraMono-Medium.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -33,7 +36,7 @@ fn main() {
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    let font = asset_server.load("fonts/FiraMono-Medium.ttf");
+    let font = asset_server.load(FONT_PATH);
 
     commands.spawn(
         TextBundle::from_sections([
@@ -96,7 +99,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         text: Text::from_section(
             "".to_string(),
             TextStyle {
-                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                font: asset_server.load(FONT_PATH),
                 font_size: 100.0,
                 ..default()
             },

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -2,6 +2,10 @@
 use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
 use std::{fs::File, io::Write};
 
+/// This example uses two RON files from the asset subdirectory
+const SCENE_FILE_PATH: &str = "scenes/load_scene_example.scn.ron";
+const NEW_SCENE_FILE_PATH: &str = "scenes/load_scene_example-new.scn.ron";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -57,12 +61,6 @@ impl FromWorld for ComponentB {
 struct ResourceA {
     pub score: u32,
 }
-
-// The initial scene file will be loaded below and not change when the scene is saved
-const SCENE_FILE_PATH: &str = "scenes/load_scene_example.scn.ron";
-
-// The new, updated scene data will be saved here so that you can see the changes
-const NEW_SCENE_FILE_PATH: &str = "scenes/load_scene_example-new.scn.ron";
 
 fn load_scene_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     // "Spawning" a scene bundle creates a new entity and spawns new instances

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -3,6 +3,8 @@ use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
 use std::{fs::File, io::Write};
 
 /// This example uses two RON files from the asset subdirectory
+/// RON (Rusty Object Notation) is similar to JSON in that it serializes data in a
+///  simple, visual manner, but differently from JSON, it does it using Rust-like syntax
 const SCENE_FILE_PATH: &str = "scenes/load_scene_example.scn.ron";
 const NEW_SCENE_FILE_PATH: &str = "scenes/load_scene_example-new.scn.ron";
 

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -3,9 +3,9 @@ use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
 use std::{fs::File, io::Write};
 
 /// This example uses two RON files from the asset subdirectory
-/// RON (Rusty Object Notation) is similar to JSON in that it serializes data in a
-///  simple, visual manner, but differently from JSON, it does it using Rust-like syntax
+// The initial scene file will be loaded below and not change when the scene is saved
 const SCENE_FILE_PATH: &str = "scenes/load_scene_example.scn.ron";
+// The new, updated scene data will be saved here so that you can see the changes
 const NEW_SCENE_FILE_PATH: &str = "scenes/load_scene_example-new.scn.ron";
 
 fn main() {

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -20,6 +20,9 @@ use bevy::{dev_tools::states::*, prelude::*};
 
 use ui::*;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 // To begin, we want to define our state objects.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
 enum AppState {
@@ -425,7 +428,7 @@ mod ui {
         commands.spawn((
             StateScoped(InGame),
             SpriteBundle {
-                texture: asset_server.load("branding/icon.png"),
+                texture: asset_server.load(ICON_PATH),
                 ..default()
             },
         ));

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -17,6 +17,9 @@ use bevy::{dev_tools::states::*, ecs::schedule::ScheduleLabel, prelude::*};
 
 use custom_transitions::*;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
 enum AppState {
     #[default]
@@ -225,7 +228,7 @@ fn setup(mut commands: Commands) {
 
 fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load(ICON_PATH),
         ..default()
     });
     info!("Setup game");

--- a/examples/state/states.rs
+++ b/examples/state/states.rs
@@ -7,6 +7,8 @@
 
 use bevy::{dev_tools::states::*, prelude::*};
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -121,7 +123,7 @@ fn cleanup_menu(mut commands: Commands, menu_data: Res<MenuData>) {
 
 fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load(ICON_PATH),
         ..default()
     });
 }

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -11,6 +11,9 @@ use bevy::{dev_tools::states::*, prelude::*};
 
 use ui::*;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
 enum AppState {
     #[default]
@@ -200,7 +203,7 @@ mod ui {
 
     pub fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
         commands.spawn(SpriteBundle {
-            texture: asset_server.load("branding/icon.png"),
+            texture: asset_server.load(ICON_PATH),
             ..default()
         });
     }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -21,6 +21,9 @@ use bevy::{
 use rand::{seq::SliceRandom, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 const BIRDS_PER_SECOND: u32 = 10000;
 const GRAVITY: f32 = -9.8 * 100.0;
 const MAX_VELOCITY: f32 = 750.;
@@ -209,7 +212,7 @@ fn setup(
 
     let mut textures = Vec::with_capacity(args.material_texture_count.max(1));
     if matches!(args.mode, Mode::Sprite) || args.material_texture_count > 0 {
-        textures.push(asset_server.load("branding/icon.png"));
+        textures.push(asset_server.load(ICON_PATH));
     }
     init_textures(&mut textures, args, images);
 

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -14,6 +14,9 @@ use bevy::{
 
 use rand::Rng;
 
+/// This example uses a png from the assets subdirectory
+const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
+
 const CAMERA_SPEED: f32 = 1000.0;
 
 fn main() {
@@ -63,7 +66,7 @@ fn setup(
     let half_x = (map_size.x / 2.0) as i32;
     let half_y = (map_size.y / 2.0) as i32;
 
-    let texture_handle = assets.load("textures/rpg/chars/gabe/gabe-idle-run.png");
+    let texture_handle = assets.load(IDLE_RUN_PATH);
     let texture_atlas = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
 

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -9,6 +9,9 @@ use bevy::{
     winit::{UpdateMode, WinitSettings},
 };
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 const FONT_SIZE: f32 = 7.0;
 
 #[derive(FromArgs, Resource)]
@@ -113,7 +116,7 @@ fn button_system(
 fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
     warn!(include_str!("warning_string.txt"));
     let image = if 0 < args.image_freq {
-        Some(asset_server.load("branding/icon.png"))
+        Some(asset_server.load(ICON_PATH))
     } else {
         None
     };
@@ -170,7 +173,7 @@ fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
 fn setup_grid(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
     warn!(include_str!("warning_string.txt"));
     let image = if 0 < args.image_freq {
-        Some(asset_server.load("branding/icon.png"))
+        Some(asset_server.load(ICON_PATH))
     } else {
         None
     };

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -13,6 +13,9 @@ use bevy::{
     winit::{UpdateMode, WinitSettings},
 };
 
+/// This example uses a 3d model file from the assets subdirectory
+const FOX_PATH: &str = "models/animated/Fox.glb";
+
 #[derive(FromArgs, Resource)]
 /// `many_foxes` stress test
 struct Args {
@@ -118,9 +121,9 @@ fn setup(
 
     // Insert a resource with the current scene information
     let animation_clips = [
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset("models/animated/Fox.glb")),
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb")),
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
+        asset_server.load(GltfAssetLabel::Animation(1).from_asset(FOX_PATH)),
+        asset_server.load(GltfAssetLabel::Animation(0).from_asset(FOX_PATH)),
     ];
     let mut animation_graph = AnimationGraph::new();
     let node_indices = animation_graph
@@ -136,8 +139,7 @@ fn setup(
     // The foxes in each ring are spaced at least 2m apart around its circumference.'
 
     // NOTE: This fox model faces +z
-    let fox_handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"));
+    let fox_handle = asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH));
 
     let ring_directions = [
         (

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -17,6 +17,9 @@ use bevy::{
 
 use rand::Rng;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 const CAMERA_SPEED: f32 = 1000.0;
 
 const COLORS: [Color; 3] = [Color::Srgba(BLUE), Color::Srgba(WHITE), Color::Srgba(RED)];
@@ -66,7 +69,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<Color
     let half_x = (map_size.x / 2.0) as i32;
     let half_y = (map_size.y / 2.0) as i32;
 
-    let sprite_handle = assets.load("branding/icon.png");
+    let sprite_handle = assets.load(ICON_PATH);
 
     // Spawns the camera
 

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -11,6 +11,10 @@ use bevy::{
     winit::{UpdateMode, WinitSettings},
 };
 
+/// This example uses two fonts from the assets subdirectory
+const FONT_PATH_MEDIUM: &str = "fonts/FiraMono-Medium.ttf";
+const FONT_PATH_BOLD: &str = "fonts/FiraMono-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -45,7 +49,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextSection {
                     value: "text".repeat(i),
                     style: TextStyle {
-                        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                        font: asset_server.load(FONT_PATH_MEDIUM),
                         font_size: (4 + i % 10) as f32,
                         color: BLUE.into(),
                     },
@@ -53,7 +57,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextSection {
                     value: "pipeline".repeat(i),
                     style: TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: asset_server.load(FONT_PATH_BOLD),
                         font_size: (4 + i % 11) as f32,
                         color: YELLOW.into(),
                     },

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -8,6 +8,9 @@ use bevy::{
     time::common_conditions::on_real_timer,
 };
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -49,7 +52,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
 
     let virtual_color = GOLD.into();
     let sprite_scale = Vec2::splat(0.5).extend(1.);
-    let texture_handle = asset_server.load("branding/icon.png");
+    let texture_handle = asset_server.load(ICON_PATH);
 
     // the sprite moving based on real time
     commands.spawn((

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -25,6 +25,12 @@ use camera_controller::{CameraController, CameraControllerPlugin};
 use morph_viewer_plugin::MorphViewerPlugin;
 use scene_viewer_plugin::{SceneHandle, SceneViewerPlugin};
 
+/// This example uses a 3d model file from the assets subdirectory
+const FLIGHT_HELMET_PATH: &str = "assets/models/FlightHelmet/FlightHelmet.gltf";
+/// This example uses two compressed texture files from the assets subdirectory
+const PISA_DIFFUSE_PATH: &str = "assets/environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2";
+const PISA_SPECULAR_PATH: &str = "assets/environment_maps/pisa_specular_rgb9e5_zstd.ktx2";
+
 fn main() {
     let mut app = App::new();
     app.add_plugins((
@@ -71,7 +77,7 @@ fn parse_scene(scene_path: String) -> (String, usize) {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let scene_path = std::env::args()
         .nth(1)
-        .unwrap_or_else(|| "assets/models/FlightHelmet/FlightHelmet.gltf".to_string());
+        .unwrap_or_else(|| FLIGHT_HELMET_PATH.to_string());
     info!("Loading {}", scene_path);
     let (file_path, scene_index) = parse_scene(scene_path);
 
@@ -140,10 +146,8 @@ fn setup_scene_after_load(
                 ..default()
             },
             EnvironmentMapLight {
-                diffuse_map: asset_server
-                    .load("assets/environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
-                specular_map: asset_server
-                    .load("assets/environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+                diffuse_map: asset_server.load(PISA_DIFFUSE_PATH),
+                specular_map: asset_server.load(PISA_SPECULAR_PATH),
                 intensity: 150.0,
             },
             camera_controller,

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -6,6 +6,9 @@ use bevy::prelude::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
+/// This example uses a 3d model file from the assets subdirectory
+const SPEEDER_PATH: &str = "models/ship/craft_speederD.gltf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -87,8 +90,7 @@ fn setup(
     // Finally, our ship that is going to rotate
     commands.spawn((
         SceneBundle {
-            scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/ship/craft_speederD.gltf")),
+            scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(SPEEDER_PATH)),
             ..default()
         },
         Ship {

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -3,6 +3,9 @@
 
 use bevy::{color::palettes::basic::*, prelude::*, winit::WinitSettings};
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -82,7 +85,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     parent.spawn(TextBundle::from_section(
                         "Button",
                         TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font: asset_server.load(FONT_PATH),
                             font_size: 40.0,
                             color: Color::srgb(0.9, 0.9, 0.9),
                         },

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -6,6 +6,9 @@ use bevy::{
     prelude::*,
 };
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 const PALETTE: [&str; 4] = ["27496D", "466B7A", "669DB3", "ADCBE3"];
 const HIDDEN_COLOR: Color = Color::srgb(1.0, 0.7, 0.7);
 
@@ -77,7 +80,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let palette: [Color; 4] = PALETTE.map(|hex| Srgba::hex(hex).unwrap().into());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+        font: asset_server.load(FONT_PATH),
         ..default()
     };
 
@@ -151,7 +154,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default() })
             .with_children(|builder| {
                 let text_style = TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: asset_server.load(FONT_PATH),
                     ..default()
                 };
 

--- a/examples/ui/flex_layout.rs
+++ b/examples/ui/flex_layout.rs
@@ -1,6 +1,9 @@
 //! Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 use bevy::prelude::*;
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 const ALIGN_ITEMS_COLOR: Color = Color::srgb(1., 0.066, 0.349);
 const JUSTIFY_CONTENT_COLOR: Color = Color::srgb(0.102, 0.522, 1.);
 const MARGIN: Val = Val::Px(12.);
@@ -19,7 +22,7 @@ fn main() {
 }
 
 fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
     commands.spawn(Camera2dBundle::default());
     commands
         .spawn(NodeBundle {

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -5,6 +5,9 @@ use bevy::{color::palettes::basic::YELLOW, prelude::*, text::FontAtlasSets};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .init_resource::<State>()
@@ -82,7 +85,7 @@ fn text_update_system(
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResMut<State>) {
-    let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font_handle = asset_server.load(FONT_PATH);
     state.handle = font_handle.clone();
     commands.spawn(Camera2dBundle::default());
     commands

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -1,6 +1,9 @@
 //! Demonstrates how CSS Grid layout can be used to lay items out in a 2D grid
 use bevy::{color::palettes::css::*, prelude::*};
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -16,7 +19,7 @@ fn main() {
 }
 
 fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
     commands.spawn(Camera2dBundle::default());
 
     // Top-level grid (app frame)

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -2,6 +2,9 @@
 
 use bevy::{color::palettes::css::*, prelude::*, winit::WinitSettings};
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -17,7 +20,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let text_style = TextStyle::default();
 
-    let image = asset_server.load("branding/icon.png");
+    let image = asset_server.load(ICON_PATH);
 
     commands
         .spawn(NodeBundle {

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -2,6 +2,11 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 use std::f32::consts::{FRAC_PI_2, PI, TAU};
 
+/// This example uses a png from the assets subdirectory
+const BEVY_LOGO_PATH: &str = "branding/bevy_logo_dark_big.png";
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 const CONTAINER_SIZE: f32 = 150.0;
 const HALF_CONTAINER_SIZE: f32 = CONTAINER_SIZE / 2.0;
 const LOOP_LENGTH: f32 = 4.0;
@@ -143,7 +148,7 @@ fn spawn_image(
 ) {
     spawn_container(parent, update_transform, |parent| {
         parent.spawn(ImageBundle {
-            image: UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),
+            image: UiImage::new(asset_server.load(BEVY_LOGO_PATH)),
             style: Style {
                 height: Val::Px(100.),
                 position_type: PositionType::Absolute,
@@ -165,7 +170,7 @@ fn spawn_text(
         parent.spawn(TextBundle::from_section(
             "Bevy",
             TextStyle {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font: asset_server.load(FONT_PATH),
                 font_size: 120.0,
                 ..default()
             },

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -4,6 +4,9 @@ use bevy::{
     prelude::*, render::camera::Viewport, ui::RelativeCursorPosition, winit::WinitSettings,
 };
 
+/// This example uses a font from the asset subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -58,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 text: Text::from_section(
                     "(0.0, 0.0)",
                     TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font: asset_server.load(FONT_PATH),
                         font_size: 40.0,
                         color: Color::srgb(0.9, 0.9, 0.9),
                     },

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -2,6 +2,9 @@
 
 use bevy::{color::palettes::css::*, prelude::*};
 
+/// This example uses a font from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -43,7 +46,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+        font: asset_server.load(FONT_PATH),
         font_size: 40.0,
         color: Color::srgb(0.9, 0.9, 0.9),
     };

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -9,6 +9,10 @@ use bevy::{
     prelude::*,
 };
 
+/// This example uses two font files from the assets subdirectory
+const FONT_PATH_MEDIUM: &str = "fonts/FiraMono-Medium.ttf";
+const FONT_PATH_BOLD: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, FrameTimeDiagnosticsPlugin))
@@ -36,7 +40,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             "hello\nbevy!",
             TextStyle {
                 // This font is loaded and will be used instead of the default font.
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font: asset_server.load(FONT_PATH_BOLD),
                 font_size: 100.0,
                 ..default()
             },
@@ -60,7 +64,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 "FPS: ",
                 TextStyle {
                     // This font is loaded and will be used instead of the default font.
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font: asset_server.load(FONT_PATH_BOLD),
                     font_size: 60.0,
                     ..default()
                 },
@@ -75,7 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             } else {
                 // "default_font" feature is unavailable, load a font to use instead.
                 TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                    font: asset_server.load(FONT_PATH_MEDIUM),
                     font_size: 60.0,
                     color: GOLD.into(),
                 }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -7,6 +7,9 @@ use bevy::{
     window::PresentMode,
 };
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins((
@@ -28,7 +31,7 @@ fn main() {
 struct TextChanges;
 
 fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font = asset_server.load(FONT_PATH);
     commands.spawn(Camera2dBundle::default());
     let root_uinode = commands
         .spawn(NodeBundle {

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -6,6 +6,9 @@ use bevy::text::BreakLineOn;
 use bevy::window::WindowResolution;
 use bevy::winit::WinitSettings;
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 #[derive(FromArgs, Resource)]
 /// `text_wrap_debug` demonstrates text wrapping and use of the `LineBreakOn` property
 struct Args {
@@ -49,7 +52,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+        font: asset_server.load(FONT_PATH),
         font_size: 14.0,
         ..default()
     };

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -3,6 +3,9 @@
 
 use bevy::prelude::*;
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
@@ -14,7 +17,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let font_handle = asset_server.load(FONT_PATH);
 
     commands
         .spawn(NodeBundle {

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -11,6 +11,11 @@ use bevy::{
     winit::WinitSettings,
 };
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+/// This example uses a png from the assets subdirectory
+const BEVY_LOGO_PATH: &str = "branding/bevy_logo_dark_big.png";
+
 fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins)
@@ -75,7 +80,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 TextBundle::from_section(
                                     "Text Example",
                                     TextStyle {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font: asset_server.load(FONT_PATH),
                                         font_size: 30.0,
                                         ..default()
                                     },
@@ -104,7 +109,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 TextBundle::from_section(
                                     "Try enabling feature \"bevy_dev_tools\".",
                                     TextStyle {
-                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font: asset_server.load(FONT_PATH),
                                         ..default()
                                     },
                                 ),
@@ -131,7 +136,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         TextBundle::from_section(
                             "Scrolling list",
                             TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font: asset_server.load(FONT_PATH),
                                 font_size: 25.,
                                 ..default()
                             },
@@ -173,8 +178,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                             TextBundle::from_section(
                                                 format!("Item {i}"),
                                                 TextStyle {
-                                                    font: asset_server
-                                                        .load("fonts/FiraSans-Bold.ttf"),
+                                                    font: asset_server.load(FONT_PATH),
                                                     ..default()
                                                 },
                                             ),
@@ -315,7 +319,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 },
                                 ..default()
                             },
-                            UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),
+                            UiImage::new(asset_server.load(BEVY_LOGO_PATH)),
                         ))
                         .with_children(|parent| {
                             // alt text

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -2,6 +2,9 @@
 
 use bevy::{color::palettes::css::*, prelude::*, text::TextSettings, utils::Duration};
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 const SCALE_TIME: u64 = 400;
 
 fn main() {
@@ -77,7 +80,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     height: Val::Px(30.0),
                     ..default()
                 },
-                image: asset_server.load("branding/icon.png").into(),
+                image: asset_server.load(ICON_PATH).into(),
                 ..default()
             });
         });

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -2,6 +2,9 @@
 
 use bevy::{color::palettes::css::*, prelude::*, winit::WinitSettings};
 
+/// This example uses a png from the assets subdirectory
+const IDLE_RUN_PATH: &str = "textures/rpg/chars/gabe/gabe-idle-run.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(
@@ -27,7 +30,7 @@ fn setup(
 
     let text_style = TextStyle::default();
 
-    let texture_handle = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
+    let texture_handle = asset_server.load(IDLE_RUN_PATH);
     let texture_atlas = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
 

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -7,6 +7,11 @@ use bevy::{
     winit::WinitSettings,
 };
 
+/// This example uses a png from the assets subdirectory
+const BORDER_SHEET_PATH: &str = "textures/fantasy_ui_borders/border_sheet.png";
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -49,7 +54,7 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,
 ) {
-    let texture_handle = asset_server.load("textures/fantasy_ui_borders/border_sheet.png");
+    let texture_handle = asset_server.load(BORDER_SHEET_PATH);
     let atlas_layout = TextureAtlasLayout::from_grid(UVec2::new(50, 50), 6, 6, None, None);
     let atlas_layout_handle = texture_atlases.add(atlas_layout);
 
@@ -104,7 +109,7 @@ fn setup(
                         parent.spawn(TextBundle::from_section(
                             "Button",
                             TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font: asset_server.load(FONT_PATH),
                                 font_size: 40.0,
                                 color: Color::srgb(0.9, 0.9, 0.9),
                             },

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -7,6 +7,11 @@ use bevy::{
     winit::WinitSettings,
 };
 
+/// This example uses a png from the assets subdirectory
+const PANEL_BORDER_PATH: &str = "textures/fantasy_ui_borders/panel-border-010.png";
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -44,7 +49,7 @@ fn button_system(
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let image = asset_server.load("textures/fantasy_ui_borders/panel-border-010.png");
+    let image = asset_server.load(PANEL_BORDER_PATH);
 
     let slicer = TextureSlicer {
         border: BorderRect::square(22.0),
@@ -89,7 +94,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         parent.spawn(TextBundle::from_section(
                             "Button",
                             TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font: asset_server.load(FONT_PATH),
                                 font_size: 40.0,
                                 color: Color::srgb(0.9, 0.9, 0.9),
                             },

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -4,6 +4,9 @@
 
 use bevy::prelude::*;
 
+/// This example uses a font file from the assets subdirectory
+const FONT_PATH: &str = "fonts/FiraSans-Bold.ttf";
+
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::NONE)) // Use a transparent window, to make effects obvious.
@@ -32,7 +35,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             // Accepts a `String` or any type that converts into a `String`, such as `&str`
             "Hit 'P' then scroll/click around!",
             TextStyle {
-                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font: asset_server.load(FONT_PATH),
                 font_size: 100.0, // Nice and big so you can see it!
                 ..default()
             },

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -2,6 +2,9 @@
 
 use bevy::{prelude::*, render::camera::RenderTarget, window::WindowRef};
 
+/// This example uses a 3d model file from the assets subdirectory
+const TORUS_PATH: &str = "models/torus/torus.gltf";
+
 fn main() {
     App::new()
         // By default, a primary window gets spawned by `WindowPlugin`, contained in `DefaultPlugins`
@@ -13,7 +16,7 @@ fn main() {
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // add entities to the world
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf")),
+        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(TORUS_PATH)),
         ..default()
     });
     // light

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -8,6 +8,9 @@ use bevy::prelude::*;
 #[cfg(target_os = "macos")]
 use bevy::window::CompositeAlphaMode;
 
+/// This example uses a png from the assets subdirectory
+const ICON_PATH: &str = "branding/icon.png";
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -31,7 +34,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(SpriteBundle {
-        texture: asset_server.load("branding/icon.png"),
+        texture: asset_server.load(ICON_PATH),
         ..default()
     });
 }


### PR DESCRIPTION
# Objective

- (hopefully) Complete #13645

## Solution

- Add a ton of constants at the top of files that hold paths to things in the `Assets` folder
- Also added documentation explaining where the constants come from

## Testing

- Ran (almost) all of the changed examples, but I still need to test examples in folders that come after `gizmos` alphabetically (not that many changed examples)