### PR TITLE
docs: Fix incorrect docs in the run conditions example

### DIFF
--- a/examples/ecs/run_conditions.rs
+++ b/examples/ecs/run_conditions.rs
@@ -25,8 +25,7 @@ fn main() {
                     .run_if(resource_exists::<Unused>.or(
                         // This is a custom run condition, defined using a system that returns
                         // a `bool` and which has read-only `SystemParam`s.
-                        // Both run conditions must return `true` in order for the system to run.
-                        // Note that this second run condition will be evaluated even if the first returns `false`.
+                        // Only a single run condition must return `true` in order for the system to run.
                         has_user_input,
                     )),
                 print_input_counter


### PR DESCRIPTION
## Objective

Make the docs say the right thing.

## Solution

Edit the docs so they say the right thing.

Seems like overtime the example has changed but the comment did not change with it. It originally was a AND but is now an OR.