### PR TITLE
Fix border color in `ui_texture_slice` and `ui_texture_atlas_slice` examples.

### DIFF
--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -19,31 +19,26 @@ fn main() {
 
 fn button_system(
     mut interaction_query: Query<
-        (
-            &Interaction,
-            &mut TextureAtlas,
-            &Children,
-            &mut BackgroundColor,
-        ),
+        (&Interaction, &mut TextureAtlas, &Children, &mut UiImage),
         (Changed<Interaction>, With<Button>),
     >,
     mut text_query: Query<&mut Text>,
 ) {
-    for (interaction, mut atlas, children, mut color) in &mut interaction_query {
+    for (interaction, mut atlas, children, mut image) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
                 text.sections[0].value = "Press".to_string();
                 atlas.index = (atlas.index + 1) % 30;
-                *color = GOLD.into();
+                image.color = GOLD.into();
             }
             Interaction::Hovered => {
                 text.sections[0].value = "Hover".to_string();
-                *color = ORANGE.into();
+                image.color = ORANGE.into();
             }
             Interaction::None => {
                 text.sections[0].value = "Button".to_string();
-                *color = Color::BLACK.into();
+                image.color = Color::WHITE;
             }
         }
     }

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -19,25 +19,25 @@ fn main() {
 
 fn button_system(
     mut interaction_query: Query<
-        (&Interaction, &Children, &mut BackgroundColor),
+        (&Interaction, &Children, &mut UiImage),
         (Changed<Interaction>, With<Button>),
     >,
     mut text_query: Query<&mut Text>,
 ) {
-    for (interaction, children, mut color) in &mut interaction_query {
+    for (interaction, children, mut image) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {
                 text.sections[0].value = "Press".to_string();
-                *color = GOLD.into();
+                image.color = GOLD.into();
             }
             Interaction::Hovered => {
                 text.sections[0].value = "Hover".to_string();
-                *color = ORANGE.into();
+                image.color = ORANGE.into();
             }
             Interaction::None => {
                 text.sections[0].value = "Button".to_string();
-                *color = Color::BLACK.into();
+                image.color = Color::WHITE;
             }
         }
     }


### PR DESCRIPTION
# Objective

Fixes #14120

`ui_texture_slice` and `ui_texture_atlas_slice` were working as intended, so undo the changes.

## Solution

Partially revert https://github.com/bevyengine/bevy/pull/14115 for `ui_texture_slice` and `ui_texture_atlas_slice`.

## Testing

Ran those two examples, confirmed the border color is the thing that changes when buttons are hovered.
