### PR TITLE
Fix Gizmos warnings and doc errors when a subset of features are selected

### DIFF
--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -160,10 +160,7 @@ impl AssetReader for FileAssetReader {
         }
     }
 
-    async fn is_directory<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> std::result::Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
         let full_path = self.root_path.join(path);
         let metadata = full_path
             .metadata()
@@ -194,35 +191,26 @@ impl AssetWriter for FileAssetWriter {
         Ok(writer)
     }
 
-    async fn remove<'a>(&'a self, path: &'a Path) -> std::result::Result<(), AssetWriterError> {
+    async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_file(full_path)?;
         Ok(())
     }
 
-    async fn remove_meta<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> std::result::Result<(), AssetWriterError> {
+    async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
         let meta_path = get_meta_path(path);
         let full_path = self.root_path.join(meta_path);
         std::fs::remove_file(full_path)?;
         Ok(())
     }
 
-    async fn remove_directory<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> std::result::Result<(), AssetWriterError> {
+    async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_dir_all(full_path)?;
         Ok(())
     }
 
-    async fn remove_empty_directory<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> std::result::Result<(), AssetWriterError> {
+    async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_dir(full_path)?;
         Ok(())
@@ -231,7 +219,7 @@ impl AssetWriter for FileAssetWriter {
     async fn remove_assets_in_directory<'a>(
         &'a self,
         path: &'a Path,
-    ) -> std::result::Result<(), AssetWriterError> {
+    ) -> Result<(), AssetWriterError> {
         let full_path = self.root_path.join(path);
         std::fs::remove_dir_all(&full_path)?;
         std::fs::create_dir_all(&full_path)?;
@@ -242,7 +230,7 @@ impl AssetWriter for FileAssetWriter {
         &'a self,
         old_path: &'a Path,
         new_path: &'a Path,
-    ) -> std::result::Result<(), AssetWriterError> {
+    ) -> Result<(), AssetWriterError> {
         let full_old_path = self.root_path.join(old_path);
         let full_new_path = self.root_path.join(new_path);
         if let Some(parent) = full_new_path.parent() {
@@ -256,7 +244,7 @@ impl AssetWriter for FileAssetWriter {
         &'a self,
         old_path: &'a Path,
         new_path: &'a Path,
-    ) -> std::result::Result<(), AssetWriterError> {
+    ) -> Result<(), AssetWriterError> {
         let old_meta_path = get_meta_path(old_path);
         let new_meta_path = get_meta_path(new_path);
         let full_old_path = self.root_path.join(old_meta_path);

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -31,7 +31,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use std::f32::consts::PI;
     /// # use bevy_color::palettes::basic::{GREEN, RED};
@@ -168,7 +167,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use std::f32::consts::PI;
     /// # use bevy_color::palettes::css::ORANGE;
@@ -225,7 +223,6 @@ where
     /// # Examples
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::ORANGE;
     /// fn system(mut gizmos: Gizmos) {
@@ -272,7 +269,6 @@ where
     /// # Examples
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::ORANGE;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/arrows.rs
+++ b/crates/bevy_gizmos/src/arrows.rs
@@ -36,7 +36,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -114,7 +113,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -146,7 +144,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/circles.rs
+++ b/crates/bevy_gizmos/src/circles.rs
@@ -31,7 +31,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -70,7 +69,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -109,7 +107,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -148,7 +145,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -186,7 +182,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::Color;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -3,7 +3,13 @@
 use crate as bevy_gizmos;
 pub use bevy_gizmos_macros::GizmoConfigGroup;
 
-use bevy_ecs::{component::Component, reflect::ReflectResource, system::Resource};
+#[cfg(all(
+    feature = "bevy_render",
+    any(feature = "bevy_pbr", feature = "bevy_sprite")
+))]
+use bevy_ecs::component::Component;
+
+use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
 use bevy_utils::TypeIdMap;
 use core::panic;
@@ -186,7 +192,10 @@ impl Default for GizmoConfig {
     }
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(all(
+    feature = "bevy_render",
+    any(feature = "bevy_pbr", feature = "bevy_sprite")
+))]
 #[derive(Component)]
 pub(crate) struct GizmoMeshConfig {
     pub line_perspective: bool,
@@ -194,7 +203,10 @@ pub(crate) struct GizmoMeshConfig {
     pub render_layers: bevy_render::view::RenderLayers,
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(all(
+    feature = "bevy_render",
+    any(feature = "bevy_pbr", feature = "bevy_sprite")
+))]
 impl From<&GizmoConfig> for GizmoMeshConfig {
     fn from(item: &GizmoConfig) -> Self {
         GizmoMeshConfig {

--- a/crates/bevy_gizmos/src/cross.rs
+++ b/crates/bevy_gizmos/src/cross.rs
@@ -18,7 +18,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::WHITE;
     /// fn system(mut gizmos: Gizmos) {
@@ -51,7 +50,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::WHITE;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -280,7 +280,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -304,7 +303,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -334,7 +332,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -357,7 +354,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -386,7 +382,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -417,7 +412,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{BLUE, GREEN, RED};
     /// fn system(mut gizmos: Gizmos) {
@@ -465,7 +459,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -489,7 +482,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_transform::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -530,7 +522,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -553,7 +544,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -582,7 +572,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -609,7 +598,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN, BLUE};
     /// fn system(mut gizmos: Gizmos) {
@@ -643,7 +631,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -666,7 +653,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::{RED, GREEN};
     /// fn system(mut gizmos: Gizmos) {
@@ -695,7 +681,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/grid.rs
+++ b/crates/bevy_gizmos/src/grid.rs
@@ -201,7 +201,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -257,7 +256,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -313,7 +311,6 @@ where
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::basic::GREEN;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -9,7 +9,6 @@
 //! # Example
 //! ```
 //! # use bevy_gizmos::prelude::*;
-//! # use bevy_render::prelude::*;
 //! # use bevy_math::prelude::*;
 //! # use bevy_color::palettes::basic::GREEN;
 //! fn system(mut gizmos: Gizmos) {
@@ -70,20 +69,31 @@ pub mod prelude {
     pub use crate::light::{LightGizmoColor, LightGizmoConfigGroup, ShowLightGizmo};
 }
 
+#[cfg(feature = "bevy_render")]
+use bevy_ecs::{
+    query::ROQueryItem,
+    system::{
+        lifetimeless::{Read, SRes},
+        Commands, SystemParamItem,
+    },
+};
+
 use bevy_app::{App, FixedFirst, FixedLast, Last, Plugin, RunFixedMainLoop};
 use bevy_asset::{Asset, AssetApp, Assets, Handle};
 use bevy_color::LinearRgba;
+#[cfg(feature = "bevy_render")]
+use bevy_ecs::component::Component;
 use bevy_ecs::{
-    component::Component,
-    query::ROQueryItem,
     schedule::{IntoSystemConfigs, SystemSet},
-    system::{
-        lifetimeless::{Read, SRes},
-        Commands, Res, ResMut, Resource, SystemParamItem,
-    },
+    system::{Res, ResMut, Resource},
 };
 use bevy_math::Vec3;
 use bevy_reflect::TypePath;
+#[cfg(all(
+    feature = "bevy_render",
+    any(feature = "bevy_pbr", feature = "bevy_sprite"),
+))]
+use bevy_render::render_resource::{VertexAttribute, VertexBufferLayout, VertexStepMode};
 #[cfg(feature = "bevy_render")]
 use bevy_render::{
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
@@ -92,19 +102,21 @@ use bevy_render::{
     render_resource::{
         binding_types::uniform_buffer, BindGroup, BindGroupEntries, BindGroupLayout,
         BindGroupLayoutEntries, Buffer, BufferInitDescriptor, BufferUsages, Shader, ShaderStages,
-        ShaderType, VertexAttribute, VertexBufferLayout, VertexFormat, VertexStepMode,
+        ShaderType, VertexFormat,
     },
     renderer::RenderDevice,
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
+
 use bevy_time::Fixed;
 use bevy_utils::TypeIdMap;
+#[cfg(feature = "bevy_render")]
 use bytemuck::cast_slice;
 use config::{
     DefaultGizmoConfigGroup, GizmoConfig, GizmoConfigGroup, GizmoConfigStore, GizmoLineJoint,
 };
 use gizmos::{GizmoStorage, Swap};
-#[cfg(feature = "bevy_pbr")]
+#[cfg(all(feature = "bevy_pbr", feature = "bevy_render"))]
 use light::LightGizmoPlugin;
 use std::{any::TypeId, mem};
 
@@ -145,7 +157,7 @@ impl Plugin for GizmoPlugin {
             .add_plugins(UniformComponentPlugin::<LineGizmoUniform>::default())
             .add_plugins(RenderAssetPlugin::<GpuLineGizmo>::default());
 
-        #[cfg(feature = "bevy_pbr")]
+        #[cfg(all(feature = "bevy_pbr", feature = "bevy_render"))]
         app.add_plugins(LightGizmoPlugin);
 
         #[cfg(feature = "bevy_render")]
@@ -402,7 +414,7 @@ fn update_gizmo_meshes<Config: GizmoConfigGroup>(
     }
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(all(feature = "bevy_render"))]
 fn extract_gizmo_data(
     mut commands: Commands,
     handles: Extract<Res<LineGizmoHandles>>,
@@ -436,6 +448,7 @@ fn extract_gizmo_data(
                 _padding: Default::default(),
             },
             (*handle).clone_weak(),
+            #[cfg(any(feature = "bevy_pbr", feature = "bevy_sprite"))]
             config::GizmoMeshConfig::from(config),
         ));
     }
@@ -676,7 +689,10 @@ impl<P: PhaseItem> RenderCommand<P> for DrawLineJointGizmo {
     }
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(all(
+    feature = "bevy_render",
+    any(feature = "bevy_pbr", feature = "bevy_sprite")
+))]
 fn line_gizmo_vertex_buffer_layouts(strip: bool) -> Vec<VertexBufferLayout> {
     use VertexFormat::*;
     let mut position_layout = VertexBufferLayout {
@@ -731,7 +747,10 @@ fn line_gizmo_vertex_buffer_layouts(strip: bool) -> Vec<VertexBufferLayout> {
     }
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(all(
+    feature = "bevy_render",
+    any(feature = "bevy_pbr", feature = "bevy_sprite")
+))]
 fn line_joint_gizmo_vertex_buffer_layouts() -> Vec<VertexBufferLayout> {
     use VertexFormat::*;
     let mut position_layout = VertexBufferLayout {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -414,7 +414,7 @@ fn update_gizmo_meshes<Config: GizmoConfigGroup>(
     }
 }
 
-#[cfg(all(feature = "bevy_render"))]
+#[cfg(feature = "bevy_render")]
 fn extract_gizmo_data(
     mut commands: Commands,
     handles: Extract<Res<LineGizmoHandles>>,

--- a/crates/bevy_gizmos/src/rounded_box.rs
+++ b/crates/bevy_gizmos/src/rounded_box.rs
@@ -227,7 +227,6 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -283,7 +282,6 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::GREEN;
     /// fn system(mut gizmos: Gizmos) {
@@ -339,7 +337,6 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// # Example
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::GREEN;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -174,7 +174,6 @@ impl<'a> TextureAtlasBuilder<'a> {
     /// # use bevy_sprite::prelude::*;
     /// # use bevy_ecs::prelude::*;
     /// # use bevy_asset::*;
-    /// # use bevy_render::prelude::*;
     ///
     /// fn my_system(mut commands: Commands, mut textures: ResMut<Assets<Image>>, mut layouts: ResMut<Assets<TextureAtlasLayout>>) {
     ///     // Declare your builder

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -174,6 +174,7 @@ impl<'a> TextureAtlasBuilder<'a> {
     /// # use bevy_sprite::prelude::*;
     /// # use bevy_ecs::prelude::*;
     /// # use bevy_asset::*;
+    /// # use bevy_render::prelude::*;
     ///
     /// fn my_system(mut commands: Commands, mut textures: ResMut<Assets<Image>>, mut layouts: ResMut<Assets<TextureAtlasLayout>>) {
     ///     // Declare your builder


### PR DESCRIPTION
# Objective

When trying to test a gizmos change I ran `cargo test -p bevy_gizmos` and the output had a lot of noise from warnings and failed doc errors. This was because I didn't have all of the features enabled.

## Solution

I admit this might be pedantic, and am happy if the concensus is to reject it. Although it does reduce the lines of code, testing noise, and the amount of code compiled. I don't think it affects the complexity of public code, and it doesn't change much to the complexity of internal code.

I've removed un-needed `bevy_render` imports in all of the gizmos docs examples, there's probably other unnecessary ones there too, but I haven't looked exhaustively. It isn't needed for those docs, and isn't available except in a subset of `cfg` combinations.

I've also made several of the `use` statements slightly more specific. I shouldn't have changed the public interfaces, except that `GizmoMeshConfig` requires either `bevy_sprite` or `bevy_pbr`, as it does nothing without them.

I've also avoided adding some systems and plugins in situations where they can't work. An example of this is where the `light` module depends on `all(feature = "bevy_pbr", feature = "bevy_render")`, but it has `use` statements that only require `bevy_render`.

## Testing

During development I ran:
```
cargo check -p bevy_gizmos && cargo check -p bevy_gizmos --features=bevy_pbr && cargo check -p bevy_gizmos --features=bevy_sprite && cargo check -p bevy_gizmos --features=bevy_render
```
Afterwards I ran this just to be sure:
```
cargo check && cargo check --features=bevy_pbr && cargo check --features=bevy_sprite && cargo check --features=bevy_render
```

Finally I ran:
```
cargo test -p bevy_gizmos && cargo test -p bevy_gizmos --features=bevy_pbr && test check -p bevy_gizmos --features=bevy_sprite && cargo test -p bevy_gizmos --features=bevy_render
```

## Migration Guide

There shouldn't be any reason to migrate, although if for some reason you use `GizmoMeshConfig` and `bevy_render`  but not `bevy_pbr` or `bevy_sprite` (such that it does nothing), then you will get an error that it no longer exists.