### PR TITLE
Remove unused type parameter in `Parallel::drain()`

### DIFF
--- a/crates/bevy_utils/src/parallel_queue.rs
+++ b/crates/bevy_utils/src/parallel_queue.rs
@@ -51,10 +51,7 @@ where
     /// chunk will be dropped, and the rest of the undrained elements will remain.
     ///
     /// The ordering is not guaranteed.
-    pub fn drain<B>(&mut self) -> impl Iterator<Item = T> + '_
-    where
-        B: FromIterator<T>,
-    {
+    pub fn drain(&mut self) -> impl Iterator<Item = T> + '_ {
         self.locals.iter_mut().flat_map(|item| item.take())
     }
 }


### PR DESCRIPTION
# Objective

- `Parallel::drain()` has an unused type parameter `B` than can be removed.
  - Caught [on Discord](https://discord.com/channels/691052431525675048/692572690833473578/1259004180560085003) by Andrew, thanks!

## Solution

- Remove it! :)

## Testing

- `Parallel::drain()` should still function exactly the same.

---

## Changelog

- Removed unused type parameter in `Parallel::drain()`.

## Migration Guide

The type parameter of `Parallel::drain()` was unused, so it is now removed. If you were manually specifying it, you can remove the bounds.

```rust
// 0.14
// Create a `Parallel` and give it a value.
let mut parallel: Parallel<Vec<u8>> = Parallel::default();
*parallel.borrow_local_mut() = vec![1, 2, 3];

for v in parallel.drain::<u8>() {
    // ...
}

// 0.15
let mut parallel: Parallel<Vec<u8>> = Parallel::default();
*parallel.borrow_local_mut() = vec![1, 2, 3];

// Remove the type parameter.
for v in parallel.drain() {
    // ...
}
```