### PR TITLE
Bump rodio to 0.19

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -23,13 +23,13 @@ bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 
 # other
-rodio = { version = "0.18", default-features = false }
+rodio = { version = "0.19", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 cpal = { version = "0.15", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.18", default-features = false, features = [
+rodio = { version = "0.19", default-features = false, features = [
   "wasm-bindgen",
 ] }
 


### PR DESCRIPTION
# Objective

- Though Rodio will eventually be replaced with Kira for `bevy_audio`, we should not let it languish.

## Solution

- Bump Rodio to 0.19.
  - This is [the changelog](https://github.com/RustAudio/rodio/blob/27f2b424060ff4a977285ff83ecd6c076205c121/CHANGELOG.md#version-0190-2024-06-29). No apparent breaking changes, only 1 feature and 1 fix.

## Testing

- Run an example that uses audio, on both native and WASM.

---

## Changelog

- Bumped Rodio to 0.19.
