### PR TITLE
Required Components

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -101,7 +101,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let required_component_docs = attrs.requires.map(|r| {
         let paths = r
             .iter()
-            .map(|r| format!("[`{}`]", r.path.to_token_stream().to_string()))
+            .map(|r| format!("[`{}`]", r.path.to_token_stream()))
             .collect::<Vec<_>>()
             .join(", ");
         let doc = format!("Required Components: {paths}. \n\n A component's Required Components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively.");

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -78,7 +78,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let mut register_recursive_requires = Vec::with_capacity(attrs.requires.iter().len());
     if let Some(requires) = requires {
         for require in requires {
-            let ident = &require.ident;
+            let ident = &require.path;
             register_recursive_requires.push(quote! {
                 <#ident as Component>::register_required_components(components, storages, required_components);
             });
@@ -146,7 +146,7 @@ enum StorageTy {
 }
 
 struct Require {
-    ident: Ident,
+    path: Path,
     func: Option<Path>,
 }
 
@@ -210,7 +210,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
 
 impl Parse for Require {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
-        let ident = input.parse::<Ident>()?;
+        let path = input.parse::<Path>()?;
         let func = if input.peek(Paren) {
             let content;
             parenthesized!(content in input);
@@ -219,7 +219,7 @@ impl Parse for Require {
         } else {
             None
         };
-        Ok(Require { ident, func })
+        Ok(Require { path, func })
     }
 }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -104,7 +104,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             .map(|r| format!("[`{}`]", r.path.to_token_stream()))
             .collect::<Vec<_>>()
             .join(", ");
-        let doc = format!("Required Components: {paths}. \n\n A component's Required Components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively.");
+        let doc = format!("Required Components: {paths}. \n\n A component's Required Components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively, in depth-first order.");
         quote! {
             #[doc = #doc]
         }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -214,7 +214,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
             let punctuated =
                 attr.parse_args_with(Punctuated::<Require, Comma>::parse_terminated)?;
             for require in punctuated.iter() {
-                if !require_paths.insert(require.path.clone()) {
+                if !require_paths.insert(require.path.to_token_stream().to_string()) {
                     return Err(syn::Error::new(
                         require.path.span(),
                         "Duplicate required components are not allowed.",

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -77,6 +77,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let mut field_get_component_ids = Vec::new();
     let mut field_get_components = Vec::new();
     let mut field_from_components = Vec::new();
+    let mut field_required_components = Vec::new();
     for (((i, field_type), field_kind), field) in field_type
         .iter()
         .enumerate()
@@ -87,6 +88,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             BundleFieldKind::Component => {
                 field_component_ids.push(quote! {
                 <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut *ids);
+                });
+                field_required_components.push(quote! {
+                    <#field_type as #ecs_path::bundle::Bundle>::register_required_components(components, storages, required_components);
                 });
                 field_get_component_ids.push(quote! {
                     <#field_type as #ecs_path::bundle::Bundle>::get_component_ids(components, &mut *ids);
@@ -152,6 +156,14 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                 Self{
                     #(#field_from_components)*
                 }
+            }
+
+            fn register_required_components(
+                components: &mut #ecs_path::component::Components,
+                storages: &mut #ecs_path::storage::Storages,
+                required_components: &mut #ecs_path::component::RequiredComponents
+            ){
+                #(#field_required_components)*
             }
         }
 
@@ -527,7 +539,7 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }
 
-#[proc_macro_derive(Component, attributes(component))]
+#[proc_macro_derive(Component, attributes(component, require))]
 pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -21,7 +21,7 @@
 
 use crate::{
     bundle::BundleId,
-    component::{ComponentId, Components, StorageType},
+    component::{ComponentId, Components, RequiredComponent, StorageType},
     entity::{Entity, EntityLocation},
     observer::Observers,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex, TableId, TableRow},
@@ -123,6 +123,8 @@ pub(crate) struct AddBundle {
     /// For each component iterated in the same order as the source [`Bundle`](crate::bundle::Bundle),
     /// indicate if the component is newly added to the target archetype or if it already existed
     pub bundle_status: Vec<ComponentStatus>,
+    /// Required components that must be initialized immediately when adding this Bundle.
+    pub required_components: Vec<RequiredComponent>,
     pub added: Vec<ComponentId>,
     pub existing: Vec<ComponentId>,
 }
@@ -208,6 +210,7 @@ impl Edges {
         bundle_id: BundleId,
         archetype_id: ArchetypeId,
         bundle_status: Vec<ComponentStatus>,
+        required_components: Vec<RequiredComponent>,
         added: Vec<ComponentId>,
         existing: Vec<ComponentId>,
     ) {
@@ -216,6 +219,7 @@ impl Edges {
             AddBundle {
                 archetype_id,
                 bundle_status,
+                required_components,
                 added,
                 existing,
             },

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -123,7 +123,9 @@ pub(crate) struct AddBundle {
     /// For each component iterated in the same order as the source [`Bundle`](crate::bundle::Bundle),
     /// indicate if the component is newly added to the target archetype or if it already existed
     pub bundle_status: Vec<ComponentStatus>,
-    /// Required components that must be initialized immediately when adding this Bundle.
+    /// The set of additional required components that must be initialized immediately when adding this Bundle.
+    ///
+    /// The initial values are determined based on the provided constructor, falling back to the `Default` trait if none is given.
     pub required_components: Vec<RequiredComponent>,
     pub added: Vec<ComponentId>,
     pub existing: Vec<ComponentId>,

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -21,7 +21,7 @@
 
 use crate::{
     bundle::BundleId,
-    component::{ComponentId, Components, RequiredComponent, StorageType},
+    component::{ComponentId, Components, RequiredComponentConstructor, StorageType},
     entity::{Entity, EntityLocation},
     observer::Observers,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex, TableId, TableRow},
@@ -126,7 +126,7 @@ pub(crate) struct AddBundle {
     /// The set of additional required components that must be initialized immediately when adding this Bundle.
     ///
     /// The initial values are determined based on the provided constructor, falling back to the `Default` trait if none is given.
-    pub required_components: Vec<RequiredComponent>,
+    pub required_components: Vec<RequiredComponentConstructor>,
     pub added: Vec<ComponentId>,
     pub existing: Vec<ComponentId>,
 }
@@ -212,7 +212,7 @@ impl Edges {
         bundle_id: BundleId,
         archetype_id: ArchetypeId,
         bundle_status: Vec<ComponentStatus>,
-        required_components: Vec<RequiredComponent>,
+        required_components: Vec<RequiredComponentConstructor>,
         added: Vec<ComponentId>,
         existing: Vec<ComponentId>,
     ) {

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -127,8 +127,25 @@ pub(crate) struct AddBundle {
     ///
     /// The initial values are determined based on the provided constructor, falling back to the `Default` trait if none is given.
     pub required_components: Vec<RequiredComponentConstructor>,
+    /// The components added by this bundle. This includes any Required Components that are inserted when adding this bundle.
     pub added: Vec<ComponentId>,
+    /// The components that were explicitly contributed by this bundle, but already existed in the archetype. This _does not_ include any
+    /// Required Components.
     pub existing: Vec<ComponentId>,
+}
+
+impl AddBundle {
+    pub(crate) fn iter_inserted(&self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.added.iter().chain(self.existing.iter()).copied()
+    }
+
+    pub(crate) fn iter_added(&self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.added.iter().copied()
+    }
+
+    pub(crate) fn iter_existing(&self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.existing.iter().copied()
+    }
 }
 
 /// This trait is used to report the status of [`Bundle`](crate::bundle::Bundle) components

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -531,7 +531,7 @@ impl BundleInfo {
     /// the type associated with `component_id`. The `entity` and `table_row` must correspond to an entity with an uninitialized
     /// component matching `component_id`.
     ///
-    /// This _should not_ be used outside of [`BundleInfo::write_components`].
+    /// This method _should not_ be called outside of [`BundleInfo::write_components`].
     /// For more information, read the [`BundleInfo::write_components`] safety docs.
     /// This function inherits the safety requirements defined there.
     #[allow(clippy::too_many_arguments)]
@@ -1262,7 +1262,7 @@ impl Bundles {
             let mut required_components = RequiredComponents::default();
             T::register_required_components(components, storages, &mut required_components);
             required_components.remove_bundle_components(&component_ids);
-            let required_components = required_components.0.drain().map(|(_, v)| v).collect();
+            let required_components = required_components.0.into_iter().map(|(_, v)| v).collect();
             let bundle_info =
                 // SAFETY: T::component_id ensures:
                 // - its info was created

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -561,7 +561,7 @@ impl BundleInfo {
     }
 
     /// Internal method to initialize a required component from an [`OwningPtr`]. This should ultimately be called
-    /// in the context of [`BundleInfo::write_components`], via [`RequiredComponent::initialize`].
+    /// in the context of [`BundleInfo::write_components`], via [`RequiredComponentConstructor::initialize`].
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1261,7 +1261,7 @@ impl Bundles {
             let id = BundleId(bundle_infos.len());
             let mut required_components = RequiredComponents::default();
             T::register_required_components(components, storages, &mut required_components);
-            required_components.remove_bundle_components(&component_ids);
+            required_components.remove_explicit_components(&component_ids);
             let required_components = required_components.0.into_iter().map(|(_, v)| v).collect();
             let bundle_info =
                 // SAFETY: T::component_id ensures:

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -182,6 +182,9 @@ use std::{cell::UnsafeCell, fmt::Debug};
 /// world.spawn(A);
 /// ```
 ///
+/// Note that cycles in the "component require tree" will result in stack overflows when attempting to
+/// insert a component.
+///
 /// # Adding component's hooks
 ///
 /// See [`ComponentHooks`] for a detailed explanation of component's hooks.

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1265,6 +1265,8 @@ impl RequiredComponents {
 
     /// Removes components that are explicitly provided in a given [`Bundle`]. These components should
     /// be logically treated as normal components, not "required components".
+    ///
+    /// [`Bundle`]: crate::bundle::Bundle
     pub fn remove_bundle_components(&mut self, components: &[ComponentId]) {
         for component in components {
             self.0.remove(component);

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1152,7 +1152,7 @@ type RequiredComponentConstructor =
 type RequiredComponentConstructor = dyn Fn(&mut Table, &mut SparseSets, Tick, TableRow, Entity);
 
 /// A context-less constructor that can be called to construct a new instance of a component.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct RequiredComponent {
     pub(crate) component_id: ComponentId,
     /// # Safety
@@ -1193,7 +1193,7 @@ impl RequiredComponent {
 }
 
 /// The collection of metadata for components that are required for a given component.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RequiredComponents(pub(crate) HashMap<ComponentId, RequiredComponent>);
 
 impl RequiredComponents {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1280,6 +1280,7 @@ impl RequiredComponentConstructor {
 /// can be called to construct a new instance of a component.
 #[derive(Clone)]
 pub(crate) struct RequiredComponent {
+    // TODO: this is stored on BundleInfo now ... we can remove this I think
     pub(crate) component_id: ComponentId,
     /// # Safety
     /// Calling this constructor is unsafe. It should only be called in the context of [`BundleInfo::write_components`], where the

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1276,31 +1276,19 @@ impl RequiredComponentConstructor {
     }
 }
 
-/// A component that another component must when it is inserted. This contains a context-less constructor that
-/// can be called to construct a new instance of a component.
-#[derive(Clone)]
-pub(crate) struct RequiredComponent {
-    // TODO: this is stored on BundleInfo now ... we can remove this I think
-    pub(crate) component_id: ComponentId,
-    /// # Safety
-    /// Calling this constructor is unsafe. It should only be called in the context of [`BundleInfo::write_components`], where the
-    /// inputs are already validated. This _should not_ have its module visibility increased.
-    pub(crate) constructor: RequiredComponentConstructor,
-}
-
-impl Debug for RequiredComponent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RequiredComponent")
-            .field("component_id", &self.component_id)
-            .finish()
-    }
-}
-
 /// The collection of metadata for components that are required for a given component.
 ///
 /// For more information, see the "Required Components" section of [`Component`].
-#[derive(Default, Debug)]
-pub struct RequiredComponents(pub(crate) HashMap<ComponentId, RequiredComponent>);
+#[derive(Default)]
+pub struct RequiredComponents(pub(crate) HashMap<ComponentId, RequiredComponentConstructor>);
+
+impl Debug for RequiredComponents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RequiredComponents")
+            .field(&self.0.keys())
+            .finish()
+    }
+}
 
 impl RequiredComponents {
     /// Registers a required component. If the component is already registered, the new registration
@@ -1317,10 +1305,7 @@ impl RequiredComponents {
         component_id: ComponentId,
         constructor: RequiredComponentConstructor,
     ) {
-        self.0.entry(component_id).or_insert(RequiredComponent {
-            component_id,
-            constructor,
-        });
+        self.0.entry(component_id).or_insert(constructor);
     }
 
     /// Registers a required component. If the component is already registered, the new registration

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -110,12 +110,13 @@ use std::{cell::UnsafeCell, fmt::Debug};
 /// #[require(B)]
 /// struct A;
 ///
-/// #[derive(Component, Default)]
+/// #[derive(Component, Default, PartialEq, Eq, Debug)]
 /// struct B(usize);
 ///
 /// # let mut world = World::default();
 /// // This will implicitly also insert B with the Default constructor
-/// world.spawn(A);
+/// let id = world.spawn(A).id();
+/// assert_eq!(&B(0), world.entity(id).get::<B>().unwrap());
 ///
 /// // This will _not_ implicitly insert B, because it was already provided
 /// world.spawn((A, B(11)));
@@ -129,16 +130,18 @@ use std::{cell::UnsafeCell, fmt::Debug};
 /// #[require(B, C)]
 /// struct A;
 ///
-/// #[derive(Component, Default)]
+/// #[derive(Component, Default, PartialEq, Eq, Debug)]
 /// #[require(C)]
 /// struct B(usize);
 ///
-/// #[derive(Component, Default)]
-/// struct C(f32);
+/// #[derive(Component, Default, PartialEq, Eq, Debug)]
+/// struct C(u32);
 ///
 /// # let mut world = World::default();
 /// // This will implicitly also insert B and C with their Default constructors
-/// world.spawn(A);
+/// let id = world.spawn(A).id();
+/// assert_eq!(&B(0), world.entity(id).get::<B>().unwrap());
+/// assert_eq!(&C(0), world.entity(id).get::<C>().unwrap());
 /// ```
 ///
 /// You can also define a custom constructor:
@@ -149,7 +152,7 @@ use std::{cell::UnsafeCell, fmt::Debug};
 /// #[require(B(init_b))]
 /// struct A;
 ///
-/// #[derive(Component)]
+/// #[derive(Component, PartialEq, Eq, Debug)]
 /// struct B(usize);
 ///
 /// fn init_b() -> B {
@@ -158,7 +161,8 @@ use std::{cell::UnsafeCell, fmt::Debug};
 ///
 /// # let mut world = World::default();
 /// // This will implicitly also insert B with the init_b() constructor
-/// world.spawn(A);
+/// let id = world.spawn(A).id();
+/// assert_eq!(&B(10), world.entity(id).get::<B>().unwrap());
 /// ```
 ///
 /// Required components are _recursive_. This means, if a Required Component has required components,
@@ -170,16 +174,18 @@ use std::{cell::UnsafeCell, fmt::Debug};
 /// #[require(B)]
 /// struct A;
 ///
-/// #[derive(Component, Default)]
+/// #[derive(Component, Default, PartialEq, Eq, Debug)]
 /// #[require(C)]
 /// struct B(usize);
 ///
-/// #[derive(Component, Default)]
-/// struct C(f32);
+/// #[derive(Component, Default, PartialEq, Eq, Debug)]
+/// struct C(u32);
 ///
 /// # let mut world = World::default();
 /// // This will implicitly also insert B and C with their Default constructors
-/// world.spawn(A);
+/// let id = world.spawn(A).id();
+/// assert_eq!(&B(0), world.entity(id).get::<B>().unwrap());
+/// assert_eq!(&C(0), world.entity(id).get::<C>().unwrap());
 /// ```
 ///
 /// Note that cycles in the "component require tree" will result in stack overflows when attempting to

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -667,7 +667,7 @@ pub struct ComponentDescriptor {
 }
 
 // We need to ignore the `drop` field in our `Debug` impl
-impl std::fmt::Debug for ComponentDescriptor {
+impl Debug for ComponentDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ComponentDescriptor")
             .field("name", &self.name)

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1251,7 +1251,7 @@ impl RequiredComponentConstructor {
     /// Calling it _anywhere else_ should be considered unsafe.
     ///
     /// `table_row` and `entity` must correspond to a valid entity that currently needs a component initialized via the constructor stored
-    /// on this [`RequiredComponent`]. The stored [`RequiredComponent::constructor`] must correspond to a component on `entity` that needs initialization.
+    /// on this [`RequiredComponentConstructor`]. The stored constructor must correspond to a component on `entity` that needs initialization.
     /// `table` and `sparse_sets` must correspond to storages on a world where `entity` needs this required component initialized.
     ///
     /// Again, don't call this anywhere but [`BundleInfo::write_components`].

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -226,7 +226,7 @@ use std::{cell::UnsafeCell, fmt::Debug};
 ///
 /// In general, this shouldn't happen often, but when it does the algorithm is simple and predictable:
 /// 1. Use all of the constructors (including default constructors) directly defined in the spawned component's require list
-/// 2. In the order the requires are defined in #[require()], recursively visit the require list of each of the components in the list (this is a depth Depth First Search). When a constructor is found, it will only be used if one has not already been found.
+/// 2. In the order the requires are defined in `#[require()]`, recursively visit the require list of each of the components in the list (this is a depth Depth First Search). When a constructor is found, it will only be used if one has not already been found.
 ///
 /// From a user perspective, just think about this as the following:
 /// 1. Specifying a required component constructor for Foo directly on a spawned component Bar will result in that constructor being used (and overriding existing constructors lower in the inheritance tree). This is the classic "inheritance override" behavior people expect.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -144,7 +144,7 @@ type IdCursor = isize;
 /// [SemVer]: https://semver.org/
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-#[cfg_attr(feature = "bevy_reflect", reflect_value(Hash, PartialEq))]
+#[cfg_attr(feature = "bevy_reflect", reflect_value(Hash, PartialEq, Debug))]
 #[cfg_attr(
     all(feature = "bevy_reflect", feature = "serialize"),
     reflect_value(Serialize, Deserialize)

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1865,6 +1865,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn generic_required_components() {
+        #[derive(Component)]
+        #[require(Y<usize>)]
+        struct X;
+
+        #[derive(Component, Default)]
+        struct Y<T> {
+            value: T,
+        }
+
+        let mut world = World::new();
+        let id = world.spawn(X).id();
+        assert_eq!(
+            0,
+            world.entity(id).get::<Y<usize>>().unwrap().value,
+            "Y should have the default value"
+        );
+    }
+
     // These structs are primarily compilation tests to test the derive macros. Because they are
     // never constructed, we have to manually silence the `dead_code` lint.
     #[allow(dead_code)]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2000,6 +2000,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dynamic_required_components() {
+        #[derive(Component)]
+        #[require(Y)]
+        struct X;
+
+        #[derive(Component, Default)]
+        struct Y;
+
+        let mut world = World::new();
+        let x_id = world.init_component::<X>();
+
+        let mut e = world.spawn_empty();
+
+        // SAFETY: x_id is a valid component id
+        bevy_ptr::OwningPtr::make(X, |ptr| unsafe {
+            e.insert_by_id(x_id, ptr);
+        });
+
+        assert!(e.contains::<Y>());
+    }
+
     // These structs are primarily compilation tests to test the derive macros. Because they are
     // never constructed, we have to manually silence the `dead_code` lint.
     #[allow(dead_code)]

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1063,7 +1063,7 @@ mod tests {
                     .get_id(TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
-                let mut bundle_components = bundle_info.components().to_vec();
+                let mut bundle_components = bundle_info.contributed_components().to_vec();
                 bundle_components.sort();
                 for component_id in &bundle_components {
                     assert!(

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -370,13 +370,13 @@ impl<'w> DeferredWorld<'w> {
         &mut self,
         event: ComponentId,
         entity: Entity,
-        components: &[ComponentId],
+        components: impl Iterator<Item = ComponentId>,
     ) {
         Observers::invoke::<_>(
             self.reborrow(),
             event,
             entity,
-            components.iter().copied(),
+            components,
             &mut (),
             &mut false,
         );

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -956,7 +956,7 @@ impl<'w> EntityWorldMut<'w> {
         let removed_components = &mut world.removed_components;
 
         let entity = self.entity;
-        let mut bundle_components = bundle_info.iter_components();
+        let mut bundle_components = bundle_info.iter_explicit_components();
         // SAFETY: bundle components are iterated in order, which guarantees that the component type
         // matches
         let result = unsafe {
@@ -1131,7 +1131,7 @@ impl<'w> EntityWorldMut<'w> {
         }
 
         let old_archetype = &world.archetypes[location.archetype_id];
-        for component_id in bundle_info.iter_components() {
+        for component_id in bundle_info.iter_explicit_components() {
             if old_archetype.contains(component_id) {
                 world.removed_components.send(component_id, entity);
 
@@ -1180,7 +1180,7 @@ impl<'w> EntityWorldMut<'w> {
         self
     }
 
-    /// Removes any components except those in the [`Bundle`] from the entity.
+    /// Removes any components except those in the [`Bundle`] (and its Required Components) from the entity.
     ///
     /// See [`EntityCommands::retain`](crate::system::EntityCommands::retain) for more details.
     pub fn retain<T: Bundle>(&mut self) -> &mut Self {
@@ -1194,9 +1194,10 @@ impl<'w> EntityWorldMut<'w> {
         let old_location = self.location;
         let old_archetype = &mut archetypes[old_location.archetype_id];
 
+        // PERF: this could be stored in an Archetype Edge
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.components().contains(c))
+            .filter(|c| !retained_bundle_info.contributed_components().contains(c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
 
@@ -1261,19 +1262,11 @@ impl<'w> EntityWorldMut<'w> {
         unsafe {
             deferred_world.trigger_on_replace(archetype, self.entity, archetype.components());
             if archetype.has_replace_observer() {
-                deferred_world.trigger_observers(
-                    ON_REPLACE,
-                    self.entity,
-                    &archetype.components().collect::<Vec<ComponentId>>(),
-                );
+                deferred_world.trigger_observers(ON_REPLACE, self.entity, archetype.components());
             }
             deferred_world.trigger_on_remove(archetype, self.entity, archetype.components());
             if archetype.has_remove_observer() {
-                deferred_world.trigger_observers(
-                    ON_REMOVE,
-                    self.entity,
-                    &archetype.components().collect::<Vec<ComponentId>>(),
-                );
+                deferred_world.trigger_observers(ON_REMOVE, self.entity, archetype.components());
             }
         }
 
@@ -1484,13 +1477,17 @@ unsafe fn trigger_on_replace_and_on_remove_hooks_and_observers(
     entity: Entity,
     bundle_info: &BundleInfo,
 ) {
-    deferred_world.trigger_on_replace(archetype, entity, bundle_info.iter_components());
+    deferred_world.trigger_on_replace(archetype, entity, bundle_info.iter_explicit_components());
     if archetype.has_replace_observer() {
-        deferred_world.trigger_observers(ON_REPLACE, entity, bundle_info.components());
+        deferred_world.trigger_observers(
+            ON_REPLACE,
+            entity,
+            bundle_info.iter_explicit_components(),
+        );
     }
-    deferred_world.trigger_on_remove(archetype, entity, bundle_info.iter_components());
+    deferred_world.trigger_on_remove(archetype, entity, bundle_info.iter_explicit_components());
     if archetype.has_remove_observer() {
-        deferred_world.trigger_observers(ON_REMOVE, entity, bundle_info.components());
+        deferred_world.trigger_observers(ON_REMOVE, entity, bundle_info.iter_explicit_components());
     }
 }
 
@@ -2423,7 +2420,7 @@ unsafe fn remove_bundle_from_archetype(
             let current_archetype = &mut archetypes[archetype_id];
             let mut removed_table_components = Vec::new();
             let mut removed_sparse_set_components = Vec::new();
-            for component_id in bundle_info.components().iter().cloned() {
+            for component_id in bundle_info.iter_explicit_components() {
                 if current_archetype.contains(component_id) {
                     // SAFETY: bundle components were already initialized by bundles.get_info
                     let component_info = unsafe { components.get_info_unchecked(component_id) };


### PR DESCRIPTION
## Introduction

This is the first step in my [Next Generation Scene / UI Proposal](https://github.com/bevyengine/bevy/discussions/14437).

Fixes https://github.com/bevyengine/bevy/issues/7272 #14800.

Bevy's current Bundles as the "unit of construction" hamstring the UI user experience and have been a pain point in the Bevy ecosystem generally when composing scenes:

* They are an additional _object defining_ concept, which must be learned separately from components. Notably, Bundles _are not present at runtime_, which is confusing and limiting.
* They can completely erase the _defining component_ during Bundle init. For example, `ButtonBundle { style: Style::default(), ..default() }` _makes no mention_ of the `Button` component symbol, which is what makes the Entity a "button"!
* They are not capable of representing "dependency inheritance" without completely non-viable / ergonomically crushing nested bundles. This limitation is especially painful in UI scenarios, but it applies to everything across the board.
* They introduce a bunch of additional nesting when defining scenes, making them ugly to look at
* They introduce component name "stutter": `SomeBundle { component_name: ComponentName::new() }`
* They require copious sprinklings of `..default()` when spawning them in Rust code, due to the additional layer of nesting

**Required Components** solve this by allowing you to define which components a given component needs, and how to construct those components when they aren't explicitly provided.

This is what a `ButtonBundle` looks like with Bundles (the current approach):

```rust
#[derive(Component, Default)]
struct Button;

#[derive(Bundle, Default)]
struct ButtonBundle {
    pub button: Button,
    pub node: Node,
    pub style: Style,
    pub interaction: Interaction,
    pub focus_policy: FocusPolicy,
    pub border_color: BorderColor,
    pub border_radius: BorderRadius,
    pub image: UiImage,
    pub transform: Transform,
    pub global_transform: GlobalTransform,
    pub visibility: Visibility,
    pub inherited_visibility: InheritedVisibility,
    pub view_visibility: ViewVisibility,
    pub z_index: ZIndex,
}

commands.spawn(ButtonBundle {
    style: Style {
        width: Val::Px(100.0),
        height: Val::Px(50.0),
        ..default()
    },
    focus_policy: FocusPolicy::Block,
    ..default()
})
```

And this is what it looks like with Required Components:

```rust
#[derive(Component)]
#[require(Node, UiImage)]
struct Button;

commands.spawn((
    Button,
    Style { 
        width: Val::Px(100.0),
        height: Val::Px(50.0),
        ..default()
    },
    FocusPolicy::Block,
));
```

With Required Components, we mention only the most relevant components. Every component required by `Node` (ex: `Style`, `FocusPolicy`, etc)  is automatically brought in!

### Efficiency

1. At insertion/spawn time, Required Components (including recursive required components) are initialized and inserted _as if they were manually inserted alongside the given components_. This means that this is maximally efficient: there are no archetype or table moves.
2. Required components are only initialized and inserted if they were not manually provided by the developer. For the code example in the previous section, because `Style` and `FocusPolicy` are inserted manually, they _will not_ be initialized and inserted as part of the required components system. Efficient!
3. The "missing required components _and_ constructors needed for an insertion" are cached in the "archetype graph edge", meaning they aren't computed per-insertion. When a component is inserted, the "missing required components" list is iterated (and that graph edge (AddBundle) is actually already looked up for us during insertion, because we need that for "normal" insert logic too).

### IDE Integration

The `#[require(SomeComponent)]` macro has been written in such a way that Rust Analyzer can provide type-inspection-on-hover and `F12` / go-to-definition for required components.

### Custom Constructors

The `require` syntax expects a `Default` constructor by default, but it can be overridden with a custom constructor:

```rust
#[derive(Component)]
#[require(
    Node,
    Style(button_style),
    UiImage
)]
struct Button;

fn button_style() -> Style {
    Style {
        width: Val::Px(100.0),
        ..default()
    }
}
```

### Multiple Inheritance

You may have noticed by now that this behaves a bit like "multiple inheritance". One of the problems that this presents is that it is possible to have duplicate requires for a given type at different levels of the inheritance tree:

```rust
#[derive(Component)
struct X(usize);

#[derive(Component)]
#[require(X(x1))
struct Y;

fn x1() -> X {
    X(1)
}

#[derive(Component)]
#[require(
    Y,
    X(x2),
)]
struct Z;

fn x2() -> X {
    X(2)
}

// What version of X is inserted for Z?
commands.spawn(Z);
```

This is allowed (and encouraged), although this doesn't appear to occur much in practice. First: only one version of `X` is initialized and inserted for `Z`. In the case above, I think we can all probably agree that it makes the most sense to use the `x2` constructor for `X`, because `Y`'s `x1` constructor exists "beneath" `Z` in the inheritance hierarchy; `Z`'s constructor is "more specific".

The algorithm is simple and predictable:

1. Use all of the constructors (including default constructors) directly defined in the spawned component's require list
2. In the order the requires are defined in `#[require()]`, recursively visit the require list of each of the components in the list (this is a depth Depth First Search). When a constructor is found, it will only be used if one has not already been found.

From a user perspective, just think about this as the following:

1. Specifying a required component constructor for `Foo` directly on a spawned component `Bar` will result in that constructor being used (and overriding existing constructors lower in the inheritance tree). This is the classic "inheritance override" behavior people expect.
2. For cases where "multiple inheritance" results in constructor clashes, Components should be listed in "importance order". List a component earlier in the requirement list to initialize its inheritance tree earlier.

Required Components _does_ generally result in a model where component values are decoupled from each other at construction time. Notably, some existing Bundle patterns use bundle constructors to initialize multiple components with shared state. I think (in general) moving away from this is necessary:

1. It allows Required Components (and the Scene system more generally) to operate according to simple rules
2. The "do arbitrary init value sharing in Bundle constructors" approach _already_ causes data consistency problems, and those problems would be exacerbated in the context of a Scene/UI system. For cases where shared state is truly necessary, I think we are better served by observers / hooks.
3. If a situation _truly_ needs shared state constructors (which should be rare / generally discouraged), Bundles are still there if they are needed.

## Next Steps

* **Require Construct-ed Components**: I have already implemented this (as defined in the [Next Generation Scene / UI Proposal](https://github.com/bevyengine/bevy/discussions/14437). However I've removed `Construct` support from this PR, as that has not landed yet. Adding this back in requires relatively minimal changes to the current impl, and can be done as part of a future Construct pr.
* **Port Built-in Bundles to Required Components**: This isn't something we should do right away. It will require rethinking our public interfaces, which IMO should be done holistically after the rest of Next Generation Scene / UI lands. I think we should merge this PR first and let people experiment _inside their own code with their own Components_ while we wait for the rest of the new scene system to land.
* **_Consider_ Automatic Required Component Removal**: We should evaluate _if_ automatic Required Component removal should be done. Ex: if all components that explicitly require a component are removed, automatically remove that component. This issue has been explicitly deferred in this PR, as I consider the insertion behavior to be desirable on its own (and viable on its own). I am also doubtful that we can find a design that has behavior we actually want. Aka: can we _really_ distinguish between a component that is "only there because it was automatically inserted" and "a component that was necessary / should be kept".  See my [discussion response here](https://github.com/bevyengine/bevy/discussions/14437#discussioncomment-10268668) for more details. 