### PR TITLE
Component Lifecycle Hook & Observer Trigger for replaced values

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -56,6 +56,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
     let on_add = hook_register_function_call(quote! {on_add}, attrs.on_add);
     let on_insert = hook_register_function_call(quote! {on_insert}, attrs.on_insert);
+    let on_replace = hook_register_function_call(quote! {on_replace}, attrs.on_replace);
     let on_remove = hook_register_function_call(quote! {on_remove}, attrs.on_remove);
 
     ast.generics
@@ -74,6 +75,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             fn register_component_hooks(hooks: &mut #bevy_ecs_path::component::ComponentHooks) {
                 #on_add
                 #on_insert
+                #on_replace
                 #on_remove
             }
         }
@@ -84,12 +86,14 @@ pub const COMPONENT: &str = "component";
 pub const STORAGE: &str = "storage";
 pub const ON_ADD: &str = "on_add";
 pub const ON_INSERT: &str = "on_insert";
+pub const ON_REPLACE: &str = "on_replace";
 pub const ON_REMOVE: &str = "on_remove";
 
 struct Attrs {
     storage: StorageTy,
     on_add: Option<ExprPath>,
     on_insert: Option<ExprPath>,
+    on_replace: Option<ExprPath>,
     on_remove: Option<ExprPath>,
 }
 
@@ -108,6 +112,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
         storage: StorageTy::Table,
         on_add: None,
         on_insert: None,
+        on_replace: None,
         on_remove: None,
     };
 
@@ -129,6 +134,9 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
                 Ok(())
             } else if nested.path.is_ident(ON_INSERT) {
                 attrs.on_insert = Some(nested.value()?.parse::<ExprPath>()?);
+                Ok(())
+            } else if nested.path.is_ident(ON_REPLACE) {
+                attrs.on_replace = Some(nested.value()?.parse::<ExprPath>()?);
                 Ok(())
             } else if nested.path.is_ident(ON_REMOVE) {
                 attrs.on_remove = Some(nested.value()?.parse::<ExprPath>()?);

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -317,10 +317,12 @@ bitflags::bitflags! {
     pub(crate) struct ArchetypeFlags: u32 {
         const ON_ADD_HOOK    = (1 << 0);
         const ON_INSERT_HOOK = (1 << 1);
-        const ON_REMOVE_HOOK = (1 << 2);
-        const ON_ADD_OBSERVER = (1 << 3);
-        const ON_INSERT_OBSERVER = (1 << 4);
-        const ON_REMOVE_OBSERVER = (1 << 5);
+        const ON_REPLACE_HOOK = (1 << 2);
+        const ON_REMOVE_HOOK = (1 << 3);
+        const ON_ADD_OBSERVER = (1 << 4);
+        const ON_INSERT_OBSERVER = (1 << 5);
+        const ON_REPLACE_OBSERVER = (1 << 6);
+        const ON_REMOVE_OBSERVER = (1 << 7);
     }
 }
 
@@ -600,6 +602,12 @@ impl Archetype {
         self.flags().contains(ArchetypeFlags::ON_INSERT_HOOK)
     }
 
+    /// Returns true if any of the components in this archetype have `on_replace` hooks
+    #[inline]
+    pub fn has_replace_hook(&self) -> bool {
+        self.flags().contains(ArchetypeFlags::ON_REPLACE_HOOK)
+    }
+
     /// Returns true if any of the components in this archetype have `on_remove` hooks
     #[inline]
     pub fn has_remove_hook(&self) -> bool {
@@ -620,6 +628,14 @@ impl Archetype {
     #[inline]
     pub fn has_insert_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_INSERT_OBSERVER)
+    }
+
+    /// Returns true if any of the components in this archetype have at least one [`OnReplace`] observer
+    ///
+    /// [`OnReplace`]: crate::world::OnReplace
+    #[inline]
+    pub fn has_replace_observer(&self) -> bool {
+        self.flags().contains(ArchetypeFlags::ON_REPLACE_OBSERVER)
     }
 
     /// Returns true if any of the components in this archetype have at least one [`OnRemove`] observer

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -121,6 +121,7 @@ pub(crate) struct AddBundle {
     /// indicate if the component is newly added to the target archetype or if it already existed
     pub bundle_status: Vec<ComponentStatus>,
     pub added: Vec<ComponentId>,
+    pub mutated: Vec<ComponentId>,
 }
 
 /// This trait is used to report the status of [`Bundle`](crate::bundle::Bundle) components
@@ -205,6 +206,7 @@ impl Edges {
         archetype_id: ArchetypeId,
         bundle_status: Vec<ComponentStatus>,
         added: Vec<ComponentId>,
+        mutated: Vec<ComponentId>,
     ) {
         self.add_bundle.insert(
             bundle_id,
@@ -212,6 +214,7 @@ impl Edges {
                 archetype_id,
                 bundle_status,
                 added,
+                mutated,
             },
         );
     }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -668,7 +668,7 @@ impl<'w> BundleInserter<'w> {
         let bundle_info = self.bundle_info.as_ref();
         let add_bundle = self.add_bundle.as_ref();
         let table = self.table.as_mut();
-        let archetype = self.archetype.as_mut();
+        let archetype = self.archetype.as_ref();
 
         // SAFETY: All components in the bundle are guaranteed to exist in the World
         // as they must be initialized before creating the BundleInfo.
@@ -689,6 +689,8 @@ impl<'w> BundleInserter<'w> {
                 );
             }
         }
+
+        let archetype = self.archetype.as_mut();
 
         let (new_archetype, new_location) = match &mut self.result {
             InsertBundleResult::SameArchetype => {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1156,7 +1156,7 @@ mod tests {
     struct A;
 
     #[derive(Component)]
-    #[component(on_add = a_on_add, on_insert = a_on_insert, on_remove = a_on_remove)]
+    #[component(on_add = a_on_add, on_insert = a_on_insert, on_replace = a_on_replace, on_remove = a_on_remove)]
     struct AMacroHooks;
 
     fn a_on_add(mut world: DeferredWorld, _: Entity, _: ComponentId) {
@@ -1167,8 +1167,12 @@ mod tests {
         world.resource_mut::<R>().assert_order(1);
     }
 
-    fn a_on_remove<T1, T2>(mut world: DeferredWorld, _: T1, _: T2) {
+    fn a_on_replace<T1, T2>(mut world: DeferredWorld, _: T1, _: T2) {
         world.resource_mut::<R>().assert_order(2);
+    }
+
+    fn a_on_remove<T1, T2>(mut world: DeferredWorld, _: T1, _: T2) {
+        world.resource_mut::<R>().assert_order(3);
     }
 
     #[derive(Component)]
@@ -1215,7 +1219,7 @@ mod tests {
         let entity = world.spawn(AMacroHooks).id();
         world.despawn(entity);
 
-        assert_eq!(3, world.resource::<R>().0);
+        assert_eq!(4, world.resource::<R>().0);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -690,6 +690,8 @@ impl<'w> BundleInserter<'w> {
             }
         }
 
+        // SAFETY: Archetype gets borrowed when running the on_replace observers above,
+        // so this reference can only be promoted from shared to &mut down here, after they have been ran
         let archetype = self.archetype.as_mut();
 
         let (new_archetype, new_location) = match &mut self.result {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -433,6 +433,9 @@ impl ComponentInfo {
         if self.hooks().on_insert.is_some() {
             flags.insert(ArchetypeFlags::ON_INSERT_HOOK);
         }
+        if self.hooks().on_replace.is_some() {
+            flags.insert(ArchetypeFlags::ON_REPLACE_HOOK);
+        }
         if self.hooks().on_remove.is_some() {
             flags.insert(ArchetypeFlags::ON_REMOVE_HOOK);
         }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -100,6 +100,7 @@ use std::{
 /// Alternatively to the example shown in [`ComponentHooks`]' documentation, hooks can be configured using following attributes:
 /// - `#[component(on_add = on_add_function)]`
 /// - `#[component(on_insert = on_insert_function)]`
+/// - `#[component(on_replace = on_replace_function)]`
 /// - `#[component(on_remove = on_remove_function)]`
 ///
 /// ```
@@ -114,8 +115,8 @@ use std::{
 /// // Another possible way of configuring hooks:
 /// // #[component(on_add = my_on_add_hook, on_insert = my_on_insert_hook)]
 /// //
-/// // We don't have a remove hook, so we can leave it out:
-/// // #[component(on_remove = my_on_remove_hook)]
+/// // We don't have a replace or remove hook, so we can leave them out:
+/// // #[component(on_replace = my_on_replace_hook, on_remove = my_on_remove_hook)]
 /// struct ComponentA;
 ///
 /// fn my_on_add_hook(world: DeferredWorld, entity: Entity, id: ComponentId) {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -275,7 +275,12 @@ impl ComponentHooks {
             .expect("Component id: {:?}, already has an on_insert hook")
     }
 
-    /// Register a [`ComponentHook`] that will be run when this component is replaced (with `.insert`) or removed.
+    /// Register a [`ComponentHook`] that will be run when this component is about to be dropped,
+    /// such as being replaced (with `.insert`) or removed.
+    ///
+    /// If this component is inserted onto an entity that already has it, this hook will run before the value is replaced,
+    /// allowing access to the previous data just before it is dropped.
+    /// This hook does *not* run if the entity did not already have this component.
     ///
     /// An `on_replace` hook always runs before any `on_remove` hooks (if the component is being removed from the entity).
     ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -329,7 +329,7 @@ impl ComponentHooks {
         Some(self)
     }
 
-    /// Attempt to register a [`ComponentHook`] that will be run when this component is replaced (with `.insert`)
+    /// Attempt to register a [`ComponentHook`] that will be run when this component is replaced (with `.insert`) or removed
     ///
     /// This is a fallible version of [`Self::on_replace`].
     ///

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -60,7 +60,8 @@ pub mod prelude {
             SystemParamFunction,
         },
         world::{
-            EntityMut, EntityRef, EntityWorldMut, FromWorld, OnAdd, OnInsert, OnRemove, World,
+            EntityMut, EntityRef, EntityWorldMut, FromWorld, OnAdd, OnInsert, OnRemove, OnReplace,
+            World,
         },
     };
 }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -143,6 +143,7 @@ pub struct Observers {
     // Cached ECS observers to save a lookup most common triggers.
     on_add: CachedObservers,
     on_insert: CachedObservers,
+    on_replace: CachedObservers,
     on_remove: CachedObservers,
     // Map from trigger type to set of observers
     cache: HashMap<ComponentId, CachedObservers>,
@@ -153,6 +154,7 @@ impl Observers {
         match event_type {
             ON_ADD => &mut self.on_add,
             ON_INSERT => &mut self.on_insert,
+            ON_REPLACE => &mut self.on_replace,
             ON_REMOVE => &mut self.on_remove,
             _ => self.cache.entry(event_type).or_default(),
         }
@@ -162,6 +164,7 @@ impl Observers {
         match event_type {
             ON_ADD => Some(&self.on_add),
             ON_INSERT => Some(&self.on_insert),
+            ON_REPLACE => Some(&self.on_replace),
             ON_REMOVE => Some(&self.on_remove),
             _ => self.cache.get(&event_type),
         }
@@ -231,6 +234,7 @@ impl Observers {
         match event_type {
             ON_ADD => Some(ArchetypeFlags::ON_ADD_OBSERVER),
             ON_INSERT => Some(ArchetypeFlags::ON_INSERT_OBSERVER),
+            ON_REPLACE => Some(ArchetypeFlags::ON_REPLACE_OBSERVER),
             ON_REMOVE => Some(ArchetypeFlags::ON_REMOVE_OBSERVER),
             _ => None,
         }
@@ -244,6 +248,7 @@ impl Observers {
         if self.on_add.component_observers.contains_key(&component_id) {
             flags.insert(ArchetypeFlags::ON_ADD_OBSERVER);
         }
+
         if self
             .on_insert
             .component_observers
@@ -251,6 +256,15 @@ impl Observers {
         {
             flags.insert(ArchetypeFlags::ON_INSERT_OBSERVER);
         }
+
+        if self
+            .on_replace
+            .component_observers
+            .contains_key(&component_id)
+        {
+            flags.insert(ArchetypeFlags::ON_REPLACE_OBSERVER);
+        }
+
         if self
             .on_remove
             .component_observers

--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -7,8 +7,10 @@ use crate::{self as bevy_ecs};
 pub const ON_ADD: ComponentId = ComponentId::new(0);
 /// [`ComponentId`] for [`OnInsert`]
 pub const ON_INSERT: ComponentId = ComponentId::new(1);
+/// [`ComponentId`] for [`OnReplace`]
+pub const ON_REPLACE: ComponentId = ComponentId::new(2);
 /// [`ComponentId`] for [`OnRemove`]
-pub const ON_REMOVE: ComponentId = ComponentId::new(2);
+pub const ON_REMOVE: ComponentId = ComponentId::new(3);
 
 /// Trigger emitted when a component is added to an entity.
 #[derive(Event)]
@@ -17,6 +19,10 @@ pub struct OnAdd;
 /// Trigger emitted when a component is inserted onto an entity.
 #[derive(Event)]
 pub struct OnInsert;
+
+/// Trigger emitted when a component is replaced on an entity.
+#[derive(Event)]
+pub struct OnReplace;
 
 /// Trigger emitted when a component is removed from an entity.
 #[derive(Event)]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -164,6 +164,7 @@ impl World {
     fn bootstrap(&mut self) {
         assert_eq!(ON_ADD, self.init_component::<OnAdd>());
         assert_eq!(ON_INSERT, self.init_component::<OnInsert>());
+        assert_eq!(ON_REPLACE, self.init_component::<OnReplace>());
         assert_eq!(ON_REMOVE, self.init_component::<OnRemove>());
     }
     /// Creates a new empty [`World`].

--- a/examples/ecs/component_hooks.rs
+++ b/examples/ecs/component_hooks.rs
@@ -53,7 +53,7 @@ fn setup(world: &mut World) {
     // This is to prevent overriding hooks defined in plugins and other crates as well as keeping things fast
     world
         .register_component_hooks::<MyComponent>()
-        // There are 3 component lifecycle hooks: `on_add`, `on_insert` and `on_remove`
+        // There are 4 component lifecycle hooks: `on_add`, `on_insert`, `on_replace` and `on_remove`
         // A hook has 3 arguments:
         // - a `DeferredWorld`, this allows access to resource and component data as well as `Commands`
         // - the entity that triggered the hook
@@ -79,6 +79,13 @@ fn setup(world: &mut World) {
         .on_insert(|world, _, _| {
             println!("Current Index: {:?}", world.resource::<MyComponentIndex>());
         })
+        // `on_replace` will trigger when a component is inserted onto an entity that already had it,
+        // and runs before the value is replaced.
+        // Also triggers when a component is removed from an entity, and runs before `on_remove`
+        .on_replace(|mut world, entity, _| {
+            let value = world.get::<MyComponent>(entity).unwrap().0;
+            world.resource_mut::<MyComponentIndex>().remove(&value);
+        })
         // `on_remove` will trigger when a component is removed from an entity,
         // since it runs before the component is removed you can still access the component data
         .on_remove(|mut world, entity, component_id| {
@@ -87,7 +94,6 @@ fn setup(world: &mut World) {
                 "Component: {:?} removed from: {:?} with value {:?}",
                 component_id, entity, value
             );
-            world.resource_mut::<MyComponentIndex>().remove(&value);
             // You can also issue commands through `.commands()`
             world.commands().entity(entity).despawn();
         });

--- a/examples/ecs/component_hooks.rs
+++ b/examples/ecs/component_hooks.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 /// using [`Component`] derive macro:
 /// ```no_run
 /// #[derive(Component)]
-/// #[component(on_add = ..., on_insert = ..., on_remove = ...)]
+/// #[component(on_add = ..., on_insert = ..., on_replace = ..., on_remove = ...)]
 /// ```
 struct MyComponent(KeyCode);
 


### PR DESCRIPTION
# Objective

Fixes #14202

## Solution

Add `on_replaced` component hook and `OnReplaced` observer trigger

## Testing

- Did you test these changes? If so, how?
  - Updated & added unit tests

---

## Changelog

- Added new `on_replaced` component hook and `OnReplaced` observer trigger for performing cleanup on component values when they are overwritten with `.insert()`