### PR TITLE
deregister events

### DIFF
--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -281,6 +281,25 @@ mod tests {
     }
 
     #[test]
+    fn test_event_registry_can_add_and_remove_events_to_world() {
+        use bevy_ecs::prelude::*;
+
+        let mut world = World::new();
+        EventRegistry::register_event::<TestEvent>(&mut world);
+
+        let has_events = world.get_resource::<Events<TestEvent>>().is_some();
+
+        assert!(has_events, "Should have the events resource");
+
+        EventRegistry::deregister_events::<TestEvent>(&mut world);
+
+
+        let has_events = world.get_resource::<Events<TestEvent>>().is_some();
+
+        assert!(!has_events, "Should not have the events resource");
+    }
+
+    #[test]
     fn test_update_drain() {
         let mut events = Events::<TestEvent>::default();
         let mut reader = events.get_reader();

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -293,7 +293,6 @@ mod tests {
 
         EventRegistry::deregister_events::<TestEvent>(&mut world);
 
-
         let has_events = world.get_resource::<Events<TestEvent>>().is_some();
 
         assert!(!has_events, "Should not have the events resource");

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -104,7 +104,7 @@ impl EventRegistry {
         }
     }
 
-    /// Removes an event from the world and it's associated EventRegistry
+    /// Removes an event from the world and it's associated [`EventRegistry`].
     pub fn deregister_events<T: Event>(world: &mut World) {
         let component_id = world.init_resource::<Events<T>>();
         let mut registry = world.get_resource_or_insert_with(Self::default);

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -45,35 +45,12 @@ impl EventRegistry {
     ///
     /// If no instance of the [`EventRegistry`] exists in the world, this will add one - otherwise it will use
     /// the existing instance.
-    ///
-    /// In contrast, [`EventRegistry::register_event_with_instance<T: Event>`] will register the events
-    /// to be updated by that specific instance rather.
     pub fn register_event<T: Event>(world: &mut World) {
         // By initializing the resource here, we can be sure that it is present,
         // and receive the correct, up-to-date `ComponentId` even if it was previously removed.
         let component_id = world.init_resource::<Events<T>>();
         let mut registry = world.get_resource_or_insert_with(Self::default);
         registry.event_updates.push(RegisteredEvent {
-            component_id,
-            previously_updated: false,
-            update: |ptr| {
-                // SAFETY: The resource was initialized with the type Events<T>.
-                unsafe { ptr.with_type::<Events<T>>() }
-                    .bypass_change_detection()
-                    .update();
-            },
-        });
-    }
-
-    /// Registers an event type from a give [`World`] to be updated bt th
-    ///
-    /// In contrast, [`EventRegistry::register_event<T: Event>`] will register the events
-    /// to be updated by the instance tied to the world.
-    pub fn register_event_with_instance<T: Event>(&mut self, world: &mut World) {
-        // By initializing the resource here, we can be sure that it is present,
-        // and receive the correct, up-to-date `ComponentId` even if it was previously removed.
-        let component_id = world.init_resource::<Events<T>>();
-        self.event_updates.push(RegisteredEvent {
             component_id,
             previously_updated: false,
             update: |ptr| {
@@ -110,17 +87,6 @@ impl EventRegistry {
         let mut registry = world.get_resource_or_insert_with(Self::default);
         registry
             .event_updates
-            .retain(|e| e.component_id != component_id);
-        world.remove_resource::<Events<T>>();
-    }
-
-    /// Removes an event from this registry and world
-    ///
-    /// In contrast, [`EventRegistry::deregister_events<T>`] will remove the events from the world's
-    /// main event registry
-    pub fn deregister_events_with_instance<T: Event>(&mut self, world: &mut World) {
-        let component_id = world.init_resource::<Events<T>>();
-        self.event_updates
             .retain(|e| e.component_id != component_id);
         world.remove_resource::<Events<T>>();
     }

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -83,7 +83,18 @@ impl EventRegistry {
         let component_id = world.init_resource::<Events<T>>();
         world.remove_resource::<Events<T>>();
         let mut registry = world.get_resource_or_insert_with(Self::default);
-        let Some(index) = registry.event_updates.iter().enumerate().find_map(|(i, e)| if e.component_id == component_id { Some(i) } else { None }) else {
+        let Some(index) = registry
+            .event_updates
+            .iter()
+            .enumerate()
+            .find_map(|(i, e)| {
+                if e.component_id == component_id {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+        else {
             return;
         };
         registry.event_updates.remove(index);

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -43,7 +43,7 @@ pub enum ShouldUpdateEvents {
 impl EventRegistry {
     /// Registers an event type to be updated in a given [`World`]
     ///
-    /// If no instance of the EventRegistry exists in the world, this will add one - otherwise it will use
+    /// If no instance of the [`EventRegistry`] exists in the world, this will add one - otherwise it will use
     /// the existing instance.
     ///
     /// In contrast, [`EventRegistry::register_event_with_instance<T: Event>`] will register the events

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -41,13 +41,39 @@ pub enum ShouldUpdateEvents {
 }
 
 impl EventRegistry {
-    /// Registers an event type to be updated.
+    /// Registers an event type to be updated in a given [`World`]
+    ///
+    /// If no instance of the EventRegistry exists in the world, this will add one - otherwise it will use
+    /// the existing instance.
+    ///
+    /// In contrast, [`EventRegistry::register_event_with_instance<T: Event>`] will register the events
+    /// to be updated by that specific instance rather.
     pub fn register_event<T: Event>(world: &mut World) {
         // By initializing the resource here, we can be sure that it is present,
         // and receive the correct, up-to-date `ComponentId` even if it was previously removed.
         let component_id = world.init_resource::<Events<T>>();
         let mut registry = world.get_resource_or_insert_with(Self::default);
         registry.event_updates.push(RegisteredEvent {
+            component_id,
+            previously_updated: false,
+            update: |ptr| {
+                // SAFETY: The resource was initialized with the type Events<T>.
+                unsafe { ptr.with_type::<Events<T>>() }
+                    .bypass_change_detection()
+                    .update();
+            },
+        });
+    }
+
+    /// Registers an event type from a give [`World`] to be updated bt th
+    ///
+    /// In contrast, [`EventRegistry::register_event<T: Event>`] will register the events
+    /// to be updated by the instance tied to the world.
+    pub fn register_event_with_instance<T: Event>(&mut self, world: &mut World) {
+        // By initializing the resource here, we can be sure that it is present,
+        // and receive the correct, up-to-date `ComponentId` even if it was previously removed.
+        let component_id = world.init_resource::<Events<T>>();
+        self.event_updates.push(RegisteredEvent {
             component_id,
             previously_updated: false,
             update: |ptr| {
@@ -78,25 +104,24 @@ impl EventRegistry {
         }
     }
 
-    /// Removes an event from the registry and world
+    /// Removes an event from the world and it's associated EventRegistry
     pub fn deregister_events<T: Event>(world: &mut World) {
         let component_id = world.init_resource::<Events<T>>();
-        world.remove_resource::<Events<T>>();
         let mut registry = world.get_resource_or_insert_with(Self::default);
-        let Some(index) = registry
+        registry
             .event_updates
-            .iter()
-            .enumerate()
-            .find_map(|(i, e)| {
-                if e.component_id == component_id {
-                    Some(i)
-                } else {
-                    None
-                }
-            })
-        else {
-            return;
-        };
-        registry.event_updates.remove(index);
+            .retain(|e| e.component_id != component_id);
+        world.remove_resource::<Events<T>>();
+    }
+
+    /// Removes an event from this registry and world
+    ///
+    /// In contrast, [`EventRegistry::deregister_events<T>`] will remove the events from the world's
+    /// main event registry
+    pub fn deregister_events_with_instance<T: Event>(&mut self, world: &mut World) {
+        let component_id = world.init_resource::<Events<T>>();
+        self.event_updates
+            .retain(|e| e.component_id != component_id);
+        world.remove_resource::<Events<T>>();
     }
 }

--- a/crates/bevy_ecs/src/event/registry.rs
+++ b/crates/bevy_ecs/src/event/registry.rs
@@ -77,4 +77,15 @@ impl EventRegistry {
             }
         }
     }
+
+    /// Removes an event from the registry and world
+    pub fn deregister_events<T: Event>(world: &mut World) {
+        let component_id = world.init_resource::<Events<T>>();
+        world.remove_resource::<Events<T>>();
+        let mut registry = world.get_resource_or_insert_with(Self::default);
+        let Some(index) = registry.event_updates.iter().enumerate().find_map(|(i, e)| if e.component_id == component_id { Some(i) } else { None }) else {
+            return;
+        };
+        registry.event_updates.remove(index);
+    }
 }


### PR DESCRIPTION
# Objective

Add ability to de-register events from the EventRegistry (and the associated World).

The initial reasoning relates to retaining support for Event hot reloading in `dexterous_developer`.

## Solution

Add a `deregister_events<T: Event>(&mut world)` method to the `EventRegistry` struct.

## Testing

Added an automated test that verifies the event registry adds and removes `Events<T>` from the world.
