### PR TITLE
prepare next version: update regexes

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -27,7 +27,7 @@ jobs:
           # Read the current version from Cargo.toml
           current_version=$(cargo metadata --format-version 1 --no-deps | \
             jq --raw-output '.packages | .[] | select(.name == "bevy").version')
-          # Sanity check: current version should be 0.X.Y
+          # Sanity check: current version should be 0.X.Y-dev
           if ! grep -q '^0\.[0-9]\+\.[0-9]\+-dev$' <<< "${current_version}"; then
             echo "Invalid version (not in 0.X.Y-dev format): ${current_version}"
             exit 1

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -32,7 +32,7 @@ jobs:
             echo "Invalid version (not in 0.X.Y-dev format): ${current_version}"
             exit 1
           fi
-          minor_version=$(sed 's/^0\.\([0-9]*\)\..*/\1/' <<< "${current_version}")
+          minor_version=$(sed 's/^0\.\([0-9]\+\).*/\1/' <<< "${current_version}")
           next_version=0.$((minor_version + 1)).0-dev
           echo "Bumping version to ${next_version}"
           # See release.yml for meaning of these arguments

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -28,11 +28,11 @@ jobs:
           current_version=$(cargo metadata --format-version 1 --no-deps | \
             jq --raw-output '.packages | .[] | select(.name == "bevy").version')
           # Sanity check: current version should be 0.X.Y
-          if ! grep -q '^0\.[0-9]\+\.[0-9]\+$' <<< "${current_version}"; then
-            echo "Invalid version (not in 0.X.Y format): ${current_version}"
+          if ! grep -q '^0\.[0-9]\+\.[0-9]\+-dev$' <<< "${current_version}"; then
+            echo "Invalid version (not in 0.X.Y-dev format): ${current_version}"
             exit 1
           fi
-          minor_version=$(sed 's/^0\.\([0-9]\+\).*/\1/' <<< "${current_version}")
+          minor_version=$(sed 's/^0\.\([0-9]*\)\..*/\1/' <<< "${current_version}")
           next_version=0.$((minor_version + 1)).0-dev
           echo "Bumping version to ${next_version}"
           # See release.yml for meaning of these arguments


### PR DESCRIPTION
# Objective

- The post release version bump job failed: https://github.com/bevyengine/bevy/actions/runs/9799332118
- This is because main didn't update to 0.14 as that happened in a branch

## Solution

- Update the regexes to work with the -dev suffix
