### PR TITLE
Fix rust beta lints

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -193,10 +193,7 @@ impl<A: Asset> DenseAssetStorage<A> {
             Entry::None => return None,
             Entry::Some { value, generation } => {
                 if *generation == index.generation {
-                    value.take().map(|value| {
-                        self.len -= 1;
-                        value
-                    })
+                    value.take().inspect(|_| self.len -= 1)
                 } else {
                     return None;
                 }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -500,7 +500,7 @@ impl AssetServer {
         let (mut meta, loader, mut reader) = self
             .get_meta_loader_and_reader(&path_clone, asset_type_id)
             .await
-            .map_err(|e| {
+            .inspect_err(|e| {
                 // if there was an input handle, a "load" operation has already started, so we must produce a "failure" event, if
                 // we cannot find the meta and loader
                 if let Some(handle) = &input_handle {
@@ -510,7 +510,6 @@ impl AssetServer {
                         error: e.clone(),
                     });
                 }
-                e
             })?;
 
         // This contains Some(UntypedHandle), if it was retrievable

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1741,7 +1741,8 @@ mod tests {
         );
     }
 
-    // These fields are never read so we get a dead code lint here.
+    // These structs are primarily compilation tests to test the derive macros. Because they are
+    // never constructed, we have to manually silence the `dead_code` lint.
     #[allow(dead_code)]
     #[derive(Component)]
     struct ComponentA(u32);
@@ -1749,4 +1750,19 @@ mod tests {
     #[allow(dead_code)]
     #[derive(Component)]
     struct ComponentB(u32);
+
+    #[allow(dead_code)]
+    #[derive(Bundle)]
+    struct Simple(ComponentA);
+
+    #[allow(dead_code)]
+    #[derive(Bundle)]
+    struct Tuple(Simple, ComponentB);
+
+    #[allow(dead_code)]
+    #[derive(Bundle)]
+    struct Record {
+        field0: Simple,
+        field1: ComponentB,
+    }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1749,16 +1749,4 @@ mod tests {
     #[allow(dead_code)]
     #[derive(Component)]
     struct ComponentB(u32);
-
-    #[derive(Bundle)]
-    struct Simple(ComponentA);
-
-    #[derive(Bundle)]
-    struct Tuple(Simple, ComponentB);
-
-    #[derive(Bundle)]
-    struct Record {
-        field0: Simple,
-        field1: ComponentB,
-    }
 }


### PR DESCRIPTION
# Objective

- Fixes #14517.

## Solution

- Replace two instances of `map()` with `inspect()`.
- `#[allow(dead_code)]` on `Bundle` derive macro tests.

## Testing

You need to install the beta toolchain, since these lints are not stable yet.

```bash
cargo +beta clippy --workspace
cargo +beta test --workspace
```
