### PR TITLE
bevy_reflect: Re-enable reflection compile fail tests

### DIFF
--- a/crates/bevy_reflect/compile_fail/tests/derive.rs
+++ b/crates/bevy_reflect/compile_fail/tests/derive.rs
@@ -1,4 +1,3 @@
 fn main() -> compile_fail_utils::ui_test::Result<()> {
-    // compile_fail_utils::test("tests/reflect_derive")
-    Ok(())
+    compile_fail_utils::test("tests/reflect_derive")
 }


### PR DESCRIPTION
# Objective

Looks like I accidentally disabled the reflection compile fail tests in #13152. These should be re-enabled.

## Solution

Re-enable reflection compile fail tests.

## Testing

CI should pass. You can also test locally by navigating to `crates/bevy_reflect/compile_fail/` and running:

```
cargo test --target-dir ../../../target
```
