### PR TITLE
Fix TextureCache memory leak and add is_empty() method

### DIFF
--- a/crates/bevy_render/src/texture/texture_cache.rs
+++ b/crates/bevy_render/src/texture/texture_cache.rs
@@ -82,16 +82,22 @@ impl TextureCache {
         }
     }
 
+    /// Returns `true` if the texture cache contains no textures.
+    pub fn is_empty(&self) -> bool {
+        self.textures.is_empty()
+    }
+
     /// Updates the cache and only retains recently used textures.
     pub fn update(&mut self) {
-        for textures in self.textures.values_mut() {
+        self.textures.retain(|_, textures| {
             for texture in textures.iter_mut() {
                 texture.frames_since_last_use += 1;
                 texture.taken = false;
             }
 
             textures.retain(|texture| texture.frames_since_last_use < 3);
-        }
+            !textures.is_empty()
+        });
     }
 }
 


### PR DESCRIPTION
# Objective

Fix a memory leak in `TextureCache` caused by the internal HashMap never having unused entries cleared. 

This isn't a giant memory leak, given the unused entries are simply empty vectors. Though, if someone goes and resizes a window a bunch, it can lead to hundreds/thousands of TextureDescriptor keys adding up in the hashmap – which isn't ideal.

## Solution

- Only retain hashmap entries that still have textures.
- I also added an `is_empty()` method to `TextureCache`, which is useful for 3rd-party higher-level caches that might have individual caches by view entity or texture type, for example.

## Testing

- Verified the examples still work (this is a trivial change)
