### PR TITLE
Updated `FromWorld` Documentation to mention `Default`

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2949,12 +2949,15 @@ unsafe impl Sync for World {}
 /// using data from the supplied [`World`].
 ///
 /// This can be helpful for complex initialization or context-aware defaults.
+///
+/// [`FromWorld`] is automatically implemented for any type implementing [`Default`].
 pub trait FromWorld {
     /// Creates `Self` using data from the given [`World`].
     fn from_world(world: &mut World) -> Self;
 }
 
 impl<T: Default> FromWorld for T {
+    /// Creates `Self` using [`default()`](`Default::default`).
     fn from_world(_world: &mut World) -> Self {
         T::default()
     }


### PR DESCRIPTION
# Objective

- Fixes #14860

## Solution

- Added a line of documentation to `FromWorld`'s trait definition mention the `Default` blanket implementation.
- Added custom documentation to the `from_world` method for the `Default` blanket implementation. This ensures when inspecting the `from_world` function within an IDE, the tooltip will explicitly state the `default()` method will be used for any `Default` types.

## Testing

- CI passes.


