### PR TITLE
Remove manual `apply_deferred` in `bevy_ui`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -166,9 +166,7 @@ impl Plugin for UiPlugin {
             PostUpdate,
             (
                 check_visibility::<WithNode>.in_set(VisibilitySystems::CheckVisibility),
-                (update_target_camera_system, apply_deferred)
-                    .chain()
-                    .in_set(UiSystem::Prepare),
+                update_target_camera_system.in_set(UiSystem::Prepare),
                 ui_layout_system
                     .in_set(UiSystem::Layout)
                     .before(TransformSystem::TransformPropagate),

--- a/tests/ecs/ambiguity_detection.rs
+++ b/tests/ecs/ambiguity_detection.rs
@@ -33,7 +33,7 @@ fn main() {
         // Over time, we are working to reduce the number: your PR should not increase it.
         // If you decrease this by fixing an ambiguity, reduce the number to prevent regressions.
         // See https://github.com/bevyengine/bevy/issues/7386 for progress.
-        72,
+        48,
         "Main app has unexpected ambiguities among the following schedules: \n{:#?}.",
         main_app_ambiguities,
     );


### PR DESCRIPTION
# Objective

This `apply_deferred` doesn't seem to have any effect, pointlessly restricts parallelism and is responsible for a large number of system order ambiguities. Spotted as part of #7386.

## Solution

Remove it.

This is the *only* manual apply_deferred in the code base currently.

## Testing

I've checked various UI examples and `split_screen`, and couldn't discern any difference.

This looks like a remnant of a `(a, apply_deferred, b).chain()` pattern where `b` got removed, leaving us with a weird vestige.