### PR TITLE
bevy_reflect: Add `#[reflect(readonly)]` attribute

### DIFF
--- a/crates/bevy_macro_utils/src/fq_std.rs
+++ b/crates/bevy_macro_utils/src/fq_std.rs
@@ -43,6 +43,8 @@ use quote::{quote, ToTokens};
 pub struct FQAny;
 /// Fully Qualified (FQ) short name for [`Box`]
 pub struct FQBox;
+/// Fully Qualified (FQ) short name for [`std::borrow::Cow`]
+pub struct FQCow;
 /// Fully Qualified (FQ) short name for [`Clone`]
 pub struct FQClone;
 /// Fully Qualified (FQ) short name for [`Default`]
@@ -65,6 +67,12 @@ impl ToTokens for FQAny {
 impl ToTokens for FQBox {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         quote!(::std::boxed::Box).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQCow {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::std::borrow::Cow).to_tokens(tokens);
     }
 }
 

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -561,10 +561,13 @@ impl<'a> StructField<'a> {
 
         let ty = self.reflected_type();
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
+        let readonly = self.attrs.readonly;
 
         #[allow(unused_mut)] // Needs mutability for the feature gate
         let mut info = quote! {
-            #field_info::new::<#ty>(#name).with_custom_attributes(#custom_attributes)
+            #field_info::new::<#ty>(#name)
+                .with_custom_attributes(#custom_attributes)
+                .with_readonly(#readonly)
         };
 
         #[cfg(feature = "documentation")]

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -1,7 +1,7 @@
 use crate::derive_data::StructField;
 use crate::field_attributes::DefaultBehavior;
 use crate::{derive_data::ReflectEnum, utility::ident_or_index};
-use bevy_macro_utils::fq_std::{FQDefault, FQOption};
+use bevy_macro_utils::fq_std::{FQDefault, FQResult};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
@@ -88,14 +88,14 @@ pub(crate) trait VariantBuilder: Sized {
 
         let construction = match &field.field.attrs.default {
             DefaultBehavior::Func(path) => quote! {
-                if let #FQOption::Some(#alias) = #field_accessor {
+                if let #FQResult::Ok(#alias) = #field_accessor {
                     #field_constructor
                 } else {
                     #path()
                 }
             },
             DefaultBehavior::Default => quote! {
-                if let #FQOption::Some(#alias) = #field_accessor {
+                if let #FQResult::Ok(#alias) = #field_accessor {
                     #field_constructor
                 } else {
                     #FQDefault::default()
@@ -106,7 +106,7 @@ pub(crate) trait VariantBuilder: Sized {
 
                 quote! {{
                     // `#alias` is used by both the unwrapper and constructor
-                    let #alias = #field_accessor;
+                    let #alias = #field_accessor.ok();
                     let #alias = #field_unwrapper;
                     #field_constructor
                 }}

--- a/crates/bevy_reflect/derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/derive/src/field_attributes.rs
@@ -16,6 +16,7 @@ mod kw {
     syn::custom_keyword!(skip_serializing);
     syn::custom_keyword!(default);
     syn::custom_keyword!(remote);
+    syn::custom_keyword!(readonly);
 }
 
 pub(crate) const IGNORE_SERIALIZATION_ATTR: &str = "skip_serializing";
@@ -80,6 +81,8 @@ pub(crate) struct FieldAttributes {
     pub custom_attributes: CustomAttributes,
     /// For defining the remote wrapper type that should be used in place of the field for reflection logic.
     pub remote: Option<Type>,
+    /// Whether this field is read-only.
+    pub readonly: bool,
 }
 
 impl FieldAttributes {
@@ -125,6 +128,8 @@ impl FieldAttributes {
             self.parse_default(input)
         } else if lookahead.peek(kw::remote) {
             self.parse_remote(input)
+        } else if lookahead.peek(kw::readonly) {
+            self.parse_readonly(input)
         } else {
             Err(lookahead.error())
         }
@@ -214,6 +219,16 @@ impl FieldAttributes {
 
         self.remote = Some(input.parse()?);
 
+        Ok(())
+    }
+
+    /// Parse `readonly` attribute.
+    ///
+    /// Examples:
+    /// - `#[reflect(readonly)]`
+    fn parse_readonly(&mut self, input: ParseStream) -> syn::Result<()> {
+        input.parse::<kw::readonly>()?;
+        self.readonly = true;
         Ok(())
     }
 

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -4,7 +4,7 @@ use crate::enum_utility::{EnumVariantOutputData, FromReflectVariantBuilder, Vari
 use crate::field_attributes::DefaultBehavior;
 use crate::utility::{ident_or_index, WhereClauseOptions};
 use crate::{ReflectMeta, ReflectStruct};
-use bevy_macro_utils::fq_std::{FQClone, FQDefault, FQOption};
+use bevy_macro_utils::fq_std::{FQClone, FQDefault, FQOption, FQResult};
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{Field, Ident, Lit, LitInt, LitStr, Member};
@@ -272,7 +272,7 @@ fn get_active_fields(
                         });
                         quote! {
                             (||
-                                if let #FQOption::Some(field) = #get_field {
+                                if let #FQResult::Ok(field) = #get_field {
                                     #value
                                 } else {
                                     #FQOption::Some(#path())
@@ -286,7 +286,7 @@ fn get_active_fields(
                         });
                         quote! {
                             (||
-                                if let #FQOption::Some(field) = #get_field {
+                                if let #FQResult::Ok(field) = #get_field {
                                     #value
                                 } else {
                                     #FQOption::Some(#FQDefault::default())
@@ -296,7 +296,7 @@ fn get_active_fields(
                     }
                     DefaultBehavior::Required => {
                         let value = into_remote(quote! {
-                            <#ty as #bevy_reflect_path::FromReflect>::from_reflect(#get_field?)
+                            <#ty as #bevy_reflect_path::FromReflect>::from_reflect(#get_field.ok()?)
                         });
                         quote! {
                             (|| #value)

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -98,7 +98,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                  match #match_this {
                     #(#enum_field,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Named(::std::convert::Into::into(#ref_name.to_string())),
+                        field: ::std::convert::Into::into(#ref_name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -108,7 +108,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                 match #match_this {
                     #(#enum_field_at,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Unnamed(#ref_index),
+                        field: ::std::convert::Into::into(#ref_index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -118,7 +118,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                  match #match_this_mut {
                     #(#enum_field_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Named(::std::convert::Into::into(#ref_name.to_string())),
+                        field: ::std::convert::Into::into(#ref_name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -128,7 +128,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                 match #match_this_mut {
                     #(#enum_field_at_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Unnamed(#ref_index),
+                        field: ::std::convert::Into::into(#ref_index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -389,7 +389,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         quote! {
                             #FQResult::Err(
                                 #bevy_reflect_path::error::ReflectFieldError::Readonly {
-                                    field: #bevy_reflect_path::FieldId::Unnamed(#reflection_index),
+                                    field: ::std::convert::Into::into(#reflection_index),
                                     container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                                 },
                             )
@@ -428,7 +428,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         quote! {
                             #FQResult::Err(
                                 #bevy_reflect_path::error::ReflectFieldError::Readonly {
-                                    field: #bevy_reflect_path::FieldId::Named(::std::convert::Into::into(#field_name.to_string())),
+                                    field: ::std::convert::Into::into(#field_name),
                                     container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                                 },
                             )
@@ -443,7 +443,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         quote! {
                             #FQResult::Err(
                                 #bevy_reflect_path::error::ReflectFieldError::Readonly {
-                                    field: #bevy_reflect_path::FieldId::Unnamed(#reflection_index),
+                                    field: ::std::convert::Into::into(#reflection_index),
                                     container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                                 },
                             )

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -98,7 +98,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                  match #match_this {
                     #(#enum_field,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
-                        field: ::std::convert::Into::into(#ref_name),
+                        field: ::std::convert::Into::into(#ref_name.to_string()),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -118,7 +118,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                  match #match_this_mut {
                     #(#enum_field_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
-                        field: ::std::convert::Into::into(#ref_name),
+                        field: ::std::convert::Into::into(#ref_name.to_string()),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -97,7 +97,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             fn field(&self, #ref_name: &str) -> #FQResult<&dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                  match #match_this {
                     #(#enum_field,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(#ref_name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
@@ -107,7 +107,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             fn field_at(&self, #ref_index: usize) -> #FQResult<&dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match #match_this {
                     #(#enum_field_at,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(#ref_index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
@@ -117,7 +117,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             fn field_mut(&mut self, #ref_name: &str) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                  match #match_this_mut {
                     #(#enum_field_mut,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(#ref_name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
@@ -127,7 +127,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             fn field_at_mut(&mut self, #ref_index: usize) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match #match_this_mut {
                     #(#enum_field_at_mut,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(#ref_index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -79,7 +79,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 match name {
                     #(#field_names => #fqresult::Ok(#fields_ref),)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Named(::std::convert::Into::into(name.to_string())),
+                        field: ::std::convert::Into::into(name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -89,7 +89,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 match name {
                     #(#field_names => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Named(::std::convert::Into::into(name.to_string())),
+                        field: ::std::convert::Into::into(name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -99,7 +99,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 match index {
                     #(#field_indices => #fqresult::Ok(#fields_ref),)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Unnamed(index),
+                        field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -109,7 +109,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 match index {
                     #(#field_indices => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Unnamed(index),
+                        field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -87,7 +87,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
 
             fn field_mut(&mut self, name: &str) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match name {
-                    #(#field_names => #fqresult::Ok(#fields_mut),)*
+                    #(#field_names => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
                         field: #bevy_reflect_path::FieldId::Named(::std::convert::Into::into(name.to_string())),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
@@ -107,7 +107,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
 
             fn field_at_mut(&mut self, index: usize) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match index {
-                    #(#field_indices => #fqresult::Ok(#fields_mut),)*
+                    #(#field_indices => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
                         field: #bevy_reflect_path::FieldId::Unnamed(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -78,7 +78,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn field(&self, name: &str) -> #FQResult<&dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match name {
                     #(#field_names => #fqresult::Ok(#fields_ref),)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
@@ -88,7 +88,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn field_mut(&mut self, name: &str) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match name {
                     #(#field_names => #fields_mut,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(name),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
@@ -98,7 +98,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn field_at(&self, index: usize) -> #FQResult<&dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match index {
                     #(#field_indices => #fqresult::Ok(#fields_ref),)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
@@ -108,7 +108,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn field_at_mut(&mut self, index: usize) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match index {
                     #(#field_indices => #fields_mut,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -79,7 +79,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 match name {
                     #(#field_names => #fqresult::Ok(#fields_ref),)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
-                        field: ::std::convert::Into::into(name),
+                        field: ::std::convert::Into::into(name.to_string()),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }
@@ -89,7 +89,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 match name {
                     #(#field_names => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
-                        field: ::std::convert::Into::into(name),
+                        field: ::std::convert::Into::into(name.to_string()),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     }),
                 }

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -66,7 +66,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
                 match index {
                     #(#field_indices => #fqresult::Ok(#fields_ref),)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Unnamed(index),
+                        field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     })
                 }
@@ -76,7 +76,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
                 match index {
                     #(#field_indices => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
-                        field: #bevy_reflect_path::FieldId::Unnamed(index),
+                        field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     })
                 }

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -74,7 +74,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
 
             fn field_mut(&mut self, index: usize) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match index {
-                    #(#field_indices => #fqresult::Ok(#fields_mut),)*
+                    #(#field_indices => #fields_mut,)*
                     _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
                         field: #bevy_reflect_path::FieldId::Unnamed(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -65,7 +65,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             fn field(&self, index: usize) -> #FQResult<&dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match index {
                     #(#field_indices => #fqresult::Ok(#fields_ref),)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     })
@@ -75,7 +75,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             fn field_mut(&mut self, index: usize) -> #FQResult<&mut dyn #bevy_reflect_path::PartialReflect, #bevy_reflect_path::error::ReflectFieldError> {
                 match index {
                     #(#field_indices => #fields_mut,)*
-                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::DoesNotExist {
+                    _ => #FQResult::Err(#bevy_reflect_path::error::ReflectFieldError::NotFound {
                         field: ::std::convert::Into::into(index),
                         container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                     })

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -363,6 +363,17 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
 /// }
 /// ```
 ///
+/// ## `#[reflect(readonly)]`
+///
+/// This attribute marks a field as being readonly.
+///
+/// Readonly fields will return an error when attempting to access them mutably,
+/// such as via `Struct::field_mut`, `Enum::field_at_mut`, etc.
+///
+/// This also has the effect of preventing the field from being modified via `PartialReflect::apply`.
+///
+/// Note that this does not prevent the field from being modified outside the realm of reflection.
+///
 /// [`reflect_trait`]: macro@reflect_trait
 #[proc_macro_derive(Reflect, attributes(reflect, reflect_value, type_path, type_name))]
 pub fn derive_reflect(input: TokenStream) -> TokenStream {

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -37,18 +37,23 @@ impl FieldAccessors {
         });
         let fields_mut = Self::get_fields(reflect_struct, |field, accessor| {
             if field.attrs.readonly {
-                let field_id = field.data.ident.as_ref().map(|ident| {
-                    let name = ident.to_string();
-                    quote!(#bevy_reflect_path::FieldId::Named(::std::convert::Into::into(#name.to_string())))
-                }).unwrap_or_else(|| {
-                    let index = field.reflection_index;
-                    quote!(#bevy_reflect_path::FieldId::Unnamed(#index))
-                });
+                let field_id = field
+                    .data
+                    .ident
+                    .as_ref()
+                    .map(|ident| {
+                        let name = ident.to_string();
+                        quote!(#name)
+                    })
+                    .unwrap_or_else(|| {
+                        let index = field.reflection_index.unwrap_or(field.declaration_index);
+                        quote!(#index)
+                    });
 
                 return quote! {
                     #FQResult::Err(
                         #bevy_reflect_path::error::ReflectFieldError::Readonly {
-                            field: #field_id,
+                            field: ::std::convert::Into::into(#field_id),
                             container_type_path: #FQCow::Borrowed(<Self as #bevy_reflect_path::TypePath>::type_path()),
                         },
                     )

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -43,7 +43,7 @@ impl FieldAccessors {
                     .as_ref()
                     .map(|ident| {
                         let name = ident.to_string();
-                        quote!(#name)
+                        quote!(#name.to_string())
                     })
                     .unwrap_or_else(|| {
                         let index = field.reflection_index.unwrap_or(field.declaration_index);

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -3,9 +3,8 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::{
     self as bevy_reflect, enum_debug, enum_hash, enum_partial_eq, ApplyError, DynamicStruct,
-    DynamicTuple, Enum, FieldId, PartialReflect, Reflect, ReflectFieldError, ReflectKind,
-    ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, TypePath, VariantFieldIter,
-    VariantType,
+    DynamicTuple, Enum, PartialReflect, Reflect, ReflectFieldError, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, TypePath, VariantFieldIter, VariantType,
 };
 
 use std::fmt::Formatter;
@@ -208,7 +207,7 @@ impl Enum for DynamicEnum {
             data.field(name)
         } else {
             Err(ReflectFieldError::DoesNotExist {
-                field: FieldId::Named(name.to_string().into()),
+                field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }
@@ -218,12 +217,12 @@ impl Enum for DynamicEnum {
         if let DynamicVariant::Tuple(data) = &self.variant {
             data.field(index)
                 .ok_or_else(|| ReflectFieldError::DoesNotExist {
-                    field: FieldId::Unnamed(index),
+                    field: index.into(),
                     container_type_path: Cow::Borrowed(Self::type_path()),
                 })
         } else {
             Err(ReflectFieldError::DoesNotExist {
-                field: FieldId::Unnamed(index),
+                field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }
@@ -234,7 +233,7 @@ impl Enum for DynamicEnum {
             data.field_mut(name)
         } else {
             Err(ReflectFieldError::DoesNotExist {
-                field: FieldId::Named(name.to_string().into()),
+                field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }
@@ -244,12 +243,12 @@ impl Enum for DynamicEnum {
         if let DynamicVariant::Tuple(data) = &mut self.variant {
             data.field_mut(index)
                 .ok_or_else(|| ReflectFieldError::DoesNotExist {
-                    field: FieldId::Unnamed(index),
+                    field: index.into(),
                     container_type_path: Cow::Borrowed(Self::type_path()),
                 })
         } else {
             Err(ReflectFieldError::DoesNotExist {
-                field: FieldId::Unnamed(index),
+                field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -207,7 +207,7 @@ impl Enum for DynamicEnum {
             data.field(name)
         } else {
             Err(ReflectFieldError::NotFound {
-                field: name.into(),
+                field: name.to_string().into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }
@@ -233,7 +233,7 @@ impl Enum for DynamicEnum {
             data.field_mut(name)
         } else {
             Err(ReflectFieldError::NotFound {
-                field: name.into(),
+                field: name.to_string().into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -203,7 +203,7 @@ impl DynamicEnum {
 impl Enum for DynamicEnum {
     fn field(&self, name: &str) -> Option<&dyn PartialReflect> {
         if let DynamicVariant::Struct(data) = &self.variant {
-            data.field(name)
+            data.field(name).ok()
         } else {
             None
         }
@@ -219,7 +219,7 @@ impl Enum for DynamicEnum {
 
     fn field_mut(&mut self, name: &str) -> Option<&mut dyn PartialReflect> {
         if let DynamicVariant::Struct(data) = &mut self.variant {
-            data.field_mut(name)
+            data.field_mut(name).ok()
         } else {
             None
         }

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -206,7 +206,7 @@ impl Enum for DynamicEnum {
         if let DynamicVariant::Struct(data) = &self.variant {
             data.field(name)
         } else {
-            Err(ReflectFieldError::DoesNotExist {
+            Err(ReflectFieldError::NotFound {
                 field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
@@ -216,12 +216,12 @@ impl Enum for DynamicEnum {
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
         if let DynamicVariant::Tuple(data) = &self.variant {
             data.field(index)
-                .ok_or_else(|| ReflectFieldError::DoesNotExist {
+                .ok_or_else(|| ReflectFieldError::NotFound {
                     field: index.into(),
                     container_type_path: Cow::Borrowed(Self::type_path()),
                 })
         } else {
-            Err(ReflectFieldError::DoesNotExist {
+            Err(ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
@@ -232,7 +232,7 @@ impl Enum for DynamicEnum {
         if let DynamicVariant::Struct(data) = &mut self.variant {
             data.field_mut(name)
         } else {
-            Err(ReflectFieldError::DoesNotExist {
+            Err(ReflectFieldError::NotFound {
                 field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
@@ -242,12 +242,12 @@ impl Enum for DynamicEnum {
     fn field_at_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError> {
         if let DynamicVariant::Tuple(data) = &mut self.variant {
             data.field_mut(index)
-                .ok_or_else(|| ReflectFieldError::DoesNotExist {
+                .ok_or_else(|| ReflectFieldError::NotFound {
                     field: index.into(),
                     container_type_path: Cow::Borrowed(Self::type_path()),
                 })
         } else {
-            Err(ReflectFieldError::DoesNotExist {
+            Err(ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -97,31 +97,31 @@ pub trait Enum: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] non-[`VariantType::Struct`] variants.
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::NotFound`] if the field is not a [`VariantType::Struct`].
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field(&self, name: &str) -> Result<&dyn PartialReflect, ReflectFieldError>;
     /// Returns a reference to the value of the field (in the current variant) at the given index.
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError>;
     /// Returns a mutable reference to the value of the field (in the current variant) with the given name.
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] non-[`VariantType::Struct`] variants.
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::NotFound`] if the field is not a [`VariantType::Struct`].
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_mut(&mut self, name: &str) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
     /// Returns a mutable reference to the value of the field (in the current variant) at the given index.
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_at_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
     /// Returns the index of the field (in the current variant) with the given name.
     ///

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -95,15 +95,33 @@ use std::sync::Arc;
 pub trait Enum: PartialReflect {
     /// Returns a reference to the value of the field (in the current variant) with the given name.
     ///
-    /// For non-[`VariantType::Struct`] variants, this should return `None`.
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] non-[`VariantType::Struct`] variants.
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field(&self, name: &str) -> Result<&dyn PartialReflect, ReflectFieldError>;
     /// Returns a reference to the value of the field (in the current variant) at the given index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError>;
     /// Returns a mutable reference to the value of the field (in the current variant) with the given name.
     ///
-    /// For non-[`VariantType::Struct`] variants, this should return `None`.
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] non-[`VariantType::Struct`] variants.
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_mut(&mut self, name: &str) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
     /// Returns a mutable reference to the value of the field (in the current variant) at the given index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_at_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
     /// Returns the index of the field (in the current variant) with the given name.
     ///

--- a/crates/bevy_reflect/src/enums/helpers.rs
+++ b/crates/bevy_reflect/src/enums/helpers.rs
@@ -46,7 +46,7 @@ pub fn enum_partial_eq<TEnum: Enum + ?Sized>(a: &TEnum, b: &dyn PartialReflect) 
             // Same struct fields?
             for field in a.iter_fields() {
                 let field_name = field.name().unwrap();
-                if let Some(field_value) = b.field(field_name) {
+                if let Ok(field_value) = b.field(field_name) {
                     if let Some(false) | None = field_value.reflect_partial_eq(field.value()) {
                         // Fields failed comparison
                         return Some(false);
@@ -61,7 +61,7 @@ pub fn enum_partial_eq<TEnum: Enum + ?Sized>(a: &TEnum, b: &dyn PartialReflect) 
         VariantType::Tuple => {
             // Same tuple fields?
             for (i, field) in a.iter_fields().enumerate() {
-                if let Some(field_value) = b.field_at(i) {
+                if let Ok(field_value) = b.field_at(i) {
                     if let Some(false) | None = field_value.reflect_partial_eq(field.value()) {
                         // Fields failed comparison
                         return Some(false);

--- a/crates/bevy_reflect/src/error.rs
+++ b/crates/bevy_reflect/src/error.rs
@@ -5,6 +5,12 @@ use thiserror::Error;
 /// An error accessing a field via reflection.
 #[derive(Error, Debug)]
 pub enum ReflectFieldError {
+    /// The field is readonly but was attempted to be accessed mutably.
+    #[error("field `{field}` in `{container_type_path}` is readonly")]
+    Readonly {
+        field: FieldId,
+        container_type_path: Cow<'static, str>,
+    },
     /// The field does not exist.
     ///
     /// This can either mean the field does not exist on the type

--- a/crates/bevy_reflect/src/error.rs
+++ b/crates/bevy_reflect/src/error.rs
@@ -1,0 +1,17 @@
+use crate::FieldId;
+use alloc::borrow::Cow;
+use thiserror::Error;
+
+/// An error accessing a field via reflection.
+#[derive(Error, Debug)]
+pub enum ReflectFieldError {
+    /// The field does not exist.
+    ///
+    /// This can either mean the field does not exist on the type
+    /// or it has been ignored with the `#[reflect(ignore)]` attribute.
+    #[error("field `{field}` in `{container_type_path}` does not exist")]
+    DoesNotExist {
+        field: FieldId,
+        container_type_path: Cow<'static, str>,
+    },
+}

--- a/crates/bevy_reflect/src/error.rs
+++ b/crates/bevy_reflect/src/error.rs
@@ -8,7 +8,7 @@ pub enum ReflectFieldError {
     /// The field is readonly but was attempted to be accessed mutably.
     #[error("field `{field}` in `{container_type_path}` is readonly")]
     Readonly {
-        field: FieldId,
+        field: FieldId<'static>,
         container_type_path: Cow<'static, str>,
     },
     /// The field could not be found.
@@ -17,7 +17,7 @@ pub enum ReflectFieldError {
     /// or it has been ignored with the `#[reflect(ignore)]` attribute.
     #[error("field `{field}` in `{container_type_path}` not found")]
     NotFound {
-        field: FieldId,
+        field: FieldId<'static>,
         container_type_path: Cow<'static, str>,
     },
 }

--- a/crates/bevy_reflect/src/error.rs
+++ b/crates/bevy_reflect/src/error.rs
@@ -11,12 +11,12 @@ pub enum ReflectFieldError {
         field: FieldId,
         container_type_path: Cow<'static, str>,
     },
-    /// The field does not exist.
+    /// The field could not be found.
     ///
     /// This can either mean the field does not exist on the type
     /// or it has been ignored with the `#[reflect(ignore)]` attribute.
-    #[error("field `{field}` in `{container_type_path}` does not exist")]
-    DoesNotExist {
+    #[error("field `{field}` in `{container_type_path}` not found")]
+    NotFound {
         field: FieldId,
         container_type_path: Cow<'static, str>,
     },

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -5,7 +5,7 @@ use core::fmt::{Display, Formatter};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 
-/// A general-purpose identifier for name or unnamed fields in structs or enum variants.
+/// A general-purpose identifier for named or unnamed fields in structs or enum variants.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FieldId<'a> {
     /// A named field.

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,7 +1,31 @@
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{MaybeTyped, PartialReflect, TypeInfo, TypePath, TypePathTable};
+use alloc::borrow::Cow;
+use core::fmt::{Display, Formatter};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
+
+/// A general-purpose field identifier.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum FieldId {
+    /// A named field.
+    ///
+    /// This includes fields of structs and enum struct variants.
+    Named(Cow<'static, str>),
+    /// An unnamed field.
+    ///
+    /// This includes fields of tuples and tuple struct variants.
+    Unnamed(usize),
+}
+
+impl Display for FieldId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FieldId::Named(name) => write!(f, "{}", name),
+            FieldId::Unnamed(index) => write!(f, "{}", index),
+        }
+    }
+}
 
 /// The named field of a reflected struct.
 #[derive(Clone, Debug)]

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -27,6 +27,30 @@ impl Display for FieldId {
     }
 }
 
+impl From<usize> for FieldId {
+    fn from(value: usize) -> Self {
+        Self::Unnamed(value)
+    }
+}
+
+impl From<&str> for FieldId {
+    fn from(value: &str) -> Self {
+        Self::Named(Cow::Owned(value.to_string()))
+    }
+}
+
+impl From<String> for FieldId {
+    fn from(value: String) -> Self {
+        Self::Named(Cow::Owned(value))
+    }
+}
+
+impl From<Cow<'static, str>> for FieldId {
+    fn from(value: Cow<'static, str>) -> Self {
+        Self::Named(value)
+    }
+}
+
 /// The named field of a reflected struct.
 #[derive(Clone, Debug)]
 pub struct NamedField {

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -7,18 +7,18 @@ use std::sync::Arc;
 
 /// A general-purpose field identifier.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum FieldId {
+pub enum FieldId<'a> {
     /// A named field.
     ///
     /// This includes fields of structs and enum struct variants.
-    Named(Cow<'static, str>),
+    Named(Cow<'a, str>),
     /// An unnamed field.
     ///
     /// This includes fields of tuples and tuple struct variants.
     Unnamed(usize),
 }
 
-impl Display for FieldId {
+impl Display for FieldId<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             FieldId::Named(name) => write!(f, "{}", name),
@@ -27,26 +27,26 @@ impl Display for FieldId {
     }
 }
 
-impl From<usize> for FieldId {
+impl From<usize> for FieldId<'static> {
     fn from(value: usize) -> Self {
         Self::Unnamed(value)
     }
 }
 
-impl From<&str> for FieldId {
-    fn from(value: &str) -> Self {
-        Self::Named(Cow::Owned(value.to_string()))
+impl<'a> From<&'a str> for FieldId<'a> {
+    fn from(value: &'a str) -> Self {
+        Self::Named(Cow::Borrowed(value))
     }
 }
 
-impl From<String> for FieldId {
+impl From<String> for FieldId<'static> {
     fn from(value: String) -> Self {
         Self::Named(Cow::Owned(value))
     }
 }
 
-impl From<Cow<'static, str>> for FieldId {
-    fn from(value: Cow<'static, str>) -> Self {
+impl<'a> From<Cow<'a, str>> for FieldId<'a> {
+    fn from(value: Cow<'a, str>) -> Self {
         Self::Named(value)
     }
 }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -34,6 +34,7 @@ pub struct NamedField {
     type_info: fn() -> Option<&'static TypeInfo>,
     type_path: TypePathTable,
     type_id: TypeId,
+    readonly: bool,
     custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -47,6 +48,7 @@ impl NamedField {
             type_info: T::maybe_type_info,
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
+            readonly: false,
             custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -57,6 +59,11 @@ impl NamedField {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Set the readonly status of this field.
+    pub fn with_readonly(self, readonly: bool) -> Self {
+        Self { readonly, ..self }
     }
 
     /// Sets the custom attributes for this field.
@@ -114,6 +121,11 @@ impl NamedField {
         self.docs
     }
 
+    /// Returns `true` if the field is readonly.
+    pub fn readonly(&self) -> bool {
+        self.readonly
+    }
+
     impl_custom_attribute_methods!(self.custom_attributes, "field");
 }
 
@@ -124,6 +136,7 @@ pub struct UnnamedField {
     type_info: fn() -> Option<&'static TypeInfo>,
     type_path: TypePathTable,
     type_id: TypeId,
+    readonly: bool,
     custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -136,6 +149,7 @@ impl UnnamedField {
             type_info: T::maybe_type_info,
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
+            readonly: false,
             custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -146,6 +160,11 @@ impl UnnamedField {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Set the readonly status of this field.
+    pub fn with_readonly(self, readonly: bool) -> Self {
+        Self { readonly, ..self }
     }
 
     /// Sets the custom attributes for this field.
@@ -201,6 +220,11 @@ impl UnnamedField {
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
+    }
+
+    /// Returns `true` if the field is readonly.
+    pub fn readonly(&self) -> bool {
+        self.readonly
     }
 
     impl_custom_attribute_methods!(self.custom_attributes, "field");

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -5,7 +5,7 @@ use core::fmt::{Display, Formatter};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 
-/// A general-purpose field identifier.
+/// A general-purpose identifier for name or unnamed fields in structs or enum variants.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FieldId<'a> {
     /// A named field.

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -2347,6 +2347,7 @@ mod tests {
         if value.is_variant(VariantType::Tuple) {
             if let Some(field) = value
                 .field_at_mut(0)
+                .ok()
                 .and_then(|field| field.try_downcast_mut::<usize>())
             {
                 *field = 321;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -560,6 +560,7 @@ mod impls {
 
 pub mod attributes;
 mod enums;
+pub mod error;
 pub mod serde;
 pub mod std_traits;
 pub mod utility;
@@ -579,6 +580,7 @@ pub mod prelude {
 
 pub use array::*;
 pub use enums::*;
+pub use error::*;
 pub use fields::*;
 pub use from_reflect::*;
 pub use list::*;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -908,6 +908,29 @@ mod tests {
     }
 
     #[test]
+    fn should_mark_fields_readonly() {
+        #[derive(Reflect)]
+        struct MyStruct {
+            is_not_readonly: u32,
+            #[reflect(readonly)]
+            is_readonly: u32,
+        }
+
+        let TypeInfo::Struct(info) = MyStruct::type_info() else {
+            panic!("Expected a struct.");
+        };
+
+        assert!(
+            !info.field("is_not_readonly").unwrap().readonly(),
+            "field should not be readonly"
+        );
+        assert!(
+            info.field("is_readonly").unwrap().readonly(),
+            "field should be readonly"
+        );
+    }
+
+    #[test]
     fn should_respect_readonly_struct_fields() {
         #[derive(Reflect)]
         struct MyStruct {

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -69,12 +69,12 @@ impl<'a> Access<'a> {
             |expected, actual| AccessErrorKind::IncompatibleEnumVariantTypes { expected, actual };
 
         match (self, base.reflect_ref()) {
-            (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field.as_ref())),
+            (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field.as_ref()).ok()),
             (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field(field.as_ref())),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
-            (&Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index)),
+            (&Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index).ok()),
             (&Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field_at(index)),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
@@ -86,7 +86,7 @@ impl<'a> Access<'a> {
                 })
             }
 
-            (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index)),
+            (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index).ok()),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Tuple => Ok(enum_ref.field_at(index)),
@@ -128,12 +128,16 @@ impl<'a> Access<'a> {
             |expected, actual| AccessErrorKind::IncompatibleEnumVariantTypes { expected, actual };
 
         match (self, base.reflect_mut()) {
-            (Self::Field(field), Struct(struct_mut)) => Ok(struct_mut.field_mut(field.as_ref())),
+            (Self::Field(field), Struct(struct_mut)) => {
+                Ok(struct_mut.field_mut(field.as_ref()).ok())
+            }
             (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_mut(field.as_ref())),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
-            (&Self::FieldIndex(index), Struct(struct_mut)) => Ok(struct_mut.field_at_mut(index)),
+            (&Self::FieldIndex(index), Struct(struct_mut)) => {
+                Ok(struct_mut.field_at_mut(index).ok())
+            }
             (&Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
@@ -145,7 +149,7 @@ impl<'a> Access<'a> {
                 })
             }
 
-            (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index)),
+            (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index).ok()),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -71,12 +71,12 @@ impl<'a> Access<'a> {
         match (self, base.reflect_ref()) {
             (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field.as_ref()).ok()),
             (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
-                VariantType::Struct => Ok(enum_ref.field(field.as_ref())),
+                VariantType::Struct => Ok(enum_ref.field(field.as_ref()).ok()),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (&Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index).ok()),
             (&Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
-                VariantType::Struct => Ok(enum_ref.field_at(index)),
+                VariantType::Struct => Ok(enum_ref.field_at(index).ok()),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (Self::Field(_) | Self::FieldIndex(_), actual) => {
@@ -89,7 +89,7 @@ impl<'a> Access<'a> {
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index).ok()),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
-                VariantType::Tuple => Ok(enum_ref.field_at(index)),
+                VariantType::Tuple => Ok(enum_ref.field_at(index).ok()),
                 actual => Err(invalid_variant(VariantType::Tuple, actual)),
             },
             (Self::TupleIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
@@ -132,14 +132,14 @@ impl<'a> Access<'a> {
                 Ok(struct_mut.field_mut(field.as_ref()).ok())
             }
             (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
-                VariantType::Struct => Ok(enum_mut.field_mut(field.as_ref())),
+                VariantType::Struct => Ok(enum_mut.field_mut(field.as_ref()).ok()),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (&Self::FieldIndex(index), Struct(struct_mut)) => {
                 Ok(struct_mut.field_at_mut(index).ok())
             }
             (&Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
-                VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
+                VariantType::Struct => Ok(enum_mut.field_at_mut(index).ok()),
                 actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (Self::Field(_) | Self::FieldIndex(_), actual) => {
@@ -152,7 +152,7 @@ impl<'a> Access<'a> {
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index).ok()),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
-                VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),
+                VariantType::Tuple => Ok(enum_mut.field_at_mut(index).ok()),
                 actual => Err(invalid_variant(VariantType::Tuple, actual)),
             },
             (Self::TupleIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -48,18 +48,36 @@ use std::{
 pub trait Struct: PartialReflect {
     /// Returns a reference to the value of the field named `name` as a `&dyn
     /// PartialReflect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
     fn field(&self, name: &str) -> Result<&dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a mutable reference to the value of the field named `name` as a
     /// `&mut dyn PartialReflect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_mut(&mut self, name: &str) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a reference to the value of the field with index `index` as a
     /// `&dyn PartialReflect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a mutable reference to the value of the field with index `index`
     /// as a `&mut dyn PartialReflect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_at_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
 
     /// Returns the name of the field with index `index`.
@@ -375,12 +393,13 @@ impl Struct for DynamicStruct {
 
     #[inline]
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
-        self.fields.get(index).map(|value| &**value).ok_or_else(|| {
-            ReflectFieldError::NotFound {
+        self.fields
+            .get(index)
+            .map(|value| &**value)
+            .ok_or_else(|| ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
-            }
-        })
+            })
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -355,7 +355,7 @@ impl Struct for DynamicStruct {
         self.field_indices
             .get(name)
             .map(|index| &*self.fields[*index])
-            .ok_or_else(|| ReflectFieldError::DoesNotExist {
+            .ok_or_else(|| ReflectFieldError::NotFound {
                 field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
@@ -366,7 +366,7 @@ impl Struct for DynamicStruct {
         if let Some(index) = self.field_indices.get(name) {
             Ok(&mut *self.fields[*index])
         } else {
-            Err(ReflectFieldError::DoesNotExist {
+            Err(ReflectFieldError::NotFound {
                 field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
@@ -376,7 +376,7 @@ impl Struct for DynamicStruct {
     #[inline]
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
         self.fields.get(index).map(|value| &**value).ok_or_else(|| {
-            ReflectFieldError::DoesNotExist {
+            ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             }
@@ -388,7 +388,7 @@ impl Struct for DynamicStruct {
         self.fields
             .get_mut(index)
             .map(|value| &mut **value)
-            .ok_or_else(|| ReflectFieldError::DoesNotExist {
+            .ok_or_else(|| ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -51,7 +51,7 @@ pub trait Struct: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
     fn field(&self, name: &str) -> Result<&dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a mutable reference to the value of the field named `name` as a
@@ -59,8 +59,8 @@ pub trait Struct: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_mut(&mut self, name: &str) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a reference to the value of the field with index `index` as a
@@ -68,7 +68,7 @@ pub trait Struct: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a mutable reference to the value of the field with index `index`
@@ -76,8 +76,8 @@ pub trait Struct: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_at_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
 
     /// Returns the name of the field with index `index`.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -374,7 +374,7 @@ impl Struct for DynamicStruct {
             .get(name)
             .map(|index| &*self.fields[*index])
             .ok_or_else(|| ReflectFieldError::NotFound {
-                field: name.into(),
+                field: name.to_string().into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
     }
@@ -385,7 +385,7 @@ impl Struct for DynamicStruct {
             Ok(&mut *self.fields[*index])
         } else {
             Err(ReflectFieldError::NotFound {
-                field: name.into(),
+                field: name.to_string().into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,8 +1,7 @@
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{
-    self as bevy_reflect, ApplyError, FieldId, NamedField, PartialReflect, Reflect,
-    ReflectFieldError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypePathTable,
+    self as bevy_reflect, ApplyError, NamedField, PartialReflect, Reflect, ReflectFieldError,
+    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable,
 };
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::HashMap;
@@ -357,7 +356,7 @@ impl Struct for DynamicStruct {
             .get(name)
             .map(|index| &*self.fields[*index])
             .ok_or_else(|| ReflectFieldError::DoesNotExist {
-                field: FieldId::Named(name.to_string().into()),
+                field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
     }
@@ -368,7 +367,7 @@ impl Struct for DynamicStruct {
             Ok(&mut *self.fields[*index])
         } else {
             Err(ReflectFieldError::DoesNotExist {
-                field: FieldId::Named(name.to_string().into()),
+                field: name.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
         }
@@ -378,7 +377,7 @@ impl Struct for DynamicStruct {
     fn field_at(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
         self.fields.get(index).map(|value| &**value).ok_or_else(|| {
             ReflectFieldError::DoesNotExist {
-                field: FieldId::Unnamed(index),
+                field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             }
         })
@@ -390,7 +389,7 @@ impl Struct for DynamicStruct {
             .get_mut(index)
             .map(|value| &mut **value)
             .ok_or_else(|| ReflectFieldError::DoesNotExist {
-                field: FieldId::Unnamed(index),
+                field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
     }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -3,9 +3,9 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{
-    self as bevy_reflect, ApplyError, DynamicTuple, FieldId, PartialReflect, Reflect,
-    ReflectFieldError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Tuple, TypeInfo,
-    TypePath, TypePathTable, UnnamedField,
+    self as bevy_reflect, ApplyError, DynamicTuple, PartialReflect, Reflect, ReflectFieldError,
+    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Tuple, TypeInfo, TypePath, TypePathTable,
+    UnnamedField,
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
@@ -282,7 +282,7 @@ impl TupleStruct for DynamicTupleStruct {
     fn field(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
         self.fields.get(index).map(|field| &**field).ok_or_else(|| {
             ReflectFieldError::DoesNotExist {
-                field: FieldId::Unnamed(index),
+                field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             }
         })
@@ -294,7 +294,7 @@ impl TupleStruct for DynamicTupleStruct {
             .get_mut(index)
             .map(|field| &mut **field)
             .ok_or_else(|| ReflectFieldError::DoesNotExist {
-                field: FieldId::Unnamed(index),
+                field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })
     }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -44,7 +44,7 @@ pub trait TupleStruct: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
     fn field(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a mutable reference to the value of the field with index `index`
@@ -52,8 +52,8 @@ pub trait TupleStruct: PartialReflect {
     ///
     /// # Errors
     ///
-    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
-    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
+    /// - [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// - [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
 
     /// Returns the number of fields in the tuple struct.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -41,10 +41,19 @@ use std::sync::Arc;
 pub trait TupleStruct: PartialReflect {
     /// Returns a reference to the value of the field with index `index` as a
     /// `&dyn Reflect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
     fn field(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError>;
 
     /// Returns a mutable reference to the value of the field with index `index`
     /// as a `&mut dyn Reflect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReflectFieldError::NotFound`] if the field does not exist or is ignored.
+    /// Returns [`ReflectFieldError::Readonly`] if the field is marked as readonly.
     fn field_mut(&mut self, index: usize) -> Result<&mut dyn PartialReflect, ReflectFieldError>;
 
     /// Returns the number of fields in the tuple struct.
@@ -280,12 +289,13 @@ impl DynamicTupleStruct {
 impl TupleStruct for DynamicTupleStruct {
     #[inline]
     fn field(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
-        self.fields.get(index).map(|field| &**field).ok_or_else(|| {
-            ReflectFieldError::NotFound {
+        self.fields
+            .get(index)
+            .map(|field| &**field)
+            .ok_or_else(|| ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
-            }
-        })
+            })
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -281,7 +281,7 @@ impl TupleStruct for DynamicTupleStruct {
     #[inline]
     fn field(&self, index: usize) -> Result<&dyn PartialReflect, ReflectFieldError> {
         self.fields.get(index).map(|field| &**field).ok_or_else(|| {
-            ReflectFieldError::DoesNotExist {
+            ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             }
@@ -293,7 +293,7 @@ impl TupleStruct for DynamicTupleStruct {
         self.fields
             .get_mut(index)
             .map(|field| &mut **field)
-            .ok_or_else(|| ReflectFieldError::DoesNotExist {
+            .ok_or_else(|| ReflectFieldError::NotFound {
                 field: index.into(),
                 container_type_path: Cow::Borrowed(Self::type_path()),
             })


### PR DESCRIPTION
# Objective

There are times when you want a type to be `Reflect`, but don't want to allow the modification of certain fields. There a many reasons you might want to do this. One of those reasons is that your type might need to maintain certain invariants in its fields.

For example, we have defined a `History` type for an editor below.

```rust
struct History {
    /// New/redone actions are pushed here.
    undo_stack: Vec<Op>,
    /// Undone actions are pushed here.
    redo_stack: Vec<Op>,
}
```

It's important that the undo and redo actions are performed through the `History::undo` and `History::redo` methods so that the `Op` gets moved to the proper stack.

However, if we derive `Reflect`, then someone could very easily break this flow through reflection.

We _could_ derive it as a `#[reflect_value]`, but then our reflection-based editor pane can no longer display the undo and redo stacks.

Ideally, we'd be able to allow those fields to be visible without sacrificing our desired level of mutability privileges.

## Solution

This PR adds a `#[reflect(readonly)]` field attribute that prevents that field from being mutably accessed via reflection.

Deriving `Reflect` on a type result in one of three subtraits being implemented: `Struct`, `TupleStruct`, or `Enum`. Because these are the only user-configurable traits (at least via the derive macro), these are the main trait affected by this PR.

All `field`, `field_mut`, `field_at`, and `field_at_mut` methods across these three traits have been modified to return a `Result` instead of an `Option`. The error type, `ReflectFieldError`, then has two variants:
- `NotFound` - This takes the place of `None`, where the given field identifier does not exist on the type or the field is marked with `#[reflect(ignore)]`.
- `Readonly` - This is returned when attempting to mutably access a field marked with `#[reflect(readonly)]`.

Additionally, the `PartialReflect::try_apply` method implementations—which rely on these field methods under the hood—will now skip readonly fields.

We also expose the readonly status of the field via type info:
- `NamedField::readonly`
- `UnnamedField::readonly`

This PR also adds the `FieldId` enum to help with error messaging. This will be super useful for error messaging in the future. And as an added benefit, it can even be used to consolidate named-vs-unnamed APIs:

```rust
// BEFORE
fn print_field(value: &dyn PartialReflect, name: &str) {/* ... */}
fn print_field_at(value: &dyn PartialReflect, index: usize) {/* ... */}

// AFTER
fn print_field(value: &dyn PartialReflect, id: impl Into<FieldId>) {/* ... */}
```

Again, not the point of this PR and not much use to us right now, but pretty cool nonetheless haha.

### Open Questions

1. Should we split `ReflectFieldError` into mutable and immutable versions? I think I prefer having one error enum for these methods, but it does mean that the immutable methods will always have an "unreachable" pattern: the `Readonly` variant. It could make sense to split them up so the immutable methods don't have to deal with the variant, but I'm pretty sure many error types behave this way (`io::Error`, for example). So I don't think we should change it, but I'm open to opinions!

## Testing

This PR adds a good handful of tests for this feature. To test locally, run the following command:

```
cargo test --package bevy_reflect
```

---

## Showcase

Fields can now be marked as `readonly` when deriving `Reflect`, allowing them to be visible via reflection, but not _mutable_.

```rust
#[derive(Reflect)]
struct PlayerScore {
    #[reflect(readonly)]
    total: u32
}

let mut score: Box<dyn Struct> = Box::new(PlayerScore { total: 100 });

// We can still immutably access the field:
let total = score.field("total").unwrap();
assert_eq!(total.try_downcast_ref::<u32>(), Some(&100));

// But we cannot access the field mutably:
score.field_mut("total").unwrap(); // PANIC!
```

## Migration Guide

The return types on the following methods have been changed from `Option<...>` to `Result<..., ReflectFieldError>`:
- `Struct::field`
- `Struct::field_mut`
- `Struct::field_at`
- `Struct::field_at_mut`
- `TupleStruct::field`
- `TupleStruct::field_mut`
- `Enum::field`
- `Enum::field_mut`
- `Enum::field_at`
- `Enum::field_at_mut`

While it's recommended to handle errors explicitly, an easy way to migrate existing code with minimal changes is to simply convert the `Result` back to an `Option`:

```rust
// BEFORE
fn extract_value(container: &dyn Struct) -> Option<&dyn PartialReflect> {
    container.field("value")
}

// AFTER
fn extract_value(container: &dyn Struct) -> Option<&dyn PartialReflect> {
    container.field("value").ok()
}
```

Also note that only the `_mut` methods return the `ReflectFieldError::Readonly` variant. For the immutable methods, only the `ReflectFieldError::NotFound` should be expected.