### PR TITLE
Fix access conflicts for resources

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -508,14 +508,14 @@ impl<T: SparseSetIndex> Access<T> {
             conflicts.extend(self.component_read_and_writes.ones());
         }
         if self.reads_all_resources {
-            if other.reads_all_resources {
+            if other.writes_all_resources {
                 return AccessConflicts::All;
             }
             conflicts.extend(other.resource_writes.ones());
         }
 
         if other.reads_all_resources {
-            if self.reads_all_resources {
+            if self.writes_all_resources {
                 return AccessConflicts::All;
             }
             conflicts.extend(self.resource_writes.ones());


### PR DESCRIPTION
# Objective

- I made a mistake when fixing the merge conflicts here: https://github.com/bevyengine/bevy/pull/14579#discussion_r1705377452

It wasn't caught because there's no easy way to trigger access conflicts with resources without triggering them with components first.
