### PR TITLE
Fix crash when an asset load failure event is processed after asset drop

### DIFF
--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -588,9 +588,10 @@ impl AssetInfos {
 
     pub(crate) fn process_asset_fail(&mut self, failed_id: UntypedAssetId, error: AssetLoadError) {
         let (dependants_waiting_on_load, dependants_waiting_on_rec_load) = {
-            let info = self
-                .get_mut(failed_id)
-                .expect("Asset info should always exist at this point");
+            let Some(info) = self.get_mut(failed_id) else {
+                // The asset was already dropped.
+                return;
+            };
             info.load_state = LoadState::Failed(Box::new(error));
             info.dep_load_state = DependencyLoadState::Failed;
             info.rec_dep_load_state = RecursiveDependencyLoadState::Failed;


### PR DESCRIPTION
# Objective

This PR fixes a crash that happens when an asset failure event is processed after the asset has already been dropped.

```
2024-07-03T17:12:16.847178Z ERROR bevy_asset::server: Encountered HTTP status 404 when loading asset
thread 'main' panicked at bevy/crates/bevy_asset/src/server/info.rs:593:18:
```

## Solution

- Update `process_asset_fail` to match the graceful behavior in `process_asset_load` (it does not assume the state still exists).

---

## Changelog

- Fixed a rare crash that happens when an asset failed event is processed after the asset has been dropped.
