### PR TITLE
Make ActiveAnimation::set_weight return &mut Self

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -442,8 +442,9 @@ impl ActiveAnimation {
     }
 
     /// Sets the weight of this animation.
-    pub fn set_weight(&mut self, weight: f32) {
+    pub fn set_weight(&mut self, weight: f32) -> &mut Self {
         self.weight = weight;
+        self
     }
 
     /// Pause the animation.


### PR DESCRIPTION
# Objective

Fixes #14907.

## Solution

Changes `ActiveAnimation::set_weight` to return `&mut Self`.

## Testing

Simple API change, I don't think this needs explicit testing.