### PR TITLE
bevy_reflect: Add `DynamicSet` to `dynamic_types` example

### DIFF
--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -381,12 +381,54 @@ impl Debug for DynamicSet {
     }
 }
 
+impl FromIterator<Box<dyn Reflect>> for DynamicSet {
+    fn from_iter<I: IntoIterator<Item = Box<dyn Reflect>>>(values: I) -> Self {
+        let mut this = Self {
+            represented_type: None,
+            hash_table: HashTable::new(),
+        };
+
+        for value in values {
+            this.insert_boxed(value);
+        }
+
+        this
+    }
+}
+
+impl<T: Reflect> FromIterator<T> for DynamicSet {
+    fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
+        let mut this = Self {
+            represented_type: None,
+            hash_table: HashTable::new(),
+        };
+
+        for value in values {
+            this.insert(value);
+        }
+
+        this
+    }
+}
+
 impl IntoIterator for DynamicSet {
     type Item = Box<dyn Reflect>;
     type IntoIter = bevy_utils::hashbrown::hash_table::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.hash_table.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DynamicSet {
+    type Item = &'a dyn Reflect;
+    type IntoIter = std::iter::Map<
+        bevy_utils::hashbrown::hash_table::Iter<'a, Box<dyn Reflect>>,
+        fn(&'a Box<dyn Reflect>) -> Self::Item,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.hash_table.iter().map(|v| v.as_reflect())
     }
 }
 

--- a/examples/reflection/dynamic_types.rs
+++ b/examples/reflection/dynamic_types.rs
@@ -2,11 +2,12 @@
 
 use bevy::reflect::{
     reflect_trait, serde::TypedReflectDeserializer, std_traits::ReflectDefault, DynamicArray,
-    DynamicEnum, DynamicList, DynamicMap, DynamicStruct, DynamicTuple, DynamicTupleStruct,
-    DynamicVariant, FromReflect, Reflect, ReflectFromReflect, ReflectRef, TypeRegistry, Typed,
+    DynamicEnum, DynamicList, DynamicMap, DynamicSet, DynamicStruct, DynamicTuple,
+    DynamicTupleStruct, DynamicVariant, FromReflect, Reflect, ReflectFromReflect, ReflectRef, Set,
+    TypeRegistry, Typed,
 };
 use serde::de::DeserializeSeed;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 fn main() {
     #[derive(Reflect, Default)]
@@ -180,7 +181,19 @@ fn main() {
         assert_eq!(my_list, vec![1, 2, 3]);
     }
 
-    // 4. `DynamicMap`
+    // 4. `DynamicSet`
+    {
+        let mut dynamic_set = DynamicSet::from_iter(["x", "y", "z"]);
+        assert!(dynamic_set.contains(&"x"));
+
+        dynamic_set.remove(&"y");
+
+        let mut my_set: HashSet<&str> = HashSet::new();
+        my_set.apply(&dynamic_set);
+        assert_eq!(my_set, HashSet::from_iter(["x", "z"]));
+    }
+
+    // 5. `DynamicMap`
     {
         let dynamic_map = DynamicMap::from_iter([("x", 1u32), ("y", 2u32), ("z", 3u32)]);
 
@@ -191,7 +204,7 @@ fn main() {
         assert_eq!(my_map.get("z"), Some(&3));
     }
 
-    // 5. `DynamicStruct`
+    // 6. `DynamicStruct`
     {
         #[derive(Reflect, Default, Debug, PartialEq)]
         struct MyStruct {
@@ -210,7 +223,7 @@ fn main() {
         assert_eq!(my_struct, MyStruct { x: 1, y: 2, z: 3 });
     }
 
-    // 6. `DynamicTupleStruct`
+    // 7. `DynamicTupleStruct`
     {
         #[derive(Reflect, Default, Debug, PartialEq)]
         struct MyTupleStruct(u32, u32, u32);
@@ -225,7 +238,7 @@ fn main() {
         assert_eq!(my_tuple_struct, MyTupleStruct(1, 2, 3));
     }
 
-    // 7. `DynamicEnum`
+    // 8. `DynamicEnum`
     {
         #[derive(Reflect, Default, Debug, PartialEq)]
         enum MyEnum {


### PR DESCRIPTION
# Objective

The `dynamic_types` example was missing a reference to the newly added `DynamicSet` type.

## Solution

Add `DynamicSet` to the `dynamic_types` example.

For parity with the other dynamic types, I also implemented `FromIterator<T: Reflect>`, `FromIterator<Box<dyn Reflect>>`, and `IntoIterator for &DynamicSet`. 

## Testing

You can run the example locally:

```
cargo run --example dynamic_types
```