### PR TITLE
Faster MeshletMesh deserialization

### DIFF
--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -18,13 +18,7 @@ shader_format_glsl = ["bevy_render/shader_format_glsl"]
 trace = ["bevy_render/trace"]
 ios_simulator = ["bevy_render/ios_simulator"]
 # Enables the meshlet renderer for dense high-poly scenes (experimental)
-meshlet = [
-  "dep:lz4_flex",
-  "dep:serde",
-  "dep:bincode",
-  "dep:thiserror",
-  "dep:range-alloc",
-]
+meshlet = ["dep:lz4_flex", "dep:thiserror", "dep:range-alloc"]
 # Enables processing meshes into meshlet meshes
 meshlet_processor = ["meshlet", "dep:meshopt", "dep:metis", "dep:itertools"]
 
@@ -53,8 +47,6 @@ fixedbitset = "0.5"
 lz4_flex = { version = "0.11", default-features = false, features = [
   "frame",
 ], optional = true }
-serde = { version = "1", features = ["derive", "rc"], optional = true }
-bincode = { version = "1", optional = true }
 thiserror = { version = "1", optional = true }
 range-alloc = { version = "0.1", optional = true }
 meshopt = { version = "0.3.0", optional = true }

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use self::{
     },
 };
 
-pub use self::asset::*;
+pub use self::asset::{MeshletMesh, MeshletMeshSaverLoader};
 #[cfg(feature = "meshlet_processor")]
 pub use self::from_mesh::MeshToMeshletMeshConversionError;
 
@@ -168,7 +168,7 @@ impl Plugin for MeshletPlugin {
         );
 
         app.init_asset::<MeshletMesh>()
-            .register_asset_loader(MeshletMeshSaverLoad)
+            .register_asset_loader(MeshletMeshSaverLoader)
             .insert_resource(Msaa::Off)
             .add_systems(
                 PostUpdate,

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -16,7 +16,7 @@ use bevy::{
 use camera_controller::{CameraController, CameraControllerPlugin};
 use std::{f32::consts::PI, path::Path, process::ExitCode};
 
-const ASSET_URL: &str = "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh";
+const ASSET_URL: &str = "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/6415487cd0af331411d3a21da4bb3c64804fe414/bunny.meshlet_mesh";
 
 fn main() -> ExitCode {
     if !Path::new("./assets/models/bunny.meshlet_mesh").exists() {


### PR DESCRIPTION
# Objective
- Using bincode to convert a MeshletMesh to binary is expensive (~77ms).

## Solution
- Write a custom deserializer using bytemuck's Pod types and slice casting (~12ms).

## Testing
- Ran the meshlet example, added timing spans to the asset loader.

---

## Changelog
- Improved `MeshletMesh` loading speed
- The `MeshletMesh` disk format has changed, and `MESHLET_MESH_ASSET_VERSION` has been bumped
- `MeshletMesh` fields are now private
- Renamed `MeshletMeshSaverLoad` to `MeshletMeshSaverLoader`
- The `Meshlet`, `MeshletBoundingSpheres`, and `MeshletBoundingSphere` types are now private
- Removed `MeshletMeshSaveOrLoadError::SerializationOrDeserialization`

## Migration Guide
- Regenerate your `MeshletMesh` assets, as the disk format has changed, and `MESHLET_MESH_ASSET_VERSION` has been bumped
- `MeshletMesh` fields are now private
- `MeshletMeshSaverLoad` is now named `MeshletMeshSaverLoader`
- The `Meshlet`, `MeshletBoundingSpheres`, and `MeshletBoundingSphere` types are now private
- `MeshletMeshSaveOrLoadError::SerializationOrDeserialization` has been removed