### PR TITLE
Stop website examples from linking to old URL with multiple redirects

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -502,18 +502,18 @@ header_message = \"Examples (WebGL2)\"
                     continue;
                 }
 
-                // This beautifys the path
+                // This beautifys the category name
                 // to make it a good looking URL
                 // rather than having weird whitespace
                 // and other characters that don't
                 // work well in a URL path.
-                let category_path = root_path.join(
-                    to_show
-                        .category
-                        .replace(['(', ')'], "")
-                        .replace(' ', "-")
-                        .to_lowercase(),
-                );
+                let beautified_category = to_show
+                    .category
+                    .replace(['(', ')'], "")
+                    .replace(' ', "-")
+                    .to_lowercase();
+
+                let category_path = root_path.join(&beautified_category);
 
                 if !categories.contains_key(&to_show.category) {
                     let _ = fs::create_dir_all(&category_path);
@@ -581,11 +581,7 @@ header_message = \"Examples ({})\"
                                 WebApi::Webgpu => "-webgpu",
                                 WebApi::Webgl2 => "",
                             },
-                            to_show
-                                .category
-                                .replace(['(', ')'], "")
-                                .replace(' ', "-")
-                                .to_lowercase(),
+                            &beautified_category,
                             &to_show.technical_name.replace('_', "-"),
                             &to_show.category,
                             &to_show.technical_name,

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -556,7 +556,7 @@ aliases = [\"/examples{}/{}/{}\"]
 
 [extra]
 technical_name = \"{}\"
-link = \"/examples{}/{}/{}\"
+link = \"/examples{}/{}/{}/\"
 image = \"../static/screenshots/{}/{}.png\"
 code_path = \"content/examples{}/{}\"
 shader_code_paths = {:?}
@@ -581,7 +581,11 @@ header_message = \"Examples ({})\"
                                 WebApi::Webgpu => "-webgpu",
                                 WebApi::Webgl2 => "",
                             },
-                            &to_show.category,
+                            to_show
+                                .category
+                                .replace(['(', ')'], "")
+                                .replace(' ', "-")
+                                .to_lowercase(),
                             &to_show.technical_name.replace('_', "-"),
                             &to_show.category,
                             &to_show.technical_name,


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy-website/issues/1558
Followup to #12348 

For the website pages extra link, it needs kebab case for the category name and a trailing forward slash to make the link for the Bevy website correct and not have unnecessary redirections.

## Solution

Changes the category name to kebab case for the extra link, and adds a trailing forward slash to the link.

## Testing

I have tested these changes.

Clone my fork with the changes in `bevy-website/generate-wasm-examples/` then `cd bevy && git switch bevy-website/1558_fix_beautify_example_links && cd ..` and then  `./generate_wasm_examples.sh` to generate examples. 

Afterwards runs `zola serve` and go to `http://127.0.0.1:1111/examples` and hover over or inspect the cards links / anchors to see that the link is now correct, click on any of the cards to see that there is no redirects.