### PR TITLE
Switch rotation & translation in grid gizmos

### DIFF
--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -378,9 +378,8 @@ fn draw_grid<Config, Clear>(
         spacing.z * Vec3::new(skew_tan.x, skew_tan.y, 1.) * if cell_count.z != 0 { 1. } else { 0. };
 
     // Bottom-left-front corner of the grid
-    let grid_start = -(cell_count.x as f32 / 2.0 * dx)
-        - cell_count.y as f32 / 2.0 * dy
-        - cell_count.z as f32 / 2.0 * dz;
+    let cell_count_half = cell_count.as_vec3() * 0.5;
+    let grid_start = -cell_count_half.x * dx - cell_count_half.y * dy - cell_count_half.z * dz;
 
     let line_count = UVec3::new(
         if outer_edges[0] {

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -378,7 +378,7 @@ fn draw_grid<Config, Clear>(
     }
 
     // Offset between two adjacent grid cells along the x/y-axis and accounting for skew.
-    let skew_tan = Vec3::from(skew.to_array().map(|v| v.tan()));
+    let skew_tan = Vec3::from(skew.to_array().map(f32::tan));
     let dx = or_zero(
         cell_count.x != 0,
         spacing.x * Vec3::new(1., skew_tan.y, skew_tan.z),

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -369,15 +369,13 @@ fn draw_grid<Config, Clear>(
     }
 
     // Offset between two adjacent grid cells along the x/y-axis and accounting for skew.
-    let dx = spacing.x
-        * Vec3::new(1., skew.y.tan(), skew.z.tan())
-        * if cell_count.x != 0 { 1. } else { 0. };
-    let dy = spacing.y
-        * Vec3::new(skew.x.tan(), 1., skew.z.tan())
-        * if cell_count.y != 0 { 1. } else { 0. };
-    let dz = spacing.z
-        * Vec3::new(skew.x.tan(), skew.y.tan(), 1.)
-        * if cell_count.z != 0 { 1. } else { 0. };
+    let skew_tan = Vec3::from(skew.to_array().map(|v| v.tan()));
+    let dx =
+        spacing.x * Vec3::new(1., skew_tan.y, skew_tan.z) * if cell_count.x != 0 { 1. } else { 0. };
+    let dy =
+        spacing.y * Vec3::new(skew_tan.x, 1., skew_tan.z) * if cell_count.y != 0 { 1. } else { 0. };
+    let dz =
+        spacing.z * Vec3::new(skew_tan.x, skew_tan.y, 1.) * if cell_count.z != 0 { 1. } else { 0. };
 
     // Bottom-left-front corner of the grid
     let grid_start = -(cell_count.x as f32 / 2.0 * dx)

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -380,8 +380,7 @@ fn draw_grid<Config, Clear>(
         * if cell_count.z != 0 { 1. } else { 0. };
 
     // Bottom-left-front corner of the grid
-    let grid_start = position
-        - cell_count.x as f32 / 2.0 * dx
+    let grid_start = -(cell_count.x as f32 / 2.0 * dx)
         - cell_count.y as f32 / 2.0 * dy
         - cell_count.z as f32 / 2.0 * dz;
 
@@ -415,7 +414,11 @@ fn draw_grid<Config, Clear>(
             let line_start = x_start + iy * dy + iz * dz;
             let line_end = line_start + dline;
 
-            gizmos.line(rotation * line_start, rotation * line_end, color);
+            gizmos.line(
+                position + rotation * line_start,
+                position + rotation * line_end,
+                color,
+            );
         }
     }
     // Lines along the y direction
@@ -427,7 +430,11 @@ fn draw_grid<Config, Clear>(
             let line_start = y_start + ix * dx + iz * dz;
             let line_end = line_start + dline;
 
-            gizmos.line(rotation * line_start, rotation * line_end, color);
+            gizmos.line(
+                position + rotation * line_start,
+                position + rotation * line_end,
+                color,
+            );
         }
     }
     // Lines along the z direction
@@ -439,7 +446,11 @@ fn draw_grid<Config, Clear>(
             let line_start = z_start + ix * dx + iy * dy;
             let line_end = line_start + dline;
 
-            gizmos.line(rotation * line_start, rotation * line_end, color);
+            gizmos.line(
+                position + rotation * line_start,
+                position + rotation * line_end,
+                color,
+            );
         }
     }
 }

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -90,6 +90,14 @@ fn draw_example_collection(
         // Light gray
         LinearRgba::gray(0.65),
     );
+    gizmos.grid(
+        Vec3::ONE * 10.0,
+        Quat::from_rotation_x(PI / 3. * 2.),
+        UVec2::splat(20),
+        Vec2::new(2., 2.),
+        PURPLE,
+    );
+    gizmos.sphere(Vec3::ONE * 10.0, Quat::default(), 1.0, PURPLE);
 
     gizmos.cuboid(
         Transform::from_translation(Vec3::Y * 0.5).with_scale(Vec3::splat(1.25)),


### PR DESCRIPTION
# Objective

- Fixes #14655

## Solution

Rotation should happen first as this is more easier to conceptualize in the mind: We rotate around the coordinate origin `Vec3::ZERO` and then we just shift the geometry so that its center is exactly on the specified position

## Testing && Showcase

Code:

```rust
    gizmos.grid(
        Vec3::ONE * 10.0,
        Quat::from_rotation_x(PI / 3. * 2.),
        UVec2::splat(20),
        Vec2::new(2., 2.),
        PURPLE,
    );
    gizmos.sphere(Vec3::ONE * 10.0, Quat::default(), 1.0, PURPLE);
```

Before picture:

![image](https://github.com/user-attachments/assets/7fea2e71-e62b-4763-9f9f-7a1ecd630ada)

After picture:

![image](https://github.com/user-attachments/assets/899dad64-010a-4e4b-86ae-53b85fef0bbc)


## Migration Guide

- Users might have to double check their already existing calls to all the `grid` methods. It should be more intuitive now though.