### PR TITLE
Clearer spatial bundle pub const docs

### DIFF
--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -41,7 +41,7 @@ impl SpatialBundle {
         }
     }
 
-    /// A visible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
+    /// A [`SpatialBundle`] with inherited visibility and identity transform.
     pub const INHERITED_IDENTITY: Self = SpatialBundle {
         visibility: Visibility::Inherited,
         inherited_visibility: InheritedVisibility::HIDDEN,
@@ -50,7 +50,7 @@ impl SpatialBundle {
         global_transform: GlobalTransform::IDENTITY,
     };
 
-    /// An invisible [`SpatialBundle`], with no translation, rotation, and a scale of 1 on all axes.
+    /// An invisible [`SpatialBundle`] with identity transform.
     pub const HIDDEN_IDENTITY: Self = SpatialBundle {
         visibility: Visibility::Hidden,
         ..Self::INHERITED_IDENTITY


### PR DESCRIPTION
# Objective

The docs on SpatialBundle's pub const constructors mention that one is "visible" when it's actually inherited, which afaik means it's conditional on its parent's visibility.

I feel it's more correct like this.

_Also I'm seeing how making a PR from github.dev works hopefully nothing weird happens_