### PR TITLE
compile_fail_utils: Ignore `target` directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Cargo.lock
 /.idea
 /.vscode
 /benches/target
+/tools/compile_fail_utils/target
 dxcompiler.dll
 dxil.dll
 


### PR DESCRIPTION
# Objective

The `target` directory in `/tools/compile_fail_utils` was not being ignored by Git.

## Solution

Added `/tools/compile_fail_utils/target` to the root `.gitignore` in the same spirit as the other top-level, workspace-excluded crate: `benches`.