### PR TITLE
Clarify docs for `RenderLayers::layer`

### DIFF
--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -58,6 +58,10 @@ impl Default for RenderLayers {
 
 impl RenderLayers {
     /// Create a new `RenderLayers` belonging to the given layer.
+    ///
+    /// This `const` constructor is limited to `size_of::<usize>()` layers.
+    /// If you need to support an arbitrary number of layers, use [`with`](RenderLayers::with)
+    /// or [`from_layers`](RenderLayers::from_layers).
     pub const fn layer(n: Layer) -> Self {
         let (buffer_index, bit) = Self::layer_info(n);
         assert!(
@@ -135,7 +139,7 @@ impl RenderLayers {
         false
     }
 
-    /// get the bitmask representation of the contained layers
+    /// Get the bitmask representation of the contained layers.
     pub fn bits(&self) -> &[u64] {
         self.0.as_slice()
     }


### PR DESCRIPTION
# Objective

`RenderLayers` was marketed as being unlimited in the Bevy 0.14 release notes, but the most obvious constructor doesn't actually support unlimited layers.

We should explicitly document this.

## Solution

Add some docs mentioning the limit and pointing the user to `with` or `from_layers` if they need an arbitrary number of layers.