### PR TITLE
Remove sparse set in Table storage

### DIFF
--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -154,7 +154,7 @@ pub(crate) fn world_query_impl(
             unsafe fn set_table<'__w>(
                 _fetch: &mut <Self as #path::query::WorldQuery>::Fetch<'__w>,
                 _state: &Self::State,
-                _archetype_id: ArchetypeId,
+                _archetype_id: #path::archetype::ArchetypeId,
                 _table: &'__w #path::storage::Table
             ) {
                 #(<#field_types>::set_table(&mut _fetch.#named_field_idents, &_state.#named_field_idents, _archetype_id, _table);)*

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -154,9 +154,10 @@ pub(crate) fn world_query_impl(
             unsafe fn set_table<'__w>(
                 _fetch: &mut <Self as #path::query::WorldQuery>::Fetch<'__w>,
                 _state: &Self::State,
+                _archetype_id: ArchetypeId,
                 _table: &'__w #path::storage::Table
             ) {
-                #(<#field_types>::set_table(&mut _fetch.#named_field_idents, &_state.#named_field_idents, _table);)*
+                #(<#field_types>::set_table(&mut _fetch.#named_field_idents, &_state.#named_field_idents, _archetype_id, _table);)*
             }
 
             /// SAFETY: we call `fetch` for each member that implements `Fetch`.

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -733,12 +733,14 @@ impl SparseSetIndex for ArchetypeComponentId {
 /// along with an [`ArchetypeRecord`] which contains some metadata about how the component is stored in the archetype.
 #[derive(Default, Debug)]
 pub struct ComponentIndex {
-    index: HashMap<ComponentId, HashMap<ArchetypeId, ArchetypeRecord>>
+    index: HashMap<ComponentId, HashMap<ArchetypeId, ArchetypeRecord>>,
 }
 
 impl ComponentIndex {
-
-    pub(crate) fn get(&self, component_id: &ComponentId) -> Option<&HashMap<ArchetypeId, ArchetypeRecord>> {
+    pub(crate) fn get(
+        &self,
+        component_id: &ComponentId,
+    ) -> Option<&HashMap<ArchetypeId, ArchetypeRecord>> {
         self.index.get(component_id)
     }
 
@@ -746,8 +748,13 @@ impl ComponentIndex {
     ///
     /// [`Column`]: crate::storage::Column
     /// [`Table`]: crate::storage::Table
-    pub(crate) fn get_column_index(&self, component_id: ComponentId, archetype_id: ArchetypeId) -> Option<usize> {
-        self.index.get(&component_id)
+    pub(crate) fn get_column_index(
+        &self,
+        component_id: ComponentId,
+        archetype_id: ArchetypeId,
+    ) -> Option<usize> {
+        self.index
+            .get(&component_id)
             .and_then(|data| data.get(&archetype_id))
             .and_then(|record| record.column)
     }
@@ -773,7 +780,6 @@ pub struct Archetypes {
 pub struct ArchetypeRecord {
     /// Index of the component in the archetype's [`Table`](crate::storage::Table),
     /// or None if the component is a sparse set component.
-    #[allow(dead_code)]
     pub(crate) column: Option<usize>,
 }
 
@@ -977,7 +983,6 @@ impl Archetypes {
             }
         }
     }
-
 }
 
 impl Index<RangeFrom<ArchetypeGeneration>> for Archetypes {

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -731,8 +731,6 @@ impl SparseSetIndex for ArchetypeComponentId {
 /// along with an [`ArchetypeRecord`] which contains some metadata about how the component is stored in the archetype.
 pub type ComponentIndex = HashMap<ComponentId, HashMap<ArchetypeId, ArchetypeRecord>>;
 
-
-
 /// The backing store of all [`Archetype`]s within a [`World`].
 ///
 /// For more information, see the *[module level documentation]*.
@@ -749,7 +747,6 @@ pub struct Archetypes {
 }
 
 /// Metadata about how a component is stored in an [`Archetype`].
-#[derive(Copy)]
 pub struct ArchetypeRecord {
     /// Index of the component in the archetype's [`Table`](crate::storage::Table),
     /// or None if the component is a sparse set component.
@@ -958,10 +955,6 @@ impl Archetypes {
         }
     }
 
-    pub(crate) fn get_archetype_record(&self, component_id: ComponentId, archetype_id: ArchetypeId) -> Option<ArchetypeRecord> {
-        self.by_component.get()
-
-    }
 }
 
 impl Index<RangeFrom<ArchetypeGeneration>> for Archetypes {

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -731,6 +731,8 @@ impl SparseSetIndex for ArchetypeComponentId {
 /// along with an [`ArchetypeRecord`] which contains some metadata about how the component is stored in the archetype.
 pub type ComponentIndex = HashMap<ComponentId, HashMap<ArchetypeId, ArchetypeRecord>>;
 
+
+
 /// The backing store of all [`Archetype`]s within a [`World`].
 ///
 /// For more information, see the *[module level documentation]*.
@@ -747,6 +749,7 @@ pub struct Archetypes {
 }
 
 /// Metadata about how a component is stored in an [`Archetype`].
+#[derive(Copy)]
 pub struct ArchetypeRecord {
     /// Index of the component in the archetype's [`Table`](crate::storage::Table),
     /// or None if the component is a sparse set component.
@@ -953,6 +956,11 @@ impl Archetypes {
                     .set(flags, set);
             }
         }
+    }
+
+    pub(crate) fn get_archetype_record(&self, component_id: ComponentId, archetype_id: ArchetypeId) -> Option<ArchetypeRecord> {
+        self.by_component.get()
+
     }
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -737,6 +737,11 @@ pub struct ComponentIndex {
 }
 
 impl ComponentIndex {
+
+    pub(crate) fn get(&self, component_id: &ComponentId) -> Option<&HashMap<ArchetypeId, ArchetypeRecord>> {
+        self.index.get(component_id)
+    }
+
     /// Retrieve the [`Column`] index for the [`ComponentId`] in the [`Table`] corresponding to the [`ArchetypeId`]
     ///
     /// [`Column`]: crate::storage::Column

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -20,12 +20,12 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, ON_ADD, ON_INSERT, ON_REPLACE},
 };
 
+use crate::archetype::ComponentIndex;
 use bevy_ptr::{ConstNonNull, OwningPtr};
 use bevy_utils::{all_tuples, HashMap, HashSet, TypeIdMap};
 #[cfg(feature = "track_change_detection")]
 use std::panic::Location;
 use std::ptr::NonNull;
-use crate::archetype::ComponentIndex;
 
 /// The `Bundle` trait enables insertion and removal of [`Component`]s from an entity.
 ///
@@ -434,7 +434,9 @@ impl BundleInfo {
                 StorageType::Table => {
                     // SAFETY: If component_id is in self.component_ids, BundleInfo::new requires that
                     // the target table contains the component.
-                    let column_index = component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
+                    let column_index = component_index
+                        .get_column_index(component_id, archetype_id)
+                        .debug_checked_unwrap();
                     let column =
                         // SAFETY: If the component_id is present in the ComponentIndex, then the table has a column for that column_index
                         unsafe { table.get_column_mut(column_index).debug_checked_unwrap() };
@@ -842,7 +844,12 @@ impl<'w> BundleInserter<'w> {
                 }
                 // PERF: store "non bundle" components in edge, then just move those to avoid
                 // redundant copies
-                let move_result = table.move_to_superset_unchecked(result.table_row, new_table, self.world.archetypes().component_index(), new_archetype.id());
+                let move_result = table.move_to_superset_unchecked(
+                    result.table_row,
+                    new_table,
+                    self.world.archetypes().component_index(),
+                    new_archetype.id(),
+                );
                 let new_location = new_archetype.allocate(entity, move_result.new_row);
                 entities.set(entity.index(), new_location);
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1918,8 +1918,8 @@ macro_rules! impl_anytuple_fetch {
 
             #[inline]
             #[allow(clippy::unused_unit)]
-            unsafe fn init_fetch<'w>(world: UnsafeWorldCell<'w>, state: &Self::State, _last_run: Tick, _this_run: Tick) -> Self::Fetch<'w> {
-                let index = world.archetypes().component_index();
+            unsafe fn init_fetch<'w>(_world: UnsafeWorldCell<'w>, state: &Self::State, _last_run: Tick, _this_run: Tick) -> Self::Fetch<'w> {
+                let index = _world.archetypes().component_index();
                 let ($($name,)*) = state;
                  // SAFETY: The invariants are uphold by the caller.
                 (index, ($(( unsafe { $name::init_fetch(_world, $name, _last_run, _this_run) }, false),)*))

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1,3 +1,4 @@
+use crate::archetype::{ArchetypeId, ComponentIndex};
 use crate::{
     archetype::{Archetype, Archetypes},
     change_detection::{MaybeThinSlicePtrLocation, Ticks, TicksMut},
@@ -13,7 +14,6 @@ use crate::{
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData};
-use crate::archetype::{ArchetypeId, ComponentIndex};
 
 /// Types that can be fetched from a [`World`] using a [`Query`].
 ///
@@ -324,7 +324,12 @@ unsafe impl WorldQuery for Entity {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId, _table: &'w Table) {
+    unsafe fn set_table<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &'w Table,
+    ) {
     }
 
     #[inline(always)]
@@ -399,7 +404,12 @@ unsafe impl WorldQuery for EntityLocation {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId, _table: &'w Table) {
+    unsafe fn set_table<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &'w Table,
+    ) {
     }
 
     #[inline(always)]
@@ -474,7 +484,12 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State,  _archetype_id: ArchetypeId, _table: &'w Table) {
+    unsafe fn set_table<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &'w Table,
+    ) {
     }
 
     #[inline(always)]
@@ -554,7 +569,12 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId, _table: &'w Table) {
+    unsafe fn set_table<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &'w Table,
+    ) {
     }
 
     #[inline(always)]
@@ -640,10 +660,20 @@ unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, archetype_id: ArchetypeId, table: &'w Table) {
+    unsafe fn set_table<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype_id: ArchetypeId,
+        table: &'w Table,
+    ) {
         let mut access = Access::default();
         state.access.component_reads().for_each(|id| {
-            let column_index = fetch.0.archetypes().component_index().get_column_index(id, archetype_id).debug_checked_unwrap();
+            let column_index = fetch
+                .0
+                .archetypes()
+                .component_index()
+                .get_column_index(id, archetype_id)
+                .debug_checked_unwrap();
             if table.has_column(column_index) {
                 access.add_component_read(id);
             }
@@ -753,17 +783,26 @@ unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, archetype_id: ArchetypeId, table: &'w Table) {
+    unsafe fn set_table<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype_id: ArchetypeId,
+        table: &'w Table,
+    ) {
         let mut access = Access::default();
         let component_index = fetch.0.archetypes().component_index();
         state.access.component_reads().for_each(|id| {
-            let column_index = component_index.get_column_index(id, archetype_id).debug_checked_unwrap();
+            let column_index = component_index
+                .get_column_index(id, archetype_id)
+                .debug_checked_unwrap();
             if table.has_column(column_index) {
                 access.add_component_read(id);
             }
         });
         state.access.component_writes().for_each(|id| {
-            let column_index = component_index.get_column_index(id, archetype_id).debug_checked_unwrap();
+            let column_index = component_index
+                .get_column_index(id, archetype_id)
+                .debug_checked_unwrap();
             if table.has_column(column_index) {
                 access.add_component_write(id);
             }
@@ -859,7 +898,12 @@ unsafe impl WorldQuery for &Archetype {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId,  _table: &'w Table) {
+    unsafe fn set_table<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &'w Table,
+    ) {
     }
 
     #[inline(always)]
@@ -988,7 +1032,10 @@ unsafe impl<T: Component> WorldQuery for &T {
         archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
-        let column = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
+        let column = fetch
+            .component_index
+            .get_column_index(component_id, archetype_id)
+            .debug_checked_unwrap();
         fetch.table_components = Some(
             table
                 .get_column(column)
@@ -1157,7 +1204,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
-        let column_index = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
+        let column_index = fetch
+            .component_index
+            .get_column_index(component_id, archetype_id)
+            .debug_checked_unwrap();
         let column = table.get_column(column_index).debug_checked_unwrap();
         fetch.table_data = Some((
             column.get_data_slice().into(),
@@ -1360,7 +1410,10 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
-        let column_index = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
+        let column_index = fetch
+            .component_index
+            .get_column_index(component_id, archetype_id)
+            .debug_checked_unwrap();
         let column = table.get_column(column_index).debug_checked_unwrap();
         fetch.table_data = Some((
             column.get_data_slice().into(),
@@ -1511,7 +1564,12 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
 
     #[inline]
     // Forwarded to `&mut T`
-    unsafe fn set_table<'w>(fetch: &mut WriteFetch<'w, T>, state: &ComponentId, archetype_id: ArchetypeId, table: &'w Table) {
+    unsafe fn set_table<'w>(
+        fetch: &mut WriteFetch<'w, T>,
+        state: &ComponentId,
+        archetype_id: ArchetypeId,
+        table: &'w Table,
+    ) {
         <&mut T as WorldQuery>::set_table(fetch, state, archetype_id, table);
     }
 
@@ -1638,11 +1696,17 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(fetch: &mut OptionFetch<'w, T>, state: &T::State, archetype_id: ArchetypeId, table: &'w Table) {
+    unsafe fn set_table<'w>(
+        fetch: &mut OptionFetch<'w, T>,
+        state: &T::State,
+        archetype_id: ArchetypeId,
+        table: &'w Table,
+    ) {
         fetch.matches = T::matches_component_set(state, &|id| {
-            fetch.component_index.get_column_index(id, archetype_id).is_some_and(
-                |column_index| table.has_column(column_index)
-            )
+            fetch
+                .component_index
+                .get_column_index(id, archetype_id)
+                .is_some_and(|column_index| table.has_column(column_index))
         });
         if fetch.matches {
             // SAFETY: The invariants are uphold by the caller.
@@ -1818,9 +1882,16 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
     }
 
     #[inline]
-    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, archetype_id: ArchetypeId, table: &'w Table) {
-        let column_index = fetch.1.get_column_index(*state, archetype_id).debug_checked_unwrap();
-        fetch.0 = table.has_column(column_index);
+    unsafe fn set_table<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype_id: ArchetypeId,
+        table: &'w Table,
+    ) {
+        fetch.0 = fetch
+            .1
+            .get_column_index(*state, archetype_id)
+            .is_some_and(|column_index| table.has_column(column_index));
     }
 
     #[inline(always)]
@@ -2077,7 +2148,13 @@ unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
     }
 
     #[inline(always)]
-    unsafe fn set_table<'w>(_fetch: &mut (), _state: &D::State, _archetype_id: ArchetypeId, _table: &Table) {}
+    unsafe fn set_table<'w>(
+        _fetch: &mut (),
+        _state: &D::State,
+        _archetype_id: ArchetypeId,
+        _table: &Table,
+    ) {
+    }
 
     #[inline(always)]
     unsafe fn fetch<'w>(
@@ -2147,7 +2224,12 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     ) {
     }
 
-    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId, _table: &'w Table) {
+    unsafe fn set_table<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &'w Table,
+    ) {
     }
 
     unsafe fn fetch<'w>(

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1946,18 +1946,18 @@ macro_rules! impl_anytuple_fetch {
             }
 
             #[inline]
-            unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, archetype_id: ArchetypeId, _table: &'w Table) {
-                let (index, ($($name,)*)) = _fetch;
+            unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId, _table: &'w Table) {
+                let (_index, ($($name,)*)) = _fetch;
                 let ($($state,)*) = _state;
                 $(
                     $name.1 = $name::matches_component_set($state, &|id| {
-                        index.get_column_index(id, archetype_id).is_some_and(
+                        _index.get_column_index(id, _archetype_id).is_some_and(
                             |column_index| _table.has_column(column_index)
                         )
-                    };
+                    });
                     if $name.1 {
                          // SAFETY: The invariants are required to be upheld by the caller.
-                        unsafe { $name::set_table(&mut $name.0, $state, archetype_id, _table); }
+                        unsafe { $name::set_table(&mut $name.0, $state, _archetype_id, _table); }
                     }
                 )*
             }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -664,17 +664,17 @@ unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
         fetch: &mut Self::Fetch<'w>,
         state: &Self::State,
         archetype_id: ArchetypeId,
-        table: &'w Table,
+        _table: &'w Table,
     ) {
         let mut access = Access::default();
         state.access.component_reads().for_each(|id| {
-            let column_index = fetch
+            let has_column = fetch
                 .0
                 .archetypes()
                 .component_index()
                 .get_column_index(id, archetype_id)
-                .debug_checked_unwrap();
-            if table.has_column(column_index) {
+                .is_some();
+            if has_column {
                 access.add_component_read(id);
             }
         });
@@ -792,18 +792,18 @@ unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
         let mut access = Access::default();
         let component_index = fetch.0.archetypes().component_index();
         state.access.component_reads().for_each(|id| {
-            let column_index = component_index
+            let has_column = component_index
                 .get_column_index(id, archetype_id)
-                .debug_checked_unwrap();
-            if table.has_column(column_index) {
+                .is_some();
+            if has_column {
                 access.add_component_read(id);
             }
         });
         state.access.component_writes().for_each(|id| {
-            let column_index = component_index
+            let has_column = component_index
                 .get_column_index(id, archetype_id)
-                .debug_checked_unwrap();
-            if table.has_column(column_index) {
+                .is_some();
+            if has_column {
                 access.add_component_write(id);
             }
         });

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,3 +1,4 @@
+use crate::archetype::{ArchetypeId, ComponentIndex};
 use crate::{
     archetype::Archetype,
     component::{Component, ComponentId, Components, StorageType, Tick},
@@ -9,7 +10,6 @@ use crate::{
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData};
-use crate::archetype::{ArchetypeId, ComponentIndex};
 
 /// Types that filter the results of a [`Query`].
 ///
@@ -171,7 +171,13 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     }
 
     #[inline]
-    unsafe fn set_table(_fetch: &mut (), _state: &ComponentId, _archetype_id: ArchetypeId, _table: &Table) {}
+    unsafe fn set_table(
+        _fetch: &mut (),
+        _state: &ComponentId,
+        _archetype_id: ArchetypeId,
+        _table: &Table,
+    ) {
+    }
 
     #[inline(always)]
     unsafe fn fetch<'w>(
@@ -281,7 +287,13 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     }
 
     #[inline]
-    unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _archetype_id: ArchetypeId, _table: &Table) {}
+    unsafe fn set_table(
+        _fetch: &mut (),
+        _state: &Self::State,
+        _archetype_id: ArchetypeId,
+        _table: &Table,
+    ) {
+    }
 
     #[inline(always)]
     unsafe fn fetch<'w>(
@@ -688,7 +700,10 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
-        let column_index = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
+        let column_index = fetch
+            .component_index
+            .get_column_index(component_id, archetype_id)
+            .debug_checked_unwrap();
         fetch.table_ticks = Some(
             Column::get_added_ticks_slice(table.get_column(column_index).debug_checked_unwrap())
                 .into(),
@@ -907,7 +922,10 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
-        let column_index = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
+        let column_index = fetch
+            .component_index
+            .get_column_index(component_id, archetype_id)
+            .debug_checked_unwrap();
         fetch.table_ticks = Some(
             Column::get_changed_ticks_slice(table.get_column(column_index).debug_checked_unwrap())
                 .into(),

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -9,6 +9,7 @@ use crate::{
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData};
+use crate::archetype::{ArchetypeId, ComponentIndex};
 
 /// Types that filter the results of a [`Query`].
 ///
@@ -382,7 +383,7 @@ macro_rules! impl_or_query_filter {
         /// `update_component_access` replace the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
         /// This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
         unsafe impl<$($filter: QueryFilter),*> WorldQuery for Or<($($filter,)*)> {
-            type Fetch<'w> = ($(OrFetch<'w, $filter>,)*);
+            type Fetch<'w> = (&'w ComponentIndex, ($(OrFetch<'w, $filter>,)*));
             type Item<'w> = bool;
             type State = ($($filter::State,)*);
 
@@ -391,13 +392,16 @@ macro_rules! impl_or_query_filter {
             }
 
             fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
-                let ($($filter,)*) = fetch;
-                ($(
-                    OrFetch {
-                        fetch: $filter::shrink_fetch($filter.fetch),
-                        matches: $filter.matches
-                    },
-                )*)
+                let (index, ($($filter,)*)) = fetch;
+                (
+                    index,
+                    ($(
+                        OrFetch {
+                            fetch: $filter::shrink_fetch($filter.fetch),
+                            matches: $filter.matches
+                        },
+                    )*)
+                )
             }
 
             const IS_DENSE: bool = true $(&& $filter::IS_DENSE)*;
@@ -405,22 +409,27 @@ macro_rules! impl_or_query_filter {
             #[inline]
             unsafe fn init_fetch<'w>(world: UnsafeWorldCell<'w>, state: &Self::State, last_run: Tick, this_run: Tick) -> Self::Fetch<'w> {
                 let ($($filter,)*) = state;
-                ($(OrFetch {
+                let index = world.archetypes().component_index();
+                (index, ($(OrFetch {
                     // SAFETY: The invariants are uphold by the caller.
                     fetch: unsafe { $filter::init_fetch(world, $filter, last_run, this_run) },
                     matches: false,
-                },)*)
+                },)*))
             }
 
             #[inline]
-            unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table) {
-                let ($($filter,)*) = fetch;
+            unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, archetype_id: ArchetypeId, table: &'w Table) {
+                let (index, ($($filter,)*)) = fetch;
                 let ($($state,)*) = state;
                 $(
-                    $filter.matches = $filter::matches_component_set($state, &|id| table.has_column(id));
+                    $filter.matches = $filter::matches_component_set($state, &|id| {
+                        index.get_column_index(id, archetype_id).is_some_and(
+                            |column_index| table.has_column(column_index)
+                        )
+                    });
                     if $filter.matches {
                         // SAFETY: The invariants are uphold by the caller.
-                        unsafe { $filter::set_table(&mut $filter.fetch, $state, table); }
+                        unsafe { $filter::set_table(&mut $filter.fetch, $state, archetype_id, table); }
                     }
                 )*
             }
@@ -432,7 +441,7 @@ macro_rules! impl_or_query_filter {
                 archetype: &'w Archetype,
                 table: &'w Table
             ) {
-                let ($($filter,)*) = fetch;
+                let (_, ($($filter,)*)) = fetch;
                 let ($($state,)*) = &state;
                 $(
                     $filter.matches = $filter::matches_component_set($state, &|id| archetype.contains(id));
@@ -449,7 +458,7 @@ macro_rules! impl_or_query_filter {
                 _entity: Entity,
                 _table_row: TableRow
             ) -> Self::Item<'w> {
-                let ($($filter,)*) = fetch;
+                let (_, ($($filter,)*)) = fetch;
                 // SAFETY: The invariants are uphold by the caller.
                 false $(|| ($filter.matches && unsafe { $filter::filter_fetch(&mut $filter.fetch, _entity, _table_row) }))*
             }
@@ -608,6 +617,7 @@ pub struct Added<T>(PhantomData<T>);
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct AddedFetch<'w> {
+    component_index: &'w ComponentIndex,
     table_ticks: Option<ThinSlicePtr<'w, UnsafeCell<Tick>>>,
     sparse_set: Option<&'w ComponentSparseSet>,
     last_run: Tick,
@@ -659,13 +669,13 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     unsafe fn set_archetype<'w>(
         fetch: &mut Self::Fetch<'w>,
         component_id: &ComponentId,
-        _archetype: &'w Archetype,
+        archetype: &'w Archetype,
         table: &'w Table,
     ) {
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
-                Self::set_table(fetch, component_id, table);
+                Self::set_table(fetch, component_id, archetype.id(), table);
             }
         }
     }
@@ -674,10 +684,12 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
         &component_id: &ComponentId,
+        archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
+        let column_index = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
         fetch.table_ticks = Some(
-            Column::get_added_ticks_slice(table.get_column(component_id).debug_checked_unwrap())
+            Column::get_added_ticks_slice(table.get_column(column_index).debug_checked_unwrap())
                 .into(),
         );
     }
@@ -823,6 +835,7 @@ pub struct Changed<T>(PhantomData<T>);
 #[doc(hidden)]
 #[derive(Clone)]
 pub struct ChangedFetch<'w> {
+    component_index: &'w ComponentIndex,
     table_ticks: Option<ThinSlicePtr<'w, UnsafeCell<Tick>>>,
     sparse_set: Option<&'w ComponentSparseSet>,
     last_run: Tick,
@@ -874,13 +887,13 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     unsafe fn set_archetype<'w>(
         fetch: &mut Self::Fetch<'w>,
         component_id: &ComponentId,
-        _archetype: &'w Archetype,
+        archetype: &'w Archetype,
         table: &'w Table,
     ) {
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
-                Self::set_table(fetch, component_id, table);
+                Self::set_table(fetch, component_id, archetype.id(), table);
             }
         }
     }
@@ -889,10 +902,12 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     unsafe fn set_table<'w>(
         fetch: &mut Self::Fetch<'w>,
         &component_id: &ComponentId,
+        archetype_id: ArchetypeId,
         table: &'w Table,
     ) {
+        let column_index = fetch.component_index.get_column_index(component_id, archetype_id).debug_checked_unwrap();
         fetch.table_ticks = Some(
-            Column::get_changed_ticks_slice(table.get_column(component_id).debug_checked_unwrap())
+            Column::get_changed_ticks_slice(table.get_column(column_index).debug_checked_unwrap())
                 .into(),
         );
     }

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -171,7 +171,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     }
 
     #[inline]
-    unsafe fn set_table(_fetch: &mut (), _state: &ComponentId, _table: &Table) {}
+    unsafe fn set_table(_fetch: &mut (), _state: &ComponentId, _archetype_id: ArchetypeId, _table: &Table) {}
 
     #[inline(always)]
     unsafe fn fetch<'w>(
@@ -281,7 +281,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     }
 
     #[inline]
-    unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _table: &Table) {}
+    unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _archetype_id: ArchetypeId, _table: &Table) {}
 
     #[inline(always)]
     unsafe fn fetch<'w>(
@@ -650,6 +650,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         this_run: Tick,
     ) -> Self::Fetch<'w> {
         Self::Fetch::<'w> {
+            component_index: world.archetypes().component_index(),
             table_ticks: None,
             sparse_set: (T::STORAGE_TYPE == StorageType::SparseSet)
                 .then(|| world.storages().sparse_sets.get(id).debug_checked_unwrap()),
@@ -868,6 +869,7 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         this_run: Tick,
     ) -> Self::Fetch<'w> {
         Self::Fetch::<'w> {
+            component_index: world.archetypes().component_index(),
             table_ticks: None,
             sparse_set: (T::STORAGE_TYPE == StorageType::SparseSet)
                 .then(|| world.storages().sparse_sets.get(id).debug_checked_unwrap()),

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1,3 +1,5 @@
+use super::{QueryData, QueryFilter, ReadOnlyQueryData};
+use crate::archetype::ArchetypeId;
 use crate::{
     archetype::{Archetype, ArchetypeEntity, Archetypes},
     component::Tick,
@@ -14,8 +16,6 @@ use std::{
     mem::MaybeUninit,
     ops::Range,
 };
-use crate::archetype::ArchetypeId;
-use super::{QueryData, QueryFilter, ReadOnlyQueryData};
 
 /// An [`Iterator`] over query results of a [`Query`](crate::system::Query).
 ///
@@ -149,7 +149,12 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
             "TableRow is only valid up to u32::MAX"
         );
 
-        D::set_table(&mut self.cursor.fetch, &self.query_state.fetch_state, archetype_id, table);
+        D::set_table(
+            &mut self.cursor.fetch,
+            &self.query_state.fetch_state,
+            archetype_id,
+            table,
+        );
         F::set_table(
             &mut self.cursor.filter,
             &self.query_state.filter_state,
@@ -1819,8 +1824,18 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                     // SAFETY: `table` is from the world that `fetch/filter` were created for,
                     // `fetch_state`/`filter_state` are the states that `fetch/filter` were initialized with
                     unsafe {
-                        D::set_table(&mut self.fetch, &query_state.fetch_state, archetype_id, table);
-                        F::set_table(&mut self.filter, &query_state.filter_state, archetype_id, table);
+                        D::set_table(
+                            &mut self.fetch,
+                            &query_state.fetch_state,
+                            archetype_id,
+                            table,
+                        );
+                        F::set_table(
+                            &mut self.filter,
+                            &query_state.filter_state,
+                            archetype_id,
+                            table,
+                        );
                     }
                     self.table_entities = table.entities();
                     self.current_len = table.entity_count();

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1493,6 +1493,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                             accum = iter.fold_over_table_range(
                                 accum,
                                 &mut func,
+                                storage_id.archetype_id,
                                 table,
                                 0..table.entity_count(),
                             );
@@ -1525,7 +1526,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                             let id = storage_id.table_id;
                             let table = world.storages().tables.get(id).debug_checked_unwrap();
                             self.iter_unchecked_manual(world, last_run, this_run)
-                                .fold_over_table_range(accum, &mut func, table, batch);
+                                .fold_over_table_range(accum, &mut func, storage_id.archetype_id, table, batch);
                         } else {
                             let id = storage_id.archetype_id;
                             let archetype = world.archetypes().get(id).debug_checked_unwrap();

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1526,7 +1526,13 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                             let id = storage_id.table_id;
                             let table = world.storages().tables.get(id).debug_checked_unwrap();
                             self.iter_unchecked_manual(world, last_run, this_run)
-                                .fold_over_table_range(accum, &mut func, storage_id.archetype_id, table, batch);
+                                .fold_over_table_range(
+                                    accum,
+                                    &mut func,
+                                    storage_id.archetype_id,
+                                    table,
+                                    batch,
+                                );
                         } else {
                             let id = storage_id.archetype_id;
                             let archetype = world.archetypes().get(id).debug_checked_unwrap();

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -201,11 +201,11 @@ macro_rules! impl_tuple_world_query {
             }
 
             #[inline]
-            unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
+            unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _archetype_id: ArchetypeId, _table: &'w Table) {
                 let ($($name,)*) = _fetch;
                 let ($($state,)*) = _state;
                 // SAFETY: The invariants are uphold by the caller.
-                $(unsafe { $name::set_table($name, $state, _table); })*
+                $(unsafe { $name::set_table($name, $state, _archetype_id, _table); })*
             }
 
             #[inline(always)]

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -7,6 +7,7 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 use bevy_utils::all_tuples;
+use crate::archetype::ArchetypeId;
 
 /// Types that can be used as parameters in a [`Query`].
 /// Types that implement this should also implement either [`QueryData`] or [`QueryFilter`]
@@ -99,7 +100,7 @@ pub unsafe trait WorldQuery {
     ///
     /// - `table` must be from the same [`World`] that [`WorldQuery::init_state`] was called on.
     /// - `state` must be the [`State`](Self::State) that `fetch` was initialized with.
-    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table);
+    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, archetype_id: ArchetypeId, table: &'w Table);
 
     /// Sets available accesses for implementors with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
     /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -1,3 +1,4 @@
+use crate::archetype::ArchetypeId;
 use crate::{
     archetype::Archetype,
     component::{ComponentId, Components, Tick},
@@ -7,7 +8,6 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 use bevy_utils::all_tuples;
-use crate::archetype::ArchetypeId;
 
 /// Types that can be used as parameters in a [`Query`].
 /// Types that implement this should also implement either [`QueryData`] or [`QueryFilter`]
@@ -100,7 +100,12 @@ pub unsafe trait WorldQuery {
     ///
     /// - `table` must be from the same [`World`] that [`WorldQuery::init_state`] was called on.
     /// - `state` must be the [`State`](Self::State) that `fetch` was initialized with.
-    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, archetype_id: ArchetypeId, table: &'w Table);
+    unsafe fn set_table<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype_id: ArchetypeId,
+        table: &'w Table,
+    );
 
     /// Sets available accesses for implementors with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
     /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -414,6 +414,7 @@ macro_rules! impl_sparse_set {
             /// Returns a mutable reference to the value for `index`.
             ///
             /// Returns `None` if `index` does not have a value in the sparse set.
+            #[allow(dead_code)]
             pub fn get_mut(&mut self, index: I) -> Option<&mut V> {
                 let dense = &mut self.dense;
                 self.sparse.get(index).map(move |dense_index| {
@@ -428,11 +429,13 @@ macro_rules! impl_sparse_set {
             }
 
             /// Returns an iterator visiting all values in arbitrary order.
+            #[allow(dead_code)]
             pub fn values(&self) -> impl Iterator<Item = &V> {
                 self.dense.iter()
             }
 
             /// Returns an iterator visiting all values mutably in arbitrary order.
+            #[allow(dead_code)]
             pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
                 self.dense.iter_mut()
             }
@@ -443,6 +446,7 @@ macro_rules! impl_sparse_set {
             }
 
             /// Returns an iterator visiting all key-value pairs in arbitrary order, with mutable references to the values.
+            #[allow(dead_code)]
             pub fn iter_mut(&mut self) -> impl Iterator<Item = (&I, &mut V)> {
                 self.indices.iter().zip(self.dense.iter_mut())
             }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -687,7 +687,7 @@ impl Table {
     /// # Safety
     /// `row` must be in-bounds
     pub(crate) unsafe fn swap_remove_unchecked(&mut self, row: TableRow) -> Option<Entity> {
-        for column in self.columns.values_mut() {
+        for column in self.columns.iter_mut() {
             column.swap_remove_unchecked(row);
         }
         let is_last = row.as_usize() == self.entities.len() - 1;
@@ -715,6 +715,7 @@ impl Table {
         debug_assert!(row.as_usize() < self.entity_count());
         let is_last = row.as_usize() == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
+        // TODO: figure this part out
         for (component_id, column) in self.columns.iter_mut() {
             if let Some(new_column) = new_table.get_column_mut(*component_id) {
                 new_column.initialize_from_unchecked(column, row, new_row);

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -669,7 +669,8 @@ impl TableBuilder {
 /// [`Component`]: crate::component::Component
 /// [`World`]: crate::world::World
 pub struct Table {
-    columns: ImmutableSparseSet<ComponentId, Column>,
+    // columns: ImmutableSparseSet<ComponentId, Column>,
+    columns: Vec<Column>,
     entities: Vec<Entity>,
 }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -1,3 +1,4 @@
+use crate::archetype::{ArchetypeId, ComponentIndex};
 use crate::{
     change_detection::{MaybeLocation, MaybeUnsafeCellLocation},
     component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick, TickCells},
@@ -14,7 +15,6 @@ use std::{
     cell::UnsafeCell,
     ops::{Index, IndexMut},
 };
-use crate::archetype::{ArchetypeId, ComponentIndex};
 
 /// An opaque unique ID for a [`Table`] within a [`World`].
 ///
@@ -644,7 +644,8 @@ impl TableBuilder {
 
     #[must_use]
     pub fn add_column(mut self, component_info: &ComponentInfo) -> Self {
-        self.columns.push(Column::with_capacity(component_info, self.capacity));
+        self.columns
+            .push(Column::with_capacity(component_info, self.capacity));
         self.components.push(component_info.id());
         self
     }
@@ -721,9 +722,13 @@ impl Table {
         let is_last = row.as_usize() == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
         for (component_id, column) in self.components.iter().zip(self.columns.iter_mut()) {
-            if let Some(column_index) = component_index.get_column_index(*component_id, new_archetype_id) {
+            if let Some(column_index) =
+                component_index.get_column_index(*component_id, new_archetype_id)
+            {
                 // SAFETY: the ComponentIndex guarantees that the table contains a column at `column_index`
-                let new_column = new_table.get_column_mut(column_index).debug_checked_unwrap();
+                let new_column = new_table
+                    .get_column_mut(column_index)
+                    .debug_checked_unwrap();
                 new_column.initialize_from_unchecked(column, row, new_row);
             } else {
                 // It's the caller's responsibility to drop these cases.
@@ -757,9 +762,13 @@ impl Table {
         let is_last = row.as_usize() == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
         for (component_id, column) in self.components.iter().zip(self.columns.iter_mut()) {
-            if let Some(column_index) = component_index.get_column_index(*component_id, new_archetype_id) {
+            if let Some(column_index) =
+                component_index.get_column_index(*component_id, new_archetype_id)
+            {
                 // SAFETY: the ComponentIndex guarantees that the table contains a column at `column_index`
-                let new_column = new_table.get_column_mut(column_index).debug_checked_unwrap();
+                let new_column = new_table
+                    .get_column_mut(column_index)
+                    .debug_checked_unwrap();
                 new_column.initialize_from_unchecked(column, row, new_row);
             } else {
                 column.swap_remove_unchecked(row);
@@ -792,7 +801,9 @@ impl Table {
         let is_last = row.as_usize() == self.entities.len() - 1;
         let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
         for (component_id, column) in self.components.iter().zip(self.columns.iter_mut()) {
-            let column_index = component_index.get_column_index(*component_id, new_archetype_id).debug_checked_unwrap();
+            let column_index = component_index
+                .get_column_index(*component_id, new_archetype_id)
+                .debug_checked_unwrap();
             new_table
                 .get_column_mut(column_index)
                 .debug_checked_unwrap()

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -801,8 +801,8 @@ impl Table {
     ///
     /// [`Component`]: crate::component::Component
     #[inline]
-    pub fn get_column(&self, component_id: ComponentId) -> Option<&Column> {
-        self.columns.get(component_id)
+    pub fn get_column(&self, column_index: usize) -> Option<&Column> {
+        self.columns.get(column_index)
     }
 
     /// Fetches a mutable reference to the [`Column`] for a given [`Component`] within the
@@ -812,8 +812,8 @@ impl Table {
     ///
     /// [`Component`]: crate::component::Component
     #[inline]
-    pub(crate) fn get_column_mut(&mut self, component_id: ComponentId) -> Option<&mut Column> {
-        self.columns.get_mut(component_id)
+    pub(crate) fn get_column_mut(&mut self, column_index: usize) -> Option<&mut Column> {
+        self.columns.get_mut(column_index)
     }
 
     /// Checks if the table contains a [`Column`] for a given [`Component`].
@@ -822,8 +822,8 @@ impl Table {
     ///
     /// [`Component`]: crate::component::Component
     #[inline]
-    pub fn has_column(&self, component_id: ComponentId) -> bool {
-        self.columns.contains(component_id)
+    pub fn has_column(&self, column_index: usize) -> bool {
+        column_index < self.columns.len()
     }
 
     /// Reserves `additional` elements worth of capacity within the table.

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -3,7 +3,7 @@ use crate::{
     component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick, TickCells},
     entity::Entity,
     query::DebugCheckedUnwrap,
-    storage::{blob_vec::BlobVec, ImmutableSparseSet, SparseSet},
+    storage::blob_vec::BlobVec,
 };
 use bevy_ptr::{OwningPtr, Ptr, PtrMut, UnsafeCellDeref};
 use bevy_utils::HashMap;

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -961,9 +961,12 @@ impl<'w> UnsafeWorldCell<'w> {
         location: EntityLocation,
         component_id: ComponentId,
     ) -> Option<&'w Column> {
-        // SAFETY: caller ensures returned data is not misused and we have not created any borrows
-        // of component/resource data
-        unsafe { self.storages() }.tables[location.table_id].get_column(component_id)
+        let column_index = self.archetypes().component_index().get_column_index(component_id, location.archetype_id);
+        column_index.and_then(|index| {
+            // SAFETY: caller ensures returned data is not misused and we have not created any borrows
+            // of component/resource data
+            unsafe { self.storages() }.tables[location.table_id].get_column(index)
+        })
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -961,7 +961,10 @@ impl<'w> UnsafeWorldCell<'w> {
         location: EntityLocation,
         component_id: ComponentId,
     ) -> Option<&'w Column> {
-        let column_index = self.archetypes().component_index().get_column_index(component_id, location.archetype_id);
+        let column_index = self
+            .archetypes()
+            .component_index()
+            .get_column_index(component_id, location.archetype_id);
         column_index.and_then(|index| {
             // SAFETY: caller ensures returned data is not misused and we have not created any borrows
             // of component/resource data


### PR DESCRIPTION
# Objective

We need to remove any `SparseSet<ComponentId>` in preparation for relations, because we will have components with very high id values once relations are added. (Because relations have a ComponentId in the high bits of the u64 id)

Part 1 was removing the FixedBitSet in Access: https://github.com/bevyengine/bevy/pull/14385
Part 2 is done in this PR: removing the `ImmutableSparseSet<ComponentId>` in `Storage::Table` that lets you access the `Column` corresponding to a given `ComponentId`.

This PR replaces it with a `Vec<ComponentId>` and `Vec<Column>` which are sorted in the same order.
We use the `ComponentIndex` (which maps from a `ComponentId` to the list of archetypes that contain this component, along with extra metadata including the `Column` index containing the `ComponentId`) to retrieve the `Column` corresponding to a given `ComponentId`.


TODO:
- run benchmarks
