### PR TITLE
Add World::trigger_ref and World::trigger_targets_ref

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -311,14 +311,37 @@ impl World {
         self.spawn(Observer::new(system))
     }
 
-    /// Triggers the given `event`, which will run any observers watching for it.
+    /// Triggers the given [`Event`], which will run any [`Observer`]s watching for it.
+    ///
+    /// This method consumes the event, so it cannot be used after this method is called.
+    /// If you need to use the event after triggering it, use [`World::trigger_ref`] instead.
     pub fn trigger(&mut self, event: impl Event) {
         TriggerEvent { event, targets: () }.trigger(self);
     }
 
-    /// Triggers the given `event` for the given `targets`, which will run any observers watching for it.
+    /// Triggers the given [`Event`] as a mutable reference, which will run any [`Observer`]s watching for it.
+    ///
+    /// Compared to [`World::trigger`], this method is most useful when it's necessary to check
+    /// or use the event after it has been modified by observers.
+    pub fn trigger_ref(&mut self, event: &mut impl Event) {
+        TriggerEvent { event, targets: () }.trigger_ref(self);
+    }
+
+    /// Triggers the given [`Event`] for the given `targets`, which will run any [`Observer`]s watching for it.
+    ///
+    /// This method consumes the event, so it cannot be used after this method is called.
+    /// If you need to use the event after triggering it, use [`World::trigger_targets_ref`] instead.
     pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets) {
         TriggerEvent { event, targets }.trigger(self);
+    }
+
+    /// Triggers the given [`Event`] as a mutable reference for the given `targets`,
+    /// which will run any [`Observer`]s watching for it.
+    ///
+    /// Compared to [`World::trigger_targets`], this method is most useful when it's necessary to check
+    /// or use the event after it has been modified by observers.
+    pub fn trigger_targets_ref(&mut self, event: &mut impl Event, targets: impl TriggerTargets) {
+        TriggerEvent { event, targets }.trigger_ref(self);
     }
 
     /// Register an observer to the cache, called when an observer is created

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -313,7 +313,8 @@ impl World {
 
     /// Triggers the given [`Event`], which will run any [`Observer`]s watching for it.
     ///
-    /// This method consumes the event, so it cannot be used after this method is called.
+    /// While event types commonly implement [`Copy`],
+    /// those that don't will be consumed and will no longer be accessible.
     /// If you need to use the event after triggering it, use [`World::trigger_ref`] instead.
     pub fn trigger(&mut self, event: impl Event) {
         TriggerEvent { event, targets: () }.trigger(self);
@@ -329,7 +330,8 @@ impl World {
 
     /// Triggers the given [`Event`] for the given `targets`, which will run any [`Observer`]s watching for it.
     ///
-    /// This method consumes the event, so it cannot be used after this method is called.
+    /// /// While event types commonly implement [`Copy`],
+    /// those that don't will be consumed and will no longer be accessible.
     /// If you need to use the event after triggering it, use [`World::trigger_targets_ref`] instead.
     pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets) {
         TriggerEvent { event, targets }.trigger(self);

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -330,7 +330,7 @@ impl World {
 
     /// Triggers the given [`Event`] for the given `targets`, which will run any [`Observer`]s watching for it.
     ///
-    /// /// While event types commonly implement [`Copy`],
+    /// While event types commonly implement [`Copy`],
     /// those that don't will be consumed and will no longer be accessible.
     /// If you need to use the event after triggering it, use [`World::trigger_targets_ref`] instead.
     pub fn trigger_targets(&mut self, event: impl Event, targets: impl TriggerTargets) {

--- a/crates/bevy_ecs/src/observer/trigger_event.rs
+++ b/crates/bevy_ecs/src/observer/trigger_event.rs
@@ -21,6 +21,13 @@ impl<E: Event, Targets: TriggerTargets> TriggerEvent<E, Targets> {
     }
 }
 
+impl<E: Event, Targets: TriggerTargets> TriggerEvent<&mut E, Targets> {
+    pub(super) fn trigger_ref(self, world: &mut World) {
+        let event_type = world.init_component::<E>();
+        trigger_event(world, event_type, self.event, self.targets);
+    }
+}
+
 impl<E: Event, Targets: TriggerTargets + Send + Sync + 'static> Command
     for TriggerEvent<E, Targets>
 {


### PR DESCRIPTION
# Objective

Closes #14888.

## Solution

Add non-consuming trigger functions:

```rust
impl World {
    pub fn trigger_ref(&mut self, event: &mut impl Event);
    pub fn trigger_targets_ref(&mut self, event: &mut impl Event, targets: impl TriggerTargets);
}
```

## Testing

- Added two new tests, `observer_trigger_ref` and `observer_trigger_targets_ref`.