### PR TITLE
Round UI in physical coordinates

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1033,7 +1033,9 @@ mod tests {
                     .sum();
                 let parent_width = world.get::<Node>(parent).unwrap().calculated_size.x;
                 assert!((width_sum - parent_width).abs() < 0.001);
-                assert!((width_sum - 320.).abs() <= 1.);
+                let width_sum_pixels = width_sum * s;
+                let expected_width_pixels = 320. * s;
+                assert!((width_sum_pixels - expected_width_pixels).abs() <= 1.);
                 s += r;
             }
         }


### PR DESCRIPTION
# Objective

- Fixes #14714 

## Solution

- Apply rounding after scaling

This solution fixes jitteriness on moving UI elements, but might reintroduce old issues with UI rounding. 

It feels like the real solution would be to have the whole UI rendering part happen in physical pixels.  I tried that at first, but there was just tons of code scaling UI element positions, sizes and border widths back and forth. Making sure all of that works as expected would be a lot of work.

## Testing

- Manual testing with the ui examples and the example from the associated issue
