### PR TITLE
rename Drop to bevy::picking::events::DragDrop to unclash std::ops:Drop

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -26,7 +26,7 @@ pub struct Pointer<E: Debug + Clone + Reflect> {
     pub pointer_id: PointerId,
     /// The location of the pointer during this event
     pub pointer_location: Location,
-    /// Additional event-specific data. [`Drop`] for example, has an additional field to describe
+    /// Additional event-specific data. [`DragDrop`] for example, has an additional field to describe
     /// the `Entity` that is being dropped on the target.
     pub event: E,
 }
@@ -193,7 +193,7 @@ pub struct DragLeave {
 
 /// Fires when a pointer drops the `dropped` entity onto the `target` entity.
 #[derive(Clone, PartialEq, Debug, Reflect)]
-pub struct Drop {
+pub struct DragDrop {
     /// Pointer button lifted to drop.
     pub button: PointerButton,
     /// The entity that was dropped onto the `target` entity.
@@ -626,7 +626,7 @@ pub fn send_drag_over_events(
                 pointer_id,
                 pointer_location.clone(),
                 target,
-                Drop {
+                DragDrop {
                     button,
                     dropped: target,
                     hit: hit.clone(),

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -517,7 +517,7 @@ pub fn send_drag_over_events(
     //  - Pointer<DragEnter>,
     //  - Pointer<DragOver>,
     //  - Pointer<DragLeave>,
-    //  - Pointer<Drop>,
+    //  - Pointer<DragDrop>,
     mut commands: Commands,
     // Input
     drag_map: Res<DragMap>,


### PR DESCRIPTION
# Objective

- Fixes #14902
- > #14686 Introduced a name clash when using use bevy::prelude::*;


## Solution

- renamed `bevy::picking::events::Drop` `bevy::picking::events::DragDrop`

 
## Testing

- Not being used in tests or examples, so I just compiled.

---

</details>

## Migration Guide

- Rename `Drop` to `DragDrop`
  - `bevy::picking::events::Drop`  is now `bevy::picking::events::DragDrop`
