### PR TITLE
bevy_core: make bevy_reflect optional

### DIFF
--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -10,15 +10,11 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.14.0-dev", features = [
-  "bevy_reflect",
-] }
-bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev", features = [
-  "bevy_reflect",
-] }
+bevy_app = { path = "../bevy_app", version = "0.14.0-dev", default-features = false }
+bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
-] }
+], optional = true }
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 
@@ -27,6 +23,12 @@ serde = { version = "1.0", optional = true }
 uuid = "1.0"
 
 [features]
+default = ["bevy_reflect"]
+bevy_reflect = [
+  "dep:bevy_reflect",
+  "bevy_app/bevy_reflect",
+  "bevy_ecs/bevy_reflect",
+]
 serialize = ["dep:serde"]
 
 [dev-dependencies]

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -36,7 +36,9 @@ use bevy_tasks::tick_global_task_pools_on_main_thread;
 pub struct TypeRegistrationPlugin;
 
 impl Plugin for TypeRegistrationPlugin {
+    #[cfg_attr(not(feature = "bevy_reflect"), allow(unused_variables))]
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "bevy_reflect")]
         app.register_type::<Name>();
     }
 }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,7 +1,11 @@
 use bevy_ecs::query::QueryData;
-use bevy_ecs::{component::Component, entity::Entity, reflect::ReflectComponent};
+#[cfg(feature = "bevy_reflect")]
+use bevy_ecs::reflect::ReflectComponent;
+use bevy_ecs::{component::Component, entity::Entity};
 
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::std_traits::ReflectDefault;
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use bevy_utils::AHasher;
 use std::{
@@ -10,7 +14,7 @@ use std::{
     ops::Deref,
 };
 
-#[cfg(feature = "serialize")]
+#[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// Component used to identify an entity. Stores a hash for faster comparisons.
@@ -20,9 +24,16 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// [`Name`] should not be treated as a globally unique identifier for entities,
 /// as multiple entities can have the same name.  [`Entity`] should be
 /// used instead as the default unique identifier.
-#[derive(Reflect, Component, Clone)]
-#[reflect(Component, Default, Debug)]
-#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[derive(Component, Clone)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Component, Default, Debug)
+)]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Deserialize, Serialize)
+)]
 pub struct Name {
     hash: u64, // Won't be serialized (see: `bevy_core::serde` module)
     name: Cow<'static, str>,


### PR DESCRIPTION
# Objective

Allow use of `bevy_core` types without needing `bevy_reflect`.

## Solution

Make `bevy_reflect` within `bevy_core` optional. It's compiled in by default.
Turn on reflect in dependencies as well when this feature is on.

## Testing

- Did you test these changes? If so, how?

I did a `cargo hack -p bevy_core--each-feature build`.


Similar PR: https://github.com/bevyengine/bevy/pull/14167

Discord context starts here: https://discord.com/channels/691052431525675048/768253008416342076/1258814534651482163