### PR TITLE
apply finished animations

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -160,6 +160,7 @@ impl VariableCurve {
     ///
     /// Returns the first keyframe if the `seek_time` is before the first keyframe, and
     /// the second-to-last keyframe if the `seek_time` is after the last keyframe.
+    /// Panics if there are less than 2 keyframes.
     pub fn find_interpolation_start_keyframe(&self, seek_time: f32) -> usize {
         // An Ok(keyframe_index) result means an exact result was found by binary search
         // An Err result means the keyframe was not found, and the index is the keyframe
@@ -174,7 +175,7 @@ impl VariableCurve {
             // An exact match was found
             Ok(i) => i.clamp(0, self.keyframe_timestamps.len() - 2),
             // No exact match was found, so return the previous keyframe to interpolate from.
-            Err(i) => (i - 1).clamp(0, self.keyframe_timestamps.len() - 2),
+            Err(i) => (i.saturating_sub(1)).clamp(0, self.keyframe_timestamps.len() - 2),
         }
     }
 }


### PR DESCRIPTION
# Objective

fix #14742

## Solution

the issue arises because "finished" animations (where current time >= last keyframe time) are not applied at all.
when transitioning from a finished animation to another later-indexed anim, the transition kind-of works because the finished anim is skipped, then the new anim is applied with a lower weight (weight / total_weight)
when transitioning from a finished animation to another earlier-indexed anim, the transition is instant as the new anim is applied with 1.0 (as weight == total_weight for the first applied), then the finished animation is skipped.

to fix this we can always apply every animation based on the nearest 2 keyframes, and clamp the interpolation between them to [0,1]. 

pros:
- finished animations can be transitioned out of correctly
- blended animations where some curves have a last-keyframe before the end of the animation will blend properly
- animations will actually finish on their last keyframe, rather than a fraction of a render-frame before the end

cons:
- we have to re-apply finished animations every frame whether it's necessary or not. i can't see a way to avoid this.