### PR TITLE
Consistency between `Wireframe2d` and `Wireframe`

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -1,7 +1,7 @@
 use crate::{Material2d, Material2dKey, Material2dPlugin, Mesh2dHandle};
 use bevy_app::{Plugin, Startup, Update};
 use bevy_asset::{load_internal_asset, Asset, Assets, Handle};
-use bevy_color::{LinearRgba, Srgba};
+use bevy_color::{Color, LinearRgba};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
 use bevy_render::{
@@ -67,7 +67,7 @@ pub struct Wireframe2d;
 #[derive(Component, Debug, Clone, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct Wireframe2dColor {
-    pub color: Srgba,
+    pub color: Color,
 }
 
 /// Disables wireframe rendering for any entity it is attached to.
@@ -81,13 +81,13 @@ pub struct NoWireframe2d;
 #[derive(Resource, Debug, Clone, Default, ExtractResource, Reflect)]
 #[reflect(Resource)]
 pub struct Wireframe2dConfig {
-    /// Whether to show wireframes for all meshes.
+    /// Whether to show wireframes for all 2D meshes.
     /// Can be overridden for individual meshes by adding a [`Wireframe2d`] or [`NoWireframe2d`] component.
     pub global: bool,
     /// If [`Self::global`] is set, any [`Entity`] that does not have a [`Wireframe2d`] component attached to it will have
     /// wireframes using this color. Otherwise, this will be the fallback color for any entity that has a [`Wireframe2d`],
     /// but no [`Wireframe2dColor`].
-    pub default_color: Srgba,
+    pub default_color: Color,
 }
 
 #[derive(Resource)]

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -44,7 +44,7 @@ fn main() {
             global: true,
             // Controls the default color of all wireframes. Used as the default color for global wireframes.
             // Can be changed per mesh using the `Wireframe2dColor` component.
-            default_color: WHITE,
+            default_color: WHITE.into(),
         })
         .add_systems(Startup, setup)
         .add_systems(Update, update_colors)
@@ -91,7 +91,9 @@ fn setup(
         Wireframe2d,
         // This lets you configure the wireframe color of this entity.
         // If not set, this will use the color in `WireframeConfig`
-        Wireframe2dColor { color: GREEN },
+        Wireframe2dColor {
+            color: GREEN.into(),
+        },
     ));
 
     // Camera
@@ -126,7 +128,8 @@ Wireframe2dConfig
 -------------
 Global: {}
 Color: {:?}",
-        config.global, config.default_color,
+        config.global,
+        config.default_color.to_srgba(),
     );
 
     // Toggle showing a wireframe on all meshes
@@ -136,17 +139,21 @@ Color: {:?}",
 
     // Toggle the global wireframe color
     if keyboard_input.just_pressed(KeyCode::KeyX) {
-        config.default_color = if config.default_color == WHITE {
-            RED
+        config.default_color = if config.default_color == WHITE.into() {
+            RED.into()
         } else {
-            WHITE
+            WHITE.into()
         };
     }
 
     // Toggle the color of a wireframe using `Wireframe2dColor` and not the global color
     if keyboard_input.just_pressed(KeyCode::KeyC) {
         for mut color in &mut wireframe_colors {
-            color.color = if color.color == GREEN { RED } else { GREEN };
+            color.color = if color.color == GREEN.into() {
+                RED.into()
+            } else {
+                GREEN.into()
+            };
         }
     }
 }


### PR DESCRIPTION
# Objective

- Wireframe plugins have inconsistencies between 3D and 2D versions. This PR addresses the following
  - 2d version uses `Srgba` for colors, 3d version uses `Color`.

  
## Solution

- This PR brings consistency by doing the following change
  - `Wireframe2d` now uses `Color` instead of `Srgba`

## Testing

- `wireframe_2d` and `wireframe` examples were verified and they work as before.

---

## Migration Guide

- `Wireframe2dConfig`.`default_color` type is now `Color` instead of `Srgba`. Use `.into()` to convert between them.
- `Wireframe2dColor`.`color` type is now `Color` instead of `Srgba`. Use `.into()` to convert between them.


