### PR TITLE
Add support for skybox transformation

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -2,7 +2,7 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, Handle};
 use bevy_ecs::{
     prelude::{Component, Entity},
-    query::{QueryItem, With},
+    query::QueryItem,
     schedule::IntoSystemConfigs,
     system::{Commands, Query, Res, ResMut, Resource},
 };

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     schedule::IntoSystemConfigs,
     system::{Commands, Query, Res, ResMut, Resource},
 };
-use bevy_math::Mat4;
+use bevy_math::{Mat4, Quat};
 use bevy_render::{
     camera::Exposure,
     extract_component::{
@@ -92,7 +92,7 @@ pub struct Skybox {
     /// After applying this multiplier to the image samples, the resulting values should
     /// be in units of [cd/m^2](https://en.wikipedia.org/wiki/Candela_per_square_metre).
     pub brightness: f32,
-    pub transform: Option<Transform>,
+    pub rotation: Option<Quat>,
 }
 
 impl ExtractComponent for Skybox {
@@ -109,9 +109,7 @@ impl ExtractComponent for Skybox {
             skybox.clone(),
             SkyboxUniforms {
                 brightness: skybox.brightness * exposure,
-                transform: skybox
-                    .transform
-                    .unwrap_or_default()
+                transform: Transform::from_rotation(skybox.rotation.unwrap_or_default())
                     .compute_matrix()
                     .inverse(),
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
@@ -249,7 +247,7 @@ fn prepare_skybox_pipelines(
                 hdr: view.hdr,
                 samples: msaa.samples(),
                 depth_format: CORE_3D_DEPTH_FORMAT,
-                has_transform: skybox.transform.is_some(),
+                has_transform: skybox.rotation.is_some(),
             },
         );
 

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -92,6 +92,10 @@ pub struct Skybox {
     /// After applying this multiplier to the image samples, the resulting values should
     /// be in units of [cd/m^2](https://en.wikipedia.org/wiki/Candela_per_square_metre).
     pub brightness: f32,
+
+    /// View space rotation applied to the skybox cubemap.
+    /// This is useful for users who require a different axis, such as the Z-axis, to serve
+    /// as the vertical axis.
     pub rotation: Quat,
 }
 

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -2,8 +2,8 @@
 #import bevy_pbr::utils::coords_to_viewport_uv
 
 struct SkyboxUniforms {
-        brightness: f32,
-        transform: mat4x4<f32>,
+	brightness: f32,
+	transform: mat4x4<f32>,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
 	_wasm_padding_8b: u32,
 	_wasm_padding_12b: u32,
@@ -31,12 +31,10 @@ fn coords_to_ray_direction(position: vec2<f32>, viewport: vec4<f32>) -> vec3<f32
         1.0,
     );
 
-#ifdef SKYBOX_TRANSFORM
+    // Transforming the view space ray direction by the skybox transform matrix, it is 
+    // equivalent to rotating the skybox itself.
     var view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
     view_ray_direction = (uniforms.transform * vec4(view_ray_direction, 1.0)).xyz;
-#else 
-    let view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
-#endif
 
     // Transforming the view space ray direction by the view matrix, transforms the
     // direction to world space. Note that the w element is set to 0.0, as this is a

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -2,8 +2,8 @@
 #import bevy_pbr::utils::coords_to_viewport_uv
 
 struct SkyboxUniforms {
-	brightness: f32,
-        transform: mat4x4<f32>,
+    brightness: f32,
+    transform: mat4x4<f32>,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
 	_wasm_padding_8b: u32,
 	_wasm_padding_12b: u32,

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -2,8 +2,8 @@
 #import bevy_pbr::utils::coords_to_viewport_uv
 
 struct SkyboxUniforms {
-    brightness: f32,
-    transform: mat4x4<f32>,
+        brightness: f32,
+        transform: mat4x4<f32>,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
 	_wasm_padding_8b: u32,
 	_wasm_padding_12b: u32,

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -3,7 +3,7 @@
 
 struct SkyboxUniforms {
 	brightness: f32,
-    transform: mat4x4<f32>,
+        transform: mat4x4<f32>,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
 	_wasm_padding_8b: u32,
 	_wasm_padding_12b: u32,

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -3,6 +3,7 @@
 
 struct SkyboxUniforms {
 	brightness: f32,
+    transform: mat4x4<f32>,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
 	_wasm_padding_8b: u32,
 	_wasm_padding_12b: u32,
@@ -29,7 +30,14 @@ fn coords_to_ray_direction(position: vec2<f32>, viewport: vec4<f32>) -> vec3<f32
         1.0,
         1.0,
     );
+
+#ifdef SKYBOX_TRANSFORM
+    var view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
+    view_ray_direction = (uniforms.transform * vec4(view_ray_direction, 1.0)).xyz;
+#else 
     let view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
+#endif
+
     // Transforming the view space ray direction by the view matrix, transforms the
     // direction to world space. Note that the w element is set to 0.0, as this is a
     // vector direction, not a position, That causes the matrix multiplication to ignore

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -240,7 +240,7 @@ fn add_skybox_and_environment_map(
         .insert(Skybox {
             brightness: 5000.0,
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            transform: None,
+            rotation: None,
         })
         .insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -240,7 +240,7 @@ fn add_skybox_and_environment_map(
         .insert(Skybox {
             brightness: 5000.0,
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            rotation: None,
+            ..Default::default()
         })
         .insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -240,6 +240,7 @@ fn add_skybox_and_environment_map(
         .insert(Skybox {
             brightness: 5000.0,
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            transform: None,
         })
         .insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -54,7 +54,7 @@ fn setup(
         Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: bevy::pbr::light_consts::lux::DIRECT_SUNLIGHT,
-            transform: None,
+            rotation: None,
         },
     ));
 

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -54,6 +54,7 @@ fn setup(
         Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: bevy::pbr::light_consts::lux::DIRECT_SUNLIGHT,
+            transform: None,
         },
     ));
 

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -54,7 +54,7 @@ fn setup(
         Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: bevy::pbr::light_consts::lux::DIRECT_SUNLIGHT,
-            rotation: None,
+            ..Default::default()
         },
     ));
 

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -224,7 +224,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .insert(Skybox {
             brightness: 5000.0,
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            transform: None,
+            rotation: None,
         })
         .insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -224,7 +224,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .insert(Skybox {
             brightness: 5000.0,
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            rotation: None,
+            ..Default::default()
         })
         .insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -224,6 +224,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .insert(Skybox {
             brightness: 5000.0,
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
+            transform: None,
         })
         .insert(EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -239,7 +239,7 @@ fn spawn_camera(commands: &mut Commands, assets: &ExampleAssets) {
         .insert(Skybox {
             image: assets.skybox.clone(),
             brightness: 150.0,
-            transform: None,
+            rotation: None,
         });
 }
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -239,6 +239,7 @@ fn spawn_camera(commands: &mut Commands, assets: &ExampleAssets) {
         .insert(Skybox {
             image: assets.skybox.clone(),
             brightness: 150.0,
+            transform: None,
         });
 }
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -239,7 +239,7 @@ fn spawn_camera(commands: &mut Commands, assets: &ExampleAssets) {
         .insert(Skybox {
             image: assets.skybox.clone(),
             brightness: 150.0,
-            rotation: None,
+            ..Default::default()
         });
 }
 

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -187,7 +187,7 @@ fn add_environment_map_to_camera(
             .insert(Skybox {
                 image: cubemaps.skybox.clone(),
                 brightness: 5000.0,
-                transform: None,
+                rotation: None,
             });
     }
 }

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -187,6 +187,7 @@ fn add_environment_map_to_camera(
             .insert(Skybox {
                 image: cubemaps.skybox.clone(),
                 brightness: 5000.0,
+                transform: None,
             });
     }
 }

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -187,7 +187,7 @@ fn add_environment_map_to_camera(
             .insert(Skybox {
                 image: cubemaps.skybox.clone(),
                 brightness: 5000.0,
-                rotation: None,
+                ..Default::default()
             });
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -81,6 +81,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Skybox {
             image: skybox_handle.clone(),
             brightness: 1000.0,
+            transform: None,
         },
     ));
 

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -81,7 +81,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Skybox {
             image: skybox_handle.clone(),
             brightness: 1000.0,
-            transform: None,
+            rotation: None,
         },
     ));
 

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -81,7 +81,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Skybox {
             image: skybox_handle.clone(),
             brightness: 1000.0,
-            rotation: None,
+            ..Default::default()
         },
     ));
 

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -246,6 +246,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .insert(Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 5000.0,
+            transform: None,
         })
         .insert(ScreenSpaceReflectionsBundle::default())
         .insert(Fxaa::default());

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -246,7 +246,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .insert(Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 5000.0,
-            rotation: None,
+            ..Default::default()
         })
         .insert(ScreenSpaceReflectionsBundle::default())
         .insert(Fxaa::default());

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -246,7 +246,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .insert(Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 5000.0,
-            transform: None,
+            rotation: None,
         })
         .insert(ScreenSpaceReflectionsBundle::default())
         .insert(Fxaa::default());

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -52,7 +52,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 1000.0,
-            rotation: None,
+            ..Default::default()
         })
         .insert(VolumetricFogSettings {
             // This value is explicitly set to 0 since we have no environment map light

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -52,6 +52,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 1000.0,
+            transform: None,
         })
         .insert(VolumetricFogSettings {
             // This value is explicitly set to 0 since we have no environment map light

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -52,7 +52,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .insert(Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             brightness: 1000.0,
-            transform: None,
+            rotation: None,
         })
         .insert(VolumetricFogSettings {
             // This value is explicitly set to 0 since we have no environment map light


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/14036

## Solution

- Add a view space transformation for the skybox

## Testing

- I have tested the newly added `transform` field using the `skybox` example.
```
diff --git a/examples/3d/skybox.rs b/examples/3d/skybox.rs
index beaf5b268..d16cbe988 100644
--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -81,6 +81,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Skybox {
             image: skybox_handle.clone(),
             brightness: 1000.0,
+            rotation: Quat::from_rotation_x(PI * -0.5),
         },
     ));
```
<img width="1280" alt="image" src="https://github.com/bevyengine/bevy/assets/6300263/1230a608-58ea-492d-a811-90c54c3b43ef">


## Migration Guide
- Since we have added a new filed to the Skybox struct, users will need to include `..Default::default()` or some rotation value in their initialization code.