### PR TITLE
Optimize common usages of `AssetReader`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.78.0"
+rust-version = "1.79.0"
 
 [workspace]
 exclude = [

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::ops::{Index, IndexMut};
 
 use bevy_asset::io::Reader;
-use bevy_asset::{Asset, AssetId, AssetLoader, AssetPath, AsyncReadExt as _, Handle, LoadContext};
+use bevy_asset::{Asset, AssetId, AssetLoader, AssetPath, Handle, LoadContext};
 use bevy_reflect::{Reflect, ReflectSerialize};
 use petgraph::graph::{DiGraph, NodeIndex};
 use ron::de::SpannedError;

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -337,7 +337,7 @@ impl AssetLoader for AnimationGraphAssetLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         _: &'a Self::Settings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -28,6 +28,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 
+stackfuture = "0.3"
 async-broadcast = "0.5"
 async-fs = "2.0"
 async-lock = "3.0"

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -16,7 +16,7 @@ use std::{ffi::CString, path::Path};
 pub struct AndroidAssetReader;
 
 impl AssetReader for AndroidAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let asset_manager = bevy_winit::ANDROID_APP
             .get()
             .expect("Bevy must be setup with the #[bevy_main] macro on Android")
@@ -25,11 +25,11 @@ impl AssetReader for AndroidAssetReader {
             .open(&CString::new(path.to_str().unwrap()).unwrap())
             .ok_or(AssetReaderError::NotFound(path.to_path_buf()))?;
         let bytes = opened_asset.buffer()?;
-        let reader: Box<Reader> = Box::new(VecReader::new(bytes.to_vec()));
+        let reader = VecReader::new(bytes.to_vec());
         Ok(reader)
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Reader + 'a, AssetReaderError> {
         let meta_path = get_meta_path(path);
         let asset_manager = bevy_winit::ANDROID_APP
             .get()
@@ -39,7 +39,7 @@ impl AssetReader for AndroidAssetReader {
             .open(&CString::new(meta_path.to_str().unwrap()).unwrap())
             .ok_or(AssetReaderError::NotFound(meta_path))?;
         let bytes = opened_asset.buffer()?;
-        let reader: Box<Reader> = Box::new(VecReader::new(bytes.to_vec()));
+        let reader = VecReader::new(bytes.to_vec());
         Ok(reader)
     }
 

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -29,7 +29,7 @@ impl AssetReader for AndroidAssetReader {
         Ok(reader)
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let meta_path = get_meta_path(path);
         let asset_manager = bevy_winit::ANDROID_APP
             .get()

--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 
 use super::{FileAssetReader, FileAssetWriter};
 
+impl Reader for File {}
+
 impl AssetReader for FileAssetReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let full_path = self.root_path.join(path);

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -87,13 +87,10 @@ impl Stream for DirReader {
 }
 
 impl AssetReader for FileAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let full_path = self.root_path.join(path);
         match File::open(&full_path) {
-            Ok(file) => {
-                let reader: Box<Reader> = Box::new(FileReader(file));
-                Ok(reader)
-            }
+            Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
                     Err(AssetReaderError::NotFound(full_path))
@@ -104,14 +101,11 @@ impl AssetReader for FileAssetReader {
         }
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let meta_path = get_meta_path(path);
         let full_path = self.root_path.join(meta_path);
         match File::open(&full_path) {
-            Ok(file) => {
-                let reader: Box<Reader> = Box::new(FileReader(file));
-                Ok(reader)
-            }
+            Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
                     Err(AssetReaderError::NotFound(full_path))

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -42,6 +42,16 @@ impl AsyncSeek for FileReader {
     }
 }
 
+impl Reader for FileReader {
+    fn read_to_end<'a>(
+        &'a mut self,
+        buf: &'a mut Vec<u8>,
+    ) -> stackfuture::StackFuture<'a, std::io::Result<usize>, { crate::io::STACK_FUTURE_SIZE }>
+    {
+        stackfuture::StackFuture::from(async { self.0.read_to_end(buf) })
+    }
+}
+
 struct FileWriter(File);
 
 impl AsyncWrite for FileWriter {

--- a/crates/bevy_asset/src/io/gated.rs
+++ b/crates/bevy_asset/src/io/gated.rs
@@ -55,7 +55,7 @@ impl<R: AssetReader> GatedReader<R> {
 }
 
 impl<R: AssetReader> AssetReader for GatedReader<R> {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let receiver = {
             let mut gates = self.gates.write();
             let gates = gates
@@ -68,7 +68,7 @@ impl<R: AssetReader> AssetReader for GatedReader<R> {
         Ok(result)
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         self.reader.read_meta(path).await
     }
 

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -278,28 +278,22 @@ impl AsyncSeek for DataReader {
 }
 
 impl AssetReader for MemoryAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         self.root
             .get_asset(path)
-            .map(|data| {
-                let reader: Box<Reader> = Box::new(DataReader {
-                    data,
-                    bytes_read: 0,
-                });
-                reader
+            .map(|data| DataReader {
+                data,
+                bytes_read: 0,
             })
             .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         self.root
             .get_metadata(path)
-            .map(|data| {
-                let reader: Box<Reader> = Box::new(DataReader {
-                    data,
-                    bytes_read: 0,
-                });
-                reader
+            .map(|data| DataReader {
+                data,
+                bytes_read: 0,
             })
             .ok_or_else(|| AssetReaderError::NotFound(path.to_path_buf()))
     }

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -130,7 +130,7 @@ pub trait AssetReader: Send + Sync + 'static {
     /// The preferred style for implementing this method is an `async fn` returning an opaque type.
     ///
     /// ```no_run
-    /// # use bevy_asset::{prelude::*, io::{AssetReader, PathStream, Reader}};
+    /// # use bevy_asset::{prelude::*, io::{AssetReader, PathStream, Reader, AssetReaderError}};
     /// # struct MyReader;
     /// impl AssetReader for MyReader {
     ///     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -151,7 +151,7 @@ pub trait AssetReader: Send + Sync + 'static {
     ///     #     let val: Box<dyn Reader> = unimplemented!(); Ok(val) }
     ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Box<PathStream>, AssetReaderError> { unimplemented!() }
     ///     # async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> { unimplemented!() }
-    ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Vec<u8>, AssetReaderError> { unimplmented!() }
+    ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Vec<u8>, AssetReaderError> { unimplemented!() }
     /// }
     /// ```
     fn read<'a>(&'a self, path: &'a Path) -> impl ReaderFuture<'a>;

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -76,6 +76,12 @@ pub const STACK_FUTURE_SIZE: usize = 10 * std::mem::size_of::<&()>();
 
 pub use stackfuture::StackFuture;
 
+/// A type returned from [`AssetReader::read`], which is used to read the contents of a file
+/// (or virtual file) corresponding to an asset.
+///
+/// This is essentially a trait alias for types implementing  [`AsyncRead`] and [`AsyncSeek`].
+/// The only reason a blanket implementation is not provided for applicable types is to allow
+/// implementors to override the provided implementaiton of [`Reader::read_to_end`].
 pub trait Reader: AsyncRead + AsyncSeek + Unpin + Send + Sync {
     /// Reads the entire contents of this reader and appends them to a vec.
     ///

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -130,6 +130,7 @@ pub trait AssetReader: Send + Sync + 'static {
     /// The preferred style for implementing this method is an `async fn` returning an opaque type.
     ///
     /// ```no_run
+    /// # use std::path::Path;
     /// # use bevy_asset::{prelude::*, io::{AssetReader, PathStream, Reader, AssetReaderError}};
     /// # struct MyReader;
     /// impl AssetReader for MyReader {

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -72,6 +72,11 @@ impl From<std::io::Error> for AssetReaderError {
     }
 }
 
+/// The maximum size of a future returned from [`Reader::read_to_end`].
+/// This is large enough to fit ten references.
+// Ideally this would be even smaller (ReadToEndFuture only needs space for two references based on its definition),
+// but compiler optimizations can apparently inflate the stack size of futures due to inlining, which makes
+// a higher maximum necessary.
 pub const STACK_FUTURE_SIZE: usize = 10 * std::mem::size_of::<&()>();
 
 pub use stackfuture::StackFuture;

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -578,7 +578,7 @@ impl Reader for VecReader {
             if self.bytes_read >= self.bytes.len() {
                 Ok(0)
             } else {
-                buf.copy_from_slice(&self.bytes[self.bytes_read..]);
+                buf.extend_from_slice(&self.bytes[self.bytes_read..]);
                 let n = self.bytes.len() - self.bytes_read;
                 self.bytes_read = self.bytes.len();
                 Ok(n)
@@ -663,7 +663,7 @@ impl Reader for SliceReader<'_> {
             if self.bytes_read >= self.bytes.len() {
                 Ok(0)
             } else {
-                buf.copy_from_slice(&self.bytes[self.bytes_read..]);
+                buf.extend_from_slice(&self.bytes[self.bytes_read..]);
                 let n = self.bytes.len() - self.bytes_read;
                 self.bytes_read = self.bytes.len();
                 Ok(n)

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -103,6 +103,15 @@ pub trait Reader: AsyncRead + AsyncSeek + Unpin + Send + Sync {
     }
 }
 
+impl Reader for Box<dyn Reader + '_> {
+    fn read_to_end<'a>(
+        &'a mut self,
+        buf: &'a mut Vec<u8>,
+    ) -> StackFuture<'a, std::io::Result<usize>, STACK_FUTURE_SIZE> {
+        (**self).read_to_end(buf)
+    }
+}
+
 /// A future that returns a type implementing [`Reader`].
 pub trait ReaderFuture<'a>:
     ConditionalSendFuture<Output = Result<Self::Reader, AssetReaderError>>

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -145,13 +145,12 @@ pub trait AssetReader: Send + Sync + 'static {
     /// impl AssetReader for MyReader {
     ///     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
     ///         // ...
-    ///         # unimplemented!()
+    ///         # let val: Box<dyn Reader> = unimplemented!(); Ok(val)
     ///     }
     ///     # async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-    ///     #     unimplemented!()
-    ///     # }
-    ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Box<PathStream>, AssetReaderError> { unimplmented!() }
-    ///     # async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> { unimplmented!() }
+    ///     #     let val: Box<dyn Reader> = unimplemented!(); Ok(val) }
+    ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Box<PathStream>, AssetReaderError> { unimplemented!() }
+    ///     # async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> { unimplemented!() }
     ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Vec<u8>, AssetReaderError> { unimplmented!() }
     /// }
     /// ```

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -86,7 +86,7 @@ pub use stackfuture::StackFuture;
 ///
 /// This is essentially a trait alias for types implementing  [`AsyncRead`] and [`AsyncSeek`].
 /// The only reason a blanket implementation is not provided for applicable types is to allow
-/// implementors to override the provided implementaiton of [`Reader::read_to_end`].
+/// implementors to override the provided implementation of [`Reader::read_to_end`].
 pub trait Reader: AsyncRead + AsyncSeek + Unpin + Send + Sync {
     /// Reads the entire contents of this reader and appends them to a vec.
     ///

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -151,7 +151,7 @@ pub trait AssetReader: Send + Sync + 'static {
     ///     #     let val: Box<dyn Reader> = unimplemented!(); Ok(val) }
     ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Box<PathStream>, AssetReaderError> { unimplemented!() }
     ///     # async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> { unimplemented!() }
-    ///     # async fn read_directory<'a>(&'a self, path: &'a Path) -> Result<Vec<u8>, AssetReaderError> { unimplemented!() }
+    ///     # async fn read_meta_bytes<'a>(&'a self, path: &'a Path) -> Result<Vec<u8>, AssetReaderError> { unimplemented!() }
     /// }
     /// ```
     fn read<'a>(&'a self, path: &'a Path) -> impl ReaderFuture<'a>;

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -51,7 +51,7 @@ impl ProcessorGatedReader {
 }
 
 impl AssetReader for ProcessorGatedReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading {asset_path}");
         let process_result = self
@@ -67,11 +67,11 @@ impl AssetReader for ProcessorGatedReader {
         trace!("Processing finished with {asset_path}, reading {process_result:?}",);
         let lock = self.get_transaction_lock(&asset_path).await?;
         let asset_reader = self.reader.read(path).await?;
-        let reader: Box<Reader<'a>> = Box::new(TransactionLockedReader::new(asset_reader, lock));
+        let reader = TransactionLockedReader::new(asset_reader, lock);
         Ok(reader)
     }
 
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let asset_path = AssetPath::from(path.to_path_buf()).with_source(self.source.clone());
         trace!("Waiting for processing to finish before reading meta for {asset_path}",);
         let process_result = self
@@ -87,7 +87,7 @@ impl AssetReader for ProcessorGatedReader {
         trace!("Processing finished with {process_result:?}, reading meta for {asset_path}",);
         let lock = self.get_transaction_lock(&asset_path).await?;
         let meta_reader = self.reader.read_meta(path).await?;
-        let reader: Box<Reader<'a>> = Box::new(TransactionLockedReader::new(meta_reader, lock));
+        let reader = TransactionLockedReader::new(meta_reader, lock);
         Ok(reader)
     }
 
@@ -119,12 +119,12 @@ impl AssetReader for ProcessorGatedReader {
 
 /// An [`AsyncRead`] impl that will hold its asset's transaction lock until [`TransactionLockedReader`] is dropped.
 pub struct TransactionLockedReader<'a> {
-    reader: Box<Reader<'a>>,
+    reader: Box<dyn Reader + 'a>,
     _file_transaction_lock: RwLockReadGuardArc<()>,
 }
 
 impl<'a> TransactionLockedReader<'a> {
-    fn new(reader: Box<Reader<'a>>, file_transaction_lock: RwLockReadGuardArc<()>) -> Self {
+    fn new(reader: Box<dyn Reader + 'a>, file_transaction_lock: RwLockReadGuardArc<()>) -> Self {
         Self {
             reader,
             _file_transaction_lock: file_transaction_lock,

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -151,3 +151,12 @@ impl<'a> AsyncSeek for TransactionLockedReader<'a> {
         Pin::new(&mut self.reader).poll_seek(cx, pos)
     }
 }
+
+impl Reader for TransactionLockedReader<'_> {
+    fn read_to_end<'a>(
+        &'a mut self,
+        buf: &'a mut Vec<u8>,
+    ) -> stackfuture::StackFuture<'a, std::io::Result<usize>, { super::STACK_FUTURE_SIZE }> {
+        self.reader.read_to_end(buf)
+    }
+}

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -132,7 +132,7 @@ impl<'a> TransactionLockedReader<'a> {
     }
 }
 
-impl<'a> AsyncRead for TransactionLockedReader<'a> {
+impl AsyncRead for TransactionLockedReader<'_> {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
@@ -142,7 +142,7 @@ impl<'a> AsyncRead for TransactionLockedReader<'a> {
     }
 }
 
-impl<'a> AsyncSeek for TransactionLockedReader<'a> {
+impl AsyncSeek for TransactionLockedReader<'_> {
     fn poll_seek(
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -460,7 +460,6 @@ mod tests {
     use bevy_log::LogPlugin;
     use bevy_reflect::TypePath;
     use bevy_utils::{Duration, HashMap};
-    use futures_lite::AsyncReadExt;
     use serde::{Deserialize, Serialize};
     use std::{path::Path, sync::Arc};
     use thiserror::Error;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -583,13 +583,13 @@ mod tests {
         async fn read_meta<'a>(
             &'a self,
             path: &'a Path,
-        ) -> Result<Box<bevy_asset::io::Reader<'a>>, AssetReaderError> {
+        ) -> Result<impl bevy_asset::io::Reader + 'a, AssetReaderError> {
             self.memory_reader.read_meta(path).await
         }
         async fn read<'a>(
             &'a self,
             path: &'a Path,
-        ) -> Result<Box<bevy_asset::io::Reader<'a>>, bevy_asset::io::AssetReaderError> {
+        ) -> Result<impl bevy_asset::io::Reader + 'a, bevy_asset::io::AssetReaderError> {
             let attempt_number = {
                 let mut attempt_counters = self.attempt_counters.lock().unwrap();
                 if let Some(existing) = attempt_counters.get_mut(path) {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -510,7 +510,7 @@ mod tests {
 
         async fn load<'a>(
             &'a self,
-            reader: &'a mut Reader<'_>,
+            reader: &'a mut dyn Reader<'_>,
             _settings: &'a Self::Settings,
             load_context: &'a mut LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -510,7 +510,7 @@ mod tests {
 
         async fn load<'a>(
             &'a self,
-            reader: &'a mut dyn Reader<'_>,
+            reader: &'a mut dyn Reader,
             _settings: &'a Self::Settings,
             load_context: &'a mut LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -9,7 +9,6 @@ use crate::{
 use bevy_ecs::world::World;
 use bevy_utils::{BoxedFuture, ConditionalSendFuture, CowArc, HashMap, HashSet};
 use downcast_rs::{impl_downcast, Downcast};
-use futures_lite::AsyncReadExt;
 use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -30,7 +30,7 @@ pub trait AssetLoader: Send + Sync + 'static {
     /// Asynchronously loads [`AssetLoader::Asset`] (and any other labeled assets) from the bytes provided by [`Reader`].
     fn load<'a>(
         &'a self,
-        reader: &'a mut Reader,
+        reader: &'a mut dyn Reader,
         settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
     ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>>;
@@ -47,7 +47,7 @@ pub trait ErasedAssetLoader: Send + Sync + 'static {
     /// Asynchronously loads the asset(s) from the bytes provided by [`Reader`].
     fn load<'a>(
         &'a self,
-        reader: &'a mut Reader,
+        reader: &'a mut dyn Reader,
         meta: Box<dyn AssetMetaDyn>,
         load_context: LoadContext<'a>,
     ) -> BoxedFuture<
@@ -78,7 +78,7 @@ where
     /// Processes the asset in an asynchronous closure.
     fn load<'a>(
         &'a self,
-        reader: &'a mut Reader,
+        reader: &'a mut dyn Reader,
         meta: Box<dyn AssetMetaDyn>,
         mut load_context: LoadContext<'a>,
     ) -> BoxedFuture<
@@ -519,7 +519,7 @@ impl<'a> LoadContext<'a> {
         path: AssetPath<'static>,
         meta: Box<dyn AssetMetaDyn>,
         loader: &dyn ErasedAssetLoader,
-        reader: &mut Reader<'_>,
+        reader: &mut dyn Reader,
     ) -> Result<ErasedLoadedAsset, LoadDirectError> {
         let loaded_asset = self
             .asset_server

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -12,12 +12,12 @@ use std::sync::Arc;
 
 // Utility type for handling the sources of reader references
 enum ReaderRef<'a, 'b> {
-    Borrowed(&'a mut Reader<'b>),
-    Boxed(Box<Reader<'b>>),
+    Borrowed(&'a mut (dyn Reader + 'b)),
+    Boxed(Box<dyn Reader + 'b>),
 }
 
 impl<'a, 'b> ReaderRef<'a, 'b> {
-    pub fn as_mut(&mut self) -> &mut Reader {
+    pub fn as_mut(&mut self) -> &mut dyn Reader {
         match self {
             ReaderRef::Borrowed(r) => r,
             ReaderRef::Boxed(b) => &mut *b,
@@ -168,13 +168,13 @@ impl<'ctx, 'builder> UntypedNestedLoader<'ctx, 'builder> {
 /// - `reader`: the lifetime of the [`Reader`] reference used to read the asset data
 pub struct DirectNestedLoader<'ctx, 'builder, 'reader> {
     base: NestedLoader<'ctx, 'builder>,
-    reader: Option<&'builder mut Reader<'reader>>,
+    reader: Option<&'builder mut (dyn Reader + 'reader)>,
 }
 
 impl<'ctx: 'reader, 'builder, 'reader> DirectNestedLoader<'ctx, 'builder, 'reader> {
     /// Specify the reader to use to read the asset data.
     #[must_use]
-    pub fn with_reader(mut self, reader: &'builder mut Reader<'reader>) -> Self {
+    pub fn with_reader(mut self, reader: &'builder mut (dyn Reader + 'reader)) -> Self {
         self.reader = Some(reader);
         self
     }

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -11,16 +11,16 @@ use std::any::TypeId;
 use std::sync::Arc;
 
 // Utility type for handling the sources of reader references
-enum ReaderRef<'a, 'b> {
-    Borrowed(&'a mut (dyn Reader + 'b)),
-    Boxed(Box<dyn Reader + 'b>),
+enum ReaderRef<'a> {
+    Borrowed(&'a mut dyn Reader),
+    Boxed(Box<dyn Reader + 'a>),
 }
 
-impl<'a, 'b> ReaderRef<'a, 'b> {
+impl ReaderRef<'_> {
     pub fn as_mut(&mut self) -> &mut dyn Reader {
         match self {
-            ReaderRef::Borrowed(r) => r,
-            ReaderRef::Boxed(b) => &mut *b,
+            ReaderRef::Borrowed(r) => &mut **r,
+            ReaderRef::Boxed(b) => &mut **b,
         }
     }
 }

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -196,7 +196,7 @@ impl AssetLoader for () {
     type Error = std::io::Error;
     async fn load<'a>(
         &'a self,
-        _reader: &'a mut crate::io::Reader<'_>,
+        _reader: &'a mut dyn crate::io::Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut crate::LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -382,7 +382,7 @@ mod tests {
 
         async fn load<'a>(
             &'a self,
-            _: &'a mut crate::io::Reader<'_>,
+            _: &'a mut dyn crate::io::Reader<'_>,
             _: &'a Self::Settings,
             _: &'a mut crate::LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -382,7 +382,7 @@ mod tests {
 
         async fn load<'a>(
             &'a self,
-            _: &'a mut dyn crate::io::Reader<'_>,
+            _: &'a mut dyn crate::io::Reader,
             _: &'a Self::Settings,
             _: &'a mut crate::LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -310,7 +310,7 @@ impl<T: AssetLoader> AssetLoader for InstrumentedAssetLoader<T> {
 
     fn load<'a>(
         &'a self,
-        reader: &'a mut crate::io::Reader,
+        reader: &'a mut dyn crate::io::Reader,
         settings: &'a Self::Settings,
         load_context: &'a mut crate::LoadContext,
     ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1064,7 +1064,7 @@ impl AssetServer {
         (
             Box<dyn AssetMetaDyn>,
             Arc<dyn ErasedAssetLoader>,
-            Box<Reader<'a>>,
+            Box<dyn Reader + 'a>,
         ),
         AssetLoadError,
     > {
@@ -1168,7 +1168,7 @@ impl AssetServer {
         asset_path: &AssetPath<'_>,
         meta: Box<dyn AssetMetaDyn>,
         loader: &dyn ErasedAssetLoader,
-        reader: &mut Reader<'_>,
+        reader: &mut dyn Reader,
         load_dependencies: bool,
         populate_hashes: bool,
     ) -> Result<ErasedLoadedAsset, AssetLoadError> {

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -46,7 +46,7 @@ impl AssetLoader for AudioLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<AudioSource, Self::Error> {

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -1,7 +1,4 @@
-use bevy_asset::{
-    io::{AsyncReadExt, Reader},
-    Asset, AssetLoader, LoadContext,
-};
+use bevy_asset::{io::Reader, Asset, AssetLoader, LoadContext};
 use bevy_reflect::TypePath;
 use std::{io::Cursor, sync::Arc};
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -173,7 +173,7 @@ impl AssetLoader for GltfLoader {
     type Error = GltfError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         settings: &'a GltfLoaderSettings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Gltf, Self::Error> {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -6,7 +6,7 @@ use crate::{
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::{AnimationTarget, AnimationTargetId};
 use bevy_asset::{
-    io::Reader, AssetLoadError, AssetLoader, AsyncReadExt, Handle, LoadContext, ReadAssetBytesError,
+    io::Reader, AssetLoadError, AssetLoader, Handle, LoadContext, ReadAssetBytesError,
 };
 use bevy_color::{Color, LinearRgba};
 use bevy_core::Name;

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -1,7 +1,7 @@
 use bevy_asset::{
     io::{Reader, Writer},
     saver::{AssetSaver, SavedAsset},
-    Asset, AssetLoader, AsyncReadExt, AsyncWriteExt, LoadContext,
+    Asset, AssetLoader, AsyncWriteExt, LoadContext,
 };
 use bevy_math::Vec3;
 use bevy_reflect::TypePath;

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -85,7 +85,7 @@ impl AssetLoader for MeshletMeshSaverLoad {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -1,5 +1,5 @@
 use bevy_asset::{
-    io::{AsyncReadAndSeek, Reader, Writer},
+    io::{Reader, Writer},
     saver::{AssetSaver, SavedAsset},
     Asset, AssetLoader, AsyncReadExt, AsyncWriteExt, LoadContext,
 };
@@ -144,9 +144,7 @@ pub enum MeshletMeshSaveOrLoadError {
     Io(#[from] std::io::Error),
 }
 
-async fn read_u64(
-    reader: &mut (dyn AsyncReadAndSeek + Sync + Send + Unpin),
-) -> Result<u64, bincode::Error> {
+async fn read_u64(reader: &mut dyn Reader) -> Result<u64, bincode::Error> {
     let mut bytes = [0u8; 8];
     reader.read_exact(&mut bytes).await?;
     Ok(u64::from_le_bytes(bytes))

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -85,7 +85,7 @@ impl AssetLoader for MeshletMeshSaverLoad {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -6,6 +6,7 @@ use bevy_asset::{
 use bevy_math::Vec3;
 use bevy_reflect::TypePath;
 use bytemuck::{Pod, Zeroable};
+use futures_lite::AsyncReadExt;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use serde::{Deserialize, Serialize};
 use std::{io::Cursor, sync::Arc};

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -1,12 +1,11 @@
 use bevy_asset::{
     io::{Reader, Writer},
     saver::{AssetSaver, SavedAsset},
-    Asset, AssetLoader, AsyncWriteExt, LoadContext,
+    Asset, AssetLoader, AsyncReadExt, AsyncWriteExt, LoadContext,
 };
 use bevy_math::Vec3;
 use bevy_reflect::TypePath;
 use bytemuck::{Pod, Zeroable};
-use futures_lite::AsyncReadExt;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use serde::{Deserialize, Serialize};
 use std::{io::Cursor, sync::Arc};

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -261,7 +261,7 @@ impl AssetLoader for ShaderLoader {
     type Error = ShaderLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Shader, Self::Error> {

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -3,7 +3,6 @@ use crate::define_atomic_id;
 use bevy_asset::{io::Reader, Asset, AssetLoader, AssetPath, Handle, LoadContext};
 use bevy_reflect::TypePath;
 use bevy_utils::tracing::error;
-use futures_lite::AsyncReadExt;
 use std::{borrow::Cow, marker::Copy};
 use thiserror::Error;
 

--- a/crates/bevy_render/src/texture/exr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/exr_texture_loader.rs
@@ -2,10 +2,7 @@ use crate::{
     render_asset::RenderAssetUsages,
     texture::{Image, TextureFormatPixelInfo},
 };
-use bevy_asset::{
-    io::{AsyncReadExt, Reader},
-    AssetLoader, LoadContext,
-};
+use bevy_asset::{io::Reader, AssetLoader, LoadContext};
 use image::ImageDecoder;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/bevy_render/src/texture/exr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/exr_texture_loader.rs
@@ -37,7 +37,7 @@ impl AssetLoader for ExrTextureLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {

--- a/crates/bevy_render/src/texture/exr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/exr_texture_loader.rs
@@ -37,7 +37,7 @@ impl AssetLoader for ExrTextureLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {

--- a/crates/bevy_render/src/texture/hdr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/hdr_texture_loader.rs
@@ -32,7 +32,7 @@ impl AssetLoader for HdrTextureLoader {
     type Error = HdrTextureLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {

--- a/crates/bevy_render/src/texture/hdr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/hdr_texture_loader.rs
@@ -2,7 +2,7 @@ use crate::{
     render_asset::RenderAssetUsages,
     texture::{Image, TextureFormatPixelInfo},
 };
-use bevy_asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext};
+use bevy_asset::{io::Reader, AssetLoader, LoadContext};
 use image::DynamicImage;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -1,4 +1,4 @@
-use bevy_asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext};
+use bevy_asset::{io::Reader, AssetLoader, LoadContext};
 use bevy_ecs::prelude::{FromWorld, World};
 use thiserror::Error;
 

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -88,7 +88,7 @@ impl AssetLoader for ImageLoader {
     type Error = ImageLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         settings: &'a ImageLoaderSettings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -47,7 +47,7 @@ impl AssetLoader for SceneLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -2,7 +2,7 @@ use crate::ron;
 #[cfg(feature = "serialize")]
 use crate::serde::SceneDeserializer;
 use crate::DynamicScene;
-use bevy_asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext};
+use bevy_asset::{io::Reader, AssetLoader, LoadContext};
 use bevy_ecs::reflect::AppTypeRegistry;
 use bevy_ecs::world::{FromWorld, World};
 use bevy_reflect::TypeRegistryArc;

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -1,5 +1,5 @@
 use crate::Font;
-use bevy_asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext};
+use bevy_asset::{io::Reader, AssetLoader, LoadContext};
 use thiserror::Error;
 
 #[derive(Default)]

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -23,7 +23,7 @@ impl AssetLoader for FontLoader {
     type Error = FontLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Font, Self::Error> {

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -3,7 +3,7 @@
 use bevy::{
     asset::{
         io::{Reader, VecReader},
-        AssetLoader, AsyncReadExt, ErasedLoadedAsset, LoadContext, LoadDirectError,
+        AssetLoader, ErasedLoadedAsset, LoadContext, LoadDirectError,
     },
     prelude::*,
     reflect::TypePath,

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -42,7 +42,7 @@ impl AssetLoader for GzAssetLoader {
     type Error = GzAssetLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         _settings: &'a (),
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -42,7 +42,7 @@ impl AssetLoader for GzAssetLoader {
     type Error = GzAssetLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a (),
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -1,7 +1,7 @@
 //! Implements loader for a custom asset type.
 
 use bevy::{
-    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    asset::{io::Reader, AssetLoader, LoadContext},
     prelude::*,
     reflect::TypePath,
 };

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -35,7 +35,7 @@ impl AssetLoader for CustomAssetLoader {
     type Error = CustomAssetLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         _settings: &'a (),
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
@@ -74,7 +74,7 @@ impl AssetLoader for BlobAssetLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         _settings: &'a (),
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -35,7 +35,7 @@ impl AssetLoader for CustomAssetLoader {
     type Error = CustomAssetLoaderError;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
@@ -74,7 +74,7 @@ impl AssetLoader for BlobAssetLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {

--- a/examples/asset/custom_asset_reader.rs
+++ b/examples/asset/custom_asset_reader.rs
@@ -19,7 +19,7 @@ impl AssetReader for CustomAssetReader {
         info!("Reading {:?}", path);
         self.0.read(path).await
     }
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Reader + 'a, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         self.0.read_meta(path).await
     }
 

--- a/examples/asset/custom_asset_reader.rs
+++ b/examples/asset/custom_asset_reader.rs
@@ -15,11 +15,11 @@ use std::path::Path;
 struct CustomAssetReader(Box<dyn ErasedAssetReader>);
 
 impl AssetReader for CustomAssetReader {
-    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         info!("Reading {:?}", path);
         self.0.read(path).await
     }
-    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<Reader + 'a, AssetReaderError> {
         self.0.read_meta(path).await
     }
 

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -83,7 +83,7 @@ impl AssetLoader for TextLoader {
     type Error = std::io::Error;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         settings: &'a TextSettings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Text, Self::Error> {
@@ -137,7 +137,7 @@ impl AssetLoader for CoolTextLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader<'_>,
+        reader: &'a mut dyn Reader<'_>,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<CoolText, Self::Error> {

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -7,7 +7,7 @@ use bevy::{
         processor::LoadTransformAndSave,
         saver::{AssetSaver, SavedAsset},
         transformer::{AssetTransformer, TransformedAsset},
-        AssetLoader, AsyncReadExt, AsyncWriteExt, LoadContext,
+        AssetLoader, AsyncWriteExt, LoadContext,
     },
     prelude::*,
     reflect::TypePath,

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -83,7 +83,7 @@ impl AssetLoader for TextLoader {
     type Error = std::io::Error;
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         settings: &'a TextSettings,
         _load_context: &'a mut LoadContext<'_>,
     ) -> Result<Text, Self::Error> {
@@ -137,7 +137,7 @@ impl AssetLoader for CoolTextLoader {
 
     async fn load<'a>(
         &'a self,
-        reader: &'a mut dyn Reader<'_>,
+        reader: &'a mut dyn Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<CoolText, Self::Error> {


### PR DESCRIPTION
# Objective

The `AssetReader` trait allows customizing the behavior of fetching bytes for an `AssetPath`, and expects implementors to return `dyn AsyncRead + AsyncSeek`. This gives implementors of `AssetLoader` great flexibility to tightly integrate their asset loading behavior with the asynchronous task system.

However, almost all implementors of `AssetLoader` don't use the async functionality at all, and just call `AsyncReadExt::read_to_end(&mut Vec<u8>)`. This is incredibly inefficient, as this method repeatedly calls `poll_read` on the trait object, filling the vector 32 bytes at a time. At my work we have assets that are hundreds of megabytes which makes this a meaningful overhead.

## Solution

Turn the `Reader` type alias into an actual trait, with a provided method `read_to_end`. This provided method should be more efficient than the existing extension method, as the compiler will know the underlying type of `Reader` when generating this function, which removes the repeated dynamic dispatches and allows the compiler to make further optimizations after inlining. Individual implementors are able to override the provided implementation -- for simple asset readers that just copy bytes from one buffer to another, this allows removing a large amount of overhead from the provided implementation.

Now that `Reader` is an actual trait, I also improved the ergonomics for implementing `AssetReader`. Currently, implementors are expected to box their reader and return it as a trait object, which adds unnecessary boilerplate to implementations. This PR changes that trait method to return a pseudo trait alias, which allows implementors to return `impl Reader` instead of `Box<dyn Reader>`. Now, the boilerplate for boxing occurs in `ErasedAssetReader`.

## Testing

I made identical changes to my company's fork of bevy. Our app, which makes heavy use of `read_to_end` for asset loading, still worked properly after this. I am not aware if we have a more systematic way of testing asset loading for correctness.

---

## Migration Guide

The trait method `bevy_asset::io::AssetReader::read` (and `read_meta`) now return an opaque type instead of a boxed trait object. Implementors of these methods should change the type signatures appropriately

```rust
impl AssetReader for MyReader {
    // Before
    async fn read<'a>(&'a self, path: &'a Path) -> Result<Box<Reader<'a>>, AssetReaderError> {
        let reader = // construct a reader
        Box::new(reader) as Box<Reader<'a>>
    }

    // After
    async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
        // create a reader
    }
}
```

`bevy::asset::io::Reader` is now a trait, rather than a type alias for a trait object. Implementors of `AssetLoader::load` will need to adjust the method signature accordingly

```rust
impl AssetLoader for MyLoader {
    async fn load<'a>(
        &'a self,
        // Before:
        reader: &'a mut bevy::asset::io::Reader,
        // After:
        reader: &'a mut dyn bevy::asset::io::Reader,
        _: &'a Self::Settings,
        load_context: &'a mut LoadContext<'_>,
    ) -> Result<Self::Asset, Self::Error> {
}
```

Additionally, implementors of `AssetReader` that return a type implementing `futures_io::AsyncRead` and `AsyncSeek` might need to explicitly implement `bevy::asset::io::Reader` for that type.

```rust
impl bevy::asset::io::Reader for MyAsyncReadAndSeek {}
```