### PR TITLE
Have EntityCommands methods consume self for easier chaining

### DIFF
--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -47,15 +47,15 @@ pub fn spawn_commands(criterion: &mut Criterion) {
                     let mut entity = commands.spawn_empty();
 
                     if black_box(i % 2 == 0) {
-                        entity.insert(A);
+                        entity = entity.insert(A);
                     }
 
                     if black_box(i % 3 == 0) {
-                        entity.insert(B);
+                        entity = entity.insert(B);
                     }
 
                     if black_box(i % 4 == 0) {
-                        entity.insert(C);
+                        entity = entity.insert(C);
                     }
 
                     if black_box(i % 5 == 0) {

--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -1,4 +1,5 @@
 use std::mem::size_of;
+
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -44,19 +45,11 @@ pub fn spawn_commands(criterion: &mut Criterion) {
             bencher.iter(|| {
                 let mut commands = Commands::new(&mut command_queue, &world);
                 for i in 0..entity_count {
-                    let mut entity = commands.spawn_empty();
-
-                    if black_box(i % 2 == 0) {
-                        entity = entity.insert(A);
-                    }
-
-                    if black_box(i % 3 == 0) {
-                        entity = entity.insert(B);
-                    }
-
-                    if black_box(i % 4 == 0) {
-                        entity = entity.insert(C);
-                    }
+                    let mut entity = commands
+                        .spawn_empty()
+                        .insert_if(A, || black_box(i % 2 == 0))
+                        .insert_if(B, || black_box(i % 3 == 0))
+                        .insert_if(C, || black_box(i % 4 == 0));
 
                     if black_box(i % 5 == 0) {
                         entity.despawn();

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -584,20 +584,12 @@ pub fn extract_camera_prepass_phase(
 
         live_entities.insert(entity);
 
-        let mut entity = commands.get_or_spawn(entity);
-
-        if depth_prepass {
-            entity = entity.insert(DepthPrepass);
-        }
-        if normal_prepass {
-            entity = entity.insert(NormalPrepass);
-        }
-        if motion_vector_prepass {
-            entity = entity.insert(MotionVectorPrepass);
-        }
-        if deferred_prepass {
-            entity.insert(DeferredPrepass);
-        }
+        commands
+            .get_or_spawn(entity)
+            .insert_if(DepthPrepass, || depth_prepass)
+            .insert_if(NormalPrepass, || normal_prepass)
+            .insert_if(MotionVectorPrepass, || motion_vector_prepass)
+            .insert_if(DeferredPrepass, || deferred_prepass);
     }
 
     opaque_3d_prepass_phases.retain(|entity, _| live_entities.contains(entity));

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -587,13 +587,13 @@ pub fn extract_camera_prepass_phase(
         let mut entity = commands.get_or_spawn(entity);
 
         if depth_prepass {
-            entity.insert(DepthPrepass);
+            entity = entity.insert(DepthPrepass);
         }
         if normal_prepass {
-            entity.insert(NormalPrepass);
+            entity = entity.insert(NormalPrepass);
         }
         if motion_vector_prepass {
-            entity.insert(MotionVectorPrepass);
+            entity = entity.insert(MotionVectorPrepass);
         }
         if deferred_prepass {
             entity.insert(DeferredPrepass);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1665,9 +1665,6 @@ mod tests {
     #[derive(Component, Resource)]
     struct W<T>(T);
 
-    #[derive(Component)]
-    struct TestComp;
-
     fn simple_command(world: &mut World) {
         world.spawn((W(0u32), W(42u64)));
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -953,9 +953,7 @@ impl EntityCommands<'_> {
         self.add(insert(bundle, InsertMode::Replace))
     }
 
-    /// Adds a [`Bundle`] of components to the entity, only if the given condition evaluates to true.
-    ///
-    /// This will overwrite any previous value(s) of the same component type.
+    /// Similar to [`Self::insert`] but will only insert if the predicate returns true.
     ///
     /// # Panics
     ///
@@ -972,41 +970,12 @@ impl EntityCommands<'_> {
     /// # impl PlayerEntity { fn is_spawned(&self) -> bool { true } }
     /// #[derive(Component)]
     /// struct Health(u32);
-    /// #[derive(Component)]
-    /// struct Strength(u32);
-    /// #[derive(Component)]
-    /// struct Defense(u32);
     ///
-    /// #[derive(Bundle)]
-    /// struct CombatBundle {
-    ///     health: Health,
-    ///     strength: Strength,
+    /// fn add_health_system(mut commands: Commands, player: Res<PlayerEntity>) {
+    ///     commands.entity(player.entity)
+    ///         .insert_if(Health(10), || player.is_spawned());
     /// }
-    ///
-    /// fn add_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
-    ///     commands
-    ///         .entity(player.entity)
-    ///         // You can insert individual components:
-    ///         .insert_if(Defense(10), || player.is_spawned())
-    ///         // You can also insert pre-defined bundles of components:
-    ///         .insert_if(CombatBundle {
-    ///                 health: Health(100),
-    ///                 strength: Strength(40),
-    ///             },
-    ///             || player.is_spawned()
-    ///         )
-    ///         // You can also insert tuples of components and bundles.
-    ///         // This is equivalent to the calls above:
-    ///         .insert_if((
-    ///             Defense(10),
-    ///             CombatBundle {
-    ///                 health: Health(100),
-    ///                 strength: Strength(40),
-    ///             }),
-    ///             || player.is_spawned()
-    ///         );
-    /// }
-    /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
+    /// # bevy_ecs::system::assert_is_system(add_health_system);
     /// ```
     #[track_caller]
     pub fn insert_if<F>(self, bundle: impl Bundle, condition: F) -> Self
@@ -1134,13 +1103,7 @@ impl EntityCommands<'_> {
         self.add(try_insert(bundle, InsertMode::Replace))
     }
 
-    /// Tries to add a [`Bundle`] of components to the entity, only if the given condition evaluates to true.
-    ///
-    /// This will overwrite any previous value(s) of the same component type.
-    ///
-    /// # Note
-    ///
-    /// Unlike [`Self::insert_if`], this will not panic if the associated entity does not exist.
+    /// Similar to [`Self::try_insert`] but will only try to insert if the predicate returns true.
     ///
     /// # Example
     ///
@@ -1151,39 +1114,16 @@ impl EntityCommands<'_> {
     /// # impl PlayerEntity { fn is_spawned(&self) -> bool { true } }
     /// #[derive(Component)]
     /// struct Health(u32);
-    /// #[derive(Component)]
-    /// struct Strength(u32);
-    /// #[derive(Component)]
-    /// struct Defense(u32);
     ///
-    /// #[derive(Bundle)]
-    /// struct CombatBundle {
-    ///     health: Health,
-    ///     strength: Strength,
-    /// }
-    ///
-    /// fn add_combat_stats_system(mut commands: Commands, player: Res<PlayerEntity>) {
+    /// fn add_health_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///   commands.entity(player.entity)
-    ///    // You can try_insert_if individual components:
-    ///     .try_insert_if(Defense(10), || player.is_spawned())
-    ///
-    ///    // You can also insert tuples of components:
-    ///     .try_insert_if(CombatBundle {
-    ///             health: Health(100),
-    ///             strength: Strength(40),
-    ///         },
-    ///         || player.is_spawned()
-    ///     );
-    ///
-    ///    // Suppose this occurs in a parallel adjacent system or process
-    ///    commands.entity(player.entity)
-    ///      .despawn();
+    ///     .try_insert_if(Health(10), || player.is_spawned());
     ///
     ///    commands.entity(player.entity)
     ///    // This will not panic nor will it add the component
-    ///      .try_insert_if(Defense(5), || player.is_spawned());
+    ///      .try_insert_if(Health(5), || player.is_spawned());
     /// }
-    /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
+    /// # bevy_ecs::system::assert_is_system(add_health_system);
     /// ```
     #[track_caller]
     pub fn try_insert_if<F>(self, bundle: impl Bundle, condition: F) -> Self

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -364,9 +364,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// - [`spawn_batch`](Self::spawn_batch) to spawn entities with a bundle each.
     #[track_caller]
     pub fn spawn<T: Bundle>(&mut self, bundle: T) -> EntityCommands {
-        let mut e = self.spawn_empty();
-        e.insert(bundle);
-        e
+        self.spawn_empty().insert(bundle)
     }
 
     /// Returns the [`EntityCommands`] for the requested [`Entity`].
@@ -951,7 +949,7 @@ impl EntityCommands<'_> {
     /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     #[track_caller]
-    pub fn insert(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn insert(self, bundle: impl Bundle) -> Self {
         self.add(insert(bundle, InsertMode::Replace))
     }
 
@@ -968,7 +966,7 @@ impl EntityCommands<'_> {
     ///
     /// To avoid a panic in this case, use the command [`Self::try_insert_if_new`]
     /// instead.
-    pub fn insert_if_new(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn insert_if_new(self, bundle: impl Bundle) -> Self {
         self.add(insert(bundle, InsertMode::Keep))
     }
 
@@ -988,16 +986,15 @@ impl EntityCommands<'_> {
     /// - `T` must have the same layout as the one passed during `component_id` creation.
     #[track_caller]
     pub unsafe fn insert_by_id<T: Send + 'static>(
-        &mut self,
+        self,
         component_id: ComponentId,
         value: T,
-    ) -> &mut Self {
+    ) -> Self {
         let caller = Location::caller();
         // SAFETY: same invariants as parent call
         self.add(unsafe {insert_by_id(component_id, value, move |entity| {
             panic!("error[B0003]: {caller}: Could not insert a component {component_id:?} (with type {}) for entity {entity:?} because it doesn't exist in this World. See: https://bevyengine.org/learn/errors/#b0003", std::any::type_name::<T>());
-        })});
-        self
+        })})
     }
 
     /// Attempts to add a dynamic component to an entity.
@@ -1009,13 +1006,12 @@ impl EntityCommands<'_> {
     /// - [`ComponentId`] must be from the same world as `self`.
     /// - `T` must have the same layout as the one passed during `component_id` creation.
     pub unsafe fn try_insert_by_id<T: Send + 'static>(
-        &mut self,
+        self,
         component_id: ComponentId,
         value: T,
-    ) -> &mut Self {
+    ) -> Self {
         // SAFETY: same invariants as parent call
-        self.add(unsafe { insert_by_id(component_id, value, |_| {}) });
-        self
+        self.add(unsafe { insert_by_id(component_id, value, |_| {}) })
     }
 
     /// Tries to add a [`Bundle`] of components to the entity.
@@ -1067,7 +1063,7 @@ impl EntityCommands<'_> {
     /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     #[track_caller]
-    pub fn try_insert(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn try_insert(self, bundle: impl Bundle) -> Self {
         self.add(try_insert(bundle, InsertMode::Replace))
     }
 
@@ -1080,7 +1076,7 @@ impl EntityCommands<'_> {
     /// # Note
     ///
     /// Unlike [`Self::insert_if_new`], this will not panic if the associated entity does not exist.
-    pub fn try_insert_if_new(&mut self, bundle: impl Bundle) -> &mut Self {
+    pub fn try_insert_if_new(self, bundle: impl Bundle) -> Self {
         self.add(try_insert(bundle, InsertMode::Keep))
     }
 
@@ -1119,7 +1115,7 @@ impl EntityCommands<'_> {
     /// }
     /// # bevy_ecs::system::assert_is_system(remove_combat_stats_system);
     /// ```
-    pub fn remove<T>(&mut self) -> &mut Self
+    pub fn remove<T>(self) -> Self
     where
         T: Bundle,
     {
@@ -1127,12 +1123,12 @@ impl EntityCommands<'_> {
     }
 
     /// Removes a component from the entity.
-    pub fn remove_by_id(&mut self, component_id: ComponentId) -> &mut Self {
+    pub fn remove_by_id(self, component_id: ComponentId) -> Self {
         self.add(remove_by_id(component_id))
     }
 
     /// Removes all components associated with the entity.
-    pub fn clear(&mut self) -> &mut Self {
+    pub fn clear(self) -> Self {
         self.add(clear())
     }
 
@@ -1164,8 +1160,8 @@ impl EntityCommands<'_> {
     /// # bevy_ecs::system::assert_is_system(remove_character_system);
     /// ```
     #[track_caller]
-    pub fn despawn(&mut self) {
-        self.add(despawn());
+    pub fn despawn(self) -> Self {
+        self.add(despawn())
     }
 
     /// Pushes an [`EntityCommand`] to the queue, which will get executed for the current [`Entity`].
@@ -1184,7 +1180,8 @@ impl EntityCommands<'_> {
     /// # }
     /// # bevy_ecs::system::assert_is_system(my_system);
     /// ```
-    pub fn add<M: 'static>(&mut self, command: impl EntityCommand<M>) -> &mut Self {
+    #[allow(clippy::should_implement_trait)]
+    pub fn add<M: 'static>(mut self, command: impl EntityCommand<M>) -> Self {
         self.commands.add(command.with_entity(self.entity));
         self
     }
@@ -1226,7 +1223,7 @@ impl EntityCommands<'_> {
     /// }
     /// # bevy_ecs::system::assert_is_system(remove_combat_stats_system);
     /// ```
-    pub fn retain<T>(&mut self) -> &mut Self
+    pub fn retain<T>(self) -> Self
     where
         T: Bundle,
     {
@@ -1238,8 +1235,8 @@ impl EntityCommands<'_> {
     /// # Panics
     ///
     /// The command will panic when applied if the associated entity does not exist.
-    pub fn log_components(&mut self) {
-        self.add(log_components);
+    pub fn log_components(self) -> Self {
+        self.add(log_components)
     }
 
     /// Returns the underlying [`Commands`].
@@ -1251,18 +1248,14 @@ impl EntityCommands<'_> {
     /// watches this entity.
     ///
     /// [`Trigger`]: crate::observer::Trigger
-    pub fn trigger(&mut self, event: impl Event) -> &mut Self {
+    pub fn trigger(mut self, event: impl Event) -> Self {
         self.commands.trigger_targets(event, self.entity);
         self
     }
 
     /// Creates an [`Observer`] listening for a trigger of type `T` that targets this entity.
-    pub fn observe<E: Event, B: Bundle, M>(
-        &mut self,
-        system: impl IntoObserverSystem<E, B, M>,
-    ) -> &mut Self {
-        self.add(observe(system));
-        self
+    pub fn observe<E: Event, B: Bundle, M>(self, system: impl IntoObserverSystem<E, B, M>) -> Self {
+        self.add(observe(system))
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -954,6 +954,7 @@ impl EntityCommands<'_> {
     }
 
     /// Similar to [`Self::insert`] but will only insert if the predicate returns true.
+    /// This is useful for chaining method calls.
     ///
     /// # Panics
     ///
@@ -967,13 +968,17 @@ impl EntityCommands<'_> {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource)]
     /// # struct PlayerEntity { entity: Entity }
-    /// # impl PlayerEntity { fn is_spawned(&self) -> bool { true } }
+    /// # impl PlayerEntity { fn is_spectator(&self) -> bool { true } }
+    /// #[derive(Component)]
+    /// struct StillLoadingStats;
     /// #[derive(Component)]
     /// struct Health(u32);
     ///
     /// fn add_health_system(mut commands: Commands, player: Res<PlayerEntity>) {
-    ///     commands.entity(player.entity)
-    ///         .insert_if(Health(10), || player.is_spawned());
+    ///     commands
+    ///         .entity(player.entity)
+    ///         .insert_if(Health(10), || !player.is_spectator())
+    ///         .remove::<StillLoadingStats>();
     /// }
     /// # bevy_ecs::system::assert_is_system(add_health_system);
     /// ```
@@ -1104,6 +1109,7 @@ impl EntityCommands<'_> {
     }
 
     /// Similar to [`Self::try_insert`] but will only try to insert if the predicate returns true.
+    /// This is useful for chaining method calls.
     ///
     /// # Example
     ///
@@ -1111,17 +1117,20 @@ impl EntityCommands<'_> {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource)]
     /// # struct PlayerEntity { entity: Entity }
-    /// # impl PlayerEntity { fn is_spawned(&self) -> bool { true } }
+    /// # impl PlayerEntity { fn is_spectator(&self) -> bool { true } }
+    /// #[derive(Component)]
+    /// struct StillLoadingStats;
     /// #[derive(Component)]
     /// struct Health(u32);
     ///
     /// fn add_health_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///   commands.entity(player.entity)
-    ///     .try_insert_if(Health(10), || player.is_spawned());
+    ///     .try_insert_if(Health(10), || !player.is_spectator())
+    ///     .remove::<StillLoadingStats>();
     ///
     ///    commands.entity(player.entity)
     ///    // This will not panic nor will it add the component
-    ///      .try_insert_if(Health(5), || player.is_spawned());
+    ///      .try_insert_if(Health(5), || !player.is_spectator());
     /// }
     /// # bevy_ecs::system::assert_is_system(add_health_system);
     /// ```

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -581,7 +581,7 @@ pub fn extract_camera_previous_view_data(
 ) {
     for (entity, camera, maybe_previous_view_data) in cameras_3d.iter() {
         if camera.is_active {
-            let mut entity = commands.get_or_spawn(entity);
+            let entity = commands.get_or_spawn(entity);
 
             if let Some(previous_view_data) = maybe_previous_view_data {
                 entity.insert(previous_view_data.clone());

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -154,7 +154,7 @@ fn apply_wireframe_material(
     global_material: Res<GlobalWireframeMaterial>,
 ) {
     for e in removed_wireframes.read().chain(no_wireframes.iter()) {
-        if let Some(mut commands) = commands.get_entity(e) {
+        if let Some(commands) = commands.get_entity(e) {
             commands.remove::<Handle<WireframeMaterial>>();
         }
     }

--- a/crates/bevy_picking/src/focus.rs
+++ b/crates/bevy_picking/src/focus.rs
@@ -231,7 +231,7 @@ pub fn update_interactions(
     for (hovered_entity, new_interaction) in new_interaction_state.drain() {
         if let Ok(mut interaction) = interact.get_mut(hovered_entity) {
             *interaction = new_interaction;
-        } else if let Some(mut entity_commands) = commands.get_entity(hovered_entity) {
+        } else if let Some(entity_commands) = commands.get_entity(hovered_entity) {
             entity_commands.try_insert(new_interaction);
         }
     }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -935,9 +935,7 @@ pub fn extract_cameras(
                 continue;
             }
 
-            let mut commands = commands.get_or_spawn(entity);
-
-            commands.insert((
+            let mut commands = commands.get_or_spawn(entity).insert((
                 ExtractedCamera {
                     target: camera.target.normalize(primary_window),
                     viewport: camera.viewport.clone(),
@@ -973,15 +971,15 @@ pub fn extract_cameras(
             ));
 
             if let Some(temporal_jitter) = temporal_jitter {
-                commands.insert(temporal_jitter.clone());
+                commands = commands.insert(temporal_jitter.clone());
             }
 
             if let Some(render_layers) = render_layers {
-                commands.insert(render_layers.clone());
+                commands = commands.insert(render_layers.clone());
             }
 
             if let Some(perspective) = projection {
-                commands.insert(perspective.clone());
+                commands = commands.insert(perspective.clone());
             }
 
             if gpu_culling {

--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -150,7 +150,7 @@ fn apply_wireframe_material(
     global_material: Res<GlobalWireframe2dMaterial>,
 ) {
     for e in removed_wireframes.read().chain(no_wireframes.iter()) {
-        if let Some(mut commands) = commands.get_entity(e) {
+        if let Some(commands) = commands.get_entity(e) {
             commands.remove::<Handle<Wireframe2dMaterial>>();
         }
     }

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -88,8 +88,7 @@ pub fn create_windows<F: QueryFilter + 'static>(
         });
 
         if let Ok(handle_wrapper) = RawHandleWrapper::new(winit_window) {
-            let mut entity = commands.entity(entity);
-            entity.insert(handle_wrapper.clone());
+            commands.entity(entity).insert(handle_wrapper.clone());
             if let Some(handle_holder) = handle_holder {
                 *handle_holder.0.lock().unwrap() = Some(handle_wrapper);
             }

--- a/examples/2d/sprite_slice.rs
+++ b/examples/2d/sprite_slice.rs
@@ -83,7 +83,7 @@ fn spawn_sprites(
             ..default()
         });
         if let Some(scale_mode) = scale_mode {
-            cmd.insert(scale_mode);
+            cmd = cmd.insert(scale_mode);
         }
         cmd.with_children(|builder| {
             builder.spawn(Text2dBundle {

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -49,16 +49,18 @@ fn modify_aa(
     // No AA
     if keys.just_pressed(KeyCode::Digit1) {
         *msaa = Msaa::Off;
-        camera.remove::<Fxaa>();
-        camera.remove::<SmaaSettings>();
-        camera.remove::<TemporalAntiAliasBundle>();
+        camera = camera
+            .remove::<Fxaa>()
+            .remove::<SmaaSettings>()
+            .remove::<TemporalAntiAliasBundle>();
     }
 
     // MSAA
     if keys.just_pressed(KeyCode::Digit2) && *msaa == Msaa::Off {
-        camera.remove::<Fxaa>();
-        camera.remove::<SmaaSettings>();
-        camera.remove::<TemporalAntiAliasBundle>();
+        camera = camera
+            .remove::<Fxaa>()
+            .remove::<SmaaSettings>()
+            .remove::<TemporalAntiAliasBundle>();
 
         *msaa = Msaa::Sample4;
     }
@@ -79,10 +81,10 @@ fn modify_aa(
     // FXAA
     if keys.just_pressed(KeyCode::Digit3) && fxaa.is_none() {
         *msaa = Msaa::Off;
-        camera.remove::<SmaaSettings>();
-        camera.remove::<TemporalAntiAliasBundle>();
-
-        camera.insert(Fxaa::default());
+        camera = camera
+            .remove::<SmaaSettings>()
+            .remove::<TemporalAntiAliasBundle>()
+            .insert(Fxaa::default());
     }
 
     // FXAA Settings
@@ -112,10 +114,10 @@ fn modify_aa(
     // SMAA
     if keys.just_pressed(KeyCode::Digit4) && smaa.is_none() {
         *msaa = Msaa::Off;
-        camera.remove::<Fxaa>();
-        camera.remove::<TemporalAntiAliasBundle>();
-
-        camera.insert(SmaaSettings::default());
+        camera = camera
+            .remove::<Fxaa>()
+            .remove::<TemporalAntiAliasBundle>()
+            .insert(SmaaSettings::default());
     }
 
     // SMAA Settings
@@ -137,10 +139,10 @@ fn modify_aa(
     // TAA
     if keys.just_pressed(KeyCode::Digit5) && taa.is_none() {
         *msaa = Msaa::Off;
-        camera.remove::<Fxaa>();
-        camera.remove::<SmaaSettings>();
-
-        camera.insert(TemporalAntiAliasBundle::default());
+        camera
+            .remove::<Fxaa>()
+            .remove::<SmaaSettings>()
+            .insert(TemporalAntiAliasBundle::default());
     }
 }
 

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -70,16 +70,17 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: Res<AppSettings>) {
     // Spawn the camera. Enable HDR and bloom, as that highlights the depth of
     // field effect.
-    let mut camera = commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 4.5, 8.25).looking_at(Vec3::ZERO, Vec3::Y),
-        camera: Camera {
-            hdr: true,
+    let camera = commands
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 4.5, 8.25).looking_at(Vec3::ZERO, Vec3::Y),
+            camera: Camera {
+                hdr: true,
+                ..default()
+            },
+            tonemapping: Tonemapping::TonyMcMapface,
             ..default()
-        },
-        tonemapping: Tonemapping::TonyMcMapface,
-        ..default()
-    });
-    camera.insert(BloomSettings::NATURAL);
+        })
+        .insert(BloomSettings::NATURAL);
 
     // Insert the depth of field settings.
     if let Some(dof_settings) = Option::<DepthOfFieldSettings>::from(*app_settings) {

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -154,7 +154,7 @@ fn spawn_cars(
             Moves(i as f32 * 2.0),
         ));
         if i == 0 {
-            entity.insert(CameraTracked);
+            entity = entity.insert(CameraTracked);
         }
         entity.with_children(|parent| {
             parent.spawn(PbrBundle {

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -144,18 +144,17 @@ fn spawn_cars(
 
     for i in 0..N_CARS {
         let color = colors[i % colors.len()].clone();
-        let mut entity = commands.spawn((
-            PbrBundle {
-                mesh: box_mesh.clone(),
-                material: color.clone(),
-                transform: Transform::from_scale(Vec3::splat(0.5)),
-                ..default()
-            },
-            Moves(i as f32 * 2.0),
-        ));
-        if i == 0 {
-            entity = entity.insert(CameraTracked);
-        }
+        let mut entity = commands
+            .spawn((
+                PbrBundle {
+                    mesh: box_mesh.clone(),
+                    material: color.clone(),
+                    transform: Transform::from_scale(Vec3::splat(0.5)),
+                    ..default()
+                },
+                Moves(i as f32 * 2.0),
+            ))
+            .insert_if(CameraTracked, || i == 0);
         entity.with_children(|parent| {
             parent.spawn(PbrBundle {
                 mesh: box_mesh.clone(),

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -123,29 +123,34 @@ fn update(
 
     let (camera_entity, ssao_settings, temporal_jitter) = camera.single();
 
-    let mut commands = commands.entity(camera_entity);
+    let mut commands = commands
+        .entity(camera_entity)
+        .insert_if(
+            ScreenSpaceAmbientOcclusionSettings {
+                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Low,
+            },
+            || keycode.just_pressed(KeyCode::Digit2),
+        )
+        .insert_if(
+            ScreenSpaceAmbientOcclusionSettings {
+                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Medium,
+            },
+            || keycode.just_pressed(KeyCode::Digit3),
+        )
+        .insert_if(
+            ScreenSpaceAmbientOcclusionSettings {
+                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::High,
+            },
+            || keycode.just_pressed(KeyCode::Digit4),
+        )
+        .insert_if(
+            ScreenSpaceAmbientOcclusionSettings {
+                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Ultra,
+            },
+            || keycode.just_pressed(KeyCode::Digit5),
+        );
     if keycode.just_pressed(KeyCode::Digit1) {
         commands = commands.remove::<ScreenSpaceAmbientOcclusionSettings>();
-    }
-    if keycode.just_pressed(KeyCode::Digit2) {
-        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
-            quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Low,
-        });
-    }
-    if keycode.just_pressed(KeyCode::Digit3) {
-        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
-            quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Medium,
-        });
-    }
-    if keycode.just_pressed(KeyCode::Digit4) {
-        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
-            quality_level: ScreenSpaceAmbientOcclusionQualityLevel::High,
-        });
-    }
-    if keycode.just_pressed(KeyCode::Digit5) {
-        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
-            quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Ultra,
-        });
     }
     if keycode.just_pressed(KeyCode::Space) {
         if temporal_jitter.is_some() {

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -125,25 +125,25 @@ fn update(
 
     let mut commands = commands.entity(camera_entity);
     if keycode.just_pressed(KeyCode::Digit1) {
-        commands.remove::<ScreenSpaceAmbientOcclusionSettings>();
+        commands = commands.remove::<ScreenSpaceAmbientOcclusionSettings>();
     }
     if keycode.just_pressed(KeyCode::Digit2) {
-        commands.insert(ScreenSpaceAmbientOcclusionSettings {
+        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
             quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Low,
         });
     }
     if keycode.just_pressed(KeyCode::Digit3) {
-        commands.insert(ScreenSpaceAmbientOcclusionSettings {
+        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
             quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Medium,
         });
     }
     if keycode.just_pressed(KeyCode::Digit4) {
-        commands.insert(ScreenSpaceAmbientOcclusionSettings {
+        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
             quality_level: ScreenSpaceAmbientOcclusionQualityLevel::High,
         });
     }
     if keycode.just_pressed(KeyCode::Digit5) {
-        commands.insert(ScreenSpaceAmbientOcclusionSettings {
+        commands = commands.insert(ScreenSpaceAmbientOcclusionSettings {
             quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Ultra,
         });
     }

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -310,7 +310,7 @@ fn setup_node_rects(commands: &mut Commands) {
             ));
 
             if let NodeType::Clip(ref clip) = node_type {
-                container.insert((
+                container = container.insert((
                     Interaction::None,
                     RelativeCursorPosition::default(),
                     (*clip).clone(),

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -148,7 +148,7 @@ fn on_remove_mine(
 fn explode_mine(trigger: Trigger<Explode>, query: Query<&Mine>, mut commands: Commands) {
     // If a triggered event is targeting a specific entity you can access it with `.entity()`
     let id = trigger.entity();
-    let Some(mut entity) = commands.get_entity(id) else {
+    let Some(entity) = commands.get_entity(id) else {
         return;
     };
     info!("Boom! {:?} exploded.", id.index());

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -743,7 +743,7 @@ mod menu {
                                     button_text_style.clone(),
                                 ));
                                 for volume_setting in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] {
-                                    let mut entity = parent.spawn((
+                                    let entity = parent.spawn((
                                         ButtonBundle {
                                             style: Style {
                                                 width: Val::Px(30.0),

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -257,7 +257,7 @@ fn spawn_button(
     ));
 
     if let Some(image) = image {
-        builder.insert(UiImage::new(image));
+        builder = builder.insert(UiImage::new(image));
     }
 
     if spawn_text {

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -163,20 +163,17 @@ fn setup(
                     fibonacci_spiral_on_sphere(golden_ratio, i, N_POINTS);
                 let unit_sphere_p = spherical_polar_to_cartesian(spherical_polar_theta_phi);
                 let (mesh, transform) = meshes.choose(&mut material_rng).unwrap();
-                let mut cube = commands.spawn(PbrBundle {
-                    mesh: mesh.clone(),
-                    material: materials.choose(&mut material_rng).unwrap().clone(),
-                    transform: Transform::from_translation((radius * unit_sphere_p).as_vec3())
-                        .looking_at(Vec3::ZERO, Vec3::Y)
-                        .mul_transform(*transform),
-                    ..default()
-                });
-                if args.no_frustum_culling {
-                    cube = cube.insert(NoFrustumCulling);
-                }
-                if args.no_automatic_batching {
-                    cube.insert(NoAutomaticBatching);
-                }
+                commands
+                    .spawn(PbrBundle {
+                        mesh: mesh.clone(),
+                        material: materials.choose(&mut material_rng).unwrap().clone(),
+                        transform: Transform::from_translation((radius * unit_sphere_p).as_vec3())
+                            .looking_at(Vec3::ZERO, Vec3::Y)
+                            .mul_transform(*transform),
+                        ..default()
+                    })
+                    .insert_if(NoFrustumCulling, || args.no_frustum_culling)
+                    .insert_if(NoAutomaticBatching, || args.no_automatic_batching);
             }
 
             // camera

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -172,7 +172,7 @@ fn setup(
                     ..default()
                 });
                 if args.no_frustum_culling {
-                    cube.insert(NoFrustumCulling);
+                    cube = cube.insert(NoFrustumCulling);
                 }
                 if args.no_automatic_batching {
                     cube.insert(NoAutomaticBatching);
@@ -182,7 +182,7 @@ fn setup(
             // camera
             let mut camera = commands.spawn(Camera3dBundle::default());
             if args.gpu_culling {
-                camera.insert(GpuCulling);
+                camera = camera.insert(GpuCulling);
             }
             if args.no_cpu_culling {
                 camera.insert(NoCpuCulling);

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -413,7 +413,7 @@ fn spawn_tree(
                 && (depth >= update_filter.min_depth && depth <= update_filter.max_depth);
 
             if update {
-                cmd.insert(UpdateValue(sep));
+                cmd = cmd.insert(UpdateValue(sep));
                 result.active_nodes += 1;
             }
 
@@ -426,7 +426,7 @@ fn spawn_tree(
             };
 
             // only insert the components necessary for the transform propagation
-            cmd.insert(TransformBundle::from(transform));
+            cmd = cmd.insert(TransformBundle::from(transform));
 
             cmd.id()
         };


### PR DESCRIPTION
# Objective

Fixes #14883

## Solution

Pretty simple update to `EntityCommands` methods to consume `self` and return it rather than taking `&mut self`. The things probably worth noting:

* I added `#[allow(clippy::should_implement_trait)]` to the `add` method because it causes a linting conflict with `std::ops::Add`.
* `despawn` and `log_components` now return `Self`. I'm not sure if that's exactly the desired behavior so I'm happy to adjust if that seems wrong.

## Testing

Tested with `cargo run -p ci`. I think that should be sufficient to call things good.

## Migration Guide

The most likely migration needed is changing code from this:

```
        let mut entity = commands.get_or_spawn(entity);

        if depth_prepass {
            entity.insert(DepthPrepass);
        }
        if normal_prepass {
            entity.insert(NormalPrepass);
        }
        if motion_vector_prepass {
            entity.insert(MotionVectorPrepass);
        }
        if deferred_prepass {
            entity.insert(DeferredPrepass);
        }
```

to this:

```
        let mut entity = commands.get_or_spawn(entity);

        if depth_prepass {
            entity = entity.insert(DepthPrepass);
        }
        if normal_prepass {
            entity = entity.insert(NormalPrepass);
        }
        if motion_vector_prepass {
            entity = entity.insert(MotionVectorPrepass);
        }
        if deferred_prepass {
            entity.insert(DeferredPrepass);
        }
```

as can be seen in several of the example code updates here. There will probably also be instances where mutable `EntityCommands` vars no longer need to be mutable.