### PR TITLE
Fix error when closing window in 2d_viewport_to_world example

### DIFF
--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -17,7 +17,11 @@ fn draw_cursor(
 ) {
     let (camera, camera_transform) = camera_query.single();
 
-    let Some(cursor_position) = windows.single().cursor_position() else {
+    let Ok(window) = windows.get_single() else {
+        return;
+    };
+
+    let Some(cursor_position) = window.cursor_position() else {
         return;
     };
 


### PR DESCRIPTION
# Objective

- Fix error when closing window in 2d_viewport_to_world example.

Before
```
2024-08-17T22:51:47.690252Z  INFO bevy_winit::system: Creating new window "App" (0v1#4294967296)
2024-08-17T22:52:22.062959Z  INFO bevy_window::system: No windows are open, exiting
2024-08-17T22:52:22.064045Z  INFO bevy_winit::system: Closing window 0v1#4294967296
thread 'Compute Task Pool (5)' panicked at examples/2d/2d_viewport_to_world.rs:20:41:
called `Result::unwrap()` on an `Err` value: NoEntities("bevy_ecs::query::state::QueryState<&bevy_window::window::Window>")
```

After
```
2024-08-17T22:57:31.623499Z  INFO bevy_winit::system: Creating new window "App" (0v1#4294967296)
2024-08-17T22:57:32.990058Z  INFO bevy_window::system: No windows are open, exiting
2024-08-17T22:57:32.991152Z  INFO bevy_winit::system: Closing window 0v1#4294967296
2024-08-17T22:57:32.994426Z  INFO bevy_window::system: No windows are open, exiting
 *  Terminal will be reused by tasks, press any key to close it. 
```

## Solution

- Check if the window still exists before drawing the cursor