### PR TITLE
Updated `LogPlugin` Documentation with Performance Warning

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -133,14 +133,22 @@ pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 /// This plugin should not be added multiple times in the same process. This plugin
 /// sets up global logging configuration for **all** Apps in a given process, and
 /// rerunning the same initialization multiple times will lead to a panic.
+///
+/// # Performance
+///
+/// Filters applied through this plugin are computed at _runtime_, which will
+/// have a non-zero impact on performance.
+/// To achieve maximum performance, consider using
+/// [_compile time_ filters](https://docs.rs/log/#compile-time-filters)
+/// provided by the [`log`](https://crates.io/crates/log) crate.
+///
+/// ```toml
+/// # cargo.toml
+/// [dependencies]
+/// log = { version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }
+/// ```
 pub struct LogPlugin {
-    /// Filters logs using the [`EnvFilter`] format.
-    ///
-    /// # Performance
-    ///
-    /// Due to how this filter is implemented, it can noticeably degrade performance to use lengthy
-    /// or otherwise complex filter strings. Where possible, use [`level`](`LogPlugin::level`), as
-    /// its global filtering is much more performant.
+    /// Filters logs using the [`EnvFilter`] format
     pub filter: String,
 
     /// Filters out logs that are "less than" the given level.

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -134,7 +134,13 @@ pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 /// sets up global logging configuration for **all** Apps in a given process, and
 /// rerunning the same initialization multiple times will lead to a panic.
 pub struct LogPlugin {
-    /// Filters logs using the [`EnvFilter`] format
+    /// Filters logs using the [`EnvFilter`] format.
+    ///
+    /// # Performance
+    ///
+    /// Due to how this filter is implemented, it can noticeably degrade performance to use lengthy
+    /// or otherwise complex filter strings. Where possible, use [`level`](`LogPlugin::level`), as
+    /// its global filtering is much more performant.
     pub filter: String,
 
     /// Filters out logs that are "less than" the given level.


### PR DESCRIPTION
# Objective

- Fixes #14966

## Solution

- Added a _Performance_ section to the documentation for `LogPlugin::filter` explaining that long filter strings can degrade performance and to instead rely on `LogPlugin::level` when possible.

## Testing

- CI passed locally.
