### PR TITLE
Use `#[doc(fake_variadic)]` for `SystemParamBuilder` tuple impls.

### DIFF
--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -194,7 +194,8 @@ unsafe impl<
 }
 
 macro_rules! impl_system_param_builder_tuple {
-    ($(($param: ident, $builder: ident)),*) => {
+    ($(#[$meta:meta])* $(($param: ident, $builder: ident)),*) => {
+        $(#[$meta])*
         // SAFETY: implementors of each `SystemParamBuilder` in the tuple have validated their impls
         unsafe impl<$($param: SystemParam,)* $($builder: SystemParamBuilder<$param>,)*> SystemParamBuilder<($($param,)*)> for ($($builder,)*) {
             fn build(self, _world: &mut World, _meta: &mut SystemMeta) -> <($($param,)*) as SystemParam>::State {
@@ -207,7 +208,14 @@ macro_rules! impl_system_param_builder_tuple {
     };
 }
 
-all_tuples!(impl_system_param_builder_tuple, 0, 16, P, B);
+all_tuples!(
+    #[doc(fake_variadic)]
+    impl_system_param_builder_tuple,
+    0,
+    16,
+    P,
+    B
+);
 
 // SAFETY: implementors of each `SystemParamBuilder` in the vec have validated their impls
 unsafe impl<P: SystemParam, B: SystemParamBuilder<P>> SystemParamBuilder<Vec<P>> for Vec<B> {


### PR DESCRIPTION
# Objective

Make the documentation for `SystemParamBuilder` nicer by combining the tuple implementations into a single line of documentation.  

## Solution

Use `#[doc(fake_variadic)]` for `SystemParamBuilder` tuple impls.

![image](https://github.com/user-attachments/assets/b4665861-c405-467f-b30b-82b4b1d99bf7)

(This got missed originally because #14050 and #14703 were open at the same time.)  