### PR TITLE
Build dev docs with cargo docs-rs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      
+      - uses: dtolnay/install@cargo-docs-rs
 
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
@@ -56,10 +58,7 @@ jobs:
           echo "<meta name=\"robots\" content=\"noindex\">" > header.html
 
       - name: Build docs
-        env:
-          # needs to be in sync with [package.metadata.docs.rs]
-          RUSTDOCFLAGS:  -Zunstable-options --cfg=docsrs
-        run: cargo doc --all-features --no-deps -p bevy -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo docs-rs -p bevy
 
       #  This adds the following:
       #   - A top level redirect to the bevy crate documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           xkb: true
 
       - name: Install cargo-docs-rs
-        run: cargo install cargo-docs-rs
+        run: cargo install cargo-docs-rs --version ^0.1.12
 
       #  This does the following:
       #   - Replaces the docs icon with one that clearly denotes it's not the released package on crates.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,14 +40,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-      
-      - uses: dtolnay/install@cargo-docs-rs
 
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
           wayland: true
           xkb: true
+
+      - name: Install cargo-docs-rs
+        run: cargo install cargo-docs-rs
 
       #  This does the following:
       #   - Replaces the docs icon with one that clearly denotes it's not the released package on crates.io


### PR DESCRIPTION
# Objective

Closes #14131

## Solution

Use docs-rs to build our dev docs

## Testing

I did install and run cargo-docs-rs locally and it did build successfully. I tried to build and deploy to github pages but it failed due to branch protection rules (presumably I have to build the pages from the main branch).
