### PR TITLE
Fix overflow in `RenderLayers::iter_layers`

### DIFF
--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -162,7 +162,7 @@ impl RenderLayers {
                 return None;
             }
             let next = buffer.trailing_zeros() + 1;
-            buffer >>= next;
+            buffer = buffer.checked_shr(next).unwrap_or(0);
             layer += next as usize;
             Some(layer - 1)
         })
@@ -358,5 +358,11 @@ mod rendering_mask_tests {
         // When excluding that layer, it should drop the extra memory block
         let layers = layers.without(77);
         assert!(layers.0.len() == 1);
+    }
+
+    #[test]
+    fn render_layer_iter_no_overflow() {
+        let layers = RenderLayers::from_layers(&[63]);
+        layers.iter().count();
     }
 }


### PR DESCRIPTION
# Objective

- Fixes overflow when calling `RenderLayers::iter_layers` on layers of the form `k * 64 - 1`
   - Causes a panic in debug mode, and an infinite iterator in release mode

## Solution

- Use `u64::checked_shr` instead of `>>=`

## Testing

- Added a test case for this: `render_layer_iter_no_overflow`