### PR TITLE
Add link to `with_children` in `with_child` doc

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -339,6 +339,10 @@ pub trait BuildChildren {
     type Builder<'a>: ChildBuild;
 
     /// Takes a closure which builds children for this entity using [`ChildBuild`].
+    ///
+    /// For convenient spawning of a single child, you can use [`with_child`].
+    ///
+    /// [`with_child`]: BuildChildren::with_child
     fn with_children(&mut self, f: impl FnOnce(&mut Self::Builder<'_>)) -> &mut Self;
 
     /// Spawns the passed bundle and adds it to this entity as a child.

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -342,6 +342,10 @@ pub trait BuildChildren {
     fn with_children(&mut self, f: impl FnOnce(&mut Self::Builder<'_>)) -> &mut Self;
 
     /// Spawns the passed bundle and adds it to this entity as a child.
+    ///
+    /// For efficient spawning of multiple children, use [`with_children`].
+    ///
+    /// [`with_children`]: BuildChildren::with_children
     fn with_child<B: Bundle>(&mut self, bundle: B) -> &mut Self;
 
     /// Pushes children to the back of the builder's children. For any entities that are


### PR DESCRIPTION
# Objective

Discourage users from using `with_child` for spawning multiple children.

## Solution

Add link to `with_children` in docs for `with_child`.