### PR TITLE
`ptr`: allow `Ptr` and `PtrMut` construction for references to values of `?Sized` types

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -314,7 +314,7 @@ impl<'a, A: IsAligned> Ptr<'a, A> {
     }
 }
 
-impl<'a, T> From<&'a T> for Ptr<'a> {
+impl<'a, T: ?Sized> From<&'a T> for Ptr<'a> {
     #[inline]
     fn from(val: &'a T) -> Self {
         // SAFETY: The returned pointer has the same lifetime as the passed reference.
@@ -384,7 +384,7 @@ impl<'a, A: IsAligned> PtrMut<'a, A> {
     }
 }
 
-impl<'a, T> From<&'a mut T> for PtrMut<'a> {
+impl<'a, T: ?Sized> From<&'a mut T> for PtrMut<'a> {
     #[inline]
     fn from(val: &'a mut T) -> Self {
         // SAFETY: The returned pointer has the same lifetime as the passed reference.


### PR DESCRIPTION
# Objective

- Currently `bevy_ptr::{Ptr, PtrMut}` have `From` implementations from references.
- These implementations impose an implicit `Sized` bound so `bevy_ptr` types cannot be created from references to slices and trait objects.
- I ran into this trying to use `Ptr<'static>` as an untyped `&'static dyn Any`, and [had to work around it](https://github.com/soqb/perfect-reflect/blob/f32b41512c77ad2d7e0f126b0a0fdf388e3e4717/src/registry.rs#L214-L219). 

## Solution

- Relax the `Sized` bound on the relevant `From` implementations.
