### PR TITLE
Add `Command` and co. to prelude

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -61,13 +61,13 @@ pub mod prelude {
             IntoSystemSetConfigs, Schedule, Schedules, SystemSet,
         },
         system::{
-            Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,
-            ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System, SystemParamBuilder,
-            SystemParamFunction,
+            Commands, Deferred, EntityCommand, EntityCommands, In, IntoSystem, Local, NonSend,
+            NonSendMut, ParallelCommands, ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource,
+            System, SystemParamBuilder, SystemParamFunction,
         },
         world::{
-            EntityMut, EntityRef, EntityWorldMut, FromWorld, OnAdd, OnInsert, OnRemove, OnReplace,
-            World,
+            Command, EntityMut, EntityRef, EntityWorldMut, FromWorld, OnAdd, OnInsert, OnRemove,
+            OnReplace, World,
         },
     };
 }


### PR DESCRIPTION
# Objective

Make it easier to write and work with custom `Command`s and `EntityCommand`s. See https://discord.com/channels/691052431525675048/692572690833473578/1273030340235100214 for (brief) context.

## Solution

Re-export `Command`, `EntityCommand`, and `EntityCommands` in the `bevy_ecs::prelude`, where `Commands` is already re-exported.