### PR TITLE
don't use padding for layout

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -264,16 +264,10 @@ pub fn ui_layout_system(
             let Ok(layout) = ui_surface.get_layout(entity) else {
                 return;
             };
-            let layout_size = inverse_target_scale_factor
-                * Vec2::new(
-                    layout.size.width - layout.padding.left - layout.padding.right,
-                    layout.size.height - layout.padding.top - layout.padding.bottom,
-                );
-            let layout_location = inverse_target_scale_factor
-                * Vec2::new(
-                    layout.location.x + layout.padding.left,
-                    layout.location.y + layout.padding.top,
-                );
+            let layout_size =
+                inverse_target_scale_factor * Vec2::new(layout.size.width, layout.size.height);
+            let layout_location =
+                inverse_target_scale_factor * Vec2::new(layout.location.x, layout.location.y);
 
             absolute_location += layout_location;
 


### PR DESCRIPTION
# Objective

- Fixes #14792 
- Padding is already handled by taffy, don't handle it also on Bevy side

## Solution

- Remove extra computation added in https://github.com/bevyengine/bevy/pull/14777
