### PR TITLE
Move GPU mesh collection out of the extract phase, in preparation for bindless textures.

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -112,6 +112,8 @@ pub enum RenderSet {
     PrepareAssets,
     /// Create any additional views such as those used for shadow mapping.
     ManageViews,
+    /// Collect meshes and produce any per-mesh data the GPU will need
+    CollectMeshes,
     /// Queue drawable entities as phase items in render phases ready for
     /// sorting (if necessary)
     Queue,
@@ -171,6 +173,7 @@ impl Render {
                 .chain()
                 .in_set(Prepare),
         );
+        schedule.configure_sets((PrepareAssets, CollectMeshes, Queue).chain());
 
         schedule
     }


### PR DESCRIPTION
Currently, the `MeshInputUniform` data, which is used to prepare `MeshUniform` data for use by the GPU, is constructed during the extraction phase. This poses a problem for bindless materials. With bindless, we need the `MeshUniform` to contain the index of the material in a buffer, and the material isn't prepared until *after* extraction, at which point it's too late because the `MeshInputUniform`s have already been built. By moving `collect_meshes_for_gpu_building` to the new `CollectMeshes` phase, which runs after asset preparation but before mesh queuing, we fix this ordering problem.

Because an up-to-date `RenderMeshInstances` is no longer available during extraction, the lightmap extraction system has been reworked to fetch the mesh ID directly from the main world instead of going through `RenderMeshInstances`.

This patch was broken out from the larger forthcoming bindless patch because it has performance benefits on its own. It allows the extraction phase to finish quicker, which allows main world systems to resume faster.