### PR TITLE
Only propagate transforms entities with GlobalTransforms.

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -53,7 +53,7 @@ pub fn propagate_transforms(
     >,
     mut orphaned: RemovedComponents<Parent>,
     transform_query: Query<(Ref<Transform>, &mut GlobalTransform, Option<&Children>), With<Parent>>,
-    parent_query: Query<(Entity, Ref<Parent>)>,
+    parent_query: Query<(Entity, Ref<Parent>), With<GlobalTransform>>,
     mut orphaned_entities: Local<Vec<Entity>>,
 ) {
     orphaned_entities.clear();
@@ -114,7 +114,7 @@ unsafe fn propagate_recursive(
         (Ref<Transform>, &mut GlobalTransform, Option<&Children>),
         With<Parent>,
     >,
-    parent_query: &Query<(Entity, Ref<Parent>)>,
+    parent_query: &Query<(Entity, Ref<Parent>), With<GlobalTransform>>,
     entity: Entity,
     mut changed: bool,
 ) {


### PR DESCRIPTION
# Objective
Fixes a performance issue when you have 1000s of entities in a bevy hierarchy without transforms.

This was prominently happening in `bevy_ecs_tilemap`.

## Solution

Filter out entities that don't have a global transform.

## Testing

CI
We should test some other way...

## Migration Guide

- To avoid surprising performance pitfalls, `Transform` / `GlobalTransform` propagation is no longer performed down through hierarchies where intermediate parent are missing a `GlobalTransform`. To restore the previous behavior, add `GlobalTransform::default` to intermediate entities.