### PR TITLE
bevy_state: Make `reflect` module public

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -41,7 +41,7 @@ pub mod state_scoped;
 
 #[cfg(feature = "bevy_reflect")]
 /// Provides definitions for the basic traits required by the state system
-mod reflect;
+pub mod reflect;
 
 /// Most commonly used re-exported types.
 pub mod prelude {


### PR DESCRIPTION
# Objective

CI is [failing](https://github.com/bevyengine/bevy/actions/runs/10308658332/job/28536587448) due to certain methods not being used.

## Solution

Make the `reflect` module public so that these warnings go away and so that the `pub` items in these modules can be used.

## Testing

CI should pass.