### PR TITLE
Fix query transmute from table to archetype iteration unsoundness

### DIFF
--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::component::StorageType;
+use crate::component::{ComponentInfo, StorageType};
 use crate::{component::ComponentId, prelude::*};
 
 use super::{FilteredAccess, QueryData, QueryFilter};
@@ -74,7 +74,7 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
             self.world()
                 .components()
                 .get_info(ComponentId::new(component_id))
-                .map(|component_info| component_info.storage_type())
+                .map(ComponentInfo::storage_type)
                 == Some(StorageType::Table)
         };
         D::IS_DENSE

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -77,11 +77,9 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
                 .map(ComponentInfo::storage_type)
                 == Some(StorageType::Table)
         };
-        D::IS_DENSE
-            && F::IS_DENSE
-            && self.access.filter_sets.iter().all(|filter_set| {
-                filter_set.with.ones().all(is_dense) && filter_set.without.ones().all(is_dense)
-            })
+        self.access.filter_sets.iter().all(|filter_set| {
+            filter_set.with.ones().all(is_dense) && filter_set.without.ones().all(is_dense)
+        })
     }
 
     /// Returns a reference to the world passed to [`Self::new`].

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -78,7 +78,15 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
                 .get_info(component_id)
                 .map_or(false, |info| info.storage_type() == StorageType::Table)
         };
-        self.access.with_filters().all(is_dense) && self.access.without_filters().all(is_dense)
+
+        self.access
+            .access()
+            .component_reads_and_writes()
+            .all(is_dense)
+            && self.access.access().archetypal().all(is_dense)
+            && !self.access.access().has_read_all_components()
+            && self.access.with_filters().all(is_dense)
+            && self.access.without_filters().all(is_dense)
     }
 
     /// Returns a reference to the world passed to [`Self::new`].

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::component::{ComponentInfo, StorageType};
+use crate::component::StorageType;
 use crate::{component::ComponentId, prelude::*};
 
 use super::{FilteredAccess, QueryData, QueryFilter};
@@ -70,16 +70,15 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
     }
 
     pub(super) fn is_dense(&self) -> bool {
+        // Note: `component_id` comes from the user in safe code, so we cannot trust it to
+        // exist. If it doesn't exist we pessimistically assume it's sparse.
         let is_dense = |component_id| {
             self.world()
                 .components()
-                .get_info(ComponentId::new(component_id))
-                .map(ComponentInfo::storage_type)
-                == Some(StorageType::Table)
+                .get_info(component_id)
+                .map_or(false, |info| info.storage_type() == StorageType::Table)
         };
-        self.access.filter_sets.iter().all(|filter_set| {
-            filter_set.with.ones().all(is_dense) && filter_set.without.ones().all(is_dense)
-        })
+        self.access.with_filters().all(is_dense) && self.access.without_filters().all(is_dense)
     }
 
     /// Returns a reference to the world passed to [`Self::new`].

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -128,7 +128,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// # Safety
     ///  - all `rows` must be in `[0, table.entity_count)`.
     ///  - `table` must match D and F
-    ///  - The query iteration must be dense (i.e. self.query_state.is_dense must be true).
+    ///  - The query iteration must be dense (i.e. `self.query_state.is_dense` must be true).
     #[inline]
     pub(super) unsafe fn fold_over_table_range<B, Func>(
         &mut self,
@@ -183,7 +183,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// # Safety
     ///  - all `indices` must be in `[0, archetype.len())`.
     ///  - `archetype` must match D and F
-    ///  - The query iteration must not be dense (i.e. self.query_state.is_dense must be false).
+    ///  - The query iteration must not be dense (i.e. `self.query_state.is_dense` must be false).
     #[inline]
     pub(super) unsafe fn fold_over_archetype_range<B, Func>(
         &mut self,
@@ -252,7 +252,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///  - all `indices` must be in `[0, archetype.len())`.
     ///  - `archetype` must match D and F
     ///  - `archetype` must have the same length with it's table.
-    ///  - The query iteration must not be dense (i.e. self.query_state.is_dense must be false).
+    ///  - The query iteration must not be dense (i.e. `self.query_state.is_dense` must be false).
     #[inline]
     pub(super) unsafe fn fold_over_dense_archetype_range<B, Func>(
         &mut self,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1741,6 +1741,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
 
     fn reborrow(&mut self) -> QueryIterationCursor<'_, 's, D, F> {
         QueryIterationCursor {
+            is_dense: self.is_dense,
             fetch: D::shrink_fetch(self.fetch.clone()),
             filter: F::shrink_fetch(self.filter.clone()),
             table_entities: self.table_entities,

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -126,6 +126,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     fn get_batch_size(&self, thread_count: usize) -> usize {
         let max_items = || {
             let id_iter = self.state.matched_storage_ids.iter();
+            // If `D::IS_DENSE && F::IS_DENSE` is false then `self.state.is_dense` must also be
+            // false, in that case the condition can be statically known.
             if D::IS_DENSE && F::IS_DENSE && self.state.is_dense {
                 // SAFETY: We only access table metadata.
                 let tables = unsafe { &self.world.world_metadata().storages().tables };

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -126,9 +126,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     fn get_batch_size(&self, thread_count: usize) -> usize {
         let max_items = || {
             let id_iter = self.state.matched_storage_ids.iter();
-            // If `D::IS_DENSE && F::IS_DENSE` is false then `self.state.is_dense` must also be
-            // false, in that case the condition can be statically known.
-            if D::IS_DENSE && F::IS_DENSE && self.state.is_dense {
+            if self.state.is_dense {
                 // SAFETY: We only access table metadata.
                 let tables = unsafe { &self.world.world_metadata().storages().tables };
                 id_iter

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -126,7 +126,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     fn get_batch_size(&self, thread_count: usize) -> usize {
         let max_items = || {
             let id_iter = self.state.matched_storage_ids.iter();
-            if D::IS_DENSE && F::IS_DENSE {
+            if D::IS_DENSE && F::IS_DENSE && self.state.is_dense {
                 // SAFETY: We only access table metadata.
                 let tables = unsafe { &self.world.world_metadata().storages().tables };
                 id_iter

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -579,11 +579,6 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             world_id: self.world_id,
             archetype_generation: self.archetype_generation,
             // TODO: This is unsound, since the dense-ness may have changed.
-            // in particular this can happen if the original access could access all components,
-            // in which case it was dense, but is now not dense due to `NewD::IS_DENSE && NewF::IS_DENSE` being false.
-            //
-            // Another way this is broken is if not all the originally matched tables match the new query filters,
-            // though in that case it is not unsound because the access is restricted.
             matched_storage_ids: self.matched_storage_ids.clone(),
             is_dense,
             fetch_state,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2077,7 +2077,7 @@ mod tests {
 
         let mut query = world
             .query_filtered::<&Dense, With<Sparse>>()
-            .transmute::<&Dense>(world.components());
+            .transmute::<&Dense>(&world);
 
         let matched = query.iter(&world).count();
         assert_eq!(matched, 1);
@@ -2098,7 +2098,7 @@ mod tests {
 
         let mut query = world
             .query::<&Dense>()
-            .transmute_filtered::<&Dense, With<Sparse>>(world.components());
+            .transmute_filtered::<&Dense, With<Sparse>>(&world);
 
         // Note: `transmute_filtered` is supposed to keep the same matched tables/archetypes,
         // so it doesn't actually filter out those entities without `Sparse` and the iteration

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2082,6 +2082,30 @@ mod tests {
         let matched = query.iter(&world).count();
         assert_eq!(matched, 1);
     }
+    #[test]
+    fn transmute_from_dense_to_sparse() {
+        #[derive(Component)]
+        struct Dense;
+
+        #[derive(Component)]
+        #[component(storage = "SparseSet")]
+        struct Sparse;
+
+        let mut world = World::new();
+
+        world.spawn(Dense);
+        world.spawn((Dense, Sparse));
+
+        let mut query = world
+            .query::<&Dense>()
+            .transmute_filtered::<&Dense, With<Sparse>>(world.components());
+
+        // Note: `transmute_filtered` is supposed to keep the same matched tables/archetypes,
+        // so it doesn't actually filter out those entities without `Sparse` and the iteration
+        // remains dense.
+        let matched = query.iter(&world).count();
+        assert_eq!(matched, 2);
+    }
 
     #[test]
     fn join() {


### PR DESCRIPTION
# Objective

- Fixes #14348 
- Fixes #14528
- Less complex (but also likely less performant) alternative to #14611

## Solution

- Add a `is_dense` field flag to `QueryIter` indicating whether it is dense or not, that is whether it can perform dense iteration or not;
- Check this flag any time iteration over a query is performed.

---

It would be nice if someone could try benching this change to see if it actually matters.

~Note that this not 100% ready for mergin, since there are a bunch of safety comments on the use of the various `IS_DENSE` for checks that still need to be updated.~ This is ready modulo benchmarks