### PR TITLE
Added serialize flag to bevy_math dep of bevy_ui

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -39,7 +39,7 @@ nonmax = "0.5"
 smallvec = "1.11"
 
 [features]
-serialize = ["serde", "smallvec/serde"]
+serialize = ["serde", "smallvec/serde", "bevy_math/serialize"]
 
 
 [lints]


### PR DESCRIPTION
# Objective

When depending on the `bevy_ui` crate specifically and using the `serialize` feature flag, the compilation fails due to `bevy_math` not having the serialize flag enabled.

## Solution

Added the `serialize` flag to the `bevy_math` dependency when using that flag on `bevy_ui`.

## Testing

Tested by adding `bevy_math = { version = "0.14", features = ["serialize"] }` on a small Bevy library to ensure compilation was successful.