### PR TITLE
Rename `Commands::register_one_shot_system` -> `register_system`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -687,7 +687,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///     if let Some(system) = *local_system {
     ///         commands.run_system(system);
     ///     } else {
-    ///         *local_system = Some(commands.register_one_shot_system(increment_counter));
+    ///         *local_system = Some(commands.register_system(increment_counter));
     ///     }
     /// }
     ///
@@ -700,7 +700,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # let mut queue_1 = CommandQueue::default();
     /// # let systemid = {
     /// #   let mut commands = Commands::new(&mut queue_1, &world);
-    /// #   commands.register_one_shot_system(increment_counter)
+    /// #   commands.register_system(increment_counter)
     /// # };
     /// # let mut queue_2 = CommandQueue::default();
     /// # {
@@ -712,7 +712,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # assert_eq!(1, world.resource::<Counter>().0);
     /// # bevy_ecs::system::assert_is_system(register_system);
     /// ```
-    pub fn register_one_shot_system<
+    pub fn register_system<
         I: 'static + Send,
         O: 'static + Send,
         M,

--- a/examples/ecs/one_shot_systems.rs
+++ b/examples/ecs/one_shot_systems.rs
@@ -40,7 +40,7 @@ struct A;
 struct B;
 
 fn setup_with_commands(mut commands: Commands) {
-    let system_id = commands.register_one_shot_system(system_a);
+    let system_id = commands.register_system(system_a);
     commands.spawn((Callback(system_id), A));
 }
 

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -70,9 +70,9 @@ struct LevelData {
 
 fn setup(mut commands: Commands) {
     let level_data = LevelData {
-        unload_level_id: commands.register_one_shot_system(unload_current_level),
-        level_1_id: commands.register_one_shot_system(load_level_1),
-        level_2_id: commands.register_one_shot_system(load_level_2),
+        unload_level_id: commands.register_system(unload_current_level),
+        level_1_id: commands.register_system(load_level_1),
+        level_2_id: commands.register_system(load_level_2),
     };
     commands.insert_resource(level_data);
 


### PR DESCRIPTION
# Objective

Improve naming consistency for functions that deal with one-shot systems via `SystemId`:

- `App::register_system`
- `SubApp::register_system`
- `World::run_system`
- `World::register_system`
- `Commands::run_system`
- :x: `Commands::register_one_shot_system`

## Solution

Rename `Commands::register_one_shot_system` -> `register_system`.

## Testing

Not tested besides CI.

## Migration Guide

`Commands::register_one_shot_system` has been renamed to `register_system`.