### PR TITLE
Add `filter_map_unchanged` to `Mut<T>`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -437,6 +437,8 @@ macro_rules! impl_methods {
                     Some(value) => Some(Mut {
                         value,
                         ticks: self.ticks,
+                        #[cfg(feature = "track_change_detection")]
+                        changed_by: self.changed_by,
                     }),
                     None => None
                 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -428,6 +428,20 @@ macro_rules! impl_methods {
                 }
             }
 
+            /// Optionally maps to an inner value by applying a function to the contained reference.
+            /// This is useful in a situation where you need to convert a `Mut<T>` to a `Mut<U>`, but only if `T` contains `U`.
+            ///
+            /// As with `map_unchanged`, you should never modify the argument passed to the closure.
+            pub fn filter_map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> Option<&mut U>) -> Option<Mut<'w, U>> {
+                match f(self.value) {
+                    Some(value) => Some(Mut {
+                        value,
+                        ticks: self.ticks,
+                    }),
+                    None => None
+                }
+            }
+
             /// Allows you access to the dereferenced value of this pointer without immediately
             /// triggering change detection.
             pub fn as_deref_mut(&mut self) -> Mut<'_, <$target as Deref>::Target>

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -433,15 +433,13 @@ macro_rules! impl_methods {
             ///
             /// As with `map_unchanged`, you should never modify the argument passed to the closure.
             pub fn filter_map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> Option<&mut U>) -> Option<Mut<'w, U>> {
-                match f(self.value) {
-                    Some(value) => Some(Mut {
-                        value,
-                        ticks: self.ticks,
-                        #[cfg(feature = "track_change_detection")]
-                        changed_by: self.changed_by,
-                    }),
-                    None => None
-                }
+                let value = f(self.value);
+                value.map(|value| Mut {
+                    value,
+                    ticks: self.ticks,
+                    #[cfg(feature = "track_change_detection")]
+                    changed_by: self.changed_by,
+                })
             }
 
             /// Allows you access to the dereferenced value of this pointer without immediately


### PR DESCRIPTION
Closes #14836.

`filter_map_unchanged` optionally maps to an inner value by applying a function to the contained reference. This is useful in a situation where you need to convert a `Mut<T>` to a `Mut<U>`, but only if `T` contains `U`.