### PR TITLE
Expose Winit's `KeyEvent::repeat` in `KeyboardInput`

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -101,6 +101,10 @@ pub struct KeyboardInput {
     pub logical_key: Key,
     /// The press state of the key.
     pub state: ButtonState,
+    /// On some systems, holding down a key for some period of time causes that key to be repeated
+    /// as though it were being pressed and released repeatedly. This field is [`true`] if this
+    /// event is the result of one of those repeats.
+    pub repeat: bool,
     /// Window that received the input.
     pub window: Entity,
 }

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -17,6 +17,7 @@ pub fn convert_keyboard_input(
         state: convert_element_state(keyboard_input.state),
         key_code: convert_physical_key_code(keyboard_input.physical_key),
         logical_key: convert_logical_key(&keyboard_input.logical_key),
+        repeat: keyboard_input.repeat,
         window,
     }
 }


### PR DESCRIPTION
# Objective

I would like to know if an event was emitted because of "key repeats" or not.
Winit already exposes this information, but it isn't sent along by Bevy, which this PR intends to address.

## Solution

Expose [`winit::event::KeyEvent::repeat`](https://docs.rs/winit/0.30.3/winit/event/struct.KeyEvent.html#structfield.repeat) in [`bevy::input::keyboard::KeyboardInput`](https://docs.rs/bevy/0.14.0/bevy/input/keyboard/struct.KeyboardInput.html).

## Testing

Just hold any regular key down and only the first event should have `KeyboardInput::repeat` set to `false`. Most OSs have "key repeat" enabled by default.

---

## Changelog

- Added `KeyboardInput::repeat` signifying if this event was sent in response to a "key repeat" event or not.