### PR TITLE
don't put previous skin/morph in the morphed_skinned_mesh_layout

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -242,10 +242,6 @@ impl MeshLayouts {
                     // The current frame's morph weight buffer.
                     (2, layout_entry::weights()),
                     (3, layout_entry::targets()),
-                    // The previous frame's joint matrix buffer.
-                    (6, layout_entry::skinning()),
-                    // The previous frame's morph weight buffer.
-                    (7, layout_entry::weights()),
                 ),
             ),
         )


### PR DESCRIPTION
# Objective

- Fixes #14059
- `morphed_skinned_mesh_layout` is the same as `morphed_skinned_motion_mesh_layout` but shouldn't have the skin / morph from previous frame, as they're used for motion

## Solution

- Remove the extra entries

## Testing

- Run with the glTF file reproducing #14059, it works
