### PR TITLE
Gizmos: `arc_2d` utility helpers

### DIFF
--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -6,8 +6,8 @@
 use crate::circles::DEFAULT_CIRCLE_RESOLUTION;
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 use bevy_color::Color;
-use bevy_math::{Isometry2d, Isometry3d, Quat, Vec2, Vec3};
-use std::f32::consts::{FRAC_PI_2, TAU};
+use bevy_math::{Isometry2d, Isometry3d, Quat, Rot2, Vec2, Vec3};
+use std::f32::consts::TAU;
 
 // === 2D ===
 
@@ -49,7 +49,7 @@ where
     pub fn arc_2d(
         &mut self,
         isometry: Isometry2d,
-        arc_angle: f32,
+        arc_angle: Rot2,
         radius: f32,
         color: impl Into<Color>,
     ) -> Arc2dBuilder<'_, 'w, 's, Config, Clear> {
@@ -72,7 +72,7 @@ where
 {
     gizmos: &'a mut Gizmos<'w, 's, Config, Clear>,
     isometry: Isometry2d,
-    arc_angle: f32,
+    arc_angle: Rot2,
     radius: f32,
     color: Color,
     resolution: Option<u32>,
@@ -102,7 +102,7 @@ where
 
         let resolution = self
             .resolution
-            .unwrap_or_else(|| resolution_from_angle(self.arc_angle));
+            .unwrap_or_else(|| resolution_from_angle(self.arc_angle.as_radians()));
 
         let positions =
             arc_2d_inner(self.arc_angle, self.radius, resolution).map(|vec2| self.isometry * vec2);
@@ -110,11 +110,11 @@ where
     }
 }
 
-fn arc_2d_inner(arc_angle: f32, radius: f32, resolution: u32) -> impl Iterator<Item = Vec2> {
+fn arc_2d_inner(arc_angle: Rot2, radius: f32, resolution: u32) -> impl Iterator<Item = Vec2> {
     (0..=resolution)
-        .map(move |n| n as f32 * arc_angle / resolution as f32)
-        .map(|angle| angle + FRAC_PI_2)
-        .map(f32::sin_cos)
+        .map(move |n| Rot2::IDENTITY.slerp(arc_angle, n as f32 / resolution as f32))
+        .map(|angle| angle * Rot2::FRAC_PI_2)
+        .map(Rot2::sin_cos)
         .map(|(sin, cos)| Vec2::new(cos, sin))
         .map(move |vec2| vec2 * radius)
 }

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -338,7 +338,6 @@ where
     /// # Examples
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::ORANGE;
     /// fn system(mut gizmos: Gizmos) {
@@ -385,7 +384,6 @@ where
     /// # Examples
     /// ```
     /// # use bevy_gizmos::prelude::*;
-    /// # use bevy_render::prelude::*;
     /// # use bevy_math::prelude::*;
     /// # use bevy_color::palettes::css::ORANGE;
     /// fn system(mut gizmos: Gizmos) {

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -7,7 +7,7 @@ use crate::circles::DEFAULT_CIRCLE_RESOLUTION;
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 use bevy_color::Color;
 use bevy_math::{Isometry2d, Isometry3d, Quat, Rot2, Vec2, Vec3};
-use std::f32::consts::TAU;
+use std::f32::consts::{FRAC_PI_2, TAU};
 
 // === 2D ===
 
@@ -56,7 +56,7 @@ where
         Arc2dBuilder {
             gizmos: self,
             isometry,
-            arc_angle,
+            arc_angle: arc_angle.as_radians(),
             radius,
             color: color.into(),
             resolution: None,
@@ -72,7 +72,7 @@ where
 {
     gizmos: &'a mut Gizmos<'w, 's, Config, Clear>,
     isometry: Isometry2d,
-    arc_angle: Rot2,
+    arc_angle: f32,
     radius: f32,
     color: Color,
     resolution: Option<u32>,
@@ -102,7 +102,7 @@ where
 
         let resolution = self
             .resolution
-            .unwrap_or_else(|| resolution_from_angle(self.arc_angle.as_radians()));
+            .unwrap_or_else(|| resolution_from_angle(self.arc_angle));
 
         let positions =
             arc_2d_inner(self.arc_angle, self.radius, resolution).map(|vec2| self.isometry * vec2);
@@ -110,11 +110,11 @@ where
     }
 }
 
-fn arc_2d_inner(arc_angle: Rot2, radius: f32, resolution: u32) -> impl Iterator<Item = Vec2> {
+fn arc_2d_inner(arc_angle: f32, radius: f32, resolution: u32) -> impl Iterator<Item = Vec2> {
     (0..=resolution)
-        .map(move |n| Rot2::IDENTITY.slerp(arc_angle, n as f32 / resolution as f32))
-        .map(|angle| angle * Rot2::FRAC_PI_2)
-        .map(Rot2::sin_cos)
+        .map(move |n| arc_angle * n as f32 / resolution as f32)
+        .map(|angle| angle + FRAC_PI_2)
+        .map(f32::sin_cos)
         .map(|(sin, cos)| Vec2::new(cos, sin))
         .map(move |vec2| vec2 * radius)
 }
@@ -316,6 +316,130 @@ where
             start_vertex,
             isometry: Isometry3d::new(center, rotation),
             angle,
+            radius,
+            color: color.into(),
+            resolution: None,
+        }
+    }
+
+    /// Draws the shortest arc between two points (`from` and `to`) relative to a specified `center` point.
+    ///
+    /// # Arguments
+    ///
+    /// - `center`: The center point around which the arc is drawn.
+    /// - `from`: The starting point of the arc.
+    /// - `to`: The ending point of the arc.
+    /// - `color`: color of the arc
+    ///
+    /// # Builder methods
+    /// The resolution of the arc (i.e. the level of detail) can be adjusted with the
+    /// `.resolution(...)` method.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_render::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use bevy_color::palettes::css::ORANGE;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.short_arc_2d_between(
+    ///        Vec2::ZERO,
+    ///        Vec2::X,
+    ///        Vec2::Y,
+    ///        ORANGE
+    ///        )
+    ///        .resolution(100);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    ///
+    /// # Notes
+    /// - This method assumes that the points `from` and `to` are distinct from `center`. If one of
+    ///     the points is coincident with `center`, nothing is rendered.
+    /// - The arc is drawn as a portion of a circle with a radius equal to the distance from the
+    ///     `center` to `from`. If the distance from `center` to `to` is not equal to the radius, then
+    ///     the results will behave as if this were the case
+    #[inline]
+    pub fn short_arc_2d_between(
+        &mut self,
+        center: Vec2,
+        from: Vec2,
+        to: Vec2,
+        color: impl Into<Color>,
+    ) -> Arc2dBuilder<'_, 'w, 's, Config, Clear> {
+        self.arc_2d_from_to(center, from, to, color, std::convert::identity)
+    }
+
+    /// Draws the longest arc between two points (`from` and `to`) relative to a specified `center` point.
+    ///
+    /// # Arguments
+    /// - `center`: The center point around which the arc is drawn.
+    /// - `from`: The starting point of the arc.
+    /// - `to`: The ending point of the arc.
+    /// - `color`: color of the arc
+    ///
+    /// # Builder methods
+    /// The resolution of the arc (i.e. the level of detail) can be adjusted with the
+    /// `.resolution(...)` method.
+    ///
+    /// # Examples
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_render::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use bevy_color::palettes::css::ORANGE;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.long_arc_2d_between(
+    ///        Vec2::ZERO,
+    ///        Vec2::X,
+    ///        Vec2::Y,
+    ///        ORANGE
+    ///        )
+    ///        .resolution(100);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    ///
+    /// # Notes
+    /// - This method assumes that the points `from` and `to` are distinct from `center`. If one of
+    ///     the points is coincident with `center`, nothing is rendered.
+    /// - The arc is drawn as a portion of a circle with a radius equal to the distance from the
+    ///     `center` to `from`. If the distance from `center` to `to` is not equal to the radius, then
+    ///     the results will behave as if this were the case.
+    #[inline]
+    pub fn long_arc_2d_between(
+        &mut self,
+        center: Vec2,
+        from: Vec2,
+        to: Vec2,
+        color: impl Into<Color>,
+    ) -> Arc2dBuilder<'_, 'w, 's, Config, Clear> {
+        self.arc_2d_from_to(center, from, to, color, |angle| angle - TAU)
+    }
+
+    #[inline]
+    fn arc_2d_from_to(
+        &mut self,
+        center: Vec2,
+        from: Vec2,
+        to: Vec2,
+        color: impl Into<Color>,
+        angle_fn: impl Fn(f32) -> f32,
+    ) -> Arc2dBuilder<'_, 'w, 's, Config, Clear> {
+        // `from` and `to` can be the same here since in either case nothing gets rendered and the
+        // orientation ambiguity of `up` doesn't matter
+        let from_axis = (from - center).normalize_or_zero();
+        let to_axis = (to - center).normalize_or_zero();
+        let rotation = Vec2::X.angle_to(from_axis);
+        let arc_angle_raw = from_axis.angle_to(to_axis);
+
+        let arc_angle = angle_fn(arc_angle_raw);
+        let radius = center.distance(from);
+
+        Arc2dBuilder {
+            gizmos: self,
+            isometry: Isometry2d::new(center, Rot2::radians(rotation)),
+            arc_angle,
             radius,
             color: color.into(),
             resolution: None,

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -49,14 +49,14 @@ where
     pub fn arc_2d(
         &mut self,
         isometry: Isometry2d,
-        arc_angle: Rot2,
+        arc_angle: f32,
         radius: f32,
         color: impl Into<Color>,
     ) -> Arc2dBuilder<'_, 'w, 's, Config, Clear> {
         Arc2dBuilder {
             gizmos: self,
             isometry,
-            arc_angle: arc_angle.as_radians(),
+            arc_angle,
             radius,
             color: color.into(),
             resolution: None,

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -112,7 +112,7 @@ where
 
 fn arc_2d_inner(arc_angle: f32, radius: f32, resolution: u32) -> impl Iterator<Item = Vec2> {
     (0..=resolution)
-        .map(move |n| arc_angle * n as f32 / resolution as f32)
+        .map(move |n| n as f32 * arc_angle / resolution as f32)
         .map(|angle| angle + FRAC_PI_2)
         .map(f32::sin_cos)
         .map(|(sin, cos)| Vec2::new(cos, sin))

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -428,7 +428,7 @@ where
         // orientation ambiguity of `up` doesn't matter
         let from_axis = (from - center).normalize_or_zero();
         let to_axis = (to - center).normalize_or_zero();
-        let rotation = Vec2::X.angle_to(from_axis);
+        let rotation = Vec2::Y.angle_to(from_axis);
         let arc_angle_raw = from_axis.angle_to(to_axis);
 
         let arc_angle = angle_fn(arc_angle_raw);

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -1,6 +1,6 @@
 //! A module for rendering each of the 2D [`bevy_math::primitives`] with [`Gizmos`].
 
-use std::f32::consts::FRAC_PI_2;
+use std::f32::consts::{FRAC_PI_2, PI};
 
 use super::helpers::*;
 
@@ -10,7 +10,7 @@ use bevy_math::primitives::{
     CircularSegment, Ellipse, Line2d, Plane2d, Polygon, Polyline2d, Primitive2d, Rectangle,
     RegularPolygon, Rhombus, Segment2d, Triangle2d,
 };
-use bevy_math::{Dir2, Isometry2d, Vec2};
+use bevy_math::{Dir2, Isometry2d, Rot2, Vec2};
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 
@@ -380,13 +380,13 @@ where
         // draw arcs
         self.arc_2d(
             Isometry2d::new(top_center, Rot2::radians(start_angle_top)),
-            Rot2::PI,
+            PI,
             primitive.radius,
             polymorphic_color,
         );
         self.arc_2d(
             Isometry2d::new(bottom_center, Rot2::radians(start_angle_bottom)),
-            Rot2::PI,
+            PI,
             primitive.radius,
             polymorphic_color,
         );

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -1,6 +1,6 @@
 //! A module for rendering each of the 2D [`bevy_math::primitives`] with [`Gizmos`].
 
-use std::f32::consts::{FRAC_PI_2, PI};
+use std::f32::consts::FRAC_PI_2;
 
 use super::helpers::*;
 
@@ -10,7 +10,7 @@ use bevy_math::primitives::{
     CircularSegment, Ellipse, Line2d, Plane2d, Polygon, Polyline2d, Primitive2d, Rectangle,
     RegularPolygon, Rhombus, Segment2d, Triangle2d,
 };
-use bevy_math::{Dir2, Isometry2d, Rot2, Vec2};
+use bevy_math::{Dir2, Isometry2d, Vec2};
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 
@@ -380,13 +380,13 @@ where
         // draw arcs
         self.arc_2d(
             Isometry2d::new(top_center, Rot2::radians(start_angle_top)),
-            PI,
+            Rot2::PI,
             primitive.radius,
             polymorphic_color,
         );
         self.arc_2d(
             Isometry2d::new(bottom_center, Rot2::radians(start_angle_bottom)),
-            PI,
+            Rot2::PI,
             primitive.radius,
             polymorphic_color,
         );

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -97,9 +97,9 @@ fn draw_example_collection(
         310.,
         ORANGE_RED,
     );
-    my_gizmos.arc_2d(Isometry2d::IDENTITY, FRAC_PI_2, 75.0, ORANGE_RED);
-    my_gizmos.long_arc_2d_between(Vec2::ZERO, Vec2::X * 25.0, Vec2::Y * 25.0, ORANGE_RED);
-    my_gizmos.short_arc_2d_between(Vec2::ZERO, Vec2::X * 50.0, Vec2::Y * 50.0, ORANGE_RED);
+    my_gizmos.arc_2d(Isometry2d::IDENTITY, FRAC_PI_2, 80.0, ORANGE_RED);
+    my_gizmos.long_arc_2d_between(Vec2::ZERO, Vec2::X * 20.0, Vec2::Y * 20.0, ORANGE_RED);
+    my_gizmos.short_arc_2d_between(Vec2::ZERO, Vec2::X * 40.0, Vec2::Y * 40.0, ORANGE_RED);
 
     gizmos.arrow_2d(
         Vec2::ZERO,

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -98,6 +98,8 @@ fn draw_example_collection(
         ORANGE_RED,
     );
     my_gizmos.arc_2d(Isometry2d::IDENTITY, FRAC_PI_2, 75.0, ORANGE_RED);
+    my_gizmos.long_arc_2d_between(Vec2::ZERO, Vec2::X * 25.0, Vec2::Y * 25.0, ORANGE_RED);
+    my_gizmos.short_arc_2d_between(Vec2::ZERO, Vec2::X * 50.0, Vec2::Y * 50.0, ORANGE_RED);
 
     gizmos.arrow_2d(
         Vec2::ZERO,


### PR DESCRIPTION
# Objective

Since https://github.com/bevyengine/bevy/pull/14731 is merged, it unblocked a few utility methods for 2D arcs. In 2D the pendant to `long_arc_3d_between` and `short_arc_3d_between` are missing. Since `arc_2d` can be a bit hard to use, this PR is trying to plug some holes in the `arcs` API.

## Solution

Implement

- `long_arc_2d_between(center, from, tp, color)`
- `short_arc_2d_between(center, from, tp, color)`

## Testing

- There are new doc tests
- The `2d_gizmos` example has been extended a bit to include a few more arcs which can easily be checked with respect to the grid

---

## Showcase

![image](https://github.com/user-attachments/assets/b90ad8b1-86c2-4304-a481-4f9a5246c457)

Code related to the screenshot (from outer = first line to inner = last line)

```rust
    my_gizmos.arc_2d(Isometry2d::IDENTITY, FRAC_PI_2, 80.0, ORANGE_RED);
    my_gizmos.short_arc_2d_between(Vec2::ZERO, Vec2::X * 40.0, Vec2::Y * 40.0, ORANGE_RED);
    my_gizmos.long_arc_2d_between(Vec2::ZERO, Vec2::X * 20.0, Vec2::Y * 20.0, ORANGE_RED);
```