### PR TITLE
Properly handle repeated window close requests

### DIFF
--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -50,6 +50,9 @@ pub fn close_when_requested(
     }
     // Mark the window as closing so we can despawn it on the next frame
     for event in closed.read() {
-        commands.entity(event.window).insert(ClosingWindow);
+        // When spamming the window close button on windows (other platforms too probably)
+        // we may receive a `WindowCloseRequested` for a window we've just despawned in the above
+        // loop.
+        commands.entity(event.window).try_insert(ClosingWindow);
     }
 }


### PR DESCRIPTION
# Objective

Spamming the window close button on window may trigger a panic.

```
thread 'main' panicked at <Bevy repo>\crates\bevy_ecs\src\system\commands\mod.rs:1320:13:
error[B0003]: Could not insert a bundle (of type `bevy_window::window::ClosingWindow`) for entity 0v1#4294967296 because it doesn't exist in this World. See: https://bevyengine.org/learn/errors/b0003
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic when applying buffers for system `bevy_window::system::close_when_requested`!
2024-08-01T15:00:29.742612Z  WARN bevy_ecs::world::command_queue: CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
error: process didn't exit successfully: `target\debug\bevy.exe` (exit code: 101)
```

## Solution

Don't panic when trying to insert the `ClosingWindow` component into a entity.

## Testing

Found and tested on windows. I haven't checked if this bug happens on linux or macos.
For testing I ran this code:

```rust
use std::{thread, time::Duration};

use bevy::prelude::*;

fn lag() {
    thread::sleep(Duration::from_millis(300));
}

fn main() -> AppExit {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Update, lag)
        .run()
}
```

Then spammed the window close button. The panic no longer occurs.