### PR TITLE
Fix TAA on camera with viewport

### DIFF
--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -410,7 +410,7 @@ fn prepare_taa_history_textures(
     views: Query<(Entity, &ExtractedCamera, &ExtractedView), With<TemporalAntiAliasSettings>>,
 ) {
     for (entity, camera, view) in &views {
-        if let Some(physical_viewport_size) = camera.physical_viewport_size {
+        if let Some(physical_viewport_size) = camera.physical_target_size {
             let mut texture_descriptor = TextureDescriptor {
                 label: None,
                 size: Extent3d {

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -410,13 +410,13 @@ fn prepare_taa_history_textures(
     views: Query<(Entity, &ExtractedCamera, &ExtractedView), With<TemporalAntiAliasSettings>>,
 ) {
     for (entity, camera, view) in &views {
-        if let Some(physical_viewport_size) = camera.physical_target_size {
+        if let Some(physical_target_size) = camera.physical_target_size {
             let mut texture_descriptor = TextureDescriptor {
                 label: None,
                 size: Extent3d {
                     depth_or_array_layers: 1,
-                    width: physical_viewport_size.x,
-                    height: physical_viewport_size.y,
+                    width: physical_target_size.x,
+                    height: physical_target_size.y,
                 },
                 mip_level_count: 1,
                 sample_count: 1,


### PR DESCRIPTION
# Objective

Closes #14526 

## Solution

The history texture was being created incorrectly with the viewport size rather than target size. When viewport < target, this meant that the render attachments would differer in size which causes a wgpu validation error.

## Testing

Example in linked issue works.