### PR TITLE
Added Sprite::sized(custom_size)

### DIFF
--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -31,6 +31,16 @@ pub struct Sprite {
     pub anchor: Anchor,
 }
 
+impl Sprite {
+    /// Create a Sprite with a custom size
+    pub fn sized(custom_size: Vec2) -> Self {
+        Sprite {
+            custom_size: Some(custom_size),
+            ..Default::default()
+        }
+    }
+}
+
 /// Controls how the image is altered when scaled.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component)]


### PR DESCRIPTION
# Objective
add a quick shorthand for creating a sprite with an custom size. This is often desired when working with custom units or scaled sprites and allows for a cleaner syntax in those cases/

## Solution

Implemented a `sized` function on the Sprite struct which creates a Sprite, sets the custom size and leaves the rest at their default values

---

## Changelog

- Added `Sprite::sized(custom_size: Vec2)`
