### PR TITLE
bevy_reflect: Add `ReflectBox` to remotely reflect `Box`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2196,6 +2196,17 @@ category = "Reflection"
 wasm = false
 
 [[example]]
+name = "nested_reflection"
+path = "examples/reflection/nested_reflection.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.nested_reflection]
+name = "Nested Reflection"
+description = "Demonstrates how reflection trait objects can be nested in other reflected types"
+category = "Reflection"
+wasm = false
+
+[[example]]
 name = "generic_reflection"
 path = "examples/reflection/generic_reflection.rs"
 doc-scrape-examples = true

--- a/crates/bevy_reflect/src/boxed.rs
+++ b/crates/bevy_reflect/src/boxed.rs
@@ -684,7 +684,7 @@ mod tests {
         let serialized = ron::to_string(&reflect_serializer).unwrap();
         assert_eq!(
             serialized,
-            r#"{"bevy_reflect::boxed::tests::MyStruct":(partial_reflect:{"i32":123},full_reflect:{"i32":456},concrete:{"i32":789})}"#
+            r#"{"bevy_reflect::boxed::tests::MyStruct":(partial_reflect:{"i32":123},full_reflect:{"i32":456},concrete:789)}"#
         );
 
         let reflect_deserializer = ReflectDeserializer::new(&registry);
@@ -719,7 +719,7 @@ mod tests {
         let serialized = ron::to_string(&reflect_serializer).unwrap();
         assert_eq!(
             serialized,
-            r#"{"bevy_reflect::boxed::tests::MyTupleStruct":({"i32":123},{"i32":456},{"i32":789})}"#
+            r#"{"bevy_reflect::boxed::tests::MyTupleStruct":({"i32":123},{"i32":456},789)}"#
         );
 
         let reflect_deserializer = ReflectDeserializer::new(&registry);
@@ -751,8 +751,8 @@ mod tests {
         #[derive(Reflect)]
         #[reflect(from_reflect = false)]
         struct MyNestedStruct {
-            #[reflect(remote = ReflectBox<MyStruct>)]
-            inner: Box<MyStruct>,
+            #[reflect(remote = ReflectBox<dyn PartialReflect>)]
+            inner: Box<dyn PartialReflect>,
         }
 
         let input = MyNestedStruct {
@@ -771,7 +771,7 @@ mod tests {
         let serialized = ron::to_string(&reflect_serializer).unwrap();
         assert_eq!(
             serialized,
-            r#"{"bevy_reflect::boxed::tests::MyNestedStruct":(inner:{"bevy_reflect::boxed::tests::MyStruct":(partial_reflect:{"i32":123},full_reflect:{"i32":456},concrete:{"i32":789})})}"#
+            r#"{"bevy_reflect::boxed::tests::MyNestedStruct":(inner:{"bevy_reflect::boxed::tests::MyStruct":(partial_reflect:{"i32":123},full_reflect:{"i32":456},concrete:789)})}"#
         );
 
         let reflect_deserializer = ReflectDeserializer::new(&registry);

--- a/crates/bevy_reflect/src/boxed.rs
+++ b/crates/bevy_reflect/src/boxed.rs
@@ -1,0 +1,636 @@
+use core::fmt::Formatter;
+use std::any::Any;
+
+use crate::__macro_exports::RegisterForReflection;
+use crate::serde::Serializable;
+use crate::utility::GenericTypePathCell;
+use crate::{
+    ApplyError, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, ReflectRemote, TypeInfo, TypePath,
+};
+
+/// A trait used to access `Self` as a [`dyn PartialReflect`].
+///
+/// This is used to provide by [`ReflectBox<T>`] in order to remotely reflect
+/// the inner type, `T`.
+///
+/// This trait can be implemented on custom trait objects to allow them to be remotely reflected
+/// by [`ReflectBox`].
+///
+/// [`dyn PartialReflect`]: PartialReflect
+#[doc(hidden)]
+pub trait ToPartialReflect: Send + Sync + 'static {
+    /// Get a reference to `Self` as a [`&dyn PartialReflect`](PartialReflect).
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect;
+    /// Get a mutable reference to `Self` as a [`&mut dyn PartialReflect`](PartialReflect).
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect;
+    /// Take `Self` as a [`Box<dyn PartialReflect>`](PartialReflect).
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect>;
+}
+
+impl<T: PartialReflect> ToPartialReflect for T {
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+impl ToPartialReflect for dyn PartialReflect {
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+/// A trait used to access `Self` as a [`dyn Reflect`].
+///
+/// This is used to provide by [`ReflectBox<T>`] in order to remotely reflect
+/// the inner type, `T`.
+///
+/// This trait can be implemented on custom trait objects to allow them to be remotely reflected
+/// by [`ReflectBox`].
+///
+/// [`dyn Reflect`]: Reflect
+#[doc(hidden)]
+pub trait ToReflect: ToPartialReflect {
+    /// Get a reference to `Self` as a [`&dyn Reflect`](Reflect).
+    fn to_reflect_ref(&self) -> &dyn Reflect;
+    /// Get a mutable reference to `Self` as a [`&mut dyn Reflect`](Reflect).
+    fn to_reflect_mut(&mut self) -> &mut dyn Reflect;
+    /// Take `Self` as a [`Box<dyn Reflect>`](Reflect).
+    fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect>;
+}
+
+impl<T: Reflect> ToReflect for T {
+    fn to_reflect_ref(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn to_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+}
+
+impl ToPartialReflect for dyn Reflect {
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+        self.as_partial_reflect()
+    }
+
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self.as_partial_reflect_mut()
+    }
+
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self.into_partial_reflect()
+    }
+}
+
+impl ToReflect for dyn Reflect {
+    fn to_reflect_ref(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn to_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+}
+
+/// A [remote wrapper] type around [`Box<T>`] where `T` is either a type that implements [`PartialReflect`]/[`Reflect`]
+/// or a [`dyn PartialReflect`]/[`dyn Reflect`] trait object.
+///
+/// `Box<T>` is not itself reflectable due to high likelihood of accidentally double-boxing it
+/// (i.e. accidentally calling `Box::new` on an already-reflectable `Box<dyn Reflect>`).
+///
+/// [`ReflectBox`] should never be created or used directly outside remote reflection,
+/// in order to avoid double-boxing.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_reflect::Reflect;
+/// use bevy_reflect::boxed::ReflectBox;
+///
+/// #[derive(Reflect)]
+/// struct Sword {
+///     attack: u32
+/// }
+///
+/// #[derive(Reflect)]
+/// // Keep in mind that `ReflectBox` does not implement `FromReflect`.
+/// // Because of this, we will need to opt-out of the automatic `FromReflect` impl:
+/// #[reflect(from_reflect = false)]
+/// struct Player {
+///     // Tell the `Reflect` derive to remotely reflect our `Box<dyn Reflect>`
+///     // using the `ReflectBox<dyn Reflect>` wrapper type:
+///     #[reflect(remote = ReflectBox<dyn Reflect>)]
+///     weapon: Box<dyn Reflect>
+/// }
+///
+/// let player = Player {
+///     // We can create our `Box<dyn Reflect>` as normal:
+///     weapon: Box::new(Sword { attack: 100 })
+/// };
+///
+/// // Now we can reflect `weapon`!
+/// // Under the hood, this `dyn Reflect` is actually a `ReflectBox<dyn Reflect>`,
+/// // and is automatically delegating all reflection methods to the inner `dyn Reflect`.
+/// // It will automatically convert to and from `ReflectBox<dyn Reflect>` as needed.
+/// let weapon: &dyn Reflect = player.weapon.as_reflect();
+/// assert!(weapon.reflect_partial_eq(&Sword { attack: 100 }).unwrap_or_default());
+/// ```
+///
+/// [remote wrapper]: ReflectRemote
+/// [`dyn PartialReflect`]: PartialReflect
+/// [`dyn Reflect`]: Reflect
+#[repr(transparent)]
+pub struct ReflectBox<T: ?Sized + ToPartialReflect + TypePath>(Box<T>);
+
+impl<T: ?Sized + ToPartialReflect + TypePath> ReflectRemote for ReflectBox<T> {
+    type Remote = Box<T>;
+
+    fn as_remote(&self) -> &Self::Remote {
+        &self.0
+    }
+
+    fn as_remote_mut(&mut self) -> &mut Self::Remote {
+        &mut self.0
+    }
+
+    fn into_remote(self) -> Self::Remote {
+        self.0
+    }
+
+    fn as_wrapper(remote: &Self::Remote) -> &Self {
+        // SAFETY: The wrapper type should be repr(transparent) over the remote type
+        #[allow(unsafe_code)]
+        unsafe {
+            core::mem::transmute::<&Self::Remote, &Self>(remote)
+        }
+    }
+
+    fn as_wrapper_mut(remote: &mut Self::Remote) -> &mut Self {
+        // SAFETY: The wrapper type should be repr(transparent) over the remote type
+        #[allow(unsafe_code)]
+        unsafe {
+            core::mem::transmute::<&mut Self::Remote, &mut Self>(remote)
+        }
+    }
+
+    fn into_wrapper(remote: Self::Remote) -> Self {
+        // SAFETY: The wrapper type should be repr(transparent) over the remote type
+        #[allow(unsafe_code)]
+        unsafe {
+            // Unfortunately, we have to use `transmute_copy` to avoid a compiler error:
+            // ```
+            // error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+            // |
+            // |                 std::mem::transmute::<A, B>(a)
+            // |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            // |
+            // = note: source type: `A` (this type does not have a fixed size)
+            // = note: target type: `B` (this type does not have a fixed size)
+            // ```
+            core::mem::transmute_copy::<Self::Remote, Self>(
+                // `ManuallyDrop` is used to prevent double-dropping `self`
+                &core::mem::ManuallyDrop::new(remote),
+            )
+        }
+    }
+}
+
+/// All methods in this implementation are delegated to the inner type, `T`.
+impl<T: ?Sized + ToPartialReflect + TypePath> PartialReflect for ReflectBox<T> {
+    fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
+        self.0.to_partial_reflect_ref().get_represented_type_info()
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self.0.to_partial_reflect_box()
+    }
+
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self.0.to_partial_reflect_ref()
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self.0.to_partial_reflect_mut()
+    }
+
+    fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
+        self.0.to_partial_reflect_box().try_into_reflect()
+    }
+
+    fn try_as_reflect(&self) -> Option<&dyn Reflect> {
+        self.0.to_partial_reflect_ref().try_as_reflect()
+    }
+
+    fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> {
+        self.0.to_partial_reflect_mut().try_as_reflect_mut()
+    }
+
+    fn apply(&mut self, value: &dyn PartialReflect) {
+        self.0.to_partial_reflect_mut().apply(value);
+    }
+
+    fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), ApplyError> {
+        self.0.to_partial_reflect_mut().try_apply(value)
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        self.0.to_partial_reflect_ref().reflect_kind()
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        self.0.to_partial_reflect_ref().reflect_ref()
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        self.0.to_partial_reflect_mut().reflect_mut()
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        self.0.to_partial_reflect_box().reflect_owned()
+    }
+
+    fn clone_value(&self) -> Box<dyn PartialReflect> {
+        self.0.to_partial_reflect_ref().clone_value()
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        self.0.to_partial_reflect_ref().reflect_hash()
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
+        self.0.to_partial_reflect_ref().reflect_partial_eq(value)
+    }
+
+    fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ReflectBox(")?;
+        self.0.to_partial_reflect_ref().debug(f)?;
+        write!(f, ")")
+    }
+
+    fn serializable(&self) -> Option<Serializable> {
+        self.0.to_partial_reflect_ref().serializable()
+    }
+
+    fn is_dynamic(&self) -> bool {
+        self.0.to_partial_reflect_ref().is_dynamic()
+    }
+}
+
+/// All methods in this implementation are delegated to the inner type, `T`.
+impl<T: ?Sized + ToReflect + TypePath> Reflect for ReflectBox<T> {
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self.0.to_reflect_box().into_any()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self.0.to_reflect_ref().as_any()
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self.0.to_reflect_mut().as_any_mut()
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self.0.to_reflect_box()
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self.0.to_reflect_ref()
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self.0.to_reflect_mut()
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        self.0.to_reflect_mut().set(value)
+    }
+}
+
+/// For most reflection methods, [`ReflectBox`] will delegate its behavior to the type, `T`, that it wraps.
+/// However, due to the static nature of [`TypePath`], [`ReflectBox`] must provide its own implementation.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_reflect::boxed::ReflectBox;
+/// # use bevy_reflect::{PartialReflect, TypePath};
+/// // Notice that we don't delegate to the `TypePath` implementation for `String`:
+/// let type_path = <ReflectBox<String> as TypePath>::type_path();
+/// assert_eq!(type_path, "bevy_reflect::boxed::ReflectBox<alloc::string::String>");
+///
+/// // The same is true for trait object types like `dyn PartialReflect`:
+/// let type_path = <ReflectBox<dyn PartialReflect> as TypePath>::type_path();
+/// assert_eq!(type_path, "bevy_reflect::boxed::ReflectBox<dyn bevy_reflect::PartialReflect>");
+/// ```
+impl<T: ?Sized + ToPartialReflect + TypePath> TypePath for ReflectBox<T> {
+    fn type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| {
+            "bevy_reflect::boxed::ReflectBox<".to_owned() + T::type_path() + ">"
+        })
+    }
+
+    fn short_type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| "ReflectBox<".to_owned() + T::short_type_path() + ">")
+    }
+
+    fn type_ident() -> Option<&'static str> {
+        Some("ReflectBox")
+    }
+
+    fn crate_name() -> Option<&'static str> {
+        Some("bevy_reflect")
+    }
+
+    fn module_path() -> Option<&'static str> {
+        Some("bevy_reflect::boxed")
+    }
+}
+
+impl<T: ?Sized + ToPartialReflect + TypePath> MaybeTyped for ReflectBox<T> {}
+impl<T: ?Sized + ToPartialReflect + TypePath> RegisterForReflection for ReflectBox<T> {}
+
+#[cfg(feature = "functions")]
+mod func {
+    use super::*;
+    use crate::func::args::{Arg, FromArg, GetOwnership, Ownership};
+    use crate::func::{ArgError, IntoReturn, Return};
+
+    impl<T: ?Sized + ToReflect + TypePath> GetOwnership for ReflectBox<T> {
+        fn ownership() -> Ownership {
+            Ownership::Owned
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> GetOwnership for &'_ ReflectBox<T> {
+        fn ownership() -> Ownership {
+            Ownership::Ref
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> GetOwnership for &'_ mut ReflectBox<T> {
+        fn ownership() -> Ownership {
+            Ownership::Mut
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> FromArg for ReflectBox<T> {
+        type This<'a> = ReflectBox<T>;
+
+        fn from_arg(arg: Arg) -> Result<Self::This<'_>, ArgError> {
+            arg.take_owned()
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> FromArg for &'static ReflectBox<T> {
+        type This<'a> = &'a ReflectBox<T>;
+
+        fn from_arg(arg: Arg) -> Result<Self::This<'_>, ArgError> {
+            arg.take_ref()
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> FromArg for &'static mut ReflectBox<T> {
+        type This<'a> = &'a mut ReflectBox<T>;
+
+        fn from_arg(arg: Arg) -> Result<Self::This<'_>, ArgError> {
+            arg.take_mut()
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> IntoReturn for ReflectBox<T> {
+        fn into_return<'into_return>(self) -> Return<'into_return>
+        where
+            Self: 'into_return,
+        {
+            Return::Owned(Box::new(self))
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> IntoReturn for &ReflectBox<T> {
+        fn into_return<'into_return>(self) -> Return<'into_return>
+        where
+            Self: 'into_return,
+        {
+            Return::Ref(self)
+        }
+    }
+
+    impl<T: ?Sized + ToReflect + TypePath> IntoReturn for &mut ReflectBox<T> {
+        fn into_return<'into_return>(self) -> Return<'into_return>
+        where
+            Self: 'into_return,
+        {
+            Return::Mut(self)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate as bevy_reflect;
+    use crate::{DynamicStruct, FromReflect, GetTypeRegistration, Struct, Typed};
+    use static_assertions::assert_not_impl_any;
+
+    use super::*;
+
+    #[test]
+    fn box_should_not_be_reflect() {
+        assert_not_impl_any!(Box<i32>: PartialReflect, Reflect, FromReflect, TypePath, Typed, GetTypeRegistration);
+    }
+
+    #[test]
+    fn should_reflect_box() {
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct Container {
+            #[reflect(remote = ReflectBox<dyn PartialReflect>)]
+            partial_reflect: Box<dyn PartialReflect>,
+            #[reflect(remote = ReflectBox<dyn Reflect>)]
+            full_reflect: Box<dyn Reflect>,
+            #[reflect(remote = ReflectBox<i32>)]
+            concrete: Box<i32>,
+        }
+
+        let mut container: Box<dyn Struct> = Box::new(Container {
+            partial_reflect: Box::new(123),
+            full_reflect: Box::new(456),
+            concrete: Box::new(789),
+        });
+
+        let partial_reflect = container.field("partial_reflect").unwrap();
+        assert!(partial_reflect.reflect_partial_eq(&123).unwrap_or_default());
+
+        let full_reflect = container.field("full_reflect").unwrap();
+        assert!(full_reflect.reflect_partial_eq(&456).unwrap_or_default());
+
+        let concrete = container.field("concrete").unwrap();
+        assert!(concrete.reflect_partial_eq(&789).unwrap_or_default());
+
+        let mut patch = DynamicStruct::default();
+        patch.insert("partial_reflect", ReflectBox(Box::new(321)));
+        patch.insert("full_reflect", ReflectBox(Box::new(654)));
+        patch.insert("concrete", ReflectBox(Box::new(987)));
+
+        container.apply(&patch);
+
+        let partial_reflect = container.field("partial_reflect").unwrap();
+        assert!(partial_reflect.reflect_partial_eq(&321).unwrap_or_default());
+
+        let full_reflect = container.field("full_reflect").unwrap();
+        assert!(full_reflect.reflect_partial_eq(&654).unwrap_or_default());
+
+        let concrete = container.field("concrete").unwrap();
+        assert!(concrete.reflect_partial_eq(&987).unwrap_or_default());
+    }
+
+    #[test]
+    fn should_debug_reflect_box() {
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct Container {
+            #[reflect(remote = ReflectBox<dyn PartialReflect>)]
+            partial_reflect: Box<dyn PartialReflect>,
+            #[reflect(remote = ReflectBox<dyn Reflect>)]
+            full_reflect: Box<dyn Reflect>,
+            #[reflect(remote = ReflectBox<i32>)]
+            concrete: Box<i32>,
+        }
+
+        let container: Box<dyn PartialReflect> = Box::new(Container {
+            partial_reflect: Box::new(123),
+            full_reflect: Box::new(456),
+            concrete: Box::new(789),
+        });
+
+        let debug = format!("{:?}", container.as_partial_reflect());
+        assert_eq!(
+            debug,
+            "bevy_reflect::boxed::tests::Container { partial_reflect: ReflectBox(123), full_reflect: ReflectBox(456), concrete: ReflectBox(789) }"
+        );
+
+        // Double-boxing should be near impossible for a user to create intentionally or unintentionally.
+        // However, we'll still test it here so that we can keep track of its behavior.
+        let double_box: Box<dyn PartialReflect> =
+            Box::new(ReflectBox(Box::new(ReflectBox(Box::new(123)))));
+
+        let deref_debug = format!("{:?}", &*double_box);
+        assert_eq!(deref_debug, "ReflectBox(ReflectBox(123))");
+
+        let as_partial_reflect_debug = format!("{:?}", double_box.as_partial_reflect());
+        assert_eq!(as_partial_reflect_debug, "ReflectBox(123)");
+    }
+
+    #[test]
+    fn should_avoid_double_boxing() {
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct Container {
+            #[reflect(remote = ReflectBox<dyn PartialReflect>)]
+            value: Box<dyn PartialReflect>,
+        }
+
+        let container = Box::new(Container {
+            value: Box::new(Some(123)),
+        });
+
+        let cloned = container.clone_value().clone_value();
+
+        let ReflectRef::Struct(cloned) = cloned.reflect_ref() else {
+            panic!("expected `ReflectRef::Struct`");
+        };
+
+        let value = cloned.field("value").unwrap();
+        let debug = format!("{:?}", value);
+        assert_eq!(debug, "DynamicEnum(Some(123))");
+
+        // Cloning a `ReflectBox` directly. Users should never have an instance of `ReflectBox`.
+        let value = ReflectBox(Box::new(Some(123)));
+        let cloned = value.clone_value();
+        let debug = format!("{:?}", cloned);
+        assert_eq!(debug, "DynamicEnum(Some(123))");
+
+        // Cloning a boxed `ReflectBox`. Users should never have an instance of `ReflectBox`.
+        let value = Box::new(ReflectBox(Box::new(Some(123))));
+        let cloned = value.clone_value();
+        let debug = format!("{:?}", cloned);
+        assert_eq!(debug, "DynamicEnum(Some(123))");
+    }
+
+    #[test]
+    fn should_allow_custom_trait_objects() {
+        trait Equippable: Reflect {}
+
+        impl TypePath for dyn Equippable {
+            fn type_path() -> &'static str {
+                todo!()
+            }
+
+            fn short_type_path() -> &'static str {
+                todo!()
+            }
+        }
+
+        impl ToPartialReflect for dyn Equippable {
+            fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+                self.as_partial_reflect()
+            }
+
+            fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+                self.as_partial_reflect_mut()
+            }
+
+            fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+                self.into_partial_reflect()
+            }
+        }
+
+        impl ToReflect for dyn Equippable {
+            fn to_reflect_ref(&self) -> &dyn Reflect {
+                self.as_reflect()
+            }
+
+            fn to_reflect_mut(&mut self) -> &mut dyn Reflect {
+                self.as_reflect_mut()
+            }
+
+            fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect> {
+                self.into_reflect()
+            }
+        }
+
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct Player {
+            #[reflect(remote = ReflectBox<dyn Equippable>)]
+            weapon: Box<dyn Equippable>,
+        }
+    }
+}

--- a/crates/bevy_reflect/src/boxed.rs
+++ b/crates/bevy_reflect/src/boxed.rs
@@ -526,11 +526,23 @@ mod tests {
         }
 
         #[derive(Reflect)]
+        struct Sword(u32);
+
+        impl Equippable for Sword {}
+
+        #[derive(Reflect)]
         #[reflect(from_reflect = false)]
         struct Player {
             #[reflect(remote = ReflectBox<dyn Equippable>)]
             weapon: Box<dyn Equippable>,
         }
+
+        let player: Box<dyn Struct> = Box::new(Player {
+            weapon: Box::new(Sword(123)),
+        });
+
+        let weapon = player.field("weapon").unwrap();
+        assert!(weapon.reflect_partial_eq(&Sword(123)).unwrap_or_default());
     }
 
     #[test]

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -1,0 +1,180 @@
+//! Traits for casting types to [`dyn PartialReflect`] and [`dyn Reflect`] trait objects.
+//!
+//! These traits are primarily used by [`ReflectBox`] to cast the inner type to
+//! the corresponding reflection trait object.
+//!
+//! # Example
+//!
+//! ```
+//! use bevy_reflect::{PartialReflect, Reflect, TypePath};
+//! use bevy_reflect::cast::{ToPartialReflect, ToReflect};
+//! use bevy_reflect::boxed::ReflectBox;
+//!
+//! // A custom trait used to represent equippable items
+//! trait Equippable: Reflect {}
+//!
+//! impl TypePath for dyn Equippable {
+//!     fn type_path() -> &'static str {
+//!         "dyn my_crate::equipment::Equippable"
+//!     }
+//!
+//!     fn short_type_path() -> &'static str {
+//!         "dyn Equippable"
+//!     }
+//! }
+//!
+//! impl ToPartialReflect for dyn Equippable {
+//!     fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+//!         self.as_partial_reflect()
+//!     }
+//!
+//!     fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+//!         self.as_partial_reflect_mut()
+//!     }
+//!
+//!     fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+//!         self.into_partial_reflect()
+//!     }
+//! }
+//!
+//! impl ToReflect for dyn Equippable {
+//!     fn to_reflect_ref(&self) -> &dyn Reflect {
+//!         self.as_reflect()
+//!     }
+//!
+//!     fn to_reflect_mut(&mut self) -> &mut dyn Reflect {
+//!         self.as_reflect_mut()
+//!     }
+//!
+//!     fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect> {
+//!         self.into_reflect()
+//!     }
+//! }
+//!
+//! #[derive(Reflect)]
+//! #[reflect(from_reflect = false)]
+//! struct Player {
+//!     // Now `dyn Equippable` can be used with `ReflectBox`:
+//!     #[reflect(remote = ReflectBox<dyn Equippable>)]
+//!     weapon: Box<dyn Equippable>,
+//! }
+//! ```
+//!
+//! [`dyn PartialReflect`]: PartialReflect
+//! [`dyn Reflect`]: Reflect
+
+use crate::{PartialReflect, Reflect};
+
+/// A trait used to access `Self` as a [`dyn PartialReflect`].
+///
+/// This is used by [`ReflectBox<T>`] in order to remotely reflect the inner type, `T`.
+/// In most cases, [`PartialReflect`] should be used instead of this trait.
+///
+/// This trait can be implemented on custom trait objects to allow them to be remotely reflected
+/// by [`ReflectBox`].
+///
+/// See the [module-level documentation] for details.
+///
+/// [`dyn PartialReflect`]: PartialReflect
+/// [`ReflectBox<T>`]: crate::boxed::ReflectBox
+/// [module-level documentation]: crate::cast
+pub trait ToPartialReflect: Send + Sync + 'static {
+    /// Get a reference to `Self` as a [`&dyn PartialReflect`](PartialReflect).
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect;
+    /// Get a mutable reference to `Self` as a [`&mut dyn PartialReflect`](PartialReflect).
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect;
+    /// Take `Self` as a [`Box<dyn PartialReflect>`](PartialReflect).
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect>;
+}
+
+impl<T: PartialReflect> ToPartialReflect for T {
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+impl ToPartialReflect for dyn PartialReflect {
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+/// A trait used to access `Self` as a [`dyn Reflect`].
+///
+/// This is used by [`ReflectBox<T>`] in order to remotely reflect the inner type, `T`.
+/// In most cases, [`Reflect`] should be used instead of this trait.
+///
+/// This trait can be implemented on custom trait objects to allow them to be remotely reflected
+/// by [`ReflectBox`].
+///
+/// See the [module-level documentation] for details.
+///
+/// [`dyn Reflect`]: Reflect
+/// [`ReflectBox<T>`]: crate::boxed::ReflectBox
+/// [module-level documentation]: crate::cast
+pub trait ToReflect: ToPartialReflect {
+    /// Get a reference to `Self` as a [`&dyn Reflect`](Reflect).
+    fn to_reflect_ref(&self) -> &dyn Reflect;
+    /// Get a mutable reference to `Self` as a [`&mut dyn Reflect`](Reflect).
+    fn to_reflect_mut(&mut self) -> &mut dyn Reflect;
+    /// Take `Self` as a [`Box<dyn Reflect>`](Reflect).
+    fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect>;
+}
+
+impl<T: Reflect> ToReflect for T {
+    fn to_reflect_ref(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn to_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+}
+
+impl ToPartialReflect for dyn Reflect {
+    fn to_partial_reflect_ref(&self) -> &dyn PartialReflect {
+        self.as_partial_reflect()
+    }
+
+    fn to_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self.as_partial_reflect_mut()
+    }
+
+    fn to_partial_reflect_box(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self.into_partial_reflect()
+    }
+}
+
+impl ToReflect for dyn Reflect {
+    fn to_reflect_ref(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn to_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn to_reflect_box(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+}

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -526,6 +526,7 @@
 //! [derive `Reflect`]: derive@crate::Reflect
 
 mod array;
+pub mod boxed;
 mod fields;
 mod from_reflect;
 #[cfg(feature = "functions")]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -527,6 +527,7 @@
 
 mod array;
 pub mod boxed;
+pub mod cast;
 mod fields;
 mod from_reflect;
 #[cfg(feature = "functions")]

--- a/crates/bevy_reflect/src/remote.rs
+++ b/crates/bevy_reflect/src/remote.rs
@@ -1,4 +1,4 @@
-use crate::Reflect;
+use crate::PartialReflect;
 
 /// Marks a type as a [reflectable] wrapper for a remote type.
 ///
@@ -40,11 +40,12 @@ use crate::Reflect;
 /// }
 /// ```
 ///
-/// [reflectable]: Reflect
+/// [reflectable]: PartialReflect
 /// [`transmute`]: core::mem::transmute
 /// [very unsafe]: https://doc.rust-lang.org/1.71.0/nomicon/transmutes.html
+/// [`Reflect`]: crate::Reflect
 /// [`FromReflect`]: crate::FromReflect
-pub trait ReflectRemote: Reflect {
+pub trait ReflectRemote: PartialReflect {
     /// The remote type this type represents via reflection.
     type Remote;
 

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -55,7 +55,7 @@ fn get_serializer<'a>(
     type_registry: &'a TypeRegistry,
 ) -> Box<dyn erased_serde::Serialize + 'a> {
     let path = reflect_value.reflect_type_path();
-    if path.starts_with("bevy_reflect::boxed::ReflectBox<") {
+    if path.starts_with("bevy_reflect::boxed::ReflectBox<dyn") {
         Box::new(ReflectSerializer::new(reflect_value, type_registry))
     } else {
         Box::new(TypedReflectSerializer::new_reflect_box(
@@ -70,7 +70,7 @@ fn get_serializable<'a, E: Error>(
     type_registry: &'a TypeRegistry,
 ) -> Result<Serializable<'a>, E> {
     let path = reflect_value.reflect_type_path();
-    if !IS_BOXED.get() && path.starts_with("bevy_reflect::boxed::ReflectBox<") {
+    if !IS_BOXED.get() && path.starts_with("bevy_reflect::boxed::ReflectBox<dyn") {
         // The value is a `ReflectBox` but it has not been flagged yet.
         // Flag it and serialize the full type map.
         IS_BOXED.set(true);
@@ -235,7 +235,7 @@ impl<'a> TypedReflectSerializer<'a> {
         IS_BOXED.set(
             value
                 .reflect_type_path()
-                .starts_with("bevy_reflect::boxed::ReflectBox<"),
+                .starts_with("bevy_reflect::boxed::ReflectBox<dyn"),
         );
         TypedReflectSerializer { value, registry }
     }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -117,8 +117,8 @@ fn get_serializable<'a, E: Error>(
 /// [`ReflectDeserializer`]: crate::serde::ReflectDeserializer
 /// [type path]: crate::TypePath::type_path
 pub struct ReflectSerializer<'a> {
-    value: &'a dyn PartialReflect,
-    registry: &'a TypeRegistry,
+    pub value: &'a dyn PartialReflect,
+    pub registry: &'a TypeRegistry,
 }
 
 impl<'a> ReflectSerializer<'a> {
@@ -195,8 +195,8 @@ impl<'a> Serialize for ReflectSerializer<'a> {
 /// [`TypedReflectDeserializer`]: crate::serde::TypedReflectDeserializer
 /// [type path]: crate::TypePath::type_path
 pub struct TypedReflectSerializer<'a> {
-    value: &'a dyn PartialReflect,
-    registry: &'a TypeRegistry,
+    pub value: &'a dyn PartialReflect,
+    pub registry: &'a TypeRegistry,
 }
 
 impl<'a> TypedReflectSerializer<'a> {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -147,8 +147,8 @@ fn get_serializable<'a, E: Error>(
 /// [`ReflectDeserializer`]: crate::serde::ReflectDeserializer
 /// [type path]: crate::TypePath::type_path
 pub struct ReflectSerializer<'a> {
-    pub value: &'a dyn PartialReflect,
-    pub registry: &'a TypeRegistry,
+    value: &'a dyn PartialReflect,
+    registry: &'a TypeRegistry,
 }
 
 impl<'a> ReflectSerializer<'a> {
@@ -225,8 +225,8 @@ impl<'a> Serialize for ReflectSerializer<'a> {
 /// [`TypedReflectDeserializer`]: crate::serde::TypedReflectDeserializer
 /// [type path]: crate::TypePath::type_path
 pub struct TypedReflectSerializer<'a> {
-    pub value: &'a dyn PartialReflect,
-    pub registry: &'a TypeRegistry,
+    value: &'a dyn PartialReflect,
+    registry: &'a TypeRegistry,
 }
 
 impl<'a> TypedReflectSerializer<'a> {
@@ -237,7 +237,7 @@ impl<'a> TypedReflectSerializer<'a> {
                 .reflect_type_path()
                 .starts_with("bevy_reflect::boxed::ReflectBox<dyn"),
         );
-        TypedReflectSerializer { value, registry }
+        Self { value, registry }
     }
 
     fn new_reflect_box(value: &'a dyn PartialReflect, registry: &'a TypeRegistry) -> Self {

--- a/examples/README.md
+++ b/examples/README.md
@@ -365,6 +365,7 @@ Example | Description
 [Custom Attributes](../examples/reflection/custom_attributes.rs) | Registering and accessing custom attributes on reflected types
 [Dynamic Types](../examples/reflection/dynamic_types.rs) | How dynamic types are used with reflection
 [Function Reflection](../examples/reflection/function_reflection.rs) | Demonstrates how functions can be called dynamically using reflection
+[Nested Reflection](../examples/reflection/nested_reflection.rs) | Demonstrates how reflection trait objects can be nested in other reflected types
 [Generic Reflection](../examples/reflection/generic_reflection.rs) | Registers concrete instances of generic types that may be used with reflection
 [Reflection](../examples/reflection/reflection.rs) | Demonstrates how reflection in Bevy provides a way to dynamically interact with Rust types
 [Reflection Types](../examples/reflection/reflection_types.rs) | Illustrates the various reflection types available

--- a/examples/reflection/nested_reflection.rs
+++ b/examples/reflection/nested_reflection.rs
@@ -1,0 +1,51 @@
+//! This example demonstrates how reflection trait objects can be nested in other reflected types
+//! using remote reflection.
+
+use bevy::prelude::*;
+
+fn main() {
+    // Bevy's reflection crate relies heavily on the `dyn Reflect` trait object.
+    // This allows the compile-time name of a type to be "erased" and passed around at runtime,
+    // most often as a `Box<dyn Reflect>`.
+    let _: Box<dyn Reflect> = Box::new(String::from("Hello, World!"));
+
+    // However, you'll notice that `Box<dyn Reflect>` itself doesn't implement `Reflect`.
+    // This makes it impossible to use `Box<dyn Reflect>` as a field in a struct that derives `Reflect`.
+    // ```
+    // #[derive(Reflect)]
+    // struct MyType {
+    //     field: Box<dyn Reflect>, // <- Compile Error
+    // }
+    // ```
+    // This is because it would be too easy to accidentally box a `Reflect` type,
+    // then accidentally box it again, and again, and so on.
+    // So instead, `bevy_reflect` exposes a `ReflectBox` type which can be used
+    // as a remote wrapper around a `Box<dyn Reflect>` (or `Box<dyn PartialReflect>`).
+    //
+    // For example, let's say we want to define some equipment for a player.
+    // We don't know what kind of equipment the player will have at compile time,
+    // so we want to store it as a `Box<dyn Reflect>`.
+    // To do this, we first need to derive `Reflect` for our `Player`.
+    #[derive(Reflect)]
+    // Next, we need to opt out of deriving `FromReflect` since `Box<dyn Reflect>`
+    // has no knowledge of `FromReflect`.
+    #[reflect(from_reflect = false)]
+    struct Player {
+        // Now we can use remote reflection to tell `Reflect` how to reflect our `Box<dyn Reflect>`.
+        #[reflect(remote = bevy::reflect::boxed::ReflectBox<dyn Reflect>)]
+        equipment: Box<dyn Reflect>,
+    }
+
+    // Now we can use any type that implements `Reflect` as equipment for our player.
+    let equipment: Box<dyn Reflect> = Box::new(String::from("Sword"));
+    let mut player: Box<dyn Struct> = Box::new(Player { equipment });
+
+    // We can also use reflection to modify our player's equipment.
+    let equipment = player.field_mut("equipment").unwrap();
+    equipment.try_apply(&String::from("Shield")).unwrap();
+    assert!(player
+        .reflect_partial_eq(&Player {
+            equipment: Box::new(String::from("Shield")),
+        })
+        .unwrap_or_default());
+}


### PR DESCRIPTION
# Objective

Closes #3392
Closes #3400
Closes #6098
Closes #9929

There are plenty of times where we want to reflect a type that itself contains reflected data:

```rust
struct Player {
    weapon: Box<dyn Reflect>
}
```

Unfortunately, `Box<dyn Reflect>`, does not implement `Reflect`, making this impossible.

#3400 does a great job at implementing `Reflect` for `Box<dyn Reflect>`, but it has one potential issue: double-boxing.

Double-boxing occurs when we erase the type of `Box<T>` and put it inside another `Box`. When `Box<T>` implements the same bounds required by `T`, this becomes very easy to do accidentally.

For instance, suppose `Box<dyn Reflect>` _did_ implement `Reflect`. That would make this possible:

```rust
fn make_box<T: Reflect>(value: T) -> Box<dyn Reflect> {
    Box::new(value)
}

let foo = make_box(123); // Creates: Box<i32>
let bar = make_box(foo); // Creates: Box<Box<i32>>
let baz = make_box(bar); // Creates: Box<Box<Box<i32>>>
```

And while we can get back to a single box through each `Box` recursively calling a method like `Reflect::into_reflect` (i.e. `Box<Box<Box<i32>>>` delegates to `Box<Box<i32>>` which delegates to `Box<i32>` which delegates to `i32` which results in `Box<i32>`), this is not very efficient—both in terms of performance and memory.

This PR aims to bring an alternative approach to the table, based on the newly merged remote reflection feature (#6042). The original idea for this PR comes from @soqb.

## Solution

Introduce a new `ReflectBox<T>` wrapper type that can be used to remotely reflect `Box<T>`.

```rust
use bevy_reflect::boxed::ReflectBox;

#[derive(Reflect)]
#[reflect(from_reflect = false)]
struct Player {
    #[reflect(remote = ReflectBox<dyn Reflect>)]
    weapon: Box<dyn Reflect>,
}
```

`ReflectBox<T>` cannot be publicly constructed or downcast to. It only exists hidden as the underlying machinery for reflecting `Box<T>`. This makes it very difficult to accidentally double-box it. In fact, I'm 99% sure you'll never accidentally have that happen (there are ways to force this if you're feeling rebellious though).

The way it works is by defining a couple new traits (both of which are hidden using `#[doc(hidden)]`): `ToPartialReflect` and `ToReflect`. These traits have a blanket impl defined for all types `T: PartialReflect` and `T: Reflect`, respectively.

However, they also have custom impls for the corresponding trait objects: `dyn PartialReflect` and `dyn Reflect`.

And because `ReflectBox<T>` requires `T: ToPartialReflect`, it works for all three: `Box<T>`, `Box<dyn PartialReflect>`, and `Box<dyn Reflect>`.

I chose to make these traits public to allow for other trait objects to join in the fun! For example, we could refactor our `Player` struct to look like this:

```rust
use bevy_reflect::boxed::ReflectBox;

trait Weapon: Reflect {
    fn damage(&self) -> u32;
}

impl ToPartialReflect for dyn Weapon {/* ... */}
impl ToReflect for dyn Weapon {/* ... */}
impl TypePath for dyn Weapon {/* ... */}

#[derive(Reflect)]
#[reflect(from_reflect = false)]
struct Player {
    // Now our Rust API can directly call `Weapon` methods
    // AND we can still reflect it
    #[reflect(remote = ReflectBox<dyn Weapon>)]
    weapon: Box<dyn Weapon>,
}
```

### Caveats

#### `FromReflect`

> [!note]
> This limitation is also an issue for #3400.

You might have noticed the `#[reflect(from_reflect = false)]` attributes.

We have to opt out of `FromReflect` because `dyn PartialReflect` and `dyn Reflect` are not aware of `FromReflect` (i.e. they are not subtraits of `FromReflect`). This means we can't delegate to the `FromReflect` impl, even if it does exist for the underlying type.

#### Enums

> [!note]
> This limitation is also an issue for #3400.

Unfortunately, due to the lack of `FromReflect`, this approach can't be used in enums.

This is due to enums internally relying on `FromReflect` within their `PartialReflect::try_apply` method body, which calls `FromReflect` when it needs to replace the current variant with a new one.

#### Usage as a Type Parameter

> [!note]
> This limitation only applies to #3400 where the type parameter has a `FromReflect` bound (or any other bound that `Box<dyn Reflect>` can't satisfy). For example, you also couldn't define a `Vec<Box<dyn Reflect>>` using #3400.

Since this approach requires the use of remote reflection, it may not be possible to handle types where `Box` is being used as a type parameter. For example, `Vec<Box<dyn Reflect>>` and `Option<Box<dyn Reflect>>` are not possible, even with this PR in place.

In some cases, it may be possible to remedy this with additional remote reflection. However, it's tricky to appease the compiler without monomorphizing the type down to a dedicated type (i.e. instead of supporting `MyType<Box<dyn Reflect>>`, having a separate `MyTypeReflectBox` which removes the generic and assumes `Box<dyn Reflect>` in its place).

Future PRs may explore adding additional types similar to `ReflectBox` for common types like `Vec` and `Option`, but these will also be limited in the same way `ReflectBox` is now.

### Serialization

While the current serialization logic isn't the most efficient (we have to do some string comparisons to determine if the type is a `ReflectBox` or not), we are able to serialize `ReflectBox` just like any other type.

Currently, it will serialize concrete `Box<T>` instances as normal and `Box<dyn Trait>` as a new type map.

For example, if we serialized the following type:

```rust
#[derive(Reflect)]
#[reflect(from_reflect = false)]
struct MyStruct {
    #[reflect(remote = ReflectBox<dyn PartialReflect>)]
    partial_reflect: Box<dyn PartialReflect>,
    #[reflect(remote = ReflectBox<dyn Reflect>)]
    full_reflect: Box<dyn Reflect>,
    #[reflect(remote = ReflectBox<i32>)]
    concrete: Box<i32>,
}

let value = MyStruct {
    partial_reflect: Box::new(123),
    full_reflect: Box::new(456),
    concrete: Box::new(789),
};
```

We'd get the following RON:

```rust
{
    "my_crate::MyStruct": (
        partial_reflect: {"i32": 123},
        full_reflect: {"i32": 456},
        concrete: 789,
    )
}
```

### Open Questions

1. Are the limitations of this PR worth the avoidance of double-boxing? Or should we continue with #3400 instead?

   Please note that we may still choose to go with this more conservative approach while we debate the true risks of #3400. We can do this because most usages of `Box` under this PR will be fully compatible with #3400—the only exception would be custom `Box<dyn SomeOtherTrait>` usages, which will need their own solution (maybe a macro?). Of the compatible cases, the only migration needed will be to remove the `#[reflect(remote = ReflectBox<...>)]` field attributes wherever they are used.

2. Are there better ways to handle serialization other than fetching the type path and comparing the prefix? We already do this for `Option` types, but that's at least only performed in specific scenarios.

   One thing we could do is add a dedicated method to `PartialReflect` called `is_pointer` or `is_indirect`, which we can then call directly to determine whether we're a `ReflectBox` or not.

   Alternatively, we could change the `PartialReflect::is_dynamic` method on `ReflectBox` to return `true` instead of delegating to the inner type. I don't really like this option because it would be the only method where we do this and it would almost certainly break places that rely on `is_dynamic` for their control flow.

   One last option could be to change the signature of the largely unused `PartialReflect::serializable` method to take in a reference to the `TypeRegistry`. Then we could have `ReflectBox` return a `ReflectSerializer` containing the inner data. I think this would be my preferred approach considering it doesn't really change the behavior in an unexpected way (unlike modifying `is_dynamic`). It would just technically be a breaking change.

3. Should the `ToPartialReflect` and `ToReflect` traits be `#[doc(hidden)]`? I did this to prevent them from coming up during autocomplete and so that users don't accidentally misuse them (although, I don't think you can really "misuse" them). But since it's really nice for users to be able to get this feature to work with their own trait objects, should we consider making it more public?

## Testing

You can test the changes locally by running:

```
cargo test --package bevy_reflect
```

---

## Showcase

A common occurrence when reflecting a type is wanting to store reflected data within a reflected type. This wasn't possible before, but now it is using the new `bevy_reflect::boxed::ReflectBox` type and remote reflection:

```rust
use bevy_reflect::boxed::ReflectBox;

#[derive(Reflect)]
struct Sword {
    damage: u32
}

#[derive(Reflect)]
// Keep in mind that `ReflectBox` does not implement `FromReflect`.
// Because of this, we will need to opt-out of the automatic `FromReflect` impl:
#[reflect(from_reflect = false)]
struct Player {
    // Tell the `Reflect` derive to remotely reflect our `Box<dyn Reflect>`
    // using the `ReflectBox<dyn Reflect>` wrapper type:
    #[reflect(remote = ReflectBox<dyn Reflect>)]
    weapon: Box<dyn Reflect>
}

let player = Player {
    // We can create our `Box<dyn Reflect>` as normal:
    weapon: Box::new(Sword { damage: 100 })
};

// Now we can reflect `weapon`!
// Under the hood, this `dyn Reflect` is actually a `ReflectBox<dyn Reflect>`,
// and is automatically delegating all reflection methods to the inner `dyn Reflect`.
// It will automatically convert to and from `ReflectBox<dyn Reflect>` as needed.
let weapon: &dyn Reflect = player.weapon.as_reflect();
assert!(weapon.reflect_partial_eq(&Sword { damage: 100 }).unwrap_or_default());
```