### PR TITLE
Fix Entity Debug Format

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -409,6 +409,7 @@ impl<'de> Deserialize<'de> for Entity {
 ///         ...
 ///       ),
 ///   ...
+/// )
 /// ```
 impl fmt::Debug for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -390,6 +390,26 @@ impl<'de> Deserialize<'de> for Entity {
     }
 }
 
+/// Outputs the full entity identifier, including the index, generation, and the raw bits.
+///
+/// This takes the format: `{index}v{generation}#{bits}`.
+///
+/// # Usage
+///
+/// Prefer to use this format for debugging and logging purposes. Because the output contains
+/// the raw bits, it is easy to check it against serialized scene data.
+///
+/// Example serialized scene data:
+/// ```text
+/// (
+///   ...
+///   entities: {
+///     4294967297: (  <--- Raw Bits
+///       components: {
+///         ...
+///       ),
+///   ...
+/// ```
 impl fmt::Debug for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -402,6 +422,9 @@ impl fmt::Debug for Entity {
     }
 }
 
+/// Outputs the short entity identifier, including the index and generation.
+///
+/// This takes the format: `{index}v{generation}`.
 impl fmt::Display for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}v{}", self.index(), self.generation())

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -392,7 +392,13 @@ impl<'de> Deserialize<'de> for Entity {
 
 impl fmt::Debug for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}v{}#{}", self.index(), self.generation(), self.to_bits())
+        write!(
+            f,
+            "{}v{}#{}",
+            self.index(),
+            self.generation(),
+            self.to_bits()
+        )
     }
 }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -142,7 +142,7 @@ type IdCursor = isize;
 /// [`Query::get`]: crate::system::Query::get
 /// [`World`]: crate::world::World
 /// [SemVer]: https://semver.org/
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect_value(Hash, PartialEq))]
 #[cfg_attr(
@@ -387,6 +387,12 @@ impl<'de> Deserialize<'de> for Entity {
         use serde::de::Error;
         let id: u64 = serde::de::Deserialize::deserialize(deserializer)?;
         Entity::try_from_bits(id).map_err(D::Error::custom)
+    }
+}
+
+impl fmt::Debug for Entity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}v{}#{}", self.index(), self.generation(), self.to_bits())
     }
 }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1159,6 +1159,15 @@ mod tests {
     }
 
     #[test]
+    fn entity_debug() {
+        let entity = Entity::from_raw(42);
+        let string = format!("{:?}", entity);
+        assert!(string.contains("42"));
+        assert!(string.contains("v1"));
+        assert!(string.contains(format!("#{}", entity.to_bits()).as_str()));
+    }
+
+    #[test]
     fn entity_display() {
         let entity = Entity::from_raw(42);
         let string = format!("{}", entity);


### PR DESCRIPTION
# Objective

Fixes #12139

## Solution

See this comment on original issue for my proposal:
https://github.com/bevyengine/bevy/issues/12139#issuecomment-2241915791

This PR is an implementation of this proposal.

I modified the implementation of `fmt::Debug` to instead display `0v0#12345` to ensure entity index, generation, and raw bits are all present in the output for debug purposes while still keeping log message concise.

`fmt::Display` remains as is (`0v0`) to offer an even shorter output.

To me, this is the most non-intrusive fix for this issue.

## Testing

Add `fn entity_debug` test
