### PR TITLE
Skip batching for phase items from other pipelines

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -425,12 +425,11 @@ pub fn batch_and_prepare_sorted_render_phase<I, GFBD>(
             // Unpack that index and metadata. Note that it's possible for index
             // and/or metadata to not be present, which signifies that this
             // entity is unbatchable. In that case, we break the batch here.
-            let (mut current_input_index, mut current_meta) = (None, None);
-            if let Some((input_index, maybe_meta)) = current_batch_input_index {
-                current_input_index = Some(input_index);
-                current_meta =
-                    maybe_meta.map(|meta| BatchMeta::new(&phase.items[current_index], meta));
-            }
+            let Some((current_input_index, current_meta)) = current_batch_input_index else {
+                continue;
+            };
+            let current_meta =
+                current_meta.map(|meta| BatchMeta::new(&phase.items[current_index], meta));
 
             // Determine if this entity can be included in the batch we're
             // building up.
@@ -474,10 +473,9 @@ pub fn batch_and_prepare_sorted_render_phase<I, GFBD>(
 
             // Add a new preprocessing work item so that the preprocessing
             // shader will copy the per-instance data over.
-            if let (Some(batch), Some(input_index)) = (batch.as_ref(), current_input_index.as_ref())
-            {
+            if let Some(batch) = batch.as_ref() {
                 work_item_buffer.buffer.push(PreprocessWorkItem {
-                    input_index: (*input_index).into(),
+                    input_index: current_input_index.into(),
                     output_index: match batch.indirect_parameters_index {
                         Some(indirect_parameters_index) => indirect_parameters_index.into(),
                         None => output_index,


### PR DESCRIPTION
# Objective

- Fix #14295

## Solution

- Early out when `GFBD::get_index_and_compare_data` returns None.

## Testing

- Tested on a selection of examples including `many_foxes` and `3d_shapes`.
- Resolve the original issue in `bevy_vector_shapes`
