### PR TITLE
Update Grid Gizmo to use Color

### DIFF
--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -4,7 +4,7 @@
 //! and assorted support items.
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};
-use bevy_color::LinearRgba;
+use bevy_color::Color;
 use bevy_math::{Quat, UVec2, UVec3, Vec2, Vec3, Vec3Swizzles};
 
 /// A builder returned by [`Gizmos::grid_3d`]
@@ -20,7 +20,7 @@ where
     cell_count: UVec3,
     skew: Vec3,
     outer_edges: [bool; 3],
-    color: LinearRgba,
+    color: Color,
 }
 /// A builder returned by [`Gizmos::grid`] and [`Gizmos::grid_2d`]
 pub struct GridBuilder2d<'a, 'w, 's, Config, Clear>
@@ -35,7 +35,7 @@ where
     cell_count: UVec2,
     skew: Vec2,
     outer_edges: [bool; 2],
-    color: LinearRgba,
+    color: Color,
 }
 
 impl<Config, Clear> GridBuilder3d<'_, '_, '_, Config, Clear>
@@ -223,7 +223,7 @@ where
         rotation: Quat,
         cell_count: UVec2,
         spacing: Vec2,
-        color: impl Into<LinearRgba>,
+        color: impl Into<Color>,
     ) -> GridBuilder2d<'_, 'w, 's, Config, Clear> {
         GridBuilder2d {
             gizmos: self,
@@ -279,7 +279,7 @@ where
         rotation: Quat,
         cell_count: UVec3,
         spacing: Vec3,
-        color: impl Into<LinearRgba>,
+        color: impl Into<Color>,
     ) -> GridBuilder3d<'_, 'w, 's, Config, Clear> {
         GridBuilder3d {
             gizmos: self,
@@ -335,7 +335,7 @@ where
         rotation: f32,
         cell_count: UVec2,
         spacing: Vec2,
-        color: impl Into<LinearRgba>,
+        color: impl Into<Color>,
     ) -> GridBuilder2d<'_, 'w, 's, Config, Clear> {
         GridBuilder2d {
             gizmos: self,
@@ -359,7 +359,7 @@ fn draw_grid<Config, Clear>(
     cell_count: UVec3,
     skew: Vec3,
     outer_edges: [bool; 3],
-    color: LinearRgba,
+    color: Color,
 ) where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,


### PR DESCRIPTION
# Objective

It looks like `Gizmos::grid*` was missed in the colour migration.

## Solution

This updates the `grid` methods and implementation to use `Color` instead of `LinearRgba`.

It looks like `ExtractedPointLight` and `ExtractedDirectionalLight` also use `LinearRgba`, although I think in extracted structures it's probably fine to make more assumptions about what you want?

## Testing

I ran `cargo test --all -- bevy_gizmos` and it passed.

## Migration Guide

This shouldn't be adding anything that isn't already in a migration guide? I assume as it uses `impl Into<...>` in the public interfaces that any users of these APIs shouldn't have to make any code changes.