### PR TITLE
Add error message if states schedule missing (usually because StatesPlugin hasn't been added)

### DIFF
--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -74,7 +74,7 @@ impl AppExtStates for SubApp {
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).expect(
-                "The `StateTransition` schedule is missing. Have you added the `StatesPlugin` to your App?"
+                "The `StateTransition` schedule is missing. Did you forget to add the `StatesPlugin` to your App?"
             );
             S::register_state(schedule);
             let state = self.world().resource::<State<S>>().get().clone();

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -74,7 +74,7 @@ impl AppExtStates for SubApp {
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
             let schedule = self.get_schedule_mut(StateTransition).expect(
-                "The `StateTransition` schedule is missing. Did you forget to add the `StatesPlugin` to your App?"
+                "The `StateTransition` schedule is missing. Did you forget to add StatesPlugin or DefaultPlugins before calling init_state?"
             );
             S::register_state(schedule);
             let state = self.world().resource::<State<S>>().get().clone();

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -96,7 +96,9 @@ impl AppExtStates for SubApp {
             self.insert_resource::<State<S>>(State::new(state.clone()))
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
-            let schedule = self.get_schedule_mut(StateTransition).unwrap();
+            let schedule = self.get_schedule_mut(StateTransition).expect(
+                "The `StateTransition` schedule is missing. Did you forget to add StatesPlugin or DefaultPlugins before calling init_state?"
+            );
             S::register_state(schedule);
             self.world_mut().send_event(StateTransitionEvent {
                 exited: None,

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -73,7 +73,9 @@ impl AppExtStates for SubApp {
             self.init_resource::<State<S>>()
                 .init_resource::<NextState<S>>()
                 .add_event::<StateTransitionEvent<S>>();
-            let schedule = self.get_schedule_mut(StateTransition).unwrap();
+            let schedule = self.get_schedule_mut(StateTransition).expect(
+                "The `StateTransition` schedule is missing. Have you added the `StatesPlugin` to your App?"
+            );
             S::register_state(schedule);
             let state = self.world().resource::<State<S>>().get().clone();
             self.world_mut().send_event(StateTransitionEvent {


### PR DESCRIPTION
# Objective

- Helps improve https://github.com/bevyengine/bevy/issues/14151

## Solution

- At least return an error message from the `Option::unwrap()` call when we try to access the `StateTransition` schedule

