### PR TITLE
Fix ecs example thread_rng duplicate creation

### DIFF
--- a/examples/ecs/observer_propagation.rs
+++ b/examples/ecs/observer_propagation.rs
@@ -69,9 +69,9 @@ struct Armor(u16);
 
 /// A normal bevy system that attacks a piece of the goblin's armor on a timer.
 fn attack_armor(entities: Query<Entity, With<Armor>>, mut commands: Commands) {
-    let mut rng = rand::thread_rng();
+    let mut rng = thread_rng();
     if let Some(target) = entities.iter().choose(&mut rng) {
-        let damage = thread_rng().gen_range(1..20);
+        let damage = rng.gen_range(1..20);
         commands.trigger_targets(Attack { damage }, target);
         info!("⚔️  Attack for {} damage", damage);
     }


### PR DESCRIPTION
# Objective

While looking through the changes #14782 will create I noticed this.

## Solution

Reuse the existing thread_rng. As this is a code change I would like to not include it in a pure lint enable PR.

## Testing

I did not test this change (other than the automated CI with this PR).  I think it should be a fairly simple change that can be reviewed only by the code.