### PR TITLE
Fix footgun for Windows users in `fast_config.toml`

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -136,7 +136,7 @@ rustflags = [
 linker = "rust-lld.exe"
 rustflags = [
   # Nightly
-  # "-Zshare-generics=y",
+  # "-Zshare-generics=n", # This needs to be off if you use dynamic linking on Windows.
   # "-Zthreads=0",
 ]
 


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/13136 changed the default value of `-Zshare-generics=n` to `-Zshare-generics=y` on Windows
- New users are encouraged to use dynamic builds and LLD when setting up Bevy
- New users are also encouraged to check out `fast_config.toml`
- https://github.com/bevyengine/bevy/issues/1126 means that running dynamic builds, using LLD and sharing generics on Windows results in a cryptic error message

As a result, a new Windows user following all recommendations for better compilation times is actually not able to compile Bevy at all.

## Solution

- Set `-Zshare-generics=n` on Windows with a comment saying this is for dynamic linking

## Testing

I verified that https://github.com/bevyengine/bevy/issues/1126 is still happening on the current nightly (1.80)

## Additional Info

Maybe the website should mention this as well? The relevant snippet there looks like this:
```toml
# /path/to/project/.cargo/config.toml
[target.x86_64-unknown-linux-gnu]
rustflags = [
  # (Nightly) Make the current crate share its generic instantiations
  "-Zshare-generics=y",
]
```
so it kinda implies it's only for Linux? Which is not quite true, this setting works on macOS as well AFAIK
