### PR TITLE
Fix repeated animation transition bug

### DIFF
--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -90,7 +90,10 @@ impl AnimationTransitions {
             }
         }
 
-        self.main_animation = Some(new_animation);
+        // If already transitioning away from this animation, cancel the transition.
+        // Otherwise the transition ending would incorrectly stop the new animation.
+        self.transitions.retain(|transition| transition.animation != new_animation);
+
         player.start(new_animation)
     }
 

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -92,7 +92,8 @@ impl AnimationTransitions {
 
         // If already transitioning away from this animation, cancel the transition.
         // Otherwise the transition ending would incorrectly stop the new animation.
-        self.transitions.retain(|transition| transition.animation != new_animation);
+        self.transitions
+            .retain(|transition| transition.animation != new_animation);
 
         player.start(new_animation)
     }


### PR DESCRIPTION
# Objective

Fixes #13910

When a transition is over, the animation is stopped. There was a race condition; if an animation was started while it also had an active transition, the transition ending would then incorrectly stop the newly added animation.

## Solution

When starting an animation, cancel any previous transition for the same animation.

## Testing

The changes were tested manually, mainly by using the `animated_fox` example. I also tested with changes from https://github.com/bevyengine/bevy/pull/13909.

I'd like to have an unit test for this as well, but it seems quite complex to do, as I'm not sure how I would detect an incorrectly paused animation.

Reviewers can follow the instructions in #13910 to reproduce.

Tested on macos 14.4 (M3 processor) Should be platform-independent, though.