### PR TITLE
Sync flags in docs.yml with `package.metadata.docs.rs`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Build docs
         env:
           # needs to be in sync with [package.metadata.docs.rs]
+          RUSTFLAGS: --cfg docsrs_dep
           RUSTDOCFLAGS: -Zunstable-options --cfg=docsrs --generate-link-to-definition
         run: |
           cargo doc \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3368,7 +3368,7 @@ panic = "abort"
 # impls for re-exported traits. See https://github.com/rust-lang/cargo/issues/8811
 # for details on why this is needed. Since dependencies don't expect to be built
 # with `--cfg docsrs` (and thus fail to compile) we use a different cfg.
-rustc-args = ["--cfg docsrs_dep"]
+rustc-args = ["--cfg", "docsrs_dep"]
 rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]
 all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]


### PR DESCRIPTION
# Objective

This PR is a follow-up to #14703. I forgot to also add the flags from `package.metadata.docs.rs` to the docs build.

## Solution

As [discussed on Discord](https://discord.com/channels/691052431525675048/1272629407659589663/1272643734260940940), I added the missing flags to `docs.yml`.

I also updated `rustc-args` to properly make use of the array (I think the value has to be either a space-separated string *or* an array of strings but not an array of space-separated strings 😆)