### PR TITLE
impl Debug for ExtendedMaterial

### DIFF
--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -121,7 +121,7 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
 /// When used with `StandardMaterial` as the base, all the standard material fields are
 /// present, so the `pbr_fragment` shader functions can be called from the extension shader (see
 /// the `extended_material` example).
-#[derive(Asset, Clone, Reflect)]
+#[derive(Asset, Clone, Debug, Reflect)]
 #[reflect(type_path = false)]
 pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
     pub base: B,


### PR DESCRIPTION
# Objective

Both `Material` and `MaterialExtension` (base and extension) can derive Debug, so there's no reason to not allow `ExtendedMaterial` to derive it

## Solution

- Describe the solution used to achieve the objective above.
Add `Debug` to the list of derived traits

## Testing

- Did you test these changes? If so, how?
I compiled my test project on latest commit, making sure it actually compiles
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Create an ExtendedMaterial instance, try to `println!("{:?}", material);`

