### PR TITLE
fix examples after the switch for msaa to a component

### DIFF
--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -35,6 +35,7 @@ fn setup(
                 ..default()
             },
             transform: Transform::from_xyz(-2.0, 2.0, -2.0).looking_at(Vec3::ZERO, Vec3::Y),
+            msaa: Msaa::Off,
             ..default()
         })
         .insert(ScreenSpaceAmbientOcclusionBundle::default())

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -99,7 +99,6 @@ fn setup(
     // Camera
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-2.0, 3.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        msaa: Msaa::Off,
         ..default()
     });
 }


### PR DESCRIPTION
# Objective

- #14273 changed MSAA to a component, and broke some examples

- SSAO needs MSAA to be disabled
https://github.com/bevyengine/bevy/blob/f0ff7fb5445996e561d9ea336ee353544d79fef6/crates/bevy_pbr/src/ssao/mod.rs#L495

- `AlphaMode::AlphaToCoverage` needs MSAA to be not off to do something
https://github.com/bevyengine/bevy/blob/f0ff7fb5445996e561d9ea336ee353544d79fef6/examples/3d/transparency_3d.rs#L113-L117

# Solution

- change MSAA in those examples
