### PR TITLE
change filter fetch to be immutable

### DIFF
--- a/crates/bevy_ecs/macros/src/query_filter.rs
+++ b/crates/bevy_ecs/macros/src/query_filter.rs
@@ -127,11 +127,11 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
             #[allow(unused_variables)]
             #[inline(always)]
             unsafe fn filter_fetch<'__w>(
-                _fetch: &mut <Self as #path::query::WorldQuery>::Fetch<'__w>,
+                _fetch: &<Self as #path::query::WorldQuery>::Fetch<'__w>,
                 _entity: #path::entity::Entity,
                 _table_row: #path::storage::TableRow,
             ) -> bool {
-                true #(&& <#field_types>::filter_fetch(&mut _fetch.#named_field_idents, _entity, _table_row))*
+                true #(&& <#field_types>::filter_fetch(&_fetch.#named_field_idents, _entity, _table_row))*
             }
         }
     };

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -472,6 +472,7 @@ macro_rules! impl_or_query_filter {
             }
         }
 
+        #[allow(non_snake_case)]
         impl<$($filter: QueryFilter),*> QueryFilter for Or<($($filter,)*)> {
             const IS_ARCHETYPAL: bool = true $(&& $filter::IS_ARCHETYPAL)*;
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -608,9 +608,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     type Fetch<'w> = AddedFetch<'w>;
     type State = ComponentId;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
+    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
     #[inline]
     unsafe fn init_fetch<'w>(
@@ -813,9 +811,7 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     type Fetch<'w> = ChangedFetch<'w>;
     type State = ComponentId;
 
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
+    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
     #[inline]
     unsafe fn init_fetch<'w>(

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -88,7 +88,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
 
             // SAFETY: set_table was called prior.
             // Caller assures `row` in range of the current archetype.
-            let fetched = unsafe { !F::filter_fetch(&mut self.cursor.filter, *entity, row) };
+            let fetched = unsafe { !F::filter_fetch(&self.cursor.filter, *entity, row) };
             if fetched {
                 continue;
             }
@@ -143,7 +143,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
             // Caller assures `index` in range of the current archetype.
             let fetched = unsafe {
                 !F::filter_fetch(
-                    &mut self.cursor.filter,
+                    &self.cursor.filter,
                     archetype_entity.id(),
                     archetype_entity.table_row(),
                 )
@@ -217,7 +217,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
 
             // SAFETY: set_table was called prior.
             // Caller assures `row` in range of the current archetype.
-            let filter_matched = unsafe { F::filter_fetch(&mut self.cursor.filter, entity, row) };
+            let filter_matched = unsafe { F::filter_fetch(&self.cursor.filter, entity, row) };
             if !filter_matched {
                 continue;
             }
@@ -1732,7 +1732,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 // `current_row` is a table row in range of the current table, because if it was not, then the above would have been executed.
                 let entity = unsafe { self.table_entities.get_unchecked(self.current_row) };
                 let row = TableRow::from_usize(self.current_row);
-                if !F::filter_fetch(&mut self.filter, *entity, row) {
+                if !F::filter_fetch(&self.filter, *entity, row) {
                     self.current_row += 1;
                     continue;
                 }
@@ -1780,7 +1780,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 let archetype_entity =
                     unsafe { self.archetype_entities.get_unchecked(self.current_row) };
                 if !F::filter_fetch(
-                    &mut self.filter,
+                    &self.filter,
                     archetype_entity.id(),
                     archetype_entity.table_row(),
                 ) {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -944,7 +944,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         D::set_archetype(&mut fetch, &self.fetch_state, archetype, table);
         F::set_archetype(&mut filter, &self.filter_state, archetype, table);
 
-        if F::filter_fetch(&mut filter, entity, location.table_row) {
+        if F::filter_fetch(&filter, entity, location.table_row) {
             Ok(D::fetch(&mut fetch, entity, location.table_row))
         } else {
             Err(QueryEntityError::QueryDoesNotMatch(entity))


### PR DESCRIPTION
> Still poking at this

# Objective

- It is unsound to access data mutably in filter_fetch.
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
