### PR TITLE
Fix `bevy_render`'s `image` dependency version

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -62,7 +62,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 
 # rendering
-image = { version = "0.25", default-features = false }
+image = { version = "0.25.2", default-features = false }
 
 # misc
 codespan-reporting = "0.11.0"


### PR DESCRIPTION
# Objective

- `bevy_render` depends on `image 0.25` but uses `image::ImageReader` which was added only in `image 0.25.2`
- users that have `image 0.25` in their `Cargo.lock` and update to the latest `bevy_render` may thus get a compilation due to this (at least I did)

## Solution

- Properly set the correct minimum version of `image` that `bevy_render` depends on.