### PR TITLE
Remove some asset examples from web showcase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1407,7 +1407,8 @@ doc-scrape-examples = true
 name = "Custom Asset IO"
 description = "Implements a custom AssetReader"
 category = "Assets"
-wasm = true
+# Incompatible with the asset path patching of the example-showcase tool
+wasm = false
 
 [[example]]
 name = "embedded_asset"
@@ -1429,7 +1430,8 @@ doc-scrape-examples = true
 name = "Extra asset source"
 description = "Load an asset from a non-standard asset source"
 category = "Assets"
-wasm = true
+# Uses non-standard asset path
+wasm = false
 
 [[example]]
 name = "hot_asset_reloading"


### PR DESCRIPTION
# Objective

- `custom_asset_reader` and `extra_asset_source` examples are not working on web.
- Fixes #14689

## Solution

- Make these examples `wasm=false` per https://github.com/bevyengine/bevy/issues/14689#issuecomment-2313064396

## Testing

