### PR TITLE
Adopt #9770: `Result`ify `Camera` methods

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -214,7 +214,7 @@ impl ExtractComponent for BloomSettings {
             camera.is_active,
             camera.hdr,
         ) {
-            (Some(URect { min: origin, .. }), Some(size), Some(target_size), true, true) => {
+            (Ok(URect { min: origin, .. }), Ok(size), Ok(target_size), true, true) => {
                 let threshold = settings.prefilter_settings.threshold;
                 let threshold_softness = settings.prefilter_settings.threshold_softness;
                 let knee = threshold * threshold_softness.clamp(0.0, 1.0);

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/inset.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/inset.rs
@@ -137,7 +137,7 @@ impl<'w, 's> InsetGizmo<'w, 's> {
         let Ok(cam) = self.cam.get_single() else {
             return Vec2::ZERO;
         };
-        if let Some(new_position) = cam.world_to_viewport(&zero, position.extend(0.)) {
+        if let Ok(new_position) = cam.world_to_viewport(&zero, position.extend(0.)) {
             position = new_position;
         };
         position.xy()

--- a/crates/bevy_pbr/src/cluster/assign.rs
+++ b/crates/bevy_pbr/src/cluster/assign.rs
@@ -209,7 +209,7 @@ pub(crate) fn assign_objects_to_clusters(
             continue;
         }
 
-        let Some(screen_size) = camera.physical_viewport_size() else {
+        let Ok(screen_size) = camera.physical_viewport_size() else {
             clusters.clear();
             continue;
         };

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -228,9 +228,9 @@ pub mod ray {
         }
         let mut viewport_pos = pointer_loc.position;
         if let Some(viewport) = &camera.viewport {
-            let viewport_logical = camera.to_logical(viewport.physical_position)?;
+            let viewport_logical = camera.to_logical(viewport.physical_position).ok()?;
             viewport_pos -= viewport_logical;
         }
-        camera.viewport_to_world(camera_tfm, viewport_pos)
+        camera.viewport_to_world(camera_tfm, viewport_pos).ok()
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -34,7 +34,6 @@ use bevy_window::{
     NormalizedWindowRef, PrimaryWindow, Window, WindowCreated, WindowRef, WindowResized,
     WindowScaleFactorChanged,
 };
-use naga_oil::derive;
 use std::ops::Range;
 use wgpu::{BlendState, TextureFormat, TextureUsages};
 

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -70,7 +70,7 @@ pub fn sprite_picking(
             continue;
         };
 
-        let Some(cursor_ray_world) = camera.viewport_to_world(cam_transform, location.position)
+        let Ok(cursor_ray_world) = camera.viewport_to_world(cam_transform, location.position)
         else {
             continue;
         };

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -41,7 +41,7 @@ fn calc_bounds(
     if let Ok((camera, camera_transform)) = camera.get_single() {
         for (mut accessible, node, transform) in &mut nodes {
             if node.is_changed() || transform.is_changed() {
-                if let Some(translation) =
+                if let Ok(translation) =
                     camera.world_to_viewport(camera_transform, transform.translation())
                 {
                     let bounds = Rect::new(

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -805,7 +805,7 @@ mod tests {
             let (target_camera_entity, _) = cameras
                 .iter()
                 .find(|(_, camera)| {
-                    let Some(logical_viewport_rect) = camera.logical_viewport_rect() else {
+                    let Ok(logical_viewport_rect) = camera.logical_viewport_rect() else {
                         panic!("missing logical viewport")
                     };
                     // make sure cursor is in viewport and that viewport has at least 1px of size

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -96,7 +96,7 @@ pub fn ui_picking(
                 continue;
             };
             let mut pointer_pos = pointer_location.position;
-            if let Some(viewport) = camera_data.logical_viewport_rect() {
+            if let Ok(viewport) = camera_data.logical_viewport_rect() {
                 pointer_pos -= viewport.min;
             }
             let scaled_pointer_pos = pointer_pos / **ui_scale;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -232,7 +232,7 @@ pub fn extract_uinode_background_colors(
         let ui_logical_viewport_size = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(|(_, c)| c.logical_viewport_size())
+            .and_then(|(_, c)| c.logical_viewport_size().ok())
             .unwrap_or(Vec2::ZERO)
             // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
             // so we have to divide by `UiScale` to get the size of the UI viewport.
@@ -375,7 +375,7 @@ pub fn extract_uinode_images(
         let ui_logical_viewport_size = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(|(_, c)| c.logical_viewport_size())
+            .and_then(|(_, c)| c.logical_viewport_size().ok())
             .unwrap_or(Vec2::ZERO)
             // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
             // so we have to divide by `UiScale` to get the size of the UI viewport.
@@ -546,7 +546,7 @@ pub fn extract_uinode_borders(
         let ui_logical_viewport_size = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(|(_, c)| c.logical_viewport_size())
+            .and_then(|(_, c)| c.logical_viewport_size().ok())
             .unwrap_or(Vec2::ZERO)
             // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
             // so we have to divide by `UiScale` to get the size of the UI viewport.
@@ -736,12 +736,12 @@ pub fn extract_default_ui_camera_view(
         }
 
         if let (
-            Some(logical_size),
-            Some(URect {
+            Ok(logical_size),
+            Ok(URect {
                 min: physical_origin,
                 ..
             }),
-            Some(physical_size),
+            Ok(physical_size),
         ) = (
             camera.logical_viewport_size(),
             camera.physical_viewport_rect(),

--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -26,7 +26,7 @@ fn draw_cursor(
     };
 
     // Calculate a world position based on the cursor's position.
-    let Some(point) = camera.viewport_to_world_2d(camera_transform, cursor_position) else {
+    let Ok(point) = camera.viewport_to_world_2d(camera_transform, cursor_position) else {
         return;
     };
 

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -24,7 +24,7 @@ fn draw_cursor(
     };
 
     // Calculate a ray pointing from the camera into the world based on the cursor's position.
-    let Some(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
+    let Ok(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
         return;
     };
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -483,7 +483,7 @@ fn handle_mouse_clicks(
     };
 
     // Figure out where the user clicked on the plane.
-    let Some(ray) = camera.viewport_to_world(camera_transform, mouse_position) else {
+    let Ok(ray) = camera.viewport_to_world(camera_transform, mouse_position) else {
         return;
     };
     let Some(ray_distance) = ray.intersect_plane(Vec3::ZERO, InfinitePlane3d::new(Vec3::Y)) else {

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -184,7 +184,7 @@ fn handle_click(
     if let Some(pos) = windows
         .single()
         .cursor_position()
-        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor))
+        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor).ok())
         .map(|ray| ray.origin.truncate())
     {
         if mouse_button_input.just_pressed(MouseButton::Left) {

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -222,9 +222,11 @@ fn get_cursor_world_pos(
     let primary_window = q_primary_window.single();
     let (main_camera, main_camera_transform) = q_camera.single();
     // Get the cursor position in the world
-    cursor_world_pos.0 = primary_window
-        .cursor_position()
-        .and_then(|cursor_pos| main_camera.viewport_to_world_2d(main_camera_transform, cursor_pos));
+    cursor_world_pos.0 = primary_window.cursor_position().and_then(|cursor_pos| {
+        main_camera
+            .viewport_to_world_2d(main_camera_transform, cursor_pos)
+            .ok()
+    });
 }
 
 /// Update whether the window is clickable or not

--- a/examples/math/cubic_splines.rs
+++ b/examples/math/cubic_splines.rs
@@ -357,11 +357,10 @@ fn handle_mouse_press(
                 };
 
                 // Convert the starting point and end point (current mouse pos) into world coords:
-                let Some(point) = camera.viewport_to_world_2d(camera_transform, start) else {
+                let Ok(point) = camera.viewport_to_world_2d(camera_transform, start) else {
                     continue;
                 };
-                let Some(end_point) = camera.viewport_to_world_2d(camera_transform, mouse_pos)
-                else {
+                let Ok(end_point) = camera.viewport_to_world_2d(camera_transform, mouse_pos) else {
                     continue;
                 };
                 let tangent = end_point - point;
@@ -396,10 +395,10 @@ fn draw_edit_move(
 
     // Resources store data in viewport coordinates, so we need to convert to world coordinates
     // to display them:
-    let Some(start) = camera.viewport_to_world_2d(camera_transform, start) else {
+    let Ok(start) = camera.viewport_to_world_2d(camera_transform, start) else {
         return;
     };
-    let Some(end) = camera.viewport_to_world_2d(camera_transform, mouse_pos) else {
+    let Ok(end) = camera.viewport_to_world_2d(camera_transform, mouse_pos) else {
         return;
     };
 


### PR DESCRIPTION
# Objective

- Adopt #9770 

A lot of the code has changed fundamentally. I'm not even sure if it's worth it to do this anymore since a lot of errors seem to come from catastrophic failures now which won't happen most of the time. No hard feelings if we close this instead of merging.

FYI @tormeh and: Are the changes still needed? What is your use case?

## Solution

- Restart the PR and adjust the relevant code to use `Result` instead of `Option`
- I tried keeping the error enums small

## Testing

- Not sure how to run the tests. `cargo nextest run` fails to compile for me but RA seems to be happy.
- Let's check if the CI runs through

## Migration Guide

> Replace code that expects `Option` with code that expects `Result`. An easy way is to append a `.ok()` to the returned `Result` to transform it into an `Option`.