### PR TITLE
implement randomize for QueryIter

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -178,6 +178,20 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This will panic if `next` has been called on `QueryIter` before, unless the underlying `Query` is empty.
     ///
+    /// # Example
+    /// 
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # let mut world = World::new();
+    /// # fn system(query: Query<()>) {
+    /// // Fetch random query item!
+    /// let random_item = query.iter().randomize().take(1);
+    /// # }
+    /// #
+    /// # let mut schedule = Schedule::default();
+    /// # schedule.add_systems(system);
+    /// # schedule.run(&mut world);
+    /// ```
     pub fn randomize(
         self,
     ) -> QueryRandomIter<

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1124,7 +1124,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>> Debug
 /// An [`Iterator`] over randomized query results of a [`Query`](crate::system::Query).
 ///
 /// This type is created by the [`QueryIter::randomize`] method.
-type QueryRandomIter<'w, 's, D, F, I> = QuerySortedIter<'w, 's, D, F, I>;
+pub type QueryRandomIter<'w, 's, D, F, I> = QuerySortedIter<'w, 's, D, F, I>;
 
 /// An [`Iterator`] over the query items generated from an iterator of [`Entity`]s.
 ///

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -179,13 +179,20 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// This will panic if `next` has been called on `QueryIter` before, unless the underlying `Query` is empty.
     ///
     /// # Example
-    /// 
+    ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// #
+    /// # #[derive(Component)]
+    /// # pub struct Nothing;
+    /// #
     /// # let mut world = World::new();
+    /// # world.spawn_batch((0..100).map(|_| Nothing));
+    /// #
     /// # fn system(query: Query<()>) {
-    /// // Fetch random query item!
-    /// let random_item = query.iter().randomize().take(1);
+    /// #     let n = 7;
+    /// // Fetch n random query items!
+    /// let random_items = query.iter().randomize().take(n);
     /// # }
     /// #
     /// # let mut schedule = Schedule::default();


### PR DESCRIPTION
# Objective

There is no out of the box way to randomize query iteration order. While order is currently not guaranteed, it is still deterministic.

Closes #14393 

## Solution

Implement a `randomize` method for `QueryIter`. This uses a cached sort of `Entity` with its hash as the key.
Since the underlying implementation is just a sort, it returns a type alias of `QuerySortedIter`, named `QueryRandomIter`.
The same could be done for `QueryManyIter` if #13443 merges.

## Testing
 
The example acts as a doc test.

## Showcase

Fetch 7 random query items!
`let random_items = query.iter().randomize().take(7);`