### PR TITLE
bevy_reflect: Improve `DynamicFunction` ergonomics

### DIFF
--- a/crates/bevy_reflect/derive/src/impls/func/from_arg.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/from_arg.rs
@@ -16,31 +16,22 @@ pub(crate) fn impl_from_arg(
     quote! {
         impl #impl_generics #bevy_reflect::func::args::FromArg for #type_path #ty_generics #where_reflect_clause {
             type Item<'from_arg> = #type_path #ty_generics;
-            fn from_arg<'from_arg>(
-                arg: #bevy_reflect::func::args::Arg<'from_arg>,
-                info: &#bevy_reflect::func::args::ArgInfo,
-            ) -> #FQResult<Self::Item<'from_arg>, #bevy_reflect::func::args::ArgError> {
-                arg.take_owned(info)
+            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::Item<'_>, #bevy_reflect::func::args::ArgError> {
+                arg.take_owned()
             }
         }
 
         impl #impl_generics #bevy_reflect::func::args::FromArg for &'static #type_path #ty_generics #where_reflect_clause {
             type Item<'from_arg> = &'from_arg #type_path #ty_generics;
-            fn from_arg<'from_arg>(
-                arg: #bevy_reflect::func::args::Arg<'from_arg>,
-                info: &#bevy_reflect::func::args::ArgInfo,
-            ) -> #FQResult<Self::Item<'from_arg>, #bevy_reflect::func::args::ArgError> {
-                arg.take_ref(info)
+            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::Item<'_>, #bevy_reflect::func::args::ArgError> {
+                arg.take_ref()
             }
         }
 
         impl #impl_generics #bevy_reflect::func::args::FromArg for &'static mut #type_path #ty_generics #where_reflect_clause {
             type Item<'from_arg> = &'from_arg mut #type_path #ty_generics;
-            fn from_arg<'from_arg>(
-                arg: #bevy_reflect::func::args::Arg<'from_arg>,
-                info: &#bevy_reflect::func::args::ArgInfo,
-            ) -> #FQResult<Self::Item<'from_arg>, #bevy_reflect::func::args::ArgError> {
-                arg.take_mut(info)
+            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::Item<'_>, #bevy_reflect::func::args::ArgError> {
+                arg.take_mut()
             }
         }
     }

--- a/crates/bevy_reflect/derive/src/impls/func/from_arg.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/from_arg.rs
@@ -15,22 +15,22 @@ pub(crate) fn impl_from_arg(
 
     quote! {
         impl #impl_generics #bevy_reflect::func::args::FromArg for #type_path #ty_generics #where_reflect_clause {
-            type Item<'from_arg> = #type_path #ty_generics;
-            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::Item<'_>, #bevy_reflect::func::args::ArgError> {
+            type This<'from_arg> = #type_path #ty_generics;
+            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::This<'_>, #bevy_reflect::func::args::ArgError> {
                 arg.take_owned()
             }
         }
 
         impl #impl_generics #bevy_reflect::func::args::FromArg for &'static #type_path #ty_generics #where_reflect_clause {
-            type Item<'from_arg> = &'from_arg #type_path #ty_generics;
-            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::Item<'_>, #bevy_reflect::func::args::ArgError> {
+            type This<'from_arg> = &'from_arg #type_path #ty_generics;
+            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::This<'_>, #bevy_reflect::func::args::ArgError> {
                 arg.take_ref()
             }
         }
 
         impl #impl_generics #bevy_reflect::func::args::FromArg for &'static mut #type_path #ty_generics #where_reflect_clause {
-            type Item<'from_arg> = &'from_arg mut #type_path #ty_generics;
-            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::Item<'_>, #bevy_reflect::func::args::ArgError> {
+            type This<'from_arg> = &'from_arg mut #type_path #ty_generics;
+            fn from_arg(arg: #bevy_reflect::func::args::Arg) -> #FQResult<Self::This<'_>, #bevy_reflect::func::args::ArgError> {
                 arg.take_mut()
             }
         }

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -57,7 +57,7 @@ impl<'a> Arg<'a> {
     /// let a = args.pop::<u32>().unwrap();
     /// assert_eq!(a, 1);
     /// ```
-    pub fn take<T: FromArg>(self) -> Result<T::Item<'a>, ArgError> {
+    pub fn take<T: FromArg>(self) -> Result<T::This<'a>, ArgError> {
         T::from_arg(self)
     }
 

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -53,14 +53,14 @@ impl<'a> Arg<'a> {
     /// let mut c = 3u32;
     /// let mut args = ArgList::new().push_owned(a).push_ref(&b).push_mut(&mut c);
     ///
-    /// let c = args.pop::<&mut u32>().unwrap();
-    /// assert_eq!(*c, 3);
+    /// let a = args.take::<u32>().unwrap();
+    /// assert_eq!(a, 1);
     ///
-    /// let b = args.pop::<&u32>().unwrap();
+    /// let b = args.take::<&u32>().unwrap();
     /// assert_eq!(*b, 2);
     ///
-    /// let a = args.pop::<u32>().unwrap();
-    /// assert_eq!(a, 1);
+    /// let c = args.take::<&mut u32>().unwrap();
+    /// assert_eq!(*c, 3);
     /// ```
     pub fn take<T: FromArg>(self) -> Result<T::This<'a>, ArgError> {
         T::from_arg(self)
@@ -78,7 +78,7 @@ impl<'a> Arg<'a> {
     /// # use bevy_reflect::func::ArgList;
     /// let value = 123u32;
     /// let mut args = ArgList::new().push_owned(value);
-    /// let value = args.pop_owned::<u32>().unwrap();
+    /// let value = args.take_owned::<u32>().unwrap();
     /// assert_eq!(value, 123);
     /// ```
     pub fn take_owned<T: Reflect + TypePath>(self) -> Result<T, ArgError> {
@@ -113,7 +113,7 @@ impl<'a> Arg<'a> {
     /// # use bevy_reflect::func::ArgList;
     /// let value = 123u32;
     /// let mut args = ArgList::new().push_ref(&value);
-    /// let value = args.pop_ref::<u32>().unwrap();
+    /// let value = args.take_ref::<u32>().unwrap();
     /// assert_eq!(*value, 123);
     /// ```
     pub fn take_ref<T: Reflect + TypePath>(self) -> Result<&'a T, ArgError> {
@@ -150,7 +150,7 @@ impl<'a> Arg<'a> {
     /// # use bevy_reflect::func::ArgList;
     /// let mut value = 123u32;
     /// let mut args = ArgList::new().push_mut(&mut value);
-    /// let value = args.pop_mut::<u32>().unwrap();
+    /// let value = args.take_mut::<u32>().unwrap();
     /// assert_eq!(*value, 123);
     /// ```
     pub fn take_mut<T: Reflect + TypePath>(self) -> Result<&'a mut T, ArgError> {

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -15,39 +15,22 @@ pub struct Arg<'a> {
 }
 
 impl<'a> Arg<'a> {
-    pub fn new(index: usize, value: ArgValue<'a>) -> Self {
+    /// Create a new [`Arg`] with the given index and value.
+    pub(crate) fn new(index: usize, value: ArgValue<'a>) -> Self {
         Self { index, value }
     }
 
-    pub fn new_owned(index: usize, arg: impl Reflect) -> Self {
-        Self {
-            index,
-            value: ArgValue::Owned(Box::new(arg)),
-        }
-    }
-
-    pub fn new_ref(index: usize, arg: &'a dyn Reflect) -> Self {
-        Self {
-            index,
-            value: ArgValue::Ref(arg),
-        }
-    }
-
-    pub fn new_mut(index: usize, arg: &'a mut dyn Reflect) -> Self {
-        Self {
-            index,
-            value: ArgValue::Mut(arg),
-        }
-    }
-
+    /// The index of the argument.
     pub fn index(&self) -> usize {
         self.index
     }
 
+    /// The value of the argument.
     pub fn value(&self) -> &ArgValue<'a> {
         &self.value
     }
 
+    /// Take the value of the argument.
     pub fn take(self) -> ArgValue<'a> {
         self.value
     }

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -16,7 +16,7 @@ pub struct Arg<'a> {
 
 impl<'a> Arg<'a> {
     /// Create a new [`Arg`] with the given index and value.
-    pub(crate) fn new(index: usize, value: ArgValue<'a>) -> Self {
+    pub fn new(index: usize, value: ArgValue<'a>) -> Self {
         Self { index, value }
     }
 

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -1,81 +1,144 @@
-use crate::func::args::{ArgError, ArgInfo, Ownership};
-use crate::Reflect;
+use crate::func::args::{ArgError, Ownership};
+use crate::{Reflect, TypePath};
+use std::ops::Deref;
 
-/// Represents an argument that can be passed to a [`DynamicFunction`] or [`DynamicClosure`].
+/// Represents an argument that can be passed to a [`DynamicFunction`], [`DynamicClosure`],
+/// or [`DynamicClosureMut`].
 ///
 /// [`DynamicFunction`]: crate::func::DynamicFunction
 /// [`DynamicClosure`]: crate::func::DynamicClosure
+/// [`DynamicClosureMut`]: crate::func::DynamicClosureMut
 #[derive(Debug)]
-pub enum Arg<'a> {
+pub struct Arg<'a> {
+    index: usize,
+    value: ArgValue<'a>,
+}
+
+impl<'a> Arg<'a> {
+    pub fn new(index: usize, value: ArgValue<'a>) -> Self {
+        Self { index, value }
+    }
+
+    pub fn new_owned(index: usize, arg: impl Reflect) -> Self {
+        Self {
+            index,
+            value: ArgValue::Owned(Box::new(arg)),
+        }
+    }
+
+    pub fn new_ref(index: usize, arg: &'a dyn Reflect) -> Self {
+        Self {
+            index,
+            value: ArgValue::Ref(arg),
+        }
+    }
+
+    pub fn new_mut(index: usize, arg: &'a mut dyn Reflect) -> Self {
+        Self {
+            index,
+            value: ArgValue::Mut(arg),
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    pub fn value(&self) -> &ArgValue<'a> {
+        &self.value
+    }
+
+    pub fn take(self) -> ArgValue<'a> {
+        self.value
+    }
+
+    /// Returns `Ok(T)` if the argument is [`ArgValue::Owned`].
+    pub fn take_owned<T: Reflect + TypePath>(self) -> Result<T, ArgError> {
+        match self.value {
+            ArgValue::Owned(arg) => arg.take().map_err(|arg| ArgError::UnexpectedType {
+                index: self.index,
+                expected: std::borrow::Cow::Borrowed(T::type_path()),
+                received: std::borrow::Cow::Owned(arg.reflect_type_path().to_string()),
+            }),
+            ArgValue::Ref(_) => Err(ArgError::InvalidOwnership {
+                index: self.index,
+                expected: Ownership::Owned,
+                received: Ownership::Ref,
+            }),
+            ArgValue::Mut(_) => Err(ArgError::InvalidOwnership {
+                index: self.index,
+                expected: Ownership::Owned,
+                received: Ownership::Mut,
+            }),
+        }
+    }
+
+    /// Returns `Ok(&T)` if the argument is [`ArgValue::Ref`].
+    pub fn take_ref<T: Reflect + TypePath>(self) -> Result<&'a T, ArgError> {
+        match self.value {
+            ArgValue::Owned(_) => Err(ArgError::InvalidOwnership {
+                index: self.index,
+                expected: Ownership::Ref,
+                received: Ownership::Owned,
+            }),
+            ArgValue::Ref(arg) => {
+                Ok(arg.downcast_ref().ok_or_else(|| ArgError::UnexpectedType {
+                    index: self.index,
+                    expected: std::borrow::Cow::Borrowed(T::type_path()),
+                    received: std::borrow::Cow::Owned(arg.reflect_type_path().to_string()),
+                })?)
+            }
+            ArgValue::Mut(_) => Err(ArgError::InvalidOwnership {
+                index: self.index,
+                expected: Ownership::Ref,
+                received: Ownership::Mut,
+            }),
+        }
+    }
+
+    /// Returns `Ok(&mut T)` if the argument is [`ArgValue::Mut`].
+    pub fn take_mut<T: Reflect + TypePath>(self) -> Result<&'a mut T, ArgError> {
+        match self.value {
+            ArgValue::Owned(_) => Err(ArgError::InvalidOwnership {
+                index: self.index,
+                expected: Ownership::Mut,
+                received: Ownership::Owned,
+            }),
+            ArgValue::Ref(_) => Err(ArgError::InvalidOwnership {
+                index: self.index,
+                expected: Ownership::Mut,
+                received: Ownership::Ref,
+            }),
+            ArgValue::Mut(arg) => {
+                let received = std::borrow::Cow::Owned(arg.reflect_type_path().to_string());
+                Ok(arg.downcast_mut().ok_or_else(|| ArgError::UnexpectedType {
+                    index: self.index,
+                    expected: std::borrow::Cow::Borrowed(T::type_path()),
+                    received,
+                })?)
+            }
+        }
+    }
+}
+
+/// Represents an argument that can be passed to a [`DynamicFunction`].
+///
+/// [`DynamicFunction`]: crate::func::DynamicFunction
+#[derive(Debug)]
+pub enum ArgValue<'a> {
     Owned(Box<dyn Reflect>),
     Ref(&'a dyn Reflect),
     Mut(&'a mut dyn Reflect),
 }
 
-impl<'a> Arg<'a> {
-    /// Returns `Ok(T)` if the argument is [`Arg::Owned`].
-    pub fn take_owned<T: Reflect>(self, info: &ArgInfo) -> Result<T, ArgError> {
-        match self {
-            Arg::Owned(arg) => arg.take().map_err(|arg| ArgError::UnexpectedType {
-                id: info.id().clone(),
-                expected: ::std::borrow::Cow::Borrowed(info.type_path()),
-                received: ::std::borrow::Cow::Owned(arg.reflect_type_path().to_string()),
-            }),
-            Arg::Ref(_) => Err(ArgError::InvalidOwnership {
-                id: info.id().clone(),
-                expected: Ownership::Owned,
-                received: Ownership::Ref,
-            }),
-            Arg::Mut(_) => Err(ArgError::InvalidOwnership {
-                id: info.id().clone(),
-                expected: Ownership::Owned,
-                received: Ownership::Mut,
-            }),
-        }
-    }
+impl<'a> Deref for ArgValue<'a> {
+    type Target = dyn Reflect;
 
-    /// Returns `Ok(&T)` if the argument is [`Arg::Ref`].
-    pub fn take_ref<T: Reflect>(self, info: &ArgInfo) -> Result<&'a T, ArgError> {
+    fn deref(&self) -> &Self::Target {
         match self {
-            Arg::Owned(_) => Err(ArgError::InvalidOwnership {
-                id: info.id().clone(),
-                expected: Ownership::Ref,
-                received: Ownership::Owned,
-            }),
-            Arg::Ref(arg) => Ok(arg.downcast_ref().ok_or_else(|| ArgError::UnexpectedType {
-                id: info.id().clone(),
-                expected: ::std::borrow::Cow::Borrowed(info.type_path()),
-                received: ::std::borrow::Cow::Owned(arg.reflect_type_path().to_string()),
-            })?),
-            Arg::Mut(_) => Err(ArgError::InvalidOwnership {
-                id: info.id().clone(),
-                expected: Ownership::Ref,
-                received: Ownership::Mut,
-            }),
-        }
-    }
-
-    /// Returns `Ok(&mut T)` if the argument is [`Arg::Mut`].
-    pub fn take_mut<T: Reflect>(self, info: &ArgInfo) -> Result<&'a mut T, ArgError> {
-        match self {
-            Arg::Owned(_) => Err(ArgError::InvalidOwnership {
-                id: info.id().clone(),
-                expected: Ownership::Mut,
-                received: Ownership::Owned,
-            }),
-            Arg::Ref(_) => Err(ArgError::InvalidOwnership {
-                id: info.id().clone(),
-                expected: Ownership::Mut,
-                received: Ownership::Ref,
-            }),
-            Arg::Mut(arg) => {
-                let received = ::std::borrow::Cow::Owned(arg.reflect_type_path().to_string());
-                Ok(arg.downcast_mut().ok_or_else(|| ArgError::UnexpectedType {
-                    id: info.id().clone(),
-                    expected: ::std::borrow::Cow::Borrowed(info.type_path()),
-                    received,
-                })?)
-            }
+            ArgValue::Owned(arg) => arg.as_ref(),
+            ArgValue::Ref(arg) => *arg,
+            ArgValue::Mut(arg) => *arg,
         }
     }
 }

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -25,6 +25,11 @@ impl<'a> Arg<'a> {
         self.index
     }
 
+    /// Set the index of the argument.
+    pub(crate) fn set_index(&mut self, index: usize) {
+        self.index = index;
+    }
+
     /// The value of the argument.
     pub fn value(&self) -> &ArgValue<'a> {
         &self.value

--- a/crates/bevy_reflect/src/func/args/error.rs
+++ b/crates/bevy_reflect/src/func/args/error.rs
@@ -2,24 +2,24 @@ use alloc::borrow::Cow;
 
 use thiserror::Error;
 
-use crate::func::args::{ArgId, Ownership};
+use crate::func::args::Ownership;
 
 /// An error that occurs when converting an [argument].
 ///
-/// [argument]: crate::func::Arg
+/// [argument]: crate::func::ArgValue
 #[derive(Debug, Error, PartialEq)]
 pub enum ArgError {
     /// The argument is not the expected type.
-    #[error("expected `{expected}` but received `{received}` (@ {id:?})")]
+    #[error("expected `{expected}` but received `{received}` (@ argument index {index})")]
     UnexpectedType {
-        id: ArgId,
+        index: usize,
         expected: Cow<'static, str>,
         received: Cow<'static, str>,
     },
     /// The argument has the wrong ownership.
-    #[error("expected {expected} value but received {received} value (@ {id:?})")]
+    #[error("expected {expected} value but received {received} value (@ argument index {index})")]
     InvalidOwnership {
-        id: ArgId,
+        index: usize,
         expected: Ownership,
         received: Ownership,
     },

--- a/crates/bevy_reflect/src/func/args/error.rs
+++ b/crates/bevy_reflect/src/func/args/error.rs
@@ -23,4 +23,9 @@ pub enum ArgError {
         expected: Ownership,
         received: Ownership,
     },
+    /// Occurs when attempting to access an argument from an empty [`ArgList`].
+    ///
+    /// [`ArgList`]: crate::func::args::ArgList
+    #[error("expected an argument but received none")]
+    EmptyArgList,
 }

--- a/crates/bevy_reflect/src/func/args/error.rs
+++ b/crates/bevy_reflect/src/func/args/error.rs
@@ -6,7 +6,7 @@ use crate::func::args::Ownership;
 
 /// An error that occurs when converting an [argument].
 ///
-/// [argument]: crate::func::Arg
+/// [argument]: crate::func::args::Arg
 #[derive(Debug, Error, PartialEq)]
 pub enum ArgError {
     /// The argument is not the expected type.

--- a/crates/bevy_reflect/src/func/args/error.rs
+++ b/crates/bevy_reflect/src/func/args/error.rs
@@ -6,7 +6,7 @@ use crate::func::args::Ownership;
 
 /// An error that occurs when converting an [argument].
 ///
-/// [argument]: crate::func::ArgValue
+/// [argument]: crate::func::Arg
 #[derive(Debug, Error, PartialEq)]
 pub enum ArgError {
     /// The argument is not the expected type.

--- a/crates/bevy_reflect/src/func/args/from_arg.rs
+++ b/crates/bevy_reflect/src/func/args/from_arg.rs
@@ -9,15 +9,18 @@ use crate::func::args::{Arg, ArgError};
 ///
 /// [derive macro]: derive@crate::Reflect
 pub trait FromArg {
-    /// The type of the item created from the argument.
+    /// The type to convert into.
     ///
     /// This should almost always be the same as `Self`, but with the lifetime `'a`.
-    type Item<'a>;
+    ///
+    /// The reason we use a separate associated type is to allow for the lifetime
+    /// to be tied to the argument, rather than the type itself.
+    type This<'a>;
 
     /// Creates an item from an argument.
     ///
     /// The argument must be of the expected type and ownership.
-    fn from_arg(arg: Arg) -> Result<Self::Item<'_>, ArgError>;
+    fn from_arg(arg: Arg) -> Result<Self::This<'_>, ArgError>;
 }
 
 /// Implements the [`FromArg`] trait for the given type.
@@ -54,8 +57,8 @@ macro_rules! impl_from_arg {
                 $($U $(: $U1 $(+ $U2)*)?),*
         )?
         {
-            type Item<'from_arg> = $ty;
-            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::Item<'_>, $crate::func::args::ArgError> {
+            type This<'from_arg> = $ty;
+            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::This<'_>, $crate::func::args::ArgError> {
                 arg.take_owned()
             }
         }
@@ -69,8 +72,8 @@ macro_rules! impl_from_arg {
                 $($U $(: $U1 $(+ $U2)*)?),*
         )?
         {
-            type Item<'from_arg> = &'from_arg $ty;
-            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::Item<'_>, $crate::func::args::ArgError> {
+            type This<'from_arg> = &'from_arg $ty;
+            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::This<'_>, $crate::func::args::ArgError> {
                 arg.take_ref()
             }
         }
@@ -84,8 +87,8 @@ macro_rules! impl_from_arg {
                 $($U $(: $U1 $(+ $U2)*)?),*
         )?
         {
-            type Item<'from_arg> = &'from_arg mut $ty;
-            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::Item<'_>, $crate::func::args::ArgError> {
+            type This<'from_arg> = &'from_arg mut $ty;
+            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::This<'_>, $crate::func::args::ArgError> {
                 arg.take_mut()
             }
         }

--- a/crates/bevy_reflect/src/func/args/from_arg.rs
+++ b/crates/bevy_reflect/src/func/args/from_arg.rs
@@ -2,11 +2,17 @@ use crate::func::args::{Arg, ArgError};
 
 /// A trait for types that can be created from an [`Arg`].
 ///
+/// This trait exists so that types can be automatically converted into an [`Arg`]
+/// by [`IntoFunction`] so they can be passed to a [`DynamicFunction`] in an [`ArgList`].
+///
 /// This trait is used instead of a blanket [`From`] implementation due to coherence issues:
 /// we can't implement `From<T>` for both `T` and `&T`/`&mut T`.
 ///
 /// This trait is automatically implemented when using the `Reflect` [derive macro].
 ///
+/// [`IntoFunction`]: crate::func::IntoFunction
+/// [`DynamicFunction`]: crate::func::DynamicFunction
+/// [`ArgList`]: crate::func::args::ArgList
 /// [derive macro]: derive@crate::Reflect
 pub trait FromArg {
     /// The type to convert into.

--- a/crates/bevy_reflect/src/func/args/from_arg.rs
+++ b/crates/bevy_reflect/src/func/args/from_arg.rs
@@ -1,4 +1,4 @@
-use crate::func::args::{Arg, ArgError, ArgInfo};
+use crate::func::args::{Arg, ArgError};
 
 /// A trait for types that can be created from an [`Arg`].
 ///
@@ -17,7 +17,7 @@ pub trait FromArg {
     /// Creates an item from an argument.
     ///
     /// The argument must be of the expected type and ownership.
-    fn from_arg<'a>(arg: Arg<'a>, info: &ArgInfo) -> Result<Self::Item<'a>, ArgError>;
+    fn from_arg(arg: Arg) -> Result<Self::Item<'_>, ArgError>;
 }
 
 /// Implements the [`FromArg`] trait for the given type.
@@ -55,11 +55,8 @@ macro_rules! impl_from_arg {
         )?
         {
             type Item<'from_arg> = $ty;
-            fn from_arg<'from_arg>(
-                arg: $crate::func::args::Arg<'from_arg>,
-                info: &$crate::func::args::ArgInfo,
-            ) -> Result<Self::Item<'from_arg>, $crate::func::args::ArgError> {
-                arg.take_owned(info)
+            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::Item<'_>, $crate::func::args::ArgError> {
+                arg.take_owned()
             }
         }
 
@@ -73,11 +70,8 @@ macro_rules! impl_from_arg {
         )?
         {
             type Item<'from_arg> = &'from_arg $ty;
-            fn from_arg<'from_arg>(
-                arg: $crate::func::args::Arg<'from_arg>,
-                info: &$crate::func::args::ArgInfo,
-            ) -> Result<Self::Item<'from_arg>, $crate::func::args::ArgError> {
-                arg.take_ref(info)
+            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::Item<'_>, $crate::func::args::ArgError> {
+                arg.take_ref()
             }
         }
 
@@ -91,11 +85,8 @@ macro_rules! impl_from_arg {
         )?
         {
             type Item<'from_arg> = &'from_arg mut $ty;
-            fn from_arg<'from_arg>(
-                arg: $crate::func::args::Arg<'from_arg>,
-                info: &$crate::func::args::ArgInfo,
-            ) -> Result<Self::Item<'from_arg>, $crate::func::args::ArgError> {
-                arg.take_mut(info)
+            fn from_arg(arg: $crate::func::args::Arg) -> Result<Self::Item<'_>, $crate::func::args::ArgError> {
+                arg.take_mut()
             }
         }
     };

--- a/crates/bevy_reflect/src/func/args/info.rs
+++ b/crates/bevy_reflect/src/func/args/info.rs
@@ -3,11 +3,13 @@ use alloc::borrow::Cow;
 use crate::func::args::{GetOwnership, Ownership};
 use crate::TypePath;
 
-/// Type information for an [`Arg`] used in a [`DynamicFunction`] or [`DynamicClosure`].
+/// Type information for an [`Arg`] used in a [`DynamicFunction`], [`DynamicClosure`],
+/// or [`DynamicClosureMut`].
 ///
 /// [`Arg`]: crate::func::args::Arg
 /// [`DynamicFunction`]: crate::func::function::DynamicFunction
 /// [`DynamicClosure`]: crate::func::closures::DynamicClosure
+/// [`DynamicClosureMut`]: crate::func::closures::DynamicClosureMut
 #[derive(Debug, Clone)]
 pub struct ArgInfo {
     /// The index of the argument within its function.

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -66,20 +66,20 @@ impl<'a> ArgList<'a> {
     }
 
     /// Pop the last argument, if any, from the list.
-    pub fn pop_arg(&mut self) -> Option<Arg<'a>> {
-        self.0.pop()
+    pub fn pop_arg(&mut self) -> Result<Arg<'a>, ArgError> {
+        self.0.pop().ok_or(ArgError::EmptyArgList)
     }
 
-    pub fn pop_owned<T: Reflect + TypePath>(&mut self) -> Option<Result<T, ArgError>> {
-        self.pop_arg().map(Arg::take_owned)
+    pub fn pop_owned<T: Reflect + TypePath>(&mut self) -> Result<T, ArgError> {
+        self.pop_arg()?.take_owned()
     }
 
-    pub fn pop_ref<T: Reflect + TypePath>(&mut self) -> Option<Result<&'a T, ArgError>> {
-        self.pop_arg().map(Arg::take_ref)
+    pub fn pop_ref<T: Reflect + TypePath>(&mut self) -> Result<&'a T, ArgError> {
+        self.pop_arg()?.take_ref()
     }
 
-    pub fn pop_mut<T: Reflect + TypePath>(&mut self) -> Option<Result<&'a mut T, ArgError>> {
-        self.pop_arg().map(Arg::take_mut)
+    pub fn pop_mut<T: Reflect + TypePath>(&mut self) -> Result<&'a mut T, ArgError> {
+        self.pop_arg()?.take_mut()
     }
 
     /// Returns the number of arguments in the list.

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -258,3 +258,91 @@ impl<'a> ArgList<'a> {
         self.0.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_push_arguments_in_order() {
+        let args = ArgList::new()
+            .push_owned(123)
+            .push_owned(456)
+            .push_owned(789);
+
+        assert_eq!(args.len(), 3);
+        assert_eq!(args.0[0].index(), 0);
+        assert_eq!(args.0[1].index(), 1);
+        assert_eq!(args.0[2].index(), 2);
+    }
+
+    #[test]
+    fn should_push_arg_with_correct_ownership() {
+        let a = String::from("a");
+        let b = String::from("b");
+        let mut c = String::from("c");
+        let d = String::from("d");
+        let e = String::from("e");
+        let f = String::from("f");
+        let mut g = String::from("g");
+
+        let args = ArgList::new()
+            .push_arg(ArgValue::Owned(Box::new(a)))
+            .push_arg(ArgValue::Ref(&b))
+            .push_arg(ArgValue::Mut(&mut c))
+            .push_owned(d)
+            .push_boxed(Box::new(e))
+            .push_ref(&f)
+            .push_mut(&mut g);
+
+        assert!(matches!(args.0[0].value(), &ArgValue::Owned(_)));
+        assert!(matches!(args.0[1].value(), &ArgValue::Ref(_)));
+        assert!(matches!(args.0[2].value(), &ArgValue::Mut(_)));
+        assert!(matches!(args.0[3].value(), &ArgValue::Owned(_)));
+        assert!(matches!(args.0[4].value(), &ArgValue::Owned(_)));
+        assert!(matches!(args.0[5].value(), &ArgValue::Ref(_)));
+        assert!(matches!(args.0[6].value(), &ArgValue::Mut(_)));
+    }
+
+    #[test]
+    fn should_take_args_in_order() {
+        let a = String::from("a");
+        let b = 123_i32;
+        let c = 456_usize;
+        let mut d = 5.78_f32;
+
+        let mut args = ArgList::new()
+            .push_owned(a)
+            .push_ref(&b)
+            .push_ref(&c)
+            .push_mut(&mut d);
+
+        assert_eq!(args.len(), 4);
+        assert_eq!(args.next_owned::<String>().unwrap(), String::from("a"));
+        assert_eq!(args.next::<&i32>().unwrap(), &123);
+        assert_eq!(args.next_ref::<usize>().unwrap(), &456);
+        assert_eq!(args.next_mut::<f32>().unwrap(), &mut 5.78);
+        assert_eq!(args.len(), 0);
+    }
+
+    #[test]
+    fn should_pop_args_in_reverse_order() {
+        let a = String::from("a");
+        let b = 123_i32;
+        let c = 456_usize;
+        let mut d = 5.78_f32;
+
+        let mut args = ArgList::new()
+            .push_owned(a)
+            .push_ref(&b)
+            .push_ref(&c)
+            .push_mut(&mut d);
+
+        assert_eq!(args.len(), 4);
+        assert_eq!(args.pop_mut::<f32>().unwrap(), &mut 5.78);
+        assert_eq!(args.pop_ref::<usize>().unwrap(), &456);
+        assert_eq!(args.pop::<&i32>().unwrap(), &123);
+        assert_eq!(args.pop_owned::<String>().unwrap(), String::from("a"));
+        assert_eq!(args.len(), 0);
+    }
+}

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -70,14 +70,29 @@ impl<'a> ArgList<'a> {
         self.0.pop().ok_or(ArgError::EmptyArgList)
     }
 
+    /// Pop the last argument, if any, from the list and downcast it to `T`.
+    ///
+    /// Returns `Ok(T)` if the argument is [`ArgValue::Owned`].
+    ///
+    /// If the list is empty or the argument is not owned, returns an error.
     pub fn pop_owned<T: Reflect + TypePath>(&mut self) -> Result<T, ArgError> {
         self.pop_arg()?.take_owned()
     }
 
+    /// Pop the last argument, if any, from the list and downcast it to `&T`.
+    ///
+    /// Returns `Ok(&T)` if the argument is [`ArgValue::Ref`].
+    ///
+    /// If the list is empty or the argument is not a reference, returns an error.
     pub fn pop_ref<T: Reflect + TypePath>(&mut self) -> Result<&'a T, ArgError> {
         self.pop_arg()?.take_ref()
     }
 
+    /// Pop the last argument, if any, from the list and downcast it to `&mut T`.
+    ///
+    /// Returns `Ok(&mut T)` if the argument is [`ArgValue::Mut`].
+    ///
+    /// If the list is empty or the argument is not a mutable reference, returns an error.
     pub fn pop_mut<T: Reflect + TypePath>(&mut self) -> Result<&'a mut T, ArgError> {
         self.pop_arg()?.take_mut()
     }

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -1,4 +1,4 @@
-use crate::func::args::{Arg, ArgInfo, ArgValue};
+use crate::func::args::{Arg, ArgValue};
 use crate::func::ArgError;
 use crate::{Reflect, TypePath};
 

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -74,7 +74,7 @@ impl<'a> ArgList<'a> {
         self.0.pop_front().ok_or(ArgError::EmptyArgList)
     }
 
-    /// Remove the first argument in the list and return `Ok(T::Item)`.
+    /// Remove the first argument in the list and return `Ok(T::This)`.
     ///
     /// If the list is empty or the [`FromArg::from_arg`] call fails, returns an error.
     ///
@@ -96,7 +96,7 @@ impl<'a> ArgList<'a> {
     /// let c = args.next::<&mut u32>().unwrap();
     /// assert_eq!(*c, 3);
     /// ```
-    pub fn next<T: FromArg>(&mut self) -> Result<T::Item<'a>, ArgError> {
+    pub fn next<T: FromArg>(&mut self) -> Result<T::This<'a>, ArgError> {
         self.next_arg()?.take::<T>()
     }
 
@@ -165,7 +165,7 @@ impl<'a> ArgList<'a> {
         self.0.pop_back().ok_or(ArgError::EmptyArgList)
     }
 
-    /// Remove the last argument in the list and return `Ok(T::Item)`.
+    /// Remove the last argument in the list and return `Ok(T::This)`.
     ///
     /// If the list is empty or the [`FromArg::from_arg`] call fails, returns an error.
     ///
@@ -187,7 +187,7 @@ impl<'a> ArgList<'a> {
     /// let a = args.pop::<u32>().unwrap();
     /// assert_eq!(a, 1);
     /// ```
-    pub fn pop<T: FromArg>(&mut self) -> Result<T::Item<'a>, ArgError> {
+    pub fn pop<T: FromArg>(&mut self) -> Result<T::This<'a>, ArgError> {
         self.pop_arg()?.take::<T>()
     }
 

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -1,4 +1,4 @@
-use crate::func::args::{Arg, ArgValue};
+use crate::func::args::{Arg, ArgInfo, ArgValue};
 use crate::func::ArgError;
 use crate::{Reflect, TypePath};
 

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -66,7 +66,7 @@ impl<'a> ArgList<'a> {
         self.push_arg(ArgValue::Owned(arg))
     }
 
-    /// Take the next argument, if any, from the list.
+    /// Remove the first argument in the list and return it.
     ///
     /// It's generally preferred to use [`Self::next`] instead of this method
     /// as it provides a more ergonomic way to immediately downcast the argument.
@@ -74,9 +74,9 @@ impl<'a> ArgList<'a> {
         self.0.pop_front().ok_or(ArgError::EmptyArgList)
     }
 
-    /// Take the next argument, if any, from the list and downcast it to a concrete value, `T`.
+    /// Remove the first argument in the list and return `Ok(T::Item)`.
     ///
-    /// This is a convenience method for calling [`FromArg::from_arg`] on the argument.
+    /// If the list is empty or the [`FromArg::from_arg`] call fails, returns an error.
     ///
     /// # Example
     ///
@@ -100,9 +100,7 @@ impl<'a> ArgList<'a> {
         self.next_arg()?.take::<T>()
     }
 
-    /// Take the next argument, if any, from the list and downcast it to `T`.
-    ///
-    /// Returns `Ok(T)` if the argument is [`ArgValue::Owned`].
+    /// Remove the first argument in the list and return `Ok(T)` if the argument is [`ArgValue::Owned`].
     ///
     /// If the list is empty or the argument is not owned, returns an error.
     ///
@@ -121,9 +119,7 @@ impl<'a> ArgList<'a> {
         self.next_arg()?.take_owned()
     }
 
-    /// Take the next argument, if any, from the list and downcast it to `&T`.
-    ///
-    /// Returns `Ok(&T)` if the argument is [`ArgValue::Ref`].
+    /// Remove the first argument in the list and return `Ok(&T)` if the argument is [`ArgValue::Ref`].
     ///
     /// If the list is empty or the argument is not a reference, returns an error.
     ///
@@ -142,9 +138,7 @@ impl<'a> ArgList<'a> {
         self.next_arg()?.take_ref()
     }
 
-    /// Take the next argument, if any, from the list and downcast it to `&mut T`.
-    ///
-    /// Returns `Ok(&mut T)` if the argument is [`ArgValue::Mut`].
+    /// Remove the first argument in the list and return `Ok(&mut T)` if the argument is [`ArgValue::Mut`].
     ///
     /// If the list is empty or the argument is not a mutable reference, returns an error.
     ///
@@ -163,7 +157,7 @@ impl<'a> ArgList<'a> {
         self.next_arg()?.take_mut()
     }
 
-    /// Pop the last argument, if any, from the list.
+    /// Remove the last argument in the list and return it.
     ///
     /// It's generally preferred to use [`Self::pop`] instead of this method
     /// as it provides a more ergonomic way to immediately downcast the argument.
@@ -171,9 +165,9 @@ impl<'a> ArgList<'a> {
         self.0.pop_back().ok_or(ArgError::EmptyArgList)
     }
 
-    /// Pop the last argument, if any, from the list and downcast it to a concrete value, `T`.
+    /// Remove the last argument in the list and return `Ok(T::Item)`.
     ///
-    /// This is a convenience method for calling [`FromArg::from_arg`] on the argument.
+    /// If the list is empty or the [`FromArg::from_arg`] call fails, returns an error.
     ///
     /// # Example
     ///
@@ -197,9 +191,7 @@ impl<'a> ArgList<'a> {
         self.pop_arg()?.take::<T>()
     }
 
-    /// Pop the last argument, if any, from the list and downcast it to `T`.
-    ///
-    /// Returns `Ok(T)` if the argument is [`ArgValue::Owned`].
+    /// Remove the last argument in the list and return `Ok(T)` if the argument is [`ArgValue::Owned`].
     ///
     /// If the list is empty or the argument is not owned, returns an error.
     ///
@@ -218,9 +210,7 @@ impl<'a> ArgList<'a> {
         self.pop_arg()?.take_owned()
     }
 
-    /// Pop the last argument, if any, from the list and downcast it to `&T`.
-    ///
-    /// Returns `Ok(&T)` if the argument is [`ArgValue::Ref`].
+    /// Remove the last argument in the list and return `Ok(&T)` if the argument is [`ArgValue::Ref`].
     ///
     /// If the list is empty or the argument is not a reference, returns an error.
     ///
@@ -239,9 +229,7 @@ impl<'a> ArgList<'a> {
         self.pop_arg()?.take_ref()
     }
 
-    /// Pop the last argument, if any, from the list and downcast it to `&mut T`.
-    ///
-    /// Returns `Ok(&mut T)` if the argument is [`ArgValue::Mut`].
+    /// Remove the last argument in the list and return `Ok(&mut T)` if the argument is [`ArgValue::Mut`].
     ///
     /// If the list is empty or the argument is not a mutable reference, returns an error.
     ///

--- a/crates/bevy_reflect/src/func/args/ownership.rs
+++ b/crates/bevy_reflect/src/func/args/ownership.rs
@@ -2,8 +2,14 @@ use core::fmt::{Display, Formatter};
 
 /// A trait for getting the ownership of a type.
 ///
+/// This trait exists so that [`IntoFunction`] can automatically generate
+/// [`FunctionInfo`] containing the proper [`Ownership`] for its [argument] types.
+///
 /// This trait is automatically implemented when using the `Reflect` [derive macro].
 ///
+/// [`IntoFunction`]: crate::func::IntoFunction
+/// [`FunctionInfo`]: crate::func::FunctionInfo
+/// [argument]: crate::func::args::Arg
 /// [derive macro]: derive@crate::Reflect
 pub trait GetOwnership {
     /// Returns the ownership of [`Self`].

--- a/crates/bevy_reflect/src/func/closures/dynamic_closure.rs
+++ b/crates/bevy_reflect/src/func/closures/dynamic_closure.rs
@@ -56,7 +56,7 @@ impl<'env> DynamicClosure<'env> {
     /// The given function can be used to call out to a regular function, closure, or method.
     ///
     /// It's important that the closure signature matches the provided [`FunctionInfo`].
-    /// This info is used to validate the arguments and return value.
+    /// This info may be used by consumers of the function for validation and debugging.
     pub fn new<F: for<'a> Fn(ArgList<'a>) -> FunctionResult<'a> + 'env>(
         func: F,
         info: FunctionInfo,
@@ -83,8 +83,8 @@ impl<'env> DynamicClosure<'env> {
 
     /// Set the arguments of the closure.
     ///
-    /// It is very important that the arguments match the intended closure signature,
-    /// as this is used to validate arguments passed to the closure.
+    /// It's important that the arguments match the intended closure signature,
+    /// as this can be used by consumers of the function for validation and debugging.
     pub fn with_args(mut self, args: Vec<ArgInfo>) -> Self {
         self.info = self.info.with_args(args);
         self

--- a/crates/bevy_reflect/src/func/closures/dynamic_closure.rs
+++ b/crates/bevy_reflect/src/func/closures/dynamic_closure.rs
@@ -47,7 +47,7 @@ use crate::func::{FunctionResult, IntoClosure, ReturnInfo};
 /// [`DynamicFunction`]: crate::func::DynamicFunction
 pub struct DynamicClosure<'env> {
     info: FunctionInfo,
-    func: Box<dyn for<'a> Fn(ArgList<'a>, &FunctionInfo) -> FunctionResult<'a> + 'env>,
+    func: Box<dyn for<'a> Fn(ArgList<'a>) -> FunctionResult<'a> + 'env>,
 }
 
 impl<'env> DynamicClosure<'env> {
@@ -57,7 +57,7 @@ impl<'env> DynamicClosure<'env> {
     ///
     /// It's important that the closure signature matches the provided [`FunctionInfo`].
     /// This info is used to validate the arguments and return value.
-    pub fn new<F: for<'a> Fn(ArgList<'a>, &FunctionInfo) -> FunctionResult<'a> + 'env>(
+    pub fn new<F: for<'a> Fn(ArgList<'a>) -> FunctionResult<'a> + 'env>(
         func: F,
         info: FunctionInfo,
     ) -> Self {
@@ -113,7 +113,7 @@ impl<'env> DynamicClosure<'env> {
     /// assert_eq!(result.take::<i32>().unwrap(), 123);
     /// ```
     pub fn call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
-        (self.func)(args, &self.info)
+        (self.func)(args)
     }
 
     /// Returns the closure info.

--- a/crates/bevy_reflect/src/func/closures/dynamic_closure_mut.rs
+++ b/crates/bevy_reflect/src/func/closures/dynamic_closure_mut.rs
@@ -56,7 +56,7 @@ use crate::func::{FunctionResult, IntoClosureMut, ReturnInfo};
 /// [`DynamicFunction`]: crate::func::DynamicFunction
 pub struct DynamicClosureMut<'env> {
     info: FunctionInfo,
-    func: Box<dyn for<'a> FnMut(ArgList<'a>, &FunctionInfo) -> FunctionResult<'a> + 'env>,
+    func: Box<dyn for<'a> FnMut(ArgList<'a>) -> FunctionResult<'a> + 'env>,
 }
 
 impl<'env> DynamicClosureMut<'env> {
@@ -66,7 +66,7 @@ impl<'env> DynamicClosureMut<'env> {
     ///
     /// It's important that the closure signature matches the provided [`FunctionInfo`].
     /// This info is used to validate the arguments and return value.
-    pub fn new<F: for<'a> FnMut(ArgList<'a>, &FunctionInfo) -> FunctionResult<'a> + 'env>(
+    pub fn new<F: for<'a> FnMut(ArgList<'a>) -> FunctionResult<'a> + 'env>(
         func: F,
         info: FunctionInfo,
     ) -> Self {
@@ -130,7 +130,7 @@ impl<'env> DynamicClosureMut<'env> {
     ///
     /// [`call_once`]: DynamicClosureMut::call_once
     pub fn call<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
-        (self.func)(args, &self.info)
+        (self.func)(args)
     }
 
     /// Call the closure with the given arguments and consume the closure.
@@ -155,7 +155,7 @@ impl<'env> DynamicClosureMut<'env> {
     /// assert_eq!(count, 5);
     /// ```
     pub fn call_once(mut self, args: ArgList) -> FunctionResult {
-        (self.func)(args, &self.info)
+        (self.func)(args)
     }
 
     /// Returns the closure info.

--- a/crates/bevy_reflect/src/func/closures/dynamic_closure_mut.rs
+++ b/crates/bevy_reflect/src/func/closures/dynamic_closure_mut.rs
@@ -65,7 +65,7 @@ impl<'env> DynamicClosureMut<'env> {
     /// The given function can be used to call out to a regular function, closure, or method.
     ///
     /// It's important that the closure signature matches the provided [`FunctionInfo`].
-    /// This info is used to validate the arguments and return value.
+    /// This info may be used by consumers of the function for validation and debugging.
     pub fn new<F: for<'a> FnMut(ArgList<'a>) -> FunctionResult<'a> + 'env>(
         func: F,
         info: FunctionInfo,
@@ -92,8 +92,8 @@ impl<'env> DynamicClosureMut<'env> {
 
     /// Set the arguments of the closure.
     ///
-    /// It is very important that the arguments match the intended closure signature,
-    /// as this is used to validate arguments passed to the closure.
+    /// It's important that the arguments match the intended closure signature,
+    /// as this can be used by consumers of the function for validation and debugging.
     pub fn with_args(mut self, args: Vec<ArgInfo>) -> Self {
         self.info = self.info.with_args(args);
         self

--- a/crates/bevy_reflect/src/func/closures/into_closure.rs
+++ b/crates/bevy_reflect/src/func/closures/into_closure.rs
@@ -21,10 +21,7 @@ where
     F: ReflectFn<'env, Marker1> + TypedFunction<Marker2> + 'env,
 {
     fn into_closure(self) -> DynamicClosure<'env> {
-        DynamicClosure::new(
-            move |args, info| self.reflect_call(args, info),
-            Self::function_info(),
-        )
+        DynamicClosure::new(move |args| self.reflect_call(args), Self::function_info())
     }
 }
 

--- a/crates/bevy_reflect/src/func/closures/into_closure_mut.rs
+++ b/crates/bevy_reflect/src/func/closures/into_closure_mut.rs
@@ -23,7 +23,7 @@ where
 {
     fn into_closure_mut(mut self) -> DynamicClosureMut<'env> {
         DynamicClosureMut::new(
-            move |args, info| self.reflect_call_mut(args, info),
+            move |args| self.reflect_call_mut(args),
             Self::function_info(),
         )
     }

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -13,7 +13,7 @@ pub enum FunctionError {
     ArgError(#[from] ArgError),
     /// The number of arguments provided does not match the expected number.
     #[error("expected {expected} arguments but received {received}")]
-    InvalidArgCount { expected: usize, received: usize },
+    ArgCountMismatch { expected: usize, received: usize },
 }
 
 /// The result of calling a dynamic [`DynamicFunction`] or [`DynamicClosure`].

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -69,8 +69,8 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 /// // Then we define the dynamic function, which will be used to call our `append` function:
 /// let mut func = DynamicFunction::new(|mut args| {
 ///   // Arguments are popped from the list in reverse order:
-///   let arg1 = args.pop_mut::<Vec<String>>()?;
-///   let arg0 = args.pop_owned::<String>()?;
+///   let arg1 = args.pop::<&mut Vec<String>>()?;
+///   let arg0 = args.pop::<String>()?;
 ///
 ///   // Then we can call our function and return the result:
 ///   Ok(Return::Mut(append(arg0, arg1)))
@@ -237,8 +237,8 @@ mod tests {
 
         let func = DynamicFunction::new(
             |mut args| {
-                let list = args.pop_ref::<Vec<String>>()?;
-                let index = args.pop_owned::<usize>()?;
+                let list = args.pop::<&Vec<String>>()?;
+                let index = args.pop::<usize>()?;
                 Ok(Return::Ref(get(index, list)))
             },
             FunctionInfo::new()

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -73,8 +73,8 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 /// // Then we define the dynamic function, which will be used to call our `append` function:
 /// let mut func = DynamicFunction::new(|mut args, info| {
 ///   // Arguments are popped from the list in reverse order:
-///   let arg1 = args.pop_mut::<Vec<String>>().unwrap()?;
-///   let arg0 = args.pop_owned::<String>().unwrap()?;
+///   let arg1 = args.pop_mut::<Vec<String>>()?;
+///   let arg0 = args.pop_owned::<String>()?;
 ///
 ///   // Then we can call our function and return the result:
 ///   Ok(Return::Mut(append(arg0, arg1)))

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -62,10 +62,8 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 /// // We start by defining the shape of the function:
 /// let info = FunctionInfo::new()
 ///   .with_name("append")
-///   .with_args(vec![
-///     ArgInfo::new::<String>(0).with_name("value"),
-///     ArgInfo::new::<&mut Vec<String>>(1).with_name("list"),
-///   ])
+///   .with_arg::<String>("value")
+///   .with_arg::<&mut Vec<String>>("list")
 ///   .with_return_info(
 ///     ReturnInfo::new::<&mut String>()
 ///   );

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -68,9 +68,9 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 ///
 /// // Then we define the dynamic function, which will be used to call our `append` function:
 /// let mut func = DynamicFunction::new(|mut args| {
-///   // Arguments are popped from the list in reverse order:
-///   let arg1 = args.pop::<&mut Vec<String>>()?;
-///   let arg0 = args.pop::<String>()?;
+///   // Arguments are removed from the list in order:
+///   let arg0 = args.next::<String>()?;
+///   let arg1 = args.next::<&mut Vec<String>>()?;
 ///
 ///   // Then we can call our function and return the result:
 ///   Ok(Return::Mut(append(arg0, arg1)))

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -71,7 +71,7 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 ///   );
 ///
 /// // Then we define the dynamic function, which will be used to call our `append` function:
-/// let mut func = DynamicFunction::new(|mut args, info| {
+/// let mut func = DynamicFunction::new(|mut args| {
 ///   // Arguments are popped from the list in reverse order:
 ///   let arg1 = args.pop_mut::<Vec<String>>()?;
 ///   let arg0 = args.pop_owned::<String>()?;
@@ -97,7 +97,7 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 /// [module-level documentation]: crate::func
 pub struct DynamicFunction {
     info: FunctionInfo,
-    func: Arc<dyn for<'a> Fn(ArgList<'a>, &FunctionInfo) -> FunctionResult<'a> + 'static>,
+    func: Arc<dyn for<'a> Fn(ArgList<'a>) -> FunctionResult<'a> + 'static>,
 }
 
 impl DynamicFunction {
@@ -107,7 +107,7 @@ impl DynamicFunction {
     ///
     /// It's important that the function signature matches the provided [`FunctionInfo`].
     /// This info is used to validate the arguments and return value.
-    pub fn new<F: for<'a> Fn(ArgList<'a>, &FunctionInfo) -> FunctionResult<'a> + 'static>(
+    pub fn new<F: for<'a> Fn(ArgList<'a>) -> FunctionResult<'a> + 'static>(
         func: F,
         info: FunctionInfo,
     ) -> Self {
@@ -159,7 +159,7 @@ impl DynamicFunction {
     /// assert_eq!(result.take::<i32>().unwrap(), 100);
     /// ```
     pub fn call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
-        (self.func)(args, &self.info)
+        (self.func)(args)
     }
 
     /// Returns the function info.

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -69,8 +69,8 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 /// // Then we define the dynamic function, which will be used to call our `append` function:
 /// let mut func = DynamicFunction::new(|mut args| {
 ///   // Arguments are removed from the list in order:
-///   let arg0 = args.next::<String>()?;
-///   let arg1 = args.next::<&mut Vec<String>>()?;
+///   let arg0 = args.take::<String>()?;
+///   let arg1 = args.take::<&mut Vec<String>>()?;
 ///
 ///   // Then we can call our function and return the result:
 ///   Ok(Return::Mut(append(arg0, arg1)))

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -64,9 +64,7 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 ///   .with_name("append")
 ///   .with_arg::<String>("value")
 ///   .with_arg::<&mut Vec<String>>("list")
-///   .with_return_info(
-///     ReturnInfo::new::<&mut String>()
-///   );
+///   .with_return::<&mut String>();
 ///
 /// // Then we define the dynamic function, which will be used to call our `append` function:
 /// let mut func = DynamicFunction::new(|mut args| {

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -73,8 +73,8 @@ use crate::func::{FunctionResult, IntoFunction, ReturnInfo};
 /// // Then we define the dynamic function, which will be used to call our `append` function:
 /// let mut func = DynamicFunction::new(|mut args, info| {
 ///   // Arguments are popped from the list in reverse order:
-///   let arg1 = args.pop().unwrap().take_mut::<Vec<String>>(&info.args()[1]).unwrap();
-///   let arg0 = args.pop().unwrap().take_owned::<String>(&info.args()[0]).unwrap();
+///   let arg1 = args.pop_mut::<Vec<String>>().unwrap()?;
+///   let arg0 = args.pop_owned::<String>().unwrap()?;
 ///
 ///   // Then we can call our function and return the result:
 ///   Ok(Return::Mut(append(arg0, arg1)))

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -106,7 +106,7 @@ impl DynamicFunction {
     /// The given function can be used to call out to a regular function, closure, or method.
     ///
     /// It's important that the function signature matches the provided [`FunctionInfo`].
-    /// This info is used to validate the arguments and return value.
+    /// This info may be used by consumers of the function for validation and debugging.
     pub fn new<F: for<'a> Fn(ArgList<'a>) -> FunctionResult<'a> + 'static>(
         func: F,
         info: FunctionInfo,
@@ -130,8 +130,8 @@ impl DynamicFunction {
 
     /// Set the arguments of the function.
     ///
-    /// It is very important that the arguments match the intended function signature,
-    /// as this is used to validate arguments passed to the function.
+    /// It's important that the arguments match the intended function signature,
+    /// as this can be used by consumers of the function for validation and debugging.
     pub fn with_args(mut self, args: Vec<ArgInfo>) -> Self {
         self.info = self.info.with_args(args);
         self

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -49,11 +49,6 @@ impl FunctionInfo {
     }
 
     /// Set the arguments of the function.
-    ///
-    /// Arguments passed to the function will be validated against the info provided here.
-    /// Mismatched arguments may result in the function call returning an [error].
-    ///
-    /// [error]: crate::func::FunctionError
     pub fn with_args(mut self, args: Vec<ArgInfo>) -> Self {
         self.args = args;
         self

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -72,7 +72,23 @@ impl FunctionInfo {
         self
     }
 
-    /// Set the return information of the function.
+    /// Set the [return information] of the function.
+    ///
+    /// To manually set the [`ReturnInfo`] of the function, see [`Self::with_return_info`].
+    ///
+    /// [return information]: ReturnInfo
+    pub fn with_return<T: TypePath + GetOwnership>(mut self) -> Self {
+        self.return_info = ReturnInfo::new::<T>();
+        self
+    }
+
+    /// Set the [return information] of the function.
+    ///
+    /// This will completely replace any existing return information.
+    ///
+    /// For a simpler, static version of this method, see [`Self::with_return`].
+    ///
+    /// [return information]: ReturnInfo
     pub fn with_return_info(mut self, return_info: ReturnInfo) -> Self {
         self.return_info = return_info;
         self

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -48,7 +48,25 @@ impl FunctionInfo {
         self
     }
 
+    /// Push an argument onto the function's argument list.
+    ///
+    /// The order in which this method is called matters as it will determine the index of the argument
+    /// based on the current number of arguments.
+    pub fn with_arg<T: TypePath + GetOwnership>(
+        mut self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        let index = self.args.len();
+        self.args.push(ArgInfo::new::<T>(index).with_name(name));
+        self
+    }
+
     /// Set the arguments of the function.
+    ///
+    /// This will completely replace any existing arguments.
+    ///
+    /// It's preferable to use [`Self::with_arg`] to add arguments to the function
+    /// as it will automatically set the index of the argument.
     pub fn with_args(mut self, args: Vec<ArgInfo>) -> Self {
         self.args = args;
         self

--- a/crates/bevy_reflect/src/func/into_function.rs
+++ b/crates/bevy_reflect/src/func/into_function.rs
@@ -47,10 +47,7 @@ where
         // However, we don't do this because it would prevent users from
         // converting function pointers into `DynamicFunction`s.
 
-        DynamicFunction::new(
-            move |args, info| self.reflect_call(args, info),
-            Self::function_info(),
-        )
+        DynamicFunction::new(move |args| self.reflect_call(args), Self::function_info())
     }
 }
 

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -99,7 +99,7 @@
 //! [lack of variadic generics]: https://poignardazur.github.io/2024/05/25/report-on-rustnl-variadics/
 //! [coherence issues]: https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#coherence-leak-check
 
-pub use args::{Arg, ArgError, ArgList};
+pub use args::{ArgError, ArgList, ArgValue};
 pub use closures::*;
 pub use error::*;
 pub use function::*;
@@ -124,7 +124,7 @@ mod return_type;
 mod tests {
     use alloc::borrow::Cow;
 
-    use crate::func::args::{ArgError, ArgId, ArgList, Ownership};
+    use crate::func::args::{ArgError, ArgList, Ownership};
     use crate::TypePath;
 
     use super::*;
@@ -171,7 +171,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             FunctionError::ArgError(ArgError::UnexpectedType {
-                id: ArgId::Index(0),
+                index: 0,
                 expected: Cow::Borrowed(i32::type_path()),
                 received: Cow::Borrowed(u32::type_path())
             })
@@ -188,7 +188,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             FunctionError::ArgError(ArgError::InvalidOwnership {
-                id: ArgId::Index(0),
+                index: 0,
                 expected: Ownership::Ref,
                 received: Ownership::Owned
             })

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -138,7 +138,7 @@ mod tests {
         let result = func.call(args);
         assert_eq!(
             result.unwrap_err(),
-            FunctionError::InvalidArgCount {
+            FunctionError::ArgCountMismatch {
                 expected: 1,
                 received: 0
             }
@@ -154,7 +154,7 @@ mod tests {
         let result = func.call(args);
         assert_eq!(
             result.unwrap_err(),
-            FunctionError::InvalidArgCount {
+            FunctionError::ArgCountMismatch {
                 expected: 0,
                 received: 1
             }

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -80,8 +80,8 @@ macro_rules! impl_reflect_fn {
             // This clause allows us to convert `ReturnType` into `Return`
             ReturnType: IntoReturn + Reflect,
             Function: Fn($($Arg),*) -> ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> Fn($($Arg::Item<'a>),*) -> ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> Fn($($Arg::This<'a>),*) -> ReturnType + 'env,
         {
             #[allow(unused_mut)]
             fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
@@ -110,8 +110,8 @@ macro_rules! impl_reflect_fn {
             // This clause allows us to convert `&ReturnType` into `Return`
             for<'a> &'a ReturnType: IntoReturn,
             Function: for<'a> Fn(&'a Receiver, $($Arg),*) -> &'a ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> Fn(&'a Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> Fn(&'a Receiver, $($Arg::This<'a>),*) -> &'a ReturnType + 'env,
         {
             fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
@@ -140,8 +140,8 @@ macro_rules! impl_reflect_fn {
             // This clause allows us to convert `&mut ReturnType` into `Return`
             for<'a> &'a mut ReturnType: IntoReturn,
             Function: for<'a> Fn(&'a mut Receiver, $($Arg),*) -> &'a mut ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> Fn(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a mut ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> Fn(&'a mut Receiver, $($Arg::This<'a>),*) -> &'a mut ReturnType + 'env,
         {
             fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
@@ -170,8 +170,8 @@ macro_rules! impl_reflect_fn {
             // This clause allows us to convert `&ReturnType` into `Return`
             for<'a> &'a ReturnType: IntoReturn,
             Function: for<'a> Fn(&'a mut Receiver, $($Arg),*) -> &'a ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> Fn(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> Fn(&'a mut Receiver, $($Arg::This<'a>),*) -> &'a ReturnType + 'env,
         {
             fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -87,7 +87,7 @@ macro_rules! impl_reflect_fn {
                 const COUNT: usize = count_tokens!($($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });
@@ -119,7 +119,7 @@ macro_rules! impl_reflect_fn {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });
@@ -154,7 +154,7 @@ macro_rules! impl_reflect_fn {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });
@@ -189,7 +189,7 @@ macro_rules! impl_reflect_fn {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -3,7 +3,7 @@ use bevy_utils::all_tuples;
 use crate::func::args::FromArg;
 use crate::func::macros::count_tokens;
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionResult, IntoReturn, ReflectFnMut};
-use crate::Reflect;
+use crate::{Reflect, TypePath};
 
 /// A reflection-based version of the [`Fn`] trait.
 ///
@@ -94,14 +94,11 @@ macro_rules! impl_reflect_fn {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [$($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                #[allow(unused_mut)]
-                let mut _index = 0;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)($($arg,)*).into_return())
             }
@@ -110,7 +107,7 @@ macro_rules! impl_reflect_fn {
         // === (&self, ...) -> &ReturnType === //
         impl<'env, Receiver, $($Arg,)* ReturnType, Function> ReflectFn<'env, fn(&Receiver, $($Arg),*) -> &ReturnType> for Function
         where
-            Receiver: Reflect,
+            Receiver: Reflect + TypePath,
             $($Arg: FromArg,)*
             ReturnType: Reflect,
             // This clause allows us to convert `&ReturnType` into `Return`
@@ -129,16 +126,14 @@ macro_rules! impl_reflect_fn {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                let receiver = receiver.take_ref::<Receiver>(_info.args().get(0).expect("argument index out of bounds"))?;
+                // Convert receiver argument into its concrete type
+                let receiver = receiver.take_ref::<Receiver>()?;
 
-                #[allow(unused_mut)]
-                let mut _index = 1;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -147,7 +142,7 @@ macro_rules! impl_reflect_fn {
         // === (&mut self, ...) -> &mut ReturnType === //
         impl<'env, Receiver, $($Arg,)* ReturnType, Function> ReflectFn<'env, fn(&mut Receiver, $($Arg),*) -> &mut ReturnType> for Function
         where
-            Receiver: Reflect,
+            Receiver: Reflect + TypePath,
             $($Arg: FromArg,)*
             ReturnType: Reflect,
             // This clause allows us to convert `&mut ReturnType` into `Return`
@@ -166,16 +161,14 @@ macro_rules! impl_reflect_fn {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                let receiver = receiver.take_mut::<Receiver>(_info.args().get(0).expect("argument index out of bounds"))?;
+                // Convert receiver argument into its concrete type
+                let receiver = receiver.take_mut::<Receiver>()?;
 
-                #[allow(unused_mut)]
-                let mut _index = 1;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -184,7 +177,7 @@ macro_rules! impl_reflect_fn {
         // === (&mut self, ...) -> &ReturnType === //
         impl<'env, Receiver, $($Arg,)* ReturnType, Function> ReflectFn<'env, fn(&mut Receiver, $($Arg),*) -> &ReturnType> for Function
         where
-            Receiver: Reflect,
+            Receiver: Reflect + TypePath,
             $($Arg: FromArg,)*
             ReturnType: Reflect,
             // This clause allows us to convert `&ReturnType` into `Return`
@@ -203,16 +196,14 @@ macro_rules! impl_reflect_fn {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                let receiver = receiver.take_mut::<Receiver>(_info.args().get(0).expect("argument index out of bounds"))?;
+                // Convert receiver argument into its concrete type
+                let receiver = receiver.take_mut::<Receiver>()?;
 
-                #[allow(unused_mut)]
-                let mut _index = 1;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -95,7 +95,7 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                $(let $arg = args.next::<$Arg>()?;)*
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)($($arg,)*).into_return())
             }
@@ -124,8 +124,8 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let receiver = args.next_ref::<Receiver>()?;
-                $(let $arg = args.next::<$Arg>()?;)*
+                let receiver = args.take_ref::<Receiver>()?;
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -154,8 +154,8 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let receiver = args.next_mut::<Receiver>()?;
-                $(let $arg = args.next::<$Arg>()?;)*
+                let receiver = args.take_mut::<Receiver>()?;
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -184,8 +184,8 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let receiver = args.next_mut::<Receiver>()?;
-                $(let $arg = args.next::<$Arg>()?;)*
+                let receiver = args.take_mut::<Receiver>()?;
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -83,7 +83,8 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn($($Arg::Item<'a>),*) -> ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
+            #[allow(unused_mut)]
+            fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!($($Arg)*);
 
                 if args.len() != COUNT {
@@ -94,10 +95,7 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let [$($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)($($arg,)*).into_return())
             }
@@ -115,7 +113,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn(&'a Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -126,13 +124,8 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert receiver argument into its concrete type
-                let receiver = receiver.take_ref::<Receiver>()?;
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                let receiver = args.next_ref::<Receiver>()?;
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -150,7 +143,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a mut ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -161,13 +154,8 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert receiver argument into its concrete type
-                let receiver = receiver.take_mut::<Receiver>()?;
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                let receiver = args.next_mut::<Receiver>()?;
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -185,7 +173,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -196,13 +184,8 @@ macro_rules! impl_reflect_fn {
                 }
 
                 // Extract all arguments (in order)
-                let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert receiver argument into its concrete type
-                let receiver = receiver.take_mut::<Receiver>()?;
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                let receiver = args.next_mut::<Receiver>()?;
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -2,7 +2,7 @@ use bevy_utils::all_tuples;
 
 use crate::func::args::FromArg;
 use crate::func::macros::count_tokens;
-use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionResult, IntoReturn, ReflectFnMut};
+use crate::func::{ArgList, FunctionError, FunctionResult, IntoReturn, ReflectFnMut};
 use crate::{Reflect, TypePath};
 
 /// A reflection-based version of the [`Fn`] trait.
@@ -33,16 +33,15 @@ use crate::{Reflect, TypePath};
 /// # Example
 ///
 /// ```
-/// # use bevy_reflect::func::{ArgList, FunctionInfo, ReflectFn, TypedFunction};
+/// # use bevy_reflect::func::{ArgList, FunctionInfo, ReflectFn};
 /// #
 /// fn add(a: i32, b: i32) -> i32 {
 ///   a + b
 /// }
 ///
 /// let args = ArgList::new().push_owned(25_i32).push_owned(75_i32);
-/// let info = add.get_function_info();
 ///
-/// let value = add.reflect_call(args, &info).unwrap().unwrap_owned();
+/// let value = add.reflect_call(args).unwrap().unwrap_owned();
 /// assert_eq!(value.take::<i32>().unwrap(), 100);
 /// ```
 ///
@@ -62,7 +61,7 @@ use crate::{Reflect, TypePath};
 /// [unconstrained type parameters]: https://doc.rust-lang.org/error_codes/E0207.html
 pub trait ReflectFn<'env, Marker>: ReflectFnMut<'env, Marker> {
     /// Call the function with the given arguments and return the result.
-    fn reflect_call<'a>(&self, args: ArgList<'a>, info: &FunctionInfo) -> FunctionResult<'a>;
+    fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a>;
 }
 
 /// Helper macro for implementing [`ReflectFn`] on Rust closures.
@@ -84,7 +83,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn($($Arg::Item<'a>),*) -> ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!($($Arg)*);
 
                 if args.len() != COUNT {
@@ -116,7 +115,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn(&'a Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -151,7 +150,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a mut ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -186,7 +185,7 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> Fn(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call<'a>(&self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -2,7 +2,7 @@ use bevy_utils::all_tuples;
 
 use crate::func::args::FromArg;
 use crate::func::macros::count_tokens;
-use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionResult, IntoReturn};
+use crate::func::{ArgList, FunctionError, FunctionResult, IntoReturn};
 use crate::{Reflect, TypePath};
 
 /// A reflection-based version of the [`FnMut`] trait.
@@ -35,7 +35,7 @@ use crate::{Reflect, TypePath};
 /// # Example
 ///
 /// ```
-/// # use bevy_reflect::func::{ArgList, FunctionInfo, ReflectFnMut, TypedFunction};
+/// # use bevy_reflect::func::{ArgList, FunctionInfo, ReflectFnMut};
 /// #
 /// let mut list: Vec<i32> = vec![1, 3];
 ///
@@ -45,9 +45,8 @@ use crate::{Reflect, TypePath};
 /// };
 ///
 /// let args = ArgList::new().push_owned(1_usize).push_owned(2_i32);
-/// let info = insert.get_function_info();
 ///
-/// insert.reflect_call_mut(args, &info).unwrap();
+/// insert.reflect_call_mut(args).unwrap();
 /// assert_eq!(list, vec![1, 2, 3]);
 /// ```
 ///
@@ -68,11 +67,7 @@ use crate::{Reflect, TypePath};
 /// [unconstrained type parameters]: https://doc.rust-lang.org/error_codes/E0207.html
 pub trait ReflectFnMut<'env, Marker> {
     /// Call the function with the given arguments and return the result.
-    fn reflect_call_mut<'a>(
-        &mut self,
-        args: ArgList<'a>,
-        info: &FunctionInfo,
-    ) -> FunctionResult<'a>;
+    fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a>;
 }
 
 /// Helper macro for implementing [`ReflectFnMut`] on Rust closures.
@@ -94,7 +89,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut($($Arg::Item<'a>),*) -> ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!($($Arg)*);
 
                 if args.len() != COUNT {
@@ -126,7 +121,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut(&'a Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -161,7 +156,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a mut ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -196,7 +191,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>, _info: &FunctionInfo) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -86,8 +86,8 @@ macro_rules! impl_reflect_fn_mut {
             // This clause allows us to convert `ReturnType` into `Return`
             ReturnType: IntoReturn + Reflect,
             Function: FnMut($($Arg),*) -> ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> FnMut($($Arg::Item<'a>),*) -> ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> FnMut($($Arg::This<'a>),*) -> ReturnType + 'env,
         {
             #[allow(unused_mut)]
             fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
@@ -116,8 +116,8 @@ macro_rules! impl_reflect_fn_mut {
             // This clause allows us to convert `&ReturnType` into `Return`
             for<'a> &'a ReturnType: IntoReturn,
             Function: for<'a> FnMut(&'a Receiver, $($Arg),*) -> &'a ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> FnMut(&'a Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> FnMut(&'a Receiver, $($Arg::This<'a>),*) -> &'a ReturnType + 'env,
         {
             fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
@@ -146,8 +146,8 @@ macro_rules! impl_reflect_fn_mut {
             // This clause allows us to convert `&mut ReturnType` into `Return`
             for<'a> &'a mut ReturnType: IntoReturn,
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg),*) -> &'a mut ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> FnMut(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a mut ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> FnMut(&'a mut Receiver, $($Arg::This<'a>),*) -> &'a mut ReturnType + 'env,
         {
             fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
@@ -176,8 +176,8 @@ macro_rules! impl_reflect_fn_mut {
             // This clause allows us to convert `&ReturnType` into `Return`
             for<'a> &'a ReturnType: IntoReturn,
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg),*) -> &'a ReturnType + 'env,
-            // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
-            Function: for<'a> FnMut(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
+            // This clause essentially asserts that `Arg::This` is the same type as `Arg`
+            Function: for<'a> FnMut(&'a mut Receiver, $($Arg::This<'a>),*) -> &'a ReturnType + 'env,
         {
             fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -101,7 +101,7 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                $(let $arg = args.next::<$Arg>()?;)*
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)($($arg,)*).into_return())
             }
@@ -130,8 +130,8 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let receiver = args.next_ref::<Receiver>()?;
-                $(let $arg = args.next::<$Arg>()?;)*
+                let receiver = args.take_ref::<Receiver>()?;
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -160,8 +160,8 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let receiver = args.next_mut::<Receiver>()?;
-                $(let $arg = args.next::<$Arg>()?;)*
+                let receiver = args.take_mut::<Receiver>()?;
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -190,8 +190,8 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let receiver = args.next_mut::<Receiver>()?;
-                $(let $arg = args.next::<$Arg>()?;)*
+                let receiver = args.take_mut::<Receiver>()?;
+                $(let $arg = args.take::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -3,7 +3,7 @@ use bevy_utils::all_tuples;
 use crate::func::args::FromArg;
 use crate::func::macros::count_tokens;
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionResult, IntoReturn};
-use crate::Reflect;
+use crate::{Reflect, TypePath};
 
 /// A reflection-based version of the [`FnMut`] trait.
 ///
@@ -104,14 +104,11 @@ macro_rules! impl_reflect_fn_mut {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [$($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                #[allow(unused_mut)]
-                let mut _index = 0;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)($($arg,)*).into_return())
             }
@@ -120,7 +117,7 @@ macro_rules! impl_reflect_fn_mut {
         // === (&self, ...) -> &ReturnType === //
         impl<'env, Receiver, $($Arg,)* ReturnType, Function> ReflectFnMut<'env, fn(&Receiver, $($Arg),*) -> &ReturnType> for Function
         where
-            Receiver: Reflect,
+            Receiver: Reflect + TypePath,
             $($Arg: FromArg,)*
             ReturnType: Reflect,
             // This clause allows us to convert `&ReturnType` into `Return`
@@ -139,16 +136,14 @@ macro_rules! impl_reflect_fn_mut {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                let receiver = receiver.take_ref::<Receiver>(_info.args().get(0).expect("argument index out of bounds"))?;
+                // Convert receiver argument into its concrete type
+                let receiver = receiver.take_ref::<Receiver>()?;
 
-                #[allow(unused_mut)]
-                let mut _index = 1;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -157,7 +152,7 @@ macro_rules! impl_reflect_fn_mut {
         // === (&mut self, ...) -> &mut ReturnType === //
         impl<'env, Receiver, $($Arg,)* ReturnType, Function> ReflectFnMut<'env, fn(&mut Receiver, $($Arg),*) -> &mut ReturnType> for Function
         where
-            Receiver: Reflect,
+            Receiver: Reflect + TypePath,
             $($Arg: FromArg,)*
             ReturnType: Reflect,
             // This clause allows us to convert `&mut ReturnType` into `Return`
@@ -176,16 +171,14 @@ macro_rules! impl_reflect_fn_mut {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                let receiver = receiver.take_mut::<Receiver>(_info.args().get(0).expect("argument index out of bounds"))?;
+                // Convert receiver argument into its concrete type
+                let receiver = receiver.take_mut::<Receiver>()?;
 
-                #[allow(unused_mut)]
-                let mut _index = 1;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -194,7 +187,7 @@ macro_rules! impl_reflect_fn_mut {
         // === (&mut self, ...) -> &ReturnType === //
         impl<'env, Receiver, $($Arg,)* ReturnType, Function> ReflectFnMut<'env, fn(&mut Receiver, $($Arg),*) -> &ReturnType> for Function
         where
-            Receiver: Reflect,
+            Receiver: Reflect + TypePath,
             $($Arg: FromArg,)*
             ReturnType: Reflect,
             // This clause allows us to convert `&ReturnType` into `Return`
@@ -213,16 +206,14 @@ macro_rules! impl_reflect_fn_mut {
                     });
                 }
 
+                // Extract all arguments (in order)
                 let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
 
-                let receiver = receiver.take_mut::<Receiver>(_info.args().get(0).expect("argument index out of bounds"))?;
+                // Convert receiver argument into its concrete type
+                let receiver = receiver.take_mut::<Receiver>()?;
 
-                #[allow(unused_mut)]
-                let mut _index = 1;
-                let ($($arg,)*) = ($($Arg::from_arg($arg, {
-                    _index += 1;
-                    _info.args().get(_index - 1).expect("argument index out of bounds")
-                })?,)*);
+                // Convert each argument into its concrete type
+                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -89,7 +89,8 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut($($Arg::Item<'a>),*) -> ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
+            #[allow(unused_mut)]
+            fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!($($Arg)*);
 
                 if args.len() != COUNT {
@@ -100,10 +101,7 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let [$($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)($($arg,)*).into_return())
             }
@@ -121,7 +119,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut(&'a Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -132,13 +130,8 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert receiver argument into its concrete type
-                let receiver = receiver.take_ref::<Receiver>()?;
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                let receiver = args.next_ref::<Receiver>()?;
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -156,7 +149,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a mut ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -167,13 +160,8 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert receiver argument into its concrete type
-                let receiver = receiver.take_mut::<Receiver>()?;
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                let receiver = args.next_mut::<Receiver>()?;
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }
@@ -191,7 +179,7 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::Item` is the same type as `Arg`
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg::Item<'a>),*) -> &'a ReturnType + 'env,
         {
-            fn reflect_call_mut<'a>(&mut self, args: ArgList<'a>) -> FunctionResult<'a> {
+            fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
@@ -202,13 +190,8 @@ macro_rules! impl_reflect_fn_mut {
                 }
 
                 // Extract all arguments (in order)
-                let [receiver, $($arg,)*] = args.take().try_into().expect("invalid number of arguments");
-
-                // Convert receiver argument into its concrete type
-                let receiver = receiver.take_mut::<Receiver>()?;
-
-                // Convert each argument into its concrete type
-                let ($($arg,)*) = ($($Arg::from_arg($arg)?,)*);
+                let receiver = args.next_mut::<Receiver>()?;
+                $(let $arg = args.next::<$Arg>()?;)*
 
                 Ok((self)(receiver, $($arg,)*).into_return())
             }

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -93,7 +93,7 @@ macro_rules! impl_reflect_fn_mut {
                 const COUNT: usize = count_tokens!($($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });
@@ -125,7 +125,7 @@ macro_rules! impl_reflect_fn_mut {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });
@@ -160,7 +160,7 @@ macro_rules! impl_reflect_fn_mut {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });
@@ -195,7 +195,7 @@ macro_rules! impl_reflect_fn_mut {
                 const COUNT: usize = count_tokens!(Receiver $($Arg)*);
 
                 if args.len() != COUNT {
-                    return Err(FunctionError::InvalidArgCount {
+                    return Err(FunctionError::ArgCountMismatch {
                         expected: COUNT,
                         received: args.len(),
                     });

--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -61,11 +61,15 @@ impl<'a> Return<'a> {
 
 /// A trait for types that can be converted into a [`Return`] value.
 ///
+/// This trait exists so that types can be automatically converted into a [`Return`]
+/// by [`IntoFunction`].
+///
 /// This trait is used instead of a blanket [`Into`] implementation due to coherence issues:
 /// we can't implement `Into<Return>` for both `T` and `&T`/`&mut T`.
 ///
 /// This trait is automatically implemented when using the `Reflect` [derive macro].
 ///
+/// [`IntoFunction`]: crate::func::IntoFunction
 /// [derive macro]: derive@crate::Reflect
 pub trait IntoReturn {
     /// Converts [`Self`] into a [`Return`] value.

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -151,7 +151,7 @@ fn main() {
             .with_arg::<i32>("value")
             .with_arg::<&mut Option<i32>>("container")
             // We can provide return information as well.
-            .with_return_info(ReturnInfo::new::<&i32>()),
+            .with_return::<&i32>(),
     ));
 
     let mut container: Option<i32> = None;

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -139,10 +139,10 @@ fn main() {
 
             // The `ArgList` contains the arguments in the order they were pushed.
             // Therefore, we need to pop them in reverse order.
-            let container = args.pop_mut::<Option<i32>>()?;
-            let value = args.pop_owned::<i32>()?;
+            let container = args.pop::<&mut Option<i32>>()?;
+            let value = args.pop::<i32>()?;
 
-            // Note that type inference could make this a bit cleaner:
+            // Note that we could also do the following to make use of type inference:
             // let container = args.pop_mut()?;
             // let value = args.pop_owned()?;
 

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -138,13 +138,13 @@ fn main() {
             }
 
             // The `ArgList` contains the arguments in the order they were pushed.
-            // Therefore, we need to pop them in reverse order.
-            let container = args.pop::<&mut Option<i32>>()?;
-            let value = args.pop::<i32>()?;
+            // We can retrieve them out in order (note that this modifies the `ArgList`):
+            let value = args.next::<i32>()?;
+            let container = args.next::<&mut Option<i32>>()?;
 
-            // Note that we could also do the following to make use of type inference:
-            // let container = args.pop_mut()?;
-            // let value = args.pop_owned()?;
+            // We could have also done the following to make use of type inference:
+            // let value = args.next_owned()?;
+            // let container = args.next_mut()?;
 
             Ok(Return::Ref(get_or_insert(value, container)))
         },

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -6,10 +6,9 @@
 //! This can be used for things like adding scripting support to your application,
 //! processing deserialized reflection data, or even just storing type-erased versions of your functions.
 
-use bevy::reflect::func::args::ArgInfo;
 use bevy::reflect::func::{
-    ArgList, DynamicClosure, DynamicClosureMut, DynamicFunction, FunctionInfo, IntoClosure,
-    IntoClosureMut, IntoFunction, Return, ReturnInfo,
+    ArgList, DynamicClosure, DynamicClosureMut, DynamicFunction, FunctionError, FunctionInfo,
+    IntoClosure, IntoClosureMut, IntoFunction, Return,
 };
 use bevy::reflect::Reflect;
 
@@ -130,6 +129,14 @@ fn main() {
 
     let get_or_insert_function = dbg!(DynamicFunction::new(
         |mut args| {
+            // We can optionally add a check to ensure we were given the correct number of arguments.
+            if args.len() != 2 {
+                return Err(FunctionError::ArgCountMismatch {
+                    expected: 2,
+                    received: args.len(),
+                });
+            }
+
             // The `ArgList` contains the arguments in the order they were pushed.
             // Therefore, we need to pop them in reverse order.
             let container = args.pop_mut::<Option<i32>>()?;

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -129,7 +129,7 @@ fn main() {
     }
 
     let get_or_insert_function = dbg!(DynamicFunction::new(
-        |mut args, _info| {
+        |mut args| {
             // The `ArgList` contains the arguments in the order they were pushed.
             // Therefore, we need to pop them in reverse order.
             let container = args.pop_mut::<Option<i32>>()?;

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -139,12 +139,12 @@ fn main() {
 
             // The `ArgList` contains the arguments in the order they were pushed.
             // We can retrieve them out in order (note that this modifies the `ArgList`):
-            let value = args.next::<i32>()?;
-            let container = args.next::<&mut Option<i32>>()?;
+            let value = args.take::<i32>()?;
+            let container = args.take::<&mut Option<i32>>()?;
 
             // We could have also done the following to make use of type inference:
-            // let value = args.next_owned()?;
-            // let container = args.next_mut()?;
+            // let value = args.take_owned()?;
+            // let container = args.take_mut()?;
 
             Ok(Return::Ref(get_or_insert(value, container)))
         },

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -148,10 +148,8 @@ fn main() {
             // This helps ensure that consumers of the function can validate the arguments they
             // pass into the function and helps for debugging.
             // Arguments should be provided in the order they are defined in the function.
-            .with_args(vec![
-                ArgInfo::new::<i32>(0).with_name("value"),
-                ArgInfo::new::<&mut Option<i32>>(1).with_name("container"),
-            ])
+            .with_arg::<i32>("value")
+            .with_arg::<&mut Option<i32>>("container")
             // We can provide return information as well.
             .with_return_info(ReturnInfo::new::<&i32>()),
     ));

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -132,8 +132,12 @@ fn main() {
         |mut args, _info| {
             // The `ArgList` contains the arguments in the order they were pushed.
             // Therefore, we need to pop them in reverse order.
-            let container = args.pop_mut::<Option<i32>>().unwrap()?;
-            let value = args.pop_owned::<i32>().unwrap()?;
+            let container = args.pop_mut::<Option<i32>>()?;
+            let value = args.pop_owned::<i32>()?;
+
+            // Note that type inference could make this a bit cleaner:
+            // let container = args.pop_mut()?;
+            // let value = args.pop_owned()?;
 
             Ok(Return::Ref(get_or_insert(value, container)))
         },

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -142,16 +142,17 @@ fn main() {
             Ok(Return::Ref(get_or_insert(value, container)))
         },
         FunctionInfo::new()
-            // We can optionally provide a name for the function
+            // We can optionally provide a name for the function.
             .with_name("get_or_insert")
-            // Since our function takes arguments, we MUST provide that argument information.
-            // The arguments should be provided in the order they are defined in the function.
-            // This is used to validate any arguments given at runtime.
+            // Since our function takes arguments, we should provide that argument information.
+            // This helps ensure that consumers of the function can validate the arguments they
+            // pass into the function and helps for debugging.
+            // Arguments should be provided in the order they are defined in the function.
             .with_args(vec![
                 ArgInfo::new::<i32>(0).with_name("value"),
                 ArgInfo::new::<&mut Option<i32>>(1).with_name("container"),
             ])
-            // We can optionally provide return information as well.
+            // We can provide return information as well.
             .with_return_info(ReturnInfo::new::<&i32>()),
     ));
 

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -129,18 +129,11 @@ fn main() {
     }
 
     let get_or_insert_function = dbg!(DynamicFunction::new(
-        |mut args, info| {
-            let container_info = &info.args()[1];
-            let value_info = &info.args()[0];
-
+        |mut args, _info| {
             // The `ArgList` contains the arguments in the order they were pushed.
             // Therefore, we need to pop them in reverse order.
-            let container = args
-                .pop()
-                .unwrap()
-                .take_mut::<Option<i32>>(container_info)
-                .unwrap();
-            let value = args.pop().unwrap().take_owned::<i32>(value_info).unwrap();
+            let container = args.pop_mut::<Option<i32>>().unwrap()?;
+            let value = args.pop_owned::<i32>().unwrap()?;
 
             Ok(Return::Ref(get_or_insert(value, container)))
         },


### PR DESCRIPTION
# Objective

Many functions can be converted to `DynamicFunction` using `IntoFunction`. Unfortunately, we are limited by Rust itself and the implementations are far from exhaustive. For example, we can't convert functions with more than 16 arguments. Additionally, we can't handle returns with lifetimes not tied to the lifetime of the first argument.

In such cases, users will have to create their `DynamicFunction` manually.

Let's take the following function:

```rust
fn get(index: usize, list: &Vec<String>) -> &String {
    &list[index]
}
```

This function cannot be converted to a `DynamicFunction` via `IntoFunction` due to the lifetime of the return value being tied to the second argument. Therefore, we need to construct the `DynamicFunction` manually:

```rust
DynamicFunction::new(
    |mut args, info| {
        let list = args
            .pop()
            .unwrap()
            .take_ref::<Vec<String>>(&info.args()[1])?;
        let index = args.pop().unwrap().take_owned::<usize>(&info.args()[0])?;
        Ok(Return::Ref(get(index, list)))
    },
    FunctionInfo::new()
        .with_name("get")
        .with_args(vec![
            ArgInfo::new::<usize>(0).with_name("index"),
            ArgInfo::new::<&Vec<String>>(1).with_name("list"),
        ])
        .with_return_info(ReturnInfo::new::<&String>()),
);
```

While still a small and straightforward snippet, there's a decent amount going on here. There's a lot of room for improvements when it comes to ergonomics and readability.

The goal of this PR is to address those issues.

## Solution

Improve the ergonomics and readability of manually created `DynamicFunction`s.

Some of the major changes:
1. Removed the need for `&ArgInfo` when reifying arguments (i.e. the `&info.args()[1]` calls)
2. Added additional `pop` methods on `ArgList` to handle both popping and casting
3. Added `take` methods on `ArgList` for taking the arguments out in order
4. Removed the need for `&FunctionInfo` in the internal closure (Change 1 made it no longer necessary)
5. Added methods to automatically handle generating `ArgInfo` and `ReturnInfo`

With all these changes in place, we get something a lot nicer to both write and look at:

```rust
DynamicFunction::new(
    |mut args| {
        let index = args.take::<usize>()?;
        let list = args.take::<&Vec<String>>()?;
        Ok(Return::Ref(get(index, list)))
    },
    FunctionInfo::new()
        .with_name("get")
        .with_arg::<usize>("index")
        .with_arg::<&Vec<String>>("list")
        .with_return::<&String>(),
);
```

Alternatively, to rely on type inference for taking arguments, you could do:

```rust
DynamicFunction::new(
    |mut args| {
        let index = args.take_owned()?;
        let list = args.take_ref()?;
        Ok(Return::Ref(get(index, list)))
    },
    FunctionInfo::new()
        .with_name("get")
        .with_arg::<usize>("index")
        .with_arg::<&Vec<String>>("list")
        .with_return::<&String>(),
);
```

## Testing

You can test locally by running:

```
cargo test --package bevy_reflect
```

---

## Changelog

- Removed `&ArgInfo` argument from `FromArg::from_arg` trait method
- Removed `&ArgInfo` argument from `Arg::take_***` methods
- Added `ArgValue`
- `Arg` is now a struct containing an `ArgValue` and an argument `index`
- `Arg::take_***` methods now require `T` is also `TypePath`
- Added `Arg::new`, `Arg::index`, `Arg::value`, `Arg::take_value`, and `Arg::take` methods
- Replaced `ArgId` in `ArgError` with just the argument `index`
- Added `ArgError::EmptyArgList`
- Renamed `ArgList::push` to `ArgList::push_arg`
- Added `ArgList::pop_arg`, `ArgList::pop_owned`, `ArgList::pop_ref`, and `ArgList::pop_mut`
- Added `ArgList::take_arg`, `ArgList::take_owned`, `ArgList::take_ref`, `ArgList::take_mut`, and `ArgList::take`
- `ArgList::pop` is now generic
- Renamed `FunctionError::InvalidArgCount` to `FunctionError::ArgCountMismatch`
- The closure given to `DynamicFunction::new` no longer has a `&FunctionInfo` argument
- Added `FunctionInfo::with_arg`
- Added `FunctionInfo::with_return`

## Internal Migration Guide

> [!important]
> Function reflection was introduced as part of the 0.15 dev cycle. This migration guide was written for developers relying on `main` during this cycle, and is not a breaking change coming from 0.14.

* The `FromArg::from_arg` trait method and the `Arg::take_***` methods no longer take a `&ArgInfo` argument.
* What used to be `Arg` is now `ArgValue`. `Arg` is now a struct which contains an `ArgValue`.
* `Arg::take_***` methods now require `T` is also `TypePath`
* Instances of `id: ArgId` in `ArgError` have been replaced with `index: usize`
* `ArgList::push` is now `ArgList::push_arg`. It also takes the new `ArgValue` type.
* `ArgList::pop` has become `ArgList::pop_arg` and now returns `ArgValue`. `Arg::pop` now takes a generic type and downcasts to that type. It's recommended to use `ArgList::take` and friends instead since they allow removing the arguments from the list in the order they were pushed (rather than reverse order).
* `FunctionError::InvalidArgCount` is now `FunctionError::ArgCountMismatch`
* The closure given to `DynamicFunction::new` no longer has a `&FunctionInfo` argument. This argument can be removed.
