### PR TITLE
 Making `DynamicEnum::is_dynamic()` return true

### DIFF
--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -415,6 +415,11 @@ impl PartialReflect for DynamicEnum {
         enum_debug(self, f)?;
         write!(f, ")")
     }
+
+    #[inline]
+    fn is_dynamic(&self) -> bool {
+        true
+    }
 }
 
 impl_type_path!((in bevy_reflect) DynamicEnum);

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -212,6 +212,12 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_enum_should_return_is_dynamic() {
+        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321));
+        assert!(dyn_enum.is_dynamic());
+    }
+
+    #[test]
     fn enum_should_iterate_fields() {
         // === Unit === //
         let value: &dyn Enum = &MyEnum::A;


### PR DESCRIPTION
# Objective

- Right now `DynamicEnum::is_dynamic()` is returning `false`. I don't think this was expected, since the rest of `Dynamic*` types return `true`.

## Solution

- Making `DynamicEnum::is_dynamic()` return true

## Testing

- Added an extra unit test to verify that `.is_dynamic()` returns `true`.
