### PR TITLE
Fix Adreno 642L crash

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -233,14 +233,16 @@ impl FromWorld for GpuPreprocessingSupport {
 
                 // Filter out Adreno 730 and earlier GPUs (except 720, as it's newer than 730)
                 // while also taking suffixes into account like Adreno 642L.
-                name.strip_prefix("Adreno (TM) ").is_some_and(|version| {
+                let applies_on_version = |version: &str| -> bool {
                     let version = version
                         .chars()
                         .map_while(|c| c.to_digit(10))
                         .fold(0, |acc, digit| acc * 10 + digit);
 
-                    return version != 720 && version <= 730
-                })
+                    version != 720 && version <= 730
+                };
+
+                name.strip_prefix("Adreno (TM) ").is_some_and(applies_on_version)
             })
         {
             GpuPreprocessingSupport::None

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -226,24 +226,31 @@ impl FromWorld for GpuPreprocessingSupport {
         let adapter = world.resource::<RenderAdapter>();
         let device = world.resource::<RenderDevice>();
 
-        if device.limits().max_compute_workgroup_size_x == 0 ||
-            // filter some Qualcomm devices on Android as they crash when using GPU preprocessing
-            (cfg!(target_os = "android") && {
-                let name = adapter.get_info().name;
+        // filter some Qualcomm devices on Android as they crash when using GPU preprocessing.
+        fn is_non_supported_android_device(adapter: &RenderAdapter) -> bool {
+            if cfg!(target_os = "android") {
+                let adapter_name = adapter.get_info().name;
 
                 // Filter out Adreno 730 and earlier GPUs (except 720, as it's newer than 730)
                 // while also taking suffixes into account like Adreno 642L.
-                let applies_on_version = |version: &str| -> bool {
-                    let version = version
+                let non_supported_adreno_model = |model: &str| -> bool {
+                    let model = model
                         .chars()
                         .map_while(|c| c.to_digit(10))
                         .fold(0, |acc, digit| acc * 10 + digit);
 
-                    version != 720 && version <= 730
+                    model != 720 && model <= 730
                 };
 
-                name.strip_prefix("Adreno (TM) ").is_some_and(applies_on_version)
-            })
+                adapter_name
+                    .strip_prefix("Adreno (TM) ")
+                    .is_some_and(non_supported_adreno_model)
+            } else {
+                false
+            }
+        }
+
+        if device.limits().max_compute_workgroup_size_x == 0 || is_non_supported_android_device(adapter)
         {
             GpuPreprocessingSupport::None
         } else if !device


### PR DESCRIPTION
# Objective

The Android example on Adreno 642L currently crashes on startup.

Previous PRs #14176 and #13323 have adressed this specific crash occurring on some Adreno GPUs, that fix works as it should but isn't applied when to the GPU name contains a suffix like in the case of `642L`.

## Solution

- Amending the logic to filter out any parts of the GPU name not containing digits thus enabling the fix on `642L`.

## Testing

- Ran the Android example on a Nothing Phone 1. Before this change it crashed, after it works as intended.
