### PR TITLE
Add `invert_winding` for triangle list meshes

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -550,6 +550,7 @@ impl Mesh {
     /// clockwise and vice versa.
     ///
     /// Does nothing if no [`Indices`] are set.
+    /// If this operation succeeded, an [`Ok`] result is returned. 
     pub fn invert_winding(&mut self) -> Result<(), MeshWindingInvertError> {
         if self.primitive_topology != PrimitiveTopology::TriangleList {
             return Err(MeshWindingInvertError::WrongTopology);

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -556,10 +556,14 @@ impl Mesh {
             return Err(MeshWindingInvertError::WrongTopology);
         }
 
-        fn invert<'a, I: 'static>(
-            indices: impl Iterator<Item = &'a mut [I]>,
+        fn invert<I>(
+            indices: &mut [I],
         ) -> Result<(), MeshWindingInvertError> {
-            for chunk in indices {
+            // Early return if the index count doesn't match
+            if indices.len() % 3 != 0 {
+                return Err(MeshWindingInvertError::AbruptIndicesEnd);
+            }
+            for chunk in indices.chunks_mut(3) {
                 // We check this every run because it will be an overhead as long as we
                 // don't use unsafe checks inside.
                 let [_, b, c] = chunk else {
@@ -570,8 +574,8 @@ impl Mesh {
             Ok(())
         }
         match &mut self.indices {
-            Some(Indices::U16(vec)) => invert(vec.chunks_mut(3)),
-            Some(Indices::U32(vec)) => invert(vec.chunks_mut(3)),
+            Some(Indices::U16(vec)) => invert(vec),
+            Some(Indices::U32(vec)) => invert(vec),
             None => Ok(()),
         }
     }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -577,7 +577,6 @@ impl Mesh {
     /// that all counter-clockwise triangles are now clockwise and vice versa.
     ///
     /// Does nothing if no [`Indices`] are set.
-    #[must_use]
     pub fn with_inverted_winding(mut self) -> Result<Self, MeshWindingInvertError> {
         self.invert_winding().map(|_| self)
     }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -550,7 +550,7 @@ impl Mesh {
     /// clockwise and vice versa.
     ///
     /// Does nothing if no [`Indices`] are set.
-    /// If this operation succeeded, an [`Ok`] result is returned. 
+    /// If this operation succeeded, an [`Ok`] result is returned.
     pub fn invert_winding(&mut self) -> Result<(), MeshWindingInvertError> {
         if self.primitive_topology != PrimitiveTopology::TriangleList {
             return Err(MeshWindingInvertError::WrongTopology);
@@ -560,6 +560,8 @@ impl Mesh {
             indices: impl Iterator<Item = &'a mut [I]>,
         ) -> Result<(), MeshWindingInvertError> {
             for chunk in indices {
+                // We check this every run because it will be an overhead as long as we
+                // don't use unsafe checks inside.
                 let [_, b, c] = chunk else {
                     return Err(MeshWindingInvertError::AbruptIndicesEnd);
                 };


### PR DESCRIPTION
# Objective

Implements #14547 

## Solution

Add a function `invert_winding` for `Mesh` that inverts the winding for `LineList`, `LineStrip`, `TriangleList` and `TriangleStrip`.

## Testing

Tests added