### PR TITLE
Fix lints in nightly

### DIFF
--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -34,6 +34,7 @@ pub struct C(usize);
 
 /// Deriving reflect on an enum will implement the `Reflect` and `Enum` traits
 #[derive(Reflect)]
+#[allow(dead_code)]
 enum D {
     A,
     B(usize),
@@ -57,6 +58,7 @@ pub struct E {
 /// that these values behave as expected when nested underneath Reflect-ed structs.
 #[derive(Reflect, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[reflect_value(PartialEq, Serialize, Deserialize)]
+#[allow(dead_code)]
 enum F {
     X,
     Y,


### PR DESCRIPTION
# Objective

Similar to #14537 , this fixes a minor lint issue causing CI failures when using nightly toolchain.

## Solution

Add `#[allow(dead_code)]` to unused sample code.

## Testing

`cargo run -p ci -- lints` using 1.82 toolchain.