### PR TITLE
impl Reflect + Clone for StateScoped

### DIFF
--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -6,6 +6,10 @@ use bevy_ecs::{
 };
 #[cfg(feature = "bevy_hierarchy")]
 use bevy_hierarchy::DespawnRecursiveExt;
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::prelude::*;
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::reflect::ReflectComponent;
 
 use crate::state::{StateTransitionEvent, States};
 
@@ -53,8 +57,7 @@ use crate::state::{StateTransitionEvent, States};
 /// app.add_systems(OnEnter(GameState::InGame), spawn_player);
 /// ```
 #[derive(Component, Clone)]
-#[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect))]
-#[cfg_attr(feature = "reflect", reflect(Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
 pub struct StateScoped<S: States>(pub S);
 
 /// Removes entities marked with [`StateScoped<S>`]

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -6,6 +6,7 @@ use bevy_ecs::{
 };
 #[cfg(feature = "bevy_hierarchy")]
 use bevy_hierarchy::DespawnRecursiveExt;
+use bevy_reflect::Reflect;
 
 use crate::state::{StateTransitionEvent, States};
 
@@ -52,7 +53,7 @@ use crate::state::{StateTransitionEvent, States};
 /// app.enable_state_scoped_entities::<GameState>();
 /// app.add_systems(OnEnter(GameState::InGame), spawn_player);
 /// ```
-#[derive(Component)]
+#[derive(Component, Reflect, Clone)]
 pub struct StateScoped<S: States>(pub S);
 
 /// Removes entities marked with [`StateScoped<S>`]

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -6,7 +6,6 @@ use bevy_ecs::{
 };
 #[cfg(feature = "bevy_hierarchy")]
 use bevy_hierarchy::DespawnRecursiveExt;
-use bevy_reflect::Reflect;
 
 use crate::state::{StateTransitionEvent, States};
 
@@ -53,7 +52,9 @@ use crate::state::{StateTransitionEvent, States};
 /// app.enable_state_scoped_entities::<GameState>();
 /// app.add_systems(OnEnter(GameState::InGame), spawn_player);
 /// ```
-#[derive(Component, Reflect, Clone)]
+#[derive(Component, Clone)]
+#[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct StateScoped<S: States>(pub S);
 
 /// Removes entities marked with [`StateScoped<S>`]

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::reflect::ReflectComponent;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -8,8 +10,6 @@ use bevy_ecs::{
 use bevy_hierarchy::DespawnRecursiveExt;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
-#[cfg(feature = "bevy_reflect")]
-use bevy_ecs::reflect::ReflectComponent;
 
 use crate::state::{StateTransitionEvent, States};
 


### PR DESCRIPTION
# Objective

- Expand the flexibilty of StateScoped by adding Reflect and Clone
- This lets StateScoped be used in Clone Bundles, for example

```rust
#[derive(Component, Reflect, Clone)]
pub struct StateScoped<S: States>(pub S);
```

Notes:
- States are already Clone.
- Type registration is up to the user, but this is commonly the case with reflected generic types.

## Testing

- Ran the examples.
