### PR TITLE
Change ReflectMapEntities to operate on components before insertion

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -122,6 +122,16 @@ impl<T: EntityMapper> DynEntityMapper for T {
     }
 }
 
+impl<'a> EntityMapper for &'a mut dyn DynEntityMapper {
+    fn map_entity(&mut self, entity: Entity) -> Entity {
+        (*self).dyn_map_entity(entity)
+    }
+
+    fn mappings(&self) -> impl Iterator<Item = (Entity, Entity)> {
+        (*self).dyn_mappings().into_iter()
+    }
+}
+
 impl EntityMapper for SceneEntityMapper<'_> {
     /// Returns the corresponding mapped entity or reserves a new dead entity ID in the current world if it is absent.
     fn map_entity(&mut self, entity: Entity) -> Entity {

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -6,15 +6,12 @@
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 
-use self::masks::IdentifierMask;
+use self::{error::IdentifierError, kinds::IdKind, masks::IdentifierMask};
 use std::{hash::Hash, num::NonZero};
 
 pub mod error;
 pub(crate) mod kinds;
 pub(crate) mod masks;
-
-pub use self::error::IdentifierError;
-pub use self::kinds::IdKind;
 
 /// A unified identifier for all entity and similar IDs.
 ///

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -6,12 +6,15 @@
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 
-use self::{error::IdentifierError, kinds::IdKind, masks::IdentifierMask};
+use self::masks::IdentifierMask;
 use std::{hash::Hash, num::NonZero};
 
 pub mod error;
 pub(crate) mod kinds;
 pub(crate) mod masks;
+
+pub use self::error::IdentifierError;
+pub use self::kinds::IdKind;
 
 /// A unified identifier for all entity and similar IDs.
 ///

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -1,9 +1,9 @@
 use crate::{
     component::Component,
-    entity::{Entity, EntityHashMap, MapEntities, SceneEntityMapper},
+    entity::{DynEntityMapper, Entity, EntityHashMap, MapEntities, SceneEntityMapper},
     world::World,
 };
-use bevy_reflect::FromType;
+use bevy_reflect::{FromReflect, FromType, PartialReflect};
 
 /// For a specific type of component, this maps any fields with values of type [`Entity`] to a new world.
 ///
@@ -13,53 +13,81 @@ use bevy_reflect::FromType;
 /// See [`SceneEntityMapper`] and [`MapEntities`] for more information.
 #[derive(Clone)]
 pub struct ReflectMapEntities {
-    map_all_entities: fn(&mut World, &mut SceneEntityMapper),
-    map_entities: fn(&mut World, &mut SceneEntityMapper, &[Entity]),
+    map_entities: fn(&mut dyn PartialReflect, &mut dyn DynEntityMapper),
+    map_all_world_entities: fn(&mut World, &mut SceneEntityMapper),
+    map_world_entities: fn(&mut World, &mut SceneEntityMapper, &[Entity]),
 }
 
 impl ReflectMapEntities {
+    /// A general method for applying [`MapEntities`] behavior to a reflected component.
+    ///
+    /// Be mindful in its usage: Works best in situations where the source entities
+    /// in the [`EntityHashMap<Entity>`] have already been populated by spawning empty
+    /// entities in the destination world if needed. For example, when spawning
+    /// entities in a scene, if this is used on a component before ensuring that
+    /// all entities in the scene have been allocated, a new mapping will be created
+    /// with a "dead" entity.
+    pub fn map_entities(
+        &self,
+        component: &mut dyn PartialReflect,
+        mapper: &mut dyn DynEntityMapper,
+    ) {
+        (self.map_entities)(component, mapper);
+    }
+
     /// A general method for applying [`MapEntities`] behavior to all elements in an [`EntityHashMap<Entity>`].
     ///
     /// Be mindful in its usage: Works best in situations where the entities in the [`EntityHashMap<Entity>`] are newly
     /// created, before systems have a chance to add new components. If some of the entities referred to
-    /// by the [`EntityHashMap<Entity>`] might already contain valid entity references, you should use [`map_entities`](Self::map_entities).
+    /// by the [`EntityHashMap<Entity>`] might already contain valid entity references, you should use [`map_world_entities`](Self::map_world_entities).
     ///
     /// An example of this: A scene can be loaded with `Parent` components, but then a `Parent` component can be added
-    /// to these entities after they have been loaded. If you reload the scene using [`map_all_entities`](Self::map_all_entities), those `Parent`
+    /// to these entities after they have been loaded. If you reload the scene using [`map_all_world_entities`](Self::map_all_world_entities), those `Parent`
     /// components with already valid entity references could be updated to point at something else entirely.
-    pub fn map_all_entities(&self, world: &mut World, entity_map: &mut EntityHashMap<Entity>) {
-        SceneEntityMapper::world_scope(entity_map, world, self.map_all_entities);
+    #[deprecated = "map_all_world_entities doesn't play well with Observers. Use map_entities instead."]
+    pub fn map_all_world_entities(
+        &self,
+        world: &mut World,
+        entity_map: &mut EntityHashMap<Entity>,
+    ) {
+        SceneEntityMapper::world_scope(entity_map, world, self.map_all_world_entities);
     }
 
     /// A general method for applying [`MapEntities`] behavior to elements in an [`EntityHashMap<Entity>`]. Unlike
-    /// [`map_all_entities`](Self::map_all_entities), this is applied to specific entities, not all values
+    /// [`map_all_world_entities`](Self::map_all_world_entities), this is applied to specific entities, not all values
     /// in the [`EntityHashMap<Entity>`].
     ///
     /// This is useful mostly for when you need to be careful not to update components that already contain valid entity
-    /// values. See [`map_all_entities`](Self::map_all_entities) for more details.
-    pub fn map_entities(
+    /// values. See [`map_all_world_entities`](Self::map_all_world_entities) for more details.
+    #[deprecated = "map_world_entities doesn't play well with Observers. Use map_entities instead."]
+    pub fn map_world_entities(
         &self,
         world: &mut World,
         entity_map: &mut EntityHashMap<Entity>,
         entities: &[Entity],
     ) {
         SceneEntityMapper::world_scope(entity_map, world, |world, mapper| {
-            (self.map_entities)(world, mapper, entities);
+            (self.map_world_entities)(world, mapper, entities);
         });
     }
 }
 
-impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
+impl<C: Component + MapEntities + FromReflect> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
-            map_entities: |world, entity_mapper, entities| {
+            map_entities: |component, mut entity_mapper| {
+                let mut concrete = C::from_reflect(component.as_partial_reflect()).unwrap();
+                concrete.map_entities(&mut entity_mapper);
+                component.apply(&concrete);
+            },
+            map_world_entities: |world, entity_mapper, entities| {
                 for &entity in entities {
                     if let Some(mut component) = world.get_mut::<C>(entity) {
                         component.map_entities(entity_mapper);
                     }
                 }
             },
-            map_all_entities: |world, entity_mapper| {
+            map_all_world_entities: |world, entity_mapper| {
                 let entities = entity_mapper
                     .get_map()
                     .values()

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,11 +1,11 @@
 use crate::{DynamicScene, SceneSpawnError};
 use bevy_asset::Asset;
 use bevy_ecs::{
-    entity::{Entity, EntityHashMap},
+    entity::{Entity, EntityHashMap, SceneEntityMapper},
     reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
     world::World,
 };
-use bevy_reflect::TypePath;
+use bevy_reflect::{PartialReflect, TypePath};
 
 /// To spawn a scene, you can use either:
 /// * [`SceneSpawner::spawn`](crate::SceneSpawner::spawn)
@@ -90,11 +90,22 @@ impl Scene {
             reflect_resource.copy(&self.world, world, &type_registry);
         }
 
+        // Ensure that all scene entities have been allocated in the destination
+        // world before handling components that may contain references that need mapping.
         for archetype in self.world.archetypes().iter() {
             for scene_entity in archetype.entities() {
-                let entity = entity_map
+                entity_map
                     .entry(scene_entity.id())
                     .or_insert_with(|| world.spawn_empty().id());
+            }
+        }
+
+        for archetype in self.world.archetypes().iter() {
+            for scene_entity in archetype.entities() {
+                let entity = *entity_map
+                    .get(&scene_entity.id())
+                    .expect("should have previously spawned an entity");
+
                 for component_id in archetype.components() {
                     let component_info = self
                         .world
@@ -102,32 +113,38 @@ impl Scene {
                         .get_info(component_id)
                         .expect("component_ids in archetypes should have ComponentInfo");
 
-                    let reflect_component = type_registry
+                    let registration = type_registry
                         .get(component_info.type_id().unwrap())
                         .ok_or_else(|| SceneSpawnError::UnregisteredType {
                             std_type_name: component_info.name().to_string(),
-                        })
-                        .and_then(|registration| {
-                            registration.data::<ReflectComponent>().ok_or_else(|| {
-                                SceneSpawnError::UnregisteredComponent {
-                                    type_path: registration.type_info().type_path().to_string(),
-                                }
-                            })
                         })?;
-                    reflect_component.copy(
-                        &self.world,
-                        world,
-                        scene_entity.id(),
-                        *entity,
+                    let reflect_component =
+                        registration.data::<ReflectComponent>().ok_or_else(|| {
+                            SceneSpawnError::UnregisteredComponent {
+                                type_path: registration.type_info().type_path().to_string(),
+                            }
+                        })?;
+
+                    let Some(mut component) = reflect_component
+                        .reflect(self.world.entity(scene_entity.id()))
+                        .map(PartialReflect::clone_value)
+                    else {
+                        continue;
+                    };
+
+                    // If this component references entities in the scene,
+                    // update them to the entities in the world.
+                    if let Some(map_entities) = registration.data::<ReflectMapEntities>() {
+                        SceneEntityMapper::world_scope(entity_map, world, |_, mapper| {
+                            map_entities.map_entities(component.as_partial_reflect_mut(), mapper);
+                        });
+                    }
+                    reflect_component.apply_or_insert(
+                        &mut world.entity_mut(entity),
+                        component.as_partial_reflect(),
                         &type_registry,
                     );
                 }
-            }
-        }
-
-        for registration in type_registry.iter() {
-            if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
-                map_entities_reflect.map_all_entities(world, entity_map);
             }
         }
 


### PR DESCRIPTION
# Objective

Fixes #14465

## Solution

Alters `ReflectMapEntities` to operate more like `MapEntities` by making it operate on the component itself rather than the `World` post-insertion. As a result, `Observers` never see the in-between state where the scene component has been added, but hasn't yet had its entities mapped.

Also brings it more in-line with `MapEntities` by accepting a generic `DynEntityMapper` rather than relying on the `EntityHashMap` and `SceneEntityMapper` implementation.

## Testing

* New unit test for `Observer`s + `DynamicScene`s
* New unit test for `Observer`s + `Scene`s
* Open to suggestions for other tests!

---

## Migration Guide

- The existing `map_entities` and `map_all_entities` methods have been renamed to `map_world_entities` and `map_all_world_entities` respectively and marked as deprecated.
  - Figured I'd leave these in some form since the new method isn't exactly a drop-in replacement.
  - ~This is in a separate commit so that they'll be easy to fully remove later.~ Edit: Oops, I forgot I did this and squashed it away. Oh well, should still be easy to remove them if/when desired.

