### PR TITLE
Add intradoc links for observer triggers

### DIFF
--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -14,21 +14,25 @@ pub const ON_REPLACE: ComponentId = ComponentId::new(2);
 /// [`ComponentId`] for [`OnRemove`]
 pub const ON_REMOVE: ComponentId = ComponentId::new(3);
 
-/// Trigger emitted when a component is added to an entity.
+/// Trigger emitted when a component is added to an entity. See [`crate::component::ComponentHooks::on_add`]
+/// for more information.
 #[derive(Event)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnAdd;
 
-/// Trigger emitted when a component is inserted onto an entity.
+/// Trigger emitted when a component is inserted onto an entity. See [`crate::component::ComponentHooks::on_insert`]
+/// for more information.
 #[derive(Event)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnInsert;
 
-/// Trigger emitted when a component is replaced on an entity.
+/// Trigger emitted when a component is replaced on an entity. See [`crate::component::ComponentHooks::on_replace`]
+/// for more information.
 #[derive(Event)]
 pub struct OnReplace;
 
-/// Trigger emitted when a component is removed from an entity.
+/// Trigger emitted when a component is removed from an entity. See [`crate::component::ComponentHooks::on_remove`]
+/// for more information.
 #[derive(Event)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnRemove;


### PR DESCRIPTION
# Objective

When using observers you might want to know what the difference is between `OnAdd` vs `OnReplace` vs `OnInsert` etc. It's not obvious where to look (`component_hooks.rs`). Added intradoc links for easier disambiguation.

