### PR TITLE
Allow removing asset from embedded asset registry

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -52,6 +52,12 @@ impl EmbeddedAssetRegistry {
         self.dir.insert_meta(asset_path, value);
     }
 
+    /// Removes an asset stored using `full_path` (the full path as [`file`] would return for that file, if it was capable of
+    /// running in a non-rust file). If no asset is stored with that name its a no-op.
+    pub fn remove_asset(&self, full_path: &Path) {
+        self.dir.remove_asset(full_path);
+    }
+
     /// Registers a `embedded` [`AssetSource`] that uses this [`EmbeddedAssetRegistry`].
     // NOTE: unused_mut because embedded_watcher feature is the only mutable consumer of `let mut source`
     #[allow(unused_mut)]

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -53,9 +53,10 @@ impl EmbeddedAssetRegistry {
     }
 
     /// Removes an asset stored using `full_path` (the full path as [`file`] would return for that file, if it was capable of
-    /// running in a non-rust file). If no asset is stored with that name its a no-op.
-    pub fn remove_asset(&self, full_path: &Path) {
-        self.dir.remove_asset(full_path);
+    /// running in a non-rust file). If no asset is stored with at `full_path` its a no-op.
+    /// It returning `Option` contains the originally stored `Data` or `None`.
+    pub fn remove_asset(&self, full_path: &Path) -> Option<super::memory::Data> {
+        self.dir.remove_asset(full_path)
     }
 
     /// Registers a `embedded` [`AssetSource`] that uses this [`EmbeddedAssetRegistry`].
@@ -306,7 +307,7 @@ macro_rules! load_internal_binary_asset {
 
 #[cfg(test)]
 mod tests {
-    use super::_embedded_asset_path;
+    use super::{EmbeddedAssetRegistry, _embedded_asset_path};
     use std::path::Path;
 
     // Relative paths show up if this macro is being invoked by a local crate.
@@ -409,5 +410,14 @@ mod tests {
         );
         // Really, should be "my_crate/src/the/asset.png"
         assert_eq!(asset_path, Path::new("my_crate/the/asset.png"));
+    }
+
+    #[test]
+    fn remove_embedded_asset() {
+        let reg = EmbeddedAssetRegistry::default();
+        let path = std::path::PathBuf::from("a/b/asset.png");
+        reg.insert_asset(path.clone().into(), &path, &[]);
+        assert!(reg.remove_asset(&path).is_some());
+        assert!(reg.remove_asset(&path).is_none());
     }
 }

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -416,7 +416,7 @@ mod tests {
     fn remove_embedded_asset() {
         let reg = EmbeddedAssetRegistry::default();
         let path = std::path::PathBuf::from("a/b/asset.png");
-        reg.insert_asset(path.clone().into(), &path, &[]);
+        reg.insert_asset(path.clone(), &path, &[]);
         assert!(reg.remove_asset(&path).is_some());
         assert!(reg.remove_asset(&path).is_none());
     }

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -417,7 +417,9 @@ mod tests {
         let reg = EmbeddedAssetRegistry::default();
         let path = std::path::PathBuf::from("a/b/asset.png");
         reg.insert_asset(path.clone(), &path, &[]);
+        assert!(reg.dir.get_asset(&path).is_some());
         assert!(reg.remove_asset(&path).is_some());
+        assert!(reg.dir.get_asset(&path).is_none());
         assert!(reg.remove_asset(&path).is_none());
     }
 }

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -55,13 +55,14 @@ impl Dir {
         );
     }
 
-    pub fn remove_asset(&self, path: &Path) {
+    pub fn remove_asset(&self, path: &Path) -> Option<Data> {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {
             dir = self.get_or_insert_dir(parent);
         }
         let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
-        dir.0.write().assets.remove(&key);
+        let data = dir.0.write().assets.remove(&key);
+        data
     }
 
     pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -55,6 +55,15 @@ impl Dir {
         );
     }
 
+    pub fn remove_asset(&self, path: &Path) {
+        let mut dir = self.clone();
+        if let Some(parent) = path.parent() {
+            dir = self.get_or_insert_dir(parent);
+        }
+        let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
+        dir.0.write().assets.remove(&key);
+    }
+
     pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -55,6 +55,7 @@ impl Dir {
         );
     }
 
+    /// Removes the stored asset at `path` and returns the `Data` stored if found and otherwise `None`.
     pub fn remove_asset(&self, path: &Path) -> Option<Data> {
         let mut dir = self.clone();
         if let Some(parent) = path.parent() {


### PR DESCRIPTION
# Objective

- Allow not only inserting `Data` into `EmbeddedAssetRegistry` and `Dir` in turn but now also removing it again.
- This way when used to embed asset data from *somewhere* but not load it using the conventional means via `AssetServer` (which I observed takes ownership of the `Data`) the `Data` does not need to stay in memory of the `EmbeddedAssetRegistry` throughout the lifetime of the application.

## Solution

- added the `remove_asset` functions in `EmbeddedAssetRegistry` and `Dir`

## Testing

- added a module unittest
- does this require changes if build with feature `embedded_watcher`?