### PR TITLE
EmptyPathStream is only used in android/wasm32

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -680,9 +680,11 @@ pub(crate) fn get_meta_path(path: &Path) -> PathBuf {
     meta_path
 }
 
+#[cfg(any(target_arch = "wasm32", target_os = "android"))]
 /// A [`PathBuf`] [`Stream`] implementation that immediately returns nothing.
 struct EmptyPathStream;
 
+#[cfg(any(target_arch = "wasm32", target_os = "android"))]
 impl Stream for EmptyPathStream {
     type Item = PathBuf;
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -511,9 +511,9 @@ async fn load_gltf<'a, 'b, 'c>(
 
                     mesh.set_morph_targets(handle);
                     let extras = gltf_mesh.extras().as_ref();
-                    if let Option::<MorphTargetNames>::Some(names) =
-                        extras.and_then(|extras| serde_json::from_str(extras.get()).ok())
-                    {
+                    if let Some(names) = extras.and_then(|extras| {
+                        serde_json::from_str::<MorphTargetNames>(extras.get()).ok()
+                    }) {
                         mesh.set_morph_target_names(names.target_names);
                     }
                 }


### PR DESCRIPTION
# Objective

- `EmptyPathStream` is only used in android and wasm32
- This now makes rust nightly warn

## Solution

- flag the struct to only be present when needed
- also change how `MorphTargetNames` is used because that makes rust happier?
