### PR TITLE
Apply unused_qualifications lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,14 @@ members = [
 ]
 
 [workspace.lints.clippy]
-type_complexity = "allow"
 doc_markdown = "warn"
 manual_let_else = "warn"
-undocumented_unsafe_blocks = "warn"
-redundant_else = "warn"
 match_same_arms = "warn"
-semicolon_if_nothing_returned = "warn"
 redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+semicolon_if_nothing_returned = "warn"
+type_complexity = "allow"
+undocumented_unsafe_blocks = "warn"
 unwrap_or_default = "warn"
 
 ptr_as_ptr = "warn"
@@ -46,10 +46,11 @@ ptr_cast_constness = "warn"
 ref_as_ptr = "warn"
 
 [workspace.lints.rust]
-unsafe_op_in_unsafe_fn = "warn"
 missing_docs = "warn"
-unsafe_code = "deny"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "warn"
+unused_qualifications = "warn"
 
 [lints]
 workspace = true

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -225,7 +225,7 @@ impl AnimationGraph {
     ) -> impl Iterator<Item = AnimationNodeIndex> + 'a
     where
         I: IntoIterator<Item = Handle<AnimationClip>>,
-        <I as std::iter::IntoIterator>::IntoIter: 'a,
+        <I as IntoIterator>::IntoIter: 'a,
     {
         clips
             .into_iter()

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1074,7 +1074,7 @@ impl From<u8> for AppExit {
 }
 
 impl Termination for AppExit {
-    fn report(self) -> std::process::ExitCode {
+    fn report(self) -> ExitCode {
         match self {
             AppExit::Success => ExitCode::SUCCESS,
             // We leave logging an error to our users
@@ -1085,7 +1085,7 @@ impl Termination for AppExit {
 
 #[cfg(test)]
 mod tests {
-    use std::{iter, marker::PhantomData, mem, sync::Mutex};
+    use std::{iter, marker::PhantomData, sync::Mutex};
 
     use bevy_ecs::{
         change_detection::{DetectChanges, ResMut},
@@ -1411,7 +1411,7 @@ mod tests {
     fn app_exit_size() {
         // There wont be many of them so the size isn't a issue but
         // it's nice they're so small let's keep it that way.
-        assert_eq!(mem::size_of::<AppExit>(), mem::size_of::<u8>());
+        assert_eq!(size_of::<AppExit>(), size_of::<u8>());
     }
 
     #[test]

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -77,7 +77,7 @@ impl From<std::io::Error> for AssetReaderError {
 // Ideally this would be even smaller (ReadToEndFuture only needs space for two references based on its definition),
 // but compiler optimizations can apparently inflate the stack size of futures due to inlining, which makes
 // a higher maximum necessary.
-pub const STACK_FUTURE_SIZE: usize = 10 * std::mem::size_of::<&()>();
+pub const STACK_FUTURE_SIZE: usize = 10 * size_of::<&()>();
 
 pub use stackfuture::StackFuture;
 
@@ -520,7 +520,7 @@ impl VecReader {
 impl AsyncRead for VecReader {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
+        cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<futures_io::Result<usize>> {
         if self.bytes_read >= self.bytes.len() {

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -137,7 +137,7 @@ impl AsyncRead for TransactionLockedReader<'_> {
         mut self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
         buf: &mut [u8],
-    ) -> std::task::Poll<futures_io::Result<usize>> {
+    ) -> Poll<futures_io::Result<usize>> {
         Pin::new(&mut self.reader).poll_read(cx, buf)
     }
 }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -583,13 +583,10 @@ mod tests {
         async fn read_meta<'a>(
             &'a self,
             path: &'a Path,
-        ) -> Result<impl bevy_asset::io::Reader + 'a, AssetReaderError> {
+        ) -> Result<impl Reader + 'a, AssetReaderError> {
             self.memory_reader.read_meta(path).await
         }
-        async fn read<'a>(
-            &'a self,
-            path: &'a Path,
-        ) -> Result<impl bevy_asset::io::Reader + 'a, bevy_asset::io::AssetReaderError> {
+        async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
             let attempt_number = {
                 let mut attempt_counters = self.attempt_counters.lock().unwrap();
                 if let Some(existing) = attempt_counters.get_mut(path) {

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 /// should be loaded.
 pub trait AssetLoader: Send + Sync + 'static {
     /// The top level [`Asset`] loaded by this [`AssetLoader`].
-    type Asset: crate::Asset;
+    type Asset: Asset;
     /// The settings type used by this [`AssetLoader`].
     type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
     /// The type of [error](`std::error::Error`) which could be encountered by this loader.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -725,7 +725,7 @@ impl AssetServer {
             .data
             .infos
             .write()
-            .create_loading_handle_untyped(std::any::TypeId::of::<A>(), std::any::type_name::<A>());
+            .create_loading_handle_untyped(TypeId::of::<A>(), std::any::type_name::<A>());
         let id = handle.id();
 
         let event_sender = self.data.asset_event_sender.clone();

--- a/crates/bevy_color/src/color_ops.rs
+++ b/crates/bevy_color/src/color_ops.rs
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_gray() {
-        verify_gray::<crate::Hsla>();
+        verify_gray::<Hsla>();
         verify_gray::<crate::Hsva>();
         verify_gray::<crate::Hwba>();
         verify_gray::<crate::Laba>();

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -13,7 +13,7 @@ use bevy_time::{Real, Time};
 pub struct FrameTimeDiagnosticsPlugin;
 
 impl Plugin for FrameTimeDiagnosticsPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&self, app: &mut App) {
         app.register_diagnostic(Diagnostic::new(Self::FRAME_TIME).with_suffix("ms"))
             .register_diagnostic(Diagnostic::new(Self::FPS))
             .register_diagnostic(Diagnostic::new(Self::FRAME_COUNT).with_smoothing_factor(0.0))

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -37,7 +37,7 @@ impl Plugin for DiagnosticsPlugin {
         app.init_resource::<DiagnosticsStore>();
 
         #[cfg(feature = "sysinfo_plugin")]
-        app.init_resource::<system_information_diagnostics_plugin::SystemInfo>();
+        app.init_resource::<SystemInfo>();
     }
 }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -101,7 +101,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                         });
                     }
                     None => {
-                        let index = syn::Index::from(i);
+                        let index = Index::from(i);
                         field_get_components.push(quote! {
                             self.#index.get_components(&mut *func);
                         });

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -19,7 +19,7 @@ use crate::{
 struct QueryDataAttributes {
     pub is_mutable: bool,
 
-    pub derive_args: Punctuated<Meta, syn::token::Comma>,
+    pub derive_args: Punctuated<Meta, Comma>,
 }
 
 static MUTABLE_ATTRIBUTE_NAME: &str = "mutable";
@@ -48,7 +48,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
         }
 
         attr.parse_args_with(|input: ParseStream| {
-            let meta = input.parse_terminated(syn::Meta::parse, Comma)?;
+            let meta = input.parse_terminated(Meta::parse, Comma)?;
             for meta in meta {
                 let ident = meta.path().get_ident().unwrap_or_else(|| {
                     panic!(

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -706,7 +706,7 @@ impl<'w> BundleInserter<'w> {
         location: EntityLocation,
         bundle: T,
         insert_mode: InsertMode,
-        #[cfg(feature = "track_change_detection")] caller: &'static core::panic::Location<'static>,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location<'static>,
     ) -> EntityLocation {
         let bundle_info = self.bundle_info.as_ref();
         let add_bundle = self.add_bundle.as_ref();

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -940,7 +940,7 @@ pub struct MutUntyped<'w> {
     pub(crate) value: PtrMut<'w>,
     pub(crate) ticks: TicksMut<'w>,
     #[cfg(feature = "track_change_detection")]
-    pub(crate) changed_by: &'w mut &'static core::panic::Location<'static>,
+    pub(crate) changed_by: &'w mut &'static Location<'static>,
 }
 
 impl<'w> MutUntyped<'w> {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -385,7 +385,7 @@ impl<'de> Deserialize<'de> for Entity {
         D: serde::Deserializer<'de>,
     {
         use serde::de::Error;
-        let id: u64 = serde::de::Deserialize::deserialize(deserializer)?;
+        let id: u64 = Deserialize::deserialize(deserializer)?;
         Entity::try_from_bits(id).map_err(D::Error::custom)
     }
 }
@@ -1007,10 +1007,7 @@ mod tests {
 
     #[test]
     fn entity_niche_optimization() {
-        assert_eq!(
-            std::mem::size_of::<Entity>(),
-            std::mem::size_of::<Option<Entity>>()
-        );
+        assert_eq!(size_of::<Entity>(), size_of::<Option<Entity>>());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -35,7 +35,7 @@ impl<'a, T: SparseSetIndex> FormattedBitSet<'a, T> {
     }
 }
 
-impl<'a, T: SparseSetIndex + fmt::Debug> fmt::Debug for FormattedBitSet<'a, T> {
+impl<'a, T: SparseSetIndex + Debug> Debug for FormattedBitSet<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list()
             .entries(self.bit_set.ones().map(T::get_sparse_set_index))
@@ -106,7 +106,7 @@ impl<T: SparseSetIndex> Clone for Access<T> {
     }
 }
 
-impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
+impl<T: SparseSetIndex + Debug> Debug for Access<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Access")
             .field(
@@ -907,7 +907,7 @@ impl<T: SparseSetIndex> Clone for AccessFilters<T> {
     }
 }
 
-impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for AccessFilters<T> {
+impl<T: SparseSetIndex + Debug> Debug for AccessFilters<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AccessFilters")
             .field("with", &FormattedBitSet::<T>::new(&self.with))

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -373,7 +373,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                         .map(|index| index.keys())
                 })
                 // select the component with the fewest archetypes
-                .min_by_key(std::iter::ExactSizeIterator::len);
+                .min_by_key(ExactSizeIterator::len);
             if let Some(archetypes) = potential_archetypes {
                 for archetype_id in archetypes {
                     // exclude archetypes that have already been processed

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -521,7 +521,7 @@ mod tests {
     use crate::{component::Component, ptr::OwningPtr, world::World};
 
     use super::BlobVec;
-    use std::{alloc::Layout, cell::RefCell, mem, rc::Rc};
+    use std::{alloc::Layout, cell::RefCell, rc::Rc};
 
     unsafe fn drop_ptr<T>(x: OwningPtr<'_>) {
         // SAFETY: The pointer points to a valid value of type `T` and it is safe to drop this value.
@@ -722,7 +722,7 @@ mod tests {
         for zst in q.iter(&world) {
             // Ensure that the references returned are properly aligned.
             assert_eq!(
-                std::ptr::from_ref::<Zst>(zst) as usize % mem::align_of::<Zst>(),
+                std::ptr::from_ref::<Zst>(zst) as usize % align_of::<Zst>(),
                 0
             );
             count += 1;

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -165,7 +165,7 @@ impl<const SEND: bool> ResourceData<SEND> {
         &mut self,
         value: OwningPtr<'_>,
         change_tick: Tick,
-        #[cfg(feature = "track_change_detection")] caller: &'static core::panic::Location,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location,
     ) {
         if self.is_present() {
             self.validate_access();
@@ -203,7 +203,7 @@ impl<const SEND: bool> ResourceData<SEND> {
         &mut self,
         value: OwningPtr<'_>,
         change_ticks: ComponentTicks,
-        #[cfg(feature = "track_change_detection")] caller: &'static core::panic::Location,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location,
     ) {
         if self.is_present() {
             self.validate_access();

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -304,7 +304,7 @@ impl ComponentSparseSet {
     pub fn get_changed_by(
         &self,
         entity: Entity,
-    ) -> Option<&UnsafeCell<&'static core::panic::Location<'static>>> {
+    ) -> Option<&UnsafeCell<&'static Location<'static>>> {
         let dense_index = *self.sparse.get(entity.index())?;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index.as_usize()]);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -87,7 +87,7 @@ const _: () = {
         type State = FetchState;
         type Item<'w, 's> = Commands<'w, 's>;
         fn init_state(
-            world: &mut bevy_ecs::world::World,
+            world: &mut World,
             system_meta: &mut bevy_ecs::system::SystemMeta,
         ) -> Self::State {
             FetchState {
@@ -114,7 +114,7 @@ const _: () = {
         fn apply(
             state: &mut Self::State,
             system_meta: &bevy_ecs::system::SystemMeta,
-            world: &mut bevy_ecs::world::World,
+            world: &mut World,
         ) {
             <__StructFieldsAlias<'_, '_> as bevy_ecs::system::SystemParam>::apply(
                 &mut state.state,
@@ -1319,7 +1319,7 @@ where
     B: Bundle,
 {
     #[cfg(feature = "track_change_detection")]
-    let caller = core::panic::Location::caller();
+    let caller = Location::caller();
     move |world: &mut World| {
         if let Err(invalid_entities) = world.insert_or_spawn_batch_with_caller(
             bundles_iter,
@@ -1353,7 +1353,7 @@ fn despawn() -> impl EntityCommand {
 /// An [`EntityCommand`] that adds the components in a [`Bundle`] to an entity.
 #[track_caller]
 fn insert<T: Bundle>(bundle: T, mode: InsertMode) -> impl EntityCommand {
-    let caller = core::panic::Location::caller();
+    let caller = Location::caller();
     move |entity: Entity, world: &mut World| {
         if let Some(mut entity) = world.get_entity_mut(entity) {
             entity.insert_with_caller(
@@ -1373,7 +1373,7 @@ fn insert<T: Bundle>(bundle: T, mode: InsertMode) -> impl EntityCommand {
 #[track_caller]
 fn try_insert(bundle: impl Bundle, mode: InsertMode) -> impl EntityCommand {
     #[cfg(feature = "track_change_detection")]
-    let caller = core::panic::Location::caller();
+    let caller = Location::caller();
     move |entity, world: &mut World| {
         if let Some(mut entity) = world.get_entity_mut(entity) {
             entity.insert_with_caller(

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -169,7 +169,7 @@ impl RawCommandQueue {
 
         let meta = CommandMeta {
             consume_command_and_get_size: |command, world, cursor| {
-                *cursor += std::mem::size_of::<C>();
+                *cursor += size_of::<C>();
 
                 // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
                 // `command` must point to a value of type `C`.
@@ -197,7 +197,7 @@ impl RawCommandQueue {
         let old_len = bytes.len();
 
         // Reserve enough bytes for both the metadata and the command itself.
-        bytes.reserve(std::mem::size_of::<Packed<C>>());
+        bytes.reserve(size_of::<Packed<C>>());
 
         // Pointer to the bytes at the end of the buffer.
         // SAFETY: We know it is within bounds of the allocation, due to the call to `.reserve()`.
@@ -217,7 +217,7 @@ impl RawCommandQueue {
         // SAFETY: The new length is guaranteed to fit in the vector's capacity,
         // due to the call to `.reserve()` above.
         unsafe {
-            bytes.set_len(old_len + std::mem::size_of::<Packed<C>>());
+            bytes.set_len(old_len + size_of::<Packed<C>>());
         }
     }
 
@@ -252,13 +252,13 @@ impl RawCommandQueue {
             };
 
             // Advance to the bytes just after `meta`, which represent a type-erased command.
-            local_cursor += std::mem::size_of::<CommandMeta>();
+            local_cursor += size_of::<CommandMeta>();
             // Construct an owned pointer to the command.
             // SAFETY: It is safe to transfer ownership out of `self.bytes`, since the increment of `cursor` above
             // guarantees that nothing stored in the buffer will get observed after this function ends.
             // `cmd` points to a valid address of a stored command, so it must be non-null.
             let cmd = unsafe {
-                OwningPtr::<Unaligned>::new(std::ptr::NonNull::new_unchecked(
+                OwningPtr::<Unaligned>::new(NonNull::new_unchecked(
                     self.bytes.as_mut().as_mut_ptr().add(local_cursor).cast(),
                 ))
             };
@@ -445,7 +445,7 @@ mod test {
 
     #[test]
     fn test_command_queue_inner_panic_safe() {
-        std::panic::set_hook(Box::new(|_| {}));
+        panic::set_hook(Box::new(|_| {}));
 
         let mut queue = CommandQueue::default();
 
@@ -454,7 +454,7 @@ mod test {
 
         let mut world = World::new();
 
-        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = panic::catch_unwind(AssertUnwindSafe(|| {
             queue.apply(&mut world);
         }));
 
@@ -468,7 +468,7 @@ mod test {
 
     #[test]
     fn test_command_queue_inner_nested_panic_safe() {
-        std::panic::set_hook(Box::new(|_| {}));
+        panic::set_hook(Box::new(|_| {}));
 
         #[derive(Resource, Default)]
         struct Order(Vec<usize>);
@@ -488,7 +488,7 @@ mod test {
         });
         world.commands().add(add_index(4));
 
-        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = panic::catch_unwind(AssertUnwindSafe(|| {
             world.flush_commands();
         }));
 

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -54,11 +54,11 @@ unsafe impl SystemParam for WorldId {
 
     type Item<'world, 'state> = WorldId;
 
-    fn init_state(_: &mut World, _: &mut crate::system::SystemMeta) -> Self::State {}
+    fn init_state(_: &mut World, _: &mut SystemMeta) -> Self::State {}
 
     unsafe fn get_param<'world, 'state>(
         _: &'state mut Self::State,
-        _: &crate::system::SystemMeta,
+        _: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         _: Tick,
     ) -> Self::Item<'world, 'state> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2348,7 +2348,7 @@ impl World {
 
         // By setting the change tick in the drop impl, we ensure that
         // the change tick gets reset even if a panic occurs during the scope.
-        impl std::ops::Drop for LastTickGuard<'_> {
+        impl Drop for LastTickGuard<'_> {
             fn drop(&mut self) {
                 self.world.last_change_tick = self.last_tick;
             }
@@ -3197,7 +3197,7 @@ mod tests {
         };
 
         assert!(iter.next().is_none());
-        std::mem::drop(iter);
+        drop(iter);
 
         assert_eq!(world.resource::<TestResource>().0, 43);
         assert_eq!(

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -120,7 +120,7 @@ const LINE_JOINT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(11627807
 pub struct GizmoPlugin;
 
 impl Plugin for GizmoPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&self, app: &mut App) {
         #[cfg(feature = "bevy_render")]
         {
             use bevy_asset::load_internal_asset;
@@ -175,7 +175,7 @@ impl Plugin for GizmoPlugin {
     }
 
     #[cfg(feature = "bevy_render")]
-    fn finish(&self, app: &mut bevy_app::App) {
+    fn finish(&self, app: &mut App) {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -108,7 +108,7 @@ pub enum GltfError {
     CircularChildren(String),
     /// Failed to load a file.
     #[error("failed to load file: {0}")]
-    Io(#[from] std::io::Error),
+    Io(#[from] Error),
 }
 
 /// Loads glTF files with all of their data as their corresponding bevy representations.
@@ -777,7 +777,7 @@ async fn load_gltf<'a, 'b, 'c>(
     })
 }
 
-fn get_gltf_extras(extras: &gltf::json::Extras) -> Option<GltfExtras> {
+fn get_gltf_extras(extras: &json::Extras) -> Option<GltfExtras> {
     extras.as_ref().map(|extras| GltfExtras {
         value: extras.get().to_string(),
     })
@@ -799,9 +799,9 @@ fn node_transform(node: &Node) -> Transform {
             rotation,
             scale,
         } => Transform {
-            translation: bevy_math::Vec3::from(translation),
+            translation: Vec3::from(translation),
             rotation: bevy_math::Quat::from_array(rotation),
-            scale: bevy_math::Vec3::from(scale),
+            scale: Vec3::from(scale),
         },
     }
 }
@@ -849,7 +849,7 @@ async fn load_image<'a, 'b>(
         .name()
         .map_or("Unknown GLTF Texture".to_string(), ToString::to_string);
     match gltf_texture.source().source() {
-        gltf::image::Source::View { view, mime_type } => {
+        Source::View { view, mime_type } => {
             let start = view.offset();
             let end = view.offset() + view.length();
             let buffer = &buffer_data[view.buffer().index()][start..end];
@@ -868,7 +868,7 @@ async fn load_image<'a, 'b>(
                 label: GltfAssetLabel::Texture(gltf_texture.index()),
             })
         }
-        gltf::image::Source::Uri { uri, mime_type } => {
+        Source::Uri { uri, mime_type } => {
             let uri = percent_encoding::percent_decode_str(uri)
                 .decode_utf8()
                 .unwrap();
@@ -1697,7 +1697,7 @@ async fn load_buffers(
 /// It resolves a Gltf tree and allows for a safe Gltf nodes iteration,
 /// putting dependant nodes before dependencies.
 struct GltfTreeIterator<'a> {
-    nodes: Vec<gltf::Node<'a>>,
+    nodes: Vec<Node<'a>>,
 }
 
 impl<'a> GltfTreeIterator<'a> {
@@ -1784,7 +1784,7 @@ impl<'a> GltfTreeIterator<'a> {
 }
 
 impl<'a> Iterator for GltfTreeIterator<'a> {
-    type Item = gltf::Node<'a>;
+    type Item = Node<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.nodes.pop()

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -763,7 +763,7 @@ mod tests {
     fn rhombus() {
         let rhombus = Rhombus::new(2.0, 1.0);
         let translation = Vec2::new(2.0, 1.0);
-        let rotation = Rot2::radians(std::f32::consts::FRAC_PI_4);
+        let rotation = Rot2::radians(FRAC_PI_4);
         let isometry = Isometry2d::new(translation, rotation);
 
         let aabb = rhombus.aabb_2d(isometry);
@@ -912,10 +912,7 @@ mod tests {
         let rectangle = Rectangle::new(2.0, 1.0);
         let translation = Vec2::new(2.0, 1.0);
 
-        let aabb = rectangle.aabb_2d(Isometry2d::new(
-            translation,
-            Rot2::radians(std::f32::consts::FRAC_PI_4),
-        ));
+        let aabb = rectangle.aabb_2d(Isometry2d::new(translation, Rot2::radians(FRAC_PI_4)));
         let expected_half_size = Vec2::splat(1.0606601);
         assert_eq!(aabb.min, translation - expected_half_size);
         assert_eq!(aabb.max, translation + expected_half_size);

--- a/crates/bevy_math/src/bounding/bounded3d/extrusion.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/extrusion.rs
@@ -310,7 +310,7 @@ mod tests {
     fn rectangle() {
         let extrusion = Extrusion::new(Rectangle::new(2.0, 1.0), 4.0);
         let translation = Vec3::new(3., 4., 5.);
-        let rotation = Quat::from_rotation_z(std::f32::consts::FRAC_PI_4);
+        let rotation = Quat::from_rotation_z(FRAC_PI_4);
         let isometry = Isometry3d::new(translation, rotation);
 
         let aabb = extrusion.aabb_3d(isometry);

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1748,7 +1748,7 @@ impl RegularPolygon {
     /// With a rotation of 0, a vertex will be placed at the top `(0.0, circumradius)`.
     pub fn vertices(self, rotation: f32) -> impl IntoIterator<Item = Vec2> {
         // Add pi/2 so that the polygon has a vertex at the top (sin is 1.0 and cos is 0.0)
-        let start_angle = rotation + std::f32::consts::FRAC_PI_2;
+        let start_angle = rotation + FRAC_PI_2;
         let step = std::f32::consts::TAU / self.sides as f32;
 
         (0..self.sides).map(move |i| {
@@ -1919,7 +1919,7 @@ mod tests {
         assert_abs_diff_eq!(rhombus.half_diagonals, Vec2::new(1.0, 1.0));
         assert_abs_diff_eq!(
             rhombus.half_diagonals,
-            Rhombus::from_inradius(std::f32::consts::FRAC_1_SQRT_2).half_diagonals
+            Rhombus::from_inradius(FRAC_1_SQRT_2).half_diagonals
         );
     }
 
@@ -2072,7 +2072,7 @@ mod tests {
         let mut rotated_vertices = polygon.vertices(std::f32::consts::FRAC_PI_4).into_iter();
 
         // Distance from the origin to the middle of a side, derived using Pythagorean theorem
-        let side_sistance = std::f32::consts::FRAC_1_SQRT_2;
+        let side_sistance = FRAC_1_SQRT_2;
         assert!(
             (rotated_vertices.next().unwrap() - Vec2::new(-side_sistance, side_sistance)).length()
                 < 1e-7,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -344,7 +344,7 @@ impl Plugin for PbrPlugin {
                 PostUpdate,
                 (
                     add_clusters.in_set(SimulationLightSystems::AddClusters),
-                    crate::assign_objects_to_clusters
+                    assign_objects_to_clusters
                         .in_set(SimulationLightSystems::AssignLightsToClusters)
                         .after(TransformSystem::TransformPropagate)
                         .after(VisibilitySystems::CheckVisibility)

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -637,7 +637,7 @@ pub fn prepare_lights(
     //   point light shadows and `spot_light_shadow_maps_count` spot light shadow maps,
     // - then by entity as a stable key to ensure that a consistent set of lights are chosen if the light count limit is exceeded.
     point_lights.sort_by(|(entity_1, light_1, _), (entity_2, light_2, _)| {
-        crate::cluster::clusterable_object_order(
+        clusterable_object_order(
             (
                 entity_1,
                 &light_1.shadows_enabled,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1027,8 +1027,7 @@ pub fn extract_meshes_for_gpu_building(
                 no_automatic_batching,
             );
 
-            let lightmap_uv_rect =
-                lightmap::pack_lightmap_uv_rect(lightmap.map(|lightmap| lightmap.uv_rect));
+            let lightmap_uv_rect = pack_lightmap_uv_rect(lightmap.map(|lightmap| lightmap.uv_rect));
 
             let gpu_mesh_culling_data = any_gpu_culling.then(|| MeshCullingData::new(aabb));
 
@@ -2376,7 +2375,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
                     return RenderCommandResult::Skip;
                 }
                 Some(buffer) => Some((
-                    index as u64 * mem::size_of::<IndirectParameters>() as u64,
+                    index as u64 * size_of::<IndirectParameters>() as u64,
                     buffer,
                 )),
             },

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -7,10 +7,10 @@ use bevy_render::{
 
 use crate::render::skin::MAX_JOINTS;
 
-const MORPH_WEIGHT_SIZE: usize = std::mem::size_of::<f32>();
+const MORPH_WEIGHT_SIZE: usize = size_of::<f32>();
 pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 
-const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
+const JOINT_SIZE: usize = size_of::<Mat4>();
 pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
 
 /// Individual layout entries.

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -83,7 +83,7 @@ const WGPU_MIN_ALIGN: usize = 256;
 /// Align a [`RawBufferVec`] to `N` bytes by padding the end with `T::default()` values.
 fn add_to_alignment<T: NoUninit + Default>(buffer: &mut RawBufferVec<T>) {
     let n = WGPU_MIN_ALIGN;
-    let t_size = mem::size_of::<T>();
+    let t_size = size_of::<T>();
     if !can_align(n, t_size) {
         // This panic is stripped at compile time, due to n, t_size and can_align being const
         panic!(
@@ -131,7 +131,7 @@ pub fn extract_morphs(
         uniform.current_buffer.extend(legal_weights);
         add_to_alignment::<f32>(&mut uniform.current_buffer);
 
-        let index = (start * mem::size_of::<f32>()) as u32;
+        let index = (start * size_of::<f32>()) as u32;
         morph_indices.current.insert(entity, MorphIndex { index });
     }
 }

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -26,7 +26,7 @@ impl SkinIndex {
     /// Index to be in address space based on the size of a skin uniform.
     const fn new(start: usize) -> Self {
         SkinIndex {
-            index: (start * std::mem::size_of::<Mat4>()) as u32,
+            index: (start * size_of::<Mat4>()) as u32,
         }
     }
 }

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -599,7 +599,7 @@ trait DebugEnsureAligned {
 impl<T: Sized> DebugEnsureAligned for *mut T {
     #[track_caller]
     fn debug_ensure_aligned(self) -> Self {
-        let align = core::mem::align_of::<T>();
+        let align = align_of::<T>();
         // Implementation shamelessly borrowed from the currently unstable
         // ptr.is_aligned_to.
         //

--- a/crates/bevy_reflect/derive/src/utility.rs
+++ b/crates/bevy_reflect/derive/src/utility.rs
@@ -150,10 +150,7 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
     ///   // Custom bounds
     ///   T: MyTrait,
     /// ```
-    pub fn extend_where_clause(
-        &self,
-        where_clause: Option<&WhereClause>,
-    ) -> proc_macro2::TokenStream {
+    pub fn extend_where_clause(&self, where_clause: Option<&WhereClause>) -> TokenStream {
         // We would normally just use `Self`, but that won't work for generating things like assertion functions
         // and trait impls for a type's reference (e.g. `impl FromArg for &MyType`)
         let this = self.meta.type_path().true_type();
@@ -259,7 +256,7 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
     }
 
     /// The minimum required bounds for a type to be reflected.
-    fn required_bounds(&self) -> proc_macro2::TokenStream {
+    fn required_bounds(&self) -> TokenStream {
         quote!(#FQAny + #FQSend + #FQSync)
     }
 }
@@ -305,7 +302,7 @@ impl<T> ResultSifter<T> {
 }
 
 /// Turns an `Option<TokenStream>` into a `TokenStream` for an `Option`.
-pub(crate) fn wrap_in_option(tokens: Option<proc_macro2::TokenStream>) -> proc_macro2::TokenStream {
+pub(crate) fn wrap_in_option(tokens: Option<TokenStream>) -> TokenStream {
     match tokens {
         Some(tokens) => quote! {
             #FQOption::Some(#tokens)
@@ -324,11 +321,11 @@ pub(crate) enum StringExpr {
     /// This is either a string literal like `"mystring"`,
     /// or a string created by a macro like [`module_path`]
     /// or [`concat`].
-    Const(proc_macro2::TokenStream),
+    Const(TokenStream),
     /// A [string slice](str) that is borrowed for a `'static` lifetime.
-    Borrowed(proc_macro2::TokenStream),
+    Borrowed(TokenStream),
     /// An [owned string](String).
-    Owned(proc_macro2::TokenStream),
+    Owned(TokenStream),
 }
 
 impl<T: ToString + Spanned> From<T> for StringExpr {
@@ -357,7 +354,7 @@ impl StringExpr {
     /// The returned expression will allocate unless the [`StringExpr`] is [already owned].
     ///
     /// [already owned]: StringExpr::Owned
-    pub fn into_owned(self) -> proc_macro2::TokenStream {
+    pub fn into_owned(self) -> TokenStream {
         match self {
             Self::Const(tokens) | Self::Borrowed(tokens) => quote! {
                 ::std::string::ToString::to_string(#tokens)
@@ -367,7 +364,7 @@ impl StringExpr {
     }
 
     /// Returns tokens for a statically borrowed [string slice](str).
-    pub fn into_borrowed(self) -> proc_macro2::TokenStream {
+    pub fn into_borrowed(self) -> TokenStream {
         match self {
             Self::Const(tokens) | Self::Borrowed(tokens) => tokens,
             Self::Owned(owned) => quote! {

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -536,7 +536,7 @@ pub fn array_partial_eq<A: Array + ?Sized>(
 /// // ]
 /// ```
 #[inline]
-pub fn array_debug(dyn_array: &dyn Array, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn array_debug(dyn_array: &dyn Array, f: &mut Formatter<'_>) -> std::fmt::Result {
     let mut debug = f.debug_list();
     for item in dyn_array.iter() {
         debug.entry(&item as &dyn Debug);

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,3 +1,6 @@
+// Temporary workaround for impl_reflect!(Option/Result false-positive
+#![allow(unused_qualifications)]
+
 use crate::std_traits::ReflectDefault;
 use crate::utility::{
     reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell,
@@ -1557,14 +1560,14 @@ impl PartialReflect for Cow<'static, str> {
 
     fn reflect_hash(&self) -> Option<u64> {
         let mut hasher = reflect_hasher();
-        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(&Any::type_id(self), &mut hasher);
         Hash::hash(self, &mut hasher);
         Some(hasher.finish())
     }
 
     fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
         if let Some(value) = value.try_downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
+            Some(PartialEq::eq(self, value))
         } else {
             Some(false)
         }
@@ -1608,7 +1611,7 @@ impl GetTypeRegistration for Cow<'static, str> {
 }
 
 impl FromReflect for Cow<'static, str> {
-    fn from_reflect(reflect: &dyn crate::PartialReflect) -> Option<Self> {
+    fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
         Some(reflect.try_downcast_ref::<Cow<'static, str>>()?.clone())
     }
 }
@@ -1855,14 +1858,14 @@ impl PartialReflect for &'static str {
 
     fn reflect_hash(&self) -> Option<u64> {
         let mut hasher = reflect_hasher();
-        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(&Any::type_id(self), &mut hasher);
         Hash::hash(self, &mut hasher);
         Some(hasher.finish())
     }
 
     fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
         if let Some(value) = value.try_downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
+            Some(PartialEq::eq(self, value))
         } else {
             Some(false)
         }
@@ -1993,14 +1996,14 @@ impl PartialReflect for &'static Path {
 
     fn reflect_hash(&self) -> Option<u64> {
         let mut hasher = reflect_hasher();
-        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(&Any::type_id(self), &mut hasher);
         Hash::hash(self, &mut hasher);
         Some(hasher.finish())
     }
 
     fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
         if let Some(value) = value.try_downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
+            Some(PartialEq::eq(self, value))
         } else {
             Some(false)
         }
@@ -2126,14 +2129,14 @@ impl PartialReflect for Cow<'static, Path> {
 
     fn reflect_hash(&self) -> Option<u64> {
         let mut hasher = reflect_hasher();
-        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(&Any::type_id(self), &mut hasher);
         Hash::hash(self, &mut hasher);
         Some(hasher.finish())
     }
 
     fn reflect_partial_eq(&self, value: &dyn PartialReflect) -> Option<bool> {
         if let Some(value) = value.try_downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
+            Some(PartialEq::eq(self, value))
         } else {
             Some(false)
         }
@@ -2443,7 +2446,7 @@ mod tests {
         let a: &dyn PartialReflect = &std::num::NonZeroUsize::new(42).unwrap();
         let b: &dyn PartialReflect = &std::num::NonZeroUsize::new(42).unwrap();
         assert!(a.reflect_partial_eq(b).unwrap_or_default());
-        let forty_two: std::num::NonZeroUsize = crate::FromReflect::from_reflect(a).unwrap();
+        let forty_two: std::num::NonZeroUsize = FromReflect::from_reflect(a).unwrap();
         assert_eq!(forty_two, std::num::NonZeroUsize::new(42).unwrap());
     }
 

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -74,7 +74,7 @@ impl<'a> AccessError<'a> {
         self.offset.as_ref()
     }
 }
-impl std::fmt::Display for AccessError<'_> {
+impl fmt::Display for AccessError<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let AccessError {
             kind,

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -801,7 +801,7 @@ impl Mesh {
         // The indices of `other` should start after the last vertex of `self`.
         let index_offset = self
             .attribute(Mesh::ATTRIBUTE_POSITION)
-            .get_or_insert(&VertexAttributeValues::Float32x3(Vec::default()))
+            .get_or_insert(&Float32x3(Vec::default()))
             .len();
 
         // Extend attributes of `self` with attributes of `other`.

--- a/crates/bevy_render/src/mesh/morph.rs
+++ b/crates/bevy_render/src/mesh/morph.rs
@@ -11,7 +11,7 @@ use bevy_hierarchy::Children;
 use bevy_math::Vec3;
 use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
-use std::{iter, mem};
+use std::iter;
 use thiserror::Error;
 
 const MAX_TEXTURE_WIDTH: u32 = 2048;
@@ -84,7 +84,7 @@ impl MorphTargetImage {
         };
         let data = targets
             .flat_map(|mut attributes| {
-                let layer_byte_count = (padding + component_count) as usize * mem::size_of::<f32>();
+                let layer_byte_count = (padding + component_count) as usize * size_of::<f32>();
                 let mut buffer = Vec::with_capacity(layer_byte_count);
                 for _ in 0..vertex_count {
                     let Some(to_add) = attributes.next() else {
@@ -93,7 +93,7 @@ impl MorphTargetImage {
                     buffer.extend_from_slice(bytemuck::bytes_of(&to_add));
                 }
                 // Pad each layer so that they fit width * height
-                buffer.extend(iter::repeat(0).take(padding as usize * mem::size_of::<f32>()));
+                buffer.extend(iter::repeat(0).take(padding as usize * size_of::<f32>()));
                 debug_assert_eq!(buffer.len(), layer_byte_count);
                 buffer
             })

--- a/crates/bevy_render/src/mesh/primitives/dim2.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim2.rs
@@ -487,7 +487,7 @@ impl MeshBuilder for EllipseMeshBuilder {
         let mut uvs = Vec::with_capacity(resolution);
 
         // Add pi/2 so that there is a vertex at the top (sin is 1.0 and cos is 0.0)
-        let start_angle = std::f32::consts::FRAC_PI_2;
+        let start_angle = FRAC_PI_2;
         let step = std::f32::consts::TAU / self.resolution as f32;
 
         for i in 0..self.resolution {
@@ -595,7 +595,7 @@ impl MeshBuilder for AnnulusMeshBuilder {
         // the vertices at `start_angle` are duplicated for the purposes of UV
         // mapping. Here, each iteration places a pair of vertices at a fixed
         // angle from the center of the annulus.
-        let start_angle = std::f32::consts::FRAC_PI_2;
+        let start_angle = FRAC_PI_2;
         let step = std::f32::consts::TAU / self.resolution as f32;
         for i in 0..=self.resolution {
             let theta = start_angle + i as f32 * step;

--- a/crates/bevy_render/src/mesh/primitives/dim3/sphere.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/sphere.rs
@@ -123,7 +123,7 @@ impl SphereMeshBuilder {
             let inclination = point.y.acos();
             let azimuth = point.z.atan2(point.x);
 
-            let norm_inclination = inclination / std::f32::consts::PI;
+            let norm_inclination = inclination / PI;
             let norm_azimuth = 0.5 - (azimuth / std::f32::consts::TAU);
 
             [norm_azimuth, norm_inclination]

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -606,7 +606,7 @@ impl<'a> TrackedRenderPass<'a> {
 }
 
 impl WriteTimestamp for TrackedRenderPass<'_> {
-    fn write_timestamp(&mut self, query_set: &wgpu::QuerySet, index: u32) {
+    fn write_timestamp(&mut self, query_set: &QuerySet, index: u32) {
         self.pass.write_timestamp(query_set, index);
     }
 }

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -53,7 +53,7 @@ impl<T: NoUninit> RawBufferVec<T> {
             values: Vec::new(),
             buffer: None,
             capacity: 0,
-            item_size: std::mem::size_of::<T>(),
+            item_size: size_of::<T>(),
             buffer_usage,
             label: None,
             changed: false,
@@ -387,7 +387,7 @@ where
             len: 0,
             buffer: None,
             capacity: 0,
-            item_size: std::mem::size_of::<T>(),
+            item_size: size_of::<T>(),
             buffer_usage,
             label: None,
             label_changed: false,
@@ -444,7 +444,7 @@ where
         let size = self.item_size * capacity;
         self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
             label: self.label.as_deref(),
-            size: size as wgpu::BufferAddress,
+            size: size as BufferAddress,
             usage: BufferUsages::COPY_DST | self.buffer_usage,
             mapped_at_creation: false,
         }));

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -32,8 +32,8 @@ use wgpu::{
 
 use crate::render_resource::resource_macros::*;
 
-render_resource_wrapper!(ErasedShaderModule, wgpu::ShaderModule);
-render_resource_wrapper!(ErasedPipelineLayout, wgpu::PipelineLayout);
+render_resource_wrapper!(ErasedShaderModule, ShaderModule);
+render_resource_wrapper!(ErasedPipelineLayout, PipelineLayout);
 
 /// A descriptor for a [`Pipeline`].
 ///
@@ -316,7 +316,7 @@ impl ShaderCache {
                             },
                         )?;
 
-                        wgpu::ShaderSource::Naga(Cow::Owned(naga))
+                        ShaderSource::Naga(Cow::Owned(naga))
                     }
                 };
 

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -210,7 +210,7 @@ pub async fn initialize_renderer(
     let mut limits = options.limits.clone();
     if matches!(options.priority, WgpuSettingsPriority::Functionality) {
         features = adapter.features();
-        if adapter_info.device_type == wgpu::DeviceType::DiscreteGpu {
+        if adapter_info.device_type == DeviceType::DiscreteGpu {
             // `MAPPABLE_PRIMARY_BUFFERS` can have a significant, negative performance impact for
             // discrete GPUs due to having to transfer data across the PCI-E bus and so it
             // should not be automatically enabled in this case. It is however beneficial for

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -98,7 +98,7 @@ fn fallback_image_new(
         render_device.create_texture_with_data(
             render_queue,
             &image.texture_descriptor,
-            wgpu::util::TextureDataOrder::default(),
+            TextureDataOrder::default(),
             &image.data,
         )
     } else {

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -763,8 +763,7 @@ mod test {
 
     #[test]
     fn ensure_visibility_enum_size() {
-        use std::mem;
-        assert_eq!(1, mem::size_of::<Visibility>());
-        assert_eq!(1, mem::size_of::<Option<Visibility>>());
+        assert_eq!(1, size_of::<Visibility>());
+        assert_eq!(1, size_of::<Option<Visibility>>());
     }
 }

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -457,7 +457,7 @@ pub fn create_surfaces(
                     }
                 }
 
-                let configuration = wgpu::SurfaceConfiguration {
+                let configuration = SurfaceConfiguration {
                     format,
                     width: window.physical_width,
                     height: window.physical_height,

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -27,7 +27,7 @@ mod sealed {
 ///
 /// It is sealed, and auto implemented for all [`States`] types and
 /// tuples containing them.
-pub trait StateSet: sealed::StateSetSealed {
+pub trait StateSet: StateSetSealed {
     /// The total [`DEPENDENCY_DEPTH`](`States::DEPENDENCY_DEPTH`) of all
     /// the states that are part of this [`StateSet`], added together.
     ///

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -113,7 +113,7 @@ impl Plugin for TextPlugin {
                         .in_set(VisibilitySystems::CalculateBounds)
                         .after(update_text2d_layout),
                     update_text2d_layout
-                        .after(font_atlas_set::remove_dropped_font_atlas_sets)
+                        .after(remove_dropped_font_atlas_sets)
                         // Potential conflict: `Assets<Image>`
                         // In practice, they run independently since `bevy_render::camera_update_system`
                         // will only ever observe its own render target, and `update_text2d_layout`

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -304,7 +304,7 @@ pub struct TextMeasureInfo {
     pub min: Vec2,
     /// Maximum size for a text area in pixels, to be used when laying out widgets with taffy
     pub max: Vec2,
-    buffer: cosmic_text::Buffer,
+    buffer: Buffer,
 }
 
 impl std::fmt::Debug for TextMeasureInfo {

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -134,7 +134,7 @@ pub fn once_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + C
 /// }
 /// ```
 pub fn once_after_real_delay(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    let mut timer = Timer::new(duration, TimerMode::Once);
     move |time: Res<Time<Real>>| {
         timer.tick(time.delta());
         timer.just_finished()

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -376,7 +376,7 @@ pub struct NoOpHasher(u64);
 
 // This is for types that already contain a high-quality hash and want to skip
 // re-hashing that hash.
-impl std::hash::Hasher for NoOpHasher {
+impl Hasher for NoOpHasher {
     fn finish(&self) -> u64 {
         self.0
     }
@@ -506,7 +506,7 @@ mod tests {
             fn write_u64(&mut self, _: u64) {}
         }
 
-        std::hash::Hash::hash(&TypeId::of::<()>(), &mut Hasher);
+        Hash::hash(&TypeId::of::<()>(), &mut Hasher);
     }
 
     #[test]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -405,7 +405,7 @@ impl Window {
     ///
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
-    pub fn physical_size(&self) -> bevy_math::UVec2 {
+    pub fn physical_size(&self) -> UVec2 {
         self.resolution.physical_size()
     }
 

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -286,7 +286,7 @@ pub fn convert_physical_key_code(virtual_key_code: winit::keyboard::PhysicalKey)
     }
 }
 
-pub fn convert_logical_key(logical_key_code: &winit::keyboard::Key) -> bevy_input::keyboard::Key {
+pub fn convert_logical_key(logical_key_code: &Key) -> bevy_input::keyboard::Key {
     match logical_key_code {
         Key::Character(s) => bevy_input::keyboard::Key::Character(s.clone()),
         Key::Unidentified(nk) => bevy_input::keyboard::Key::Unidentified(convert_native_key(nk)),

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -159,7 +159,7 @@ pub struct WakeUp;
 ///
 /// Use `Res<EventLoopProxy>` to receive this resource.
 #[derive(Resource, Deref)]
-pub struct EventLoopProxyWrapper<T: 'static>(winit::event_loop::EventLoopProxy<T>);
+pub struct EventLoopProxyWrapper<T: 'static>(EventLoopProxy<T>);
 
 trait AppSendEvent {
     fn send(&mut self, event: impl Into<WinitEvent>);

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -53,7 +53,7 @@ fn setup(
         },
         Skybox {
             image: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            brightness: bevy::pbr::light_consts::lux::DIRECT_SUNLIGHT,
+            brightness: light_consts::lux::DIRECT_SUNLIGHT,
             ..default()
         },
     ));

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -118,7 +118,7 @@ fn main() {
 
                     // Calculate the length for the array based on the layout created for this component id
                     let info = world.components().get_info(id).unwrap();
-                    let len = info.layout().size() / std::mem::size_of::<u64>();
+                    let len = info.layout().size() / size_of::<u64>();
                     let mut values: Vec<u64> = component
                         .take(len)
                         .filter_map(|value| value.parse::<u64>().ok())
@@ -155,7 +155,7 @@ fn main() {
                         .map(|id| {
                             let ptr = filtered_entity.get_by_id(id).unwrap();
                             let info = component_info.get(&id).unwrap();
-                            let len = info.layout().size() / std::mem::size_of::<u64>();
+                            let len = info.layout().size() / size_of::<u64>();
 
                             // SAFETY:
                             // - All components are created with layout [u64]

--- a/examples/ecs/observer_propagation.rs
+++ b/examples/ecs/observer_propagation.rs
@@ -69,7 +69,7 @@ struct Armor(u16);
 
 /// A normal bevy system that attacks a piece of the goblin's armor on a timer.
 fn attack_armor(entities: Query<Entity, With<Armor>>, mut commands: Commands) {
-    let mut rng = rand::thread_rng();
+    let mut rng = thread_rng();
     if let Some(target) = entities.iter().choose(&mut rng) {
         let damage = thread_rng().gen_range(1..20);
         commands.trigger_targets(Attack { damage }, target);
@@ -107,7 +107,7 @@ fn take_damage(
     trigger: Trigger<Attack>,
     mut hp: Query<(&mut HitPoints, &Name)>,
     mut commands: Commands,
-    mut app_exit: EventWriter<bevy::app::AppExit>,
+    mut app_exit: EventWriter<AppExit>,
 ) {
     let attack = trigger.event();
     let (mut hp, name) = hp.get_mut(trigger.entity()).unwrap();
@@ -118,7 +118,7 @@ fn take_damage(
     } else {
         warn!("💀 {} has died a gruesome death", name);
         commands.entity(trigger.entity()).despawn_recursive();
-        app_exit.send(bevy::app::AppExit::Success);
+        app_exit.send(AppExit::Success);
     }
 
     info!("(propagation reached root)\n");

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -332,7 +332,7 @@ mod pipelines_ready {
             // and then update the pipelines status from there.
             // Writing between these Apps can only be done through the
             // `ExtractSchedule`.
-            app.sub_app_mut(bevy::render::RenderApp)
+            app.sub_app_mut(RenderApp)
                 .add_systems(ExtractSchedule, update_pipelines_ready);
         }
     }

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -473,7 +473,7 @@ impl MeshBuilder for HeartMeshBuilder {
 
 // The `Extrudable` trait can be used to easily implement meshing for extrusions.
 impl Extrudable for HeartMeshBuilder {
-    fn perimeter(&self) -> Vec<bevy::render::mesh::PerimeterSegment> {
+    fn perimeter(&self) -> Vec<PerimeterSegment> {
         let resolution = self.resolution as u32;
         vec![
             // The left wing of the heart

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -174,7 +174,7 @@ impl Shape {
 
 impl ShapeSample for Shape {
     type Output = Vec3;
-    fn sample_interior<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Vec3 {
+    fn sample_interior<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec3 {
         match self {
             Shape::Cuboid => CUBOID.sample_interior(rng),
             Shape::Sphere => SPHERE.sample_interior(rng),
@@ -185,7 +185,7 @@ impl ShapeSample for Shape {
         }
     }
 
-    fn sample_boundary<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> Self::Output {
+    fn sample_boundary<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::Output {
         match self {
             Shape::Cuboid => CUBOID.sample_boundary(rng),
             Shape::Sphere => SPHERE.sample_boundary(rng),

--- a/examples/shader/custom_phase_item.rs
+++ b/examples/shader/custom_phase_item.rs
@@ -7,8 +7,6 @@
 //! into Bevy—render nodes are another, lower-level method—but it does allow
 //! for better reuse of parts of Bevy's built-in mesh rendering logic.
 
-use std::mem;
-
 use bevy::{
     core_pipeline::core_3d::{Opaque3d, Opaque3dBinKey, CORE_3D_DEPTH_FORMAT},
     ecs::{
@@ -302,7 +300,7 @@ impl SpecializedRenderPipeline for CustomPhasePipeline {
                 shader_defs: vec![],
                 entry_point: "vertex".into(),
                 buffers: vec![VertexBufferLayout {
-                    array_stride: mem::size_of::<Vertex>() as u64,
+                    array_stride: size_of::<Vertex>() as u64,
                     step_mode: VertexStepMode::Vertex,
                     // This needs to match the layout of [`Vertex`].
                     attributes: vec![

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -129,7 +129,7 @@ impl FromWorld for Buffers {
         // copy the buffer modified by the GPU into a mappable, CPU-accessible buffer
         let cpu_buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("readback_buffer"),
-            size: (BUFFER_LEN * std::mem::size_of::<u32>()) as u64,
+            size: (BUFFER_LEN * size_of::<u32>()) as u64,
             usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -250,7 +250,7 @@ fn map_and_read_buffer(
     {
         let buffer_view = buffer_slice.get_mapped_range();
         let data = buffer_view
-            .chunks(std::mem::size_of::<u32>())
+            .chunks(size_of::<u32>())
             .map(|chunk| u32::from_ne_bytes(chunk.try_into().expect("should be a u32")))
             .collect::<Vec<u32>>();
         sender
@@ -306,7 +306,7 @@ impl render_graph::Node for ComputeNode {
             0,
             &buffers.cpu_buffer,
             0,
-            (BUFFER_LEN * std::mem::size_of::<u32>()) as u64,
+            (BUFFER_LEN * size_of::<u32>()) as u64,
         );
 
         Ok(())

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -212,7 +212,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
 
         descriptor.vertex.shader = self.shader.clone();
         descriptor.vertex.buffers.push(VertexBufferLayout {
-            array_stride: std::mem::size_of::<InstanceData>() as u64,
+            array_stride: size_of::<InstanceData>() as u64,
             step_mode: VertexStepMode::Instance,
             attributes: vec![
                 VertexAttribute {

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -284,7 +284,7 @@ fn main() {
 
             let reports_path = "example-showcase-reports";
             if report_details {
-                std::fs::create_dir(reports_path)
+                fs::create_dir(reports_path)
                     .expect("Failed to create example-showcase-reports directory");
             }
 


### PR DESCRIPTION
# Objective

Fixes #14782

## Solution

Enable the lint and fix all upcoming hints (`--fix`). Also try to figure out the false-positive (see review comment). Maybe split this PR up into multiple parts where only the last one enables the lint, so some can already be merged resulting in less many files touched / less potential for merge conflicts?

Currently, there are some cases where it might be easier to read the code with the qualifier, so perhaps remove the import of it and adapt all cases? In the current stage it's just a plain adoption of the suggestions in order to have a base to discuss.

## Testing

`cargo clippy` and `cargo run -p ci` are happy.