### PR TITLE
Add `Self: Sized` bounds to `Bundle` trait methods

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -157,10 +157,13 @@ pub unsafe trait Bundle: DynamicBundle + Send + Sync + 'static {
         components: &mut Components,
         storages: &mut Storages,
         ids: &mut impl FnMut(ComponentId),
-    );
+    ) where
+        Self: Sized;
 
     /// Gets this [`Bundle`]'s component ids. This will be [`None`] if the component has not been registered.
-    fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>));
+    fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>))
+    where
+        Self: Sized;
 
     /// Calls `func`, which should return data for each component in the bundle, in the order of
     /// this bundle's [`Component`]s
@@ -185,7 +188,9 @@ pub trait DynamicBundle {
     /// Calls `func` on each value, in the order of this bundle's [`Component`]s. This passes
     /// ownership of the component values to `func`.
     #[doc(hidden)]
-    fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>));
+    fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>))
+    where
+        Self: Sized;
 }
 
 // SAFETY:


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/3227.

I'll admit upfront this might be some silly shenanigans.

This came about based on some Rust-fu I was trying to do to enable generic dynamic bundle insertion/removal. Consider the following snippet:
```rs
#[derive(Component)]
pub struct InsertThisLater(Box<dyn Bundle>);
```
This doesn't compile, and from my perspective, understandably: a `Bundle` that doesn't know its type can't get into the world. A workaround I came up with is this:
```rs
pub trait DynBundle {
    fn insert(self: Box<Self>, mut e: EntityWorldMut);
}

pub struct InsertThisLater(Box<DynBundle>);
```
A component can impl this trait (or derive it) and suddenly you have a working system! Only problem is Rust thinks it's not possible since some of `Bundle`'s methods (erroneously) assume `Self: ?Sized`.

## Solution

Add `where Self: Sized` to the rest of `Bundle`'s (and `DynamicBundle`'s) trait methods

---

## Breaking change?

Technically, I think?

I'm not exactly sure what kind of code you'd have to write to run into this breaking change, but this change *expands* what you can do with bundles, not the other way around. I'll try and find some weird bit of code that breaks with this, but I don't think it needs a migration guide section, and honestly, I don't think it would be bad to shove it into 0.14.2, however I understand that still breaks the letter of the law and is a solid argument against doing so.