### PR TITLE
Draft: Implement `Resource` for `()`

### DIFF
--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -13,6 +13,8 @@ pub const ON_INSERT: ComponentId = ComponentId::new(1);
 pub const ON_REPLACE: ComponentId = ComponentId::new(2);
 /// [`ComponentId`] for [`OnRemove`]
 pub const ON_REMOVE: ComponentId = ComponentId::new(3);
+/// [`ComponentId`] for [`()`]
+pub const UNIT: ComponentId = ComponentId::new(4);
 
 /// Trigger emitted when a component is added to an entity. See [`crate::component::ComponentHooks::on_add`]
 /// for more information.
@@ -37,3 +39,6 @@ pub struct OnReplace;
 #[derive(Event)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct OnRemove;
+
+#[cfg(feature = "bevy_reflect")]
+impl Resource for () {}

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -174,6 +174,7 @@ impl World {
         assert_eq!(ON_INSERT, self.init_component::<OnInsert>());
         assert_eq!(ON_REPLACE, self.init_component::<OnReplace>());
         assert_eq!(ON_REMOVE, self.init_component::<OnRemove>());
+        assert_eq!(UNIT, self.init_resource::<()>());
     }
     /// Creates a new empty [`World`].
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3157,6 +3157,8 @@ mod tests {
 
         let mut iter = world.iter_resources();
 
+        let (info, _ptr) = iter.next().unwrap();
+        assert_eq!(info.name(), std::any::type_name::<()>());
         let (info, ptr) = iter.next().unwrap();
         assert_eq!(info.name(), std::any::type_name::<TestResource>());
         // SAFETY: We know that the resource is of type `TestResource`
@@ -3188,6 +3190,8 @@ mod tests {
 
         let mut iter = world.iter_resources_mut();
 
+        let (info, _ptr) = iter.next().unwrap();
+        assert_eq!(info.name(), std::any::type_name::<()>());
         let (info, mut mut_untyped) = iter.next().unwrap();
         assert_eq!(info.name(), std::any::type_name::<TestResource>());
         // SAFETY: We know that the resource is of type `TestResource`

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3174,6 +3174,11 @@ mod tests {
     }
 
     #[test]
+    fn has_unit() {
+        World::new().get_resource::<()>().unwrap();
+    }
+
+    #[test]
     fn iter_resources_mut() {
         let mut world = World::new();
         world.insert_resource(TestResource(42));

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -27,6 +27,7 @@ macro_rules! impl_reflect_enum {
                     Self::Set(_) => ReflectKind::Set,
                     Self::Enum(_) => ReflectKind::Enum,
                     Self::Value(_) => ReflectKind::Value,
+                    Self::Unit(_) => ReflectKind::Unit,
                 }
             }
         }
@@ -43,6 +44,7 @@ macro_rules! impl_reflect_enum {
                     $name::Set(_) => Self::Set,
                     $name::Enum(_) => Self::Enum,
                     $name::Value(_) => Self::Value,
+                    $name::Unit(_) => Self::Unit,
                 }
             }
         }
@@ -65,6 +67,7 @@ pub enum ReflectRef<'a> {
     Set(&'a dyn Set),
     Enum(&'a dyn Enum),
     Value(&'a dyn PartialReflect),
+    Unit(&'a ()),
 }
 impl_reflect_enum!(ReflectRef<'_>);
 
@@ -84,6 +87,7 @@ pub enum ReflectMut<'a> {
     Set(&'a mut dyn Set),
     Enum(&'a mut dyn Enum),
     Value(&'a mut dyn PartialReflect),
+    Unit(&'a ()),
 }
 impl_reflect_enum!(ReflectMut<'_>);
 
@@ -103,6 +107,7 @@ pub enum ReflectOwned {
     Set(Box<dyn Set>),
     Enum(Box<dyn Enum>),
     Value(Box<dyn PartialReflect>),
+    Unit(Box<()>),
 }
 impl_reflect_enum!(ReflectOwned);
 
@@ -157,6 +162,7 @@ pub enum ReflectKind {
     Set,
     Enum,
     Value,
+    Unit,
 }
 
 impl std::fmt::Display for ReflectKind {
@@ -171,6 +177,7 @@ impl std::fmt::Display for ReflectKind {
             ReflectKind::Set => f.pad("set"),
             ReflectKind::Enum => f.pad("enum"),
             ReflectKind::Value => f.pad("value"),
+            ReflectKind::Unit => f.pad("unit"),
         }
     }
 }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -240,6 +240,11 @@ impl<'a> Serialize for TypedReflectSerializer<'a> {
             }
             .serialize(serializer),
             ReflectRef::Value(_) => Err(serializable.err().unwrap()),
+            ReflectRef::Unit(_) => TupleSerializer {
+                tuple: &(),
+                registry: self.registry,
+            }
+            .serialize(serializer),
         }
     }
 }

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -116,6 +116,7 @@ fn setup() {
         // implementation. Value is implemented for core types like i32, usize, f32, and
         // String.
         ReflectRef::Value(_) => {}
+        ReflectRef::Unit(_) => {}
     }
 
     let mut dynamic_list = DynamicList::default();


### PR DESCRIPTION
# Objective
 - Fixes https://github.com/bevyengine/bevy/issues/14640
## Solution
 - Implement resource for () and insert it as a constant resource.
## Testing
 - Wrote a test to make sure all worlds spawn with () available as a resource.