### PR TITLE
Fix observer unregistering unsetting archetype flags

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -367,7 +367,7 @@ pub struct Archetype {
     edges: Edges,
     entities: Vec<ArchetypeEntity>,
     components: ImmutableSparseSet<ComponentId, ArchetypeComponentInfo>,
-    flags: ArchetypeFlags,
+    pub(crate) flags: ArchetypeFlags,
 }
 
 impl Archetype {


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/14961

## Solution

- Check that the archetypes don't contain any other observed components before unsetting their flags

## Testing

- I added a regression test: `observer_despawn_archetype_flags`
