### PR TITLE
Update `trigger_observers` to operate over slices of data

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -682,11 +682,7 @@ impl<'w> BundleInserter<'w> {
                 add_bundle.mutated.iter().copied(),
             );
             if archetype.has_replace_observer() {
-                deferred_world.trigger_observers(
-                    ON_REPLACE,
-                    entity,
-                    add_bundle.mutated.iter().copied(),
-                );
+                deferred_world.trigger_observers(ON_REPLACE, entity, &add_bundle.mutated);
             }
         }
 
@@ -842,11 +838,11 @@ impl<'w> BundleInserter<'w> {
         unsafe {
             deferred_world.trigger_on_add(new_archetype, entity, add_bundle.added.iter().cloned());
             if new_archetype.has_add_observer() {
-                deferred_world.trigger_observers(ON_ADD, entity, add_bundle.added.iter().cloned());
+                deferred_world.trigger_observers(ON_ADD, entity, &add_bundle.added);
             }
             deferred_world.trigger_on_insert(new_archetype, entity, bundle_info.iter_components());
             if new_archetype.has_insert_observer() {
-                deferred_world.trigger_observers(ON_INSERT, entity, bundle_info.iter_components());
+                deferred_world.trigger_observers(ON_INSERT, entity, bundle_info.components());
             }
         }
 
@@ -959,11 +955,11 @@ impl<'w> BundleSpawner<'w> {
         unsafe {
             deferred_world.trigger_on_add(archetype, entity, bundle_info.iter_components());
             if archetype.has_add_observer() {
-                deferred_world.trigger_observers(ON_ADD, entity, bundle_info.iter_components());
+                deferred_world.trigger_observers(ON_ADD, entity, bundle_info.components());
             }
             deferred_world.trigger_on_insert(archetype, entity, bundle_info.iter_components());
             if archetype.has_insert_observer() {
-                deferred_world.trigger_observers(ON_INSERT, entity, bundle_info.iter_components());
+                deferred_world.trigger_observers(ON_INSERT, entity, bundle_info.components());
             }
         };
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -370,13 +370,13 @@ impl<'w> DeferredWorld<'w> {
         &mut self,
         event: ComponentId,
         entity: Entity,
-        components: impl Iterator<Item = ComponentId>,
+        components: &[ComponentId],
     ) {
         Observers::invoke::<_>(
             self.reborrow(),
             event,
             entity,
-            components,
+            components.iter().copied(),
             &mut (),
             &mut false,
         );

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1224,11 +1224,19 @@ impl<'w> EntityWorldMut<'w> {
         unsafe {
             deferred_world.trigger_on_replace(archetype, self.entity, archetype.components());
             if archetype.has_replace_observer() {
-                deferred_world.trigger_observers(ON_REPLACE, self.entity, archetype.components());
+                deferred_world.trigger_observers(
+                    ON_REPLACE,
+                    self.entity,
+                    &archetype.components().collect::<Vec<ComponentId>>(),
+                );
             }
             deferred_world.trigger_on_remove(archetype, self.entity, archetype.components());
             if archetype.has_remove_observer() {
-                deferred_world.trigger_observers(ON_REMOVE, self.entity, archetype.components());
+                deferred_world.trigger_observers(
+                    ON_REMOVE,
+                    self.entity,
+                    &archetype.components().collect::<Vec<ComponentId>>(),
+                );
             }
         }
 
@@ -1435,11 +1443,11 @@ unsafe fn trigger_on_replace_and_on_remove_hooks_and_observers(
 ) {
     deferred_world.trigger_on_replace(archetype, entity, bundle_info.iter_components());
     if archetype.has_replace_observer() {
-        deferred_world.trigger_observers(ON_REPLACE, entity, bundle_info.iter_components());
+        deferred_world.trigger_observers(ON_REPLACE, entity, bundle_info.components());
     }
     deferred_world.trigger_on_remove(archetype, entity, bundle_info.iter_components());
     if archetype.has_remove_observer() {
-        deferred_world.trigger_observers(ON_REMOVE, entity, bundle_info.iter_components());
+        deferred_world.trigger_observers(ON_REMOVE, entity, bundle_info.components());
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #14333 

## Solution

- Updated `trigger_observers` signature to operate over a slice instead of an `Iterator`.
- Updated calls to `trigger_observers` to match the new signature.

---

## Migration Guide

- TBD