### PR TITLE
[Experimental] Runtime materials 👩‍🔬

### DIFF
--- a/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_draw_prepare.rs
@@ -187,7 +187,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass<M: Material>(
                 }),
                 multisample: MultisampleState::default(),
                 fragment: Some(FragmentState {
-                    shader: match M::meshlet_mesh_fragment_shader() {
+                    shader: match M::meshlet_mesh_fragment_shader(&self) {
                         ShaderRef::Default => MESHLET_MESH_MATERIAL_SHADER_HANDLE,
                         ShaderRef::Handle(handle) => handle,
                         ShaderRef::Path(path) => asset_server.load(path),
@@ -305,9 +305,9 @@ pub fn prepare_material_meshlet_meshes_prepass<M: Material>(
             };
 
             let fragment_shader = if view_key.contains(MeshPipelineKey::DEFERRED_PREPASS) {
-                M::meshlet_mesh_deferred_fragment_shader()
+                M::meshlet_mesh_deferred_fragment_shader(&self)
             } else {
-                M::meshlet_mesh_prepass_fragment_shader()
+                M::meshlet_mesh_prepass_fragment_shader(&self)
             };
 
             let entry_point = match fragment_shader {

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -1248,7 +1248,7 @@ impl From<&StandardMaterial> for StandardMaterialKey {
 }
 
 impl Material for StandardMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         PBR_SHADER_HANDLE.into()
     }
 
@@ -1284,27 +1284,27 @@ impl Material for StandardMaterial {
         self.specular_transmission > 0.0
     }
 
-    fn prepass_fragment_shader() -> ShaderRef {
+    fn prepass_fragment_shader(&self) -> ShaderRef {
         PBR_PREPASS_SHADER_HANDLE.into()
     }
 
-    fn deferred_fragment_shader() -> ShaderRef {
+    fn deferred_fragment_shader(&self) -> ShaderRef {
         PBR_SHADER_HANDLE.into()
     }
 
     #[cfg(feature = "meshlet")]
-    fn meshlet_mesh_fragment_shader() -> ShaderRef {
+    fn meshlet_mesh_fragment_shader(&self) -> ShaderRef {
         Self::fragment_shader()
     }
 
     #[cfg(feature = "meshlet")]
-    fn meshlet_mesh_prepass_fragment_shader() -> ShaderRef {
-        Self::prepass_fragment_shader()
+    fn meshlet_mesh_prepass_fragment_shader(&self) -> ShaderRef {
+        Self::prepass_fragment_shader(&self)
     }
 
     #[cfg(feature = "meshlet")]
-    fn meshlet_mesh_deferred_fragment_shader() -> ShaderRef {
-        Self::deferred_fragment_shader()
+    fn meshlet_mesh_deferred_fragment_shader(&self) -> ShaderRef {
+        Self::deferred_fragment_shader(&self)
     }
 
     fn specialize(

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -241,7 +241,6 @@ pub struct PrepassPipeline<M: Material> {
     pub view_layout_motion_vectors: BindGroupLayout,
     pub view_layout_no_motion_vectors: BindGroupLayout,
     pub mesh_layouts: MeshLayouts,
-    pub material_layout: BindGroupLayout,
     pub prepass_material_vertex_shader: Option<Handle<Shader>>,
     pub prepass_material_fragment_shader: Option<Handle<Shader>>,
     pub deferred_material_vertex_shader: Option<Handle<Shader>>,
@@ -309,7 +308,6 @@ impl<M: Material> FromWorld for PrepassPipeline<M> {
                 ShaderRef::Handle(handle) => Some(handle),
                 ShaderRef::Path(path) => Some(asset_server.load(path)),
             },
-            material_layout: M::bind_group_layout(render_device),
             material_pipeline: world.resource::<MaterialPipeline<M>>().clone(),
             _marker: PhantomData,
         }
@@ -345,7 +343,7 @@ where
 
         // NOTE: Eventually, it would be nice to only add this when the shaders are overloaded by the Material.
         // The main limitation right now is that bind group order is hardcoded in shaders.
-        bind_group_layouts.push(self.material_layout.clone());
+        bind_group_layouts.push(key.bind_group_layout.clone());
 
         #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
         shader_defs.push("WEBGL2".into());
@@ -841,6 +839,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                 MaterialPipelineKey {
                     mesh_key,
                     bind_group_data: material.key.clone(),
+                    bind_group_layout: material.bind_group_layout.clone(),
                 },
                 &mesh.layout,
             );

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1269,6 +1269,7 @@ pub fn queue_shadows<M: Material>(
                         mesh_key,
                         bind_group_data: material.key.clone(),
                         bind_group_layout: material.bind_group_layout.clone(),
+                        shaders: material.shaders.clone(),
                     },
                     &mesh.layout,
                 );

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1268,6 +1268,7 @@ pub fn queue_shadows<M: Material>(
                     MaterialPipelineKey {
                         mesh_key,
                         bind_group_data: material.key.clone(),
+                        bind_group_layout: material.bind_group_layout.clone(),
                     },
                     &mesh.layout,
                 );

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -220,7 +220,7 @@ pub struct WireframeMaterial {
 }
 
 impl Material for WireframeMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         WIREFRAME_SHADER_HANDLE.into()
     }
 

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -542,7 +542,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                 })
             }
 
-            fn bind_group_layout_entries(render_device: &#render_path::renderer::RenderDevice) -> Vec<#render_path::render_resource::BindGroupLayoutEntry> {
+            fn bind_group_layout_entries(&self, render_device: &#render_path::renderer::RenderDevice) -> Vec<#render_path::render_resource::BindGroupLayoutEntry> {
                 vec![#(#binding_layouts,)*]
             }
         }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -80,7 +80,7 @@ use crate::{
 use bevy_app::{App, AppLabel, Plugin, SubApp};
 use bevy_asset::{load_internal_asset, AssetApp, AssetServer, Handle};
 use bevy_ecs::{prelude::*, schedule::ScheduleLabel, system::SystemState};
-use bevy_utils::tracing::debug;
+use bevy_utils::tracing::{info, debug};
 use std::{
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
@@ -281,6 +281,8 @@ impl Plugin for RenderPlugin {
                         Query<&RawHandleWrapperHolder, With<PrimaryWindow>>,
                     > = SystemState::new(app.world_mut());
                     let primary_window = system_state.get(app.world()).get_single().ok().cloned();
+
+                    info!("Primary window: {:?}", primary_window);
                     let settings = render_creation.clone();
                     let async_renderer = async move {
                         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -330,18 +330,18 @@ pub trait AsBindGroup {
     ) -> Result<UnpreparedBindGroup<Self::Data>, AsBindGroupError>;
 
     /// Creates the bind group layout matching all bind groups returned by [`AsBindGroup::as_bind_group`]
-    fn bind_group_layout(render_device: &RenderDevice) -> BindGroupLayout
+    fn bind_group_layout(&self, render_device: &RenderDevice) -> BindGroupLayout
     where
         Self: Sized,
     {
         render_device.create_bind_group_layout(
             Self::label(),
-            &Self::bind_group_layout_entries(render_device),
+            &self.bind_group_layout_entries(render_device),
         )
     }
 
     /// Returns a vec of bind group layout entries
-    fn bind_group_layout_entries(render_device: &RenderDevice) -> Vec<BindGroupLayoutEntry>
+    fn bind_group_layout_entries(&self, render_device: &RenderDevice) -> Vec<BindGroupLayoutEntry>
     where
         Self: Sized;
 }

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -180,6 +180,8 @@ pub async fn initialize_renderer(
     options: &WgpuSettings,
     request_adapter_options: &RequestAdapterOptions<'_, '_>,
 ) -> (RenderDevice, RenderQueue, RenderAdapterInfo, RenderAdapter) {
+    info!("Initializing renderer {:?}", request_adapter_options);
+
     let adapter = instance
         .request_adapter(request_adapter_options)
         .await

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -149,7 +149,7 @@ impl AsBindGroupShaderType<ColorMaterialUniform> for ColorMaterial {
 }
 
 impl Material2d for ColorMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         COLOR_MATERIAL_SHADER_HANDLE.into()
     }
 

--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -212,7 +212,7 @@ pub struct Wireframe2dMaterial {
 }
 
 impl Material2d for Wireframe2dMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         WIREFRAME_2D_SHADER_HANDLE.into()
     }
 

--- a/crates/bevy_ui/src/ui_material.rs
+++ b/crates/bevy_ui/src/ui_material.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use bevy_asset::Asset;
-use bevy_render::render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef};
+use bevy_render::render_resource::{AsBindGroup, BindGroupLayout, RenderPipelineDescriptor, ShaderRef};
 
 /// Materials are used alongside [`UiMaterialPlugin`](crate::UiMaterialPlugin) and [`MaterialNodeBundle`](crate::prelude::MaterialNodeBundle)
 /// to spawn entities that are rendered with a specific [`UiMaterial`] type. They serve as an easy to use high level
@@ -111,6 +111,7 @@ pub trait UiMaterial: AsBindGroup + Asset + Clone + Sized {
 pub struct UiMaterialKey<M: UiMaterial> {
     pub hdr: bool,
     pub bind_group_data: M::Data,
+    pub layout: BindGroupLayout,
 }
 
 impl<M: UiMaterial> Eq for UiMaterialKey<M> where M::Data: PartialEq {}
@@ -132,6 +133,7 @@ where
         Self {
             hdr: self.hdr,
             bind_group_data: self.bind_group_data.clone(),
+            layout: self.layout.clone(),
         }
     }
 }

--- a/examples/2d/custom_gltf_vertex_attribute.rs
+++ b/examples/2d/custom_gltf_vertex_attribute.rs
@@ -70,10 +70,10 @@ fn setup(
 struct CustomMaterial {}
 
 impl Material2d for CustomMaterial {
-    fn vertex_shader() -> ShaderRef {
+    fn vertex_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -649,7 +649,7 @@ fn toggle_voxel_visibility(
 }
 
 impl MaterialExtension for VoxelVisualizationExtension {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -74,7 +74,7 @@ struct LineMaterial {
 }
 
 impl Material for LineMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -290,7 +290,7 @@ fn create_text(app_settings: &AppSettings) -> Text {
 }
 
 impl MaterialExtension for Water {
-    fn deferred_fragment_shader() -> ShaderRef {
+    fn deferred_fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -615,7 +615,7 @@ impl Default for PerMethodSettings {
 }
 
 impl Material for ColorGradientMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -41,7 +41,7 @@ fn setup(
 struct CustomMaterial {}
 
 impl Material for CustomMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -91,7 +91,7 @@ struct ArrayTextureMaterial {
 }
 
 impl Material for ArrayTextureMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -67,10 +67,10 @@ struct CustomMaterial {
 }
 
 impl Material for CustomMaterial {
-    fn vertex_shader() -> ShaderRef {
+    fn vertex_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -81,11 +81,11 @@ struct MyExtension {
 }
 
 impl MaterialExtension for MyExtension {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 
-    fn deferred_fragment_shader() -> ShaderRef {
+    fn deferred_fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/fallback_image.rs
+++ b/examples/shader/fallback_image.rs
@@ -75,7 +75,7 @@ struct FallbackTestMaterial {
 }
 
 impl Material for FallbackTestMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -58,7 +58,7 @@ fn setup(
 }
 
 impl Material for CustomMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -56,7 +56,7 @@ struct CustomMaterial {
 /// The Material trait is very configurable, but comes with sensible defaults for all methods.
 /// You only need to implement functions for features that need non-default behavior. See the Material api docs for details!
 impl Material for CustomMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 

--- a/examples/shader/shader_material_2d.rs
+++ b/examples/shader/shader_material_2d.rs
@@ -55,7 +55,7 @@ struct CustomMaterial {
 /// The Material2d trait is very configurable, but comes with sensible defaults for all methods.
 /// You only need to implement functions for features that need non-default behavior. See the Material2d api docs for details!
 impl Material2d for CustomMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -64,11 +64,11 @@ struct CustomMaterial {
 /// You only need to implement functions for features that need non-default behavior. See the Material api docs for details!
 /// When using the GLSL shading language for your shader, the specialize method must be overridden.
 impl Material for CustomMaterial {
-    fn vertex_shader() -> ShaderRef {
+    fn vertex_shader(&self) -> ShaderRef {
         VERTEX_SHADER_ASSET_PATH.into()
     }
 
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         FRAGMENT_SHADER_ASSET_PATH.into()
     }
 

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -76,7 +76,7 @@ struct CustomMaterial {
 }
 
 impl Material for CustomMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -169,7 +169,7 @@ struct CustomMaterial {
 /// Not shown in this example, but if you need to specialize your material, the specialize
 /// function will also be used by the prepass
 impl Material for CustomMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         MATERIAL_SHADER_ASSET_PATH.into()
     }
 
@@ -179,7 +179,7 @@ impl Material for CustomMaterial {
 
     // You can override the default shaders used in the prepass if your material does
     // anything not supported by the default prepass
-    // fn prepass_fragment_shader() -> ShaderRef {
+    // fn prepass_fragment_shader(&self) -> ShaderRef {
     //     "shaders/custom_material.wgsl".into()
     // }
 }
@@ -211,7 +211,7 @@ struct PrepassOutputMaterial {
 }
 
 impl Material for PrepassOutputMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         PREPASS_SHADER_ASSET_PATH.into()
     }
 

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -188,7 +188,7 @@ impl AsBindGroup for BindlessMaterial {
 }
 
 impl Material for BindlessMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }

--- a/examples/ui/ui_material.rs
+++ b/examples/ui/ui_material.rs
@@ -70,7 +70,7 @@ struct CustomUiMaterial {
 }
 
 impl UiMaterial for CustomUiMaterial {
-    fn fragment_shader() -> ShaderRef {
+    fn fragment_shader(&self) -> ShaderRef {
         SHADER_ASSET_PATH.into()
     }
 }


### PR DESCRIPTION
# Objective

Allow all material properties to be configured at runtime, namely it's bind group layer and shaders. This enables more flexibility that is necessary for enabling dynamic (i.e. reflection) materials that cannot describe their properties statically.

## Solution

Make most methods in `Material` and `AsBindGroup` take `&self` rather than being state. These properties are then moved to the respective pipeline keys where they are used for specialization.

## Testing

As expected, without any further optimizations, we see a significant slowdown in `queue_material_meshes`:

1000 materials:

![image](https://github.com/user-attachments/assets/e7b5fbf4-3faf-4b3a-a50a-16b6e0c92ef8)

10 materials:

![image](https://github.com/user-attachments/assets/8de6b25c-619f-454e-8f3f-bec1290f7841)