### PR TITLE
Specify test group names in github summary for compile fail tests

### DIFF
--- a/crates/bevy_derive/compile_fail/tests/derive.rs
+++ b/crates/bevy_derive/compile_fail/tests/derive.rs
@@ -1,4 +1,4 @@
 fn main() -> compile_fail_utils::ui_test::Result<()> {
-    compile_fail_utils::test_multiple(["tests/deref_derive", "tests/deref_mut_derive"])
+    compile_fail_utils::test_multiple("derive_deref", ["tests/deref_derive", "tests/deref_mut_derive"])
 }
 

--- a/crates/bevy_ecs/compile_fail/tests/ui.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ui.rs
@@ -1,3 +1,3 @@
 fn main() -> compile_fail_utils::ui_test::Result<()> {
-    compile_fail_utils::test("tests/ui")
+    compile_fail_utils::test("ecs_ui", "tests/ui")
 }

--- a/crates/bevy_reflect/compile_fail/tests/derive.rs
+++ b/crates/bevy_reflect/compile_fail/tests/derive.rs
@@ -1,3 +1,3 @@
 fn main() -> compile_fail_utils::ui_test::Result<()> {
-    compile_fail_utils::test("tests/reflect_derive")
+    compile_fail_utils::test("reflect_derive", "tests/reflect_derive")
 }

--- a/crates/bevy_reflect/compile_fail/tests/func.rs
+++ b/crates/bevy_reflect/compile_fail/tests/func.rs
@@ -1,3 +1,3 @@
 fn main() -> compile_fail_utils::ui_test::Result<()> {
-    compile_fail_utils::test("tests/into_function")
+    compile_fail_utils::test("reflect_into_function", "tests/into_function")
 }

--- a/tools/compile_fail_utils/src/lib.rs
+++ b/tools/compile_fail_utils/src/lib.rs
@@ -18,7 +18,7 @@ use ui_test::{
 /// Use this instead of hand rolling configs.
 ///
 /// `root_dir` is the directory your tests are contained in. Needs to be a path from crate root.
-/// This config will build dependencies and will assume that the cargo manifest is placed at the 
+/// This config will build dependencies and will assume that the cargo manifest is placed at the
 /// current working directory.
 fn basic_config(root_dir: impl Into<PathBuf>, args: &Args) -> Config {
     let mut config = Config {
@@ -52,7 +52,7 @@ fn basic_config(root_dir: impl Into<PathBuf>, args: &Args) -> Config {
         "$HOME",
     );
 
-    // Manually insert @aux-build:<dep> comments into test files. This needs to 
+    // Manually insert @aux-build:<dep> comments into test files. This needs to
     // be done to build and link dependencies. Dependencies will be pulled from a
     // Cargo.toml file.
     config.comment_defaults.base().custom.insert(
@@ -66,43 +66,40 @@ fn basic_config(root_dir: impl Into<PathBuf>, args: &Args) -> Config {
 /// Runs ui tests for a single directory.
 ///
 /// `root_dir` is the directory your tests are contained in. Needs to be a path from crate root.
-pub fn test(test_root: impl Into<PathBuf>) -> ui_test::Result<()> {
-    test_multiple([test_root])
+pub fn test(test_name: impl Into<String>, test_root: impl Into<PathBuf>) -> ui_test::Result<()> {
+    test_multiple(test_name, [test_root])
 }
 
 /// Run ui tests with the given config
-pub fn test_with_config(config: Config) -> ui_test::Result<()> {
-    test_with_multiple_configs([config])
+pub fn test_with_config(test_name: impl Into<String>, config: Config) -> ui_test::Result<()> {
+    test_with_multiple_configs(test_name, [config])
 }
 
 /// Runs ui tests for a multiple directories.
 ///
 /// `root_dirs` paths need to come from crate root.
 pub fn test_multiple(
+    test_name: impl Into<String>,
     test_roots: impl IntoIterator<Item = impl Into<PathBuf>>,
 ) -> ui_test::Result<()> {
     let args = Args::test()?;
 
     let configs = test_roots.into_iter().map(|root| basic_config(root, &args));
 
-    test_with_multiple_configs(configs)
+    test_with_multiple_configs(test_name, configs)
 }
 
 /// Run ui test with the given configs.
 ///
 /// Tests for configs are run in parallel.
 pub fn test_with_multiple_configs(
+    test_name: impl Into<String>,
     configs: impl IntoIterator<Item = Config>,
 ) -> ui_test::Result<()> {
     let configs = configs.into_iter().collect();
 
     let emitter: Box<dyn StatusEmitter + Send> = if env::var_os("CI").is_some() {
-        Box::new((
-            Text::verbose(),
-            Gha::<true> {
-                name: env!("CARGO_PKG_NAME").to_string(),
-            },
-        ))
+        Box::new((Text::verbose(), Gha::<true> { name: test_name.into() }))
     } else {
         Box::new(Text::quiet())
     };


### PR DESCRIPTION
# Objective

The github action summary titles every compile test group as `compile_fail_utils`.

![image](https://github.com/user-attachments/assets/9d00a113-6772-430c-8da9-bffe6a60a8f8)

## Solution

Manually specify group names for compile fail tests.

## Testing

- Wait for compile fail tests to run.
- Observe the generated summary.
