### PR TITLE
Do not implement `ObserverSystem` for `fn(In<Trigger<...>>, ...)`

### DIFF
--- a/crates/bevy_ecs/compile_fail/Cargo.toml
+++ b/crates/bevy_ecs/compile_fail/Cargo.toml
@@ -14,5 +14,5 @@ bevy_ecs = { path = "../" }
 compile_fail_utils = { path = "../../../tools/compile_fail_utils" }
 
 [[test]]
-name = "ui"
+name = "ecs"
 harness = false

--- a/crates/bevy_ecs/compile_fail/tests/ecs.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ecs.rs
@@ -1,3 +1,4 @@
+
 fn main() -> compile_fail_utils::ui_test::Result<()> {
     compile_fail_utils::test_multiple("ecs", ["tests/ui", "tests/ecs"])
 }

--- a/crates/bevy_ecs/compile_fail/tests/ecs.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ecs.rs
@@ -1,0 +1,3 @@
+fn main() -> compile_fail_utils::ui_test::Result<()> {
+    compile_fail_utils::test_multiple("ecs", ["tests/ui", "tests/ecs"])
+}

--- a/crates/bevy_ecs/compile_fail/tests/ecs/observer_system.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ecs/observer_system.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::{bundle::Bundle, observer::Trigger};
+use bevy_ecs::system::In;
+use bevy_ecs::{event::Event, system::IntoObserverSystem};
+
+#[derive(Debug, Event)]
+struct MyEvent;
+
+fn observer(_: In<Trigger<'static, MyEvent, ()>>) {}
+
+pub fn is_observer<E: Event, B: Bundle, M>(_: impl IntoObserverSystem<E, B, M>) {}
+
+fn main() {
+    is_observer(observer);
+}

--- a/crates/bevy_ecs/compile_fail/tests/ecs/observer_system.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ecs/observer_system.rs
@@ -7,8 +7,9 @@ struct MyEvent;
 
 fn observer(_: In<Trigger<'static, MyEvent, ()>>) {}
 
-pub fn is_observer<E: Event, B: Bundle, M>(_: impl IntoObserverSystem<E, B, M>) {}
+pub fn check_observer<E: Event, B: Bundle, M>(_: impl IntoObserverSystem<E, B, M>) {}
 
 fn main() {
-    is_observer(observer);
+    check_observer(observer);
+    //~^ E0277
 }

--- a/crates/bevy_ecs/compile_fail/tests/ui.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ui.rs
@@ -1,3 +1,0 @@
-fn main() -> compile_fail_utils::ui_test::Result<()> {
-    compile_fail_utils::test("ecs_ui", "tests/ui")
-}

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -57,7 +57,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// fn identity() -> impl Condition<(), bool> {
+/// fn identity() -> impl Condition<(), In<bool>> {
 ///     IntoSystem::into_system(|In(x)| x)
 /// }
 ///

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -309,7 +309,7 @@ pub struct Pipe;
 impl<A, B> Combine<A, B> for Pipe
 where
     A: System,
-    B: System<In = A::Out>,
+    B: System<In = crate::system::In<A::Out>>,
 {
     type In = A::In;
     type Out = B::Out;
@@ -320,6 +320,6 @@ where
         b: impl FnOnce(B::In) -> B::Out,
     ) -> Self::Out {
         let value = a(input);
-        b(value)
+        b(crate::system::In(value))
     }
 }

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -9,7 +9,7 @@ use crate::{
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 
-use super::{ReadOnlySystem, System};
+use super::{ReadOnlySystem, System, SystemInput};
 
 /// Customizes the behavior of a [`CombinatorSystem`].
 ///
@@ -306,10 +306,11 @@ pub type PipeSystem<SystemA, SystemB> = CombinatorSystem<Pipe, SystemA, SystemB>
 #[doc(hidden)]
 pub struct Pipe;
 
-impl<A, B> Combine<A, B> for Pipe
+impl<A, B, M> Combine<A, B> for Pipe
 where
     A: System,
-    B: System<In = crate::system::In<A::Out>>,
+    B: System<In = M>,
+    M: SystemInput<Inner = A::Out>,
 {
     type In = A::In;
     type Out = B::Out;
@@ -320,6 +321,6 @@ where
         b: impl FnOnce(B::In) -> B::Out,
     ) -> Self::Out {
         let value = a(input);
-        b(crate::system::In(value))
+        b(M::wrap(value))
     }
 }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2,7 +2,7 @@ mod parallel_scope;
 
 use core::panic::Location;
 
-use super::{Deferred, IntoObserverSystem, IntoSystem, RegisterSystem, Resource};
+use super::{Deferred, IntoObserverSystem, IntoSystem, RegisterSystem, Resource, SystemInput};
 use crate::{
     self as bevy_ecs,
     bundle::{Bundle, InsertMode},
@@ -657,7 +657,13 @@ impl<'w, 's> Commands<'w, 's> {
     /// There is no way to get the output of a system when run as a command, because the
     /// execution of the system happens later. To get the output of a system, use
     /// [`World::run_system`] or [`World::run_system_with_input`] instead of running the system as a command.
-    pub fn run_system_with_input<I: 'static + Send>(&mut self, id: SystemId<I>, input: I) {
+    pub fn run_system_with_input<I: 'static + SystemInput>(
+        &mut self,
+        id: SystemId<I>,
+        input: <I as SystemInput>::Inner,
+    ) where
+        <I as SystemInput>::Inner: Send,
+    {
         self.push(RunSystemWithInput::new_with_input(id, input));
     }
 

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -240,22 +240,22 @@ macro_rules! impl_exclusive_system_function {
                 FnMut(In<Input>, &mut World, $(ExclusiveSystemParamItem<$param>),*) -> Out,
             Out: 'static,
         {
-            type In = Input;
+            type In = In<Input>;
             type Out = Out;
             type Param = ($($param,)*);
             #[inline]
-            fn run(&mut self, world: &mut World, input: Input, param_value: ExclusiveSystemParamItem< ($($param,)*)>) -> Out {
+            fn run(&mut self, world: &mut World, input: Self::In, param_value: ExclusiveSystemParamItem< ($($param,)*)>) -> Out {
                 // Yes, this is strange, but `rustc` fails to compile this impl
                 // without using this function. It fails to recognize that `func`
                 // is a function, potentially because of the multiple impls of `FnMut`
                 #[allow(clippy::too_many_arguments)]
                 fn call_inner<Input, Out, $($param,)*>(
                     mut f: impl FnMut(In<Input>, &mut World, $($param,)*) -> Out,
-                    input: Input,
+                    input: In<Input>,
                     world: &mut World,
                     $($param: $param,)*
                 ) -> Out {
-                    f(In(input), world, $($param,)*)
+                    f(input, world, $($param,)*)
                 }
                 let ($($param,)*) = param_value;
                 call_inner(self, input, world, $($param),*)

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -670,16 +670,16 @@ where
 /// pub fn pipe<A, B, AMarker, BMarker>(
 ///     mut a: A,
 ///     mut b: B,
-/// ) -> impl FnMut(In<A::In>, ParamSet<(A::Param, B::Param)>) -> B::Out
+/// ) -> impl FnMut(A::In, ParamSet<(A::Param, B::Param)>) -> B::Out
 /// where
 ///     // We need A and B to be systems, add those bounds
 ///     A: SystemParamFunction<AMarker>,
-///     B: SystemParamFunction<BMarker, In = A::Out>,
+///     B: SystemParamFunction<BMarker, In = In<A::Out>>,
 /// {
 ///     // The type of `params` is inferred based on the return of this function above
-///     move |In(a_in), mut params| {
+///     move |a_in, mut params| {
 ///         let shared = a.run(a_in, params.p0());
-///         b.run(shared, params.p1())
+///         b.run(In(shared), params.p1())
 ///     }
 /// }
 ///

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -761,11 +761,11 @@ macro_rules! impl_system_function {
                 FnMut(In<Input>, $($param),*) -> Out +
                 FnMut(In<Input>, $(SystemParamItem<$param>),*) -> Out, Out: 'static
         {
-            type In = Input;
+            type In = In<Input>;
             type Out = Out;
             type Param = ($($param,)*);
             #[inline]
-            fn run(&mut self, input: Input, param_value: SystemParamItem< ($($param,)*)>) -> Out {
+            fn run(&mut self, input: Self::In, param_value: SystemParamItem< ($($param,)*)>) -> Out {
                 #[allow(clippy::too_many_arguments)]
                 fn call_inner<Input, Out, $($param,)*>(
                     mut f: impl FnMut(In<Input>, $($param,)*)->Out,
@@ -775,7 +775,7 @@ macro_rules! impl_system_function {
                     f(input, $($param,)*)
                 }
                 let ($($param,)*) = param_value;
-                call_inner(self, In(input), $($param),*)
+                call_inner(self, input, $($param),*)
             }
         }
     };

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -168,7 +168,7 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
     /// where `T` is the return type of the first system.
     fn pipe<B, Final, MarkerB>(self, system: B) -> PipeSystem<Self::System, B::System>
     where
-        B: IntoSystem<Out, Final, MarkerB>,
+        B: IntoSystem<super::system::In<Out>, Final, MarkerB>,
     {
         let system_a = IntoSystem::into_system(self);
         let system_b = IntoSystem::into_system(system);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -358,9 +358,7 @@ pub trait SystemInput {
 
 impl SystemInput for () {
     type Inner = ();
-    fn wrap(_: Self::Inner) -> Self {
-        ()
-    }
+    fn wrap(_: Self::Inner) -> Self {}
 }
 
 impl<T> SystemInput for In<T> {

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -10,7 +10,7 @@ use crate::{archetype::ArchetypeComponentId, component::ComponentId, query::Acce
 use std::any::TypeId;
 use std::borrow::Cow;
 
-use super::IntoSystem;
+use super::{IntoSystem, SystemInput};
 
 /// An ECS system that can be added to a [`Schedule`](crate::schedule::Schedule)
 ///
@@ -283,22 +283,22 @@ pub trait RunSystemOnce: Sized {
     }
 
     /// Runs a system with given input and applies its deferred parameters.
-    fn run_system_once_with<T: IntoSystem<In, Out, Marker>, In, Out, Marker>(
+    fn run_system_once_with<T: IntoSystem<In, Out, Marker>, In: SystemInput, Out, Marker>(
         self,
-        input: In,
+        input: <In as SystemInput>::Inner,
         system: T,
     ) -> Out;
 }
 
 impl RunSystemOnce for &mut World {
-    fn run_system_once_with<T: IntoSystem<In, Out, Marker>, In, Out, Marker>(
+    fn run_system_once_with<T: IntoSystem<In, Out, Marker>, In: SystemInput, Out, Marker>(
         self,
-        input: In,
+        input: <In as SystemInput>::Inner,
         system: T,
     ) -> Out {
         let mut system: T::System = IntoSystem::into_system(system);
         system.initialize(self);
-        system.run(input, self)
+        system.run(In::wrap(input), self)
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -400,7 +400,6 @@ where
 {
     #[inline]
     fn apply(self, world: &mut World) {
-        println!("Running system: {:?}", self.system_id);
         let _ = world.run_system_with_input(self.system_id, self.input);
     }
 }
@@ -638,7 +637,6 @@ mod tests {
 
         fn nested(query: Query<&Callback>, mut commands: Commands) {
             for callback in query.iter() {
-                println!("running nested system with input {}", callback.1);
                 commands.run_system_with_input(callback.0, callback.1);
             }
         }
@@ -648,17 +646,13 @@ mod tests {
 
         let increment_by =
             world.register_system(|In(amt): In<u8>, mut counter: ResMut<Counter>| {
-                println!("incrementing by {}", amt);
                 counter.0 += amt;
             });
-        println!("system id: {:?}", increment_by);
         let nested_id = world.register_system(nested);
 
         world.spawn(Callback(increment_by, 2));
         world.spawn(Callback(increment_by, 3));
         let _ = world.run_system(nested_id);
-        world.flush();
-        world.flush();
         assert_eq!(*world.resource::<Counter>(), Counter(5));
     }
 }

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -360,7 +360,7 @@ where
 {
     fn clone(&self) -> Self {
         RunSystemWithInput {
-            system_id: self.system_id.clone(),
+            system_id: self.system_id,
             input: self.input.clone(),
         }
     }


### PR DESCRIPTION
# Objective

- Fix #14924
- The implementation of `SystemParamFunction` for `fn(In<T>, ...)` does not constrain the lifetime of `T`. Allowing `fn(In<T>, ...)` to be called by bevy as a `fn(T, ...)` system would enable users to arbitrarily specify the lifetime of the `T` value provided by bevy

## Solution

- Change the associated type `In` from `Input` to `In<Input>` in the implementation of `SystemParamFunction` for `fn(In<Input>, ...)`, to prevent automatically implementing the `XXXSystem` trait for `fn(In<T>, ...)` when implementing the trait for `fn(T, ...)`

## Testing

- The code provided in #14924 can no longer compile

---

## Migration Guide

- `fn(In<Trigger<...>>, ...)` no longer implements `ObserverSystem`
