### PR TITLE
Implement FromIterator/IntoIterator for dynamic types

### DIFF
--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -192,7 +192,12 @@ impl DynamicArray {
         }
     }
 
+    #[deprecated(since = "0.15.0", note = "use from_values")]
     pub fn from_vec<T: Reflect>(values: Vec<T>) -> Self {
+        Self::from_values(values)
+    }
+
+    pub fn from_values<T: Reflect>(values: impl IntoIterator<Item = T>) -> Self {
         Self {
             represented_type: None,
             values: values

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -379,7 +379,7 @@ impl IntoIterator for DynamicArray {
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        Box::<[_]>::into_iter(self.values)
+        self.values.into_vec().into_iter()
     }
 }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -379,7 +379,7 @@ impl IntoIterator for DynamicArray {
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        Box::into_iter(self.values)
+        Box::<[_]>::into_iter(self.values)
     }
 }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -363,14 +363,10 @@ impl FromIterator<Box<dyn Reflect>> for DynamicArray {
 
 impl<T: Reflect> FromIterator<T> for DynamicArray {
     fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
-        Self {
-            represented_type: None,
-            values: values
-                .into_iter()
-                .map(|field| Box::new(field) as Box<dyn Reflect>)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        }
+        values
+            .into_iter()
+            .map(|value| Box::new(value).into_reflect())
+            .collect()
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1088,7 +1088,7 @@ mod tests {
         });
         foo_patch.insert("g", composite);
 
-        let array = DynamicArray::from_vec(vec![2u32, 2u32]);
+        let array = DynamicArray::from_values([2u32, 2u32]);
         foo_patch.insert("h", array);
 
         foo.apply(&foo_patch);

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1088,7 +1088,7 @@ mod tests {
         });
         foo_patch.insert("g", composite);
 
-        let array = DynamicArray::from_values([2u32, 2u32]);
+        let array = DynamicArray::from_iter([2u32, 2u32]);
         foo_patch.insert("h", array);
 
         foo.apply(&foo_patch);

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -378,12 +378,42 @@ impl Debug for DynamicList {
     }
 }
 
+impl FromIterator<Box<dyn Reflect>> for DynamicList {
+    fn from_iter<I: IntoIterator<Item = Box<dyn Reflect>>>(values: I) -> Self {
+        Self {
+            represented_type: None,
+            values: values.into_iter().collect(),
+        }
+    }
+}
+
+impl<T: Reflect> FromIterator<T> for DynamicList {
+    fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
+        Self {
+            represented_type: None,
+            values: values
+                .into_iter()
+                .map(|field| Box::new(field) as Box<dyn Reflect>)
+                .collect(),
+        }
+    }
+}
+
 impl IntoIterator for DynamicList {
     type Item = Box<dyn Reflect>;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.values.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DynamicList {
+    type Item = &'a dyn Reflect;
+    type IntoIter = ListIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -389,13 +389,10 @@ impl FromIterator<Box<dyn Reflect>> for DynamicList {
 
 impl<T: Reflect> FromIterator<T> for DynamicList {
     fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
-        Self {
-            represented_type: None,
-            values: values
-                .into_iter()
-                .map(|field| Box::new(field) as Box<dyn Reflect>)
-                .collect(),
-        }
+        values
+            .into_iter()
+            .map(|field| Box::new(field).into_reflect())
+            .collect()
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -455,12 +455,41 @@ impl<'a> Iterator for MapIter<'a> {
     }
 }
 
+impl FromIterator<(Box<dyn Reflect>, Box<dyn Reflect>)> for DynamicMap {
+    fn from_iter<I: IntoIterator<Item = (Box<dyn Reflect>, Box<dyn Reflect>)>>(items: I) -> Self {
+        let mut dynamic_map = Self::default();
+        for (key, value) in items.into_iter() {
+            dynamic_map.insert_boxed(key, value);
+        }
+        dynamic_map
+    }
+}
+
+impl<K: Reflect, V: Reflect> FromIterator<(K, V)> for DynamicMap {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(items: I) -> Self {
+        let mut map = Self::default();
+        for (key, value) in items.into_iter() {
+            map.insert(key, value);
+        }
+        map
+    }
+}
+
 impl IntoIterator for DynamicMap {
     type Item = (Box<dyn Reflect>, Box<dyn Reflect>);
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.values.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DynamicMap {
+    type Item = (&'a dyn Reflect, &'a dyn Reflect);
+    type IntoIter = MapIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -457,11 +457,11 @@ impl<'a> Iterator for MapIter<'a> {
 
 impl FromIterator<(Box<dyn Reflect>, Box<dyn Reflect>)> for DynamicMap {
     fn from_iter<I: IntoIterator<Item = (Box<dyn Reflect>, Box<dyn Reflect>)>>(items: I) -> Self {
-        let mut dynamic_map = Self::default();
+        let mut map = Self::default();
         for (key, value) in items.into_iter() {
-            dynamic_map.insert_boxed(key, value);
+            map.insert_boxed(key, value);
         }
-        dynamic_map
+        map
     }
 }
 

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -508,10 +508,13 @@ impl Debug for DynamicStruct {
     }
 }
 
-impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
+impl<'a, N> FromIterator<(N, Box<dyn Reflect>)> for DynamicStruct
+where
+    N: Into<Cow<'a, str>>,
+{
     /// Create a dynamic struct that doesn't represent a type from the
     /// field name, field value pairs.
-    fn from_iter<I: IntoIterator<Item = (String, Box<dyn Reflect>)>>(fields: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = (N, Box<dyn Reflect>)>>(fields: I) -> Self {
         let mut dynamic_struct = Self::default();
         for (name, value) in fields.into_iter() {
             dynamic_struct.insert_boxed(name, value);

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -520,18 +520,6 @@ impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
     }
 }
 
-impl<V: Reflect> FromIterator<(String, V)> for DynamicStruct {
-    /// Create a dynamic struct that doesn't represent a type from the
-    /// field name, field value pairs.
-    fn from_iter<I: IntoIterator<Item = (String, V)>>(fields: I) -> Self {
-        let mut dynamic_struct = Self::default();
-        for (name, value) in fields.into_iter() {
-            dynamic_struct.insert(name, value);
-        }
-        dynamic_struct
-    }
-}
-
 impl IntoIterator for DynamicStruct {
     type Item = Box<dyn Reflect>;
     type IntoIter = std::vec::IntoIter<Self::Item>;

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -508,6 +508,44 @@ impl Debug for DynamicStruct {
     }
 }
 
+impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
+    fn from_iter<I: IntoIterator<Item = (String, Box<dyn Reflect>)>>(fields: I) -> Self {
+        let mut dynamic_struct = Self::default();
+        for (name, value) in fields.into_iter() {
+            dynamic_struct.insert_boxed(name, value);
+        }
+        dynamic_struct
+    }
+}
+
+impl<V: Reflect> FromIterator<(String, V)> for DynamicStruct {
+    fn from_iter<I: IntoIterator<Item = (String, V)>>(fields: I) -> Self {
+        let mut dynamic_struct = Self::default();
+        for (name, value) in fields.into_iter() {
+            dynamic_struct.insert(name, value);
+        }
+        dynamic_struct
+    }
+}
+
+impl IntoIterator for DynamicStruct {
+    type Item = Box<dyn Reflect>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DynamicStruct {
+    type Item = &'a dyn Reflect;
+    type IntoIter = FieldIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_fields()
+    }
+}
+
 /// Compares a [`Struct`] with a [`Reflect`] value.
 ///
 /// Returns true if and only if all of the following are true:

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -509,7 +509,7 @@ impl Debug for DynamicStruct {
 }
 
 impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
-    /// Create a dynmic struct that doesn't represent a type from the
+    /// Create a dynamic struct that doesn't represent a type from the
     /// field name, field value pairs.
     fn from_iter<I: IntoIterator<Item = (String, Box<dyn Reflect>)>>(fields: I) -> Self {
         let mut dynamic_struct = Self::default();
@@ -521,7 +521,7 @@ impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
 }
 
 impl<V: Reflect> FromIterator<(String, V)> for DynamicStruct {
-    /// Create a dynmic struct that doesn't represent a type from the
+    /// Create a dynamic struct that doesn't represent a type from the
     /// field name, field value pairs.
     fn from_iter<I: IntoIterator<Item = (String, V)>>(fields: I) -> Self {
         let mut dynamic_struct = Self::default();

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -509,6 +509,8 @@ impl Debug for DynamicStruct {
 }
 
 impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
+    /// Create a dynmic struct that doesn't represent a type from the
+    /// field name, field value pairs.
     fn from_iter<I: IntoIterator<Item = (String, Box<dyn Reflect>)>>(fields: I) -> Self {
         let mut dynamic_struct = Self::default();
         for (name, value) in fields.into_iter() {
@@ -519,6 +521,8 @@ impl FromIterator<(String, Box<dyn Reflect>)> for DynamicStruct {
 }
 
 impl<V: Reflect> FromIterator<(String, V)> for DynamicStruct {
+    /// Create a dynmic struct that doesn't represent a type from the
+    /// field name, field value pairs.
     fn from_iter<I: IntoIterator<Item = (String, V)>>(fields: I) -> Self {
         let mut dynamic_struct = Self::default();
         for (name, value) in fields.into_iter() {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -391,6 +391,45 @@ impl Reflect for DynamicTuple {
 
 impl_type_path!((in bevy_reflect) DynamicTuple);
 
+impl FromIterator<Box<dyn Reflect>> for DynamicTuple {
+    fn from_iter<I: IntoIterator<Item = Box<dyn Reflect>>>(fields: I) -> Self {
+        Self {
+            represented_type: None,
+            fields: fields.into_iter().collect(),
+        }
+    }
+}
+
+impl<T: Reflect> FromIterator<T> for DynamicTuple {
+    fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
+        Self {
+            represented_type: None,
+            fields: values
+                .into_iter()
+                .map(|field| Box::new(field) as Box<dyn Reflect>)
+                .collect(),
+        }
+    }
+}
+
+impl IntoIterator for DynamicTuple {
+    type Item = Box<dyn Reflect>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DynamicTuple {
+    type Item = &'a dyn Reflect;
+    type IntoIter = TupleFieldIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_fields()
+    }
+}
+
 /// Applies the elements of `b` to the corresponding elements of `a`.
 ///
 /// # Panics

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -400,18 +400,6 @@ impl FromIterator<Box<dyn Reflect>> for DynamicTuple {
     }
 }
 
-impl<T: Reflect> FromIterator<T> for DynamicTuple {
-    fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
-        Self {
-            represented_type: None,
-            fields: values
-                .into_iter()
-                .map(|field| Box::new(field) as Box<dyn Reflect>)
-                .collect(),
-        }
-    }
-}
-
 impl IntoIterator for DynamicTuple {
     type Item = Box<dyn Reflect>;
     type IntoIter = std::vec::IntoIter<Self::Item>;

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -435,18 +435,6 @@ impl FromIterator<Box<dyn Reflect>> for DynamicTupleStruct {
     }
 }
 
-impl<T: Reflect> FromIterator<T> for DynamicTupleStruct {
-    fn from_iter<I: IntoIterator<Item = T>>(fields: I) -> Self {
-        Self {
-            represented_type: None,
-            fields: fields
-                .into_iter()
-                .map(|field| Box::new(field) as Box<dyn Reflect>)
-                .collect(),
-        }
-    }
-}
-
 impl IntoIterator for DynamicTupleStruct {
     type Item = Box<dyn Reflect>;
     type IntoIter = std::vec::IntoIter<Self::Item>;

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -426,6 +426,45 @@ impl From<DynamicTuple> for DynamicTupleStruct {
     }
 }
 
+impl FromIterator<Box<dyn Reflect>> for DynamicTupleStruct {
+    fn from_iter<I: IntoIterator<Item = Box<dyn Reflect>>>(fields: I) -> Self {
+        Self {
+            represented_type: None,
+            fields: fields.into_iter().collect(),
+        }
+    }
+}
+
+impl<T: Reflect> FromIterator<T> for DynamicTupleStruct {
+    fn from_iter<I: IntoIterator<Item = T>>(fields: I) -> Self {
+        Self {
+            represented_type: None,
+            fields: fields
+                .into_iter()
+                .map(|field| Box::new(field) as Box<dyn Reflect>)
+                .collect(),
+        }
+    }
+}
+
+impl IntoIterator for DynamicTupleStruct {
+    type Item = Box<dyn Reflect>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.fields.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DynamicTupleStruct {
+    type Item = &'a dyn Reflect;
+    type IntoIter = TupleStructFieldIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_fields()
+    }
+}
+
 /// Compares a [`TupleStruct`] with a [`Reflect`] value.
 ///
 /// Returns true if and only if all of the following are true:

--- a/examples/reflection/dynamic_types.rs
+++ b/examples/reflection/dynamic_types.rs
@@ -167,7 +167,7 @@ fn main() {
 
     // 2. `DynamicArray`
     {
-        let dynamic_array = DynamicArray::from_values([1u32, 2u32, 3u32]);
+        let dynamic_array = DynamicArray::from_iter([1u32, 2u32, 3u32]);
 
         let mut my_array = [0u32; 3];
         my_array.apply(&dynamic_array);

--- a/examples/reflection/dynamic_types.rs
+++ b/examples/reflection/dynamic_types.rs
@@ -167,7 +167,7 @@ fn main() {
 
     // 2. `DynamicArray`
     {
-        let dynamic_array = DynamicArray::from_vec(vec![1u32, 2u32, 3u32]);
+        let dynamic_array = DynamicArray::from_values([1u32, 2u32, 3u32]);
 
         let mut my_array = [0u32; 3];
         my_array.apply(&dynamic_array);

--- a/examples/reflection/dynamic_types.rs
+++ b/examples/reflection/dynamic_types.rs
@@ -135,10 +135,7 @@ fn main() {
     // Lastly, while dynamic types are commonly generated via reflection methods like
     // `Reflect::clone_value` or via the reflection deserializers,
     // you can also construct them manually.
-    let mut my_dynamic_list = DynamicList::default();
-    my_dynamic_list.push(1u32);
-    my_dynamic_list.push(2u32);
-    my_dynamic_list.push(3u32);
+    let mut my_dynamic_list = DynamicList::from_iter([1u32, 2u32, 3u32]);
 
     // This is useful when you just need to apply some subset of changes to a type.
     let mut my_list: Vec<u32> = Vec::new();
@@ -176,10 +173,7 @@ fn main() {
 
     // 3. `DynamicList`
     {
-        let mut dynamic_list = DynamicList::default();
-        dynamic_list.push(1u32);
-        dynamic_list.push(2u32);
-        dynamic_list.push(3u32);
+        let dynamic_list = DynamicList::from_iter([1u32, 2u32, 3u32]);
 
         let mut my_list: Vec<u32> = Vec::new();
         my_list.apply(&dynamic_list);
@@ -188,10 +182,7 @@ fn main() {
 
     // 4. `DynamicMap`
     {
-        let mut dynamic_map = DynamicMap::default();
-        dynamic_map.insert("x", 1u32);
-        dynamic_map.insert("y", 2u32);
-        dynamic_map.insert("z", 3u32);
+        let dynamic_map = DynamicMap::from_iter([("x", 1u32), ("y", 2u32), ("z", 3u32)]);
 
         let mut my_map: HashMap<&str, u32> = HashMap::new();
         my_map.apply(&dynamic_map);


### PR DESCRIPTION
# Objective

Implement FromIterator/IntoIterator for dynamic types where missing

Note:
- can't impl `IntoIterator` for `&Array` & co because of orphan rules
- `into_iter().collect()` is a no-op for `Vec`s because of specialization

---

## Migration Guide

- Change `DynamicArray::from_vec` to `DynamicArray::from_iter`
