### PR TITLE
Prevent division by zero in HWBA to HSVA conversions

### DIFF
--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -157,7 +157,11 @@ impl From<Hwba> for Hsva {
     ) -> Self {
         // Based on https://en.wikipedia.org/wiki/HWB_color_model#Conversion
         let value = 1. - blackness;
-        let saturation = 1. - whiteness.checked_div(value).unwrap_or(1.);
+        let saturation = if value != 0. {
+            1. - (whiteness / value)
+        } else {
+            0.
+        };
 
         Hsva::new(hue, saturation, value, alpha)
     }

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -157,7 +157,11 @@ impl From<Hwba> for Hsva {
     ) -> Self {
         // Based on https://en.wikipedia.org/wiki/HWB_color_model#Conversion
         let value = 1. - blackness;
-        let saturation = 1. - (whiteness / value);
+        let saturation = if value != 0. {
+            1. - (whiteness / value)
+        } else {
+            0.
+        };
 
         Hsva::new(hue, saturation, value, alpha)
     }

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -157,11 +157,7 @@ impl From<Hwba> for Hsva {
     ) -> Self {
         // Based on https://en.wikipedia.org/wiki/HWB_color_model#Conversion
         let value = 1. - blackness;
-        let saturation = if value != 0. {
-            1. - (whiteness / value)
-        } else {
-            0.
-        };
+        let saturation = 1. - whiteness.checked_div(value).unwrap_or(1.);
 
         Hsva::new(hue, saturation, value, alpha)
     }


### PR DESCRIPTION
# Problem

Division by zero in `crates/bevy_color/src/hsva.rs` when `blackness` is `1`:

```rust
impl From<Hwba> for Hsva {
    fn from(
        Hwba {
            hue,
            whiteness,
            blackness,
            alpha,
        }: Hwba,
    ) -> Self {
        // Based on https://en.wikipedia.org/wiki/HWB_color_model#Conversion
        let value = 1. - blackness;
        let saturation = 1. - (whiteness / value);

        Hsva::new(hue, saturation, value, alpha)
    }
}
```

## Solution
With `Hsva` colors if the `value` component is set to `0.`  the output will be pure black regardless of the values of the `hue` or `saturation` components.

So if `value` is `0`, we don't need to calculate a `saturation` value and can just set it to `0`:

```rust
impl From<Hwba> for Hsva {
    fn from(
        Hwba {
            hue,
            whiteness,
            blackness,
            alpha,
        }: Hwba,
    ) -> Self {
        // Based on https://en.wikipedia.org/wiki/HWB_color_model#Conversion
        let value = 1. - blackness;
        let saturation = if value != 0. {
            1. - (whiteness / value)
        } else {
            0.
        };

        Hsva::new(hue, saturation, value, alpha)
    }
}

```