### PR TITLE
Remove `#[cfg]` from the `From` impls of `TextSection`

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -128,6 +128,7 @@ impl Text {
 
 /// Contains the value of the text in a section and how it should be styled.
 #[derive(Debug, Default, Clone, Reflect)]
+#[reflect(Default)]
 pub struct TextSection {
     /// The content (in `String` form) of the text in the section.
     pub value: String,
@@ -153,7 +154,6 @@ impl TextSection {
     }
 }
 
-#[cfg(feature = "default_font")]
 impl From<&str> for TextSection {
     fn from(value: &str) -> Self {
         Self {
@@ -163,7 +163,6 @@ impl From<&str> for TextSection {
     }
 }
 
-#[cfg(feature = "default_font")]
 impl From<String> for TextSection {
     fn from(value: String) -> Self {
         Self {
@@ -217,7 +216,8 @@ pub struct TextStyle {
     /// If the `font` is not specified, then
     /// * if `default_font` feature is enabled (enabled by default in `bevy` crate),
     ///   `FiraMono-subset.ttf` compiled into the library is used.
-    /// * otherwise no text will be rendered.
+    /// * otherwise no text will be rendered, unless a custom font is loaded into the default font
+    ///   handle.
     pub font: Handle<Font>,
     /// The vertical height of rasterized glyphs in the font atlas in pixels.
     ///


### PR DESCRIPTION
# Objective

- Not including bevy's default font shouldn't result in code not compiling anymore.
- Games may want to load their own default font into the default `Handle<Font>` and not include bevy's default font, but still use these convenience impls (https://github.com/bevyengine/bevy/issues/12192 currently makes this a bit inconvenient, but it does work).

## Solution

- Include these impls unconditionally.
- Slightly expand the comment on the `font` field to indicate that a custom font can be used to override the default font.
- (drive-by: add `#[reflect(Default)]` on `TextSection`, since it was missing a way to construct it via reflection)