### PR TITLE
Fix inaccurate docs for `Commands::spawn_empty`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -235,8 +235,8 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Pushes a [`Command`] to the queue for creating a new empty [`Entity`],
-    /// and returns its corresponding [`EntityCommands`].
+    /// Immediately spawns a new empty [`Entity`] and returns its corresponding
+    /// [`EntityCommands`].
     ///
     /// See [`World::spawn_empty`] for more details.
     ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -235,8 +235,7 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
-    /// Immediately spawns a new empty [`Entity`] and returns its corresponding
-    /// [`EntityCommands`].
+    /// Reserves a new empty [`Entity`] to be spawned, and returns its corresponding [`EntityCommands`].
     ///
     /// See [`World::spawn_empty`] for more details.
     ///


### PR DESCRIPTION
# Objective

`Commands::spawn_empty` docs say that it queues a command to spawn an entity, but it doesn't. It immediately reserves an `Entity` to be spawned at the next flush point, which is possible because `Entities::reserve_entity()` takes `&self` and no components are added yet.

## Solution

Fix docs.