### PR TITLE
Fix `MeshAllocator` panic

### DIFF
--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -588,6 +588,8 @@ impl MeshAllocator {
         }
 
         for empty_slab in empty_slabs {
+            self.slab_layouts
+                .retain(|_, slab_ids| !slab_ids.contains(&empty_slab));
             self.slabs.remove(&empty_slab);
         }
     }

--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -588,8 +588,12 @@ impl MeshAllocator {
         }
 
         for empty_slab in empty_slabs {
-            self.slab_layouts
-                .retain(|_, slab_ids| !slab_ids.contains(&empty_slab));
+            self.slab_layouts.values_mut().for_each(|slab_ids| {
+                let idx = slab_ids.iter().position(|&slab_id| slab_id == empty_slab);
+                if let Some(idx) = idx {
+                    slab_ids.remove(idx);
+                }
+            });
             self.slabs.remove(&empty_slab);
         }
     }


### PR DESCRIPTION
# Objective

 Fixes #14540

## Solution

- Clean slab layouts from stale `SlabId`s when freeing meshes
- Technically performance requirements of freeing now increase based on the number of existing meshes, but maybe it doesn't matter too much in practice
- This was the case before this PR too, but it's technically possible to free and allocate 2^32 times and overflow with `SlabId`s and cause incorrect behavior. It looks like new meshes would then override old ones.

## Testing

- Tested in `loading_screen` example and tapping keyboard 1 and 2.