### PR TITLE
Replace UnsafeCell<World> usage with UnsafeWorldCell in CombinatorSystem

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -1,6 +1,4 @@
-use std::{borrow::Cow, cell::UnsafeCell, marker::PhantomData};
-
-use bevy_ptr::UnsafeCellDeref;
+use std::{borrow::Cow, marker::PhantomData};
 
 use crate::{
     archetype::ArchetypeComponentId,

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -180,7 +180,7 @@ where
         )
     }
 
-    fn run<'w>(&mut self, input: Self::In, world: &'w mut World) -> Self::Out {
+    fn run(&mut self, input: Self::In, world: &mut World) -> Self::Out {
         let world = world.as_unsafe_world_cell();
         Func::combine(
             input,


### PR DESCRIPTION
# Objective

Replace usage of `UnsafeCell<World>` with our standard `UnsafeWorldCell` that seemed to have been missed.

## Solution

Do just that.