### PR TITLE
Fix window position patch

### DIFF
--- a/tools/example-showcase/fixed-window-position.patch
+++ b/tools/example-showcase/fixed-window-position.patch
@@ -1,9 +1,9 @@
 diff --git a/crates/bevy_window/src/window.rs b/crates/bevy_window/src/window.rs
-index 10bdd8fe8..dda272569 100644
+index f578658cd..ffac22062 100644
 --- a/crates/bevy_window/src/window.rs
 +++ b/crates/bevy_window/src/window.rs
-@@ -232,7 +232,7 @@ impl Default for Window {
-             cursor: Default::default(),
+@@ -318,7 +318,7 @@ impl Default for Window {
+             cursor_options: Default::default(),
              present_mode: Default::default(),
              mode: Default::default(),
 -            position: Default::default(),


### PR DESCRIPTION
# Objective

- CI broke after #14284 because of the `cursor_options` rename

## Solution

- Update the broken patch

## Testing

- Patch tested with `git apply`.
