### PR TITLE
Dirty fix for App hanging when windows are invisible on WindowsOS

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -421,6 +421,7 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
 
         let (config, windows) = focused_windows_state.get(self.world());
         let focused = windows.iter().any(|(_, window)| window.focused);
+        // If no windows exist, this will evaluate to `true`.
         let all_invisible = windows.iter().all(|w| !w.1.visible);
 
         let mut update_mode = config.update_mode(focused);

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -421,8 +421,6 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
 
         let (config, windows) = focused_windows_state.get(self.world());
         let focused = windows.iter().any(|(_, window)| window.focused);
-        // If no windows exist, this will evaluate to `true`.
-        let all_invisible = windows.iter().all(|w| !w.1.visible);
 
         let mut update_mode = config.update_mode(focused);
         let mut should_update = self.should_update(update_mode);
@@ -506,9 +504,15 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
         let begin_frame_time = Instant::now();
 
         if should_update {
+            let (_, windows) = focused_windows_state.get(self.world());
+            // If no windows exist, this will evaluate to `true`.
+            let all_invisible = windows.iter().all(|w| !w.1.visible);
+
             // Not redrawing, but the timeout elapsed.
-            // NOTE: Additional condition for WindowsOS.
+            //
+            // Additional condition for Windows OS.
             // If no windows are visible, redraw calls will never succeed, which results in no app update calls being performed.
+            // This is a temporary solution, full solution is mentioned here: https://github.com/bevyengine/bevy/issues/1343#issuecomment-770091684
             if !self.ran_update_since_last_redraw || all_invisible {
                 self.run_app_update();
                 self.ran_update_since_last_redraw = true;

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -421,6 +421,7 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
 
         let (config, windows) = focused_windows_state.get(self.world());
         let focused = windows.iter().any(|(_, window)| window.focused);
+        let all_invisible = windows.iter().all(|w| !w.1.visible);
 
         let mut update_mode = config.update_mode(focused);
         let mut should_update = self.should_update(update_mode);
@@ -505,7 +506,9 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
 
         if should_update {
             // Not redrawing, but the timeout elapsed.
-            if !self.ran_update_since_last_redraw {
+            // NOTE: Additional condition for WindowsOS.
+            // If no windows are visible, redraw calls will never succeed, which results in no app update calls being performed.
+            if !self.ran_update_since_last_redraw || all_invisible {
                 self.run_app_update();
                 self.ran_update_since_last_redraw = true;
             } else {


### PR DESCRIPTION
# Objective

- Fixes #14135 

## Solution

- If no windows are visible, app updates will run regardless of redraw call result.

This a relatively dirty fix, a more robust solution is desired in the long run:
https://github.com/bevyengine/bevy/issues/1343#issuecomment-770091684
https://discord.com/channels/691052431525675048/1253771396832821270/1258805997011730472
The solution would disconnect rendering from app updates.

## Testing

- `window_settings` now works

## Other platforms

Not a problem on Linux: https://discord.com/channels/691052431525675048/692572690833473578/1259526650622640160
Not a problem on MacOS: https://discord.com/channels/691052431525675048/692572690833473578/1259563986148659272
