### PR TITLE
time_system is ambiguous_with event_update_system

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -30,7 +30,9 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, RunFixedMainLoop};
-use bevy_ecs::event::{signal_event_update_system, EventRegistry, ShouldUpdateEvents};
+use bevy_ecs::event::{
+    event_update_system, signal_event_update_system, EventRegistry, ShouldUpdateEvents,
+};
 use bevy_ecs::prelude::*;
 use bevy_utils::{tracing::warn, Duration, Instant};
 pub use crossbeam_channel::TrySendError;
@@ -62,8 +64,13 @@ impl Plugin for TimePlugin {
                 .register_type::<Timer>();
         }
 
-        app.add_systems(First, time_system.in_set(TimeSystem))
-            .add_systems(RunFixedMainLoop, run_fixed_main_schedule);
+        app.add_systems(
+            First,
+            time_system
+                .in_set(TimeSystem)
+                .ambiguous_with(event_update_system),
+        )
+        .add_systems(RunFixedMainLoop, run_fixed_main_schedule);
 
         // Ensure the events are not dropped until `FixedMain` systems can observe them
         app.add_systems(FixedPostUpdate, signal_event_update_system);

--- a/tests/ecs/ambiguity_detection.rs
+++ b/tests/ecs/ambiguity_detection.rs
@@ -69,7 +69,7 @@ pub fn main() {
 
     let total_ambiguities = ambiguities.total();
     assert_eq!(
-        total_ambiguities, 82,
+        total_ambiguities, 81,
         "Main app does not have an expected conflicting systems count, \
         you might consider verifying if it's normal, or change the expected number.\n\
         Details:\n{:#?}",


### PR DESCRIPTION
# Objective

Resolve possible ambiguity detection panic between `time_system` and `event_update_system`.

Fixes #14524

## Solution

Sets `.ambiguous_with(event_update_system)` on `time_system`. This is slightly new territory for me, so please treat with scepticism.

## Testing

As described in the issue, added
```
        .configure_schedules(ScheduleBuildSettings {
            ambiguity_detection: LogLevel::Error,
            ..default()
        })
```
to the `time` example and ran it.