### PR TITLE
Add `RenderSet::FinalCleanup` for `World::clear_entities`

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -165,7 +165,7 @@ impl Render {
                 Prepare,
                 Render,
                 Cleanup,
-                FinalCleanup,
+                PostCleanup,
             )
                 .chain(),
         );

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -139,6 +139,8 @@ pub enum RenderSet {
     /// Cleanup render resources here.
     Cleanup,
     /// Final cleanup occurs: all entities will be despawned.
+    ///
+    /// Runs after [`Cleanup`](RenderSet::Cleanup).
     FinalCleanup,
 }
 
@@ -164,6 +166,7 @@ impl Render {
                 Prepare,
                 Render,
                 Cleanup,
+                FinalCleanup,
             )
                 .chain(),
         );
@@ -473,8 +476,7 @@ unsafe fn initialize_render_app(app: &mut App) {
                     .in_set(RenderSet::Render),
                 World::clear_entities.in_set(RenderSet::FinalCleanup),
             ),
-        )
-        .configure_sets(Render, RenderSet::FinalCleanup.after(RenderSet::Cleanup));
+        );
 
     render_app.set_extract(|main_world, render_world| {
         #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -138,6 +138,8 @@ pub enum RenderSet {
     Render,
     /// Cleanup render resources here.
     Cleanup,
+    /// Final cleanup occurs: all entities will be despawned.
+    FinalCleanup,
 }
 
 /// The main render schedule.
@@ -469,9 +471,10 @@ unsafe fn initialize_render_app(app: &mut App) {
                     render_system,
                 )
                     .in_set(RenderSet::Render),
-                World::clear_entities.in_set(RenderSet::Cleanup),
+                World::clear_entities.in_set(RenderSet::FinalCleanup),
             ),
-        );
+        )
+        .configure_sets(Render, RenderSet::FinalCleanup.after(RenderSet::Cleanup));
 
     render_app.set_extract(|main_world, render_world| {
         #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -140,7 +140,7 @@ pub enum RenderSet {
     /// Final cleanup occurs: all entities will be despawned.
     ///
     /// Runs after [`Cleanup`](RenderSet::Cleanup).
-    FinalCleanup,
+    PostCleanup,
 }
 
 /// The main render schedule.
@@ -473,7 +473,7 @@ unsafe fn initialize_render_app(app: &mut App) {
                     render_system,
                 )
                     .in_set(RenderSet::Render),
-                World::clear_entities.in_set(RenderSet::FinalCleanup),
+                World::clear_entities.in_set(RenderSet::PostCleanup),
             ),
         );
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -104,7 +104,6 @@ pub struct RenderPlugin {
 
 /// The systems sets of the default [`App`] rendering schedule.
 ///
-/// that runs immediately after the matching system set.
 /// These can be useful for ordering, but you almost never want to add your systems to these sets.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum RenderSet {


### PR DESCRIPTION
# Objective

`World::clear_entities` is ambiguous with all of the other systems in `RenderSet::Cleanup` because it access `&mut World`.

## Solution

 I've added another system set variant, and made sure that this runs after everything else.
 
## Testing

The `ambiguity_detection` example

## Migration Guide

`World::clear_entities` is now part of `RenderSet::PostCleanup` rather than `RenderSet::Cleanup`. Your cleanup systems should likely stay in `RenderSet::Cleanup`.

## Additional context

Spotted when working on #7386: this was responsible for a large number of ambiguities.

This should be removed if / when #14449 is merged: there's no need to call `clear_entities` at all if the rendering world is retained!