### PR TITLE
Add trigger_map to support triggering mapped events

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -445,7 +445,7 @@ impl World {
 /// #[derive(Event, Clone, Debug)]
 /// struct Foo(usize);
 ///
-/// #[derive(Event, Debug)]
+/// #[derive(Event, Clone, Debug)]
 /// struct Bar(bool);
 ///
 /// #[derive(Event, Debug)]
@@ -458,6 +458,29 @@ impl World {
 /// world.observe(trigger_map(Combined::Bar));
 /// world.observe(|trigger: Trigger<Combined>| {
 ///     println!("Combined Event: {:?}", trigger.event());
+/// });
+/// ```
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::observer::trigger_map;
+/// # let mut world = World::new();
+///
+/// #[derive(Event, Clone, Debug)]
+/// struct Foo(usize);
+///
+/// #[derive(Event, Clone, Debug)]
+/// struct Bar(bool);
+///
+/// // If you don't care about capturing the original event context,
+/// // you can just use a unit struct.
+/// #[derive(Event, Debug)]
+/// struct Combined;
+///
+/// world.observe(trigger_map(|event: Foo| Combined));
+/// world.observe(trigger_map(|event: Bar| Combined));
+/// world.observe(|trigger: Trigger<Combined>| {
+///     println!("Combined Event");
 /// });
 /// ```
 pub fn trigger_map<T: Event + Clone, U: Event, F: Fn(T) -> U + Send + Sync + 'static>(

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -455,6 +455,7 @@ impl World {
 /// }
 ///
 /// world.observe(trigger_map(Combined::Foo));
+/// world.observe(trigger_map(Combined::Bar));
 /// world.observe(|trigger: Trigger<Combined>| {
 ///     println!("Combined Event: {:?}", trigger.event());
 /// });


### PR DESCRIPTION
# Objective

Alternative to the suggestion in #14649

Sometimes people want observers to watch for multiple events instead of just one. We should provide some mechanism for this to happen.

## Solution

Add a `trigger_map` function, which returns an ObserverSystem that will use a given `map` function to trigger a mapped event when a certain event type is triggered:

```rust
#[derive(Event, Clone, Debug)]
struct Foo(usize);

#[derive(Event, Debug)]
struct Bar(bool);

#[derive(Event, Debug)]
enum Combined {
    Foo(Foo),
    Bar(Bar),
}

app
    .observe(trigger_map(Combined::Foo))
    .observe(|trigger: Trigger<Combined>| {
        println!("Combined Event: {:?}", trigger.event());
    });
```
