### PR TITLE
update bunny meshlet url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1063,7 +1063,7 @@ setup = [
     "curl",
     "-o",
     "assets/models/bunny.meshlet_mesh",
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/bd869887bc5c9c6e74e353f657d342bef84bacd8/bunny.meshlet_mesh",
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/b6c712cfc87c65de419f856845401aba336a7bcd/bunny.meshlet_mesh",
   ],
 ]
 


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/14193 changed the bunny meshlet url but didn't update example metadata

## Solution

- Also update the url there
