### PR TITLE
remove check-cfg job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,28 +436,3 @@ jobs:
               echo " Example: 'use bevy::sprite::MaterialMesh2dBundle;' instead of 'bevy_internal::sprite::MaterialMesh2dBundle;'"
               exit 1
           fi
-  check-cfg:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-      - name: Install Linux dependencies
-        uses: ./.github/actions/install-linux-deps
-        with:
-          wayland: true
-          xkb: true
-      - name: Build and check cfg typos
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- cfg-check


### PR DESCRIPTION
# Objective

- Fixes #13268

## Solution

- Remove the job as it's now part of rust stable https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#checked-cfg-names-and-values

