### PR TITLE
Add `AnimationGraph::from_clips` and simplify `animated_fox` example

### DIFF
--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -192,6 +192,23 @@ impl AnimationGraph {
         (graph, node_index)
     }
 
+    /// A convenience method to create an [`AnimationGraph`]s with an iterator
+    /// of clips.
+    ///
+    /// All of the animation clips will be direct children of the root with
+    /// weight 1.0.
+    ///
+    /// Returns the the graph and indices of the new nodes.
+    pub fn from_clips<'a, I>(clips: I) -> (Self, Vec<AnimationNodeIndex>)
+    where
+        I: IntoIterator<Item = Handle<AnimationClip>>,
+        <I as IntoIterator>::IntoIter: 'a,
+    {
+        let mut graph = Self::new();
+        let indices = graph.add_clips(clips, 1.0, graph.root).collect();
+        (graph, indices)
+    }
+
     /// Adds an [`AnimationClip`] to the animation graph with the given weight
     /// and returns its index.
     ///

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -528,7 +528,10 @@ impl ActiveAnimation {
     }
 }
 
-/// Animation controls
+/// Animation controls.
+///
+/// Automatically added to any root animations of a `SceneBundle` when it is
+/// spawned.
 #[derive(Component, Default, Reflect)]
 #[reflect(Component)]
 pub struct AnimationPlayer {


### PR DESCRIPTION
# Objective

Add a convenience constructor to make simple animation graphs easier to build.

I've had some notes about attempting this since #11989 that I just remembered after seeing #14852.

This partially addresses #14852, but I don't really know animation well enough to write all of the documentation it's asking for.

## Solution

Add `AnimationGraph::from_clips` and use it to simplify `animated_fox`.

Do some other little bits of incidental cleanup and documentation .

## Testing

I ran `cargo run --example animated_fox`.