### PR TITLE
add `Interval::UNIT` constant

### DIFF
--- a/crates/bevy_math/src/curve/interval.rs
+++ b/crates/bevy_math/src/curve/interval.rs
@@ -65,6 +65,12 @@ impl Interval {
         }
     }
 
+    /// The unit interval covering the range between `0.0` and `1.0`.
+    pub const UNIT: Self = Self {
+        start: 0.0,
+        end: 1.0,
+    };
+
     /// An interval which stretches across the entire real line from negative infinity to infinity.
     pub const EVERYWHERE: Self = Self {
         start: f32::NEG_INFINITY,
@@ -255,16 +261,12 @@ mod tests {
         let ivl5 = interval(f32::NEG_INFINITY, 0.0).unwrap();
         let ivl6 = Interval::EVERYWHERE;
 
-        assert!(ivl1
-            .intersect(ivl2)
-            .is_ok_and(|ivl| ivl == interval(0.0, 1.0).unwrap()));
+        assert!(ivl1.intersect(ivl2).is_ok_and(|ivl| ivl == Interval::UNIT));
         assert!(ivl1
             .intersect(ivl3)
             .is_ok_and(|ivl| ivl == interval(-1.0, 0.0).unwrap()));
         assert!(ivl2.intersect(ivl3).is_err());
-        assert!(ivl1
-            .intersect(ivl4)
-            .is_ok_and(|ivl| ivl == interval(0.0, 1.0).unwrap()));
+        assert!(ivl1.intersect(ivl4).is_ok_and(|ivl| ivl == Interval::UNIT));
         assert!(ivl1
             .intersect(ivl5)
             .is_ok_and(|ivl| ivl == interval(-1.0, 0.0).unwrap()));
@@ -276,7 +278,7 @@ mod tests {
 
     #[test]
     fn containment() {
-        let ivl = interval(0.0, 1.0).unwrap();
+        let ivl = Interval::UNIT;
         assert!(ivl.contains(0.0));
         assert!(ivl.contains(1.0));
         assert!(ivl.contains(0.5));
@@ -295,7 +297,7 @@ mod tests {
 
     #[test]
     fn interval_containment() {
-        let ivl = interval(0.0, 1.0).unwrap();
+        let ivl = Interval::UNIT;
         assert!(ivl.contains_interval(interval(-0.0, 0.5).unwrap()));
         assert!(ivl.contains_interval(interval(0.5, 1.0).unwrap()));
         assert!(ivl.contains_interval(interval(0.25, 0.75).unwrap()));
@@ -323,18 +325,18 @@ mod tests {
     #[test]
     fn linear_maps() {
         let ivl1 = interval(-3.0, 5.0).unwrap();
-        let ivl2 = interval(0.0, 1.0).unwrap();
+        let ivl2 = Interval::UNIT;
         let map = ivl1.linear_map_to(ivl2);
         assert!(map.is_ok_and(|f| f(-3.0).abs_diff_eq(&0.0, f32::EPSILON)
             && f(5.0).abs_diff_eq(&1.0, f32::EPSILON)
             && f(1.0).abs_diff_eq(&0.5, f32::EPSILON)));
 
-        let ivl1 = interval(0.0, 1.0).unwrap();
+        let ivl1 = Interval::UNIT;
         let ivl2 = Interval::EVERYWHERE;
         assert!(ivl1.linear_map_to(ivl2).is_err());
 
         let ivl1 = interval(f32::NEG_INFINITY, -4.0).unwrap();
-        let ivl2 = interval(0.0, 1.0).unwrap();
+        let ivl2 = Interval::UNIT;
         assert!(ivl1.linear_map_to(ivl2).is_err());
     }
 

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -78,7 +78,7 @@ pub trait Curve<T> {
     /// factor rather than multiplying:
     /// ```
     /// # use bevy_math::curve::*;
-    /// let my_curve = constant_curve(interval(0.0, 1.0).unwrap(), 1.0);
+    /// let my_curve = constant_curve(Interval::UNIT, 1.0);
     /// let scaled_curve = my_curve.reparametrize(interval(0.0, 2.0).unwrap(), |t| t / 2.0);
     /// ```
     /// This kind of linear remapping is provided by the convenience method
@@ -89,17 +89,17 @@ pub trait Curve<T> {
     /// // Reverse a curve:
     /// # use bevy_math::curve::*;
     /// # use bevy_math::vec2;
-    /// let my_curve = constant_curve(interval(0.0, 1.0).unwrap(), 1.0);
+    /// let my_curve = constant_curve(Interval::UNIT, 1.0);
     /// let domain = my_curve.domain();
     /// let reversed_curve = my_curve.reparametrize(domain, |t| domain.end() - t);
     ///
     /// // Take a segment of a curve:
-    /// # let my_curve = constant_curve(interval(0.0, 1.0).unwrap(), 1.0);
+    /// # let my_curve = constant_curve(Interval::UNIT, 1.0);
     /// let curve_segment = my_curve.reparametrize(interval(0.0, 0.5).unwrap(), |t| 0.5 + t);
     ///
     /// // Reparametrize by an easing curve:
-    /// # let my_curve = constant_curve(interval(0.0, 1.0).unwrap(), 1.0);
-    /// # let easing_curve = constant_curve(interval(0.0, 1.0).unwrap(), vec2(1.0, 1.0));
+    /// # let my_curve = constant_curve(Interval::UNIT, 1.0);
+    /// # let easing_curve = constant_curve(Interval::UNIT, vec2(1.0, 1.0));
     /// let domain = my_curve.domain();
     /// let eased_curve = my_curve.reparametrize(domain, |t| easing_curve.sample_unchecked(t).y);
     /// ```
@@ -386,7 +386,7 @@ pub trait Curve<T> {
     /// # Example
     /// ```
     /// # use bevy_math::curve::*;
-    /// let my_curve = function_curve(interval(0.0, 1.0).unwrap(), |t| t * t + 1.0);
+    /// let my_curve = function_curve(Interval::UNIT, |t| t * t + 1.0);
     /// // Borrow `my_curve` long enough to resample a mapped version. Note that `map` takes
     /// // ownership of its input.
     /// let samples = my_curve.by_ref().map(|x| x * 2.0).resample_auto(100).unwrap();
@@ -980,7 +980,7 @@ mod tests {
         let curve = constant_curve(Interval::EVERYWHERE, 5.0);
         assert!(curve.sample_unchecked(-35.0) == 5.0);
 
-        let curve = constant_curve(interval(0.0, 1.0).unwrap(), true);
+        let curve = constant_curve(Interval::UNIT, true);
         assert!(curve.sample_unchecked(2.0));
         assert!(curve.sample(2.0).is_none());
     }
@@ -1008,11 +1008,11 @@ mod tests {
         );
         assert_eq!(mapped_curve.domain(), Interval::EVERYWHERE);
 
-        let curve = function_curve(interval(0.0, 1.0).unwrap(), |t| t * TAU);
+        let curve = function_curve(Interval::UNIT, |t| t * TAU);
         let mapped_curve = curve.map(Quat::from_rotation_z);
         assert_eq!(mapped_curve.sample_unchecked(0.0), Quat::IDENTITY);
         assert!(mapped_curve.sample_unchecked(1.0).is_near_identity());
-        assert_eq!(mapped_curve.domain(), interval(0.0, 1.0).unwrap());
+        assert_eq!(mapped_curve.domain(), Interval::UNIT);
     }
 
     #[test]
@@ -1028,18 +1028,16 @@ mod tests {
             interval(0.0, f32::INFINITY).unwrap()
         );
 
-        let reparametrized_curve = curve
-            .by_ref()
-            .reparametrize(interval(0.0, 1.0).unwrap(), |t| t + 1.0);
+        let reparametrized_curve = curve.by_ref().reparametrize(Interval::UNIT, |t| t + 1.0);
         assert_abs_diff_eq!(reparametrized_curve.sample_unchecked(0.0), 0.0);
         assert_abs_diff_eq!(reparametrized_curve.sample_unchecked(1.0), 1.0);
-        assert_eq!(reparametrized_curve.domain(), interval(0.0, 1.0).unwrap());
+        assert_eq!(reparametrized_curve.domain(), Interval::UNIT);
     }
 
     #[test]
     fn multiple_maps() {
         // Make sure these actually happen in the right order.
-        let curve = function_curve(interval(0.0, 1.0).unwrap(), ops::exp2);
+        let curve = function_curve(Interval::UNIT, ops::exp2);
         let first_mapped = curve.map(ops::log2);
         let second_mapped = first_mapped.map(|x| x * -2.0);
         assert_abs_diff_eq!(second_mapped.sample_unchecked(0.0), 0.0);
@@ -1050,9 +1048,9 @@ mod tests {
     #[test]
     fn multiple_reparams() {
         // Make sure these happen in the right order too.
-        let curve = function_curve(interval(0.0, 1.0).unwrap(), ops::exp2);
+        let curve = function_curve(Interval::UNIT, ops::exp2);
         let first_reparam = curve.reparametrize(interval(1.0, 2.0).unwrap(), ops::log2);
-        let second_reparam = first_reparam.reparametrize(interval(0.0, 1.0).unwrap(), |t| t + 1.0);
+        let second_reparam = first_reparam.reparametrize(Interval::UNIT, |t| t + 1.0);
         assert_abs_diff_eq!(second_reparam.sample_unchecked(0.0), 1.0);
         assert_abs_diff_eq!(second_reparam.sample_unchecked(0.5), 1.5);
         assert_abs_diff_eq!(second_reparam.sample_unchecked(1.0), 2.0);


### PR DESCRIPTION
# Objective

This is a value that is and will be used as a domain of curves pretty often. By adding it as a dedicated constant we can get rid of some `unwraps` and function calls.

## Solution

added `Interval::UNIT`

## Testing

I replaced all occurrences of `interval(0.0, 1.0).unwrap()` with the new `Interval::UNIT` constant in tests and doc tests.
