### PR TITLE
`Trigger::entity()` only returns valid entities

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -576,7 +576,7 @@ mod tests {
             })
     }
 
-    fn observe_trigger(app: &mut App, scene_id: InstanceId, scene_entity: Entity) {
+    fn observe_trigger(app: &mut App, scene_id: InstanceId, scene_entity: Option<Entity>) {
         // Add observer
         app.world_mut().observe(
             move |trigger: Trigger<SceneInstanceReady>,
@@ -588,7 +588,7 @@ mod tests {
                     "`SceneInstanceReady` contains the wrong `InstanceId`"
                 );
                 assert_eq!(
-                    trigger.entity(),
+                    trigger.get_entity(),
                     scene_entity,
                     "`SceneInstanceReady` triggered on the wrong parent entity"
                 );
@@ -626,7 +626,7 @@ mod tests {
                 });
 
         // Check trigger.
-        observe_trigger(&mut app, scene_id, Entity::PLACEHOLDER);
+        observe_trigger(&mut app, scene_id, None);
     }
 
     #[test]
@@ -644,7 +644,7 @@ mod tests {
                 });
 
         // Check trigger.
-        observe_trigger(&mut app, scene_id, Entity::PLACEHOLDER);
+        observe_trigger(&mut app, scene_id, None);
     }
 
     #[test]
@@ -664,7 +664,7 @@ mod tests {
         );
 
         // Check trigger.
-        observe_trigger(&mut app, scene_id, scene_entity);
+        observe_trigger(&mut app, scene_id, Some(scene_entity));
     }
 
     #[test]
@@ -684,7 +684,7 @@ mod tests {
         );
 
         // Check trigger.
-        observe_trigger(&mut app, scene_id, scene_entity);
+        observe_trigger(&mut app, scene_id, Some(scene_entity));
     }
 
     #[test]

--- a/examples/ecs/observer_propagation.rs
+++ b/examples/ecs/observer_propagation.rs
@@ -78,8 +78,10 @@ fn attack_armor(entities: Query<Entity, With<Armor>>, mut commands: Commands) {
 }
 
 fn attack_hits(trigger: Trigger<Attack>, name: Query<&Name>) {
-    if let Ok(name) = name.get(trigger.entity()) {
-        info!("Attack hit {}", name);
+    if let Some(entity) = trigger.get_entity() {
+        if let Ok(name) = name.get(entity) {
+            info!("Attack hit {}", name);
+        }
     }
 }
 

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -147,7 +147,9 @@ fn on_remove_mine(
 
 fn explode_mine(trigger: Trigger<Explode>, query: Query<&Mine>, mut commands: Commands) {
     // If a triggered event is targeting a specific entity you can access it with `.entity()`
-    let id = trigger.entity();
+    let Some(id) = trigger.get_entity() else {
+        return;
+    };
     let Some(mut entity) = commands.get_entity(id) else {
         return;
     };


### PR DESCRIPTION
# Objective

Fixes #14236 

## Solution

Made `Trigger::entity()` panic on `Entity::PLACEHOLDER` and added a `Trigger::get_entity()`

---

## Migration Guide

Anyone using `Trigger::entity()` should switch to `Trigger::get_entity()` unless they know that the event will always be triggered on an entity.
