### PR TITLE
Make `AnimationPlayer::start` and `::play` work accordingly to documentation

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -564,14 +564,14 @@ thread_local! {
 impl AnimationPlayer {
     /// Start playing an animation, restarting it if necessary.
     pub fn start(&mut self, animation: AnimationNodeIndex) -> &mut ActiveAnimation {
-        self.active_animations.entry(animation).or_default()
+        let playing_animation = self.active_animations.entry(animation).or_default();
+        playing_animation.replay();
+        playing_animation
     }
 
     /// Start playing an animation, unless the requested animation is already playing.
     pub fn play(&mut self, animation: AnimationNodeIndex) -> &mut ActiveAnimation {
-        let playing_animation = self.active_animations.entry(animation).or_default();
-        playing_animation.weight = 1.0;
-        playing_animation
+        self.active_animations.entry(animation).or_default()
     }
 
     /// Stops playing the given animation, removing it from the list of playing


### PR DESCRIPTION
# Objective

While scrolling through the animation crate, I was confused by the docs and code for the two methods. One does nothing for resetting an animation, the other just resets the weights for whatever reason.

## Solution

Made the functions work accordingly to their documentation.
`start` now replays the animation.
And `play` doesn't reset the weight anymore. I have no clue why it should. `play` is there to don't do anything to an already existing animation.

## Testing

I tested the current 0.14 code with bevy playground in the Animated Fox exampled and changed it such that on pressing space, either `play` or `start` would be called. Neither changed anything.
I then inlined the function for start there and it restarted the animation, so it should work.

---

## Migration Guide

`AnimationPlayer::start` now correspondingly to its docs restarts a running animation.
`AnimationPlayer::play` doesn't reset the weight anymore.