### PR TITLE
Rename `bevy_core::name::DebugName` to `bevy_core::name::NameOrEntity`

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -20,7 +20,8 @@ pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
     pub use crate::{
-        DebugLabel, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin, TypeRegistrationPlugin,
+        FrameCountPlugin, Name, NameOrEntity, TaskPoolOptions, TaskPoolPlugin,
+        TypeRegistrationPlugin,
     };
 }
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
     pub use crate::{
-        DebugName, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin, TypeRegistrationPlugin,
+        DebugLabel, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin, TypeRegistrationPlugin,
     };
 }
 

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -96,7 +96,7 @@ impl std::fmt::Debug for Name {
 /// # use bevy_core::prelude::*;
 /// # use bevy_ecs::prelude::*;
 /// # #[derive(Component)] pub struct Score(f32);
-/// fn increment_score(mut scores: Query<(DebugLabel, &mut Score)>) {
+/// fn increment_score(mut scores: Query<(NameOrEntity, &mut Score)>) {
 ///     for (name, mut score) in &mut scores {
 ///         score.0 += 1.0;
 ///         if score.0.is_nan() {
@@ -109,18 +109,18 @@ impl std::fmt::Debug for Name {
 ///
 /// # Implementation
 ///
-/// The `Display` impl for `DebugLabel` returns the `Name` where there is one
+/// The `Display` impl for `NameOrEntity` returns the `Name` where there is one
 /// or {index}v{generation} for entities without one.
 #[derive(QueryData)]
 #[query_data(derive(Debug))]
-pub struct DebugLabel {
+pub struct NameOrEntity {
     /// A [`Name`] that the entity might have that is displayed if available.
     pub name: Option<&'static Name>,
     /// The unique identifier of the entity as a fallback.
     pub entity: Entity,
 }
 
-impl<'a> std::fmt::Display for DebugLabelItem<'a> {
+impl<'a> std::fmt::Display for NameOrEntityItem<'a> {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {
@@ -216,12 +216,12 @@ mod tests {
         let e1 = world.spawn_empty().id();
         let name = Name::new("MyName");
         let e2 = world.spawn(name.clone()).id();
-        let mut query = world.query::<DebugLabel>();
+        let mut query = world.query::<NameOrEntity>();
         let d1 = query.get(&world, e1).unwrap();
         let d2 = query.get(&world, e2).unwrap();
-        // DebugName Display for entities without a Name should be {index}v{generation}
+        // NameOrEntity Display for entities without a Name should be {index}v{generation}
         assert_eq!(d1.to_string(), "0v1");
-        // DebugName Display for entities with a Name should be the Name
+        // NameOrEntity Display for entities with a Name should be the Name
         assert_eq!(d2.to_string(), "MyName");
     }
 }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -96,7 +96,7 @@ impl std::fmt::Debug for Name {
 /// # use bevy_core::prelude::*;
 /// # use bevy_ecs::prelude::*;
 /// # #[derive(Component)] pub struct Score(f32);
-/// fn increment_score(mut scores: Query<(DebugName, &mut Score)>) {
+/// fn increment_score(mut scores: Query<(DebugLabel, &mut Score)>) {
 ///     for (name, mut score) in &mut scores {
 ///         score.0 += 1.0;
 ///         if score.0.is_nan() {
@@ -109,18 +109,18 @@ impl std::fmt::Debug for Name {
 ///
 /// # Implementation
 ///
-/// The `Display` impl for `DebugName` returns the `Name` where there is one
+/// The `Display` impl for `DebugLabel` returns the `Name` where there is one
 /// or {index}v{generation} for entities without one.
 #[derive(QueryData)]
 #[query_data(derive(Debug))]
-pub struct DebugName {
+pub struct DebugLabel {
     /// A [`Name`] that the entity might have that is displayed if available.
     pub name: Option<&'static Name>,
     /// The unique identifier of the entity as a fallback.
     pub entity: Entity,
 }
 
-impl<'a> std::fmt::Display for DebugNameItem<'a> {
+impl<'a> std::fmt::Display for DebugLabelItem<'a> {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {
@@ -216,7 +216,7 @@ mod tests {
         let e1 = world.spawn_empty().id();
         let name = Name::new("MyName");
         let e2 = world.spawn(name.clone()).id();
-        let mut query = world.query::<DebugName>();
+        let mut query = world.query::<DebugLabel>();
         let d1 = query.get(&world, e1).unwrap();
         let d2 = query.get(&world, e2).unwrap();
         // DebugName Display for entities without a Name should be {index}v{generation}


### PR DESCRIPTION
# Objective

- Fixes #14039

## Solution

- Rename.

## Testing

- CI

---

## Migration Guide

- Rename usages of `bevy_core::name::DebugName` to `bevy_core::name::NameOrEntity`
