### PR TITLE
Don't ask for ResMut in `queue_view_auto_exposure_pipelines`

### DIFF
--- a/crates/bevy_core_pipeline/src/auto_exposure/mod.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/mod.rs
@@ -110,7 +110,7 @@ impl FromWorld for AutoExposureResources {
 
 fn queue_view_auto_exposure_pipelines(
     mut commands: Commands,
-    pipeline_cache: ResMut<PipelineCache>,
+    pipeline_cache: Res<PipelineCache>,
     mut compute_pipelines: ResMut<SpecializedComputePipelines<AutoExposurePipeline>>,
     pipeline: Res<AutoExposurePipeline>,
     view_targets: Query<(Entity, &AutoExposureSettings)>,


### PR DESCRIPTION
This was creating a spurious ambiguity: `PipelineCache` uses interior mutability.

Spotted as part of #7386.