### PR TITLE
Observers overhaul: statically-typed multi-event-listening and safer dynamic-event-listening

### DIFF
--- a/benches/benches/bevy_ecs/observers/dynamic.rs
+++ b/benches/benches/bevy_ecs/observers/dynamic.rs
@@ -1,22 +1,25 @@
 use bevy_ecs::{
     event::Event,
-    observer::{EventSet, Observer, Trigger, UntypedEvent},
-    world::World,
+    observer::{DynamicEvent, EmitDynamicTrigger, EventSet, Observer, Trigger},
+    world::{Command, World},
 };
 use criterion::{black_box, Criterion};
 
-pub fn observe_untyped(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("observe_untyped");
+pub fn observe_dynamic(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("observe_dynamic");
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
 
     group.bench_function("1", |bencher| {
         let mut world = World::new();
         let event_id_1 = world.init_component::<TestEvent<1>>();
-        world.spawn(Observer::new(empty_listener_set::<UntypedEvent>).with_event(event_id_1));
+        world.spawn(Observer::new(empty_listener_set::<DynamicEvent>).with_event(event_id_1));
         bencher.iter(|| {
             for _ in 0..10000 {
-                world.trigger(TestEvent::<1>);
+                unsafe {
+                    EmitDynamicTrigger::new_with_id(event_id_1, TestEvent::<1>, ())
+                        .apply(&mut world)
+                };
             }
         });
     });
@@ -25,13 +28,16 @@ pub fn observe_untyped(criterion: &mut Criterion) {
         let event_id_1 = world.init_component::<TestEvent<1>>();
         let event_id_2 = world.init_component::<TestEvent<2>>();
         world.spawn(
-            Observer::new(empty_listener_set::<UntypedEvent>)
+            Observer::new(empty_listener_set::<DynamicEvent>)
                 .with_event(event_id_1)
                 .with_event(event_id_2),
         );
         bencher.iter(|| {
             for _ in 0..10000 {
-                world.trigger(TestEvent::<2>);
+                unsafe {
+                    EmitDynamicTrigger::new_with_id(event_id_2, TestEvent::<2>, ())
+                        .apply(&mut world)
+                };
             }
         });
     });

--- a/benches/benches/bevy_ecs/observers/mod.rs
+++ b/benches/benches/bevy_ecs/observers/mod.rs
@@ -1,8 +1,18 @@
 use criterion::criterion_group;
 
+mod multievent;
 mod propagation;
 mod simple;
+mod untyped;
+use multievent::*;
 use propagation::*;
 use simple::*;
+use untyped::*;
 
-criterion_group!(observer_benches, event_propagation, observe_simple);
+criterion_group!(
+    observer_benches,
+    event_propagation,
+    observe_simple,
+    observe_multievent,
+    observe_untyped
+);

--- a/benches/benches/bevy_ecs/observers/mod.rs
+++ b/benches/benches/bevy_ecs/observers/mod.rs
@@ -1,18 +1,21 @@
 use criterion::criterion_group;
 
+mod dynamic;
 mod multievent;
 mod propagation;
+mod semidynamic;
 mod simple;
-mod untyped;
+use dynamic::*;
 use multievent::*;
 use propagation::*;
+use semidynamic::*;
 use simple::*;
-use untyped::*;
 
 criterion_group!(
     observer_benches,
     event_propagation,
     observe_simple,
     observe_multievent,
-    observe_untyped
+    observe_dynamic,
+    observe_semidynamic
 );

--- a/benches/benches/bevy_ecs/observers/multievent.rs
+++ b/benches/benches/bevy_ecs/observers/multievent.rs
@@ -11,43 +11,19 @@ pub fn observe_multievent(criterion: &mut Criterion) {
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
 
+    group.bench_function("trigger_single", |bencher| {
+        let mut world = World::new();
+        world.observe(empty_listener_set::<TestEvent<1>>);
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(TestEvent::<1>);
+            }
+        });
+    });
+
     bench_in_set::<1, (TestEvent<1>,)>(&mut group);
     bench_in_set::<2, (TestEvent<1>, TestEvent<2>)>(&mut group);
-    bench_in_set::<3, (TestEvent<1>, TestEvent<2>, TestEvent<3>)>(&mut group);
     bench_in_set::<4, (TestEvent<1>, TestEvent<2>, TestEvent<3>, TestEvent<4>)>(&mut group);
-    bench_in_set::<
-        5,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        6,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        7,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-            TestEvent<7>,
-        ),
-    >(&mut group);
     bench_in_set::<
         8,
         (
@@ -59,51 +35,6 @@ pub fn observe_multievent(criterion: &mut Criterion) {
             TestEvent<6>,
             TestEvent<7>,
             TestEvent<8>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        9,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-            TestEvent<7>,
-            TestEvent<8>,
-            TestEvent<9>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        10,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-            TestEvent<7>,
-            TestEvent<8>,
-            TestEvent<9>,
-            TestEvent<10>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        11,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-            TestEvent<7>,
-            TestEvent<8>,
-            TestEvent<9>,
-            TestEvent<10>,
-            TestEvent<11>,
         ),
     >(&mut group);
     bench_in_set::<
@@ -121,43 +52,6 @@ pub fn observe_multievent(criterion: &mut Criterion) {
             TestEvent<10>,
             TestEvent<11>,
             TestEvent<12>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        13,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-            TestEvent<7>,
-            TestEvent<8>,
-            TestEvent<9>,
-            TestEvent<10>,
-            TestEvent<11>,
-            TestEvent<12>,
-            TestEvent<13>,
-        ),
-    >(&mut group);
-    bench_in_set::<
-        14,
-        (
-            TestEvent<1>,
-            TestEvent<2>,
-            TestEvent<3>,
-            TestEvent<4>,
-            TestEvent<5>,
-            TestEvent<6>,
-            TestEvent<7>,
-            TestEvent<8>,
-            TestEvent<9>,
-            TestEvent<10>,
-            TestEvent<11>,
-            TestEvent<12>,
-            TestEvent<13>,
-            TestEvent<14>,
         ),
     >(&mut group);
     bench_in_set::<

--- a/benches/benches/bevy_ecs/observers/multievent.rs
+++ b/benches/benches/bevy_ecs/observers/multievent.rs
@@ -1,0 +1,211 @@
+use bevy_ecs::{
+    component::Component,
+    event::Event,
+    observer::{EventSet, Observer, Trigger},
+    world::World,
+};
+use criterion::{black_box, measurement::WallTime, BenchmarkGroup, Criterion};
+
+pub fn observe_multievent(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("observe_multievent");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+
+    bench_in_set::<1, (TestEvent<1>,)>(&mut group);
+    bench_in_set::<2, (TestEvent<1>, TestEvent<2>)>(&mut group);
+    bench_in_set::<3, (TestEvent<1>, TestEvent<2>, TestEvent<3>)>(&mut group);
+    bench_in_set::<4, (TestEvent<1>, TestEvent<2>, TestEvent<3>, TestEvent<4>)>(&mut group);
+    bench_in_set::<
+        5,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        6,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        7,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        8,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        9,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        10,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+            TestEvent<10>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        11,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+            TestEvent<10>,
+            TestEvent<11>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        12,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+            TestEvent<10>,
+            TestEvent<11>,
+            TestEvent<12>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        13,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+            TestEvent<10>,
+            TestEvent<11>,
+            TestEvent<12>,
+            TestEvent<13>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        14,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+            TestEvent<10>,
+            TestEvent<11>,
+            TestEvent<12>,
+            TestEvent<13>,
+            TestEvent<14>,
+        ),
+    >(&mut group);
+    bench_in_set::<
+        15,
+        (
+            TestEvent<1>,
+            TestEvent<2>,
+            TestEvent<3>,
+            TestEvent<4>,
+            TestEvent<5>,
+            TestEvent<6>,
+            TestEvent<7>,
+            TestEvent<8>,
+            TestEvent<9>,
+            TestEvent<10>,
+            TestEvent<11>,
+            TestEvent<12>,
+            TestEvent<13>,
+            TestEvent<14>,
+            TestEvent<15>,
+        ),
+    >(&mut group);
+}
+
+fn bench_in_set<const LAST: usize, Set: EventSet>(group: &mut BenchmarkGroup<WallTime>) {
+    group.bench_function(format!("trigger_first/{LAST}"), |bencher| {
+        let mut world = World::new();
+        world.observe(empty_listener_set::<Set>);
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(TestEvent::<1>);
+            }
+        });
+    });
+    group.bench_function(format!("trigger_last/{LAST}"), |bencher| {
+        let mut world = World::new();
+        world.observe(empty_listener_set::<Set>);
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(TestEvent::<LAST>);
+            }
+        });
+    });
+}
+
+#[derive(Event)]
+struct TestEvent<const N: usize>;
+
+fn empty_listener_set<Set: EventSet>(trigger: Trigger<Set>) {
+    black_box(trigger);
+}

--- a/benches/benches/bevy_ecs/observers/semidynamic.rs
+++ b/benches/benches/bevy_ecs/observers/semidynamic.rs
@@ -1,0 +1,183 @@
+use bevy_ecs::{
+    event::Event,
+    observer::{EmitDynamicTrigger, EventSet, Observer, SemiDynamicEvent, Trigger},
+    world::{Command, World},
+};
+use criterion::{black_box, Criterion};
+
+pub fn observe_semidynamic(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("observe_semidynamic");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+
+    group.bench_function("static/1s-1d", |bencher| {
+        let mut world = World::new();
+        let event_id_1 = world.init_component::<Dynamic<1>>();
+        world.spawn(
+            Observer::new(empty_listener_set::<SemiDynamicEvent<Static<1>>>).with_event(event_id_1),
+        );
+
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(Static::<1>);
+            }
+        });
+    });
+    group.bench_function("dynamic/1s-1d", |bencher| {
+        let mut world = World::new();
+        let event_id_1 = world.init_component::<Dynamic<1>>();
+        world.spawn(
+            Observer::new(empty_listener_set::<SemiDynamicEvent<Static<1>>>).with_event(event_id_1),
+        );
+
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                unsafe {
+                    EmitDynamicTrigger::new_with_id(event_id_1, Dynamic::<1>, ()).apply(&mut world)
+                };
+            }
+        });
+    });
+
+    group.bench_function("static/15s-15d", |bencher| {
+        // Aint she perdy?
+        let mut world = World::new();
+        let event_id_1 = world.init_component::<Dynamic<1>>();
+        let event_id_2 = world.init_component::<Dynamic<2>>();
+        let event_id_3 = world.init_component::<Dynamic<3>>();
+        let event_id_4 = world.init_component::<Dynamic<4>>();
+        let event_id_5 = world.init_component::<Dynamic<5>>();
+        let event_id_6 = world.init_component::<Dynamic<6>>();
+        let event_id_7 = world.init_component::<Dynamic<7>>();
+        let event_id_8 = world.init_component::<Dynamic<8>>();
+        let event_id_9 = world.init_component::<Dynamic<9>>();
+        let event_id_10 = world.init_component::<Dynamic<10>>();
+        let event_id_11 = world.init_component::<Dynamic<11>>();
+        let event_id_12 = world.init_component::<Dynamic<12>>();
+        let event_id_13 = world.init_component::<Dynamic<13>>();
+        let event_id_14 = world.init_component::<Dynamic<14>>();
+        let event_id_15 = world.init_component::<Dynamic<15>>();
+        world.spawn(
+            Observer::new(
+                empty_listener_set::<
+                    SemiDynamicEvent<(
+                        Static<1>,
+                        Static<2>,
+                        Static<3>,
+                        Static<4>,
+                        Static<5>,
+                        Static<6>,
+                        Static<7>,
+                        Static<8>,
+                        Static<9>,
+                        Static<10>,
+                        Static<11>,
+                        Static<12>,
+                        Static<13>,
+                        Static<14>,
+                        Static<15>,
+                    )>,
+                >,
+            )
+            .with_event(event_id_1)
+            .with_event(event_id_2)
+            .with_event(event_id_3)
+            .with_event(event_id_4)
+            .with_event(event_id_5)
+            .with_event(event_id_6)
+            .with_event(event_id_7)
+            .with_event(event_id_8)
+            .with_event(event_id_9)
+            .with_event(event_id_10)
+            .with_event(event_id_11)
+            .with_event(event_id_12)
+            .with_event(event_id_13)
+            .with_event(event_id_14)
+            .with_event(event_id_15),
+        );
+
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(Static::<14>);
+            }
+        });
+    });
+    group.bench_function("dynamic/15s-15d", |bencher| {
+        // Aint she perdy?
+        let mut world = World::new();
+        let event_id_1 = world.init_component::<Dynamic<1>>();
+        let event_id_2 = world.init_component::<Dynamic<2>>();
+        let event_id_3 = world.init_component::<Dynamic<3>>();
+        let event_id_4 = world.init_component::<Dynamic<4>>();
+        let event_id_5 = world.init_component::<Dynamic<5>>();
+        let event_id_6 = world.init_component::<Dynamic<6>>();
+        let event_id_7 = world.init_component::<Dynamic<7>>();
+        let event_id_8 = world.init_component::<Dynamic<8>>();
+        let event_id_9 = world.init_component::<Dynamic<9>>();
+        let event_id_10 = world.init_component::<Dynamic<10>>();
+        let event_id_11 = world.init_component::<Dynamic<11>>();
+        let event_id_12 = world.init_component::<Dynamic<12>>();
+        let event_id_13 = world.init_component::<Dynamic<13>>();
+        let event_id_14 = world.init_component::<Dynamic<14>>();
+        let event_id_15 = world.init_component::<Dynamic<15>>();
+        world.spawn(
+            Observer::new(
+                empty_listener_set::<
+                    SemiDynamicEvent<(
+                        Static<1>,
+                        Static<2>,
+                        Static<3>,
+                        Static<4>,
+                        Static<5>,
+                        Static<6>,
+                        Static<7>,
+                        Static<8>,
+                        Static<9>,
+                        Static<10>,
+                        Static<11>,
+                        Static<12>,
+                        Static<13>,
+                        Static<14>,
+                        Static<15>,
+                    )>,
+                >,
+            )
+            .with_event(event_id_1)
+            .with_event(event_id_2)
+            .with_event(event_id_3)
+            .with_event(event_id_4)
+            .with_event(event_id_5)
+            .with_event(event_id_6)
+            .with_event(event_id_7)
+            .with_event(event_id_8)
+            .with_event(event_id_9)
+            .with_event(event_id_10)
+            .with_event(event_id_11)
+            .with_event(event_id_12)
+            .with_event(event_id_13)
+            .with_event(event_id_14)
+            .with_event(event_id_15),
+        );
+
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                unsafe {
+                    EmitDynamicTrigger::new_with_id(event_id_14, Dynamic::<14>, ())
+                        .apply(&mut world)
+                };
+            }
+        });
+    });
+}
+
+/// Static event type
+#[derive(Event)]
+struct Static<const N: usize>;
+
+/// Dynamic event type
+#[derive(Event)]
+struct Dynamic<const N: usize>;
+
+fn empty_listener_set<Set: EventSet>(trigger: Trigger<Set>) {
+    black_box(trigger);
+}

--- a/benches/benches/bevy_ecs/observers/untyped.rs
+++ b/benches/benches/bevy_ecs/observers/untyped.rs
@@ -1,0 +1,45 @@
+use bevy_ecs::{
+    event::Event,
+    observer::{EventSet, Observer, Trigger, UntypedEvent},
+    world::World,
+};
+use criterion::{black_box, Criterion};
+
+pub fn observe_untyped(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("observe_untyped");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+
+    group.bench_function("1", |bencher| {
+        let mut world = World::new();
+        let event_id_1 = world.init_component::<TestEvent<1>>();
+        world.spawn(Observer::new(empty_listener_set::<UntypedEvent>).with_event(event_id_1));
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(TestEvent::<1>);
+            }
+        });
+    });
+    group.bench_function("2", |bencher| {
+        let mut world = World::new();
+        let event_id_1 = world.init_component::<TestEvent<1>>();
+        let event_id_2 = world.init_component::<TestEvent<2>>();
+        world.spawn(
+            Observer::new(empty_listener_set::<UntypedEvent>)
+                .with_event(event_id_1)
+                .with_event(event_id_2),
+        );
+        bencher.iter(|| {
+            for _ in 0..10000 {
+                world.trigger(TestEvent::<2>);
+            }
+        });
+    });
+}
+
+#[derive(Event)]
+struct TestEvent<const N: usize>;
+
+fn empty_listener_set<Set: EventSet>(trigger: Trigger<Set>) {
+    black_box(trigger);
+}

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -6,6 +6,7 @@ pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     event::{event_update_system, EventCursor},
     intern::Interned,
+    observer::EventSet,
     prelude::*,
     schedule::{ScheduleBuildSettings, ScheduleLabel},
     system::{IntoObserverSystem, SystemId},
@@ -990,7 +991,7 @@ impl App {
     }
 
     /// Spawns an [`Observer`] entity, which will watch for and respond to the given event.
-    pub fn observe<E: Event, B: Bundle, M>(
+    pub fn observe<E: EventSet, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -639,8 +639,8 @@ mod tests {
         let on_remove = world.init_component::<OnRemove>();
         world.spawn(
             Observer::new(|_: Trigger<UntypedEvent, A>, mut res: ResMut<R>| res.0 += 1)
-                .with_event_safe(on_add)
-                .with_event_safe(on_remove),
+                .with_event(on_add)
+                .with_event(on_remove),
         );
 
         let entity = world.spawn(A).id();

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -611,7 +611,7 @@ mod tests {
         #[derive(Event)]
         struct Bar;
         world.observe(|_: Trigger<(Foo, Bar)>, mut res: ResMut<R>| res.0 += 1);
-        world.flush();
+        world.flush(); // TODO: should we auto-flush after observe?
         world.trigger(Foo);
         world.trigger(Bar);
         assert_eq!(2, world.resource::<R>().0);

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1033,6 +1033,9 @@ mod tests {
         world.trigger_targets(EventPropagating, child);
         world.flush();
         assert_eq!(3, world.resource::<R>().0);
+        world.trigger_targets(Foo, parent);
+        world.flush();
+        assert_eq!(4, world.resource::<R>().0);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[test]
-    fn observer_multiple_events_static_untyped() {
+    fn observer_multiple_events_untyped_autoregister_static() {
         let mut world = World::new();
         world.init_resource::<R>();
         world.spawn(Observer::new(
@@ -634,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn observer_multiple_events_dynamic_untyped() {
+    fn observer_multiple_events_untyped() {
         let mut world = World::new();
         world.init_resource::<R>();
         let on_add = world.init_component::<OnAdd>();
@@ -642,6 +642,21 @@ mod tests {
         world.spawn(
             Observer::new(|_: Trigger<UntypedEvent, A>, mut res: ResMut<R>| res.0 += 1)
                 .with_event(on_add)
+                .with_event(on_remove),
+        );
+
+        let entity = world.spawn(A).id();
+        world.despawn(entity);
+        assert_eq!(2, world.resource::<R>().0);
+    }
+
+    #[test]
+    fn observer_multiple_events_mixed() {
+        let mut world = World::new();
+        world.init_resource::<R>();
+        let on_remove = world.init_component::<OnRemove>();
+        world.spawn(
+            Observer::new(|_: Trigger<(OnAdd, UntypedEvent), A>, mut res: ResMut<R>| res.0 += 1)
                 .with_event(on_remove),
         );
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -644,8 +644,8 @@ mod tests {
         let on_remove = world.init_component::<OnRemove>();
         world.spawn(
             Observer::new(|_: Trigger<Untyped<()>, A>, mut res: ResMut<R>| res.0 += 1)
-                .with_event_safe(on_add)
-                .with_event_safe(on_remove),
+                .with_event(on_add)
+                .with_event(on_remove),
         );
 
         let entity = world.spawn(A).id();

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -642,11 +642,11 @@ mod tests {
         world.init_resource::<R>();
         let on_add = world.init_component::<OnAdd>();
         let on_remove = world.init_component::<OnRemove>();
-        world.spawn(
+        world.spawn(unsafe {
             Observer::new(|_: Trigger<Untyped<()>, A>, mut res: ResMut<R>| res.0 += 1)
                 .with_event(on_add)
-                .with_event(on_remove),
-        );
+                .with_event(on_remove)
+        });
 
         let entity = world.spawn(A).id();
         world.despawn(entity);

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -621,19 +621,6 @@ mod tests {
     }
 
     #[test]
-    fn observer_multiple_events_dynamic_autoregister() {
-        let mut world = World::new();
-        world.init_resource::<R>();
-        world.spawn(Observer::new(
-            |_: Trigger<DynamicEvent<(OnAdd, OnRemove)>, A>, mut res: ResMut<R>| res.0 += 1,
-        ));
-
-        let entity = world.spawn(A).id();
-        world.despawn(entity);
-        assert_eq!(2, world.resource::<R>().0);
-    }
-
-    #[test]
     fn observer_multiple_events_dynamic() {
         let mut world = World::new();
         world.init_resource::<R>();
@@ -644,6 +631,19 @@ mod tests {
                 .with_event(on_add)
                 .with_event(on_remove),
         );
+
+        let entity = world.spawn(A).id();
+        world.despawn(entity);
+        assert_eq!(2, world.resource::<R>().0);
+    }
+
+    #[test]
+    fn observer_multiple_events_dynamic_autoregister() {
+        let mut world = World::new();
+        world.init_resource::<R>();
+        world.spawn(Observer::new(
+            |_: Trigger<DynamicEvent<(OnAdd, OnRemove)>, A>, mut res: ResMut<R>| res.0 += 1,
+        ));
 
         let entity = world.spawn(A).id();
         world.despawn(entity);

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -12,7 +12,6 @@ pub use trigger_event::*;
 use crate::observer::entity_observer::ObservedBy;
 use crate::{archetype::ArchetypeFlags, system::IntoObserverSystem, world::*};
 use crate::{component::ComponentId, prelude::*, world::DeferredWorld};
-use bevy_ptr::Ptr;
 use bevy_utils::{EntityHashMap, HashMap};
 use std::marker::PhantomData;
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -612,14 +612,16 @@ mod tests {
                 Or2::B(Bar(v)) => assert!(*v),
             }
         });
-        world.flush(); // TODO: should we auto-flush after observe?
+        // TODO: ideally this flush is not necessary, but right now observe() returns WorldEntityMut
+        // and therefore does not automatically flush.
+        world.flush();
         world.trigger(Foo(5));
         world.trigger(Bar(true));
         assert_eq!(2, world.resource::<R>().0);
     }
 
     #[test]
-    fn observer_multiple_events_untyped() {
+    fn observer_multiple_events_static_untyped() {
         let mut world = World::new();
         world.init_resource::<R>();
         world.spawn(Observer::new(
@@ -632,7 +634,7 @@ mod tests {
     }
 
     #[test]
-    fn observer_multiple_events_unsafe() {
+    fn observer_multiple_events_dynamic_untyped() {
         let mut world = World::new();
         world.init_resource::<R>();
         let on_add = world.init_component::<OnAdd>();

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -638,19 +638,6 @@ mod tests {
     }
 
     #[test]
-    fn observer_multiple_events_dynamic_autoregister() {
-        let mut world = World::new();
-        world.init_resource::<R>();
-        world.spawn(Observer::new(
-            |_: Trigger<DynamicEvent<(OnAdd, OnRemove)>, A>, mut res: ResMut<R>| res.0 += 1,
-        ));
-
-        let entity = world.spawn(A).id();
-        world.despawn(entity);
-        assert_eq!(2, world.resource::<R>().0);
-    }
-
-    #[test]
     fn observer_multiple_events_semidynamic() {
         let mut world = World::new();
         world.init_resource::<R>();
@@ -666,24 +653,6 @@ mod tests {
             )
             .with_event(on_remove),
         );
-
-        let entity = world.spawn(A).id();
-        world.despawn(entity);
-        assert_eq!(2, world.resource::<R>().0);
-    }
-
-    #[test]
-    fn observer_multiple_events_semidynamic_autoregister() {
-        let mut world = World::new();
-        world.init_resource::<R>();
-        world.spawn(Observer::new(
-            |trigger: Trigger<SemiDynamicEvent<OnAdd, OnRemove>, A>, mut res: ResMut<R>| {
-                match trigger.event() {
-                    Ok(_onadd) => res.assert_order(0),
-                    Err(_ptr) => res.assert_order(1),
-                };
-            },
-        ));
 
         let entity = world.spawn(A).id();
         world.despawn(entity);

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -1,6 +1,9 @@
 use crate::{
     component::{ComponentHooks, ComponentId, StorageType},
-    observer::{DynamicEventSafe, EventSet, ObserverDescriptor, ObserverTrigger},
+    observer::{
+        DynamicEvent, EventSet, ObserverDescriptor, ObserverTrigger, SemiDynamicEvent,
+        StaticEventSet,
+    },
     prelude::*,
     query::DebugCheckedUnwrap,
     system::{IntoObserverSystem, ObserverSystem},
@@ -307,7 +310,26 @@ impl<E: EventSet, B: Bundle> Observer<E, B> {
     }
 }
 
-impl<E: DynamicEventSafe, B: Bundle> Observer<E, B> {
+impl<Register, B: Bundle> Observer<DynamicEvent<Register>, B>
+where
+    DynamicEvent<Register>: EventSet,
+{
+    /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
+    /// is triggered.
+    ///
+    /// # Note
+    /// As opposed to [`Observer::with_event_unchecked`], this method is safe to use because no pointer casting is performed automatically.
+    /// That is left to the user to do manually.
+    pub fn with_event(self, event: ComponentId) -> Self {
+        // SAFETY: UntypedEvent<E> itself does not perform any unsafe operations (like casting), so this is safe.
+        unsafe { self.with_event_unchecked(event) }
+    }
+}
+
+impl<Static: StaticEventSet, Register, B: Bundle> Observer<SemiDynamicEvent<Static, Register>, B>
+where
+    SemiDynamicEvent<Static, Register>: EventSet,
+{
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.
     ///
@@ -400,7 +422,8 @@ fn observer_system_runner<E: EventSet, B: Bundle>(
     // SAFETY: We have immutable access to the world from the passed in DeferredWorld
     let world_ref = unsafe { world.world() };
     // SAFETY: Observer was triggered with an event in the set of events it observes, so it must be convertible to E
-    let Some(event) = (unsafe { E::unchecked_cast(world_ref, &observer_trigger, ptr) }) else {
+    // We choose to use unchecked_cast over the safe cast method to avoid the overhead of matching in the single event type case (which is the common case).
+    let Ok(event) = (unsafe { E::unchecked_cast(world_ref, &observer_trigger, ptr) }) else {
         // This branch is only ever hit if the user called Observer::with_event_unchecked with a component ID not matching the event set E,
         // EXCEPT when the event set is a singular event type, in which case the event will always match.
         // This is a user error and should be logged.

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -385,7 +385,9 @@ fn observer_system_runner<E: EventSet, B: Bundle>(
     state.last_trigger_id = last_trigger;
 
     // SAFETY: We have immutable access to the world from the passed in DeferredWorld
-    let Some(event) = E::checked_cast(unsafe { world.world() }, &observer_trigger, ptr) else {
+    let world_ref = unsafe { world.world() };
+    // SAFETY: Caller ensures `ptr` is castable to `&mut T`, or the function will check it itself. TODO: can we revert this to a safe function?
+    let Some(event) = (unsafe { E::checked_cast(world_ref, &observer_trigger, ptr) }) else {
         return;
     };
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -310,10 +310,7 @@ impl<E: EventSet, B: Bundle> Observer<E, B> {
     }
 }
 
-impl<Register, B: Bundle> Observer<DynamicEvent<Register>, B>
-where
-    DynamicEvent<Register>: EventSet,
-{
+impl<B: Bundle> Observer<DynamicEvent, B> {
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.
     ///
@@ -326,10 +323,7 @@ where
     }
 }
 
-impl<Static: StaticEventSet, Register, B: Bundle> Observer<SemiDynamicEvent<Static, Register>, B>
-where
-    SemiDynamicEvent<Static, Register>: EventSet,
-{
+impl<Static: StaticEventSet, B: Bundle> Observer<SemiDynamicEvent<Static>, B> {
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.
     ///

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::{ComponentHooks, ComponentId, StorageType},
-    observer::{EventSet, ObserverDescriptor, ObserverTrigger, UntypedEvent},
+    observer::{DynamicEventSafe, EventSet, ObserverDescriptor, ObserverTrigger},
     prelude::*,
     query::DebugCheckedUnwrap,
     system::{IntoObserverSystem, ObserverSystem},
@@ -307,10 +307,7 @@ impl<E: EventSet, B: Bundle> Observer<E, B> {
     }
 }
 
-impl<E, B: Bundle> Observer<UntypedEvent<E>, B>
-where
-    UntypedEvent<E>: EventSet,
-{
+impl<E: DynamicEventSafe, B: Bundle> Observer<E, B> {
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.
     ///

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::{ComponentHooks, ComponentId, StorageType},
-    observer::{EventSet, ObserverDescriptor, ObserverTrigger, Untyped},
+    observer::{EventSet, ObserverDescriptor, ObserverTrigger, UntypedEvent},
     prelude::*,
     query::DebugCheckedUnwrap,
     system::{IntoObserverSystem, ObserverSystem},
@@ -307,9 +307,9 @@ impl<E: EventSet, B: Bundle> Observer<E, B> {
     }
 }
 
-impl<E, B: Bundle> Observer<Untyped<E>, B>
+impl<E, B: Bundle> Observer<UntypedEvent<E>, B>
 where
-    Untyped<E>: EventSet,
+    UntypedEvent<E>: EventSet,
 {
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -407,7 +407,14 @@ fn observer_system_runner<E: EventSet, B: Bundle>(
         // This branch is only ever hit if the user called Observer::with_event_unchecked with a component ID not matching the event set E,
         // EXCEPT when the event set is a singular event type, in which case the event will always match.
         // This is a user error and should be logged.
-        bevy_utils::tracing::error!("Observer was triggered with an event that does not match the event set. Did you call Observer::with_event_unchecked with the wrong ID? Id: {:?} Set: {:?}", observer_trigger.event_type, std::any::type_name::<E>());
+        bevy_utils::tracing::error!(
+            "Observer was triggered with an event that does not match the event set. \
+             Did you call Observer::with_event_unchecked with the wrong ID? \
+             Observer: {:?} Event: {:?} Set: {:?}",
+            observer_trigger.observer,
+            observer_trigger.event_type,
+            std::any::type_name::<E>()
+        );
         return;
     };
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -301,7 +301,7 @@ impl<E: EventSet, B: Bundle> Observer<E, B> {
     /// # Safety
     /// The type of the `event` [`ComponentId`] _must_ match the actual value
     /// of the event passed into the observer system.
-    pub unsafe fn with_event(mut self, event: ComponentId) -> Self {
+    pub unsafe fn with_event_unchecked(mut self, event: ComponentId) -> Self {
         self.descriptor.events.push(event);
         self
     }
@@ -314,8 +314,10 @@ where
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.
     ///
-    /// As opposed to [`Observer::with_event`], this method is safe to use because it does not cast any pointers automatically.
-    pub fn with_event_safe(mut self, event: ComponentId) -> Self {
+    /// # Note
+    /// As opposed to [`Observer::with_event_unchecked`], this method is safe to use because no pointer casting is performed automatically.
+    /// That is left to the user to do manually.
+    pub fn with_event(mut self, event: ComponentId) -> Self {
         self.descriptor.events.push(event);
         self
     }

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -404,6 +404,10 @@ fn observer_system_runner<E: EventSet, B: Bundle>(
     let world_ref = unsafe { world.world() };
     // SAFETY: Observer was triggered with an event in the set of events it observes, so it must be convertible to E
     let Some(event) = (unsafe { E::unchecked_cast(world_ref, &observer_trigger, ptr) }) else {
+        // This branch is only ever hit if the user called Observer::with_event_unchecked with a component ID not matching the event set E,
+        // EXCEPT when the event set is a singular event type, in which case the event will always match.
+        // This is a user error and should be logged.
+        bevy_utils::tracing::error!("Observer was triggered with an event that does not match the event set. Did you call Observer::with_event_unchecked with the wrong ID? Id: {:?} Set: {:?}", observer_trigger.event_type, std::any::type_name::<E>());
         return;
     };
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -425,7 +425,7 @@ fn observer_system_runner<E: EventSet, B: Bundle>(
     // We choose to use unchecked_cast over the safe cast method to avoid the overhead of matching in the single event type case (which is the common case).
     let Ok(event) = (unsafe { E::unchecked_cast(world_ref, &observer_trigger, ptr) }) else {
         // This branch is only ever hit if the user called Observer::with_event_unchecked with a component ID not matching the event set E,
-        // EXCEPT when the event set is a singular event type, in which case the event will always match.
+        // EXCEPT when the event set is a singular event type, in which case the cast will always succeed.
         // This is a user error and should be logged.
         bevy_utils::tracing::error!(
             "Observer was triggered with an event that does not match the event set. \

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -386,8 +386,9 @@ fn observer_system_runner<E: EventSet, B: Bundle>(
 
     // SAFETY: We have immutable access to the world from the passed in DeferredWorld
     let world_ref = unsafe { world.world() };
-    // SAFETY: Caller ensures `ptr` is castable to `&mut T`, or the function will check it itself. TODO: can we revert this to a safe function?
-    let Some(event) = (unsafe { E::checked_cast(world_ref, &observer_trigger, ptr) }) else {
+    // TODO: should we check E::matches here?
+    // SAFETY: Caller ensures `ptr` is castable to `&mut T`, or the function will check it itself.
+    let Some(event) = (unsafe { E::cast(world_ref, &observer_trigger, ptr) }) else {
         return;
     };
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -317,9 +317,9 @@ where
     /// # Note
     /// As opposed to [`Observer::with_event_unchecked`], this method is safe to use because no pointer casting is performed automatically.
     /// That is left to the user to do manually.
-    pub fn with_event(mut self, event: ComponentId) -> Self {
-        self.descriptor.events.push(event);
-        self
+    pub fn with_event(self, event: ComponentId) -> Self {
+        // SAFETY: UntypedEvent<E> itself does not perform any unsafe operations (like casting), so this is safe.
+        unsafe { self.with_event_unchecked(event) }
     }
 }
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -298,24 +298,10 @@ impl<E: EventSet, B: Bundle> Observer<E, B> {
 
     /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
     /// is triggered.
-    /// # Safety
-    /// The type of the `event` [`ComponentId`] _must_ match the actual value
-    /// of the event passed into the observer system.
-    pub unsafe fn with_event(mut self, event: ComponentId) -> Self {
-        self.descriptor.events.push(event);
-        self
-    }
-}
-
-impl<E, B: Bundle> Observer<Untyped<E>, B>
-where
-    Untyped<E>: EventSet,
-{
-    /// Observe the given `event`. This will cause the [`Observer`] to run whenever an event with the given [`ComponentId`]
-    /// is triggered.
     ///
-    /// As opposed to [`Observer::with_event`], this method is safe to use because it does not cast the event to a specific type.
-    pub fn with_event_safe(mut self, event: ComponentId) -> Self {
+    /// Note that for any event types that are not matched by `E`, the observer will not be triggered.
+    /// Use [`Untyped<()>`] to match all events added through this method.
+    pub fn with_event(mut self, event: ComponentId) -> Self {
         self.descriptor.events.push(event);
         self
     }

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -321,7 +321,7 @@ where
     /// As opposed to [`Observer::with_event_unchecked`], this method is safe to use because no pointer casting is performed automatically.
     /// That is left to the user to do manually.
     pub fn with_event(self, event: ComponentId) -> Self {
-        // SAFETY: UntypedEvent<E> itself does not perform any unsafe operations (like casting), so this is safe.
+        // SAFETY: DynamicEvent itself does not perform any unsafe operations (like casting), so this is safe.
         unsafe { self.with_event_unchecked(event) }
     }
 }
@@ -334,10 +334,11 @@ where
     /// is triggered.
     ///
     /// # Note
-    /// As opposed to [`Observer::with_event_unchecked`], this method is safe to use because no pointer casting is performed automatically.
-    /// That is left to the user to do manually.
+    /// As opposed to [`Observer::with_event_unchecked`], this method is safe to use because no pointer casting is performed automatically
+    /// on event types outside its statically-known set of. That is left to the user to do manually.
     pub fn with_event(self, event: ComponentId) -> Self {
-        // SAFETY: UntypedEvent<E> itself does not perform any unsafe operations (like casting), so this is safe.
+        // SAFETY: SemiDynamicEvent itself does not perform any unsafe operations (like casting)
+        // for event types outside its statically-known set, so this is safe.
         unsafe { self.with_event_unchecked(event) }
     }
 }

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -82,6 +82,7 @@ unsafe impl<E: Event> EventSet for E {
     }
 }
 
+// SAFETY: Inherits the safety of the inner event type.
 unsafe impl<A: EventSet> EventSet for (A,) {
     type Item<'trigger> = A::Item<'trigger>;
     type ReadOnlyItem<'trigger> = A::ReadOnlyItem<'trigger>;
@@ -205,6 +206,7 @@ impl_event_set!(
 pub struct UntypedEvent<E = ()>(std::marker::PhantomData<E>);
 
 /// An [`EventSet`] that matches the specified event type(s), but does not cast the pointer.
+// SAFETY: Performs no unsafe operations, returns the pointer as is.
 unsafe impl<E: EventSet> EventSet for UntypedEvent<E> {
     type Item<'trigger> = PtrMut<'trigger>;
     type ReadOnlyItem<'trigger> = Ptr<'trigger>;
@@ -237,6 +239,7 @@ unsafe impl<E: EventSet> EventSet for UntypedEvent<E> {
 }
 
 /// An [`EventSet`] that matches any event type.
+// SAFETY: Performs no unsafe operations, returns the pointer as is.
 unsafe impl EventSet for UntypedEvent<()> {
     type Item<'trigger> = PtrMut<'trigger>;
     type ReadOnlyItem<'trigger> = Ptr<'trigger>;

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -126,7 +126,7 @@ macro_rules! impl_event_set {
         }
 
         // SAFETY: All event types have a component id registered in `init_components`,
-        // and `cast` calls `matches` before casting the pointer to one of the event types.
+        // and `unchecked_cast` calls `matches` before casting to one of the inner event sets.
         unsafe impl<$($P: EventSet),*> EventSet for ($($P,)*) {
             type Item<'trigger> = $Or<$($P::Item<'trigger>),*>;
             type ReadOnlyItem<'trigger> = $Or<$($P::ReadOnlyItem<'trigger>),*>;

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -308,6 +308,7 @@ impl_event_set!(
 );
 
 /// A wrapper around an [`EventSet`] that foregoes safety checks and casting, and passes the pointer as is.
+/// This is useful for observers that do not need to access the event data, or need to do so dynamically.
 pub struct UntypedEvent<E = ()>(std::marker::PhantomData<E>);
 
 /// An [`EventSet`] that matches the specified event type(s), but does not cast the pointer.
@@ -325,7 +326,7 @@ unsafe impl<E: EventSet> EventSet for UntypedEvent<E> {
     }
 
     fn matches(world: &World, observer_trigger: &ObserverTrigger) -> bool {
-        E::matches(world, observer_trigger)
+        true
     }
 
     fn init_components(world: &mut World, ids: impl FnMut(ComponentId)) {

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -374,3 +374,160 @@ unsafe impl EventSet for UntypedEvent<()> {
         item.as_ref()
     }
 }
+
+/// This trait is implemented on [`EventSet`]s where it is safe to call
+/// [`Observer::with_event`](crate::observer::Observer::with_event).
+pub unsafe trait DynamicEventSafe: EventSet {}
+
+unsafe impl<E: EventSet> DynamicEventSafe for UntypedEvent<E> {}
+unsafe impl DynamicEventSafe for UntypedEvent<()> {}
+unsafe impl<A: DynamicEventSafe> DynamicEventSafe for (A,) {}
+unsafe impl<A: EventSet, B: DynamicEventSafe> DynamicEventSafe for (A, B) {}
+unsafe impl<A: EventSet, B: EventSet, C: DynamicEventSafe> DynamicEventSafe for (A, B, C) {}
+unsafe impl<A: EventSet, B: EventSet, C: EventSet, D: DynamicEventSafe> DynamicEventSafe
+    for (A, B, C, D)
+{
+}
+unsafe impl<A: EventSet, B: EventSet, C: EventSet, D: EventSet, E: DynamicEventSafe>
+    DynamicEventSafe for (A, B, C, D, E)
+{
+}
+unsafe impl<A: EventSet, B: EventSet, C: EventSet, D: EventSet, E: EventSet, F: DynamicEventSafe>
+    DynamicEventSafe for (A, B, C, D, E, F)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: EventSet,
+        J: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: EventSet,
+        J: EventSet,
+        K: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: EventSet,
+        J: EventSet,
+        K: EventSet,
+        L: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: EventSet,
+        J: EventSet,
+        K: EventSet,
+        L: EventSet,
+        M: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L, M)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: EventSet,
+        J: EventSet,
+        K: EventSet,
+        L: EventSet,
+        M: EventSet,
+        N: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+{
+}
+unsafe impl<
+        A: EventSet,
+        B: EventSet,
+        C: EventSet,
+        D: EventSet,
+        E: EventSet,
+        F: EventSet,
+        G: EventSet,
+        H: EventSet,
+        I: EventSet,
+        J: EventSet,
+        K: EventSet,
+        L: EventSet,
+        M: EventSet,
+        N: EventSet,
+        O: DynamicEventSafe,
+    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+{
+}

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -325,7 +325,7 @@ unsafe impl<E: EventSet> EventSet for UntypedEvent<E> {
         Some(ptr)
     }
 
-    fn matches(world: &World, observer_trigger: &ObserverTrigger) -> bool {
+    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
         true
     }
 

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -1,0 +1,197 @@
+use bevy_ptr::PtrMut;
+
+use crate::component::ComponentId;
+use crate::event::Event;
+use crate::observer::ObserverTrigger;
+use crate::world::World;
+
+/// A set of events that can trigger an observer.
+///
+/// # Safety
+///
+/// Implementor must ensure that [`checked_cast`] and [`init_components`] obey the following:
+/// - Each event type must have a component id registered in [`init_components`].
+/// - [`checked_cast`] must check that the component id matches the event type in order to safely cast a pointer to the output type.
+///
+pub unsafe trait EventSet: 'static {
+    /// The output type that will be passed to the observer.
+    type Out<'trigger>;
+    /// The read-only variant of the output type.
+    type OutReadonly<'trigger>;
+
+    /// Safely casts the pointer to the output type, or a variant of it.
+    /// Returns `None` if the event type does not match.
+    fn checked_cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Option<Self::Out<'trigger>>;
+
+    /// Initialize the components required by the event set.
+    fn init_components(world: &mut World, ids: impl FnMut(ComponentId));
+}
+
+unsafe impl<A: Event> EventSet for A {
+    type Out<'trigger> = &'trigger mut A;
+    type OutReadonly<'trigger> = &'trigger A;
+
+    fn checked_cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Option<Self::Out<'trigger>> {
+        <(A,) as EventSet>::checked_cast(world, observer_trigger, ptr)
+    }
+
+    fn init_components(world: &mut World, ids: impl FnMut(ComponentId)) {
+        <(A,) as EventSet>::init_components(world, ids)
+    }
+}
+
+unsafe impl<A: Event> EventSet for (A,) {
+    type Out<'trigger> = &'trigger mut A;
+    type OutReadonly<'trigger> = &'trigger A;
+
+    fn checked_cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Option<Self::Out<'trigger>> {
+        let Some(a_id) = world.component_id::<A>() else {
+            return None;
+        };
+
+        if a_id == observer_trigger.event_type {
+            // SAFETY: We just checked that the component id matches the event type
+            let a = unsafe { ptr.deref_mut() };
+            Some(a)
+        } else {
+            None
+        }
+    }
+
+    fn init_components(world: &mut World, mut ids: impl FnMut(ComponentId)) {
+        let a_id = world.init_component::<A>();
+        ids(a_id);
+    }
+}
+
+/// The output type of an observer that observes two different event types.
+pub enum Or2<A, B> {
+    /// The first event type.
+    A(A),
+    /// The second event type.
+    B(B),
+}
+
+impl<'a, A, B> From<&'a Or2<&'a mut A, &'a mut B>> for Or2<&'a A, &'a B> {
+    fn from(or: &'a Or2<&'a mut A, &'a mut B>) -> Self {
+        match or {
+            Or2::A(a) => Or2::A(a),
+            Or2::B(b) => Or2::B(b),
+        }
+    }
+}
+
+unsafe impl<A: Event, B: Event> EventSet for (A, B) {
+    type Out<'trigger> = Or2<&'trigger mut A, &'trigger mut B>;
+    type OutReadonly<'trigger> = Or2<&'trigger A, &'trigger B>;
+
+    fn checked_cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Option<Self::Out<'trigger>> {
+        let Some(a_id) = world.component_id::<A>() else {
+            return None;
+        };
+        let Some(b_id) = world.component_id::<B>() else {
+            return None;
+        };
+
+        if a_id == observer_trigger.event_type {
+            // SAFETY: We just checked that the component id matches the event type
+            let a = unsafe { ptr.deref_mut() };
+            Some(Or2::A(a))
+        } else if b_id == observer_trigger.event_type {
+            // SAFETY: We just checked that the component id matches the event type
+            let b = unsafe { ptr.deref_mut() };
+            Some(Or2::B(b))
+        } else {
+            None
+        }
+    }
+
+    fn init_components(world: &mut World, mut ids: impl FnMut(ComponentId)) {
+        let a_id = world.init_component::<A>();
+        let b_id = world.init_component::<B>();
+        ids(a_id);
+        ids(b_id);
+    }
+}
+
+/// The output type of an observer that observes three different event types.
+pub enum Or3<A, B, C> {
+    /// The first event type.
+    A(A),
+    /// The second event type.
+    B(B),
+    /// The third event type.
+    C(C),
+}
+
+impl<'a, A, B, C> From<&'a Or3<&'a mut A, &'a mut B, &'a mut C>> for Or3<&'a A, &'a B, &'a C> {
+    fn from(or: &'a Or3<&'a mut A, &'a mut B, &'a mut C>) -> Self {
+        match or {
+            Or3::A(a) => Or3::A(a),
+            Or3::B(b) => Or3::B(b),
+            Or3::C(c) => Or3::C(c),
+        }
+    }
+}
+
+unsafe impl<A: Event, B: Event, C: Event> EventSet for (A, B, C) {
+    type Out<'trigger> = Or3<&'trigger mut A, &'trigger mut B, &'trigger mut C>;
+    type OutReadonly<'trigger> = Or3<&'trigger A, &'trigger B, &'trigger C>;
+
+    fn checked_cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Option<Self::Out<'trigger>> {
+        let Some(a_id) = world.component_id::<A>() else {
+            return None;
+        };
+        let Some(b_id) = world.component_id::<B>() else {
+            return None;
+        };
+        let Some(c_id) = world.component_id::<C>() else {
+            return None;
+        };
+
+        if a_id == observer_trigger.event_type {
+            // SAFETY: We just checked that the component id matches the event type
+            let a = unsafe { ptr.deref_mut() };
+            Some(Or3::A(a))
+        } else if b_id == observer_trigger.event_type {
+            // SAFETY: We just checked that the component id matches the event type
+            let b = unsafe { ptr.deref_mut() };
+            Some(Or3::B(b))
+        } else if c_id == observer_trigger.event_type {
+            // SAFETY: We just checked that the component id matches the event type
+            let c = unsafe { ptr.deref_mut() };
+            Some(Or3::C(c))
+        } else {
+            None
+        }
+    }
+
+    fn init_components(world: &mut World, mut ids: impl FnMut(ComponentId)) {
+        let a_id = world.init_component::<A>();
+        let b_id = world.init_component::<B>();
+        let c_id = world.init_component::<C>();
+        ids(a_id);
+        ids(b_id);
+        ids(c_id);
+    }
+}

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -9,9 +9,9 @@ use crate::world::World;
 ///
 /// # Safety
 ///
-/// Implementor must ensure that [`checked_cast`] and [`init_components`] obey the following:
-/// - Each event type must have a component id registered in [`init_components`].
-/// - [`checked_cast`] must check that the component id matches the event type in order to safely cast a pointer to the output type.
+/// Implementor must ensure that:
+/// - [`EventSet::init_components`] must register a component id for each event type in the set.
+/// - [`EventSet::matches`] must return `true` if and only if the event type is in the set.
 ///
 pub unsafe trait EventSet: 'static {
     /// The output type that will be passed to the observer.

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -231,6 +231,7 @@ impl_event_set!(
 /// A wrapper around an [`EventSet`] that foregoes safety checks and casting.
 pub struct Untyped<E>(std::marker::PhantomData<E>);
 
+/// An [`EventSet`] that matches the specified event type(s), but does not cast the pointer.
 unsafe impl<E: EventSet> EventSet for Untyped<E> {
     type Item<'trigger> = PtrMut<'trigger>;
     type ReadOnlyItem<'trigger> = Ptr<'trigger>;
@@ -243,8 +244,8 @@ unsafe impl<E: EventSet> EventSet for Untyped<E> {
         Some(ptr)
     }
 
-    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
-        true
+    fn matches(world: &World, observer_trigger: &ObserverTrigger) -> bool {
+        E::matches(world, observer_trigger)
     }
 
     fn init_components(world: &mut World, ids: impl FnMut(ComponentId)) {
@@ -266,6 +267,7 @@ unsafe impl<E: EventSet> EventSet for Untyped<E> {
     }
 }
 
+/// An [`EventSet`] that matches any event type.
 unsafe impl EventSet for Untyped<()> {
     type Item<'trigger> = PtrMut<'trigger>;
     type ReadOnlyItem<'trigger> = Ptr<'trigger>;

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -82,7 +82,7 @@ unsafe impl<E: Event> EventSet for E {
     }
 }
 
-// SAFETY: Inherits the safety of the inner event type.
+// SAFETY: Forwards to the inner event type, and inherits its safety properties.
 unsafe impl<A: EventSet> EventSet for (A,) {
     type Item<'trigger> = A::Item<'trigger>;
     type ReadOnlyItem<'trigger> = A::ReadOnlyItem<'trigger>;
@@ -201,6 +201,111 @@ impl_event_set!(
     (G, g),
     (H, h)
 );
+impl_event_set!(
+    Or9,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i)
+);
+impl_event_set!(
+    Or10,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i),
+    (J, j)
+);
+impl_event_set!(
+    Or11,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i),
+    (J, j),
+    (K, k)
+);
+impl_event_set!(
+    Or12,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i),
+    (J, j),
+    (K, k),
+    (L, l)
+);
+impl_event_set!(
+    Or13,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i),
+    (J, j),
+    (K, k),
+    (L, l),
+    (M, m)
+);
+impl_event_set!(
+    Or14,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i),
+    (J, j),
+    (K, k),
+    (L, l),
+    (M, m),
+    (N, n)
+);
+impl_event_set!(
+    Or15,
+    (A, a),
+    (B, b),
+    (C, c),
+    (D, d),
+    (E, e),
+    (F, f),
+    (G, g),
+    (H, h),
+    (I, i),
+    (J, j),
+    (K, k),
+    (L, l),
+    (M, m),
+    (N, n),
+    (O, o)
+);
 
 /// A wrapper around an [`EventSet`] that foregoes safety checks and casting, and passes the pointer as is.
 pub struct UntypedEvent<E = ()>(std::marker::PhantomData<E>);
@@ -238,7 +343,7 @@ unsafe impl<E: EventSet> EventSet for UntypedEvent<E> {
     }
 }
 
-/// An [`EventSet`] that matches any event type.
+/// An [`EventSet`] that matches any event type, but does not cast the pointer.
 // SAFETY: Performs no unsafe operations, returns the pointer as is.
 unsafe impl EventSet for UntypedEvent<()> {
     type Item<'trigger> = PtrMut<'trigger>;

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -228,7 +228,7 @@ impl_event_set!(
     (H, h)
 );
 
-/// A wrapper around an [`EventSet`] that foregoes safety checks and casting.
+/// A wrapper around an [`EventSet`] that foregoes safety checks and casting, and passes the pointer as is.
 pub struct Untyped<E>(std::marker::PhantomData<E>);
 
 /// An [`EventSet`] that matches the specified event type(s), but does not cast the pointer.

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -21,7 +21,7 @@ pub unsafe trait EventSet: 'static {
 
     /// Safely casts the pointer to the output type, or a variant of it.
     /// Returns `None` if the event type does not match.
-    fn checked_cast<'trigger>(
+    unsafe fn checked_cast<'trigger>(
         world: &World,
         observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
@@ -36,7 +36,7 @@ unsafe impl<A: Event> EventSet for A {
     type Out<'trigger> = &'trigger mut A;
     type OutReadonly<'trigger> = &'trigger A;
 
-    fn checked_cast<'trigger>(
+    unsafe fn checked_cast<'trigger>(
         world: &World,
         observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
@@ -55,20 +55,13 @@ unsafe impl<A: Event> EventSet for (A,) {
     type Out<'trigger> = &'trigger mut A;
     type OutReadonly<'trigger> = &'trigger A;
 
-    fn checked_cast<'trigger>(
-        world: &World,
-        observer_trigger: &ObserverTrigger,
+    unsafe fn checked_cast<'trigger>(
+        _world: &World,
+        _observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
     ) -> Option<Self::Out<'trigger>> {
-        let a_id = world.component_id::<A>()?;
-
-        if a_id == observer_trigger.event_type {
-            // SAFETY: We just checked that the component id matches the event type
-            let a = unsafe { ptr.deref_mut() };
-            Some(a)
-        } else {
-            None
-        }
+        // SAFETY: Caller must ensure that the component id matches the event type
+        Some(unsafe { ptr.deref_mut() })
     }
 
     fn init_components(world: &mut World, mut ids: impl FnMut(ComponentId)) {
@@ -91,7 +84,7 @@ unsafe impl<A: Event, B: Event> EventSet for (A, B) {
     type Out<'trigger> = Or2<&'trigger mut A, &'trigger mut B>;
     type OutReadonly<'trigger> = Or2<&'trigger A, &'trigger B>;
 
-    fn checked_cast<'trigger>(
+    unsafe fn checked_cast<'trigger>(
         world: &World,
         observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
@@ -136,7 +129,7 @@ unsafe impl<A: Event, B: Event, C: Event> EventSet for (A, B, C) {
     type Out<'trigger> = Or3<&'trigger mut A, &'trigger mut B, &'trigger mut C>;
     type OutReadonly<'trigger> = Or3<&'trigger A, &'trigger B, &'trigger C>;
 
-    fn checked_cast<'trigger>(
+    unsafe fn checked_cast<'trigger>(
         world: &World,
         observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -281,6 +281,7 @@ unsafe impl<A: StaticEventSet> EventSet for (A,) {
     }
 }
 
+// SAFETY: The inner event set is a static event set.
 unsafe impl<A: StaticEventSet> StaticEventSet for (A,) {}
 
 macro_rules! impl_event_set {

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -11,7 +11,7 @@ use crate::world::World;
 ///
 /// Implementor must ensure that:
 /// - [`EventSet::init_components`] must register a component id for each event type in the set.
-/// - [`EventSet::matches`] must return `true` if and only if the event type is in the set.
+/// - [`EventSet::matches`] must return `true` if the event type is in the set, or if the set matches any event type.
 ///
 pub unsafe trait EventSet: 'static {
     /// The output type that will be passed to the observer.
@@ -19,16 +19,30 @@ pub unsafe trait EventSet: 'static {
     /// The read-only variant of the output type.
     type ReadOnlyItem<'trigger>: Copy;
 
+    /// Safely casts a pointer to the output type, checking if the event type matches this event set.
+    fn cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        if Self::matches(world, observer_trigger) {
+            // SAFETY: We have checked that the event component id matches the event type
+            unsafe { Self::unchecked_cast(world, observer_trigger, ptr) }
+        } else {
+            Err(ptr)
+        }
+    }
+
     /// Casts a pointer to the output type.
     ///
     /// # Safety
     ///
-    /// Caller must ensure that the component id [`EventSet::matches`] this event set before calling this function.
+    /// Caller must ensure that the event component id [`matches`](EventSet::matches) this event set before calling this function.
     unsafe fn unchecked_cast<'trigger>(
         world: &World,
         observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
-    ) -> Option<Self::Item<'trigger>>;
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>>;
 
     /// Checks if the event type matches the observer trigger.
     fn matches(world: &World, observer_trigger: &ObserverTrigger) -> bool;
@@ -45,8 +59,17 @@ pub unsafe trait EventSet: 'static {
     ) -> Self::ReadOnlyItem<'short>;
 }
 
+/// An [`EventSet`] that matches a statically pre-defined set of event types.
+///
+/// # Safety
+///
+/// Implementors must ensure that [`matches`](EventSet::matches)
+/// returns `true` if and only if the event component id matches the event type,
+/// AND does not match any other event type.
+pub unsafe trait StaticEventSet: EventSet {}
+
 // SAFETY: The event type has a component id registered in `init_components`,
-// and `matches` checks that the component id matches the event type.
+// and `matches` checks that the event component id matches the event type.
 unsafe impl<E: Event> EventSet for E {
     type Item<'trigger> = &'trigger mut E;
     type ReadOnlyItem<'trigger> = &'trigger E;
@@ -55,9 +78,9 @@ unsafe impl<E: Event> EventSet for E {
         _world: &World,
         _observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
-    ) -> Option<Self::Item<'trigger>> {
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
         // SAFETY: Caller must ensure that the component id matches the event type
-        Some(unsafe { ptr.deref_mut() })
+        Ok(unsafe { ptr.deref_mut() })
     }
 
     fn matches(world: &World, observer_trigger: &ObserverTrigger) -> bool {
@@ -82,16 +105,160 @@ unsafe impl<E: Event> EventSet for E {
     }
 }
 
-// SAFETY: Forwards to the inner event type, and inherits its safety properties.
-unsafe impl<A: EventSet> EventSet for (A,) {
-    type Item<'trigger> = A::Item<'trigger>;
-    type ReadOnlyItem<'trigger> = A::ReadOnlyItem<'trigger>;
+// SAFETY: The event type is a statically known type.
+unsafe impl<E: Event> StaticEventSet for E {}
+
+/// An [`EventSet`] that matches any event type, but does not cast the pointer. Instead, it returns the pointer as is.
+/// This is useful for observers that do not need to access the event data, or need to do so dynamically.
+pub struct DynamicEvent<Register = ()>(std::marker::PhantomData<Register>);
+
+// SAFETY: Performs no unsafe operations, returns the pointer as is.
+unsafe impl<Register: StaticEventSet> EventSet for DynamicEvent<Register> {
+    type Item<'trigger> = PtrMut<'trigger>;
+    type ReadOnlyItem<'trigger> = Ptr<'trigger>;
+
+    fn cast<'trigger>(
+        _world: &World,
+        _observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        Ok(ptr)
+    }
+
+    unsafe fn unchecked_cast<'trigger>(
+        _world: &World,
+        _observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        Ok(ptr)
+    }
+
+    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
+        true
+    }
+
+    fn init_components(world: &mut World, ids: impl FnMut(ComponentId)) {
+        Register::init_components(world, ids);
+    }
+
+    fn shrink<'long: 'short, 'short>(item: &'short mut Self::Item<'long>) -> Self::Item<'short> {
+        item.reborrow()
+    }
+
+    fn shrink_readonly<'long: 'short, 'short>(
+        item: &'short Self::Item<'long>,
+    ) -> Self::ReadOnlyItem<'short> {
+        item.as_ref()
+    }
+}
+
+// SAFETY: Performs no unsafe operations, returns the pointer as is.
+unsafe impl EventSet for DynamicEvent<()> {
+    type Item<'trigger> = PtrMut<'trigger>;
+    type ReadOnlyItem<'trigger> = Ptr<'trigger>;
+
+    fn cast<'trigger>(
+        _world: &World,
+        _observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        Ok(ptr)
+    }
+
+    unsafe fn unchecked_cast<'trigger>(
+        _world: &World,
+        _observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        Ok(ptr)
+    }
+
+    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
+        true
+    }
+
+    fn init_components(_world: &mut World, _ids: impl FnMut(ComponentId)) {}
+
+    fn shrink<'long: 'short, 'short>(item: &'short mut Self::Item<'long>) -> Self::Item<'short> {
+        item.reborrow()
+    }
+
+    fn shrink_readonly<'long: 'short, 'short>(
+        item: &'short Self::Item<'long>,
+    ) -> Self::ReadOnlyItem<'short> {
+        item.as_ref()
+    }
+}
+
+/// An [`EventSet`] that matches a statically pre-defined set of event types and casts the pointer to the event type,
+/// or returns the pointer as is if the event type does not match.
+pub struct SemiDynamicEvent<Static: StaticEventSet, Register = ()>(
+    std::marker::PhantomData<(Static, Register)>,
+);
+
+// SAFETY: No unsafe operations are performed. The checked cast variant is used for the static event type.
+unsafe impl<Static: StaticEventSet, Register> EventSet for SemiDynamicEvent<Static, Register>
+where
+    DynamicEvent<Register>: EventSet,
+{
+    type Item<'trigger> = Result<Static::Item<'trigger>, PtrMut<'trigger>>;
+    type ReadOnlyItem<'trigger> = Result<Static::ReadOnlyItem<'trigger>, Ptr<'trigger>>;
 
     unsafe fn unchecked_cast<'trigger>(
         world: &World,
         observer_trigger: &ObserverTrigger,
         ptr: PtrMut<'trigger>,
-    ) -> Option<Self::Item<'trigger>> {
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        match Static::cast(world, observer_trigger, ptr) {
+            Ok(item) => Ok(Ok(item)),
+            Err(ptr) => Ok(Err(ptr)),
+        }
+    }
+
+    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
+        true
+    }
+
+    fn init_components(world: &mut World, mut ids: impl FnMut(ComponentId)) {
+        Static::init_components(world, &mut ids);
+        DynamicEvent::<Register>::init_components(world, ids);
+    }
+
+    fn shrink<'long: 'short, 'short>(item: &'short mut Self::Item<'long>) -> Self::Item<'short> {
+        match item {
+            Ok(item) => Ok(Static::shrink(item)),
+            Err(ptr) => Err(ptr.reborrow()),
+        }
+    }
+
+    fn shrink_readonly<'long: 'short, 'short>(
+        item: &'short Self::Item<'long>,
+    ) -> Self::ReadOnlyItem<'short> {
+        match item {
+            Ok(item) => Ok(Static::shrink_readonly(item)),
+            Err(ptr) => Err(ptr.as_ref()),
+        }
+    }
+}
+
+// SAFETY: Forwards to the inner event type, and inherits its safety properties.
+unsafe impl<A: StaticEventSet> EventSet for (A,) {
+    type Item<'trigger> = A::Item<'trigger>;
+    type ReadOnlyItem<'trigger> = A::ReadOnlyItem<'trigger>;
+
+    fn cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+        A::cast(world, observer_trigger, ptr)
+    }
+
+    unsafe fn unchecked_cast<'trigger>(
+        world: &World,
+        observer_trigger: &ObserverTrigger,
+        ptr: PtrMut<'trigger>,
+    ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
         A::unchecked_cast(world, observer_trigger, ptr)
     }
 
@@ -114,6 +281,8 @@ unsafe impl<A: EventSet> EventSet for (A,) {
     }
 }
 
+unsafe impl<A: StaticEventSet> StaticEventSet for (A,) {}
+
 macro_rules! impl_event_set {
     ($Or:ident, $(($P:ident, $p:ident)),*) => {
         /// An output type of an observer that observes multiple event types.
@@ -127,27 +296,37 @@ macro_rules! impl_event_set {
 
         // SAFETY: All event types have a component id registered in `init_components`,
         // and `unchecked_cast` calls `matches` before casting to one of the inner event sets.
-        unsafe impl<$($P: EventSet),*> EventSet for ($($P,)*) {
+        unsafe impl<$($P: StaticEventSet),*> EventSet for ($($P,)*) {
             type Item<'trigger> = $Or<$($P::Item<'trigger>),*>;
             type ReadOnlyItem<'trigger> = $Or<$($P::ReadOnlyItem<'trigger>),*>;
+
+            fn cast<'trigger>(
+                world: &World,
+                observer_trigger: &ObserverTrigger,
+                ptr: PtrMut<'trigger>,
+            ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
+                // SAFETY: Each inner event set is checked in order for a match and then casted.
+                unsafe { Self::unchecked_cast(world, observer_trigger, ptr) }
+            }
 
             unsafe fn unchecked_cast<'trigger>(
                 world: &World,
                 observer_trigger: &ObserverTrigger,
                 ptr: PtrMut<'trigger>,
-            ) -> Option<Self::Item<'trigger>> {
+            ) -> Result<Self::Item<'trigger>, PtrMut<'trigger>> {
                 if false {
                     unreachable!();
                 }
                 $(
                     else if $P::matches(world, observer_trigger) {
-                        if let Some($p) = $P::unchecked_cast(world, observer_trigger, ptr) {
-                            return Some($Or::$P($p));
+                        match $P::unchecked_cast(world, observer_trigger, ptr) {
+                            Ok($p) => return Ok($Or::$P($p)),
+                            Err(ptr) => return Err(ptr),
                         }
                     }
                 )*
 
-                None
+                Err(ptr)
             }
 
             fn matches(world: &World, observer_trigger: &ObserverTrigger) -> bool {
@@ -181,353 +360,23 @@ macro_rules! impl_event_set {
                 }
             }
         }
+
+        // SAFETY: All inner event types are static event sets.
+        unsafe impl<$($P: StaticEventSet),*> StaticEventSet for ($($P,)*) {}
     };
 }
 
-impl_event_set!(Or2, (A, a), (B, b));
-impl_event_set!(Or3, (A, a), (B, b), (C, c));
-impl_event_set!(Or4, (A, a), (B, b), (C, c), (D, d));
-impl_event_set!(Or5, (A, a), (B, b), (C, c), (D, d), (E, e));
-impl_event_set!(Or6, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f));
-impl_event_set!(Or7, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g));
-impl_event_set!(
-    Or8,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h)
-);
-impl_event_set!(
-    Or9,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i)
-);
-impl_event_set!(
-    Or10,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i),
-    (J, j)
-);
-impl_event_set!(
-    Or11,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i),
-    (J, j),
-    (K, k)
-);
-impl_event_set!(
-    Or12,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i),
-    (J, j),
-    (K, k),
-    (L, l)
-);
-impl_event_set!(
-    Or13,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i),
-    (J, j),
-    (K, k),
-    (L, l),
-    (M, m)
-);
-impl_event_set!(
-    Or14,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i),
-    (J, j),
-    (K, k),
-    (L, l),
-    (M, m),
-    (N, n)
-);
-impl_event_set!(
-    Or15,
-    (A, a),
-    (B, b),
-    (C, c),
-    (D, d),
-    (E, e),
-    (F, f),
-    (G, g),
-    (H, h),
-    (I, i),
-    (J, j),
-    (K, k),
-    (L, l),
-    (M, m),
-    (N, n),
-    (O, o)
-);
-
-/// A wrapper around an [`EventSet`] that foregoes safety checks and casting, and passes the pointer as is.
-/// This is useful for observers that do not need to access the event data, or need to do so dynamically.
-pub struct UntypedEvent<E = ()>(std::marker::PhantomData<E>);
-
-/// An [`EventSet`] that matches the specified event type(s), but does not cast the pointer.
-// SAFETY: Performs no unsafe operations, returns the pointer as is.
-unsafe impl<E: EventSet> EventSet for UntypedEvent<E> {
-    type Item<'trigger> = PtrMut<'trigger>;
-    type ReadOnlyItem<'trigger> = Ptr<'trigger>;
-
-    unsafe fn unchecked_cast<'trigger>(
-        _world: &World,
-        _observer_trigger: &ObserverTrigger,
-        ptr: PtrMut<'trigger>,
-    ) -> Option<Self::Item<'trigger>> {
-        Some(ptr)
-    }
-
-    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
-        true
-    }
-
-    fn init_components(world: &mut World, ids: impl FnMut(ComponentId)) {
-        E::init_components(world, ids);
-    }
-
-    fn shrink<'long: 'short, 'short>(item: &'short mut Self::Item<'long>) -> Self::Item<'short> {
-        item.reborrow()
-    }
-
-    fn shrink_readonly<'long: 'short, 'short>(
-        item: &'short Self::Item<'long>,
-    ) -> Self::ReadOnlyItem<'short> {
-        item.as_ref()
-    }
-}
-
-/// An [`EventSet`] that matches any event type, but does not cast the pointer.
-// SAFETY: Performs no unsafe operations, returns the pointer as is.
-unsafe impl EventSet for UntypedEvent<()> {
-    type Item<'trigger> = PtrMut<'trigger>;
-    type ReadOnlyItem<'trigger> = Ptr<'trigger>;
-
-    unsafe fn unchecked_cast<'trigger>(
-        _world: &World,
-        _observer_trigger: &ObserverTrigger,
-        ptr: PtrMut<'trigger>,
-    ) -> Option<Self::Item<'trigger>> {
-        Some(ptr)
-    }
-
-    fn matches(_world: &World, _observer_trigger: &ObserverTrigger) -> bool {
-        true
-    }
-
-    fn init_components(_world: &mut World, _ids: impl FnMut(ComponentId)) {}
-
-    fn shrink<'long: 'short, 'short>(item: &'short mut Self::Item<'long>) -> Self::Item<'short> {
-        item.reborrow()
-    }
-
-    fn shrink_readonly<'long: 'short, 'short>(
-        item: &'short Self::Item<'long>,
-    ) -> Self::ReadOnlyItem<'short> {
-        item.as_ref()
-    }
-}
-
-/// This trait is implemented on [`EventSet`]s where it is safe to call
-/// [`Observer::with_event`](crate::observer::Observer::with_event).
-pub unsafe trait DynamicEventSafe: EventSet {}
-
-unsafe impl<E: EventSet> DynamicEventSafe for UntypedEvent<E> {}
-unsafe impl DynamicEventSafe for UntypedEvent<()> {}
-unsafe impl<A: DynamicEventSafe> DynamicEventSafe for (A,) {}
-unsafe impl<A: EventSet, B: DynamicEventSafe> DynamicEventSafe for (A, B) {}
-unsafe impl<A: EventSet, B: EventSet, C: DynamicEventSafe> DynamicEventSafe for (A, B, C) {}
-unsafe impl<A: EventSet, B: EventSet, C: EventSet, D: DynamicEventSafe> DynamicEventSafe
-    for (A, B, C, D)
-{
-}
-unsafe impl<A: EventSet, B: EventSet, C: EventSet, D: EventSet, E: DynamicEventSafe>
-    DynamicEventSafe for (A, B, C, D, E)
-{
-}
-unsafe impl<A: EventSet, B: EventSet, C: EventSet, D: EventSet, E: EventSet, F: DynamicEventSafe>
-    DynamicEventSafe for (A, B, C, D, E, F)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: EventSet,
-        J: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: EventSet,
-        J: EventSet,
-        K: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: EventSet,
-        J: EventSet,
-        K: EventSet,
-        L: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: EventSet,
-        J: EventSet,
-        K: EventSet,
-        L: EventSet,
-        M: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L, M)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: EventSet,
-        J: EventSet,
-        K: EventSet,
-        L: EventSet,
-        M: EventSet,
-        N: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
-{
-}
-unsafe impl<
-        A: EventSet,
-        B: EventSet,
-        C: EventSet,
-        D: EventSet,
-        E: EventSet,
-        F: EventSet,
-        G: EventSet,
-        H: EventSet,
-        I: EventSet,
-        J: EventSet,
-        K: EventSet,
-        L: EventSet,
-        M: EventSet,
-        N: EventSet,
-        O: DynamicEventSafe,
-    > DynamicEventSafe for (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
-{
-}
+#[rustfmt::skip] impl_event_set!(Or2, (A, a), (B, b));
+#[rustfmt::skip] impl_event_set!(Or3, (A, a), (B, b), (C, c));
+#[rustfmt::skip] impl_event_set!(Or4, (A, a), (B, b), (C, c), (D, d));
+#[rustfmt::skip] impl_event_set!(Or5, (A, a), (B, b), (C, c), (D, d), (E, e));
+#[rustfmt::skip] impl_event_set!(Or6, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f));
+#[rustfmt::skip] impl_event_set!(Or7, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g));
+#[rustfmt::skip] impl_event_set!(Or8, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h));
+#[rustfmt::skip] impl_event_set!(Or9, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i));
+#[rustfmt::skip] impl_event_set!(Or10, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i), (J, j));
+#[rustfmt::skip] impl_event_set!(Or11, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i), (J, j), (K, k));
+#[rustfmt::skip] impl_event_set!(Or12, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i), (J, j), (K, k), (L, l));
+#[rustfmt::skip] impl_event_set!(Or13, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i), (J, j), (K, k), (L, l), (M, m));
+#[rustfmt::skip] impl_event_set!(Or14, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i), (J, j), (K, k), (L, l), (M, m), (N, n));
+#[rustfmt::skip] impl_event_set!(Or15, (A, a), (B, b), (C, c), (D, d), (E, e), (F, f), (G, g), (H, h), (I, i), (J, j), (K, k), (L, l), (M, m), (N, n), (O, o));

--- a/crates/bevy_ecs/src/observer/set.rs
+++ b/crates/bevy_ecs/src/observer/set.rs
@@ -146,9 +146,9 @@ unsafe impl<E: Event> StaticEventSet for E {}
 /// `DynamicEvent` accepts one type parameter:
 ///
 /// - **Register**
-///  The event set that will have its types automatically registered to the observer.
-///  This reduces the boilerplate of registering the event types manually when some or all are statically known.
-///  However, these types will not be matched or casted by the observer.
+///   The event set that will have its types automatically registered to the observer.
+///   This reduces the boilerplate of registering the event types manually when some or all are statically known.
+///   However, these types will not be matched or casted by the observer.
 ///
 /// # Example
 ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     component::{ComponentId, ComponentInfo},
     entity::{Entities, Entity},
     event::Event,
-    observer::{Observer, TriggerEvent, TriggerTargets},
+    observer::{EventSet, Observer, TriggerEvent, TriggerTargets},
     system::{RunSystemWithInput, SystemId},
     world::{
         command_queue::RawCommandQueue, Command, CommandQueue, EntityWorldMut, FromWorld,
@@ -778,7 +778,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     /// Spawn an [`Observer`] and returns the [`EntityCommands`] associated with the entity that stores the observer.  
-    pub fn observe<E: Event, B: Bundle, M>(
+    pub fn observe<E: EventSet, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> EntityCommands {
@@ -1211,7 +1211,7 @@ impl EntityCommands<'_> {
     }
 
     /// Creates an [`Observer`] listening for a trigger of type `T` that targets this entity.
-    pub fn observe<E: Event, B: Bundle, M>(
+    pub fn observe<E: EventSet, B: Bundle, M>(
         &mut self,
         system: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
@@ -1443,7 +1443,7 @@ fn log_components(entity: Entity, world: &mut World) {
     info!("Entity {entity}: {debug_infos:?}");
 }
 
-fn observe<E: Event, B: Bundle, M>(
+fn observe<E: EventSet, B: Bundle, M>(
     observer: impl IntoObserverSystem<E, B, M>,
 ) -> impl EntityCommand {
     move |entity, world: &mut World| {

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -1,6 +1,7 @@
 use bevy_utils::all_tuples;
 
 use crate::{
+    observer::EventSet,
     prelude::{Bundle, Trigger},
     system::{System, SystemParam, SystemParamFunction, SystemParamItem},
 };
@@ -10,13 +11,13 @@ use super::IntoSystem;
 /// Implemented for systems that have an [`Observer`] as the first argument.
 ///
 /// [`Observer`]: crate::observer::Observer
-pub trait ObserverSystem<E: 'static, B: Bundle, Out = ()>:
+pub trait ObserverSystem<E: EventSet + 'static, B: Bundle, Out = ()>:
     System<In = Trigger<'static, E, B>, Out = Out> + Send + 'static
 {
 }
 
 impl<
-        E: 'static,
+        E: EventSet + 'static,
         B: Bundle,
         Out,
         T: System<In = Trigger<'static, E, B>, Out = Out> + Send + 'static,
@@ -25,7 +26,9 @@ impl<
 }
 
 /// Implemented for systems that convert into [`ObserverSystem`].
-pub trait IntoObserverSystem<E: 'static, B: Bundle, M, Out = ()>: Send + 'static {
+pub trait IntoObserverSystem<E: EventSet + 'static, B: Bundle, M, Out = ()>:
+    Send + 'static
+{
     /// The type of [`System`] that this instance converts into.
     type System: ObserverSystem<E, B, Out>;
 
@@ -37,7 +40,7 @@ impl<
         S: IntoSystem<Trigger<'static, E, B>, Out, M> + Send + 'static,
         M,
         Out,
-        E: 'static,
+        E: EventSet + 'static,
         B: Bundle,
     > IntoObserverSystem<E, B, M, Out> for S
 where
@@ -53,7 +56,7 @@ where
 macro_rules! impl_system_function {
     ($($param: ident),*) => {
         #[allow(non_snake_case)]
-        impl<E: 'static, B: Bundle, Out, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<fn(Trigger<E, B>, $($param,)*)> for Func
+        impl<E: EventSet + 'static, B: Bundle, Out, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<fn(Trigger<E, B>, $($param,)*)> for Func
         where
         for <'a> &'a mut Func:
                 FnMut(Trigger<E, B>, $($param),*) -> Out +
@@ -65,7 +68,7 @@ macro_rules! impl_system_function {
             #[inline]
             fn run(&mut self, input: Trigger<'static, E, B>, param_value: SystemParamItem< ($($param,)*)>) -> Out {
                 #[allow(clippy::too_many_arguments)]
-                fn call_inner<E: 'static, B: Bundle, Out, $($param,)*>(
+                fn call_inner<E: EventSet + 'static, B: Bundle, Out, $($param,)*>(
                     mut f: impl FnMut(Trigger<'static, E, B>, $($param,)*) -> Out,
                     input: Trigger<'static, E, B>,
                     $($param: $param,)*

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -4,7 +4,6 @@ use crate::{
     change_detection::MutUntyped,
     component::{Component, ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
-    event::Event,
     observer::{EventSet, Observer, Observers},
     query::Access,
     removal_detection::RemovedComponentEvents,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5,7 +5,7 @@ use crate::{
     component::{Component, ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     event::Event,
-    observer::{Observer, Observers},
+    observer::{EventSet, Observer, Observers},
     query::Access,
     removal_detection::RemovedComponentEvents,
     storage::Storages,
@@ -1445,7 +1445,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Creates an [`Observer`] listening for events of type `E` targeting this entity.
     /// In order to trigger the callback the entity must also match the query when the event is fired.
-    pub fn observe<E: Event, B: Bundle, M>(
+    pub fn observe<E: EventSet, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {


### PR DESCRIPTION
# Objective

Closes #14649.

## Solution

The following presented solution is:
- Safe: The previous (unsafe required) solution to statically-unknown event types now has a 100% safe alternative.
- Ergonomic: Simply upgrade your observers by going from `Trigger<Foo>` to `Trigger<(Foo, Bar)>`.
- Zero-abstraction overhead: Single-event observers remain as fast as they were prior, and multi-event observers have little or no additional overhead.
- Backwards-compatible: All observers written for `0.14` will continue to function as expected without any code changes.

### Event Sets

We introduce a new trait named `EventSet` that performs a role similar to `WorldQuery`, although with a much smaller API surface. An `EventSet` can be / is implemented by:
- All normal `Event` types.
- A tuple of normal `Event` types (up to arity =15). Supports nesting tuples inside tuples.
- A `DynamicEvent` type that allows raw-pointer-style observation.
- A `SemiDynamicEvent` type that allows you to first match on statically-known event types, and if none match operates like a `DynamicEvent`.

The most notable operations that an `EventSet` provides are:
- `unchecked_cast`: Casts the raw pointer into the type of the output item.
- `matches`: Returns true if the event set contains the provided event component ID.
- `init_components`: Initializes all required event types to have component IDs.

### Statically-known multiple-event observers

Your observers can now be upgraded from single-event observers to multiple-event observers with the simple change to a tuple for your `Trigger` generic parameter. If a single event type is specified in the trigger, then the returned item type remains a `&Event` or `&mut Event`. If a tuple of event types are specified in the trigger, then an enum with the same arity is the returned item type, for example: `enum Or2<EventA, EventB> { A(EventA), B(EventB) }`.

```rust
#[derive(Event)]
struct Foo(i32);
#[derive(Event)]
struct Bar(bool);
#[derive(Event)]
struct Baz(String);

// Also works with Commands!
world.observe(|trigger: Trigger<(Foo, Bar, Baz)> {
    match trigger.event() {
        Or3::A(Foo(v)) => { assert_eq!(5, *v); }
        Or3::B(Bar(v)) => { assert!(*v); }
        Or3::C(Baz(v)) => { assert_eq!("Hello world!", *v); }
    }
});
world.trigger(Foo(5));
world.trigger(Bar(true));
world.trigger(Baz("Hello world!".into()));
```

### Dynamically-known event observers

The `DynamicEvent` type does not perform any pointer casting or type matching logic, and instead returns `true` when matching on ANY event type. This is most useful when you want to listen for event types that are not known at compile time. The returned items accessible with `Trigger::event()` and `Trigger::event_mut()` are `Ptr` and `PtrMut`, respectively, which are type-erased but lifetime'd pointers.

```rust
// Get our event component IDs somehow. They don't need to be statically known!
let foo_id = world.init_component::<Foo>();
let bar_id = world.init_component::<Bar>();

world.spawn(
    Observer::new(|trigger: Trigger<DynamicEvent> {
        // Called for foo and bar events
    })
    .with_event(foo_id) // This method was previously unsafe because it could result in UB.
    .with_event(bar_id) // But we don't do any casting automatically here, so we're safe! (It's on the user's side to do that)
);
// Trigger our runtime-known events dynamically:
unsafe {
    EmitDynamicTrigger::new_with_id(foo_id, Foo(10), ()).apply(&mut world);
    EmitDynamicTrigger::new_with_id(bar_id, Bar(false), ()).apply(&mut world);
}
```

### Semi-dynamically-known event observers

For complex scenarios, we can also combine both statically-known and runtime-known event types in a single observer, using `SemiDynamicEvent<Static>`. This means all event types that don't match the specified statically-known event types will be returned as a `Ptr`/`PtrMut`. The returned item type for `SemiDynamicEvent` is `Result<StaticallyKnownItems, PtrMut>`.

```rust
#[derive(Event)]
struct Foo(i32);
#[derive(Event)]
struct Bar(bool);

// Get our event component IDs that are only runtime-known
let baz_id = world.init_component::<Baz>();

world.spawn(
    Observer::new(|trigger: Trigger<SemiDynamicEvent<(Foo, Bar)>>| {
        match trigger.event() {
            Ok(Or2::A(Foo(v))) => { assert_eq!(6, *v); },
            Ok(Or2::B(Bar(v))) => { assert!(*v); },
            Err(ptr) => { /* do stuff with our `Ptr` */ }
        }
    })
    .with_event(baz_id)
);

// Trigger our statically known event types
world.trigger(Foo(6));
world.trigger(Bar(true));
// Trigger our runtime-known events dynamically:
unsafe {
    EmitDynamicTrigger::new_with_id(baz_id, Baz("Hello world!".into()), ()).apply(&mut world);
}
```

## TODO

- [ ] Add a lot more docs.
- [ ] Open a subsequent issue for adding a derive macro for custom `EventSet` types.

## Testing

- I've added 5 new tests:
    - `observer_multiple_events_static`: Tests functionality of reading event data from two different statically-known event types.
    - `observer_multiple_events_dynamic`: Tests `DynamicEvent`'s behavior of passing pointers as-is.
    - `observer_multiple_events_semidynamic`: Tests `SemiDynamicEvent`'s behavior of first trying to match on statically-known event types, and falling back to `DynamicEvent` if none match.
    - `observer_propagating_multi_event_between`: Tests that event sets do not interfere with current propagation code.
    - `observer_propagating_multi_event_all`: Same as above
- I've added 3 new benchmarks:
    - `observe_multievent`: Tests the matching speed of tuple event sets from size 1 to 15 (No observed slowdowns).
        - The `(A,)` (size=1) tuple implementation simply forwards to `A`, which is equivalent to current observer code.
    - `observe_dynamic`: Tests the matching speed of runtime known event types with `DynamicEvent` (No observed slowdowns).
    - `observe_semidynamic`: Tests the matching speed of combined statically-known and runtime-known event types with `SemiDynamicEvent` (No observed slowdowns).
    
## Migration Guide

`Observer::with_event` was renamed to `Observer::with_event_unchecked`. If you were using this function, consider using a new one that has been added under the old name, which isn't marked `unsafe` but requires your `Trigger<E>`'s `E` type to be either `DynamicEvent` or `SemiDynamicEvent`.