### PR TITLE
Bump `accesskit` to 0.16

### DIFF
--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -14,7 +14,7 @@ bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 
-accesskit = "0.15"
+accesskit = "0.16"
 
 [lints]
 workspace = true

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -124,14 +124,14 @@ fn label_changed(
             .collect::<Vec<String>>();
         let name = Some(values.join(" ").into_boxed_str());
         if let Some(mut accessible) = accessible {
-            accessible.set_role(Role::StaticText);
+            accessible.set_role(Role::Label);
             if let Some(name) = name {
                 accessible.set_name(name);
             } else {
                 accessible.clear_name();
             }
         } else {
-            let mut node = NodeBuilder::new(Role::StaticText);
+            let mut node = NodeBuilder::new(Role::Label);
             if let Some(name) = name {
                 node.set_name(name);
             }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -33,7 +33,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 # other
 # feature rwh_06 refers to window_raw_handle@v0.6
 winit = { version = "0.30", default-features = false, features = ["rwh_06"] }
-accesskit_winit = { version = "0.21", default-features = false, features = [
+accesskit_winit = { version = "0.22", default-features = false, features = [
   "rwh_06",
 ] }
 approx = { version = "0.5", default-features = false }


### PR DESCRIPTION
Also bumps `accesskit_winit` to 0.22 and fixes one breaking change.

# Objective

- `accesskit` has been updated recently to 0.16!

## Solution

- Update `accesskit`, as well as `accesskit_winit`.
  - [`accesskit` changelog](https://github.com/AccessKit/accesskit/blob/552032c8393ccaa7c900b861de059da00d789544/common/CHANGELOG.md#0160-2024-06-29)
  - [`accesskit_winit` changelog](https://github.com/AccessKit/accesskit/blob/552032c8393ccaa7c900b861de059da00d789544/platforms/winit/CHANGELOG.md#0220-2024-06-29)
- Fix one breaking change where `Role::StaticText` has been renamed to `Role::Label`.

## Testing

- The test suite should cover most things.
- It would be good to test this with an example, but I don't know how.

---

## Changelog

- Update `accesskit` to 0.16 and `accesskit_winit` to 0.22.

## Migration Guide

`accesskit`'s `Role::StaticText` variant has been renamed to `Role::Label`.