### PR TITLE
Add freebsd support for sysinfo

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -32,8 +32,8 @@ sysinfo = { version = "0.31.0", optional = true, default-features = false, featu
   "system",
 ] }
 
-# Only include when on linux/windows/android
-[target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android"))'.dependencies]
+# Only include when on linux/windows/android/freebsd
+[target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android", target_os = "freebsd"))'.dependencies]
 sysinfo = { version = "0.31.0", optional = true, default-features = false, features = [
   "system",
 ] }


### PR DESCRIPTION
I'm not sure if bevy works on FreeBSD or not. But in case it does, better allow `sysinfo` to be used as well if users want.