### PR TITLE
Make `reserve_generations` public

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -768,7 +768,7 @@ impl Entities {
     /// value + 1.
     ///
     /// Does nothing if no entity with this `index` has been allocated yet.
-    pub(crate) fn reserve_generations(&mut self, index: u32, generations: u32) -> bool {
+    pub fn reserve_generations(&mut self, index: u32, generations: u32) -> bool {
         if (index as usize) >= self.meta.len() {
             return false;
         }


### PR DESCRIPTION
# Objective

`reserve_generations` is generally useful - it powers mapping entities across worlds for `SceneEntityMapper`.

I want to write my own entity mapper - the current one is built for `ReflectMapEntities` and causes issues because it requires a `&mut EntityHashMap<Entity>` - for my use cases the mapper would ideally also own the map. 

## Solution

Make `reserve_generations` public.

Alternatively we could have a 

```rust
struct OwnedEntityMapper {
    map: EntityHashMap<Entity>,
    dead_start: Entity,
    generations: u32,
}
```

I think this is generally useful in-tree for working with multiple worlds and programmatically working with Scenes. Potentially niche/controversial since the multiple world story for Bevy doesn't seem to be a priority.