### PR TITLE
Move the default LogPlugin filter to a public constant

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -157,7 +157,7 @@ pub struct LogPlugin {
 /// A boxed [`Layer`] that can be used with [`LogPlugin`].
 pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 
-/// The default [`LogPlugin`] [`EnvFilter`]
+/// The default [`LogPlugin`] [`EnvFilter`].
 pub const DEFAULT_FILTER: &str = "wgpu=error,naga=warn";
 
 impl Default for LogPlugin {

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -157,10 +157,13 @@ pub struct LogPlugin {
 /// A boxed [`Layer`] that can be used with [`LogPlugin`].
 pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 
+/// The default [`LogPlugin`] [`EnvFilter`]
+pub const DEFAULT_FILTER: &str = "wgpu=error,naga=warn";
+
 impl Default for LogPlugin {
     fn default() -> Self {
         Self {
-            filter: "wgpu=error,naga=warn".to_string(),
+            filter: DEFAULT_FILTER.to_string(),
             level: Level::INFO,
             custom_layer: |_| None,
         }


### PR DESCRIPTION
# Objective

This moves the default `LogPlugin` filter to be a public constant so that it can be updated and referenced from outside code without changes across releases:

```
fn main() {
    App::new().add_plugins(
        DefaultPlugins
            .set(bevy::log::LogPlugin {
                filter: format!("{},mylogs=error", bevy::log::LogPlugin::DEFAULT_FILTER),
                ..default()
            })).run();
}
```

## Testing

Tested with `cargo run -p ci`