### PR TITLE
Use AccumulatedMouseMotion, AccumulatedMouseScroll in examples

### DIFF
--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -43,7 +43,7 @@
 //! | arrow down           | Increase FOV  |
 
 use bevy::color::palettes::tailwind;
-use bevy::input::mouse::MouseMotion;
+use bevy::input::mouse::AccumulatedMouseMotion;
 use bevy::pbr::NotShadowCaster;
 use bevy::prelude::*;
 use bevy::render::view::RenderLayers;
@@ -219,13 +219,15 @@ fn spawn_text(mut commands: Commands) {
 }
 
 fn move_player(
-    mut mouse_motion: EventReader<MouseMotion>,
+    accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     mut player: Query<&mut Transform, With<Player>>,
 ) {
     let mut transform = player.single_mut();
-    for motion in mouse_motion.read() {
-        let yaw = -motion.delta.x * 0.003;
-        let pitch = -motion.delta.y * 0.002;
+    let delta = accumulated_mouse_motion.delta;
+
+    if delta != Vec2::ZERO {
+        let yaw = -delta.x * 0.003;
+        let pitch = -delta.y * 0.002;
         // Order of rotations is important, see <https://gamedev.stackexchange.com/a/136175/103059>
         transform.rotate_y(yaw);
         transform.rotate_local_x(pitch);

--- a/examples/math/random_sampling.rs
+++ b/examples/math/random_sampling.rs
@@ -1,7 +1,7 @@
 //! This example shows how to sample random points from primitive shapes.
 
 use bevy::{
-    input::mouse::{MouseButtonInput, MouseMotion},
+    input::mouse::{AccumulatedMouseMotion, MouseButtonInput},
     math::prelude::*,
     prelude::*,
     render::mesh::SphereKind,
@@ -119,7 +119,7 @@ fn setup(
             R: Restart (erase all samples).\n\
             S: Add one random sample.\n\
             D: Add 100 random samples.\n\
-            Rotate camera by panning left/right.",
+            Rotate camera by holding left mouse and panning left/right.",
             TextStyle::default(),
         )
         .with_style(Style {
@@ -230,8 +230,8 @@ fn handle_keypress(
 
 // Handle user mouse input for panning the camera around:
 fn handle_mouse(
+    accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     mut button_events: EventReader<MouseButtonInput>,
-    mut motion_events: EventReader<MouseMotion>,
     mut camera: Query<&mut Transform, With<Camera>>,
     mut mouse_pressed: ResMut<MousePressed>,
 ) {
@@ -247,7 +247,9 @@ fn handle_mouse(
     if !mouse_pressed.0 {
         return;
     }
-    let displacement: f32 = motion_events.read().map(|motion| motion.delta.x).sum();
-    let mut camera_transform = camera.single_mut();
-    camera_transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(-displacement / 150.));
+    if accumulated_mouse_motion.delta != Vec2::ZERO {
+        let displacement = accumulated_mouse_motion.delta.x;
+        let mut camera_transform = camera.single_mut();
+        camera_transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(-displacement / 150.));
+    }
 }

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -1,7 +1,7 @@
 //! This example shows how to align the orientations of objects in 3D space along two axes using the `Transform::align` API.
 
 use bevy::color::palettes::basic::{GRAY, RED, WHITE};
-use bevy::input::mouse::{MouseButtonInput, MouseMotion};
+use bevy::input::mouse::{AccumulatedMouseMotion, MouseButtonInput};
 use bevy::prelude::*;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -209,8 +209,8 @@ fn handle_keypress(
 
 // Handle user mouse input for panning the camera around
 fn handle_mouse(
+    accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     mut button_events: EventReader<MouseButtonInput>,
-    mut motion_events: EventReader<MouseMotion>,
     mut camera: Query<&mut Transform, With<Camera>>,
     mut mouse_pressed: ResMut<MousePressed>,
 ) {
@@ -226,11 +226,11 @@ fn handle_mouse(
     if !mouse_pressed.0 {
         return;
     }
-    let displacement = motion_events
-        .read()
-        .fold(0., |acc, mouse_motion| acc + mouse_motion.delta.x);
-    let mut camera_transform = camera.single_mut();
-    camera_transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(-displacement / 75.));
+    if accumulated_mouse_motion.delta != Vec2::ZERO {
+        let displacement = accumulated_mouse_motion.delta.x;
+        let mut camera_transform = camera.single_mut();
+        camera_transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(-displacement / 75.));
+    }
 }
 
 // Helper functions (i.e. non-system functions)


### PR DESCRIPTION

# Objective

Use the new `AccumulatedMouseMotion` and `AccumulatedMouseScroll` resources in place of mouse event handling.

I left the `mouse_input_events` example alone, since by its nature it demonstrates event detection.

Fixes #14066 

## Testing

Ran each example locally before and after changes.
