### PR TITLE
Reorganize some of `bevy_animation`'s imports into a more consistent style

### DIFF
--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -3,8 +3,7 @@
 use std::io::{self, Write};
 use std::ops::{Index, IndexMut};
 
-use bevy_asset::io::Reader;
-use bevy_asset::{Asset, AssetId, AssetLoader, AssetPath, Handle, LoadContext};
+use bevy_asset::{io::Reader, Asset, AssetId, AssetLoader, AssetPath, Handle, LoadContext};
 use bevy_reflect::{Reflect, ReflectSerialize};
 use petgraph::graph::{DiGraph, NodeIndex};
 use ron::de::SpannedError;

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -21,24 +21,19 @@ use std::ops::{Add, Mul};
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_asset::{Asset, AssetApp, Assets, Handle};
 use bevy_core::Name;
-use bevy_ecs::entity::MapEntities;
-use bevy_ecs::prelude::*;
-use bevy_ecs::reflect::ReflectMapEntities;
+use bevy_ecs::{entity::MapEntities, prelude::*, reflect::ReflectMapEntities};
 use bevy_math::{FloatExt, Quat, Vec3};
 use bevy_reflect::Reflect;
 use bevy_render::mesh::morph::MorphWeights;
 use bevy_time::Time;
 use bevy_transform::{prelude::Transform, TransformSystem};
-use bevy_utils::hashbrown::HashMap;
 use bevy_utils::{
+    hashbrown::HashMap,
     tracing::{error, trace},
     NoOpHash,
 };
 use fixedbitset::FixedBitSet;
-use graph::{AnimationGraph, AnimationNodeIndex};
-use petgraph::graph::NodeIndex;
-use petgraph::Direction;
-use prelude::{AnimationGraphAssetLoader, AnimationTransitions};
+use petgraph::{graph::NodeIndex, Direction};
 use thread_local::ThreadLocal;
 use uuid::Uuid;
 
@@ -51,7 +46,10 @@ pub mod prelude {
     };
 }
 
-use crate::transition::{advance_transitions, expire_completed_transitions};
+use crate::{
+    graph::{AnimationGraph, AnimationGraphAssetLoader, AnimationNodeIndex},
+    transition::{advance_transitions, expire_completed_transitions, AnimationTransitions},
+};
 
 /// The [UUID namespace] of animation targets (e.g. bones).
 ///


### PR DESCRIPTION
# Objective
`bevy_animation` imports a lot of items - and it uses a very inconsistent code style to do so.

## Solution
Changes the offending `use` statements to be more consistent across the crate.

## Testing
- Did you test these changes? If so, how?
  - No testing is needed beyond lint checks, and those finished successfully.
- ~~Are there any parts that need more testing?~~
- ~~How can other people (reviewers) test your changes? Is there anything specific they need to know?~~
- ~~If relevant, what platforms did you test these changes on, and are there any important ones you can't test?~~
