### PR TITLE
Fix `bevy_window` failing with `serialize` feature

### DIFF
--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+default = []
 serialize = ["serde", "smol_str/serde", "bevy_ecs/serialize"]
 
 [dependencies]

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-serialize = ["serde", "smol_str/serde"]
+serialize = ["serde", "smol_str/serde", "bevy_ecs/serialize"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = []
 serialize = ["serde", "smol_str/serde"]
 
 [dependencies]


### PR DESCRIPTION
# Objective

- [`flag-frenzy`](https://github.com/TheBevyFlock/flag-frenzy) found an issue where `bevy_window` would fail to build when its `serialize` feature is enabled.
  - See [here](https://github.com/TheBevyFlock/flag-frenzy/actions/runs/9924187577/job/27415224405) for the specific log.

## Solution

- Turns out it was failing because the `bevy_ecs/serialize` feature was not enabled. This error can be fixed by adding the flag as a dependency.

## Testing

```bash
cargo check -p bevy_window -F serialize
# Or if you're very cool...
flag-frenzy --manifest-path path/to/bevy/Cargo.toml --config config -p bevy_window
```
