### PR TITLE
Derive and reflect `Debug` for `CameraRenderGraph`

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -510,8 +510,8 @@ impl Default for CameraOutputMode {
 }
 
 /// Configures the [`RenderGraph`](crate::render_graph::RenderGraph) name assigned to be run for a given [`Camera`] entity.
-#[derive(Component, Deref, DerefMut, Reflect, Clone)]
-#[reflect_value(Component)]
+#[derive(Component, Debug, Deref, DerefMut, Reflect, Clone)]
+#[reflect_value(Component, Debug)]
 pub struct CameraRenderGraph(InternedRenderSubGraph);
 
 impl CameraRenderGraph {


### PR DESCRIPTION
# Objective

- `CameraRenderGraph` is not inspectable via reflection, but should be (the name of the configured render graph should be visible in editors, etc.)

## Solution

- Derive and reflect `Debug` for `CameraRenderGraph`