### PR TITLE
Add a method for asynchronously waiting for an asset to load

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1036,9 +1036,11 @@ impl AssetServer {
     /// or if the asset has not been queued up to be loaded.
     pub async fn wait_for_asset<A: Asset>(
         &self,
-        handle: impl AsRef<Handle<A>>,
+        // NOTE: We take a reference to a handle so we know it will outlive the future,
+        // which ensures the handle won't be dropped while waiting for the asset.
+        handle: &Handle<A>,
     ) -> Result<(), WaitForAssetError> {
-        self.wait_for_asset_id(handle.as_ref().id()).await
+        self.wait_for_asset_id(handle.id()).await
     }
 
     /// Returns a future that will suspend until the specified asset and its dependencies finish loading.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1034,7 +1034,26 @@ impl AssetServer {
     ///
     /// This will return an error if the asset or any of its dependencies fail to load,
     /// or if the asset has not been queued up to be loaded.
-    pub fn wait_for_asset(
+    pub async fn wait_for_asset<A: Asset>(
+        &self,
+        handle: impl AsRef<Handle<A>>,
+    ) -> Result<(), WaitForAssetError> {
+        self.wait_for_asset_id(handle.as_ref().id()).await
+    }
+
+    /// Returns a future that will suspend until the specified asset and its dependencies finish loading.
+    ///
+    /// Note that since an asset ID does not count as a reference to the asset,
+    /// the future returned from this method will *not* keep the asset alive.
+    /// This may lead to the asset unexepctedly being dropped while you are waiting for it to finish loading.
+    /// If you have access to an asset's strong [`Handle`], you should prefer to call [`AssetServer::wait_for_asset`]
+    /// to ensure the asset finishes loading, or store a strong handle somewhere else while waiting for it to load.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if the asset or any of its dependencies fail to load,
+    /// or if the asset has not been queued up to be loaded.
+    pub fn wait_for_asset_id(
         &self,
         id: impl Into<UntypedAssetId>,
     ) -> impl Future<Output = Result<(), WaitForAssetError>> + 'static {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1045,11 +1045,28 @@ impl AssetServer {
 
     /// Returns a future that will suspend until the specified asset and its dependencies finish loading.
     ///
+    /// # Errors
+    ///
+    /// This will return an error if the asset or any of its dependencies fail to load,
+    /// or if the asset has not been queued up to be loaded.
+    pub async fn wait_for_asset_untyped(
+        &self,
+        // NOTE: We take a reference to a handle so we know it will outlive the future,
+        // which ensures the handle won't be dropped while waiting for the asset.
+        handle: &UntypedHandle,
+    ) -> Result<(), WaitForAssetError> {
+        self.wait_for_asset_id(handle.id()).await
+    }
+
+    /// Returns a future that will suspend until the specified asset and its dependencies finish loading.
+    ///
     /// Note that since an asset ID does not count as a reference to the asset,
     /// the future returned from this method will *not* keep the asset alive.
     /// This may lead to the asset unexpectedly being dropped while you are waiting for it to finish loading.
+    ///
+    /// When calling this method, make sure a strong handle is stored elsewhere to prevent the asset from being dropped.
     /// If you have access to an asset's strong [`Handle`], you should prefer to call [`AssetServer::wait_for_asset`]
-    /// to ensure the asset finishes loading, or store a strong handle somewhere else while waiting for it to load.
+    /// or [`wait_for_assest_untyped`](Self::wait_for_asset_untyped )to ensure the asset finishes loading.
     ///
     /// # Errors
     ///

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1066,7 +1066,7 @@ impl AssetServer {
     ///
     /// When calling this method, make sure a strong handle is stored elsewhere to prevent the asset from being dropped.
     /// If you have access to an asset's strong [`Handle`], you should prefer to call [`AssetServer::wait_for_asset`]
-    /// or [`wait_for_assest_untyped`](Self::wait_for_asset_untyped )to ensure the asset finishes loading.
+    /// or [`wait_for_assest_untyped`](Self::wait_for_asset_untyped) to ensure the asset finishes loading.
     ///
     /// # Errors
     ///

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1045,7 +1045,7 @@ impl AssetServer {
     ///
     /// Note that since an asset ID does not count as a reference to the asset,
     /// the future returned from this method will *not* keep the asset alive.
-    /// This may lead to the asset unexepctedly being dropped while you are waiting for it to finish loading.
+    /// This may lead to the asset unexpectedly being dropped while you are waiting for it to finish loading.
     /// If you have access to an asset's strong [`Handle`], you should prefer to call [`AssetServer::wait_for_asset`]
     /// to ensure the asset finishes loading, or store a strong handle somewhere else while waiting for it to load.
     ///


### PR DESCRIPTION
# Objective

Currently, is is very painful to wait for an asset to load from the context of an `async` task. While bevy's `AssetServer` is asynchronous at its core, the public API is mainly focused on being used from *synchronous* contexts such as bevy systems. Currently, the best way of waiting for an asset handle to finish loading is to have a system that runs every frame, and either listens for `AssetEvent`s or manually polls the asset server. While this is an acceptable interface for bevy systems, it is extremely awkward to do this in a way that integrates well with the async task system. At my work we had to create our own (inefficient) abstraction that encapsulated the boilerplate of checking an asset's load status and waking up a task when it's done.

## Solution

Add the method `AssetServer::wait_for_asset`, which returns a future that suspends until the asset associated with a given `Handle` either finishes loading or fails to load.

## Testing

TODO
