### PR TITLE
add more `Curve` adaptors

### DIFF
--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -1,0 +1,253 @@
+//! A module containing utility helper structs to transform a [`Curve`] into another. This is useful
+//! for building up complex curves from simple segments.
+use std::marker::PhantomData;
+
+use crate::VectorSpace;
+
+use super::{Curve, Interval};
+
+/// The curve that results from chaining one curve with another. The second curve is
+/// effectively reparametrized so that its start is at the end of the first.
+///
+/// For this to be well-formed, the first curve's domain must be right-finite and the second's
+/// must be left-finite.
+///
+/// Curves of this type are produced by [`Curve::chain`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct ChainCurve<T, C, D> {
+    pub(super) first: C,
+    pub(super) second: D,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T, C, D> Curve<T> for ChainCurve<T, C, D>
+where
+    C: Curve<T>,
+    D: Curve<T>,
+{
+    #[inline]
+    fn domain(&self) -> Interval {
+        // This unwrap always succeeds because `first` has a valid Interval as its domain and the
+        // length of `second` cannot be NAN. It's still fine if it's infinity.
+        Interval::new(
+            self.first.domain().start(),
+            self.first.domain().end() + self.second.domain().length(),
+        )
+        .unwrap()
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> T {
+        if t > self.first.domain().end() {
+            self.second.sample_unchecked(
+                // `t - first.domain.end` computes the offset into the domain of the second.
+                t - self.first.domain().end() + self.second.domain().start(),
+            )
+        } else {
+            self.first.sample_unchecked(t)
+        }
+    }
+}
+
+/// The curve that results from reversing another.
+///
+/// Curves of this type are produced by [`Curve::reverse`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct ReverseCurve<T, C> {
+    pub(super) curve: C,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T, C> Curve<T> for ReverseCurve<T, C>
+where
+    C: Curve<T>,
+{
+    #[inline]
+    fn domain(&self) -> Interval {
+        self.curve.domain()
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> T {
+        self.curve
+            .sample_unchecked(self.domain().end() - (t - self.domain().start()))
+    }
+}
+
+/// The curve that results from repeating a curve `N` times.
+///
+/// # Notes
+///
+/// - the domain of this curve has to be bounded
+/// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
+///   value at `domain.end()` in the original curve
+///
+/// Curves of this type are produced by [`Curve::repeat`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct RepeatCurve<T, C> {
+    pub(super) domain: Interval,
+    pub(super) curve: C,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T, C> Curve<T> for RepeatCurve<T, C>
+where
+    C: Curve<T>,
+{
+    #[inline]
+    fn domain(&self) -> Interval {
+        self.domain
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> T {
+        // the domain is bounded by construction
+        let d = self.curve.domain();
+        let cyclic_t = (t - d.start()) % d.length();
+        let t = if t != d.start() && cyclic_t == 0.0 {
+            d.end()
+        } else {
+            d.start() + cyclic_t
+        };
+        self.curve.sample_unchecked(t)
+    }
+}
+
+/// The curve that results from repeating a curve forever.
+///
+/// # Notes
+///
+/// - the domain of this curve has to be bounded
+/// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
+///   value at `domain.end()` in the original curve
+///
+/// Curves of this type are produced by [`Curve::repeat`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct ForeverCurve<T, C> {
+    pub(super) curve: C,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T, C> Curve<T> for ForeverCurve<T, C>
+where
+    C: Curve<T>,
+{
+    #[inline]
+    fn domain(&self) -> Interval {
+        Interval::EVERYWHERE
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> T {
+        // the domain is bounded by construction
+        let d = self.curve.domain();
+        let cyclic_t = (t - d.start()) % d.length();
+        let t = if t != d.start() && cyclic_t == 0.0 {
+            d.end()
+        } else {
+            d.start() + cyclic_t
+        };
+        self.curve.sample_unchecked(t)
+    }
+}
+
+/// The curve that results from chaining a curve with its reversed version. The transition point
+/// is guaranteed to make no jump.
+///
+/// # Notes
+///
+/// - the domain end of this curve has to be finite
+///
+/// Curves of this type are produced by [`Curve::ping_pong`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct PingPongCurve<T, C> {
+    pub(super) curve: C,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T, C> Curve<T> for PingPongCurve<T, C>
+where
+    C: Curve<T>,
+{
+    #[inline]
+    fn domain(&self) -> Interval {
+        // This unwrap always succeeds because `curve` has a valid Interval as its domain and the
+        // length of `curve` cannot be NAN. It's still fine if it's infinity.
+        Interval::new(
+            self.curve.domain().start(),
+            self.curve.domain().end() + self.curve.domain().length(),
+        )
+        .unwrap()
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> T {
+        // the domain is bounded by construction
+        let final_t = if t > self.curve.domain().end() {
+            self.curve.domain().end() * 2.0 - t
+        } else {
+            t
+        };
+        self.curve.sample_unchecked(final_t)
+    }
+}
+
+/// The curve that results from chaining two curves.
+///
+/// Additionally the transition of the samples is guaranteed to not make sudden jumps. This is
+/// useful if you really just know about the shapes of your curves and don't want to deal with
+/// stitching them together properly when it would just introduce useless complexity. It is
+/// realized by translating the second curve so that its start sample point coincides with the
+/// first curves' end sample point.
+///
+/// Curves of this type are produced by [`Curve::chain_continue`].
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct ContinuationCurve<T, C, D> {
+    pub(super) first: C,
+    pub(super) second: D,
+    // cache the offset in the curve directly to prevent triple sampling for every sample we make
+    pub(super) offset: T,
+    pub(super) _phantom: PhantomData<T>,
+}
+
+impl<T, C, D> Curve<T> for ContinuationCurve<T, C, D>
+where
+    T: VectorSpace,
+    C: Curve<T>,
+    D: Curve<T>,
+{
+    #[inline]
+    fn domain(&self) -> Interval {
+        // This unwrap always succeeds because `curve` has a valid Interval as its domain and the
+        // length of `curve` cannot be NAN. It's still fine if it's infinity.
+        Interval::new(
+            self.first.domain().start(),
+            self.first.domain().end() + self.second.domain().length(),
+        )
+        .unwrap()
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> T {
+        if t > self.first.domain().end() {
+            self.second.sample_unchecked(
+                // `t - first.domain.end` computes the offset into the domain of the second.
+                t - self.first.domain().end() + self.second.domain().start(),
+            ) + self.offset
+        } else {
+            self.first.sample_unchecked(t)
+        }
+    }
+}

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -118,7 +118,7 @@ where
     fn sample_unchecked(&self, t: f32) -> T {
         // the domain is bounded by construction
         let d = self.curve.domain();
-        let cyclic_t = (t - d.start()) % d.length();
+        let cyclic_t = (t - d.start()).rem_euclid(d.length());
         let t = if t != d.start() && cyclic_t == 0.0 {
             d.end()
         } else {
@@ -135,7 +135,7 @@ where
 /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
 ///   value at `domain.end()` in the original curve
 ///
-/// Curves of this type are produced by [`Curve::repeat`].
+/// Curves of this type are produced by [`Curve::forever`].
 ///
 /// # Domain
 ///
@@ -161,7 +161,7 @@ where
     fn sample_unchecked(&self, t: f32) -> T {
         // the domain is bounded by construction
         let d = self.curve.domain();
-        let cyclic_t = (t - d.start()) % d.length();
+        let cyclic_t = (t - d.start()).rem_euclid(d.length());
         let t = if t != d.start() && cyclic_t == 0.0 {
             d.end()
         } else {
@@ -227,7 +227,7 @@ where
 /// # Domain
 ///
 /// The first curve's domain must be right-finite and the second's must be left-finite to get a
-/// valid [`ChainCurve`].
+/// valid [`ContinuationCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -1,6 +1,6 @@
 //! A module containing utility helper structs to transform a [`Curve`] into another. This is useful
 //! for building up complex curves from simple segments.
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::VectorSpace;
 
@@ -89,7 +89,7 @@ where
 /// # Notes
 ///
 /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
-/// value at `domain.end()` in the original curve
+///   value at `domain.end()` in the original curve
 ///
 /// Curves of this type are produced by [`Curve::repeat`].
 ///

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -9,10 +9,12 @@ use super::{Curve, Interval};
 /// The curve that results from chaining one curve with another. The second curve is
 /// effectively reparametrized so that its start is at the end of the first.
 ///
-/// For this to be well-formed, the first curve's domain must be right-finite and the second's
-/// must be left-finite.
-///
 /// Curves of this type are produced by [`Curve::chain`].
+///
+/// # Domain
+///
+/// The first curve's domain must be right-finite and the second's must be left-finite to get a
+/// valid [`ChainCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
@@ -54,6 +56,10 @@ where
 /// The curve that results from reversing another.
 ///
 /// Curves of this type are produced by [`Curve::reverse`].
+///
+/// # Domain
+///
+/// The original curve's domain must be bounded to get a valid [`ReverseCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
@@ -82,11 +88,14 @@ where
 ///
 /// # Notes
 ///
-/// - the domain of this curve has to be bounded
 /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
-///   value at `domain.end()` in the original curve
+/// value at `domain.end()` in the original curve
 ///
 /// Curves of this type are produced by [`Curve::repeat`].
+///
+/// # Domain
+///
+/// The original curve's domain must be bounded to get a valid [`RepeatCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
@@ -123,11 +132,14 @@ where
 ///
 /// # Notes
 ///
-/// - the domain of this curve has to be bounded
 /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
 ///   value at `domain.end()` in the original curve
 ///
 /// Curves of this type are produced by [`Curve::repeat`].
+///
+/// # Domain
+///
+/// The original curve's domain must be bounded to get a valid [`ForeverCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
@@ -162,11 +174,11 @@ where
 /// The curve that results from chaining a curve with its reversed version. The transition point
 /// is guaranteed to make no jump.
 ///
-/// # Notes
-///
-/// - the domain end of this curve has to be finite
-///
 /// Curves of this type are produced by [`Curve::ping_pong`].
+///
+/// # Domain
+///
+/// The original curve's domain must be right-finite to get a valid [`PingPongCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
@@ -211,6 +223,11 @@ where
 /// first curves' end sample point.
 ///
 /// Curves of this type are produced by [`Curve::chain_continue`].
+///
+/// # Domain
+///
+/// The first curve's domain must be right-finite and the second's must be left-finite to get a
+/// valid [`ChainCurve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -11,9 +11,9 @@ pub use interval::{interval, Interval};
 use itertools::Itertools;
 
 use crate::{StableInterpolate, VectorSpace};
+use core::{marker::PhantomData, ops::Deref};
 use cores::{EvenCore, EvenCoreError, UnevenCore, UnevenCoreError};
 use interval::InvalidIntervalError;
-use core::{marker::PhantomData, ops::Deref};
 use thiserror::Error;
 
 /// A trait for a type that can represent values of type `T` parametrized over a fixed interval.

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -244,7 +244,7 @@ pub trait Curve<T> {
 
     /// Create a new [`Curve`] by composing this curve end-to-start with another, producing another curve
     /// with outputs of the same type. The domain of the other curve is translated so that its start
-    /// coincides with where this curve ends. 
+    /// coincides with where this curve ends.
     ///
     /// # Errors
     ///
@@ -275,7 +275,7 @@ pub trait Curve<T> {
     ///
     /// # Error
     ///
-    /// A [`ReverseError`] is returned if this curve's domain isn't bounded
+    /// A [`ReverseError`] is returned if this curve's domain isn't bounded.
     fn reverse(self) -> Result<ReverseCurve<T, Self>, ReverseError>
     where
         Self: Sized,
@@ -289,8 +289,8 @@ pub trait Curve<T> {
             .ok_or(ReverseError::SourceDomainEndInfinite)
     }
 
-    /// Create a new [`Curve`] repeating this curve `n` times, producing another curve with outputs
-    /// of the same type. The domain of the new curve will be bigger by a factor of `n`.
+    /// Create a new [`Curve`] repeating this curve `N` times, producing another curve with outputs
+    /// of the same type. The domain of the new curve will be bigger by a factor of `n + 1`.
     ///
     /// # Notes
     ///
@@ -302,7 +302,7 @@ pub trait Curve<T> {
     ///
     /// # Error
     ///
-    /// A [`RepeatError`] is returned if this curve's domain isn't bounded
+    /// A [`RepeatError`] is returned if this curve's domain isn't bounded.
     fn repeat(self, count: usize) -> Result<RepeatCurve<T, Self>, RepeatError>
     where
         Self: Sized,
@@ -338,7 +338,7 @@ pub trait Curve<T> {
     ///
     /// # Error
     ///
-    /// A [`RepeatError`] is returned if this curve's domain isn't bounded
+    /// A [`RepeatError`] is returned if this curve's domain isn't bounded.
     fn forever(self) -> Result<ForeverCurve<T, Self>, RepeatError>
     where
         Self: Sized,
@@ -356,9 +356,9 @@ pub trait Curve<T> {
     /// another curve with outputs of the same type. The domain of the new curve will be twice as
     /// long. The transition point is guaranteed to not make any jumps.
     ///
-    /// # Error 
+    /// # Error
     ///
-    /// A [`PingPongError`] is returned if this curve's domain isn't right-finite
+    /// A [`PingPongError`] is returned if this curve's domain isn't right-finite.
     fn ping_pong(self) -> Result<PingPongCurve<T, Self>, PingPongError>
     where
         Self: Sized,
@@ -374,7 +374,7 @@ pub trait Curve<T> {
 
     /// Create a new [`Curve`] by composing this curve end-to-start with another, producing another
     /// curve with outputs of the same type. The domain of the other curve is translated so that
-    /// its start coincides with where this curve ends. 
+    /// its start coincides with where this curve ends.
     ///
     ///
     /// Additionally the transition of the samples is guaranteed to make no sudden jumps. This is
@@ -383,7 +383,7 @@ pub trait Curve<T> {
     /// realized by translating the other curve so that its start sample point coincides with the
     /// current curves' end sample point.
     ///
-    /// # Error 
+    /// # Error
     ///
     /// A [`ChainError`] is returned if this curve's domain doesn't have a finite end or if
     /// `other`'s domain doesn't have a finite start.
@@ -828,7 +828,7 @@ where
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct LinearReparamCurve<T, C> {
-    /// Invariants: The domain of this curve must always be bounded.
+    /// Invariants: The domain of the inner curve must always be bounded.
     base: C,
     /// Invariants: This interval must always be bounded.
     new_domain: Interval,

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -292,7 +292,7 @@ pub trait Curve<T> {
     ///
     /// # Notes
     ///
-    /// - this doesn't guarantee a smooth transition from one occurence of the curve to its next
+    /// - this doesn't guarantee a smooth transition from one occurrence of the curve to its next
     ///   iteration. The curve will make a jump if `self.domain().start() != self.domain().end()`!
     /// - for `RepeatMode::Fixed(0)` the output of this adaptor is basically identical to the previous curve
     /// - the domain of this curve has to be bounded

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -244,8 +244,12 @@ pub trait Curve<T> {
 
     /// Create a new [`Curve`] by composing this curve end-to-start with another, producing another curve
     /// with outputs of the same type. The domain of the other curve is translated so that its start
-    /// coincides with where this curve ends. A [`ChainError`] is returned if this curve's domain
-    /// doesn't have a finite end or if `other`'s domain doesn't have a finite start.
+    /// coincides with where this curve ends. 
+    ///
+    /// # Errors
+    ///
+    /// A [`ChainError`] is returned if this curve's domain doesn't have a finite end or if
+    /// `other`'s domain doesn't have a finite start.
     fn chain<C>(self, other: C) -> Result<ChainCurve<T, Self, C>, ChainError>
     where
         Self: Sized,
@@ -269,9 +273,9 @@ pub trait Curve<T> {
     /// and transitioning over to `self.domain().start()`. The domain of the new curve is still the
     /// same.
     ///
-    /// # Notes
+    /// # Error
     ///
-    /// - the domain of this curve has to be bounded
+    /// A [`ReverseError`] is returned if this curve's domain isn't bounded
     fn reverse(self) -> Result<ReverseCurve<T, Self>, ReverseError>
     where
         Self: Sized,
@@ -293,9 +297,12 @@ pub trait Curve<T> {
     /// - this doesn't guarantee a smooth transition from one occurrence of the curve to its next
     ///   iteration. The curve will make a jump if `self.domain().start() != self.domain().end()`!
     /// - for `count == 0` the output of this adaptor is basically identical to the previous curve
-    /// - the domain of the input curve has to be bounded
     /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
     ///   value at `domain.end()` in the original curve
+    ///
+    /// # Error
+    ///
+    /// A [`RepeatError`] is returned if this curve's domain isn't bounded
     fn repeat(self, count: usize) -> Result<RepeatCurve<T, Self>, RepeatError>
     where
         Self: Sized,
@@ -326,9 +333,12 @@ pub trait Curve<T> {
     ///
     /// - this doesn't guarantee a smooth transition from one occurrence of the curve to its next
     ///   iteration. The curve will make a jump if `self.domain().start() != self.domain().end()`!
-    /// - the domain of the input curve has to be bounded
     /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
     ///   value at `domain.end()` in the original curve
+    ///
+    /// # Error
+    ///
+    /// A [`RepeatError`] is returned if this curve's domain isn't bounded
     fn forever(self) -> Result<ForeverCurve<T, Self>, RepeatError>
     where
         Self: Sized,
@@ -344,7 +354,11 @@ pub trait Curve<T> {
 
     /// Create a new [`Curve`] chaining the original curve with its inverse, producing
     /// another curve with outputs of the same type. The domain of the new curve will be twice as
-    /// long. The transition point is guaranteed to not make a jump
+    /// long. The transition point is guaranteed to not make any jumps.
+    ///
+    /// # Error 
+    ///
+    /// A [`PingPongError`] is returned if this curve's domain isn't right-finite
     fn ping_pong(self) -> Result<PingPongCurve<T, Self>, PingPongError>
     where
         Self: Sized,
@@ -358,16 +372,21 @@ pub trait Curve<T> {
             .ok_or(PingPongError::SourceDomainEndInfinite)
     }
 
-    /// Create a new [`Curve`] by composing this curve end-to-start with another, producing another curve
-    /// with outputs of the same type. The domain of the other curve is translated so that its start
-    /// coincides with where this curve ends. A [`ChainError`] is returned if this curve's domain
-    /// doesn't have a finite end or if `other`'s domain doesn't have a finite start.
+    /// Create a new [`Curve`] by composing this curve end-to-start with another, producing another
+    /// curve with outputs of the same type. The domain of the other curve is translated so that
+    /// its start coincides with where this curve ends. 
+    ///
     ///
     /// Additionally the transition of the samples is guaranteed to make no sudden jumps. This is
     /// useful if you really just know about the shapes of your curves and don't want to deal with
     /// stitching them together properly when it would just introduce useless complexity. It is
     /// realized by translating the other curve so that its start sample point coincides with the
     /// current curves' end sample point.
+    ///
+    /// # Error 
+    ///
+    /// A [`ChainError`] is returned if this curve's domain doesn't have a finite end or if
+    /// `other`'s domain doesn't have a finite start.
     fn chain_continue<C>(self, other: C) -> Result<ContinuationCurve<T, Self, C>, ChainError>
     where
         Self: Sized,

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -1060,7 +1060,7 @@ where
 pub struct ContinuousChainCurve<T, C, D> {
     first: C,
     second: D,
-    // cache the offset in the curve directly to prevent tripple sampling for every sample we make
+    // cache the offset in the curve directly to prevent triple sampling for every sample we make
     offset: T,
     _phantom: PhantomData<T>,
 }

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use crate::{StableInterpolate, VectorSpace};
 use cores::{EvenCore, EvenCoreError, UnevenCore, UnevenCoreError};
 use interval::InvalidIntervalError;
-use std::{marker::PhantomData, ops::Deref};
+use core::{marker::PhantomData, ops::Deref};
 use thiserror::Error;
 
 /// A trait for a type that can represent values of type `T` parametrized over a fixed interval.


### PR DESCRIPTION
# Objective

This implements another item on the way to complete the `Curves` implementation initiative

Citing @mweatherley 

> Curve adaptors for making a curve repeat or ping-pong would be useful.

This adds three widely applicable adaptors:

- `ReverseCurve` "plays" the curve backwards
- `RepeatCurve` to repeat the curve for `n` times where `n` in `[0,inf)`
- `ForeverCurve` which extends the curves domain to `EVERYWHERE`
- `PingPongCurve` (name wip (?)) to chain the curve with it's reverse. This would be achievable with `ReverseCurve` and `ChainCurve`, but it would require the use of `by_ref` which can be restrictive in some scenarios where you'd rather just consume the curve. Users can still create the same effect by combination of the former two, but since this will be most likely a very typical adaptor we should also provide it on the library level. (Why it's typical: you can create a single period of common waves with it pretty easily, think square wave (= pingpong + step), triangle wave ( = pingpong + linear), etc.) 
- `ContinuationCurve` which chains two curves but also makes sure that the samples of the second curve are translated so that `sample(first.end) == sample(second.start)`

## Solution

Implement the adaptors above. (More suggestions are welcome!)

## Testing

- [x] add simple tests. One per adaptor