### PR TITLE
Fix tracing with `transform_hierarchy` example

### DIFF
--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -20,7 +20,6 @@
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-    log::LogPlugin,
     prelude::*,
     window::{PresentMode, WindowResolution},
 };

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -18,7 +18,7 @@
 //! | `humanoids_inactive` | 4000 humanoid rigs. Only 10 are active.                           |
 //! | `humanoids_mixed`    | 2000 active and 2000 inactive humanoid rigs.                      |
 
-use bevy::prelude::*;
+use bevy::{log::LogPlugin, prelude::*};
 use rand::Rng;
 
 /// pre-defined test configurations with name
@@ -183,7 +183,7 @@ fn main() {
 
     App::new()
         .insert_resource(cfg)
-        .add_plugins((MinimalPlugins, TransformPlugin))
+        .add_plugins((MinimalPlugins, TransformPlugin, LogPlugin::default()))
         .add_systems(Startup, setup)
         // Updating transforms *must* be done before `PostUpdate`
         // or the hierarchy will momentarily be in an invalid state.

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -21,7 +21,7 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{PresentMode, WindowResolution},
+    window::{ExitCondition, PresentMode, WindowResolution},
 };
 use rand::Rng;
 
@@ -189,12 +189,8 @@ fn main() {
         .insert_resource(cfg)
         .add_plugins((
             DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    present_mode: PresentMode::AutoNoVsync,
-                    ..default()
-                }),
+                primary_window: None,
+                exit_condition: ExitCondition::DontExit,
                 ..default()
             }),
             FrameTimeDiagnosticsPlugin,

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -21,7 +21,7 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{ExitCondition, PresentMode, WindowResolution},
+    window::ExitCondition,
 };
 use rand::Rng;
 

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -18,7 +18,12 @@
 //! | `humanoids_inactive` | 4000 humanoid rigs. Only 10 are active.                           |
 //! | `humanoids_mixed`    | 2000 active and 2000 inactive humanoid rigs.                      |
 
-use bevy::{log::LogPlugin, prelude::*};
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    log::LogPlugin,
+    prelude::*,
+    window::{PresentMode, WindowResolution},
+};
 use rand::Rng;
 
 /// pre-defined test configurations with name
@@ -183,7 +188,19 @@ fn main() {
 
     App::new()
         .insert_resource(cfg)
-        .add_plugins((MinimalPlugins, TransformPlugin, LogPlugin::default()))
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    resolution: WindowResolution::new(1920.0, 1080.0)
+                        .with_scale_factor_override(1.0),
+                    present_mode: PresentMode::AutoNoVsync,
+                    ..default()
+                }),
+                ..default()
+            }),
+            FrameTimeDiagnosticsPlugin,
+            LogDiagnosticsPlugin::default(),
+        ))
         .add_systems(Startup, setup)
         // Updating transforms *must* be done before `PostUpdate`
         // or the hierarchy will momentarily be in an invalid state.


### PR DESCRIPTION
# Objective

Fixes #7433
Alternative to #14323

## Solution

Add `DefaultPlugins` so we actually have tracing spans when using `trace_tracy` or `trace_chrome`.

## Testing

```
cargo run --release --features trace_tracy --example transform_hierarchy large_tree
```
This now connects to Tracy and sends a bunch of data.