### PR TITLE
Add some missing reflect attributes

### DIFF
--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -5,9 +5,10 @@
 
 use bevy_ecs::{
     component::Component,
+    reflect::ReflectComponent,
     system::{Query, Res},
 };
-use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_time::Time;
 use bevy_utils::Duration;
 

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -28,6 +28,7 @@ use crate::{graph::AnimationNodeIndex, ActiveAnimation, AnimationPlayer};
 /// component to get confused about which animation is the "main" animation, and
 /// transitions will usually be incorrect as a result.
 #[derive(Component, Default, Reflect)]
+#[reflect(Component, Default)]
 pub struct AnimationTransitions {
     main_animation: Option<AnimationNodeIndex>,
     transitions: Vec<AnimationTransition>,

--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::{self as bevy_ecs};
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
 /// Internal components used by bevy with a fixed component id.
 /// Constants are used to skip [`TypeId`] lookups in hot paths.
 

--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -12,12 +12,15 @@ pub const ON_REMOVE: ComponentId = ComponentId::new(2);
 
 /// Trigger emitted when a component is added to an entity.
 #[derive(Event)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnAdd;
 
 /// Trigger emitted when a component is inserted onto an entity.
 #[derive(Event)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnInsert;
 
 /// Trigger emitted when a component is removed from an entity.
 #[derive(Event)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnRemove;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1988,7 +1988,7 @@ impl Default for ZIndex {
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius>
 #[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
-#[reflect(PartialEq, Default)]
+#[reflect(Component, PartialEq, Default)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),


### PR DESCRIPTION
# Objective

- Some types are missing reflection attributes, which means we can't use them in scene serialization etc.
- Effected types
   - `BorderRadius`
   - `AnimationTransitions`
   - `OnAdd`
   - `OnInsert`
   - `OnRemove`
- My use-case for `OnAdd` etc to derive reflect is 'Serializable Observer Components'. Add the component, save the scene, then the observer is re-added on scene load.

```rust
#[derive(Reflect)]
struct MySerializeableObserver<T: Event>(#[reflect(ignore)]PhantomData<T>);

impl<T: Event> Component for MySerializeableObserver<T> {
  const STORAGE_TYPE: StorageType  = StorageType::Table;
    fn register_component_hooks(hooks: &mut ComponentHooks) {
      hooks.on_add(|mut world, entity, _| {
        world
          .commands()
          .entity(entity)
          .observe(|_trigger: Trigger<T>| {
            println!("it triggered etc.");
          });
    });
  }
}
```

## Solution

- Add the missing traits

---