### PR TITLE
Fix underflow panic in `InitTriInfo`

### DIFF
--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -1030,7 +1030,7 @@ unsafe fn InitTriInfo<I: Geometry>(
         }
         f += 1
     }
-    while t < iNrTrianglesIn - 1 {
+    while t + 1 < iNrTrianglesIn {
         let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
         let iFO_b: i32 = (*pTriInfos.offset((t + 1) as isize)).iOrgFaceNumber;
         if iFO_a == iFO_b {

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -253,6 +253,10 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         t += 1
     }
     iNrTrianglesIn = iTotTris - iDegenTriangles;
+
+    if iNrTrianglesIn <= 0 {
+        return false;
+    }
     DegenPrologue(
         pTriInfos.as_mut_ptr(),
         piTriListIn.as_mut_ptr(),
@@ -335,8 +339,7 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         f += 1
     }
 
-    // TODO: Find a better place to return
-    return iNrTrianglesIn > 0;
+    return true;
 }
 unsafe fn DegenEpilogue<I: Geometry>(
     mut psTspace: *mut STSpace,

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -335,7 +335,8 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
         f += 1
     }
 
-    return true;
+    // TODO: Find a better place to return
+    return iNrTrianglesIn > 0;
 }
 unsafe fn DegenEpilogue<I: Geometry>(
     mut psTspace: *mut STSpace,


### PR DESCRIPTION
# Objective

- Fix #14874

## Solution

- Change the place where a panic occurs from `t < iNrTrianglesIn - 1` to `t + 1 < iNrTrianglesIn`.

## Testing

- After the fix, the following code runs successfully without any panic.

```rust
use bevy::prelude::Mesh;
use bevy_render::{
    mesh::{Indices, PrimitiveTopology},
    render_asset::RenderAssetUsages,
};

const POSITIONS: &[[f32; 3]] = &[[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0]];

const NORMALS: &[[f32; 3]] = &[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]];

const INDICES: &[u32] = &[0, 1, 2];

const UVS: &[[f32; 2]] = &[[0.0, 1.0], [0.0, 0.0], [0.0, 1.0]];

fn main() {
    let mut mesh = Mesh::new(
        PrimitiveTopology::TriangleList,
        RenderAssetUsages::default(),
    );

    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, POSITIONS.to_vec());
    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, UVS.to_vec());
    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, NORMALS.to_vec());
    mesh.insert_indices(Indices::U32(INDICES.to_vec()));
    mesh.generate_tangents().ok();

}

```

## Migration Guide

- No breaking changes introduced.