### PR TITLE
Don't debug `SystemId`'s entity field twice

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -94,10 +94,7 @@ impl<I, O> std::hash::Hash for SystemId<I, O> {
 
 impl<I, O> std::fmt::Debug for SystemId<I, O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SystemId")
-            .field(&self.entity)
-            .field(&self.entity)
-            .finish()
+        f.debug_tuple("SystemId").field(&self.entity).finish()
     }
 }
 


### PR DESCRIPTION
# Objective

- `SystemId`'s `Debug` implementation includes its `entity` field twice.
- This was likely an oversight in #11019, since before that PR the second field was the `PhantomData` one.

## Solution

- Only include it once

Alternatively, this could be changed to match the struct representation of `SystemId`, thus instructing the formatter to print a named struct and including the `PhantomData` field.
