### PR TITLE
Remove incorrect equality comparisons for asset load error types

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -738,7 +738,7 @@ mod tests {
             let a_text = get::<CoolText>(app.world(), a_id);
             let (a_load, a_deps, a_rec_deps) = asset_server.get_load_states(a_id).unwrap();
             assert!(a_text.is_none(), "a's asset should not exist yet");
-            assert_eq!(a_load, LoadState::Loading, "a should still be loading");
+            assert!(a_load.is_loading(), "a should still be loading");
             assert_eq!(
                 a_deps,
                 DependencyLoadState::Loading,
@@ -866,7 +866,7 @@ mod tests {
             let d_text = get::<CoolText>(world, d_id);
             let (d_load, d_deps, d_rec_deps) = asset_server.get_load_states(d_id).unwrap();
             assert!(d_text.is_none(), "d component should not exist yet");
-            assert_eq!(d_load, LoadState::Loading);
+            assert!(d_load.is_loading());
             assert_eq!(d_deps, DependencyLoadState::Loading);
             assert_eq!(d_rec_deps, RecursiveDependencyLoadState::Loading);
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -767,7 +767,7 @@ mod tests {
             let b_text = get::<CoolText>(world, b_id);
             let (b_load, b_deps, b_rec_deps) = asset_server.get_load_states(b_id).unwrap();
             assert!(b_text.is_none(), "b component should not exist yet");
-            assert!(b_load.is_loaded());
+            assert!(b_load.is_loading());
             assert_eq!(b_deps, DependencyLoadState::Loading);
             assert_eq!(b_rec_deps, RecursiveDependencyLoadState::Loading);
 
@@ -775,7 +775,7 @@ mod tests {
             let c_text = get::<CoolText>(world, c_id);
             let (c_load, c_deps, c_rec_deps) = asset_server.get_load_states(c_id).unwrap();
             assert!(c_text.is_none(), "c component should not exist yet");
-            assert!(c_load.is_loaded());
+            assert!(c_load.is_loading());
             assert_eq!(c_deps, DependencyLoadState::Loading);
             assert_eq!(c_rec_deps, RecursiveDependencyLoadState::Loading);
             Some(())
@@ -805,7 +805,7 @@ mod tests {
             let c_text = get::<CoolText>(world, c_id);
             let (c_load, c_deps, c_rec_deps) = asset_server.get_load_states(c_id).unwrap();
             assert!(c_text.is_none(), "c component should not exist yet");
-            assert!(c_load.is_loaded());
+            assert!(c_load.is_loading());
             assert_eq!(c_deps, DependencyLoadState::Loading);
             assert_eq!(c_rec_deps, RecursiveDependencyLoadState::Loading);
             Some(())

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -759,7 +759,7 @@ mod tests {
             let (a_load, a_deps, a_rec_deps) = asset_server.get_load_states(a_id).unwrap();
             assert_eq!(a_text.text, "a");
             assert_eq!(a_text.dependencies.len(), 2);
-            assert_eq!(a_load, LoadState::Loaded, "a is loaded");
+            assert!(a_load.is_loaded(), "a is loaded");
             assert_eq!(a_deps, DependencyLoadState::Loading);
             assert_eq!(a_rec_deps, RecursiveDependencyLoadState::Loading);
 
@@ -767,7 +767,7 @@ mod tests {
             let b_text = get::<CoolText>(world, b_id);
             let (b_load, b_deps, b_rec_deps) = asset_server.get_load_states(b_id).unwrap();
             assert!(b_text.is_none(), "b component should not exist yet");
-            assert_eq!(b_load, LoadState::Loading);
+            assert!(b_load.is_loaded());
             assert_eq!(b_deps, DependencyLoadState::Loading);
             assert_eq!(b_rec_deps, RecursiveDependencyLoadState::Loading);
 
@@ -775,7 +775,7 @@ mod tests {
             let c_text = get::<CoolText>(world, c_id);
             let (c_load, c_deps, c_rec_deps) = asset_server.get_load_states(c_id).unwrap();
             assert!(c_text.is_none(), "c component should not exist yet");
-            assert_eq!(c_load, LoadState::Loading);
+            assert!(c_load.is_loaded());
             assert_eq!(c_deps, DependencyLoadState::Loading);
             assert_eq!(c_rec_deps, RecursiveDependencyLoadState::Loading);
             Some(())
@@ -789,7 +789,7 @@ mod tests {
             let (a_load, a_deps, a_rec_deps) = asset_server.get_load_states(a_id).unwrap();
             assert_eq!(a_text.text, "a");
             assert_eq!(a_text.dependencies.len(), 2);
-            assert_eq!(a_load, LoadState::Loaded);
+            assert!(a_load.is_loaded());
             assert_eq!(a_deps, DependencyLoadState::Loading);
             assert_eq!(a_rec_deps, RecursiveDependencyLoadState::Loading);
 
@@ -797,7 +797,7 @@ mod tests {
             let b_text = get::<CoolText>(world, b_id)?;
             let (b_load, b_deps, b_rec_deps) = asset_server.get_load_states(b_id).unwrap();
             assert_eq!(b_text.text, "b");
-            assert_eq!(b_load, LoadState::Loaded);
+            assert!(b_load.is_loaded());
             assert_eq!(b_deps, DependencyLoadState::Loaded);
             assert_eq!(b_rec_deps, RecursiveDependencyLoadState::Loaded);
 
@@ -805,7 +805,7 @@ mod tests {
             let c_text = get::<CoolText>(world, c_id);
             let (c_load, c_deps, c_rec_deps) = asset_server.get_load_states(c_id).unwrap();
             assert!(c_text.is_none(), "c component should not exist yet");
-            assert_eq!(c_load, LoadState::Loading);
+            assert!(c_load.is_loaded());
             assert_eq!(c_deps, DependencyLoadState::Loading);
             assert_eq!(c_rec_deps, RecursiveDependencyLoadState::Loading);
             Some(())
@@ -824,14 +824,14 @@ mod tests {
             assert_eq!(a_text.text, "a");
             assert_eq!(a_text.embedded, "");
             assert_eq!(a_text.dependencies.len(), 2);
-            assert_eq!(a_load, LoadState::Loaded);
+            assert!(a_load.is_loaded());
 
             let b_id = a_text.dependencies[0].id();
             let b_text = get::<CoolText>(world, b_id)?;
             let (b_load, b_deps, b_rec_deps) = asset_server.get_load_states(b_id).unwrap();
             assert_eq!(b_text.text, "b");
             assert_eq!(b_text.embedded, "");
-            assert_eq!(b_load, LoadState::Loaded);
+            assert!(b_load.is_loaded());
             assert_eq!(b_deps, DependencyLoadState::Loaded);
             assert_eq!(b_rec_deps, RecursiveDependencyLoadState::Loaded);
 
@@ -840,7 +840,7 @@ mod tests {
             let (c_load, c_deps, c_rec_deps) = asset_server.get_load_states(c_id).unwrap();
             assert_eq!(c_text.text, "c");
             assert_eq!(c_text.embedded, "ab");
-            assert_eq!(c_load, LoadState::Loaded);
+            assert!(c_load.is_loaded());
             assert_eq!(
                 c_deps,
                 DependencyLoadState::Loading,
@@ -858,7 +858,7 @@ mod tests {
             assert_eq!(sub_text.text, "hello");
             let (sub_text_load, sub_text_deps, sub_text_rec_deps) =
                 asset_server.get_load_states(sub_text_id).unwrap();
-            assert_eq!(sub_text_load, LoadState::Loaded);
+            assert!(sub_text_load.is_loaded());
             assert_eq!(sub_text_deps, DependencyLoadState::Loaded);
             assert_eq!(sub_text_rec_deps, RecursiveDependencyLoadState::Loaded);
 
@@ -870,9 +870,8 @@ mod tests {
             assert_eq!(d_deps, DependencyLoadState::Loading);
             assert_eq!(d_rec_deps, RecursiveDependencyLoadState::Loading);
 
-            assert_eq!(
-                a_deps,
-                DependencyLoadState::Loaded,
+            assert!(
+                a_deps.is_loaded(),
                 "If c has been loaded, the a deps should all be considered loaded"
             );
             assert_eq!(
@@ -900,11 +899,11 @@ mod tests {
             assert_eq!(d_text.text, "d");
             assert_eq!(d_text.embedded, "");
 
-            assert_eq!(c_load, LoadState::Loaded);
+            assert!(c_load.is_loaded());
             assert_eq!(c_deps, DependencyLoadState::Loaded);
             assert_eq!(c_rec_deps, RecursiveDependencyLoadState::Loaded);
 
-            assert_eq!(d_load, LoadState::Loaded);
+            assert!(d_load.is_loaded());
             assert_eq!(d_deps, DependencyLoadState::Loaded);
             assert_eq!(d_rec_deps, RecursiveDependencyLoadState::Loaded);
 
@@ -1089,17 +1088,17 @@ mod tests {
             assert_eq!(d_rec_deps, RecursiveDependencyLoadState::Failed);
 
             assert_eq!(a_text.text, "a");
-            assert_eq!(a_load, LoadState::Loaded);
+            assert!(a_load.is_loaded());
             assert_eq!(a_deps, DependencyLoadState::Loaded);
             assert_eq!(a_rec_deps, RecursiveDependencyLoadState::Failed);
 
             assert_eq!(b_text.text, "b");
-            assert_eq!(b_load, LoadState::Loaded);
+            assert!(b_load.is_loaded());
             assert_eq!(b_deps, DependencyLoadState::Loaded);
             assert_eq!(b_rec_deps, RecursiveDependencyLoadState::Loaded);
 
             assert_eq!(c_text.text, "c");
-            assert_eq!(c_load, LoadState::Loaded);
+            assert!(c_load.is_loaded());
             assert_eq!(c_deps, DependencyLoadState::Failed);
             assert_eq!(c_rec_deps, RecursiveDependencyLoadState::Failed);
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -870,8 +870,9 @@ mod tests {
             assert_eq!(d_deps, DependencyLoadState::Loading);
             assert_eq!(d_rec_deps, RecursiveDependencyLoadState::Loading);
 
-            assert!(
-                a_deps.is_loaded(),
+            assert_eq!(
+                a_deps,
+                DependencyLoadState::Loaded,
                 "If c has been loaded, the a deps should all be considered loaded"
             );
             assert_eq!(

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -540,7 +540,7 @@ impl AssetInfos {
             info.loading_rec_dependencies.remove(&loaded_id);
             if info.loading_rec_dependencies.is_empty() && info.failed_rec_dependencies.is_empty() {
                 info.rec_dep_load_state = RecursiveDependencyLoadState::Loaded;
-                if info.load_state == LoadState::Loaded {
+                if info.load_state.is_loaded() {
                     sender
                         .send(InternalAssetEvent::LoadedWithDependencies { id: waiting_id })
                         .unwrap();

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1352,6 +1352,13 @@ impl LoadState {
     // into thinking it is complementary to `is_loaded`.
     // `NotLoaded` is a very specific failure mode and in most cases it is not necessary to directly check for it.
     // If this is necessary the `matches!` macro can be used instead of a helper method.
+
+    /// Returns `true` if the asset is loaded or in the process of being loaded. If true true,
+    /// then the asset can be considered to be in a "normal" state: the asset either exists
+    /// or will exist, and no errors have been encountered yet.
+    pub fn is_loaded_or_loading(&self) -> bool {
+        self.is_loaded() || self.is_loading()
+    }
 }
 
 /// The load state of an asset's dependencies.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1349,9 +1349,9 @@ impl LoadState {
         matches!(self, Self::Loaded)
     }
     // NOTE: an `is_not_loaded` method is intentionally not included, as it may mislead some users
-    // into thinking it is complementary to `is_not_loaded`.
+    // into thinking it is complementary to `is_loaded`.
     // `NotLoaded` is a very specific failure mode and in most cases it is not necessary to directly check for it.
-    // If this is necessary the `matches!` macro can be used
+    // If this is necessary the `matches!` macro can be used instead of a helper method.
 }
 
 /// The load state of an asset's dependencies.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1341,7 +1341,7 @@ pub enum LoadState {
 
 impl LoadState {
     /// Returns `true` if this instance is [`LoadState::Loaded`]
-    fn is_loaded(&self) -> bool {
+    pub fn is_loaded(&self) -> bool {
         matches!(self, Self::Loaded)
     }
 }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1366,7 +1366,7 @@ pub enum RecursiveDependencyLoadState {
 }
 
 /// An error that occurs during an [`Asset`] load.
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum AssetLoadError {
     #[error("Requested handle of type {requested:?} for asset '{path}' does not match actual asset type '{actual_asset_name}', which used loader '{loader_name}'")]
     RequestedHandleTypeMismatch {
@@ -1439,8 +1439,6 @@ impl PartialEq for AssetLoaderError {
     }
 }
 
-impl Eq for AssetLoaderError {}
-
 impl AssetLoaderError {
     pub fn path(&self) -> &AssetPath<'static> {
         &self.path
@@ -1460,8 +1458,6 @@ impl PartialEq for AddAsyncError {
         self.error.type_id() == other.error.type_id()
     }
 }
-
-impl Eq for AddAsyncError {}
 
 /// An error that occurs when an [`AssetLoader`] is not registered for a given extension.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1359,6 +1359,11 @@ impl LoadState {
     pub fn is_loaded_or_loading(&self) -> bool {
         self.is_loaded() || self.is_loading()
     }
+
+    /// Returns `true` if this instance is [`LoadState::Failed`]
+    pub fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
 }
 
 /// The load state of an asset's dependencies.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1348,6 +1348,10 @@ impl LoadState {
     pub fn is_loaded(&self) -> bool {
         matches!(self, Self::Loaded)
     }
+    // NOTE: an `is_not_loaded` method is intentionally not included, as it may mislead some users
+    // into thinking it is complementary to `is_not_loaded`.
+    // `NotLoaded` is a very specific failure mode and in most cases it is not necessary to directly check for it.
+    // If this is necessary the `matches!` macro can be used
 }
 
 /// The load state of an asset's dependencies.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1340,6 +1340,10 @@ pub enum LoadState {
 }
 
 impl LoadState {
+    /// Returns `true` if this instance is [`LoadState::Loading`]
+    pub fn is_loading(&self) -> bool {
+        matches!(self, Self::Loading)
+    }
     /// Returns `true` if this instance is [`LoadState::Loaded`]
     pub fn is_loaded(&self) -> bool {
         matches!(self, Self::Loaded)

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -2063,7 +2063,7 @@ mod test {
         app.update();
         run_app_until(&mut app, |_world| {
             let load_state = asset_server.get_load_state(handle_id).unwrap();
-            if load_state == LoadState::Loaded {
+            if load_state.is_loaded() {
                 Some(())
             } else {
                 None

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,6 +1,6 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
-use bevy::{asset::LoadState, prelude::*};
+use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -142,8 +142,12 @@ fn environment_map_load_finish(
     label_query: Query<Entity, With<EnvironmentMapLabel>>,
 ) {
     if let Ok(environment_map) = environment_maps.get_single() {
-        if asset_server.load_state(&environment_map.diffuse_map) == LoadState::Loaded
-            && asset_server.load_state(&environment_map.specular_map) == LoadState::Loaded
+        if asset_server
+            .load_state(&environment_map.diffuse_map)
+            .is_loaded()
+            && asset_server
+                .load_state(&environment_map.specular_map)
+                .is_loaded()
         {
             if let Ok(label_entity) = label_query.get_single() {
                 commands.entity(label_entity).despawn();

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -4,7 +4,6 @@
 mod camera_controller;
 
 use bevy::{
-    asset::LoadState,
     core_pipeline::Skybox,
     prelude::*,
     render::{

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -147,7 +147,7 @@ fn asset_loaded(
     mut cubemap: ResMut<Cubemap>,
     mut skyboxes: Query<&mut Skybox>,
 ) {
-    if !cubemap.is_loaded && asset_server.load_state(&cubemap.image_handle) == LoadState::Loaded {
+    if !cubemap.is_loaded && asset_server.load_state(&cubemap.image_handle).is_loaded() {
         info!("Swapping to {}...", CUBEMAPS[cubemap.index].0);
         let image = images.get_mut(&cubemap.image_handle).unwrap();
         // NOTE: PNGs do not have any metadata that could indicate they contain a cubemap texture,

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -2,7 +2,6 @@
 //! uniform variable.
 
 use bevy::{
-    asset::LoadState,
     prelude::*,
     reflect::TypePath,
     render::render_resource::{AsBindGroup, ShaderRef},

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -57,7 +57,9 @@ fn create_array_texture(
     mut materials: ResMut<Assets<ArrayTextureMaterial>>,
 ) {
     if loading_texture.is_loaded
-        || asset_server.load_state(loading_texture.handle.id()) != LoadState::Loaded
+        || !asset_server
+            .load_state(loading_texture.handle.id())
+            .is_loaded()
     {
         return;
     }

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -92,7 +92,10 @@ fn scene_load_check(
 ) {
     match scene_handle.instance_id {
         None => {
-            if asset_server.load_state(&scene_handle.gltf_handle) == LoadState::Loaded {
+            if asset_server
+                .load_state(&scene_handle.gltf_handle)
+                .is_loaded()
+            {
                 let gltf = gltf_assets.get(&scene_handle.gltf_handle).unwrap();
                 if gltf.scenes.len() > 1 {
                     info!(

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -4,8 +4,7 @@
 //! - Insert an initialized `SceneHandle` resource into your App's `AssetServer`.
 
 use bevy::{
-    asset::LoadState, gltf::Gltf, input::common_conditions::input_just_pressed, prelude::*,
-    scene::InstanceId,
+    gltf::Gltf, input::common_conditions::input_just_pressed, prelude::*, scene::InstanceId,
 };
 
 use std::f32::consts::*;


### PR DESCRIPTION
# Objective

The type `AssetLoadError` has `PartialEq` and `Eq` impls, which is problematic due to the fact that the `AssetLoaderError` and `AddAsyncError` variants lie in their impls: they will return `true` for any `Box<dyn Error>` with the same `TypeId`, even if the actual value is different. This can lead to subtle bugs if a user relies on the equality comparison to ensure that two values are equal.

More generally, it is an anti-pattern for large error types involving dynamic dispatch, such as `AssetLoadError`, to have equality comparisons. Directly comparing two errors for equality is usually not desired -- if some logic needs to branch based on the value of an error, it is usually more correct to check for specific variants and inspect their fields.

As far as I can tell, the only reason these errors have equality comparisons is because the `LoadState` enum wraps `AssetLoadError` for its `Failed` variant. This equality comparison is only used to check for `== LoadState::Loaded`, which we can easily replace with an `is_loaded` method.

## Solution

Remove the `{Partial}Eq` impls from `LoadState`, which also allows us to remove it from the error types.

## Migration Guide

The types `bevy_asset::AssetLoadError` and `bevy_asset::LoadState` no longer support equality comparisons. If you need to check for an asset's load state, consider checking for a specific variant using `LoadState::is_loaded` or the `matches!` macro. Similarly, consider using the `matches!` macro to check for specific variants of the `AssetLoadError` type if you need to inspect the value of an asset load error in your code.