### PR TITLE
Update sysinfo version to 0.31.0

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -27,13 +27,16 @@ const-fnv1a-hash = "1.1.0"
 # MacOS
 [target.'cfg(all(target_os="macos"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
-sysinfo = { version = "0.30.0", optional = true, default-features = false, features = [
+sysinfo = { version = "0.31.0", optional = true, default-features = false, features = [
   "apple-app-store",
+  "system",
 ] }
 
 # Only include when on linux/windows/android
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android"))'.dependencies]
-sysinfo = { version = "0.30.0", optional = true, default-features = false }
+sysinfo = { version = "0.31.0", optional = true, default-features = false, features = [
+  "system",
+] }
 
 [lints]
 workspace = true

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -133,7 +133,7 @@ pub mod internal {
 
                 sys.refresh_cpu_specifics(CpuRefreshKind::new().with_cpu_usage());
                 sys.refresh_memory();
-                let current_cpu_usage = sys.global_cpu_info().cpu_usage().into();
+                let current_cpu_usage = sys.global_cpu_usage().into();
                 // `memory()` fns return a value in bytes
                 let total_mem = sys.total_memory() as f64 / BYTES_TO_GIB;
                 let used_mem = sys.used_memory() as f64 / BYTES_TO_GIB;


### PR DESCRIPTION
This release will likely remove a few dependencies in bevy since you only need the `system` feature.