### PR TITLE
Color gradient curve

### DIFF
--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -1,21 +1,22 @@
-use crate::{ColorRange, Mix};
-use bevy_math::curve::{Curve, Interval};
+use crate::Mix;
+use bevy_math::curve::{cores::EvenCoreError, Curve, Interval, SampleCurve};
 
-/// Represents a gradient of a minimum of 1 up to arbitrary many colors. Supported colors have to
-/// implement [`Mix`] and have to be from the same color space.
-///
-/// By default the color values are linearly interpolated.
-///
-/// This is useful for defining complex gradients or animated color transitions.
-#[derive(Debug, Clone)]
-pub struct ColorGradient<T: Mix> {
-    colors: Vec<T>,
+/// A curve whose samples are defined by a collection of colors. Curves of this type are produced
+/// by calling [`ColorGradient::to_curve`].
+#[derive(Clone, Debug)]
+pub struct ColorCurve<T: Mix + Clone, I> {
+    curve: SampleCurve<T, I>,
 }
 
-impl<T: Mix> ColorGradient<T> {
-    /// Create a new [`ColorGradient`] from a collection of [mixable] types.
+impl<T, I> ColorCurve<T, I>
+where
+    T: Mix + Clone,
+{
+    /// Create a new [`ColorCurve`] from a collection of [mixable] types and a mixing function. The
+    /// domain of this curve will always be `[0.0, len - 1]` where `len` is the amount of mixable
+    /// objects in the collection.
     ///
-    /// This fails if there's not at least one mixable type in the collection.
+    /// This fails if there's not at least two mixable things in the collection.
     ///
     /// [mixable]: `Mix`
     ///
@@ -23,98 +24,50 @@ impl<T: Mix> ColorGradient<T> {
     ///
     /// ```
     /// # use bevy_color::palettes::basic::*;
-    /// # use bevy_color::ColorGradient;
-    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]);
-    /// assert!(gradient.is_ok());
-    /// ```
-    pub fn new(colors: impl IntoIterator<Item = T>) -> Result<Self, ColorGradientError> {
-        let colors = colors.into_iter().collect::<Vec<_>>();
-        let len = colors.len();
-        (!colors.is_empty())
-            .then(|| Self { colors })
-            .ok_or(ColorGradientError(len))
-    }
-
-    /// Converts the [`ColorGradient`] to a [`ColorCurve`] which implements the [`Curve`] trait
-    /// along with its adaptor methods
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_color::palettes::basic::*;
-    /// # use bevy_color::ColorGradient;
-    /// # use bevy_color::Srgba;
     /// # use bevy_color::Mix;
+    /// # use bevy_color::Srgba;
+    /// # use bevy_color::ColorCurve;
+    /// # use bevy_math::curve::Interval;
     /// # use bevy_math::curve::Curve;
-    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]).unwrap();
-    /// let curve = gradient.to_curve();
-    ///
-    /// // you can then apply useful methods ontop of the gradient
-    /// let brighter_curve = curve.map(|c| c.mix(&WHITE, 0.25));
-    ///
-    /// assert_eq!(brighter_curve.sample_unchecked(0.0), Srgba::new(1.0, 0.25, 0.25, 1.0));
+    /// let broken = ColorCurve::new([RED], Srgba::mix);
+    /// assert!(broken.is_err());
+    /// let gradient = ColorCurve::new([RED, GREEN, BLUE], Srgba::mix);
+    /// assert!(gradient.is_ok());
+    /// assert_eq!(gradient.unwrap().domain(), Interval::new(0.0, 2.0).unwrap());
     /// ```
-    pub fn to_curve(self) -> ColorCurve<T> {
-        let domain =
-            Interval::new(0.0, (self.colors.len() - 1) as f32).expect("at least 1 by construction");
-        ColorCurve {
-            domain,
-            gradient: self,
-        }
+    pub fn new(
+        colors: impl IntoIterator<Item = impl Into<T>>,
+        interpolation: I,
+    ) -> Result<Self, EvenCoreError>
+    where
+        I: Fn(&T, &T, f32) -> T,
+    {
+        let colors = colors.into_iter().map(|ic| ic.into()).collect::<Vec<_>>();
+        Interval::new(0.0, colors.len().saturating_sub(1) as f32)
+            .map_err(|_| EvenCoreError::NotEnoughSamples {
+                samples: colors.len(),
+            })
+            .and_then(|domain| SampleCurve::new(domain, colors, interpolation))
+            .map(|curve| Self { curve })
     }
 }
 
-impl<T: Mix> ColorRange<T> for ColorGradient<T> {
-    fn at(&self, factor: f32) -> T {
-        match self.colors.len() {
-            0 => {
-                unreachable!("at least 1 by construction")
-            }
-            1 => {
-                // This weirdness exists to prevent adding a `Clone` bound on the type `T` and instead
-                // work with what we already have here
-                self.colors[0].mix(&self.colors[0], 0.0)
-            }
-            len => {
-                // clamp to range of valid indices
-                let factor = factor.clamp(0.0, (len - 1) as f32);
-                let fract = factor.fract();
-                if fract == 0.0 {
-                    // doesn't need clamping since it already was clamped to valid indices
-                    let exact_n = factor as usize;
-                    // weirdness again
-                    self.colors[exact_n].mix(&self.colors[exact_n], 0.0)
-                } else {
-                    // SAFETY: we know that `len != 0` and `len != 1` here so `len >= 2`
-                    let below = (factor.floor() as usize).min(len - 2);
-                    self.colors[below].mix(&self.colors[below + 1], fract)
-                }
-            }
-        }
-    }
-}
-
-/// Error related to violations of invariants of [`ColorGradient`]
+/// Error related to violations of invariants of [`ColorCurve`]
 #[derive(Debug, thiserror::Error)]
-#[error(
-    "Couldn't construct a ColorGradient since there were too few colors. Got {0}, expected >=1"
-)]
-pub struct ColorGradientError(usize);
+#[error("Couldn't construct a ColorCurve since there were too few colors. Got {0}, expected >=2")]
+pub struct ColorCurveError(usize);
 
-/// A curve whose samples are defined by a [`ColorGradient`]. Curves of this type are produced by
-/// calling [`ColorGradient::to_curve`].
-#[derive(Clone, Debug)]
-pub struct ColorCurve<T: Mix> {
-    domain: Interval,
-    gradient: ColorGradient<T>,
-}
-
-impl<T: Mix> Curve<T> for ColorCurve<T> {
+impl<T, F> Curve<T> for ColorCurve<T, F>
+where
+    T: Mix + Clone,
+    F: Fn(&T, &T, f32) -> T,
+{
     fn domain(&self) -> Interval {
-        self.domain
+        self.curve.domain()
     }
 
     fn sample_unchecked(&self, t: f32) -> T {
-        self.gradient.at(t)
+        self.curve.sample_unchecked(t)
     }
 }
 
@@ -122,42 +75,15 @@ impl<T: Mix> Curve<T> for ColorCurve<T> {
 mod tests {
     use super::*;
     use crate::palettes::basic;
-    use crate::{LinearRgba, Srgba};
-
-    #[test]
-    fn test_color_gradient() {
-        let gradient =
-            ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).expect("Valid gradient");
-        assert_eq!(gradient.at(-1.5), basic::RED);
-        assert_eq!(gradient.at(-1.0), basic::RED);
-        assert_eq!(gradient.at(0.0), basic::RED);
-        assert_eq!(gradient.at(0.5), Srgba::new(0.5, 0.5, 0.0, 1.0));
-        assert_eq!(gradient.at(1.0), basic::LIME);
-        assert_eq!(gradient.at(1.5), Srgba::new(0.0, 0.5, 0.5, 1.0));
-        assert_eq!(gradient.at(2.0), basic::BLUE);
-        assert_eq!(gradient.at(2.5), basic::BLUE);
-        assert_eq!(gradient.at(3.0), basic::BLUE);
-
-        let lred: LinearRgba = basic::RED.into();
-        let lgreen: LinearRgba = basic::LIME.into();
-        let lblue: LinearRgba = basic::BLUE.into();
-
-        let gradient = ColorGradient::new([lred, lgreen, lblue]).expect("Valid gradient");
-        assert_eq!(gradient.at(-1.5), lred);
-        assert_eq!(gradient.at(-1.0), lred);
-        assert_eq!(gradient.at(0.0), lred);
-        assert_eq!(gradient.at(0.5), LinearRgba::new(0.5, 0.5, 0.0, 1.0));
-        assert_eq!(gradient.at(1.0), lgreen);
-        assert_eq!(gradient.at(1.5), LinearRgba::new(0.0, 0.5, 0.5, 1.0));
-        assert_eq!(gradient.at(2.0), lblue);
-        assert_eq!(gradient.at(2.5), lblue);
-        assert_eq!(gradient.at(3.0), lblue);
-    }
+    use crate::Srgba;
 
     #[test]
     fn test_color_curve() {
-        let gradient = ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).unwrap();
-        let curve = gradient.to_curve();
+        let broken = ColorCurve::new([basic::RED], Srgba::mix);
+        assert!(broken.is_err());
+
+        let gradient = [basic::RED, basic::LIME, basic::BLUE];
+        let curve = ColorCurve::new(gradient, Srgba::mix).unwrap();
 
         assert_eq!(curve.domain(), Interval::new(0.0, 2.0).unwrap());
 

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -1,0 +1,156 @@
+use crate::{ColorRange, Mix};
+use bevy_math::curve::{Curve, Interval};
+
+/// Represents a gradient of a minimum of 1 up to arbitrary many colors. Supported colors have to
+/// implement [`Mix`] and have to be from the same color space.
+///
+/// By default the color values are linearly interpolated.
+///
+/// This is useful for defining complex gradients or animated color transitions.
+#[derive(Debug, Clone)]
+pub struct ColorGradient<T: Mix> {
+    colors: Vec<T>,
+}
+
+impl<T: Mix> ColorGradient<T> {
+    /// Create a new [`ColorGradient`] from a collection of [mixable] types.
+    ///
+    /// This fails if there's not at least one mixable type in the collection.
+    ///
+    /// [mixable]: `Mix`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_color::palettes::basic::*;
+    /// # use bevy_color::ColorGradient;
+    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]);
+    /// assert!(gradient.is_ok());
+    /// ```
+    pub fn new(colors: impl IntoIterator<Item = T>) -> Result<Self, ColorGradientError> {
+        let colors = colors.into_iter().collect::<Vec<_>>();
+        let len = colors.len();
+        (!colors.is_empty())
+            .then(|| Self { colors })
+            .ok_or_else(|| ColorGradientError(len))
+    }
+
+    /// Converts the [`ColorGradient`] to a [`ColorCurve`] which implements the [`Curve`] trait
+    /// along with its adaptor methods
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_color::palettes::basic::*;
+    /// # use bevy_color::ColorGradient;
+    /// # use bevy_color::Srgba;
+    /// # use bevy_color::Mix;
+    /// # use bevy_math::curve::Curve;
+    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]).unwrap();
+    /// let curve = gradient.to_curve();
+    ///
+    /// // you can then apply useful methods ontop of the gradient
+    /// let brighter_curve = curve.map(|c| c.mix(&WHITE, 0.25));
+    ///
+    /// assert_eq!(brighter_curve.sample_unchecked(0.0), Srgba::new(1.0, 0.25, 0.25, 1.0));
+    /// ```
+    pub fn to_curve(self) -> ColorCurve<T> {
+        let domain =
+            Interval::new(0.0, (self.colors.len() - 1) as f32).expect("at least 1 by construction");
+        ColorCurve {
+            domain,
+            gradient: self,
+        }
+    }
+}
+
+impl<T: Mix> ColorRange<T> for ColorGradient<T> {
+    fn at(&self, factor: f32) -> T {
+        match self.colors.len() {
+            len if len == 0 => {
+                unreachable!("at least 1 by construction")
+            }
+            len if len == 1 => {
+                // This weirdness exists to prevent adding a `Clone` bound on the type `T` and instead
+                // work with what we already have here
+                self.colors[0].mix(&self.colors[0], 0.0)
+            }
+            len => {
+                // clamp to range of valid indices
+                let factor = factor.clamp(0.0, (len - 1) as f32);
+                let fract = factor.fract();
+                if fract == 0.0 {
+                    // doesn't need clamping since it already was clamped to valid indices
+                    let exact_n = factor as usize;
+                    // weirdness again
+                    self.colors[exact_n].mix(&self.colors[exact_n], 0.0)
+                } else {
+                    // SAFETY: we know that `len != 0` and `len != 1` here so `len >= 2`
+                    let below = (factor.floor() as usize).min(len - 2);
+                    self.colors[below].mix(&self.colors[below + 1], fract)
+                }
+            }
+        }
+    }
+}
+
+/// Error related to violations of invariants of [`ColorGradient`]
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Couldn't construct a ColorGradient since there were too few colors. Got {0}, expected >=1"
+)]
+pub struct ColorGradientError(usize);
+
+/// A curve whose samples are defined by a [`ColorGradient`]. Curves of this type are produced by
+/// calling [`ColorGradien::to_curve`].
+#[derive(Clone, Debug)]
+pub struct ColorCurve<T: Mix> {
+    domain: Interval,
+    gradient: ColorGradient<T>,
+}
+
+impl<T: Mix> Curve<T> for ColorCurve<T> {
+    fn domain(&self) -> Interval {
+        self.domain
+    }
+
+    fn sample_unchecked(&self, t: f32) -> T {
+        self.gradient.at(t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::palettes::basic;
+    use crate::{LinearRgba, Srgba};
+
+    #[test]
+    fn test_color_gradient() {
+        let gradient =
+            ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).expect("Valid gradient");
+        assert_eq!(gradient.at(-1.5), basic::RED);
+        assert_eq!(gradient.at(-1.0), basic::RED);
+        assert_eq!(gradient.at(0.0), basic::RED);
+        assert_eq!(gradient.at(0.5), Srgba::new(0.5, 0.5, 0.0, 1.0));
+        assert_eq!(gradient.at(1.0), basic::LIME);
+        assert_eq!(gradient.at(1.5), Srgba::new(0.0, 0.5, 0.5, 1.0));
+        assert_eq!(gradient.at(2.0), basic::BLUE);
+        assert_eq!(gradient.at(2.5), basic::BLUE);
+        assert_eq!(gradient.at(3.0), basic::BLUE);
+
+        let lred: LinearRgba = basic::RED.into();
+        let lgreen: LinearRgba = basic::LIME.into();
+        let lblue: LinearRgba = basic::BLUE.into();
+
+        let gradient = ColorGradient::new([lred, lgreen, lblue]).expect("Valid gradient");
+        assert_eq!(gradient.at(-1.5), lred);
+        assert_eq!(gradient.at(-1.0), lred);
+        assert_eq!(gradient.at(0.0), lred);
+        assert_eq!(gradient.at(0.5), LinearRgba::new(0.5, 0.5, 0.0, 1.0));
+        assert_eq!(gradient.at(1.0), lgreen);
+        assert_eq!(gradient.at(1.5), LinearRgba::new(0.0, 0.5, 0.5, 1.0));
+        assert_eq!(gradient.at(2.0), lblue);
+        assert_eq!(gradient.at(2.5), lblue);
+        assert_eq!(gradient.at(3.0), lblue);
+    }
+}

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -12,9 +12,9 @@ impl<T> ColorCurve<T>
 where
     T: Mix + Clone,
 {
-    /// Create a new [`ColorCurve`] from a collection of [mixable] types and a mixing function. The
-    /// domain of this curve will always be `[0.0, len - 1]` where `len` is the amount of mixable
-    /// objects in the collection.
+    /// Create a new [`ColorCurve`] from a collection of [mixable] types. The domain of this curve
+    /// will always be `[0.0, len - 1]` where `len` is the amount of mixable objects in the
+    /// collection.
     ///
     /// This fails if there's not at least two mixable things in the collection.
     ///

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -153,4 +153,33 @@ mod tests {
         assert_eq!(gradient.at(2.5), lblue);
         assert_eq!(gradient.at(3.0), lblue);
     }
+
+    #[test]
+    fn test_color_curve() {
+        let gradient = ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).unwrap();
+        let curve = gradient.to_curve();
+
+        assert_eq!(curve.domain(), Interval::new(0.0, 2.0).unwrap());
+
+        // you can then apply useful methods ontop of the gradient
+        let brighter_curve = curve.map(|c| c.mix(&basic::WHITE, 0.5));
+
+        [
+            (-0.1, None),
+            (0.0, Some([1.0, 0.5, 0.5, 1.0])),
+            (0.5, Some([0.75, 0.75, 0.5, 1.0])),
+            (1.0, Some([0.5, 1.0, 0.5, 1.0])),
+            (1.5, Some([0.5, 0.75, 0.75, 1.0])),
+            (2.0, Some([0.5, 0.5, 1.0, 1.0])),
+            (2.1, None),
+        ]
+        .map(|(t, maybe_rgba)| {
+            let maybe_srgba = maybe_rgba.map(|[r, g, b, a]| Srgba::new(r, g, b, a));
+            (t, maybe_srgba)
+        })
+        .into_iter()
+        .for_each(|(t, maybe_color)| {
+            assert_eq!(brighter_curve.sample(t), maybe_color);
+        });
+    }
 }

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -41,7 +41,7 @@ where
     where
         I: Fn(&T, &T, f32) -> T,
     {
-        let colors = colors.into_iter().map(|ic| ic.into()).collect::<Vec<_>>();
+        let colors = colors.into_iter().map(Into::into).collect::<Vec<_>>();
         Interval::new(0.0, colors.len().saturating_sub(1) as f32)
             .map_err(|_| EvenCoreError::NotEnoughSamples {
                 samples: colors.len(),

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -32,7 +32,7 @@ impl<T: Mix> ColorGradient<T> {
         let len = colors.len();
         (!colors.is_empty())
             .then(|| Self { colors })
-            .ok_or_else(|| ColorGradientError(len))
+            .ok_or(ColorGradientError(len))
     }
 
     /// Converts the [`ColorGradient`] to a [`ColorCurve`] which implements the [`Curve`] trait
@@ -66,10 +66,10 @@ impl<T: Mix> ColorGradient<T> {
 impl<T: Mix> ColorRange<T> for ColorGradient<T> {
     fn at(&self, factor: f32) -> T {
         match self.colors.len() {
-            len if len == 0 => {
+            0 => {
                 unreachable!("at least 1 by construction")
             }
-            len if len == 1 => {
+            1 => {
                 // This weirdness exists to prevent adding a `Clone` bound on the type `T` and instead
                 // work with what we already have here
                 self.colors[0].mix(&self.colors[0], 0.0)
@@ -161,7 +161,6 @@ mod tests {
 
         assert_eq!(curve.domain(), Interval::new(0.0, 2.0).unwrap());
 
-        // you can then apply useful methods ontop of the gradient
         let brighter_curve = curve.map(|c| c.mix(&basic::WHITE, 0.5));
 
         [

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -101,7 +101,7 @@ impl<T: Mix> ColorRange<T> for ColorGradient<T> {
 pub struct ColorGradientError(usize);
 
 /// A curve whose samples are defined by a [`ColorGradient`]. Curves of this type are produced by
-/// calling [`ColorGradien::to_curve`].
+/// calling [`ColorGradient::to_curve`].
 #[derive(Clone, Debug)]
 pub struct ColorCurve<T: Mix> {
     domain: Interval,

--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -1,8 +1,7 @@
 use crate::Mix;
 use bevy_math::curve::{cores::EvenCoreError, Curve, Interval, SampleCurve};
 
-/// A curve whose samples are defined by a collection of colors. Curves of this type are produced
-/// by calling [`ColorGradient::to_curve`].
+/// A curve whose samples are defined by a collection of colors.
 #[derive(Clone, Debug)]
 pub struct ColorCurve<T: Mix + Clone, I> {
     curve: SampleCurve<T, I>,
@@ -51,11 +50,6 @@ where
             .map(|curve| Self { curve })
     }
 }
-
-/// Error related to violations of invariants of [`ColorCurve`]
-#[derive(Debug, thiserror::Error)]
-#[error("Couldn't construct a ColorCurve since there were too few colors. Got {0}, expected >=2")]
-pub struct ColorCurveError(usize);
 
 impl<T, F> Curve<T> for ColorCurve<T, F>
 where

--- a/crates/bevy_color/src/color_range.rs
+++ b/crates/bevy_color/src/color_range.rs
@@ -15,7 +15,9 @@ pub trait ColorRange<T: Mix> {
 
 impl<T: Mix> ColorRange<T> for Range<T> {
     fn at(&self, factor: f32) -> T {
-        self.start.mix(&self.end, factor)
+        self.start.mix(&self.end, factor.clamp(0.0, 1.0))
+    }
+}
     }
 }
 

--- a/crates/bevy_color/src/color_range.rs
+++ b/crates/bevy_color/src/color_range.rs
@@ -6,7 +6,7 @@ use crate::Mix;
 /// end point which must be in the same color space. It works for any color type that
 /// implements [`Mix`].
 ///
-/// This is useful for defining simple gradients or animated color transitions.
+/// This is useful for defining gradients or animated color transitions.
 pub trait ColorRange<T: Mix> {
     /// Get the color value at the given interpolation factor, which should be between 0.0 (start)
     /// and 1.0 (end).

--- a/crates/bevy_color/src/color_range.rs
+++ b/crates/bevy_color/src/color_range.rs
@@ -28,16 +28,20 @@ mod tests {
     #[test]
     fn test_color_range() {
         let range = basic::RED..basic::BLUE;
+        assert_eq!(range.at(-0.5), basic::RED);
         assert_eq!(range.at(0.0), basic::RED);
         assert_eq!(range.at(0.5), Srgba::new(0.5, 0.0, 0.5, 1.0));
         assert_eq!(range.at(1.0), basic::BLUE);
+        assert_eq!(range.at(1.5), basic::BLUE);
 
         let lred: LinearRgba = basic::RED.into();
         let lblue: LinearRgba = basic::BLUE.into();
 
         let range = lred..lblue;
+        assert_eq!(range.at(-0.5), lred);
         assert_eq!(range.at(0.0), lred);
         assert_eq!(range.at(0.5), LinearRgba::new(0.5, 0.0, 0.5, 1.0));
         assert_eq!(range.at(1.0), lblue);
+        assert_eq!(range.at(1.5), lblue);
     }
 }

--- a/crates/bevy_color/src/color_range.rs
+++ b/crates/bevy_color/src/color_range.rs
@@ -6,7 +6,7 @@ use crate::Mix;
 /// end point which must be in the same color space. It works for any color type that
 /// implements [`Mix`].
 ///
-/// This is useful for defining gradients or animated color transitions.
+/// This is useful for defining simple gradients or animated color transitions.
 pub trait ColorRange<T: Mix> {
     /// Get the color value at the given interpolation factor, which should be between 0.0 (start)
     /// and 1.0 (end).
@@ -18,8 +18,77 @@ impl<T: Mix> ColorRange<T> for Range<T> {
         self.start.mix(&self.end, factor.clamp(0.0, 1.0))
     }
 }
+
+/// Represents a gradient of a minimum of 1 up to arbitrary many colors. Supported colors have to
+/// implement [`Mix`] and have to be from the same color space.
+///
+/// By default the color values are linearly interpolated.
+///
+/// This is useful for defining complex gradients or animated color transitions.
+pub struct ColorGradient<T: Mix> {
+    colors: Vec<T>,
+}
+
+impl<T: Mix> ColorGradient<T> {
+    /// Create a new [`ColorGradient`] from a collection of [mixable] types.
+    ///
+    /// This fails if there's not at least one mixable type in the collection.
+    ///
+    /// [mixable]: `Mix`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_color::palettes::basic::*;
+    /// # use bevy_color::ColorGradient;
+    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]);
+    /// assert!(gradient.is_ok());
+    /// ```
+    pub fn new(colors: impl IntoIterator<Item = T>) -> Result<Self, ColorGradientError> {
+        let colors = colors.into_iter().collect::<Vec<_>>();
+        let len = colors.len();
+        (!colors.is_empty())
+            .then(|| Self { colors })
+            .ok_or_else(|| ColorGradientError(len))
     }
 }
+
+impl<T: Mix> ColorRange<T> for ColorGradient<T> {
+    fn at(&self, factor: f32) -> T {
+        match self.colors.len() {
+            len if len == 0 => {
+                unreachable!("at least 1 by construction")
+            }
+            len if len == 1 => {
+                // This weirdness exists to prevent adding a `Clone` bound on the type `T` and instead
+                // work with what we already have here
+                self.colors[0].mix(&self.colors[0], 0.0)
+            }
+            len => {
+                // clamp to range of valid indices
+                let factor = factor.clamp(0.0, (len - 1) as f32);
+                let fract = factor.fract();
+                if fract == 0.0 {
+                    // doesn't need clamping since it already was clamped to valid indices
+                    let exact_n = factor as usize;
+                    // weirdness again
+                    self.colors[exact_n].mix(&self.colors[exact_n], 0.0)
+                } else {
+                    // SAFETY: we know that `len != 0` and `len != 1` here so `len >= 2`
+                    let below = (factor.floor() as usize).min(len - 2);
+                    self.colors[below].mix(&self.colors[below + 1], fract)
+                }
+            }
+        }
+    }
+}
+
+/// Error related to violations of invariants of [`ColorGradient`]
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Couldn't construct a ColorGradient since there were too few colors. Got {0}, expected >=1"
+)]
+pub struct ColorGradientError(usize);
 
 #[cfg(test)]
 mod tests {
@@ -41,5 +110,35 @@ mod tests {
         assert_eq!(range.at(0.0), lred);
         assert_eq!(range.at(0.5), LinearRgba::new(0.5, 0.0, 0.5, 1.0));
         assert_eq!(range.at(1.0), lblue);
+    }
+
+    #[test]
+    fn test_color_gradient() {
+        let gradient =
+            ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).expect("Valid gradient");
+        assert_eq!(gradient.at(-1.5), basic::RED);
+        assert_eq!(gradient.at(-1.0), basic::RED);
+        assert_eq!(gradient.at(0.0), basic::RED);
+        assert_eq!(gradient.at(0.5), Srgba::new(0.5, 0.5, 0.0, 1.0));
+        assert_eq!(gradient.at(1.0), basic::LIME);
+        assert_eq!(gradient.at(1.5), Srgba::new(0.0, 0.5, 0.5, 1.0));
+        assert_eq!(gradient.at(2.0), basic::BLUE);
+        assert_eq!(gradient.at(2.5), basic::BLUE);
+        assert_eq!(gradient.at(3.0), basic::BLUE);
+
+        let lred: LinearRgba = basic::RED.into();
+        let lgreen: LinearRgba = basic::LIME.into();
+        let lblue: LinearRgba = basic::BLUE.into();
+
+        let gradient = ColorGradient::new([lred, lgreen, lblue]).expect("Valid gradient");
+        assert_eq!(gradient.at(-1.5), lred);
+        assert_eq!(gradient.at(-1.0), lred);
+        assert_eq!(gradient.at(0.0), lred);
+        assert_eq!(gradient.at(0.5), LinearRgba::new(0.5, 0.5, 0.0, 1.0));
+        assert_eq!(gradient.at(1.0), lgreen);
+        assert_eq!(gradient.at(1.5), LinearRgba::new(0.0, 0.5, 0.5, 1.0));
+        assert_eq!(gradient.at(2.0), lblue);
+        assert_eq!(gradient.at(2.5), lblue);
+        assert_eq!(gradient.at(3.0), lblue);
     }
 }

--- a/crates/bevy_color/src/color_range.rs
+++ b/crates/bevy_color/src/color_range.rs
@@ -1,7 +1,5 @@
 use std::ops::Range;
 
-use bevy_math::curve::{Curve, Interval};
-
 use crate::Mix;
 
 /// Represents a range of colors that can be linearly interpolated, defined by a start and
@@ -18,123 +16,6 @@ pub trait ColorRange<T: Mix> {
 impl<T: Mix> ColorRange<T> for Range<T> {
     fn at(&self, factor: f32) -> T {
         self.start.mix(&self.end, factor.clamp(0.0, 1.0))
-    }
-}
-
-/// Represents a gradient of a minimum of 1 up to arbitrary many colors. Supported colors have to
-/// implement [`Mix`] and have to be from the same color space.
-///
-/// By default the color values are linearly interpolated.
-///
-/// This is useful for defining complex gradients or animated color transitions.
-#[derive(Debug, Clone)]
-pub struct ColorGradient<T: Mix> {
-    colors: Vec<T>,
-}
-
-impl<T: Mix> ColorGradient<T> {
-    /// Create a new [`ColorGradient`] from a collection of [mixable] types.
-    ///
-    /// This fails if there's not at least one mixable type in the collection.
-    ///
-    /// [mixable]: `Mix`
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_color::palettes::basic::*;
-    /// # use bevy_color::ColorGradient;
-    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]);
-    /// assert!(gradient.is_ok());
-    /// ```
-    pub fn new(colors: impl IntoIterator<Item = T>) -> Result<Self, ColorGradientError> {
-        let colors = colors.into_iter().collect::<Vec<_>>();
-        let len = colors.len();
-        (!colors.is_empty())
-            .then(|| Self { colors })
-            .ok_or_else(|| ColorGradientError(len))
-    }
-
-    /// Converts the [`ColorGradient`] to a [`ColorCurve`] which implements the [`Curve`] trait
-    /// along with its adaptor methods
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_color::palettes::basic::*;
-    /// # use bevy_color::ColorGradient;
-    /// # use bevy_color::Srgba;
-    /// # use bevy_color::Mix;
-    /// # use bevy_math::curve::Curve;
-    /// let gradient = ColorGradient::new([RED, GREEN, BLUE]).unwrap();
-    /// let curve = gradient.to_curve();
-    ///
-    /// // you can then apply useful methods ontop of the gradient
-    /// let brighter_curve = curve.map(|c| c.mix(&WHITE, 0.25));
-    ///
-    /// assert_eq!(brighter_curve.sample_unchecked(0.0), Srgba::new(1.0, 0.25, 0.25, 1.0));
-    /// ```
-    pub fn to_curve(self) -> ColorCurve<T> {
-        let domain =
-            Interval::new(0.0, (self.colors.len() - 1) as f32).expect("at least 1 by construction");
-        ColorCurve {
-            domain,
-            gradient: self,
-        }
-    }
-}
-
-impl<T: Mix> ColorRange<T> for ColorGradient<T> {
-    fn at(&self, factor: f32) -> T {
-        match self.colors.len() {
-            len if len == 0 => {
-                unreachable!("at least 1 by construction")
-            }
-            len if len == 1 => {
-                // This weirdness exists to prevent adding a `Clone` bound on the type `T` and instead
-                // work with what we already have here
-                self.colors[0].mix(&self.colors[0], 0.0)
-            }
-            len => {
-                // clamp to range of valid indices
-                let factor = factor.clamp(0.0, (len - 1) as f32);
-                let fract = factor.fract();
-                if fract == 0.0 {
-                    // doesn't need clamping since it already was clamped to valid indices
-                    let exact_n = factor as usize;
-                    // weirdness again
-                    self.colors[exact_n].mix(&self.colors[exact_n], 0.0)
-                } else {
-                    // SAFETY: we know that `len != 0` and `len != 1` here so `len >= 2`
-                    let below = (factor.floor() as usize).min(len - 2);
-                    self.colors[below].mix(&self.colors[below + 1], fract)
-                }
-            }
-        }
-    }
-}
-
-/// Error related to violations of invariants of [`ColorGradient`]
-#[derive(Debug, thiserror::Error)]
-#[error(
-    "Couldn't construct a ColorGradient since there were too few colors. Got {0}, expected >=1"
-)]
-pub struct ColorGradientError(usize);
-
-/// A curve whose samples are defined by a [`ColorGradient`]. Curves of this type are produced by
-/// calling [`ColorGradien::to_curve`].
-#[derive(Clone, Debug)]
-pub struct ColorCurve<T: Mix> {
-    domain: Interval,
-    gradient: ColorGradient<T>,
-}
-
-impl<T: Mix> Curve<T> for ColorCurve<T> {
-    fn domain(&self) -> Interval {
-        self.domain
-    }
-
-    fn sample_unchecked(&self, t: f32) -> T {
-        self.gradient.at(t)
     }
 }
 
@@ -158,35 +39,5 @@ mod tests {
         assert_eq!(range.at(0.0), lred);
         assert_eq!(range.at(0.5), LinearRgba::new(0.5, 0.0, 0.5, 1.0));
         assert_eq!(range.at(1.0), lblue);
-    }
-
-    #[test]
-    fn test_color_gradient() {
-        let gradient =
-            ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).expect("Valid gradient");
-        assert_eq!(gradient.at(-1.5), basic::RED);
-        assert_eq!(gradient.at(-1.0), basic::RED);
-        assert_eq!(gradient.at(0.0), basic::RED);
-        assert_eq!(gradient.at(0.5), Srgba::new(0.5, 0.5, 0.0, 1.0));
-        assert_eq!(gradient.at(1.0), basic::LIME);
-        assert_eq!(gradient.at(1.5), Srgba::new(0.0, 0.5, 0.5, 1.0));
-        assert_eq!(gradient.at(2.0), basic::BLUE);
-        assert_eq!(gradient.at(2.5), basic::BLUE);
-        assert_eq!(gradient.at(3.0), basic::BLUE);
-
-        let lred: LinearRgba = basic::RED.into();
-        let lgreen: LinearRgba = basic::LIME.into();
-        let lblue: LinearRgba = basic::BLUE.into();
-
-        let gradient = ColorGradient::new([lred, lgreen, lblue]).expect("Valid gradient");
-        assert_eq!(gradient.at(-1.5), lred);
-        assert_eq!(gradient.at(-1.0), lred);
-        assert_eq!(gradient.at(0.0), lred);
-        assert_eq!(gradient.at(0.5), LinearRgba::new(0.5, 0.5, 0.0, 1.0));
-        assert_eq!(gradient.at(1.0), lgreen);
-        assert_eq!(gradient.at(1.5), LinearRgba::new(0.0, 0.5, 0.5, 1.0));
-        assert_eq!(gradient.at(2.0), lblue);
-        assert_eq!(gradient.at(2.5), lblue);
-        assert_eq!(gradient.at(3.0), lblue);
     }
 }

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -92,6 +92,7 @@
 
 mod color;
 pub mod color_difference;
+mod color_gradient;
 mod color_ops;
 mod color_range;
 mod hsla;
@@ -127,6 +128,7 @@ pub mod prelude {
 }
 
 pub use color::*;
+pub use color_gradient::*;
 pub use color_ops::*;
 pub use color_range::*;
 pub use hsla::*;


### PR DESCRIPTION
# Objective

- Currently we have the `ColorRange` trait to interpolate linearly between two colors
- It would be cool to have:
  1. linear interpolation between n colors where `n >= 1`
  2. other kinds of interpolation

## Solution

1. Implement `ColorGradient` which takes `n >= 1` colors and linearly interpolates between consecutive pairs of them
2. Implement `Curve` intergration for this `ColorGradient` which yields a curve struct. After that we can apply all of the cool curve adaptors like `.reparametrize()` and `.map()` to the gradient

## Testing

- Added doc tests
- Added tests

## Showcase

```rust
// let gradient = ColorGradient::new(vec![]).unwrap(); // panic! 💥
let gradient = ColorGradient::new([basic::RED, basic::LIME, basic::BLUE]).expect("non-empty");
let curve = gradient.to_curve();
let brighter_curve = curve.map(|c| c.mix(&basic::WHITE, 0.5));
```

--- 

Kind of related to https://github.com/bevyengine/bevy/pull/14971#discussion_r1736337631