### PR TITLE
Fix key bindings in 3d_gizmos example after camera controller

### DIFF
--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -58,12 +58,12 @@ fn setup(
     // example instructions
     commands.spawn(
         TextBundle::from_section(
-            "Press 'D' to toggle drawing gizmos on top of everything else in the scene\n\
+            "Press 'T' to toggle drawing gizmos on top of everything else in the scene\n\
             Press 'P' to toggle perspective for line gizmos\n\
             Hold 'Left' or 'Right' to change the line width of straight gizmos\n\
             Hold 'Up' or 'Down' to change the line width of round gizmos\n\
             Press '1' or '2' to toggle the visibility of straight gizmos or round gizmos\n\
-            Press 'A' to show all AABB boxes\n\
+            Press 'B' to show all AABB boxes\n\
             Press 'U' or 'I' to cycle through line styles for straight or round gizmos\n\
             Press 'J' or 'K' to cycle through line joins for straight or round gizmos",
             TextStyle::default(),
@@ -166,7 +166,7 @@ fn update_config(
     keyboard: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
-    if keyboard.just_pressed(KeyCode::KeyD) {
+    if keyboard.just_pressed(KeyCode::KeyT) {
         for (_, config, _) in config_store.iter_mut() {
             config.depth_bias = if config.depth_bias == 0. { -1. } else { 0. };
         }
@@ -234,7 +234,7 @@ fn update_config(
         };
     }
 
-    if keyboard.just_pressed(KeyCode::KeyA) {
+    if keyboard.just_pressed(KeyCode::KeyB) {
         // AABB gizmos are normally only drawn on entities with a ShowAabbGizmo component
         // We can change this behaviour in the configuration of AabbGizmoGroup
         config_store.config_mut::<AabbGizmoConfigGroup>().1.draw_all ^= true;


### PR DESCRIPTION
# Objective

Fixes #14811

## Solution

- Switch `D` to `T`: `T` for "on top of"
- Switch `A` to `B`: `B` in "AABB", or "boxes"

## Testing

- Ran the example locally
- Checked the key bindings that the camera controller uses and made sure we're not using them in the 3d_gizmos example anymore

After:

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/4f558d09-5acf-4eb8-8ece-6d4297e62c9f">

