### PR TITLE
Make `bevy_math::common_traits` public

### DIFF
--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -1,3 +1,5 @@
+//! This module contains abstract mathematical traits shared by types used in `bevy_math`.
+
 use crate::{Dir2, Dir3, Dir3A, Quat, Rot2, Vec2, Vec3, Vec3A, Vec4};
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -14,7 +14,7 @@
 mod affine3;
 mod aspect_ratio;
 pub mod bounding;
-mod common_traits;
+pub mod common_traits;
 mod compass;
 pub mod cubic_splines;
 mod direction;


### PR DESCRIPTION
# Objective

Fixes #14243 

## Solution

`bevy_math::common_traits` is now a public module. 