### PR TITLE
Fix the dev docs robots.txt containing a literal \n instead of a newline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo "<meta http-equiv=\"refresh\" content=\"0; url=bevy/index.html\">" > target/doc/index.html
           echo "dev-docs.bevyengine.org" > target/doc/CNAME
-          echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
+          echo $'User-Agent: *\nDisallow: /' > target/doc/robots.txt
           rm target/doc/.lock
 
       - name: Upload site artifact


### PR DESCRIPTION
# Objective

The robots.txt file for the [dev docs](https://dev-docs.bevyengine.org) looks like this `User-Agent: *\nDisallow: /`
It should look like this
```
User-Agent: *
Disallow: /
```

## Solution

Use [`ANSI-C`](https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting) quoting to properly handle the `\n`

## Testing

- [x] Run the fixed echo command in local terminal.
- [ ] Wait for the dev doces to deploy and observe if the mistake has been fixed

