### PR TITLE
Allow non-static trigger targets

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -272,12 +272,12 @@ impl World {
 
     /// Triggers the given `event`, which will run any observers watching for it.
     pub fn trigger(&mut self, event: impl Event) {
-        TriggerEvent { event, targets: () }.apply(self);
+        TriggerEvent { event, targets: () }.trigger(self);
     }
 
     /// Triggers the given `event` for the given `targets`, which will run any observers watching for it.
     pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets) {
-        TriggerEvent { event, targets }.apply(self);
+        TriggerEvent { event, targets }.trigger(self);
     }
 
     /// Register an observer to the cache, called when an observer is created

--- a/crates/bevy_ecs/src/observer/trigger_event.rs
+++ b/crates/bevy_ecs/src/observer/trigger_event.rs
@@ -21,7 +21,9 @@ impl<E: Event, Targets: TriggerTargets> TriggerEvent<E, Targets> {
     }
 }
 
-impl<E: Event, Targets: TriggerTargets + 'static> Command for TriggerEvent<E, Targets> {
+impl<E: Event, Targets: TriggerTargets + Send + Sync + 'static> Command
+    for TriggerEvent<E, Targets>
+{
     fn apply(self, world: &mut World) {
         self.trigger(world);
     }
@@ -47,7 +49,9 @@ impl<E, Targets: TriggerTargets> EmitDynamicTrigger<E, Targets> {
     }
 }
 
-impl<E: Event, Targets: TriggerTargets + 'static> Command for EmitDynamicTrigger<E, Targets> {
+impl<E: Event, Targets: TriggerTargets + Send + Sync + 'static> Command
+    for EmitDynamicTrigger<E, Targets>
+{
     fn apply(mut self, world: &mut World) {
         trigger_event(world, self.event_type, &mut self.event_data, self.targets);
     }
@@ -92,7 +96,7 @@ fn trigger_event<E, Targets: TriggerTargets>(
 ///
 /// [`Trigger`]: crate::observer::Trigger
 /// [`Observer`]: crate::observer::Observer
-pub trait TriggerTargets: Send + Sync {
+pub trait TriggerTargets {
     /// The components the trigger should target.
     fn components(&self) -> impl ExactSizeIterator<Item = ComponentId>;
 

--- a/crates/bevy_ecs/src/observer/trigger_event.rs
+++ b/crates/bevy_ecs/src/observer/trigger_event.rs
@@ -22,9 +22,8 @@ impl<E: Event, Targets: TriggerTargets> TriggerEvent<E, Targets> {
 }
 
 impl<E: Event, Targets: TriggerTargets + 'static> Command for TriggerEvent<E, Targets> {
-    fn apply(mut self, world: &mut World) {
-        let event_type = world.init_component::<E>();
-        trigger_event(world, event_type, &mut self.event, self.targets);
+    fn apply(self, world: &mut World) {
+        self.trigger(world);
     }
 }
 

--- a/crates/bevy_ecs/src/observer/trigger_event.rs
+++ b/crates/bevy_ecs/src/observer/trigger_event.rs
@@ -14,7 +14,14 @@ pub struct TriggerEvent<E, Targets: TriggerTargets = ()> {
     pub targets: Targets,
 }
 
-impl<E: Event, Targets: TriggerTargets> Command for TriggerEvent<E, Targets> {
+impl<E: Event, Targets: TriggerTargets> TriggerEvent<E, Targets> {
+    pub(super) fn trigger(mut self, world: &mut World) {
+        let event_type = world.init_component::<E>();
+        trigger_event(world, event_type, &mut self.event, self.targets);
+    }
+}
+
+impl<E: Event, Targets: TriggerTargets + 'static> Command for TriggerEvent<E, Targets> {
     fn apply(mut self, world: &mut World) {
         let event_type = world.init_component::<E>();
         trigger_event(world, event_type, &mut self.event, self.targets);
@@ -41,7 +48,7 @@ impl<E, Targets: TriggerTargets> EmitDynamicTrigger<E, Targets> {
     }
 }
 
-impl<E: Event, Targets: TriggerTargets> Command for EmitDynamicTrigger<E, Targets> {
+impl<E: Event, Targets: TriggerTargets + 'static> Command for EmitDynamicTrigger<E, Targets> {
     fn apply(mut self, world: &mut World) {
         trigger_event(world, self.event_type, &mut self.event_data, self.targets);
     }
@@ -86,7 +93,7 @@ fn trigger_event<E, Targets: TriggerTargets>(
 ///
 /// [`Trigger`]: crate::observer::Trigger
 /// [`Observer`]: crate::observer::Observer
-pub trait TriggerTargets: Send + Sync + 'static {
+pub trait TriggerTargets: Send + Sync {
     /// The components the trigger should target.
     fn components(&self) -> impl ExactSizeIterator<Item = ComponentId>;
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -760,7 +760,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// watches those targets.
     ///
     /// [`Trigger`]: crate::observer::Trigger
-    pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets) {
+    pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets + 'static) {
         self.add(TriggerEvent { event, targets });
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -760,7 +760,11 @@ impl<'w, 's> Commands<'w, 's> {
     /// watches those targets.
     ///
     /// [`Trigger`]: crate::observer::Trigger
-    pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets + 'static) {
+    pub fn trigger_targets(
+        &mut self,
+        event: impl Event,
+        targets: impl TriggerTargets + Send + Sync + 'static,
+    ) {
         self.add(TriggerEvent { event, targets });
     }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -374,7 +374,11 @@ impl<'w> DeferredWorld<'w> {
     }
 
     /// Sends a [`Trigger`](crate::observer::Trigger) with the given `targets`.
-    pub fn trigger_targets(&mut self, trigger: impl Event, targets: impl TriggerTargets + 'static) {
+    pub fn trigger_targets(
+        &mut self,
+        trigger: impl Event,
+        targets: impl TriggerTargets + Send + Sync + 'static,
+    ) {
         self.commands().trigger_targets(trigger, targets);
     }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -374,7 +374,7 @@ impl<'w> DeferredWorld<'w> {
     }
 
     /// Sends a [`Trigger`](crate::observer::Trigger) with the given `targets`.
-    pub fn trigger_targets(&mut self, trigger: impl Event, targets: impl TriggerTargets) {
+    pub fn trigger_targets(&mut self, trigger: impl Event, targets: impl TriggerTargets + 'static) {
         self.commands().trigger_targets(trigger, targets);
     }
 


### PR DESCRIPTION
# Objective

`TriggerTargets` can not be borrowed for use in `World::trigger_targets`

## Solution

Drop `'static` bound on `TriggerEvent`, keep it for `Command` impl.

## Testing

n/a
