### PR TITLE
Queries as Entities

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -19,11 +19,13 @@
 //! [`Table`]: crate::storage::Table
 //! [`World::archetypes`]: crate::world::World::archetypes
 
+use crate as bevy_ecs;
 use crate::{
     bundle::BundleId,
     component::{ComponentId, Components, StorageType},
     entity::{Entity, EntityLocation},
     observer::Observers,
+    prelude::Event,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex, TableId, TableRow},
 };
 use std::{
@@ -107,6 +109,9 @@ impl ArchetypeId {
         self.0 as usize
     }
 }
+
+#[derive(Event)]
+pub(crate) struct ArchetypeCreated(pub ArchetypeId);
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum ComponentStatus {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -58,6 +58,7 @@ pub(super) union StorageId {
 // SAFETY NOTE:
 // Do not add any new fields that use the `D` or `F` generic parameters as this may
 // make `QueryState::as_transmuted_state` unsound if not done with care.
+#[derive(Clone)]
 pub struct QueryState<D: QueryData, F: QueryFilter = ()> {
     world_id: WorldId,
     pub(crate) archetype_generation: ArchetypeGeneration,
@@ -88,7 +89,7 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> Component for QueryState<
                 let mut entity = world.entity_mut(trigger.entity());
                 let mut state = entity.get_mut::<QueryState<D, F>>().unwrap();
                 unsafe {
-                    state.new_archetype(&*archetype_ptr, &mut Access::<ArchetypeComponentId>::default());
+                    state.new_archetype_internal(&*archetype_ptr);
                 }
             });
             observer.watch_entity(entity);

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -127,9 +127,10 @@ impl<'w> DeferredWorld<'w> {
         // SAFETY: We ran validate_world to ensure our state matches
         unsafe {
             let world_cell = self.world;
+            let id = world_cell.world_mut().spawn(*state).id();
             Query::new(
                 world_cell,
-                state,
+                id,
                 world_cell.last_change_tick(),
                 world_cell.change_tick(),
             )


### PR DESCRIPTION
# Objective

Quoting the [Relations RFC](https://github.com/james-j-obrien/rfcs/blob/minimal-fragmenting-relationships/rfcs/79-minimal-fragmenting-relationships.md#query-and-system-caches):

> Query's caches of matching tables and archetypes are updated each time the query is accessed by iterating through the archetypes that have been created since it was last accessed. As the number of archetypes in bevy is expected to stabilize over the runtime of a program this isn't currently an issue. However with the increased archetype fragmentation caused by fragmenting relationships and the new wrinkle of archetype deletion the updating of the query caches is poised to become a performance bottleneck.
> 
> An appropriate solution would allow us to expose new/deleted archetypes to only the queries that may be interested in iterating them. Luckily observers https://github.com/bevyengine/bevy/pull/10839 could cleanly model this pattern. By sending ECS triggers each time an archetype is created and creating an observer for each query we can target the updates so that we no longer need to iterate every new archetype. Similarly we can fire archetype deletion events to cause queries to remove the archetype from their cache.

## Solution

Continuing the quote:

> In order to implement such a mechanism we need some way for the observer to have access to the query state. Currently QueryState is stored in the system state, so in order to update it we would need to expose several additional APIs, even then it's quite difficult to reach into the system state tuple to access the correct query without some macros to handle tuple indexing. An alternative would be to move the query state into a component on an associated entity (WIP branch here: [queries-as-entities](https://github.com/james-j-obrien/bevy/tree/queries-as-entities)) this provides additional benefits in making it easier manage dynamic queries, but they are largely tangential to this RFC.

---

## Migration Guide

TBD
