### PR TITLE
hooking up observers and clicking for ui node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3351,6 +3351,18 @@ description = "Demonstrates how to rotate the skybox and the environment map sim
 category = "3D Rendering"
 wasm = false
 
+[[example]]
+name = "simple_picking"
+path = "examples/picking/simple_picking.rs"
+doc-scrape-examples = true
+required-features = ["bevy_picking"]
+
+[package.metadata.example.simple_picking]
+name = "Showcases simple picking events and usage"
+description = "Demonstrates how to use picking events to spawn simple objects"
+category = "Picking"
+wasm = true
+
 [profile.wasm-release]
 inherits = "release"
 opt-level = "z"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -191,7 +191,7 @@ meshlet_processor = ["bevy_pbr?/meshlet_processor"]
 bevy_dev_tools = ["dep:bevy_dev_tools"]
 
 # Provides a picking functionality
-bevy_picking = ["dep:bevy_picking"]
+bevy_picking = ["dep:bevy_picking", "bevy_ui?/bevy_picking"]
 
 # Enable support for the ios_simulator by downgrading some rendering capabilities
 ios_simulator = ["bevy_pbr?/ios_simulator", "bevy_render?/ios_simulator"]

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -56,6 +56,12 @@ plugin_group! {
         bevy_gizmos:::GizmoPlugin,
         #[cfg(feature = "bevy_state")]
         bevy_state::app:::StatesPlugin,
+        #[cfg(feature = "bevy_picking")]
+        bevy_picking::input:::InputPlugin,
+        #[cfg(feature = "bevy_picking")]
+        bevy_picking:::PickingPlugin,
+        #[cfg(feature = "bevy_picking")]
+        bevy_picking:::InteractionPlugin,
         #[cfg(feature = "bevy_dev_tools")]
         bevy_dev_tools:::DevToolsPlugin,
         #[cfg(feature = "bevy_ci_testing")]

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -57,11 +57,7 @@ plugin_group! {
         #[cfg(feature = "bevy_state")]
         bevy_state::app:::StatesPlugin,
         #[cfg(feature = "bevy_picking")]
-        bevy_picking::input:::InputPlugin,
-        #[cfg(feature = "bevy_picking")]
-        bevy_picking:::PickingPlugin,
-        #[cfg(feature = "bevy_picking")]
-        bevy_picking:::InteractionPlugin,
+        bevy_picking:::DefaultPickingPlugins,
         #[cfg(feature = "bevy_dev_tools")]
         bevy_dev_tools:::DevToolsPlugin,
         #[cfg(feature = "bevy_ci_testing")]

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -66,3 +66,7 @@ pub use crate::state::prelude::*;
 #[doc(hidden)]
 #[cfg(feature = "bevy_gltf")]
 pub use crate::gltf::prelude::*;
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_picking")]
+pub use crate::picking::prelude::*;

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -20,6 +20,9 @@ bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
+bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }
+bevy_asset = { path = "../bevy_asset", version = "0.15.0-dev" }
+
 uuid = { version = "1.1", features = ["v4"] }
 
 [lints]

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -368,6 +368,9 @@ pub struct DragEntry {
 #[allow(clippy::too_many_arguments)]
 pub fn send_click_and_drag_events(
     // for triggering observers
+    //  - Pointer<Click>
+    //  - Pointer<Drag>
+    //  - Pointer<DragStart>
     mut commands: Commands,
     // Input
     mut pointer_down: EventReader<Pointer<Down>>,
@@ -380,12 +383,9 @@ pub fn send_click_and_drag_events(
     mut down_map: Local<
         HashMap<(PointerId, PointerButton), HashMap<Entity, (Pointer<Down>, Instant)>>,
     >,
-    // Output
+    // Outputs used for further processing
     mut drag_map: ResMut<DragMap>,
-    mut pointer_click: EventWriter<Pointer<Click>>,
-    mut pointer_drag_start: EventWriter<Pointer<DragStart>>,
     mut pointer_drag_end: EventWriter<Pointer<DragEnd>>,
-    mut pointer_drag: EventWriter<Pointer<Drag>>,
 ) {
     let pointer_location = |pointer_id: PointerId| {
         pointer_map
@@ -428,7 +428,6 @@ pub fn send_click_and_drag_events(
                     },
                 );
                 commands.trigger_targets(event.clone(), event.target);
-                pointer_drag_start.send(event);
             }
 
             for (dragged_entity, drag) in drag_list.iter_mut() {
@@ -440,7 +439,6 @@ pub fn send_click_and_drag_events(
                 drag.latest_pos = location.position;
                 let event = Pointer::new(pointer_id, location.clone(), *dragged_entity, drag_event);
                 commands.trigger_targets(event.clone(), event.target);
-                pointer_drag.send(event);
             }
         }
     }
@@ -471,7 +469,6 @@ pub fn send_click_and_drag_events(
                 },
             );
             commands.trigger_targets(event.clone(), event.target);
-            pointer_click.send(event);
         }
     }
 
@@ -515,6 +512,11 @@ pub fn send_click_and_drag_events(
 /// Uses pointer events to determine when drag-over events occur
 #[allow(clippy::too_many_arguments)]
 pub fn send_drag_over_events(
+    // uses this to trigger the following
+    //  - Pointer<DragEnter>,
+    //  - Pointer<DragOver>,
+    //  - Pointer<DragLeave>,
+    //  - Pointer<Drop>,
     mut commands: Commands,
     // Input
     drag_map: Res<DragMap>,
@@ -524,12 +526,6 @@ pub fn send_drag_over_events(
     mut pointer_drag_end: EventReader<Pointer<DragEnd>>,
     // Local
     mut drag_over_map: Local<HashMap<(PointerId, PointerButton), HashMap<Entity, HitData>>>,
-
-    // Output
-    mut pointer_drag_enter: EventWriter<Pointer<DragEnter>>,
-    mut pointer_drag_over: EventWriter<Pointer<DragOver>>,
-    mut pointer_drag_leave: EventWriter<Pointer<DragLeave>>,
-    mut pointer_drop: EventWriter<Pointer<Drop>>,
 ) {
     // Fire PointerDragEnter events.
     for Pointer {
@@ -561,7 +557,6 @@ pub fn send_drag_over_events(
                     },
                 );
                 commands.trigger_targets(event.clone(), event.target);
-                pointer_drag_enter.send(event);
             }
         }
     }
@@ -594,7 +589,6 @@ pub fn send_drag_over_events(
                     },
                 );
                 commands.trigger_targets(event.clone(), event.target);
-                pointer_drag_over.send(event);
             }
         }
     }
@@ -625,7 +619,6 @@ pub fn send_drag_over_events(
                 },
             );
             commands.trigger_targets(event.clone(), event.target);
-            pointer_drag_leave.send(event);
 
             let event = Pointer::new(
                 pointer_id,
@@ -638,7 +631,6 @@ pub fn send_drag_over_events(
                 },
             );
             commands.trigger_targets(event.clone(), event.target);
-            pointer_drop.send(event);
         }
     }
 
@@ -672,7 +664,6 @@ pub fn send_drag_over_events(
                     },
                 );
                 commands.trigger_targets(event.clone(), event.target);
-                pointer_drag_leave.send(event);
             }
         }
     }

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -427,7 +427,7 @@ pub fn send_click_and_drag_events(
                         hit: down.hit.clone(),
                     },
                 );
-                commands.trigger_targets(event.clone(), event.target);
+                commands.trigger_targets(event, down.target);
             }
 
             for (dragged_entity, drag) in drag_list.iter_mut() {
@@ -437,8 +437,9 @@ pub fn send_click_and_drag_events(
                     delta: location.position - drag.latest_pos,
                 };
                 drag.latest_pos = location.position;
-                let event = Pointer::new(pointer_id, location.clone(), *dragged_entity, drag_event);
-                commands.trigger_targets(event.clone(), event.target);
+                let target = *dragged_entity;
+                let event = Pointer::new(pointer_id, location.clone(), target, drag_event);
+                commands.trigger_targets(event, target);
             }
         }
     }
@@ -468,7 +469,7 @@ pub fn send_click_and_drag_events(
                     duration,
                 },
             );
-            commands.trigger_targets(event.clone(), event.target);
+            commands.trigger_targets(event, target);
         }
     }
 
@@ -556,7 +557,7 @@ pub fn send_drag_over_events(
                         hit: hit.clone(),
                     },
                 );
-                commands.trigger_targets(event.clone(), event.target);
+                commands.trigger_targets(event, target);
             }
         }
     }
@@ -588,7 +589,7 @@ pub fn send_drag_over_events(
                         hit: hit.clone(),
                     },
                 );
-                commands.trigger_targets(event.clone(), event.target);
+                commands.trigger_targets(event, target);
             }
         }
     }
@@ -597,7 +598,7 @@ pub fn send_drag_over_events(
     for Pointer {
         pointer_id,
         pointer_location,
-        target,
+        target: drag_end_target,
         event: DragEnd {
             button,
             distance: _,
@@ -608,29 +609,30 @@ pub fn send_drag_over_events(
             continue;
         };
         for (dragged_over, hit) in drag_over_set.drain() {
+            let target = dragged_over;
             let event = Pointer::new(
                 pointer_id,
                 pointer_location.clone(),
                 dragged_over,
                 DragLeave {
                     button,
-                    dragged: target,
+                    dragged: drag_end_target,
                     hit: hit.clone(),
                 },
             );
-            commands.trigger_targets(event.clone(), event.target);
+            commands.trigger_targets(event, target);
 
             let event = Pointer::new(
                 pointer_id,
                 pointer_location.clone(),
-                dragged_over,
+                target,
                 Drop {
                     button,
                     dropped: target,
                     hit: hit.clone(),
                 },
             );
-            commands.trigger_targets(event.clone(), event.target);
+            commands.trigger_targets(event, target);
         }
     }
 
@@ -663,7 +665,7 @@ pub fn send_drag_over_events(
                         hit: hit.clone(),
                     },
                 );
-                commands.trigger_targets(event.clone(), event.target);
+                commands.trigger_targets(event, target);
             }
         }
     }

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -195,7 +195,7 @@ impl Plugin for PickingPlugin {
                     pointer::update_pointer_map,
                     pointer::InputMove::receive,
                     pointer::InputPress::receive,
-                    backend::ray::RayMap::repopulate,
+                    backend::ray::RayMap::repopulate.after(pointer::InputMove::receive),
                 )
                     .in_set(PickSet::ProcessInput),
             )

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -16,8 +16,8 @@ use bevy_reflect::prelude::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        events::*, input::InputPlugin, pointer::PointerButton, InteractionPlugin, Pickable,
-        PickingPlugin, PickingPluginsSettings,
+        events::*, input::InputPlugin, pointer::PointerButton, DefaultPickingPlugins,
+        InteractionPlugin, Pickable, PickingPlugin, PickingPluginsSettings,
     };
 }
 
@@ -174,6 +174,24 @@ pub enum PickSet {
     PostFocus,
     /// Runs after all other picking sets. In the [`PreUpdate`] schedule.
     Last,
+}
+
+/// One plugin that contains the [`input::InputPlugin`], [`PickingPlugin`] and the [`InteractionPlugin`],
+/// this is probable the plugin that will be most used.
+/// Note: for any of these plugins to work, they require a picking backend to be active,
+/// The picking backend is responsible to turn an input, into a [`crate::backend::PointerHits`]
+/// that [`PickingPlugin`] and [`InteractionPlugin`] will refine into Triggers
+#[derive(Default)]
+pub struct DefaultPickingPlugins;
+
+impl Plugin for DefaultPickingPlugins {
+    fn build(&self, app: &mut App) {
+        app.add_plugins((
+            input::InputPlugin::default(),
+            PickingPlugin,
+            InteractionPlugin,
+        ));
+    }
 }
 
 /// This plugin sets up the core picking infrastructure. It receives input events, and provides the shared

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -239,15 +239,8 @@ impl Plugin for InteractionPlugin {
             .add_event::<Pointer<Up>>()
             .add_event::<Pointer<Move>>()
             .add_event::<Pointer<Over>>()
-            .add_event::<Pointer<Click>>()
             .add_event::<Pointer<Out>>()
-            .add_event::<Pointer<Drag>>()
-            .add_event::<Pointer<DragStart>>()
-            .add_event::<Pointer<DragEnter>>()
-            .add_event::<Pointer<DragOver>>()
-            .add_event::<Pointer<DragLeave>>()
             .add_event::<Pointer<DragEnd>>()
-            .add_event::<Pointer<Drop>>()
             .add_systems(
                 PreUpdate,
                 (

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -177,10 +177,10 @@ pub enum PickSet {
 }
 
 /// One plugin that contains the [`input::InputPlugin`], [`PickingPlugin`] and the [`InteractionPlugin`],
-/// this is probable the plugin that will be most used.
+/// this is probably the plugin that will be most used.
 /// Note: for any of these plugins to work, they require a picking backend to be active,
 /// The picking backend is responsible to turn an input, into a [`crate::backend::PointerHits`]
-/// that [`PickingPlugin`] and [`InteractionPlugin`] will refine into Triggers
+/// that [`PickingPlugin`] and [`InteractionPlugin`] will refine into [`bevy_ecs::observer::Trigger`]s.
 #[derive(Default)]
 pub struct DefaultPickingPlugins;
 

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -12,6 +12,15 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
 
+/// common exports for picking interaction
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::{
+        events::*, input::InputPlugin, pointer::PointerButton, InteractionPlugin, Pickable,
+        PickingPlugin, PickingPluginsSettings,
+    };
+}
+
 /// Used to globally toggle picking features at runtime.
 #[derive(Clone, Debug, Resource, Reflect)]
 #[reflect(Resource, Default)]
@@ -169,6 +178,7 @@ pub enum PickSet {
 
 /// This plugin sets up the core picking infrastructure. It receives input events, and provides the shared
 /// types used by other picking plugins.
+#[derive(Default)]
 pub struct PickingPlugin;
 
 impl Plugin for PickingPlugin {
@@ -213,6 +223,7 @@ impl Plugin for PickingPlugin {
 }
 
 /// Generates [`Pointer`](events::Pointer) events and handles event bubbling.
+#[derive(Default)]
 pub struct InteractionPlugin;
 
 impl Plugin for InteractionPlugin {
@@ -224,6 +235,19 @@ impl Plugin for InteractionPlugin {
             .init_resource::<focus::PreviousHoverMap>()
             .init_resource::<DragMap>()
             .add_event::<PointerCancel>()
+            .add_event::<Pointer<Down>>()
+            .add_event::<Pointer<Up>>()
+            .add_event::<Pointer<Move>>()
+            .add_event::<Pointer<Over>>()
+            .add_event::<Pointer<Click>>()
+            .add_event::<Pointer<Out>>()
+            .add_event::<Pointer<Drag>>()
+            .add_event::<Pointer<DragStart>>()
+            .add_event::<Pointer<DragEnter>>()
+            .add_event::<Pointer<DragOver>>()
+            .add_event::<Pointer<DragLeave>>()
+            .add_event::<Pointer<DragEnd>>()
+            .add_event::<Pointer<Drop>>()
             .add_systems(
                 PreUpdate,
                 (

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -199,7 +199,14 @@ impl Plugin for PickingPlugin {
                 )
                     .in_set(PickSet::ProcessInput),
             )
-            .configure_sets(First, (PickSet::Input, PickSet::PostInput).chain())
+            .configure_sets(
+                First,
+                (PickSet::Input, PickSet::PostInput)
+                    .after(bevy_time::TimeSystem)
+                    .ambiguous_with(bevy_asset::handle_internal_asset_events)
+                    .after(bevy_ecs::event::EventUpdates)
+                    .chain(),
+            )
             .configure_sets(
                 PreUpdate,
                 (
@@ -210,6 +217,7 @@ impl Plugin for PickingPlugin {
                     // Eventually events will need to be dispatched here
                     PickSet::Last,
                 )
+                    .ambiguous_with(bevy_asset::handle_internal_asset_events)
                     .chain(),
             )
             .register_type::<pointer::PointerId>()

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -26,6 +26,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.15.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.15.0-dev", optional = true }
+bevy_picking= { path = "../bevy_picking", version = "0.15.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
@@ -40,6 +41,7 @@ smallvec = "1.11"
 
 [features]
 serialize = ["serde", "smallvec/serde", "bevy_math/serialize"]
+bevy_picking = ["dep:bevy_picking"]
 
 
 [lints]

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -26,7 +26,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.15.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.15.0-dev", optional = true }
-bevy_picking= { path = "../bevy_picking", version = "0.15.0-dev", optional = true }
+bevy_picking = { path = "../bevy_picking", version = "0.15.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -17,6 +17,9 @@ pub mod ui_material;
 pub mod update;
 pub mod widget;
 
+#[cfg(feature = "bevy_picking")]
+pub mod picking_backend;
+
 use bevy_derive::{Deref, DerefMut};
 use bevy_reflect::Reflect;
 #[cfg(feature = "bevy_text")]
@@ -202,6 +205,9 @@ impl Plugin for UiPlugin {
         build_text_interop(app);
 
         build_ui_render(app);
+
+        #[cfg(feature = "bevy_picking")]
+        app.add_plugins(picking_backend::UiPickingBackend);
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -1,4 +1,4 @@
-//! A picking backend for [`bevy_ui`].
+//! A picking backend for Ui nodes.
 //!
 //! # Usage
 //!
@@ -7,9 +7,10 @@
 //!
 //! ## Important Note
 //!
-//! This backend completely ignores [`FocusPolicy`](bevy_ui::FocusPolicy). The design of bevy ui's
+//! This backend completely ignores [`FocusPolicy`](crate::FocusPolicy). The design of bevy ui's
 //! focus systems and the picking plugin are not compatible. Instead, use the [`Pickable`] component
-//! to customize how an entity responds to picking focus.
+//! to customize how an entity responds to picking focus. Nodes without the [`Pickable`] component
+//! will not trigger events.
 //!
 //! ## Implementation Notes
 //!
@@ -33,7 +34,7 @@ use bevy_window::PrimaryWindow;
 
 use bevy_picking::backend::prelude::*;
 
-/// Adds picking support for [`bevy_ui`].
+/// Adds picking support for Ui nodes.
 #[derive(Clone)]
 pub struct UiPickingBackend;
 impl Plugin for UiPickingBackend {

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -23,7 +23,7 @@
 #![allow(clippy::too_many_arguments)]
 #![deny(missing_docs)]
 
-use crate::{prelude::*, RelativeCursorPosition, UiStack};
+use crate::{prelude::*, UiStack};
 use bevy_app::prelude::*;
 use bevy_ecs::{prelude::*, query::QueryData};
 use bevy_math::Vec2;
@@ -50,7 +50,6 @@ pub struct NodeQuery {
     entity: Entity,
     node: &'static Node,
     global_transform: &'static GlobalTransform,
-    relative_cursor_position: Option<&'static mut RelativeCursorPosition>,
     pickable: Option<&'static Pickable>,
     calculated_clip: Option<&'static CalculatedClip>,
     view_visibility: Option<&'static ViewVisibility>,

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -1,4 +1,4 @@
-//! A picking backend for Ui nodes.
+//! A picking backend for UI nodes.
 //!
 //! # Usage
 //!
@@ -7,17 +7,17 @@
 //!
 //! ## Important Note
 //!
-//! This backend completely ignores [`FocusPolicy`](crate::FocusPolicy). The design of bevy ui's
+//! This backend completely ignores [`FocusPolicy`](crate::FocusPolicy). The design of `bevy_ui`'s
 //! focus systems and the picking plugin are not compatible. Instead, use the [`Pickable`] component
 //! to customize how an entity responds to picking focus. Nodes without the [`Pickable`] component
 //! will not trigger events.
 //!
 //! ## Implementation Notes
 //!
-//! - Bevy ui can only render to the primary window
-//! - Bevy ui can render on any camera with a flag, it is special, and is not tied to a particular
+//! - `bevy_ui` can only render to the primary window
+//! - `bevy_ui` can render on any camera with a flag, it is special, and is not tied to a particular
 //!   camera.
-//! - To correctly sort picks, the order of bevy UI is set to be the camera order plus 0.5.
+//! - To correctly sort picks, the order of `bevy_ui` is set to be the camera order plus 0.5.
 
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
@@ -34,7 +34,7 @@ use bevy_window::PrimaryWindow;
 
 use bevy_picking::backend::prelude::*;
 
-/// Adds picking support for Ui nodes.
+/// A plugin that adds picking support for UI nodes.
 #[derive(Clone)]
 pub struct UiPickingBackend;
 impl Plugin for UiPickingBackend {

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -1,0 +1,214 @@
+//! A picking backend for [`bevy_ui`].
+//!
+//! # Usage
+//!
+//! This backend does not require markers on cameras or entities to function. It will look for any
+//! pointers using the same render target as the UI camera, and run hit tests on the UI node tree.
+//!
+//! ## Important Note
+//!
+//! This backend completely ignores [`FocusPolicy`](bevy_ui::FocusPolicy). The design of bevy ui's
+//! focus systems and the picking plugin are not compatible. Instead, use the [`Pickable`] component
+//! to customize how an entity responds to picking focus.
+//!
+//! ## Implementation Notes
+//!
+//! - Bevy ui can only render to the primary window
+//! - Bevy ui can render on any camera with a flag, it is special, and is not tied to a particular
+//!   camera.
+//! - To correctly sort picks, the order of bevy UI is set to be the camera order plus 0.5.
+
+#![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+#![deny(missing_docs)]
+
+use crate::{prelude::*, RelativeCursorPosition, UiStack};
+use bevy_app::prelude::*;
+use bevy_ecs::{prelude::*, query::QueryData};
+use bevy_math::Vec2;
+use bevy_render::prelude::*;
+use bevy_transform::prelude::*;
+use bevy_utils::hashbrown::HashMap;
+use bevy_window::PrimaryWindow;
+
+use bevy_picking::backend::prelude::*;
+
+/// Adds picking support for [`bevy_ui`].
+#[derive(Clone)]
+pub struct UiPickingBackend;
+impl Plugin for UiPickingBackend {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PreUpdate, ui_picking.in_set(PickSet::Backend));
+    }
+}
+
+/// Main query from bevy's `ui_focus_system`
+#[derive(QueryData)]
+#[query_data(mutable)]
+pub struct NodeQuery {
+    entity: Entity,
+    node: &'static Node,
+    global_transform: &'static GlobalTransform,
+    relative_cursor_position: Option<&'static mut RelativeCursorPosition>,
+    pickable: Option<&'static Pickable>,
+    calculated_clip: Option<&'static CalculatedClip>,
+    view_visibility: Option<&'static ViewVisibility>,
+    target_camera: Option<&'static TargetCamera>,
+}
+
+/// Computes the UI node entities under each pointer.
+///
+/// Bevy's [`UiStack`] orders all nodes in the order they will be rendered, which is the same order
+/// we need for determining picking.
+pub fn ui_picking(
+    pointers: Query<(&PointerId, &PointerLocation)>,
+    camera_query: Query<(Entity, &Camera, Has<IsDefaultUiCamera>)>,
+    default_ui_camera: DefaultUiCamera,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    ui_scale: Res<UiScale>,
+    ui_stack: Res<UiStack>,
+    mut node_query: Query<NodeQuery>,
+    mut output: EventWriter<PointerHits>,
+) {
+    // For each camera, the pointer and its position
+    let mut pointer_pos_by_camera = HashMap::<Entity, HashMap<PointerId, Vec2>>::new();
+
+    for (pointer_id, pointer_location) in
+        pointers.iter().filter_map(|(pointer, pointer_location)| {
+            Some(*pointer).zip(pointer_location.location().cloned())
+        })
+    {
+        // This pointer is associated with a render target, which could be used by multiple
+        // cameras. We want to ensure we return all cameras with a matching target.
+        for camera in camera_query
+            .iter()
+            .map(|(entity, camera, _)| {
+                (
+                    entity,
+                    camera.target.normalize(primary_window.get_single().ok()),
+                )
+            })
+            .filter_map(|(entity, target)| Some(entity).zip(target))
+            .filter(|(_entity, target)| target == &pointer_location.target)
+            .map(|(cam_entity, _target)| cam_entity)
+        {
+            let Ok((_, camera_data, _)) = camera_query.get(camera) else {
+                continue;
+            };
+            let mut pointer_pos = pointer_location.position;
+            if let Some(viewport) = camera_data.logical_viewport_rect() {
+                pointer_pos -= viewport.min;
+            }
+            let scaled_pointer_pos = pointer_pos / **ui_scale;
+            pointer_pos_by_camera
+                .entry(camera)
+                .or_default()
+                .insert(pointer_id, scaled_pointer_pos);
+        }
+    }
+
+    // The list of node entities hovered for each (camera, pointer) combo
+    let mut hit_nodes = HashMap::<(Entity, PointerId), Vec<Entity>>::new();
+
+    // prepare an iterator that contains all the nodes that have the cursor in their rect,
+    // from the top node to the bottom one. this will also reset the interaction to `None`
+    // for all nodes encountered that are no longer hovered.
+    for node_entity in ui_stack
+        .uinodes
+        .iter()
+        // reverse the iterator to traverse the tree from closest nodes to furthest
+        .rev()
+    {
+        let Ok(node) = node_query.get_mut(*node_entity) else {
+            continue;
+        };
+
+        // Nodes that are not rendered should not be interactable
+        if node
+            .view_visibility
+            .map(|view_visibility| view_visibility.get())
+            != Some(true)
+        {
+            continue;
+        }
+        let Some(camera_entity) = node
+            .target_camera
+            .map(TargetCamera::entity)
+            .or(default_ui_camera.get())
+        else {
+            continue;
+        };
+
+        let node_rect = node.node.logical_rect(node.global_transform);
+
+        // Nodes with Display::None have a (0., 0.) logical rect and can be ignored
+        if node_rect.size() == Vec2::ZERO {
+            continue;
+        }
+
+        // Intersect with the calculated clip rect to find the bounds of the visible region of the node
+        let visible_rect = node
+            .calculated_clip
+            .map(|clip| node_rect.intersect(clip.clip))
+            .unwrap_or(node_rect);
+
+        let pointers_on_this_cam = pointer_pos_by_camera.get(&camera_entity);
+
+        // The mouse position relative to the node
+        // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
+        // Coordinates are relative to the entire node, not just the visible region.
+        for (pointer_id, cursor_position) in pointers_on_this_cam.iter().flat_map(|h| h.iter()) {
+            let relative_cursor_position = (*cursor_position - node_rect.min) / node_rect.size();
+
+            if visible_rect
+                .normalize(node_rect)
+                .contains(relative_cursor_position)
+            {
+                hit_nodes
+                    .entry((camera_entity, *pointer_id))
+                    .or_default()
+                    .push(*node_entity);
+            }
+        }
+    }
+
+    for ((camera, pointer), hovered_nodes) in hit_nodes.iter() {
+        // As soon as a node with a `Block` focus policy is detected, the iteration will stop on it
+        // because it "captures" the interaction.
+        let mut iter = node_query.iter_many_mut(hovered_nodes.iter());
+        let mut picks = Vec::new();
+        let mut depth = 0.0;
+
+        while let Some(node) = iter.fetch_next() {
+            let Some(camera_entity) = node
+                .target_camera
+                .map(TargetCamera::entity)
+                .or(default_ui_camera.get())
+            else {
+                continue;
+            };
+
+            picks.push((node.entity, HitData::new(camera_entity, depth, None, None)));
+
+            if let Some(pickable) = node.pickable {
+                // If an entity has a `Pickable` component, we will use that as the source of truth.
+                if pickable.should_block_lower {
+                    break;
+                }
+            } else {
+                // If the Pickable component doesn't exist, default behavior is to block.
+                break;
+            }
+
+            depth += 0.00001; // keep depth near 0 for precision
+        }
+
+        let order = camera_query
+            .get(*camera)
+            .map(|(_, cam, _)| cam.order)
+            .unwrap_or_default() as f32
+            + 0.5; // bevy ui can run on any camera, it's a special case
+
+        output.send(PointerHits::new(*pointer, picks, order));
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ git checkout v0.4.0
   - [Input](#input)
   - [Math](#math)
   - [Movement](#movement)
+  - [Picking](#picking)
   - [Reflection](#reflection)
   - [Scene](#scene)
   - [Shaders](#shaders)
@@ -349,6 +350,12 @@ Example | Description
 Example | Description
 --- | ---
 [Run physics in a fixed timestep](../examples/movement/physics_in_fixed_timestep.rs) | Handles input, physics, and rendering in an industry-standard way by using a fixed timestep
+
+## Picking
+
+Example | Description
+--- | ---
+[Showcases simple picking events and usage](../examples/picking/simple_picking.rs) | Demonstrates how to use picking events to spawn simple objects
 
 ## Reflection
 

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -2,6 +2,7 @@
 
 use std::{
     f32::consts::PI,
+    ops::Drop,
     sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
         Arc,

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -6,14 +6,9 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins);
 
-    // Enable ambiguity warnings for the Update schedule
-    app.edit_schedule(PreUpdate, |schedule| {
-        schedule.set_build_settings(bevy::ecs::schedule::ScheduleBuildSettings {
-            ambiguity_detection: bevy::ecs::schedule::LogLevel::Warn,
-            ..default()
-        });
-    });
-    app.add_systems(Startup, setup).run();
+    app.add_systems(Startup, setup);
+
+    app.run();
 }
 
 /// set up a simple 3D scene

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -1,0 +1,121 @@
+//! A simple scene to demonstrate picking events
+
+use bevy::{color::palettes::css::*, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, click_event)
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands
+        .spawn((
+            TextBundle {
+                text: Text::from_section("Click Me to get a box", TextStyle::default()),
+                style: Style {
+                    position_type: PositionType::Absolute,
+                    top: Val::Percent(10.0),
+                    left: Val::Percent(10.0),
+                    ..default()
+                },
+                ..Default::default()
+            },
+            Pickable::default(),
+        ))
+        .observe(
+            |_click: Trigger<Pointer<Click>>,
+             mut commands: Commands,
+             mut meshes: ResMut<Assets<Mesh>>,
+             mut materials: ResMut<Assets<StandardMaterial>>,
+             mut num: Local<usize>| {
+                commands.spawn(PbrBundle {
+                    mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
+                    material: materials.add(Color::srgb_u8(124, 144, 255)),
+                    transform: Transform::from_xyz(0.0, 0.5 + 1.1 * *num as f32, 0.0),
+                    ..default()
+                });
+                *num += 1;
+            },
+        )
+        .observe(|evt: Trigger<Pointer<Out>>, mut texts: Query<&mut Text>| {
+            let mut text = texts.get_mut(evt.entity()).unwrap();
+            let first = text.sections.first_mut().unwrap();
+            first.style.color = WHITE.into();
+        })
+        .observe(|evt: Trigger<Pointer<Over>>, mut texts: Query<&mut Text>| {
+            let mut text = texts.get_mut(evt.entity()).unwrap();
+            let first = text.sections.first_mut().unwrap();
+            first.style.color = BLUE.into();
+        });
+    // circular base
+    commands
+        .spawn((
+            PbrBundle {
+                mesh: meshes.add(Circle::new(4.0)),
+                material: materials.add(Color::WHITE),
+                transform: Transform::from_rotation(Quat::from_rotation_x(
+                    -std::f32::consts::FRAC_PI_2,
+                )),
+                ..default()
+            },
+            Pickable::default(),
+        ))
+        .observe(|click: Trigger<Pointer<Click>>| {
+            let click = click.event();
+            println!("{click:?}");
+        });
+    // light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}
+
+fn click_event(
+    mut eventreader: EventReader<Pointer<Move>>,
+    mut pointer_move: EventReader<Pointer<Move>>,
+    mut pointer_over: EventReader<Pointer<Over>>,
+    mut pointer_out: EventReader<Pointer<Out>>,
+    mut pointer_up: EventReader<Pointer<Up>>,
+    mut pointer_click: EventReader<Pointer<Click>>,
+    mut pointer_down: EventReader<Pointer<Down>>,
+) {
+    for ev in pointer_click.read() {
+        println!("click eventreader: {ev:?}");
+    }
+    // for ev in eventreader.read() {
+    //     println!("{ev:?}");
+    // }
+    // for ev in pointer_move.read() {
+    //     println!("{ev:?}");
+    // }
+    // for ev in pointer_over.read() {
+    //     println!("{ev:?}");
+    // }
+    // for ev in pointer_out.read() {
+    //     println!("{ev:?}");
+    // }
+    // for ev in pointer_up.read() {
+    //     println!("{ev:?}");
+    // }
+    // for ev in pointer_down.read() {
+    //     println!("{ev:?}");
+    // }
+}

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -3,10 +3,17 @@
 use bevy::{color::palettes::css::*, prelude::*};
 
 fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_systems(Startup, setup)
-        .run();
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins);
+
+    // Enable ambiguity warnings for the Update schedule
+    app.edit_schedule(PreUpdate, |schedule| {
+        schedule.set_build_settings(bevy::ecs::schedule::ScheduleBuildSettings {
+            ambiguity_detection: bevy::ecs::schedule::LogLevel::Warn,
+            ..default()
+        });
+    });
+    app.add_systems(Startup, setup).run();
 }
 
 /// set up a simple 3D scene

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -6,7 +6,6 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, click_event)
         .run();
 }
 
@@ -86,36 +85,4 @@ fn setup(
         transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
-}
-
-fn click_event(
-    mut eventreader: EventReader<Pointer<Move>>,
-    mut pointer_move: EventReader<Pointer<Move>>,
-    mut pointer_over: EventReader<Pointer<Over>>,
-    mut pointer_out: EventReader<Pointer<Out>>,
-    mut pointer_up: EventReader<Pointer<Up>>,
-    mut pointer_click: EventReader<Pointer<Click>>,
-    mut pointer_down: EventReader<Pointer<Down>>,
-) {
-    for ev in pointer_click.read() {
-        println!("click eventreader: {ev:?}");
-    }
-    // for ev in eventreader.read() {
-    //     println!("{ev:?}");
-    // }
-    // for ev in pointer_move.read() {
-    //     println!("{ev:?}");
-    // }
-    // for ev in pointer_over.read() {
-    //     println!("{ev:?}");
-    // }
-    // for ev in pointer_out.read() {
-    //     println!("{ev:?}");
-    // }
-    // for ev in pointer_up.read() {
-    //     println!("{ev:?}");
-    // }
-    // for ev in pointer_down.read() {
-    //     println!("{ev:?}");
-    // }
 }


### PR DESCRIPTION
Makes the newly merged picking usable for UI elements. 

currently it both triggers the events, as well as sends them as throught commands.trigger_targets. We should probably figure out if this is needed for them all. 

# Objective

Hooks up obserers and picking for a very simple example

## Solution

upstreamed the UI picking backend from bevy_mod_picking

## Testing

tested with the new example picking/simple_picking.rs


---