### PR TITLE
Update gilrs to 0.10.8

### DIFF
--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -17,7 +17,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
 
 # other
-gilrs = "0.10.1"
+gilrs = "0.10.8"
 thiserror = "1.0"
 
 [lints]


### PR DESCRIPTION
# Objective

Bevy is currently on a pretty old version of gilrs, dating back to November 2022. This version doesn't work for my Xbox controller on MacOS, but the new version does.

## Solution

Update gilrs to 0.10.8.

## Testing

I tested the gamepad_viewer example and it now displays the expected behavior for me.
