### PR TITLE
Add `Dir2::from_xy_unchecked` and `Dir3::from_xyz_unchecked`

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -169,6 +169,15 @@ impl Dir2 {
         Self::new(Vec2::new(x, y))
     }
 
+    /// Create a direction from its `x` and `y` components, assuming the resulting vector is normalized.
+    ///
+    /// # Warning
+    ///
+    /// The vector produced from `x` and `y` must be normalized, i.e its length must be `1.0`.
+    pub fn from_xy_unchecked(x: f32, y: f32) -> Self {
+        Self::new_unchecked(Vec2::new(x, y))
+    }
+
     /// Returns the inner [`Vec2`]
     pub const fn as_vec2(&self) -> Vec2 {
         self.0
@@ -417,6 +426,15 @@ impl Dir3 {
     /// of the vector formed by the components is zero (or very close to zero), infinite, or `NaN`.
     pub fn from_xyz(x: f32, y: f32, z: f32) -> Result<Self, InvalidDirectionError> {
         Self::new(Vec3::new(x, y, z))
+    }
+
+    /// Create a direction from its `x`, `y`, and `z` components, assuming the resulting vector is normalized.
+    ///
+    /// # Warning
+    ///
+    /// The vector produced from `x`, `y`, and `z` must be normalized, i.e its length must be `1.0`.
+    pub fn from_xyz_unchecked(x: f32, y: f32, z: f32) -> Self {
+        Self::new_unchecked(Vec3::new(x, y, z))
     }
 
     /// Returns the inner [`Vec3`]
@@ -673,6 +691,15 @@ impl Dir3A {
     /// of the vector formed by the components is zero (or very close to zero), infinite, or `NaN`.
     pub fn from_xyz(x: f32, y: f32, z: f32) -> Result<Self, InvalidDirectionError> {
         Self::new(Vec3A::new(x, y, z))
+    }
+
+    /// Create a direction from its `x`, `y`, and `z` components, assuming the resulting vector is normalized.
+    ///
+    /// # Warning
+    ///
+    /// The vector produced from `x`, `y`, and `z` must be normalized, i.e its length must be `1.0`.
+    pub fn from_xyz_unchecked(x: f32, y: f32, z: f32) -> Self {
+        Self::new_unchecked(Vec3A::new(x, y, z))
     }
 
     /// Returns the inner [`Vec3A`]


### PR DESCRIPTION
# Objective

Bevy's direction types have `new` and `new_unchecked` constructors, but no unchecked variant for the `Dir2::from_xy` and `Dir3::from_xyz` methods.

For me, this has several times lead to constructing directions like this, in cases where the components of the direction are already known to be normalized:

```rust
let normal = Dir2::new_unchecked(Vec2::new(-ray.direction.x.signum(), 0.0));
```

```rust
segment.direction =
    Dir2::new_unchecked(Vec2::new(-segment.direction.x, segment.direction.y));
```

For consistency and ergonomics, it would be nice to have unchecked variants of `Dir2::from_xy` and `Dir3::from_xyz`:

```rust
let normal = Dir2::from_xy_unchecked(-ray.direction.x.signum(), 0.0);
```

```rust
segment.direction = Dir2::from_xy_unchecked(-segment.direction.x, segment.direction.y);
```

## Solution

Add `Dir2::from_xy_unchecked` and `Dir3::from_xyz_unchecked`.