### PR TITLE
Fix breaking image 0.25.2 release.

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -744,7 +744,7 @@ impl Image {
                 let image_crate_format = format
                     .as_image_crate_format()
                     .ok_or_else(|| TextureError::UnsupportedTextureFormat(format!("{format:?}")))?;
-                let mut reader = image::io::Reader::new(std::io::Cursor::new(buffer));
+                let mut reader = image::ImageReader::new(std::io::Cursor::new(buffer));
                 reader.set_format(image_crate_format);
                 reader.no_limits();
                 let dyn_img = reader.decode()?;


### PR DESCRIPTION
Deprecated item breaking ci: https://github.com/image-rs/image/releases/tag/v0.25.2. See https://github.com/bevyengine/bevy/actions/runs/10030764981/job/27720434072?pr=14419 for example.