### PR TITLE
Fix `bevy_gltf` PBR features not enabling corresponding `bevy_pbr` flags

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -11,7 +11,9 @@ keywords = ["bevy"]
 [features]
 dds = ["bevy_render/dds", "bevy_core_pipeline/dds"]
 pbr_transmission_textures = ["bevy_pbr/pbr_transmission_textures"]
-pbr_multi_layer_material_textures = ["bevy_pbr/pbr_multi_layer_material_textures"]
+pbr_multi_layer_material_textures = [
+  "bevy_pbr/pbr_multi_layer_material_textures",
+]
 pbr_anisotropy_texture = ["bevy_pbr/pbr_anisotropy_texture"]
 
 [dependencies]

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["bevy"]
 [features]
 dds = ["bevy_render/dds", "bevy_core_pipeline/dds"]
 pbr_transmission_textures = ["bevy_pbr/pbr_transmission_textures"]
-pbr_multi_layer_material_textures = []
-pbr_anisotropy_texture = []
+pbr_multi_layer_material_textures = ["bevy_pbr/pbr_multi_layer_material_textures"]
+pbr_anisotropy_texture = ["bevy_pbr/pbr_anisotropy_texture"]
 
 [dependencies]
 # bevy


### PR DESCRIPTION
# Objective

- `bevy_gltf` does not build with only the `pbr_multi_layer_material_textures` or `pbr_anisotropy_texture` features.
  - Caught by [`flag-frenzy`](https://github.com/TheBevyFlock/flag-frenzy) in [this run](https://github.com/TheBevyFlock/flag-frenzy/actions/runs/10087486444/job/27891723948).

## Solution

- This error was due to the feature not enabling the corresponding feature in `bevy_pbr`. Adding these flags as a dependency fixes this error.

## Testing

The following commands fail on `main`, but pass with this PR:

```bash
cargo check -p bevy_gltf --no-default-features -F pbr_multi_layer_material_textures
cargo check -p bevy_gltf --no-default-features -F pbr_anisotropy_texture
```
