### PR TITLE
Fix inconsistency in `KeyboardInput` examples to match migration guide

### DIFF
--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -1,10 +1,7 @@
 //! Prints out all chars as they are inputted.
 
 use bevy::{
-    input::{
-        keyboard::{Key, KeyboardInput},
-        ButtonState,
-    },
+    input::keyboard::{Key, KeyboardInput},
     prelude::*,
 };
 
@@ -15,11 +12,11 @@ fn main() {
         .run();
 }
 
-/// This system prints out all char events as they come in
+/// This system prints out all char events as they come in.
 fn print_char_event_system(mut char_input_events: EventReader<KeyboardInput>) {
     for event in char_input_events.read() {
-        // Only check for characters when the key is pressed
-        if event.state == ButtonState::Released {
+        // Only check for characters when the key is pressed.
+        if !event.state.is_pressed() {
             continue;
         }
         if let Key::Character(character) = &event.logical_key {

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -7,10 +7,7 @@
 use std::mem;
 
 use bevy::{
-    input::{
-        keyboard::{Key, KeyboardInput},
-        ButtonState,
-    },
+    input::keyboard::{Key, KeyboardInput},
     prelude::*,
 };
 
@@ -173,7 +170,7 @@ fn listen_keyboard_input_events(
 ) {
     for event in events.read() {
         // Only trigger changes when the key is first pressed.
-        if event.state == ButtonState::Released {
+        if !event.state.is_pressed() {
             continue;
         }
 


### PR DESCRIPTION
# Objective

- The API usage of `KeyboardInput` in the `char_input_events` and `text_input` examples don't match the [migration guide](https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#deprecate-receivedcharacter).

## Solution

- Check using `is_pressed` over `ButtonState::Released`.