### PR TITLE
Handle 0 height in prepare_bloom_textures

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -338,7 +338,11 @@ fn prepare_bloom_textures(
         {
             // How many times we can halve the resolution minus one so we don't go unnecessarily low
             let mip_count = MAX_MIP_DIMENSION.ilog2().max(2) - 1;
-            let mip_height_ratio = MAX_MIP_DIMENSION as f32 / height as f32;
+            let mip_height_ratio = if height != 0 {
+                MAX_MIP_DIMENSION as f32 / height as f32
+            } else {
+                0.
+            };
 
             let texture_descriptor = TextureDescriptor {
                 label: Some("bloom_texture"),


### PR DESCRIPTION
# Objective

- Fix a confusing panic when the viewport width is non-zero and the height is 0, `prepare_bloom_textures` tries to create a `4294967295x1` texture.

## Solution

- Avoid dividing by zero
- Apps still crash after this, but now on a more reasonable error about the zero-size viewport

## Testing

- I isolated and tested the math. A height of 0 sets `mip_height_ratio`  to `inf`, causing the width to explode if it isn't also 0