### PR TITLE
Fix `bevy_winit` not building with `serialize` feature

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -13,7 +13,7 @@ trace = []
 wayland = ["winit/wayland", "winit/wayland-csd-adwaita"]
 x11 = ["winit/x11"]
 accesskit_unix = ["accesskit_winit/accesskit_unix", "accesskit_winit/async-io"]
-serialize = ["serde"]
+serialize = ["serde", "bevy_input/serialize", "bevy_window/serialize"]
 
 [dependencies]
 # bevy
@@ -51,7 +51,6 @@ winit = { version = "0.30", default-features = false, features = [
 wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
 crossbeam-channel = "0.5"
-
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- `bevy_winit` fails to build with just the `serialize` feature.
  - Caught by [`flag-frenzy`](https://github.com/TheBevyFlock/flag-frenzy) in [this run](https://github.com/TheBevyFlock/flag-frenzy/actions/runs/10087486444/job/27891723948), using the new, nuanced configuration system!

## Solution

- It was failing because `bevy_winit` did not pass the `serialize` flag to two of its dependencies: `bevy_input` and `bevy_window`.
- To fix this, add these crates to the feature flag.

## Testing

```bash
# On Linux, you must also specify a backend: `x11` or `wayland`.
# You can do this with `-F serialize,x11`, etc.
cargo check -p bevy_winit --no-default-features -F serialize
```