### PR TITLE
Fix typo in `World::observe`

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -303,7 +303,7 @@ impl Observers {
 }
 
 impl World {
-    /// Spawn a "global" [`Observer`] and returns it's [`Entity`].
+    /// Spawns a "global" [`Observer`] and returns its [`Entity`].
     pub fn observe<E: Event, B: Bundle, M>(
         &mut self,
         system: impl IntoObserverSystem<E, B, M>,


### PR DESCRIPTION
# Objective

- Fix a typo in the documentation for `World::observe`

## Solution

- Change `Spawn` to `Spawns` and `it's` to `its`
