### PR TITLE
Optimize transform propagation

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -154,7 +154,7 @@ unsafe fn propagate_recursive(
         if changed {
             *global_transform = parent.mul_transform(*transform);
         }
-        (*global_transform, children)
+        (global_transform, children)
     };
 
     let Some(children) = children else { return };
@@ -170,7 +170,7 @@ unsafe fn propagate_recursive(
         // entire hierarchy.
         unsafe {
             propagate_recursive(
-                &global_matrix,
+                global_matrix.as_ref(),
                 transform_query,
                 parent_query,
                 child,


### PR DESCRIPTION
# Objective

- Optimize the `propagate_recursive` function in the transform system to reduce CPU usage.
- Addresses performance bottleneck in transform propagation, especially for scenes with complex hierarchies.

## Solution

- Avoided unnecessary cloning of `global_transform` when creating the tuple in the `propagate_recursive` function.
- Used `as_ref()` method on `Mut<GlobalTransform>` when passing it to the recursive call, avoiding an extra dereference.
- These changes significantly reduced the CPU usage of this function from 4.91% to 1.16% of self function time.

## Testing

- Performance testing was conducted using the Hotspot GUI tool, comparing CPU usage before and after the changes.
- `cargo run --release --example many_foxes`
- Tested on Fedora Linux.
---

## Showcase

Here are the PERF GUI results showing the improvement in CPU usage:

### Before
![image](https://github.com/user-attachments/assets/b5c52800-710b-4793-bf75-33e3eb1d2083)

### After
![image](https://github.com/user-attachments/assets/654a4feb-924c-41c8-8ff9-3a1027bd28b9)

As we can see, the CPU usage for the `propagate_recursive` function has been reduced from 4.91% to 1.16%, resulting in a significant performance improvement.

## Migration Guide

This change does not introduce any breaking changes. Users of the Bevy engine will automatically benefit from this performance improvement without needing to modify their code.