### PR TITLE
Add `Isometry2d::from_xy` and `Isometry3d::from_xyz`

### DIFF
--- a/crates/bevy_math/src/isometry.rs
+++ b/crates/bevy_math/src/isometry.rs
@@ -71,6 +71,15 @@ impl Isometry2d {
         }
     }
 
+    /// Create a two-dimensional isometry from a translation with the given `x` and `y` components.
+    #[inline]
+    pub fn from_xy(x: f32, y: f32) -> Self {
+        Isometry2d {
+            rotation: Rot2::IDENTITY,
+            translation: Vec2::new(x, y),
+        }
+    }
+
     /// The inverse isometry that undoes this one.
     #[inline]
     pub fn inverse(&self) -> Self {
@@ -226,6 +235,15 @@ impl Isometry3d {
         Isometry3d {
             rotation: Quat::IDENTITY,
             translation: translation.into(),
+        }
+    }
+
+    /// Create a three-dimensional isometry from a translation with the given `x`, `y`, and `z` components.
+    #[inline]
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Self {
+        Isometry3d {
+            rotation: Quat::IDENTITY,
+            translation: Vec3A::new(x, y, z),
         }
     }
 


### PR DESCRIPTION
# Objective

Creating isometry types with just a translation is a bit more verbose than it needs to be for cases where you don't have an existing vector to pass in.

```rust
let iso = Isometry3d::from_translation(Vec3::new(2.0, 1.0, -1.0));
```

This could be made more ergonomic with a method similar to `Dir2::from_xy`, `Dir3::from_xyz`, and `Transform::from_xyz`:

```rust
let iso = Isometry3d::from_xyz(2.0, 1.0, -1.0);
```

## Solution

Add `Isometry2d::from_xy` and `Isometry3d::from_xyz`.