### PR TITLE
Document private items in dev-docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,7 @@ jobs:
             --all-features \
             --workspace \
             --no-deps \
+            --document-private-items \
             --exclude ci \
             --exclude errors \
             --exclude bevy_mobile_example \


### PR DESCRIPTION
# Objective

- The [developer docs](https://dev-docs.bevyengine.org) are primarily used by developers, who often deal with internal and private functions.
- @mweatherley suggested [on Discord](https://discord.com/channels/691052431525675048/743559241461399582/1273658470134186112) that CI passes `--document-private-items` to the dev-docs, so contributors can easily browse these internal details.

## Solution

- Add `--document-private-items` to the CI job that builds the dev-docs.

## Testing

- TODO :)

## Drawbacks

- Users that track the main branch may use the dev-docs instead of <https://docs.rs/bevy>, which may now show a lot of unwanted internal details.
- Searching may be slower / bloated with internal details.