### PR TITLE
Enables bevy_render feature for bevy_gizmos dependency in bevy_dev_tools

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -22,7 +22,9 @@ bevy_core = { path = "../bevy_core", version = "0.15.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.15.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.15.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev" }
-bevy_gizmos = { path = "../bevy_gizmos", version = "0.15.0-dev" }
+bevy_gizmos = { path = "../bevy_gizmos", version = "0.15.0-dev", features = [
+  "bevy_render"
+] }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.15.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev" }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -23,7 +23,7 @@ bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.15.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.15.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev" }
 bevy_gizmos = { path = "../bevy_gizmos", version = "0.15.0-dev", features = [
-  "bevy_render"
+  "bevy_render",
 ] }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.15.0-dev" }


### PR DESCRIPTION
# Objective

Fixes #14736

## Solution

Enables feature `bevy_render` for dependency `bevy_gizmos` in `bevy_dev_tools` cargo.

`bevy_dev_tools` has `bevy_render` as a required dependency, whereas it is optional for `bevy_gizmos`. When building with no default features, this causes gizmos to not compile with `bevy_render` features, meaning some fields and code are not available. Since these features are required in dev tools, it makes sense to ensure they are enabled. Making `bevy_render` optional would introduce additional and potentially unwanted change wake. in dev tools.

## Testing
Reproed and tested on Windows 10, issue originally reported on Ubuntu and MacOS.

- Original issue command completed without error: `cargo c -p bevy --no-default-features -F bevy_dev_tools`
- Ran full ci validations with `cargo run -p ci`
