### PR TITLE
Expose loading system fonts

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -105,7 +105,7 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_text")]
         {
-            group = group.add(bevy_text::TextPlugin);
+            group = group.add(bevy_text::TextPlugin::default());
         }
 
         #[cfg(feature = "bevy_ui")]

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -75,8 +75,19 @@ use bevy_sprite::SpriteSystem;
 ///
 /// When the `bevy_text` feature is enabled with the `bevy` crate, this
 /// plugin is included by default in the `DefaultPlugins`.
-#[derive(Default)]
-pub struct TextPlugin;
+pub struct TextPlugin {
+    /// If [false], some characters (esspecially Unicode emojies) might not load properly due to unsupported font
+    /// Caution: this can be relatively slow
+    pub load_system_fonts: bool,
+}
+
+impl Default for TextPlugin {
+    fn default() -> Self {
+        Self {
+            load_system_fonts: false,
+        }
+    }
+}
 
 /// Text is rendered for two different view projections;
 /// 2-dimensional text ([`Text2dBundle`]) is rendered in "world space" with a `BottomToTop` Y-axis,
@@ -101,7 +112,7 @@ impl Plugin for TextPlugin {
             .register_type::<TextBounds>()
             .init_asset_loader::<FontLoader>()
             .init_resource::<FontAtlasSets>()
-            .insert_resource(TextPipeline::default())
+            .insert_resource(TextPipeline::new(self.load_system_fonts))
             .add_systems(
                 PostUpdate,
                 (

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -7,11 +7,17 @@ use bevy::{
     color::palettes::css::GOLD,
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
+    text::TextPlugin,
 };
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, FrameTimeDiagnosticsPlugin))
+        .add_plugins((
+            DefaultPlugins.set(TextPlugin {
+                load_system_fonts: true,
+            }),
+            FrameTimeDiagnosticsPlugin,
+        ))
         .add_systems(Startup, setup)
         .add_systems(Update, (text_update_system, text_color_system))
         .run();
@@ -26,6 +32,12 @@ struct FpsText;
 struct ColorText;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let text_content = if cfg!(target_arch = "wasm32") {
+        "hello\nbevy!"
+    } else {
+        "hello\nbevy! 😌"
+    };
+
     // UI camera
     commands.spawn(Camera2dBundle::default());
     // Text with one section
@@ -33,7 +45,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // Create a TextBundle that has a Text with a single section.
         TextBundle::from_section(
             // Accepts a `String` or any type that converts into a `String`, such as `&str`
-            "hello\nbevy!",
+            text_content,
             TextStyle {
                 // This font is loaded and will be used instead of the default font.
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),


### PR DESCRIPTION
# Objective

Expose `cosmic-text` functionality to load system fonts.

## Solution

Add `load_system_fonts` to `TextPlugin` struct.

## Testing

`cargo r --example text --release` by setting `load_system_fonts` to true emoji is rendered correctly:

https://github.com/bevyengine/bevy/assets/111751109/63b25a6d-944b-43f9-8dac-da6de3e08809

---

## Migration Guide

TextPlugin started to have a field, so in places where TextPlugin was used have to use `bevy_text::TextPlugin::default()` or create a struct with `load_system_fonts` field.
