### PR TITLE
Implement `std::fmt::Debug` for `ecs::observer::Trigger`

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -12,7 +12,7 @@ use crate::{archetype::ArchetypeFlags, system::IntoObserverSystem, world::*};
 use crate::{component::ComponentId, prelude::*, world::DeferredWorld};
 use bevy_ptr::Ptr;
 use bevy_utils::{EntityHashMap, HashMap};
-use std::marker::PhantomData;
+use std::{fmt::Debug, marker::PhantomData};
 
 /// Type containing triggered [`Event`] information for a given run of an [`Observer`]. This contains the
 /// [`Event`] data itself. If it was triggered for a specific [`Entity`], it includes that as well. It also
@@ -81,6 +81,17 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
     /// [`propagate`]: Trigger::propagate
     pub fn get_propagate(&self) -> bool {
         *self.propagate
+    }
+}
+
+impl<'w, E: Debug, B: Bundle> Debug for Trigger<'w, E, B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Trigger")
+            .field("event", &self.event)
+            .field("propagate", &self.propagate)
+            .field("trigger", &self.trigger)
+            .field("_marker", &self._marker)
+            .finish()
     }
 }
 

--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -16,24 +16,28 @@ pub const ON_REMOVE: ComponentId = ComponentId::new(3);
 
 /// Trigger emitted when a component is added to an entity. See [`crate::component::ComponentHooks::on_add`]
 /// for more information.
-#[derive(Event)]
+#[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct OnAdd;
 
 /// Trigger emitted when a component is inserted onto an entity. See [`crate::component::ComponentHooks::on_insert`]
 /// for more information.
-#[derive(Event)]
+#[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct OnInsert;
 
 /// Trigger emitted when a component is replaced on an entity. See [`crate::component::ComponentHooks::on_replace`]
 /// for more information.
-#[derive(Event)]
+#[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct OnReplace;
 
 /// Trigger emitted when a component is removed from an entity. See [`crate::component::ComponentHooks::on_remove`]
 /// for more information.
-#[derive(Event)]
+#[derive(Event, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct OnRemove;


### PR DESCRIPTION
# Objective
I tried writing something like this in my project
```rust
.observe(|e: Trigger<OnAdd, Skeleton>| {
    panic!("Skeletoned! {e:?}");
});
```
and it didn't compile.
Having `Debug` trait defined on `Trigger` event will ease debugging the observers a little bit.

## Solution

Add a bespoke `Debug` implementation when both the bundle and the event have `Debug` implemented for them.

## Testing

I've added `println!("{trigger:#?}");` to the [observers example](https://github.com/bevyengine/bevy/blob/938d810766d34f1a300beb440273c3db1635ee5c/examples/ecs/observers.rs#L124)
and it compiled!

Caveats with this PR are: 
- removing this implementation if for any reason we will need it, will be a breaking change
- the implementation is manually generated, which adds potential toil when changing the `Trigger` structure

## Showcase

Log output:
```rust
on_add_mine: Trigger {
    event: OnAdd,
    propagate: false,
    trigger: ObserverTrigger {
        observer: 2v1#4294967298,
        event_type: ComponentId(
            0,
        ),
        entity: 454v1#4294967750,
    },
    _marker: PhantomData<observers::Mine>,
}
```

Thank you for maintaining this engine! :orange_heart: 
