### PR TITLE
Fix error in `bevy_ui` when building without `bevy_text`

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,6 +1,3 @@
-use bevy_text::TextPipeline;
-use thiserror::Error;
-
 use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
@@ -14,10 +11,13 @@ use bevy_ecs::{
 use bevy_hierarchy::{Children, Parent};
 use bevy_math::{UVec2, Vec2};
 use bevy_render::camera::{Camera, NormalizedRenderTarget};
+#[cfg(feature = "bevy_text")]
+use bevy_text::TextPipeline;
 use bevy_transform::components::Transform;
 use bevy_utils::tracing::warn;
 use bevy_utils::{HashMap, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
+use thiserror::Error;
 use ui_surface::UiSurface;
 
 mod convert;

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -231,6 +231,8 @@ without UI components as a child of an entity with UI components, results may be
                                         available_height: available_space.height,
                                         #[cfg(feature = "bevy_text")]
                                         font_system,
+                                        #[cfg(not(feature = "bevy_text"))]
+                                        font_system: std::marker::PhantomData,
                                     },
                                     style,
                                 );

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -25,7 +25,7 @@ pub struct MeasureArgs<'a> {
     pub font_system: &'a mut bevy_text::cosmic_text::FontSystem,
     // When `bevy_text` is disabled, use `PhantomData` in order to keep lifetime in type signature.
     #[cfg(not(feature = "bevy_text"))]
-    pub font_system: std::marker::PhantomData<&'a ()>,
+    pub font_system: std::marker::PhantomData<&'a mut ()>,
 }
 
 /// A `Measure` is used to compute the size of a ui node

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -23,6 +23,9 @@ pub struct MeasureArgs<'a> {
     pub available_height: AvailableSpace,
     #[cfg(feature = "bevy_text")]
     pub font_system: &'a mut bevy_text::cosmic_text::FontSystem,
+    // When `bevy_text` is disabled, use `PhantomData` in order to keep lifetime in type signature.
+    #[cfg(not(feature = "bevy_text"))]
+    pub font_system: std::marker::PhantomData<&'a ()>,
 }
 
 /// A `Measure` is used to compute the size of a ui node

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -10,6 +10,7 @@ use crate::{
     UiImage, UiMaterial, ZIndex,
 };
 use bevy_asset::Handle;
+#[cfg(feature = "bevy_text")]
 use bevy_color::Color;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::view::{InheritedVisibility, ViewVisibility, Visibility};


### PR DESCRIPTION
# Objective

- `bevy_ui` does not build without the `bevy_text` feature due to improper feature gating.
  - Specifically, `MeasureArgs<'a>` had an unused lifetime `'a` without `bevy_text` enabled. This is because it stores a reference to a `cosmic_text::FontSystem`.
  - This was caught by `flag-frenzy` in [this run](https://github.com/TheBevyFlock/flag-frenzy/actions/runs/10024258523/job/27706132250).

## Solution

- Add a `PhantomData` to `MeasureArgs<'a>` in order to maintain its lifetime argument.
  - I also named it `font_system`, after the feature-gated argument that actually needs a lifetime, for usability. Please comment if you have a better solution!
- Move some unused imports to be behind the `bevy_text` feature gate.

## Testing

```bash
# Fails on main.
cargo check -p bevy_ui --no-default-features
# Succeeds on main.
cargo check -p bevy_ui --no-default-features -F bevy_text
```

---

## Migration Guide

**This is not a breaking change for users migrating from 0.14, since `MeasureArgs` did not exist then.**

When the `bevy_text` feature is disabled for `bevy_ui`, the type of the `MeasureArgs::font_system` field is now a `PhantomData` instead of being removed entirely. This is in order to keep the lifetime parameter, even though it is unused without text being enabled.