### PR TITLE
Ignore clicks on uinodes outside of rounded corners

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -308,6 +308,8 @@ pub fn ui_layout_system(
     }
 }
 
+pub fn resolve_border_radius_system() {}
+
 /// Resolve and update the widths of Node outlines
 pub fn resolve_outlines_system(
     primary_window: Query<&Window, With<PrimaryWindow>>,

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -26,7 +26,7 @@
 use crate::{prelude::*, UiStack};
 use bevy_app::prelude::*;
 use bevy_ecs::{prelude::*, query::QueryData};
-use bevy_math::{Vec2, VectorSpace};
+use bevy_math::Vec2;
 use bevy_render::prelude::*;
 use bevy_transform::prelude::*;
 use bevy_utils::hashbrown::HashMap;
@@ -163,7 +163,7 @@ pub fn ui_picking(
             if visible_rect
                 .normalize(node_rect)
                 .contains(relative_cursor_position)
-                && pick_rounded_box(
+                && pick_rounded_rect(
                     *cursor_position - node_rect.center(),
                     node_rect.size(),
                     node.node.border_radius,
@@ -218,7 +218,11 @@ pub fn ui_picking(
     }
 }
 
-pub(crate) fn pick_rounded_box(
+// Returns true if `point`` (relative to the rectangle's center) is within the bounds of a rounded rectangle with
+// the given size and border radius.
+//
+// Matches the sdf function in `ui.wgsl` that is used by the UI renderer to draw rounded rectangles.
+pub(crate) fn pick_rounded_rect(
     point: Vec2,
     size: Vec2,
     border_radius: ResolvedBorderRadius,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2189,6 +2189,59 @@ impl BorderRadius {
         self.bottom_right = radius;
         self
     }
+
+    /// Compute the border radius for a single corner from the given values
+    pub fn resolve_single_corner(
+        radius: Val,
+        node_size: Vec2,
+        viewport_size: Vec2,
+        ui_scale: f32,
+    ) -> f32 {
+        match radius {
+            Val::Auto => 0.,
+            Val::Px(px) => ui_scale * px,
+            Val::Percent(percent) => node_size.min_element() * percent / 100.,
+            Val::Vw(percent) => viewport_size.x * percent / 100.,
+            Val::Vh(percent) => viewport_size.y * percent / 100.,
+            Val::VMin(percent) => viewport_size.min_element() * percent / 100.,
+            Val::VMax(percent) => viewport_size.max_element() * percent / 100.,
+        }
+        .clamp(0., 0.5 * node_size.min_element() * ui_scale)
+    }
+
+    pub fn resolve_border_radius(
+        &self,
+        node_size: Vec2,
+        viewport_size: Vec2,
+        ui_scale: f32,
+    ) -> ResolvedBorderRadius {
+        ResolvedBorderRadius {
+            top_left: Self::resolve_single_corner(
+                self.top_left,
+                node_size,
+                viewport_size,
+                ui_scale,
+            ),
+            top_right: Self::resolve_single_corner(
+                self.top_right,
+                node_size,
+                viewport_size,
+                ui_scale,
+            ),
+            bottom_left: Self::resolve_single_corner(
+                self.bottom_left,
+                node_size,
+                viewport_size,
+                ui_scale,
+            ),
+            bottom_right: Self::resolve_single_corner(
+                self.bottom_right,
+                node_size,
+                viewport_size,
+                ui_scale,
+            ),
+        }
+    }
 }
 
 /// Represents the resolved border radius values for a UI node.

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -45,6 +45,7 @@ pub struct Node {
     /// Automatically calculated by [`super::layout::ui_layout_system`].
     pub(crate) unrounded_size: Vec2,
     /// Resolved border radius values in logical pixels.
+    /// Border radius updates bypass change detection.
     ///
     /// Automatically calculated by [`super::layout::ui_layout_system`].
     pub(crate) border_radius: ResolvedBorderRadius,
@@ -2190,56 +2191,26 @@ impl BorderRadius {
         self
     }
 
-    /// Compute the border radius for a single corner from the given values
-    pub fn resolve_single_corner(
-        radius: Val,
-        node_size: Vec2,
-        viewport_size: Vec2,
-        ui_scale: f32,
-    ) -> f32 {
+    /// Compute the logical border radius for a single corner from the given values
+    pub fn resolve_single_corner(radius: Val, node_size: Vec2, viewport_size: Vec2) -> f32 {
         match radius {
             Val::Auto => 0.,
-            Val::Px(px) => ui_scale * px,
+            Val::Px(px) => px,
             Val::Percent(percent) => node_size.min_element() * percent / 100.,
             Val::Vw(percent) => viewport_size.x * percent / 100.,
             Val::Vh(percent) => viewport_size.y * percent / 100.,
             Val::VMin(percent) => viewport_size.min_element() * percent / 100.,
             Val::VMax(percent) => viewport_size.max_element() * percent / 100.,
         }
-        .clamp(0., 0.5 * node_size.min_element() * ui_scale)
+        .clamp(0., 0.5 * node_size.min_element())
     }
 
-    pub fn resolve_border_radius(
-        &self,
-        node_size: Vec2,
-        viewport_size: Vec2,
-        ui_scale: f32,
-    ) -> ResolvedBorderRadius {
+    pub fn resolve(&self, node_size: Vec2, viewport_size: Vec2) -> ResolvedBorderRadius {
         ResolvedBorderRadius {
-            top_left: Self::resolve_single_corner(
-                self.top_left,
-                node_size,
-                viewport_size,
-                ui_scale,
-            ),
-            top_right: Self::resolve_single_corner(
-                self.top_right,
-                node_size,
-                viewport_size,
-                ui_scale,
-            ),
-            bottom_left: Self::resolve_single_corner(
-                self.bottom_left,
-                node_size,
-                viewport_size,
-                ui_scale,
-            ),
-            bottom_right: Self::resolve_single_corner(
-                self.bottom_right,
-                node_size,
-                viewport_size,
-                ui_scale,
-            ),
+            top_left: Self::resolve_single_corner(self.top_left, node_size, viewport_size),
+            top_right: Self::resolve_single_corner(self.top_right, node_size, viewport_size),
+            bottom_left: Self::resolve_single_corner(self.bottom_left, node_size, viewport_size),
+            bottom_right: Self::resolve_single_corner(self.bottom_right, node_size, viewport_size),
         }
     }
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -45,11 +45,10 @@ pub struct Node {
     ///
     /// Automatically calculated by [`super::layout::ui_layout_system`].
     pub(crate) unrounded_size: Vec2,
-    /// Resolved border radius values, calculated by `resolve_border_radius` system.
-    /// In order: top left, top right, bottom right, bottom left.
+    /// Resolved border radius values in logical pixels.
     ///
-    /// Automatically calculated by [`super::layout::resolve_border_radius_sytem`].
-    pub(crate) border_radius: Vec4,
+    /// Automatically calculated by [`super::layout::ui_layout_system`].
+    pub(crate) border_radius: ResolvedBorderRadius,
 }
 
 impl Node {
@@ -124,7 +123,7 @@ impl Node {
         outline_width: 0.,
         outline_offset: 0.,
         unrounded_size: Vec2::ZERO,
-        border_radius: Vec4::ZERO,
+        border_radius: ResolvedBorderRadius::DEFAULT,
     };
 }
 
@@ -2191,6 +2190,26 @@ impl BorderRadius {
         self.bottom_right = radius;
         self
     }
+}
+
+/// Represents the resolved border radius values for a UI node.
+///
+/// The values are in logical pixels.
+#[derive(Copy, Clone, Debug, PartialEq, Reflect)]
+pub struct ResolvedBorderRadius {
+    pub top_left: f32,
+    pub top_right: f32,
+    pub bottom_left: f32,
+    pub bottom_right: f32,
+}
+
+impl ResolvedBorderRadius {
+    pub const DEFAULT: Self = Self {
+        top_left: 0.,
+        top_right: 0.,
+        bottom_left: 0.,
+        bottom_right: 0.,
+    };
 }
 
 #[cfg(test)]

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2,13 +2,12 @@ use crate::{UiRect, Val};
 use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_ecs::{prelude::*, system::SystemParam};
-use bevy_math::{Rect, Vec2, Vec4};
+use bevy_math::{Rect, Vec2};
 use bevy_reflect::prelude::*;
 use bevy_render::{
     camera::{Camera, RenderTarget},
     texture::{Image, TRANSPARENT_IMAGE_HANDLE},
 };
-use bevy_text::cosmic_text::ttf_parser::feat;
 use bevy_transform::prelude::GlobalTransform;
 use bevy_utils::warn_once;
 use bevy_window::{PrimaryWindow, WindowRef};

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2,12 +2,13 @@ use crate::{UiRect, Val};
 use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_ecs::{prelude::*, system::SystemParam};
-use bevy_math::{Rect, Vec2};
+use bevy_math::{Rect, Vec2, Vec4};
 use bevy_reflect::prelude::*;
 use bevy_render::{
     camera::{Camera, RenderTarget},
     texture::{Image, TRANSPARENT_IMAGE_HANDLE},
 };
+use bevy_text::cosmic_text::ttf_parser::feat;
 use bevy_transform::prelude::GlobalTransform;
 use bevy_utils::warn_once;
 use bevy_window::{PrimaryWindow, WindowRef};
@@ -44,6 +45,11 @@ pub struct Node {
     ///
     /// Automatically calculated by [`super::layout::ui_layout_system`].
     pub(crate) unrounded_size: Vec2,
+    /// Resolved border radius values, calculated by `resolve_border_radius` system.
+    /// In order: top left, top right, bottom right, bottom left.
+    ///
+    /// Automatically calculated by [`super::layout::resolve_border_radius_sytem`].
+    pub(crate) border_radius: Vec4,
 }
 
 impl Node {
@@ -118,6 +124,7 @@ impl Node {
         outline_width: 0.,
         outline_offset: 0.,
         unrounded_size: Vec2::ZERO,
+        border_radius: Vec4::ZERO,
     };
 }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -122,7 +122,7 @@ impl Node {
         outline_width: 0.,
         outline_offset: 0.,
         unrounded_size: Vec2::ZERO,
-        border_radius: ResolvedBorderRadius::DEFAULT,
+        border_radius: ResolvedBorderRadius::ZERO,
     };
 }
 
@@ -2203,7 +2203,7 @@ pub struct ResolvedBorderRadius {
 }
 
 impl ResolvedBorderRadius {
-    pub const DEFAULT: Self = Self {
+    pub const ZERO: Self = Self {
         top_left: 0.,
         top_right: 0.,
         bottom_left: 0.,


### PR DESCRIPTION
# Objective

Fixes #14941

## Solution
1. Added a `resolved_border_radius` field to `Node` to hold the resolved border radius values.
2. Removed the border radius calculations from the extraction functions. 
4. Compute the border radius during UI relayouts in `ui_layout_system` and store them in `Node`. 
5. New `pick_rounded_rect` function based on the border radius SDF function from `ui.wgsl`.
6. Use `pick_rounded_rect` to check if pointer is within rounded rects.
---

## Showcase

https://github.com/user-attachments/assets/ea951a64-17ef-455e-b5c9-a2e6f6360648
