### PR TITLE
Identify a subset of texture formats suitable for rendering in preparation for #13146

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -46,7 +46,9 @@ pub mod prelude {
         mesh::{morph::MorphWeights, primitives::MeshBuilder, primitives::Meshable, Mesh},
         render_resource::Shader,
         spatial_bundle::SpatialBundle,
-        texture::{image_texture_conversion::IntoDynamicImageError, Image, ImagePlugin},
+        texture::{
+            image_texture_conversion::IntoDynamicImageError, Image, ImagePlugin, ViewTargetFormat,
+        },
         view::{InheritedVisibility, Msaa, ViewVisibility, Visibility, VisibilityBundle},
         ExtractSchedule,
     };

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -65,6 +65,7 @@ use extract_resource::ExtractResourcePlugin;
 use globals::GlobalsPlugin;
 use render_asset::RenderAssetBytesPerFrame;
 use renderer::{RenderAdapter, RenderAdapterInfo, RenderDevice, RenderQueue};
+use texture::ViewTargetFormat;
 
 use crate::mesh::RenderMesh;
 use crate::renderer::WgpuWrapper;
@@ -230,6 +231,7 @@ struct FutureRendererResources(
                 RenderAdapterInfo,
                 RenderAdapter,
                 RenderInstance,
+                SupportedViewTargetFormats,
             )>,
         >,
     >,
@@ -253,13 +255,22 @@ impl Plugin for RenderPlugin {
 
         match &self.render_creation {
             RenderCreation::Manual(device, queue, adapter_info, adapter, instance) => {
+                let device_features = device.features();
+
+                let view_formats = SupportedViewTargetFormats {
+                    is_rg11b10_renderable: device_features
+                        .contains(ViewTargetFormat::Rb11b10Float.required_features()),
+                };
+
                 let future_renderer_resources_wrapper = Arc::new(Mutex::new(Some((
                     device.clone(),
                     queue.clone(),
                     adapter_info.clone(),
                     adapter.clone(),
                     instance.clone(),
+                    view_formats,
                 ))));
+
                 app.insert_resource(FutureRendererResources(
                     future_renderer_resources_wrapper.clone(),
                 ));
@@ -309,7 +320,7 @@ impl Plugin for RenderPlugin {
                             ..Default::default()
                         };
 
-                        let (device, queue, adapter_info, render_adapter) =
+                        let (device, queue, adapter_info, render_adapter, view_formats) =
                             renderer::initialize_renderer(
                                 &instance,
                                 &settings,
@@ -326,6 +337,7 @@ impl Plugin for RenderPlugin {
                             adapter_info,
                             render_adapter,
                             RenderInstance(Arc::new(WgpuWrapper::new(instance))),
+                            view_formats,
                         ));
                     };
                     // In wasm, spawn a task and detach it for execution
@@ -384,13 +396,14 @@ impl Plugin for RenderPlugin {
         if let Some(future_renderer_resources) =
             app.world_mut().remove_resource::<FutureRendererResources>()
         {
-            let (device, queue, adapter_info, render_adapter, instance) =
+            let (device, queue, adapter_info, render_adapter, instance, view_formats) =
                 future_renderer_resources.0.lock().unwrap().take().unwrap();
 
             app.insert_resource(device.clone())
                 .insert_resource(queue.clone())
                 .insert_resource(adapter_info.clone())
-                .insert_resource(render_adapter.clone());
+                .insert_resource(render_adapter.clone())
+                .insert_resource(view_formats.clone());
 
             let render_app = app.sub_app_mut(RenderApp);
 
@@ -404,6 +417,7 @@ impl Plugin for RenderPlugin {
                 .insert_resource(device)
                 .insert_resource(queue)
                 .insert_resource(render_adapter)
+                .insert_resource(view_formats)
                 .insert_resource(adapter_info)
                 .add_systems(
                     Render,
@@ -520,4 +534,28 @@ fn apply_extract_commands(render_world: &mut World) {
             .unwrap()
             .apply_deferred(render_world);
     });
+}
+
+/// All [`ViewTargetFormat`]s supported by the current [`RenderDevice`]
+#[derive(Resource, Clone, Debug)]
+pub struct SupportedViewTargetFormats {
+    is_rg11b10_renderable: bool,
+}
+
+impl SupportedViewTargetFormats {
+    pub fn is_supported(&self, view_target_format: ViewTargetFormat) -> bool {
+        match view_target_format {
+            ViewTargetFormat::Rgba8UnormSrgb
+            | ViewTargetFormat::Rgba8Unorm
+            | ViewTargetFormat::R8Unorm
+            | ViewTargetFormat::Rg8Unorm
+            | ViewTargetFormat::Bgra8Unorm
+            | ViewTargetFormat::Bgra8UnormSrgb
+            | ViewTargetFormat::R16Float
+            | ViewTargetFormat::Rg16Float
+            | ViewTargetFormat::Rgb10a2Unorm
+            | ViewTargetFormat::Rgba16Float => true,
+            ViewTargetFormat::Rb11b10Float => self.is_rg11b10_renderable,
+        }
+    }
 }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -13,7 +13,9 @@ use crate::{
     render_phase::TrackedRenderPass,
     render_resource::RenderPassDescriptor,
     settings::{WgpuSettings, WgpuSettingsPriority},
+    texture::ViewTargetFormat,
     view::{ExtractedWindows, ViewTarget},
+    SupportedViewTargetFormats,
 };
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_time::TimeSender;
@@ -179,7 +181,13 @@ pub async fn initialize_renderer(
     instance: &Instance,
     options: &WgpuSettings,
     request_adapter_options: &RequestAdapterOptions<'_, '_>,
-) -> (RenderDevice, RenderQueue, RenderAdapterInfo, RenderAdapter) {
+) -> (
+    RenderDevice,
+    RenderQueue,
+    RenderAdapterInfo,
+    RenderAdapter,
+    SupportedViewTargetFormats,
+) {
     let adapter = instance
         .request_adapter(request_adapter_options)
         .await
@@ -208,6 +216,7 @@ pub async fn initialize_renderer(
     // Maybe get features and limits based on what is supported by the adapter/backend
     let mut features = wgpu::Features::empty();
     let mut limits = options.limits.clone();
+
     if matches!(options.priority, WgpuSettingsPriority::Functionality) {
         features = adapter.features();
         if adapter_info.device_type == wgpu::DeviceType::DiscreteGpu {
@@ -367,6 +376,10 @@ pub async fn initialize_renderer(
         RenderQueue(queue),
         RenderAdapterInfo(WgpuWrapper::new(adapter_info)),
         RenderAdapter(adapter),
+        SupportedViewTargetFormats {
+            is_rg11b10_renderable: features
+                .contains(ViewTargetFormat::Rb11b10Float.required_features()),
+        },
     )
 }
 

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -19,9 +19,12 @@ mod texture_cache;
 
 pub(crate) mod image_texture_conversion;
 
+use std::fmt::Display;
+
 pub use self::image::*;
 #[cfg(feature = "ktx2")]
 pub use self::ktx2::*;
+use bevy_reflect::Reflect;
 #[cfg(feature = "dds")]
 pub use dds::*;
 #[cfg(feature = "exr")]
@@ -35,6 +38,7 @@ pub use fallback_image::*;
 pub use image_loader::*;
 pub use texture_attachment::*;
 pub use texture_cache::*;
+use wgpu::TextureFormat;
 
 use crate::{
     render_asset::RenderAssetPlugin, renderer::RenderDevice, Render, RenderApp, RenderSet,
@@ -170,8 +174,176 @@ pub trait BevyDefault {
     fn bevy_default() -> Self;
 }
 
-impl BevyDefault for wgpu::TextureFormat {
+impl BevyDefault for TextureFormat {
     fn bevy_default() -> Self {
-        wgpu::TextureFormat::Rgba8UnormSrgb
+        TextureFormat::Rgba8UnormSrgb
+    }
+}
+
+/// Defines the subset of [`TextureFormat`]s suitable for rendering
+///
+/// Not all of these formats may be available on all devices. See [`ViewTargetFormat::required_features`].
+#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq, Reflect)]
+#[reflect(Debug, PartialEq)]
+pub enum ViewTargetFormat {
+    // BEFORE_MERGE: What about depth or stencil formats
+
+    // NOTE: The formats are pulled from https://gpuweb.github.io/gpuweb/#plain-color-formats
+    //       If you want to add more of the to this enum they'll have to, support being a `RENDER_ATTACHMENT`, be `blendable`,
+    //       allow multisampling and have their `GPUTextureSampleType` be float.
+    //       These requirements may be relaxed in the future.
+    /// Red channel only. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
+    R8Unorm,
+
+    /// Red and green channels. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
+    Rg8Unorm,
+
+    /// Red, green, blue, and alpha channels. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
+    Rgba8Unorm,
+
+    /// The default texture format used by bevy. It being clamped means view targets using it won't support effects like bloom.
+    /// Red, green, blue, and alpha channels. 8 bit integer per channel. Srgb-color [0, 255] converted to/from linear-color float [0, 1] in shader.
+    #[default]
+    Rgba8UnormSrgb,
+
+    /// Blue, green, red, and alpha channels. 8 bit integer per channel. [0, 255] converted to/from float [0, 1] in shader.
+    Bgra8Unorm,
+
+    /// Blue, green, red, and alpha channels. 8 bit integer per channel. Srgb-color [0, 255] converted to/from linear-color float [0, 1] in shader.
+    Bgra8UnormSrgb,
+
+    /// Red channel only. 16 bit float per channel. Float in shader.
+    R16Float,
+
+    /// Red and green channels. 16 bit float per channel. Float in shader.
+    Rg16Float,
+
+    // BEFORE_MERGE: Figure these out. Since they're wgpu specific they aren't in the WebGPU spec.
+    //
+    // R16Unorm
+    // R16Snorm
+    // Rg16Unorm
+    // Rg16Snorm
+    // Rgba16Unorm
+    // Rgba16Snorm
+    /// A common texture format for color in HDR textures and the default texture format used by bevy when it needs unclamped texture format.
+    ///
+    /// Red, green, blue, and alpha channels. 16 bit float per channel. Float in shader.
+    Rgba16Float,
+
+    /// A cheaper to render unclamped texture format than [`ViewTargetFormat::UNCLAMPED_DEFAULT`]. Might encounter to precision issues.
+    ///
+    /// Can only be used if the render device supports the [`RG11B10UFLOAT_RENDERABLE`](wgpu::Features::RG11B10UFLOAT_RENDERABLE)
+    /// feature.
+    ///
+    /// Red, green, and blue channels. 11 bit float with no sign bit for RG channels. 10 bit float with no sign bit for blue channel. Float in shader.
+    Rb11b10Float,
+
+    /// Red, green, blue, and alpha channels. 10 bit integer for RGB channels, 2 bit integer for alpha channel. [0, 1023] ([0, 3] for alpha) converted to/from float [0, 1] in shader.
+    Rgb10a2Unorm,
+    // TODO: These may be supported in the future. See https://github.com/gpuweb/gpuweb/issues/3556.
+    //
+    // If/When this happen they'll require the `float32-blendable` (pressumed name) + `float32-filterable`
+    //
+    // /// Red channel only. 32 bit float per channel. Float in shader.
+    // R32Float,
+    // /// Red and green channels. 32 bit float per channel. Float in shader.
+    // Rg32Float,
+    // /// Red, green, blue, and alpha channels. 32 bit float per channel. Float in shader.
+    // Rgba32Float,
+}
+
+impl ViewTargetFormat {
+    pub const DEFAULT: Self = Self::Rgba8UnormSrgb;
+    pub const UNCLAMPED_DEFAULT: Self = Self::Rgba16Float;
+
+    /// Defines what [`features`](wgpu::Features) the render device needs to support for the format to
+    /// be available.
+    ///
+    /// Currently the only [`ViewTargetFormat`] that requires any features is [`Rb11b10Float`](ViewTargetFormat::Rb11b10Float).
+    pub const fn required_features(&self) -> wgpu::Features {
+        match self {
+            ViewTargetFormat::R8Unorm
+            | ViewTargetFormat::Rg8Unorm
+            | ViewTargetFormat::Bgra8Unorm
+            | ViewTargetFormat::Rgba8Unorm
+            | ViewTargetFormat::Rgba8UnormSrgb
+            | ViewTargetFormat::Bgra8UnormSrgb
+            | ViewTargetFormat::Rgba16Float
+            | ViewTargetFormat::R16Float
+            | ViewTargetFormat::Rg16Float
+            | ViewTargetFormat::Rgb10a2Unorm => wgpu::Features::empty(),
+            ViewTargetFormat::Rb11b10Float => wgpu::Features::RG11B10UFLOAT_RENDERABLE,
+        }
+    }
+
+    /// Unclamped [`ViewTargetFormat`]s are ones whose float values in shader won't be clamped between 0.0 and 1.0.
+    ///
+    /// Bloom and other such effects only work with these formats.
+    pub const fn is_unclamped(&self) -> bool {
+        // BEFORE_MERGE: Heavily bikeshed the name
+
+        match self {
+            ViewTargetFormat::R16Float
+            | ViewTargetFormat::Rg16Float
+            | ViewTargetFormat::Rgba16Float
+            | ViewTargetFormat::Rb11b10Float => true,
+            ViewTargetFormat::R8Unorm
+            | ViewTargetFormat::Rg8Unorm
+            | ViewTargetFormat::Rgba8Unorm
+            | ViewTargetFormat::Bgra8Unorm
+            | ViewTargetFormat::Rgba8UnormSrgb
+            | ViewTargetFormat::Bgra8UnormSrgb
+            | ViewTargetFormat::Rgb10a2Unorm => false,
+        }
+    }
+}
+
+impl From<ViewTargetFormat> for TextureFormat {
+    fn from(value: ViewTargetFormat) -> Self {
+        match value {
+            ViewTargetFormat::Rgba16Float => TextureFormat::Rgba16Float,
+            ViewTargetFormat::Rb11b10Float => TextureFormat::Rg11b10Float,
+            ViewTargetFormat::Rgba8UnormSrgb => TextureFormat::Rgba8UnormSrgb,
+            ViewTargetFormat::Rgba8Unorm => TextureFormat::Rgba8Unorm,
+            ViewTargetFormat::R8Unorm => TextureFormat::R8Unorm,
+            ViewTargetFormat::Rg8Unorm => TextureFormat::Rg8Unorm,
+            ViewTargetFormat::Bgra8Unorm => TextureFormat::Bgra8Unorm,
+            ViewTargetFormat::Bgra8UnormSrgb => TextureFormat::Bgra8UnormSrgb,
+            ViewTargetFormat::R16Float => TextureFormat::R16Float,
+            ViewTargetFormat::Rg16Float => TextureFormat::Rg16Float,
+            ViewTargetFormat::Rgb10a2Unorm => TextureFormat::Rgb10a2Unorm,
+        }
+    }
+}
+
+/// The error type returned when converting a [`TextureFormat`] into [`ViewTargetFormat`] fails.
+#[derive(Debug, Clone, Copy)]
+pub struct TryFromTextureFormatError {}
+
+impl Display for TryFromTextureFormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("this texture type can't be rendered to")
+    }
+}
+
+impl TryFrom<TextureFormat> for ViewTargetFormat {
+    type Error = TryFromTextureFormatError;
+
+    fn try_from(value: TextureFormat) -> Result<Self, Self::Error> {
+        match value {
+            TextureFormat::Rgba16Float => Ok(ViewTargetFormat::Rgba16Float),
+            TextureFormat::Rg11b10Float => Ok(ViewTargetFormat::Rb11b10Float),
+            TextureFormat::Rgba8UnormSrgb => Ok(ViewTargetFormat::Rgba8UnormSrgb),
+            TextureFormat::Rgba8Unorm => Ok(ViewTargetFormat::Rgba8Unorm),
+            TextureFormat::R8Unorm => Ok(ViewTargetFormat::R8Unorm),
+            TextureFormat::Rg8Unorm => Ok(ViewTargetFormat::Rg8Unorm),
+            TextureFormat::Bgra8Unorm => Ok(ViewTargetFormat::Bgra8Unorm),
+            TextureFormat::Bgra8UnormSrgb => Ok(ViewTargetFormat::Bgra8UnormSrgb),
+            TextureFormat::R16Float => Ok(ViewTargetFormat::R16Float),
+            TextureFormat::Rg16Float => Ok(ViewTargetFormat::Rg16Float),
+            TextureFormat::Rgb10a2Unorm => Ok(ViewTargetFormat::Rgb10a2Unorm),
+            _ => Err(TryFromTextureFormatError {}),
+        }
     }
 }


### PR DESCRIPTION
# Objective

Find a subset of `TextureFormat`s that can rendered to. This way, when we allow people to change the texture format used for rendering, they won't be selecting unsupported formats (and getting runtime crashes).

This is a predecessor to #13146.
