### PR TITLE
Exposes Common Window Resolutions as an Enum.

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -873,13 +873,21 @@ impl From<DVec2> for WindowResolution {
 /// Creates and defines a Resolution Enum to expose common resolutions.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Resolution{
+    /// 640 x 360
     R360p,
+
+    /// 1280 x 720
     R720p,
+
+    /// 1920 x 1080
     R1080p,
+
+    /// 2560 x 1440
     R2k,
 }
 
 impl Resolution {
+    /// Gets all the available resolutions as an iterator.
     pub fn iter() -> impl Iterator<Item = Resolution> {
         [
             Resolution::R360p,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -871,7 +871,7 @@ impl From<DVec2> for WindowResolution {
 
 /// Common screen resolutions.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Resolution {
+pub enum CommonScreenResolution {
     /// 640 x 360
     R360p,
 
@@ -885,26 +885,26 @@ pub enum Resolution {
     R2k,
 }
 
-impl Resolution {
-    /// Iterates through all [`Resolution`] variants.
-    pub fn iter() -> impl Iterator<Item = Resolution> {
+impl CommonScreenResolution {
+    /// Iterates through all [`CommonScreenResolution`] variants.
+    pub fn iter() -> impl Iterator<Item =CommonScreenResolution> {
         [
-            Resolution::R360p,
-            Resolution::R720p,
-            Resolution::R1080p,
-            Resolution::R2k,
+            CommonScreenResolution::R360p,
+            CommonScreenResolution::R720p,
+            CommonScreenResolution::R1080p,
+            CommonScreenResolution::R2k,
         ]
         .into_iter()
     }
 }
 
-impl From<Resolution> for UVec2 {
-    fn from(resolution: Resolution) -> Self {
+impl From<CommonScreenResolution> for UVec2 {
+    fn from(resolution: CommonScreenResolution) -> Self {
         match resolution {
-            Resolution::R360p => Self::new(640, 360),
-            Resolution::R720p => Self::new(1280, 720),
-            Resolution::R1080p => Self::new(1920, 1080),
-            Resolution::R2k => Self::new(2560, 1440),
+            CommonScreenResolution::R360p => Self::new(640, 360),
+            CommonScreenResolution::R720p => Self::new(1280, 720),
+            CommonScreenResolution::R1080p => Self::new(1920, 1080),
+            CommonScreenResolution::R2k => Self::new(2560, 1440),
         }
     }
 }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -913,6 +913,17 @@ impl From<CommonScreenResolution> for UVec2 {
     }
 }
 
+impl From<CommonScreenResolution> for WindowResolution {
+    fn from(resolution: CommonScreenResolution) -> Self {
+        match resolution {
+            CommonScreenResolution::R360p => Self::new(640., 360.),
+            CommonScreenResolution::R720p => Self::new(1280., 720.),
+            CommonScreenResolution::R1080p => Self::new(1920., 1080.),
+            CommonScreenResolution::R2k => Self::new(2560., 1440.),
+        }
+    }
+}
+
 /// Defines if and how the [`Cursor`] is grabbed by a [`Window`].
 ///
 /// ## Platform-specific

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -870,6 +870,10 @@ impl From<DVec2> for WindowResolution {
 }
 
 /// Common screen resolutions.
+///
+/// These resolutions are common resolutions that are more than likely going to be used, using the
+/// common name. This keeps developers from having to remember each resolution they wish to use, along
+/// with makes things simpler for implementing menus.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum CommonScreenResolution {
     /// 640 x 360

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -892,7 +892,7 @@ pub enum CommonScreenResolution {
 
 impl CommonScreenResolution {
     /// Iterates through all [`CommonScreenResolution`] variants.
-    pub fn iter() -> impl Iterator<Item =CommonScreenResolution> {
+    pub fn iter() -> impl Iterator<Item = CommonScreenResolution> {
         [
             CommonScreenResolution::R360p,
             CommonScreenResolution::R720p,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -876,6 +876,7 @@ impl From<DVec2> for WindowResolution {
 /// common name. This keeps developers from having to remember each resolution they wish to use, along
 /// with makes things simpler for implementing menus.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum CommonScreenResolution {
     /// 640 x 360
     R360p,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::num::NonZeroU32;
 
 use bevy_ecs::{
@@ -921,6 +922,12 @@ impl From<CommonScreenResolution> for WindowResolution {
             CommonScreenResolution::R1080p => Self::new(1920., 1080.),
             CommonScreenResolution::R2k => Self::new(2560., 1440.),
         }
+    }
+}
+
+impl Display for CommonScreenResolution {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} x {}", UVec2::from(self).x, UVec2::from(self).y)
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -914,6 +914,17 @@ impl From<CommonScreenResolution> for UVec2 {
     }
 }
 
+impl From<CommonScreenResolution> for Vec2 {
+    fn from(resolution: CommonScreenResolution) -> Self {
+        match resolution {
+            CommonScreenResolution::R360p => Self::new(640., 360.),
+            CommonScreenResolution::R720p => Self::new(1280., 720.),
+            CommonScreenResolution::R1080p => Self::new(1920., 1080.),
+            CommonScreenResolution::R2k => Self::new(2560., 1440.),
+        }
+    }
+}
+
 impl From<CommonScreenResolution> for WindowResolution {
     fn from(resolution: CommonScreenResolution) -> Self {
         match resolution {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -869,7 +869,7 @@ impl From<DVec2> for WindowResolution {
     }
 }
 
-// Common screen resolutions.
+/// Common screen resolutions.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Resolution {
     /// 640 x 360

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -709,8 +709,8 @@ pub struct WindowResolution {
 impl Default for WindowResolution {
     fn default() -> Self {
         WindowResolution {
-            physical_width: 1280,
-            physical_height: 720,
+            physical_width: UVec2::from(CommonScreenResolution::R720p).x,
+            physical_height: UVec2::from(CommonScreenResolution::R720p).y,
             scale_factor_override: None,
             scale_factor: 1.0,
         }
@@ -927,7 +927,12 @@ impl From<CommonScreenResolution> for WindowResolution {
 
 impl Display for CommonScreenResolution {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} x {}", UVec2::from(self).x, UVec2::from(self).y)
+        match self {
+            CommonScreenResolution::R360p => write!(f, "{} x {}", 640, 360),
+            CommonScreenResolution::R720p => write!(f, "{} x {}", 1280, 720),
+            CommonScreenResolution::R1080p => write!(f, "{} x {}", 1920, 1080),
+            CommonScreenResolution::R2k => write!(f, "{} x {}", 2560, 1440),
+        }
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -714,7 +714,6 @@ impl Default for WindowResolution {
             scale_factor: 1.0,
         }
     }
-
 }
 
 impl WindowResolution {
@@ -870,9 +869,9 @@ impl From<DVec2> for WindowResolution {
     }
 }
 
-/// Creates and defines a Resolution Enum to expose common resolutions.
+// Common screen resolutions.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub enum Resolution{
+pub enum Resolution {
     /// 640 x 360
     R360p,
 
@@ -887,14 +886,15 @@ pub enum Resolution{
 }
 
 impl Resolution {
-    /// Gets all the available resolutions as an iterator.
+    // Iterates through all [`Resolution`] variants.
     pub fn iter() -> impl Iterator<Item = Resolution> {
         [
             Resolution::R360p,
             Resolution::R720p,
             Resolution::R1080p,
             Resolution::R2k,
-        ].into_iter()
+        ]
+        .into_iter()
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -714,6 +714,7 @@ impl Default for WindowResolution {
             scale_factor: 1.0,
         }
     }
+
 }
 
 impl WindowResolution {
@@ -866,6 +867,37 @@ impl From<Vec2> for WindowResolution {
 impl From<DVec2> for WindowResolution {
     fn from(res: DVec2) -> WindowResolution {
         WindowResolution::new(res.x as f32, res.y as f32)
+    }
+}
+
+/// Creates and defines a Resolution Enum to expose common resolutions.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum Resolution{
+    R360p,
+    R720p,
+    R1080p,
+    R2k,
+}
+
+impl Resolution {
+    pub fn iter() -> impl Iterator<Item = Resolution> {
+        [
+            Resolution::R360p,
+            Resolution::R720p,
+            Resolution::R1080p,
+            Resolution::R2k,
+        ].into_iter()
+    }
+}
+
+impl From<Resolution> for UVec2 {
+    fn from(resolution: Resolution) -> Self {
+        match resolution {
+            Resolution::R360p => Self::new(640, 360),
+            Resolution::R720p => Self::new(1280, 720),
+            Resolution::R1080p => Self::new(1920, 1080),
+            Resolution::R2k => Self::new(2560, 1440),
+        }
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -886,7 +886,7 @@ pub enum Resolution {
 }
 
 impl Resolution {
-    // Iterates through all [`Resolution`] variants.
+    /// Iterates through all [`Resolution`] variants.
     pub fn iter() -> impl Iterator<Item = Resolution> {
         [
             Resolution::R360p,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -917,34 +917,20 @@ impl From<CommonScreenResolution> for UVec2 {
 
 impl From<CommonScreenResolution> for Vec2 {
     fn from(resolution: CommonScreenResolution) -> Self {
-        match resolution {
-            CommonScreenResolution::R360p => Self::new(640., 360.),
-            CommonScreenResolution::R720p => Self::new(1280., 720.),
-            CommonScreenResolution::R1080p => Self::new(1920., 1080.),
-            CommonScreenResolution::R2k => Self::new(2560., 1440.),
-        }
+        UVec2::from(resolution).as_vec2()
     }
 }
 
 impl From<CommonScreenResolution> for WindowResolution {
     fn from(resolution: CommonScreenResolution) -> Self {
-        match resolution {
-            CommonScreenResolution::R360p => Self::new(640., 360.),
-            CommonScreenResolution::R720p => Self::new(1280., 720.),
-            CommonScreenResolution::R1080p => Self::new(1920., 1080.),
-            CommonScreenResolution::R2k => Self::new(2560., 1440.),
-        }
+        WindowResolution::from(Vec2::from(resolution))
     }
 }
 
 impl Display for CommonScreenResolution {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CommonScreenResolution::R360p => write!(f, "{} x {}", 640, 360),
-            CommonScreenResolution::R720p => write!(f, "{} x {}", 1280, 720),
-            CommonScreenResolution::R1080p => write!(f, "{} x {}", 1920, 1080),
-            CommonScreenResolution::R2k => write!(f, "{} x {}", 2560, 1440),
-        }
+        let res = UVec2::from(*self);
+        write!(f, "{} x {}", res.x, res.y)
     }
 }
 

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -1,6 +1,6 @@
 //! This example illustrates how to resize windows, and how to respond to a window being resized.
-use bevy::{prelude::*, window::WindowResized};
 use bevy::window::CommonScreenResolution;
+use bevy::{prelude::*, window::WindowResized};
 
 fn main() {
     App::new()

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -1,12 +1,13 @@
 //! This example illustrates how to resize windows, and how to respond to a window being resized.
 use bevy::{prelude::*, window::WindowResized};
+use bevy::window::CommonScreenResolution;
 
 fn main() {
     App::new()
         .insert_resource(ResolutionSettings {
-            large: Vec2::new(1920.0, 1080.0),
+            large: CommonScreenResolution::R1080p.into(),
             medium: Vec2::new(800.0, 600.0),
-            small: Vec2::new(640.0, 360.0),
+            small: CommonScreenResolution::R360p.into(),
         })
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, (setup_camera, setup_ui))

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,13 +1,13 @@
 //! Illustrates how to change window settings and shows how to affect
 //! the mouse pointer in various ways.
 
+use bevy::window::{CommonScreenResolution, WindowResolution};
 use bevy::{
     core::FrameCount,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
 };
-use bevy::window::{CommonScreenResolution, WindowResolution};
 
 fn main() {
     App::new()
@@ -129,12 +129,17 @@ fn toggle_window_controls(input: Res<ButtonInput<KeyCode>>, mut windows: Query<&
 fn toggle_resolutions(input: Res<ButtonInput<KeyCode>>, mut windows: Query<&mut Window>) {
     if input.just_pressed(KeyCode::KeyR) {
         let mut window = windows.single_mut();
-        let current_resolution = CommonScreenResolution::iter().find(|&r| WindowResolution::from(r) == window.resolution);
+        let current_resolution = CommonScreenResolution::iter()
+            .find(|&r| WindowResolution::from(r) == window.resolution);
         window.resolution = if current_resolution.is_none() {
             CommonScreenResolution::R360p.into()
         } else {
-            let resolutions = CommonScreenResolution::iter().map(|r| r.into()).collect::<Vec<CommonScreenResolution>>();
-            let current_resolution_index = CommonScreenResolution::iter().position(|r| r == current_resolution.unwrap()).unwrap();
+            let resolutions = CommonScreenResolution::iter()
+                .map(|r| r.into())
+                .collect::<Vec<CommonScreenResolution>>();
+            let current_resolution_index = CommonScreenResolution::iter()
+                .position(|r| r == current_resolution.unwrap())
+                .unwrap();
 
             if current_resolution_index + 1 >= resolutions.len() {
                 resolutions[0].into()

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -7,6 +7,7 @@ use bevy::{
     prelude::*,
     window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
 };
+use bevy::window::{CommonScreenResolution, WindowResolution};
 
 fn main() {
     App::new()
@@ -15,7 +16,7 @@ fn main() {
                 primary_window: Some(Window {
                     title: "I am a window!".into(),
                     name: Some("bevy.app".into()),
-                    resolution: (500., 300.).into(),
+                    resolution: CommonScreenResolution::R360p.into(),
                     present_mode: PresentMode::AutoVsync,
                     // Tells wasm to resize the window according to the available canvas
                     fit_canvas_to_parent: true,
@@ -45,6 +46,7 @@ fn main() {
                 toggle_cursor,
                 toggle_vsync,
                 toggle_window_controls,
+                toggle_resolutions,
                 cycle_cursor_icon,
                 switch_level,
                 make_visible,
@@ -120,6 +122,25 @@ fn toggle_window_controls(input: Res<ButtonInput<KeyCode>>, mut windows: Query<&
         }
         if toggle_close {
             window.enabled_buttons.close = !window.enabled_buttons.close;
+        }
+    }
+}
+
+fn toggle_resolutions(input: Res<ButtonInput<KeyCode>>, mut windows: Query<&mut Window>) {
+    if input.just_pressed(KeyCode::KeyR) {
+        let mut window = windows.single_mut();
+        let current_resolution = CommonScreenResolution::iter().find(|&r| WindowResolution::from(r) == window.resolution);
+        window.resolution = if current_resolution.is_none() {
+            CommonScreenResolution::R360p.into()
+        } else {
+            let resolutions = CommonScreenResolution::iter().map(|r| r.into()).collect::<Vec<CommonScreenResolution>>();
+            let current_resolution_index = CommonScreenResolution::iter().position(|r| r == current_resolution.unwrap()).unwrap();
+
+            if current_resolution_index + 1 >= resolutions.len() {
+                resolutions[0].into()
+            } else {
+                resolutions[current_resolution_index + 1].into()
+            }
         }
     }
 }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -135,7 +135,7 @@ fn toggle_resolutions(input: Res<ButtonInput<KeyCode>>, mut windows: Query<&mut 
             CommonScreenResolution::R360p.into()
         } else {
             let resolutions = CommonScreenResolution::iter()
-                .map(|r| r.into())
+                .map(std::convert::Into::into)
                 .collect::<Vec<CommonScreenResolution>>();
             let current_resolution_index = CommonScreenResolution::iter()
                 .position(|r| r == current_resolution.unwrap())


### PR DESCRIPTION
# Objective
Implements: #14153

## Solution
Exposes Common Window Resolutions that are likely to be used through an Enum (Resolution) that can be turned into a UVec2 and an iterable.
 
## Testing
I've tested this briefly locally. I wrote a small test just to double check that things worked as expected and it passed. 