### PR TITLE
use Display for entity id in log_components

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1308,7 +1308,7 @@ fn log_components(entity: Entity, world: &mut World) {
         .inspect_entity(entity)
         .map(ComponentInfo::name)
         .collect();
-    info!("Entity {:?}: {:?}", entity, debug_infos);
+    info!("Entity {}: {:?}", entity, debug_infos);
 }
 
 fn observe<E: Event, B: Bundle, M>(

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1308,7 +1308,7 @@ fn log_components(entity: Entity, world: &mut World) {
         .inspect_entity(entity)
         .map(ComponentInfo::name)
         .collect();
-    info!("Entity {}: {:?}", entity, debug_infos);
+    info!("Entity {entity}: {debug_infos:?}");
 }
 
 fn observe<E: Event, B: Bundle, M>(


### PR DESCRIPTION
# Objective

- Cleanup a doubled `Entity` in log components

```
// Before
2024-07-05T19:54:09.082773Z  INFO bevy_ecs::system::commands: Entity Entity { index: 2, generation: 1 }: ["bevy_transform::components::transform::Transform"]

// After
2024-07-05T19:54:09.082773Z  INFO bevy_ecs::system::commands: Entity 2v1: ["bevy_transform::components::transform::Transform"]
```