### PR TITLE
Making `bevy_render` an optional dependency for `bevy_gizmos`

### DIFF
--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -91,6 +91,10 @@ impl AssetProcessor {
         Self { server, data }
     }
 
+    pub fn data(&self) -> &Arc<AssetProcessorData> {
+        &self.data
+    }
+
     /// The "internal" [`AssetServer`] used by the [`AssetProcessor`]. This is _separate_ from the asset processor used by
     /// the main App. It has different processor-specific configuration and a different ID space.
     pub fn server(&self) -> &AssetServer {

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -21,7 +21,7 @@ bevy_color = { path = "../bevy_color", version = "0.15.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.15.0-dev" }
-bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.15.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.15.0-dev" }

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["bevy"]
 [features]
 webgl = []
 webgpu = []
+bevy_render = ["dep:bevy_render", "bevy_core_pipeline"]
 
 [dependencies]
 # Bevy
@@ -24,7 +25,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.15.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.15.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.15.0-dev" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.15.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_gizmos_macros = { path = "macros", version = "0.15.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -5,7 +5,6 @@ pub use bevy_gizmos_macros::GizmoConfigGroup;
 
 use bevy_ecs::{component::Component, reflect::ReflectResource, system::Resource};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
-use bevy_render::view::RenderLayers;
 use bevy_utils::TypeIdMap;
 use core::panic;
 use std::{
@@ -164,7 +163,8 @@ pub struct GizmoConfig {
     /// Describes which rendering layers gizmos will be rendered to.
     ///
     /// Gizmos will only be rendered to cameras with intersecting layers.
-    pub render_layers: RenderLayers,
+    #[cfg(feature = "bevy_render")]
+    pub render_layers: bevy_render::view::RenderLayers,
 
     /// Describe how lines should join
     pub line_joints: GizmoLineJoint,
@@ -178,6 +178,7 @@ impl Default for GizmoConfig {
             line_perspective: false,
             line_style: GizmoLineStyle::Solid,
             depth_bias: 0.,
+            #[cfg(feature = "bevy_render")]
             render_layers: Default::default(),
 
             line_joints: GizmoLineJoint::None,
@@ -185,18 +186,21 @@ impl Default for GizmoConfig {
     }
 }
 
+#[cfg(feature = "bevy_render")]
 #[derive(Component)]
 pub(crate) struct GizmoMeshConfig {
     pub line_perspective: bool,
     pub line_style: GizmoLineStyle,
-    pub render_layers: RenderLayers,
+    pub render_layers: bevy_render::view::RenderLayers,
 }
 
+#[cfg(feature = "bevy_render")]
 impl From<&GizmoConfig> for GizmoMeshConfig {
     fn from(item: &GizmoConfig) -> Self {
         GizmoMeshConfig {
             line_perspective: item.line_perspective,
             line_style: item.line_style,
+            #[cfg(feature = "bevy_render")]
             render_layers: item.render_layers.clone(),
         }
     }

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -200,7 +200,6 @@ impl From<&GizmoConfig> for GizmoMeshConfig {
         GizmoMeshConfig {
             line_perspective: item.line_perspective,
             line_style: item.line_style,
-            #[cfg(feature = "bevy_render")]
             render_layers: item.render_layers.clone(),
         }
     }

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -368,13 +368,13 @@ fn update_gizmo_meshes<Config: GizmoConfigGroup>(
             list.positions = mem::take(&mut storage.list_positions);
             list.colors = mem::take(&mut storage.list_colors);
         } else {
-            let mut list = LineGizmo {
+            let list = LineGizmo {
                 strip: false,
-                ..Default::default()
+                config_ty: TypeId::of::<Config>(),
+                positions: mem::take(&mut storage.list_positions),
+                colors: mem::take(&mut storage.list_colors),
+                joints: GizmoLineJoint::None,
             };
-
-            list.positions = mem::take(&mut storage.list_positions);
-            list.colors = mem::take(&mut storage.list_colors);
 
             *handle = Some(line_gizmos.add(list));
         }
@@ -391,14 +391,13 @@ fn update_gizmo_meshes<Config: GizmoConfigGroup>(
             strip.colors = mem::take(&mut storage.strip_colors);
             strip.joints = config.line_joints;
         } else {
-            let mut strip = LineGizmo {
+            let strip = LineGizmo {
                 strip: true,
                 joints: config.line_joints,
-                ..Default::default()
+                config_ty: TypeId::of::<Config>(),
+                positions: mem::take(&mut storage.strip_positions),
+                colors: mem::take(&mut storage.strip_colors),
             };
-
-            strip.positions = mem::take(&mut storage.strip_positions);
-            strip.colors = mem::take(&mut storage.strip_colors);
 
             *handle = Some(line_gizmos.add(strip));
         }
@@ -456,14 +455,19 @@ struct LineGizmoUniform {
     _padding: f32,
 }
 
-#[derive(Asset, Debug, Default, Clone, TypePath)]
-struct LineGizmo {
-    positions: Vec<Vec3>,
-    colors: Vec<LinearRgba>,
+/// A gizmo asset that represents a line.
+#[derive(Asset, Debug, Clone, TypePath)]
+pub struct LineGizmo {
+    /// Positions of the gizmo's vertices
+    pub positions: Vec<Vec3>,
+    /// Colors of the gizmo's vertices
+    pub colors: Vec<LinearRgba>,
     /// Whether this gizmo's topology is a line-strip or line-list
-    strip: bool,
+    pub strip: bool,
     /// Whether this gizmo should draw line joints. This is only applicable if the gizmo's topology is line-strip.
-    joints: GizmoLineJoint,
+    pub joints: GizmoLineJoint,
+    /// The type of the gizmo's configuration group
+    pub config_ty: TypeId,
 }
 
 #[cfg(feature = "bevy_render")]

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -139,16 +139,15 @@ impl Plugin for GizmoPlugin {
             .init_resource::<LineGizmoHandles>()
             // We insert the Resource GizmoConfigStore into the world implicitly here if it does not exist.
             .init_gizmo_group::<DefaultGizmoConfigGroup>();
-        
+
         #[cfg(feature = "bevy_render")]
         app.add_plugins(aabb::AabbGizmoPlugin)
-        .add_plugins(UniformComponentPlugin::<LineGizmoUniform>::default())
-        .add_plugins(RenderAssetPlugin::<GpuLineGizmo>::default());
+            .add_plugins(UniformComponentPlugin::<LineGizmoUniform>::default())
+            .add_plugins(RenderAssetPlugin::<GpuLineGizmo>::default());
 
         #[cfg(feature = "bevy_pbr")]
         app.add_plugins(LightGizmoPlugin);
 
-        
         #[cfg(feature = "bevy_render")]
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(
@@ -173,7 +172,6 @@ impl Plugin for GizmoPlugin {
         } else {
             bevy_utils::tracing::warn!("bevy_render feature is enabled but RenderApp was not detected. Are you sure you loaded GizmoPlugin after RenderPlugin?");
         }
-
     }
 
     #[cfg(feature = "bevy_render")]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -155,7 +155,7 @@ bevy_text = ["dep:bevy_text", "bevy_ui?/bevy_text"]
 bevy_render = [
   "dep:bevy_render",
   "bevy_scene?/bevy_render",
-  "bevy_gizmos?/bevy_render"
+  "bevy_gizmos?/bevy_render",
 ]
 
 # Enable assertions to check the validity of parameters passed to glam

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -152,7 +152,7 @@ accesskit_unix = ["bevy_winit/accesskit_unix"]
 
 bevy_text = ["dep:bevy_text", "bevy_ui?/bevy_text"]
 
-bevy_render = ["dep:bevy_render", "bevy_scene?/bevy_render"]
+bevy_render = ["dep:bevy_render", "bevy_scene?/bevy_render", "bevy_gizmos?/bevy_render"]
 
 # Enable assertions to check the validity of parameters passed to glam
 glam_assert = ["bevy_math/glam_assert"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -152,7 +152,11 @@ accesskit_unix = ["bevy_winit/accesskit_unix"]
 
 bevy_text = ["dep:bevy_text", "bevy_ui?/bevy_text"]
 
-bevy_render = ["dep:bevy_render", "bevy_scene?/bevy_render", "bevy_gizmos?/bevy_render"]
+bevy_render = [
+  "dep:bevy_render",
+  "bevy_scene?/bevy_render",
+  "bevy_gizmos?/bevy_render"
+]
 
 # Enable assertions to check the validity of parameters passed to glam
 glam_assert = ["bevy_math/glam_assert"]


### PR DESCRIPTION
# Objective

This PR makes `bevy_render` an optional dependency for `bevy_gizmos`, thereby allowing `bevy_gizmos` to be used with alternative rendering backend.

Previously `bevy_gizmos` assumes that one of `bevy_pbr` or `bevy_sprite` will be enabled. Here we introduced a new feature named `bevy_render` which disables all rendering-related code paths. An alternative renderer will then take the `LineGizmo` assets (made public in this PR) and issue draw calls on their own. A new field `config_ty` was added to `LineGizmo` to help looking up the related configuration info.

---

## Migration Guide
No user-visible changes needed from the users.
