### PR TITLE
Update WGPU to version 22

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -17,7 +17,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
-wgpu-types = { version = "0.20", default-features = false, optional = true }
+wgpu-types = { version = "22", default-features = false, optional = true }
 encase = { version = "0.9", default-features = false }
 
 [features]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -29,7 +29,7 @@ zstd = ["ruzstd"]
 
 trace = ["profiling"]
 tracing-tracy = []
-wgpu_trace = ["wgpu/trace"]
+wgpu_trace = []
 ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
@@ -70,15 +70,14 @@ codespan-reporting = "0.11.0"
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
 # and Bevy instead wraps `wgpu` types to verify they are not used off their origin thread.
-wgpu = { version = "0.20", default-features = false, features = [
+wgpu = { version = "22", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
-  "naga",
   "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-naga = { version = "0.20", features = ["wgsl-in"] }
+naga = { version = "22", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
@@ -105,12 +104,12 @@ offset-allocator = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Omit the `glsl` feature in non-WebAssembly by default.
-naga_oil = { version = "0.14", default-features = false, features = [
+naga_oil = { version = "0.15", default-features = false, features = [
   "test_shader",
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-naga_oil = "0.14"
+naga_oil = "0.15"
 js-sys = "0.3"
 web-sys = { version = "0.3.67", features = [
   'Blob',

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -742,6 +742,7 @@ impl PipelineCache {
                 let compilation_options = PipelineCompilationOptions {
                     constants: &std::collections::HashMap::new(),
                     zero_initialize_workgroup_memory: false,
+                    vertex_pulling_transform: Default::default(),
                 };
 
                 let descriptor = RawRenderPipelineDescriptor {
@@ -767,6 +768,7 @@ impl PipelineCache {
                             // TODO: Should this be the same as the vertex compilation options?
                             compilation_options,
                         }),
+                    cache: None,
                 };
 
                 Ok(Pipeline::RenderPipeline(
@@ -822,7 +824,9 @@ impl PipelineCache {
                     compilation_options: PipelineCompilationOptions {
                         constants: &std::collections::HashMap::new(),
                         zero_initialize_workgroup_memory: false,
+                        vertex_pulling_transform: Default::default(),
                     },
+                    cache: None,
                 };
 
                 Ok(Pipeline::ComputePipeline(

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -996,10 +996,8 @@ pub enum PipelineCacheError {
 
 // TODO: This needs to be kept up to date with the capabilities in the `create_validator` function in wgpu-core
 // https://github.com/gfx-rs/wgpu/blob/trunk/wgpu-core/src/device/mod.rs#L449
-// We use a modified version of the `create_validator` function because `naga_oil`'s composer stores the capabilities
-// and subgroup shader stages instead of a `Validator`.
-// We also can't use that function because `wgpu-core` isn't included in WebGPU builds.
-/// Get the device capabilities and subgroup support for use in `naga_oil`.
+// We can't use the `wgpu-core` function to detect the device's capabilities because `wgpu-core` isn't included in WebGPU builds.
+/// Get the device's capabilities for use in `naga_oil`.
 fn get_capabilities(features: Features, downlevel: DownlevelFlags) -> Capabilities {
     let mut capabilities = Capabilities::empty();
     capabilities.set(
@@ -1044,6 +1042,16 @@ fn get_capabilities(features: Features, downlevel: DownlevelFlags) -> Capabiliti
         features.contains(Features::SHADER_INT64),
     );
     capabilities.set(
+        Capabilities::SHADER_INT64_ATOMIC_MIN_MAX,
+        features.intersects(
+            Features::SHADER_INT64_ATOMIC_MIN_MAX | Features::SHADER_INT64_ATOMIC_ALL_OPS,
+        ),
+    );
+    capabilities.set(
+        Capabilities::SHADER_INT64_ATOMIC_ALL_OPS,
+        features.contains(Features::SHADER_INT64_ATOMIC_ALL_OPS),
+    );
+    capabilities.set(
         Capabilities::MULTISAMPLED_SHADING,
         downlevel.contains(DownlevelFlags::MULTISAMPLED_SHADING),
     );
@@ -1062,6 +1070,10 @@ fn get_capabilities(features: Features, downlevel: DownlevelFlags) -> Capabiliti
     capabilities.set(
         Capabilities::SUBGROUP_BARRIER,
         features.intersects(Features::SUBGROUP_BARRIER),
+    );
+    capabilities.set(
+        Capabilities::SUBGROUP_VERTEX_STAGE,
+        features.contains(Features::SUBGROUP_VERTEX),
     );
 
     capabilities

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -173,7 +173,7 @@ impl ShaderDefVal {
 
 impl ShaderCache {
     fn new(render_device: &RenderDevice, render_adapter: &RenderAdapter) -> Self {
-        let (capabilities, subgroup_stages) = get_capabilities(
+        let capabilities = get_capabilities(
             render_device.features(),
             render_adapter.get_downlevel_capabilities().flags,
         );
@@ -183,7 +183,7 @@ impl ShaderCache {
         #[cfg(not(debug_assertions))]
         let composer = naga_oil::compose::Composer::non_validating();
 
-        let composer = composer.with_capabilities(capabilities, subgroup_stages);
+        let composer = composer.with_capabilities(capabilities);
 
         Self {
             composer,
@@ -1000,10 +1000,7 @@ pub enum PipelineCacheError {
 // and subgroup shader stages instead of a `Validator`.
 // We also can't use that function because `wgpu-core` isn't included in WebGPU builds.
 /// Get the device capabilities and subgroup support for use in `naga_oil`.
-fn get_capabilities(
-    features: Features,
-    downlevel: DownlevelFlags,
-) -> (Capabilities, naga::valid::ShaderStages) {
+fn get_capabilities(features: Features, downlevel: DownlevelFlags) -> Capabilities {
     let mut capabilities = Capabilities::empty();
     capabilities.set(
         Capabilities::PUSH_CONSTANT,
@@ -1067,15 +1064,5 @@ fn get_capabilities(
         features.intersects(Features::SUBGROUP_BARRIER),
     );
 
-    let mut subgroup_stages = naga::valid::ShaderStages::empty();
-    subgroup_stages.set(
-        naga::valid::ShaderStages::COMPUTE | naga::valid::ShaderStages::FRAGMENT,
-        features.contains(Features::SUBGROUP),
-    );
-    subgroup_stages.set(
-        naga::valid::ShaderStages::VERTEX,
-        features.contains(Features::SUBGROUP_VERTEX),
-    );
-
-    (capabilities, subgroup_stages)
+    capabilities
 }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -355,7 +355,7 @@ pub async fn initialize_renderer(
                 label: options.device_label.as_ref().map(AsRef::as_ref),
                 required_features: features,
                 required_limits: limits,
-                memory_hints: wgpu::MemoryHints::default(),
+                memory_hints: options.memory_hints.clone(),
             },
             trace_path,
         )

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -355,6 +355,7 @@ pub async fn initialize_renderer(
                 label: options.device_label.as_ref().map(AsRef::as_ref),
                 required_features: features,
                 required_limits: limits,
+                memory_hints: wgpu::MemoryHints::default(),
             },
             trace_path,
         )
@@ -431,7 +432,7 @@ impl<'w> RenderContext<'w> {
     /// configured using the provided `descriptor`.
     pub fn begin_tracked_render_pass<'a>(
         &'a mut self,
-        descriptor: RenderPassDescriptor<'a, '_>,
+        descriptor: RenderPassDescriptor<'_>,
     ) -> TrackedRenderPass<'a> {
         // Cannot use command_encoder() as we need to split the borrow on self
         let command_encoder = self.command_encoder.get_or_insert_with(|| {

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 pub use wgpu::{
     Backends, Dx12Compiler, Features as WgpuFeatures, Gles3MinorVersion, InstanceFlags,
-    Limits as WgpuLimits, PowerPreference,
+    Limits as WgpuLimits, MemoryHints, PowerPreference,
 };
 
 /// Configures the priority used when automatically configuring the features/limits of `wgpu`.
@@ -50,6 +50,8 @@ pub struct WgpuSettings {
     pub gles3_minor_version: Gles3MinorVersion,
     /// These are for controlling WGPU's debug information to eg. enable validation and shader debug info in release builds.
     pub instance_flags: InstanceFlags,
+    /// This hints to the WGPU device about the preferred memory allocation strategy.
+    pub memory_hints: MemoryHints,
 }
 
 impl Default for WgpuSettings {
@@ -113,6 +115,7 @@ impl Default for WgpuSettings {
             dx12_shader_compiler: dx12_compiler,
             gles3_minor_version,
             instance_flags,
+            memory_hints: MemoryHints::default(),
         }
     }
 }


### PR DESCRIPTION
Upgrading to WGPU 22.

Needs `naga_oil` to upgrade first, I've got a fork that compiles but fails tests, so until that's fixed and the crate is officially updated/released this will be blocked.