### PR TITLE
Make the `GltfNode::children` links actually point to children.

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -604,7 +604,7 @@ async fn load_gltf<'a, 'b, 'c>(
                     (
                         child.index(),
                         load_context
-                            .get_label_handle(format!("{}", GltfAssetLabel::Node(node.index()))),
+                            .get_label_handle(format!("{}", GltfAssetLabel::Node(child.index()))),
                     )
                 })
                 .collect::<Vec<_>>(),


### PR DESCRIPTION
Due to a bug in `load_gltf`, the `GltfNode::children` links of each node actually point to the node itself, rather than to the node's children. This commit fixes that bug.

Note that this didn't affect the scene hierarchy of the instantiated glTF, only the hierarchy as present in the `GltfNode` assets. This is likely why the bug was never noticed until now.