### PR TITLE
Observers feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ default = [
   "default_font",
   "webgl2",
   "sysinfo_plugin",
+  "ecs_observers"
 ]
 
 # Force dynamic linking, which improves iterative compile times
@@ -353,6 +354,9 @@ track_change_detection = ["bevy_internal/track_change_detection"]
 
 # Enable function reflection
 reflect_functions = ["bevy_internal/reflect_functions"]
+
+# Enable ECS observers
+ecs_observers = ["bevy_internal/ecs_observers"]
 
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.15.0-dev", default-features = false }
@@ -2569,6 +2573,7 @@ wasm = false
 name = "observers"
 path = "examples/ecs/observers.rs"
 doc-scrape-examples = true
+required-features = ["ecs_observers"]
 
 [package.metadata.example.observers]
 name = "Observers"
@@ -2580,6 +2585,7 @@ wasm = true
 name = "observer_propagation"
 path = "examples/ecs/observer_propagation.rs"
 doc-scrape-examples = true
+required-features = ["ecs_observers"]
 
 [package.metadata.example.observer_propagation]
 name = "Observer Propagation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ default = [
   "default_font",
   "webgl2",
   "sysinfo_plugin",
-  "ecs_observers"
+  "ecs_observers",
 ]
 
 # Force dynamic linking, which improves iterative compile times

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -11,8 +11,9 @@ keywords = ["bevy"]
 [features]
 trace = []
 bevy_debug_stepping = []
-default = ["bevy_reflect"]
+default = ["bevy_reflect", "ecs_observers"]
 bevy_reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect"]
+ecs_observers = ["bevy_ecs/observers"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -3,6 +3,8 @@ use crate::{
     SubApps,
 };
 pub use bevy_derive::AppLabel;
+#[cfg(feature = "ecs_observers")]
+use bevy_ecs::system::IntoObserverSystem;
 use bevy_ecs::{
     event::{event_update_system, EventCursor},
     intern::Interned,
@@ -10,8 +12,6 @@ use bevy_ecs::{
     schedule::{ScheduleBuildSettings, ScheduleLabel},
     system::SystemId,
 };
-#[cfg(feature = "ecs_observers")]
-use bevy_ecs::system::IntoObserverSystem;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 use bevy_utils::{tracing::debug, HashMap};

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -8,8 +8,10 @@ use bevy_ecs::{
     intern::Interned,
     prelude::*,
     schedule::{ScheduleBuildSettings, ScheduleLabel},
-    system::{IntoObserverSystem, SystemId},
+    system::SystemId,
 };
+#[cfg(feature = "ecs_observers")]
+use bevy_ecs::system::IntoObserverSystem;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 use bevy_utils::{tracing::debug, HashMap};
@@ -834,7 +836,10 @@ impl App {
 
         None
     }
+}
 
+#[cfg(feature = "ecs_observers")]
+impl App {
     /// Spawns an [`Observer`] entity, which will watch for and respond to the given event.
     pub fn observe<E: Event, B: Bundle, M>(
         &mut self,

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,12 +11,13 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.77.0"
 
 [features]
-default = ["bevy_reflect"]
+default = ["bevy_reflect", "observers"]
 trace = []
 multi_threaded = ["bevy_tasks/multi_threaded", "arrayvec"]
 bevy_debug_stepping = []
 serialize = ["dep:serde"]
 track_change_detection = []
+observers = []
 
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.15.0-dev" }

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -354,8 +354,7 @@ pub struct Archetype {
 impl Archetype {
     pub(crate) fn new(
         components: &Components,
-        #[cfg(feature = "observers")]
-        observers: &Observers,
+        #[cfg(feature = "observers")] observers: &Observers,
         id: ArchetypeId,
         table_id: TableId,
         table_components: impl Iterator<Item = (ComponentId, ArchetypeComponentId)>,
@@ -851,8 +850,7 @@ impl Archetypes {
     pub(crate) unsafe fn get_id_or_insert(
         &mut self,
         components: &Components,
-        #[cfg(feature = "observers")]
-        observers: &Observers,
+        #[cfg(feature = "observers")] observers: &Observers,
         table_id: TableId,
         table_components: Vec<ComponentId>,
         sparse_set_components: Vec<ComponentId>,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -472,8 +472,7 @@ impl BundleInfo {
         archetypes: &mut Archetypes,
         storages: &mut Storages,
         components: &Components,
-        #[cfg(feature = "observers")]
-        observers: &Observers,
+        #[cfg(feature = "observers")] observers: &Observers,
         archetype_id: ArchetypeId,
     ) -> ArchetypeId {
         if let Some(add_bundle_id) = archetypes[archetype_id].edges().get_add_bundle(self.id) {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -21,6 +21,7 @@ pub mod event;
 pub mod identifier;
 pub mod intern;
 pub mod label;
+#[cfg(feature = "observers")]
 pub mod observer;
 pub mod query;
 #[cfg(feature = "bevy_reflect")]
@@ -41,6 +42,11 @@ pub mod prelude {
     pub use crate::reflect::{
         AppTypeRegistry, ReflectComponent, ReflectFromWorld, ReflectResource,
     };
+    
+    #[doc(hidden)]
+    #[cfg(feature = "observers")]
+    pub use crate::observer::{Observer, Trigger};
+
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,
@@ -48,7 +54,6 @@ pub mod prelude {
         component::Component,
         entity::{Entity, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
-        observer::{Observer, Trigger},
         query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         removal_detection::RemovedComponents,
         schedule::{

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -42,7 +42,7 @@ pub mod prelude {
     pub use crate::reflect::{
         AppTypeRegistry, ReflectComponent, ReflectFromWorld, ReflectResource,
     };
-    
+
     #[doc(hidden)]
     #[cfg(feature = "observers")]
     pub use crate::observer::{Observer, Trigger};

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -3,14 +3,19 @@ mod parallel_scope;
 #[cfg(feature = "track_change_detection")]
 use core::panic::Location;
 
-use super::{Deferred, IntoObserverSystem, IntoSystem, RegisterSystem, Resource};
+#[cfg(feature = "observers")]
+use crate::{
+    event::Event,
+    observer::{Observer, TriggerEvent, TriggerTargets},
+    system::IntoObserverSystem,
+};
+
+use super::{Deferred, IntoSystem, RegisterSystem, Resource};
 use crate::{
     self as bevy_ecs,
     bundle::Bundle,
     component::{ComponentId, ComponentInfo},
     entity::{Entities, Entity},
-    event::Event,
-    observer::{Observer, TriggerEvent, TriggerTargets},
     system::{RunSystemWithInput, SystemId},
     world::{
         command_queue::RawCommandQueue, Command, CommandQueue, EntityWorldMut, FromWorld,
@@ -757,7 +762,10 @@ impl<'w, 's> Commands<'w, 's> {
     pub fn add<C: Command>(&mut self, command: C) {
         self.push(command);
     }
+}
 
+#[cfg(feature = "observers")]
+impl<'w, 's> Commands<'w, 's> {
     /// Sends a "global" [`Trigger`] without any targets. This will run any [`Observer`] of the `event` that
     /// isn't scoped to specific targets.
     ///
@@ -1207,7 +1215,10 @@ impl EntityCommands<'_> {
     pub fn commands(&mut self) -> Commands {
         self.commands.reborrow()
     }
+}
 
+#[cfg(feature = "observers")]
+impl EntityCommands<'_> {
     /// Creates an [`Observer`] listening for a trigger of type `T` that targets this entity.
     pub fn observe<E: Event, B: Bundle, M>(
         &mut self,
@@ -1438,6 +1449,7 @@ fn log_components(entity: Entity, world: &mut World) {
     info!("Entity {entity}: {debug_infos:?}");
 }
 
+#[cfg(feature = "observers")]
 fn observe<E: Event, B: Bundle, M>(
     observer: impl IntoObserverSystem<E, B, M>,
 ) -> impl EntityCommand {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -108,6 +108,7 @@ mod commands;
 mod exclusive_function_system;
 mod exclusive_system_param;
 mod function_system;
+#[cfg(feature = "observers")]
 mod observer_system;
 mod query;
 #[allow(clippy::module_inception)]
@@ -125,6 +126,7 @@ pub use commands::*;
 pub use exclusive_function_system::*;
 pub use exclusive_system_param::*;
 pub use function_system::*;
+#[cfg(feature = "observers")]
 pub use observer_system::*;
 pub use query::*;
 pub use system::*;

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -6,11 +6,15 @@ use crate::{
     component::ComponentId,
     entity::Entity,
     event::{Event, EventId, Events, SendBatchIds},
-    observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
     query::{QueryData, QueryFilter},
     system::{Commands, Query, Resource},
+};
+
+#[cfg(feature = "observers")]
+use crate::{
     traversal::Traversal,
+    observer::{Observers, TriggerTargets},
 };
 
 use super::{
@@ -361,6 +365,18 @@ impl<'w> DeferredWorld<'w> {
         }
     }
 
+    /// Gets an [`UnsafeWorldCell`] containing the underlying world.
+    ///
+    /// # Safety
+    /// - must only be used to make non-structural ECS changes
+    #[inline]
+    pub(crate) fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell {
+        self.world
+    }
+}
+
+#[cfg(feature = "observers")]
+impl<'w> DeferredWorld<'w> {
     /// Triggers all event observers for [`ComponentId`] in target.
     ///
     /// # Safety
@@ -429,14 +445,5 @@ impl<'w> DeferredWorld<'w> {
         targets: impl TriggerTargets + Send + Sync + 'static,
     ) {
         self.commands().trigger_targets(trigger, targets);
-    }
-
-    /// Gets an [`UnsafeWorldCell`] containing the underlying world.
-    ///
-    /// # Safety
-    /// - must only be used to make non-structural ECS changes
-    #[inline]
-    pub(crate) fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCell {
-        self.world
     }
 }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -13,8 +13,8 @@ use crate::{
 
 #[cfg(feature = "observers")]
 use crate::{
-    traversal::Traversal,
     observer::{Observers, TriggerTargets},
+    traversal::Traversal,
 };
 
 use super::{

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -13,8 +13,8 @@ use crate::{
 #[cfg(feature = "observers")]
 use crate::{
     event::Event,
-    system::IntoObserverSystem,
     observer::{Observer, Observers},
+    system::IntoObserverSystem,
     world::{ON_REMOVE, ON_REPLACE},
 };
 
@@ -2387,8 +2387,7 @@ unsafe fn remove_bundle_from_archetype(
     archetypes: &mut Archetypes,
     storages: &mut Storages,
     components: &Components,
-    #[cfg(feature = "observers")]
-    observers: &Observers,
+    #[cfg(feature = "observers")] observers: &Observers,
     archetype_id: ArchetypeId,
     bundle_info: &BundleInfo,
     intersection: bool,

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -3,6 +3,8 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
 use super::{Mut, Ref, World, WorldId};
+#[cfg(feature = "observers")]
+use crate::observer::Observers;
 use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
@@ -16,8 +18,6 @@ use crate::{
     world::RawCommandQueue,
 };
 use bevy_ptr::Ptr;
-#[cfg(feature = "observers")]
-use crate::observer::Observers;
 #[cfg(feature = "track_change_detection")]
 use bevy_ptr::UnsafeCellDeref;
 use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, ptr};

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -9,7 +9,6 @@ use crate::{
     change_detection::{MaybeUnsafeCellLocation, MutUntyped, Ticks, TicksMut},
     component::{ComponentId, ComponentTicks, Components, StorageType, Tick, TickCells},
     entity::{Entities, Entity, EntityLocation},
-    observer::Observers,
     prelude::Component,
     removal_detection::RemovedComponentEvents,
     storage::{Column, ComponentSparseSet, Storages},
@@ -17,6 +16,8 @@ use crate::{
     world::RawCommandQueue,
 };
 use bevy_ptr::Ptr;
+#[cfg(feature = "observers")]
+use crate::observer::Observers;
 #[cfg(feature = "track_change_detection")]
 use bevy_ptr::UnsafeCellDeref;
 use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, ptr};
@@ -232,13 +233,6 @@ impl<'w> UnsafeWorldCell<'w> {
         // SAFETY:
         // - we only access world metadata
         &unsafe { self.world_metadata() }.removed_components
-    }
-
-    /// Retrieves this world's [`Observers`] collection.
-    pub(crate) unsafe fn observers(self) -> &'w Observers {
-        // SAFETY:
-        // - we only access world metadata
-        &unsafe { self.world_metadata() }.observers
     }
 
     /// Retrieves this world's [`Bundles`] collection.
@@ -600,6 +594,16 @@ impl<'w> UnsafeWorldCell<'w> {
         // - caller ensures there are no existing mutable references
         // - caller ensures that we have permission to access the queue
         unsafe { (*self.0).command_queue.clone() }
+    }
+}
+
+#[cfg(feature = "observers")]
+impl<'w> UnsafeWorldCell<'w> {
+    /// Retrieves this world's [`Observers`] collection.
+    pub(crate) unsafe fn observers(self) -> &'w Observers {
+        // SAFETY:
+        // - we only access world metadata
+        &unsafe { self.world_metadata() }.observers
     }
 
     /// # Safety

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -201,6 +201,9 @@ track_change_detection = ["bevy_ecs/track_change_detection"]
 # Enable function reflection
 reflect_functions = ["bevy_reflect/functions"]
 
+# Enable ecs observers
+ecs_observers = ["bevy_ecs/observers", "bevy_app/ecs_observers"]
+
 [dependencies]
 # bevy
 bevy_a11y = { path = "../bevy_a11y", version = "0.15.0-dev" }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -31,6 +31,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_ui|A custom ECS-driven UI framework|
 |bevy_winit|winit window and input backend|
 |default_font|Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase|
+|ecs_observers|Enable ECS observers|
 |hdr|HDR image format support|
 |ktx2|KTX2 compressed texture support|
 |multi_threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|


### PR DESCRIPTION
# Objective

- #14509
- To add feature flags for ecs observers

## Solution

- In bevy_ecs the "observers" feature flag was added; In bevy, bevy_internal and bevy_app the "ecs_observers" feature flag was added; The new flags are default for the crates where they are used, barring bevy_internal which has no default flags.
- Inside bevy_ecs the cfg attribute was used to flag relevant code, modules, and impl blocks.
- Inside bevy_app the cfg attribute was used on the App.observe method.

## Testing

- It was tested by using flag-frenzy on the bevy_ecs and bevy_app crates.

