### PR TITLE
Fix num_cascades in split_screen exmample for WebGL

### DIFF
--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -46,7 +46,7 @@ fn setup(
                 target_arch = "wasm32",
                 not(feature = "webgpu")
             )) {
-                // Currently limited to 1 cascade in WebGL
+                // Limited to 1 cascade in WebGL
                 1
             } else {
                 2

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -41,7 +41,16 @@ fn setup(
             ..default()
         },
         cascade_shadow_config: CascadeShadowConfigBuilder {
-            num_cascades: 2,
+            num_cascades: if cfg!(all(
+                feature = "webgl2",
+                target_arch = "wasm32",
+                not(feature = "webgpu")
+            )) {
+                // Currently limited to 1 cascade in WebGL
+                1
+            } else {
+                2
+            },
             first_cascade_far_bound: 200.0,
             maximum_distance: 280.0,
             ..default()


### PR DESCRIPTION
# Objective

- Fixes #14595

## Solution

- Use `num_cascades: 1` in WebGL build. `CascadeShadowConfigBuilder::default()` gives this number in WebGL: https://github.com/bevyengine/bevy/blob/8235daaea0e3aa930e34c57887e1ffea08a8150a/crates/bevy_pbr/src/light/mod.rs#L241-L248

## Testing

- Tested the modified example in WebGL with Firefox/Chrome
