### PR TITLE
Fix hue mixing for `Lcha` and `Oklcha`

### DIFF
--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -118,7 +118,7 @@ impl Mix for Lcha {
         Self {
             lightness: self.lightness * n_factor + other.lightness * factor,
             chroma: self.chroma * n_factor + other.chroma * factor,
-            hue: self.hue * n_factor + other.hue * factor,
+            hue: crate::color_ops::lerp_hue(self.hue, other.hue, factor),
             alpha: self.alpha * n_factor + other.alpha * factor,
         }
     }

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -114,7 +114,7 @@ impl Mix for Oklcha {
         Self {
             lightness: self.lightness * n_factor + other.lightness * factor,
             chroma: self.chroma * n_factor + other.chroma * factor,
-            hue: self.hue * n_factor + other.hue * factor,
+            hue: crate::color_ops::lerp_hue(self.hue, other.hue, factor),
             alpha: self.alpha * n_factor + other.alpha * factor,
         }
     }


### PR DESCRIPTION
# Objective

Fix erroneous hue mixing in `Lcha` and `Oklcha`. Purple + Red == Green is the current behavior (expected a reddish-purple).

## Solution

Use `crate::color_ops::lerp_hue` to handle the wrap-around at 360 degrees like `Hsla`, `Hsva`, and `Hwba` do.

## Testing

Game jamming, but tested that the workaround below produces correct-looking colors in my jam game.