### PR TITLE
Fix `push_children` inserting a `Children` component even when no children are supplied

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -1214,4 +1214,14 @@ mod tests {
         let children = query.get(&world, parent).unwrap();
         assert_eq!(**children, [child]);
     }
+
+    #[test]
+    fn push_children_does_not_insert_empty_children() {
+        let mut world = World::new();
+        let parent = world.spawn_empty().push_children(&[]).id();
+
+        let mut query = world.query::<&Children>();
+        let children = query.get(&world, parent);
+        assert!(children.is_err());
+    }
 }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -584,6 +584,10 @@ impl BuildChildren for EntityWorldMut<'_> {
     }
 
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
+        if children.is_empty() {
+            return self;
+        }
+
         let parent = self.id();
         if children.contains(&parent) {
             panic!("Cannot push entity as a child of itself.");


### PR DESCRIPTION
# Objective

The Bevy API around manipulating hierarchies removes `Children` if the operation results in an entity having no children. This means that `Children` is guaranteed to hold actual children. However, the following code unexpectedly inserts empty `Children`:

```rust
commands.entity(entity).with_children(|_| {});
```

This was discovered by @Jondolf: https://discord.com/channels/691052431525675048/1124043933886976171/1257660865625325800

## Solution

- `with_children` is now a noop when no children were passed

## Testing

- Added a regression test

