### PR TITLE
Fix query transmute from table to archetype iteration unsoundness

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -52,16 +52,18 @@ pub mod prelude {
         entity::{Entity, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         observer::{Observer, Trigger},
-        query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
+        query::{
+            Added, AnyOf, Changed, DynQueryState, Has, Or, QueryBuilder, QueryState, With, Without,
+        },
         removal_detection::RemovedComponents,
         schedule::{
             apply_deferred, common_conditions::*, Condition, IntoSystemConfigs, IntoSystemSet,
             IntoSystemSetConfigs, Schedule, Schedules, SystemSet,
         },
         system::{
-            Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,
-            ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System, SystemBuilder,
-            SystemParamFunction,
+            Commands, Deferred, DynQuery, In, IntoSystem, Local, NonSend, NonSendMut,
+            ParallelCommands, ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System,
+            SystemBuilder, SystemParamFunction,
         },
         world::{
             EntityMut, EntityRef, EntityWorldMut, FromWorld, OnAdd, OnInsert, OnRemove, OnReplace,

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -419,4 +419,27 @@ mod tests {
             assert_eq!(1, b.deref::<B>().0);
         }
     }
+
+    /// Regression test for issue #14348
+    #[test]
+    fn builder_static_dense_dynamic_sparse() {
+        #[derive(Component)]
+        struct Dense;
+
+        #[derive(Component)]
+        #[component(storage = "SparseSet")]
+        struct Sparse;
+
+        let mut world = World::new();
+
+        world.spawn(Dense);
+        world.spawn((Dense, Sparse));
+
+        let mut query = QueryBuilder::<&Dense>::new(&mut world)
+            .with::<Sparse>()
+            .build();
+
+        let matched = query.iter(&world).count();
+        assert_eq!(matched, 1);
+    }
 }

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -57,7 +57,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, M: QueryStaticMarker> QueryIter<'w, '
     /// # Safety
     ///  - all `rows` must be in `[0, table.entity_count)`.
     ///  - `table` must match D and F
-    ///  - `self.query_state.is_dense` must be true.
+    ///  - The query iteration must be dense (i.e. `self.query_state.is_dense` must be true).
     #[inline]
     pub(super) unsafe fn fold_over_table_range<B, Func>(
         &mut self,
@@ -109,7 +109,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, M: QueryStaticMarker> QueryIter<'w, '
     /// # Safety
     ///  - all `indices` must be in `[0, archetype.len())`.
     ///  - `archetype` must match D and F
-    ///  - `self.query_state.is_dense` must be false
+    ///  - The query iteration must not be dense (i.e. `self.query_state.is_dense` must be false).
     #[inline]
     pub(super) unsafe fn fold_over_archetype_range<B, Func>(
         &mut self,
@@ -175,7 +175,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, M: QueryStaticMarker> QueryIter<'w, '
     ///  - all `indices` must be in `[0, archetype.len())`.
     ///  - `archetype` must match D and F
     ///  - `archetype` must have the same length with it's table.
-    ///  - Either `D::IS_DENSE` or `F::IS_DENSE` must be false.
+    ///  - The query iteration must not be dense (i.e. `self.query_state.is_dense` must be false).
     #[inline]
     pub(super) unsafe fn fold_over_dense_archetype_range<B, Func>(
         &mut self,
@@ -970,7 +970,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, M: QueryStaticMarker> Iterator
                     // SAFETY: 
                     // - The fetched table matches both D and F
                     // - The provided range is equivalent to [0, table.entity_count)
-                    // - The if block ensures that D::IS_DENSE and F::IS_DENSE are both true
+                    // - The if block ensures that `self.query_state.is_dense` is true
                     unsafe { self.fold_over_table_range(accum, &mut func, table, 0..table.entity_count()) };
             } else {
                 let archetype =
@@ -987,14 +987,14 @@ impl<'w, 's, D: QueryData, F: QueryFilter, M: QueryStaticMarker> Iterator
                     // - The fetched archetype matches both D and F
                     // - The provided archetype and its' table have the same length.
                     // - The provided range is equivalent to [0, archetype.len)
-                    // - The if block ensures that ether D::IS_DENSE or F::IS_DENSE are false
+                    // - The if block ensures that `self.query_state.is_dense` is false
                     unsafe { self.fold_over_dense_archetype_range(accum, &mut func, archetype,0..archetype.len()) };
                 } else {
                     accum =
                     // SAFETY:
                     // - The fetched archetype matches both D and F
                     // - The provided range is equivalent to [0, archetype.len)
-                    // - The if block ensures that ether D::IS_DENSE or F::IS_DENSE are false
+                    // - The if block ensures that `self.query_state.is_dense` is false
                     unsafe { self.fold_over_archetype_range(accum, &mut func, archetype,0..archetype.len()) };
                 }
             }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -97,7 +97,7 @@ pub struct QueryState<D: QueryData, F: QueryFilter = (), M: QueryStaticMarker = 
     pub(super) matched_storage_ids: Vec<StorageId>,
     /// Whether the iteration will be dense or sparse. Needed to disambiguate whether
     /// `matched_storage_ids` holds [`TableId`]s or [`ArchetypeId`]s.
-    /// When `M::IS_STATIC`` is true this is guaranteed to be the same as `D::IS_DENSE && F::IS_DENSE`,
+    /// When `M::IS_STATIC` is true this is guaranteed to be the same as `D::IS_DENSE && F::IS_DENSE`,
     /// so that can be used instead to avoid a runtime branch.
     pub(super) is_dense: bool,
     pub(crate) fetch_state: D::State,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2125,6 +2125,29 @@ mod tests {
         world.query::<(&A, &B)>().transmute::<&B>(&world2);
     }
 
+    /// Regression test for issue #14528
+    #[test]
+    fn transmute_from_sparse_to_dense() {
+        #[derive(Component)]
+        struct Dense;
+
+        #[derive(Component)]
+        #[component(storage = "SparseSet")]
+        struct Sparse;
+
+        let mut world = World::new();
+
+        world.spawn(Dense);
+        world.spawn((Dense, Sparse));
+
+        let mut query = world
+            .query_filtered::<&Dense, With<Sparse>>()
+            .transmute::<&Dense>(world.components());
+
+        let matched = query.iter(&world).count();
+        assert_eq!(matched, 1);
+    }
+
     #[test]
     fn join() {
         let mut world = World::new();

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -223,6 +223,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F, StaticMarker> {
             is_dense: self.is_dense,
             fetch_state: self.fetch_state,
             filter_state: self.filter_state,
+            #[cfg(feature = "trace")]
+            par_iter_span: self.par_iter_span,
             _marker: PhantomData,
         }
     }
@@ -230,7 +232,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F, StaticMarker> {
     /// TODO
     pub fn transmute_marker_ref<M: QueryStaticMarker>(&self) -> &QueryState<D, F, M> {
         // SAFETY: TODO
-        unsafe { &*(self as *const _ as *const QueryState<D, F, M>) }
+        unsafe { &*std::ptr::from_ref(self).cast::<QueryState<D, F, M>>() }
     }
 }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -48,7 +48,9 @@ impl QueryStaticMarker for DynamicMarker {
 /// An ID for either a table or an archetype. Used for Query iteration.
 ///
 /// Query iteration is exclusively dense (over tables) or archetypal (over archetypes) based on whether
-/// both `D::IS_DENSE` and `F::IS_DENSE` are true or not.
+/// [`QueryState::is_dense`] is true or not.
+/// Note that when `M::IS_STATIC` is true then `QueryState::is_dense` can be assumed to be equal to
+/// the statically known `D::IS_DENSE && F::IS_DENSE`.
 ///
 /// This is a union instead of an enum as the usage is determined at compile time, as all [`StorageId`]s for
 /// a [`QueryState`] will be all [`TableId`]s or all [`ArchetypeId`]s, and not a mixture of both. This
@@ -191,7 +193,7 @@ impl<D: QueryData, F: QueryFilter> DynQueryState<D, F> {
             world_id: builder.world().id(),
             archetype_generation: ArchetypeGeneration::initial(),
             matched_storage_ids: Vec::new(),
-            is_dense: builder.is_dense,
+            is_dense: builder.is_dense(),
             fetch_state,
             filter_state,
             component_access: builder.access().clone(),

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -97,6 +97,8 @@ pub struct QueryState<D: QueryData, F: QueryFilter = (), M: QueryStaticMarker = 
     pub(super) matched_storage_ids: Vec<StorageId>,
     /// Whether the iteration will be dense or sparse. Needed to disambiguate whether
     /// `matched_storage_ids` holds [`TableId`]s or [`ArchetypeId`]s.
+    /// When `M::IS_STATIC`` is true this is guaranteed to be the same as `D::IS_DENSE && F::IS_DENSE`,
+    /// so that can be used instead to avoid a runtime branch.
     pub(super) is_dense: bool,
     pub(crate) fetch_state: D::State,
     pub(crate) filter_state: F::State,
@@ -2144,7 +2146,7 @@ mod tests {
 
         let mut query = world
             .query_filtered::<&Dense, With<Sparse>>()
-            .transmute::<&Dense>(world.components());
+            .transmute::<&Dense>(&world);
 
         let matched = query.iter(&world).count();
         assert_eq!(matched, 1);

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -147,7 +147,7 @@ all_tuples!(impl_system_builder, 0, 15, P);
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;
-    use crate::prelude::{Component, Query};
+    use crate::prelude::{Component, DynQuery};
     use crate::system::{Local, RunSystemOnce};
 
     use super::*;
@@ -159,7 +159,7 @@ mod tests {
         *local
     }
 
-    fn query_system(query: Query<()>) -> usize {
+    fn query_system(query: DynQuery<()>) -> usize {
         query.iter().count()
     }
 
@@ -187,7 +187,7 @@ mod tests {
         world.spawn_empty();
 
         let system = SystemBuilder::<()>::new(&mut world)
-            .builder::<Query<()>>(|query| {
+            .builder::<DynQuery<()>>(|query| {
                 query.with::<A>();
             })
             .build(query_system);

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -8,7 +8,7 @@ use crate::{
     event::{Event, EventId, Events, SendBatchIds},
     observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
-    query::{QueryData, QueryFilter},
+    query::{QueryData, QueryFilter, QueryStaticMarker},
     system::{Commands, Query, Resource},
     traversal::Traversal,
 };
@@ -118,10 +118,10 @@ impl<'w> DeferredWorld<'w> {
     /// # Panics
     /// If state is from a different world then self
     #[inline]
-    pub fn query<'s, D: QueryData, F: QueryFilter>(
+    pub fn query<'s, D: QueryData, F: QueryFilter, M: QueryStaticMarker>(
         &'w mut self,
-        state: &'s mut QueryState<D, F>,
-    ) -> Query<'w, 's, D, F> {
+        state: &'s mut QueryState<D, F, M>,
+    ) -> Query<'w, 's, D, F, M> {
         state.validate_world(self.world.id());
         state.update_archetypes(self);
         // SAFETY: We ran validate_world to ensure our state matches


### PR DESCRIPTION
# Objective

- Fixes #14348 
- Fixes #14528
- Fixes the fundamental issue with the table vs archetype iteration optimization not being compatible with dynamic query filters
    - The table vs archetype iteration optimization switches between iterating over tables when all the query filters are dense;
    - However to get good performance, especially in `QueryIter::next` (used for iterating with `for`), this needs to be a compile time switch on `D::IS_DENSE && F::IS_DENSE`;
    - We thus need to setup this compiler time check in such a way that when dynamic query filters that require archetype iteration may be present then this compiler time check is false.
    - An alternative not explored in this PR would be to remove the table iteration optimization from `QueryIter::next` (while keeping it where a dynamic check is acceptable).

- NOTE: this is a pretty big breaking change. Where possible I've tried to make the migration manageable by introducing type aliases and some conversions.

## Solution

- Introduce a new parameter `M` to `Query`, `QueryState`, `QueryIter` and other similar types, which contains a compile type switch on whether the query is static (i.e. its filters are only determined by the `D` and `F` parameters) or dynamic (e.g. the `Query`s produced by `QueryBuilder` and `QueryState::transmute`). The allowed types for `M` are `StaticMarker` and `DynamicMarker`, and a sealed trait used to limit parameter to only these two types.
- I choose to default this type parameter to `StaticMarker`, meaning existing `Query`s that don't use dynamic filters will continue to benefit from the table iteration optimization, while however breaking the code for users that used dynamic filters. For making it easier to migrate to use `DynamicMarker` I introduced a `DynQuery` and `DynQueryState` type aliases.
    - The alternative would be doing the opposite, but this would be a silent performance regression for users not using dynamic queries, and will forever be a footgun to not use an hypothesis `StaticQuery`.
- Introduce a new `is_dense` field in `QueryBuilder` which will reflect whether the dynamic filters are dense or not. This will have two uses:
    - It allows transmuting `Query`/`QueryState` with a static marker to one with a dynamic marker, where the crucial part is ensuring the the `matched_storage_ids` is still accessed in the same way; this also helps the migration between uses of these queries;
    - It allows using table iteration in situations where a dynamic check is not very costly, e.g. in `QueryIter::for_each`, hence limiting the performance difference to `QueryIter::next`.

## Migration Guide

- `Query`, `QueryState`, `QueryIter` and other `Query`-related types now have a third `M` generic parameter which is either `StaticMarker` or `DynamicMarker`, depending on whether dynamic filters are allowed or not, with `StaticMarker` as default;
- It will not be possible to produce a `Query` with a `StaticMarker` from APIs that allow dynamic filters, like `QueryBuilder`, `Query::transmute_lens` and `QueryState::transmute`;
- If you were using dynamic filters you can switch your `Query`es to use the `DynamicMarker`; the `DynQuery` and `DynQueryState` type aliases can be used to make this shorter to type. This will basically restore the functionality to before this change, at the cost of a performance penality when iterating using `for` over dense queries (which were previously broken).