### PR TITLE
document using `ObserverState` as filter for `Observer` `Entity`s

### DIFF
--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -257,17 +257,14 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// You can call [`Observer::watch_entity`] more than once, which allows you to watch multiple entities with the same [`Observer`].
 ///
 /// When first added, [`Observer`] will also create an [`ObserverState`] component, which registers the observer with the [`World`] and
-/// serves as the "source of truth" of the observer.
+/// serves as the "source of truth" of the observer. [`ObserverState`] can be used to filter for [`Observer`] [`Entity`]s, e.g.
+/// [`With<ObserverState>`].
 ///
 /// [`SystemParam`]: crate::system::SystemParam
 pub struct Observer<T: 'static, B: Bundle> {
     system: BoxedObserverSystem<T, B>,
     descriptor: ObserverDescriptor,
 }
-
-/// Marker [`Component`](Component) for identifying [`Observer`] [`Entity`]s.
-#[derive(Component)]
-pub struct ObserverMarker;
 
 impl<E: Event, B: Bundle> Observer<E, B> {
     /// Creates a new [`Observer`], which defaults to a "global" observer. This means it will run whenever the event `E` is triggered
@@ -348,7 +345,6 @@ impl<E: Event, B: Bundle> Component for Observer<E, B> {
                             runner: observer_system_runner::<E, B>,
                             ..Default::default()
                         });
-                        entity.insert(ObserverMarker);
                     }
                 }
             });

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{ComponentHooks, ComponentId, StorageType},
+    component::{Component, ComponentHooks, ComponentId, StorageType},
     observer::{ObserverDescriptor, ObserverTrigger},
     prelude::*,
     query::DebugCheckedUnwrap,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -265,6 +265,10 @@ pub struct Observer<T: 'static, B: Bundle> {
     descriptor: ObserverDescriptor,
 }
 
+/// Marker [`Component`](Component) for identifying [`Observer`] [`Entity`]s.
+#[derive(Component)]
+pub struct ObserverMarker;
+
 impl<E: Event, B: Bundle> Observer<E, B> {
     /// Creates a new [`Observer`], which defaults to a "global" observer. This means it will run whenever the event `E` is triggered
     /// for _any_ entity (or no entity).
@@ -312,6 +316,7 @@ impl<E: Event, B: Bundle> Component for Observer<E, B> {
     fn register_component_hooks(hooks: &mut ComponentHooks) {
         hooks.on_add(|mut world, entity, _| {
             world.commands().add(move |world: &mut World| {
+                world.entity_mut(entity).insert(ObserverMarker);
                 let event_type = world.init_component::<E>();
                 let mut components = Vec::new();
                 B::component_ids(&mut world.components, &mut world.storages, &mut |id| {

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -316,7 +316,6 @@ impl<E: Event, B: Bundle> Component for Observer<E, B> {
     fn register_component_hooks(hooks: &mut ComponentHooks) {
         hooks.on_add(|mut world, entity, _| {
             world.commands().add(move |world: &mut World| {
-                world.entity_mut(entity).insert(ObserverMarker);
                 let event_type = world.init_component::<E>();
                 let mut components = Vec::new();
                 B::component_ids(&mut world.components, &mut world.storages, &mut |id| {
@@ -349,6 +348,7 @@ impl<E: Event, B: Bundle> Component for Observer<E, B> {
                             runner: observer_system_runner::<E, B>,
                             ..Default::default()
                         });
+                        entity.insert(ObserverMarker);
                     }
                 }
             });

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{Component, ComponentHooks, ComponentId, StorageType},
+    component::{ComponentHooks, ComponentId, StorageType},
     observer::{ObserverDescriptor, ObserverTrigger},
     prelude::*,
     query::DebugCheckedUnwrap,


### PR DESCRIPTION
# Objective

~~Enables writing queries like `Query<Entity, With<ObserverMarker>>` to filter `Entity`s that are, or are not (with `Without`), `Observer`s.~~

~~`Observer` version of [similar PR](https://github.com/bevyengine/bevy/pull/14584) for `SystemId`s.~~

just adding a line to the docs :)

## Solution

~~Simple unit struct `ObserverMarker` added in `Observer`'s `.on_add` component hook.~~

## Testing

No tests, but happy to write some with direction.