### PR TITLE
Impl VisitAssetDependencies for HashSet and HashMap

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -284,7 +284,7 @@ impl VisitAssetDependencies for Vec<UntypedHandle> {
 
 impl<K, A: Asset> VisitAssetDependencies for HashMap<K, Handle<A>> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
-        for (_, dependency) in self {
+        for dependency in self.values() {
             visit(dependency.id().untyped());
         }
     }
@@ -292,7 +292,7 @@ impl<K, A: Asset> VisitAssetDependencies for HashMap<K, Handle<A>> {
 
 impl<K> VisitAssetDependencies for HashMap<K, UntypedHandle> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
-        for (_, dependency) in self {
+        for dependency in self.values() {
             visit(dependency.id());
         }
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -62,7 +62,7 @@ use bevy_ecs::{
     world::FromWorld,
 };
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
-use bevy_utils::{tracing::error, HashSet};
+use bevy_utils::{tracing::error, HashMap, HashSet};
 use std::{any::TypeId, sync::Arc};
 
 #[cfg(all(feature = "file_watcher", not(feature = "multi_threaded")))]
@@ -275,6 +275,38 @@ impl<A: Asset> VisitAssetDependencies for Vec<Handle<A>> {
 }
 
 impl VisitAssetDependencies for Vec<UntypedHandle> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            visit(dependency.id());
+        }
+    }
+}
+
+impl<K, A: Asset> VisitAssetDependencies for HashMap<K, Handle<A>> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for (_, dependency) in self {
+            visit(dependency.id().untyped());
+        }
+    }
+}
+
+impl<K> VisitAssetDependencies for HashMap<K, UntypedHandle> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for (_, dependency) in self {
+            visit(dependency.id());
+        }
+    }
+}
+
+impl<A: Asset> VisitAssetDependencies for HashSet<Handle<A>> {
+    fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
+        for dependency in self {
+            visit(dependency.id().untyped());
+        }
+    }
+}
+
+impl VisitAssetDependencies for HashSet<UntypedHandle> {
     fn visit_dependencies(&self, visit: &mut impl FnMut(UntypedAssetId)) {
         for dependency in self {
             visit(dependency.id());


### PR DESCRIPTION
# Objective

Enables gathering asset dependencies for asset fields of type `HashSet`/`HashMap`.

This can be worked-around by new-typing the field. `#[derive(Asset)]` doesn't seem to allow skipping the automatic `VisitAssetDependencies` implementation.

## Solution

More trait impls.

## Testing

`cargo build`

