### PR TITLE
Deprecate `is_playing_animation`

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -603,6 +603,7 @@ impl AnimationPlayer {
         self.active_animations.iter_mut()
     }
 
+    #[deprecated = "Use `animation_is_playing` instead"]
     /// Check if the given animation node is being played.
     pub fn is_playing_animation(&self, animation: AnimationNodeIndex) -> bool {
         self.active_animations.contains_key(&animation)


### PR DESCRIPTION
# Objective

Fixes #14386

## Solution

- Added the `#[deprecate]` attribute to the `is_playing_animation` function.

## Testing

The project successfully builds.

---

## Migration Guide

The user will just need to replace functions named `is_playing_animation` with `animation_is_playing`.
