### PR TITLE
Add Color::srgb_u32

### DIFF
--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -171,6 +171,18 @@ impl Color {
         })
     }
 
+    /// Creates a new [`Color`] object storing a [`Srgba`] color from a [`u32`] value with an alpha of 1.0.
+    ///
+    /// For example, a value of `0x000000` results in black, and a value of `0xff0000` results in red.
+    pub fn srgb_u32(color: u32) -> Self {
+        Self::Srgba(Srgba {
+            red: ((color >> 16) & 0xff) as f32 / 255.,
+            green: ((color >> 8) & 0xff) as f32 / 255.,
+            blue: (color & 0xff) as f32 / 255.,
+            alpha: 1.0,
+        })
+    }
+
     #[deprecated = "Use Color::linear_rgba instead."]
     /// Creates a new [`Color`] object storing a [`LinearRgba`] color.
     pub const fn rbga_linear(red: f32, green: f32, blue: f32, alpha: f32) -> Self {


### PR DESCRIPTION
# Objective

Allows using a color value like `0xffffff`.

Instead of doing this:
```rust
let r = ((delta.background_color >> 16) & 0xff) as f32 / 255.;
let g = ((delta.background_color >> 8) & 0xff) as f32 / 255.;
let b = (delta.background_color & 0xff) as f32 / 255.;

let color = Color::srgb(r, g, b);
```
This PR allows doing this:
```rust
let color = Color::srgb_u32(delta.background_color);
```

## Solution

New method `srgb_u32`, similar to `srgb_u8` but all in one value.