### PR TITLE
Interpolate `WorldQuery` path in docs of generated types

### DIFF
--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -335,9 +335,13 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
 
         const _: () = {
             #[doc(hidden)]
-            #[doc = "Automatically generated internal [`WorldQuery`] state type for [`"]
-            #[doc = stringify!(#struct_name)]
-            #[doc = "`], used for caching."]
+            #[doc = concat!(
+                "Automatically generated internal [`WorldQuery`](",
+                stringify!(#path),
+                "::query::WorldQuery) state type for [`",
+                stringify!(#struct_name),
+                "`], used for caching."
+            )]
             #[automatically_derived]
             #visibility struct #state_struct_name #user_impl_generics #user_where_clauses {
                 #(#named_field_idents: <#field_types as #path::query::WorldQuery>::State,)*

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -250,9 +250,13 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
             user_where_clauses_with_world,
         );
         let read_only_structs = quote! {
-            #[doc = "Automatically generated [`WorldQuery`] type for a read-only variant of [`"]
-            #[doc = stringify!(#struct_name)]
-            #[doc = "`]."]
+            #[doc = concat!(
+                "Automatically generated [`WorldQuery`](",
+                stringify!(#path),
+                "::query::WorldQuery) type for a read-only variant of [`",
+                stringify!(#struct_name),
+                "`]."
+            )]
             #[automatically_derived]
             #visibility struct #read_only_struct_name #user_impl_generics #user_where_clauses {
                 #(

--- a/crates/bevy_ecs/macros/src/query_filter.rs
+++ b/crates/bevy_ecs/macros/src/query_filter.rs
@@ -145,9 +145,13 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
 
         const _: () = {
             #[doc(hidden)]
-            #[doc = "Automatically generated internal [`WorldQuery`] state type for [`"]
-            #[doc = stringify!(#struct_name)]
-            #[doc = "`], used for caching."]
+            #[doc = concat!(
+                "Automatically generated internal [`WorldQuery`](",
+                stringify!(#path),
+                "::query::WorldQuery) state type for [`",
+                stringify!(#struct_name),
+                "`], used for caching."
+            )]
             #[automatically_derived]
             #visibility struct #state_struct_name #user_impl_generics #user_where_clauses {
                 #(#named_field_idents: <#field_types as #path::query::WorldQuery>::State,)*

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -19,12 +19,16 @@ pub(crate) fn item_struct(
     user_ty_generics_with_world: &TypeGenerics,
     user_where_clauses_with_world: Option<&WhereClause>,
 ) -> proc_macro2::TokenStream {
-    let item_attrs = quote!(
-            #[doc = "Automatically generated [`WorldQuery`](#path::query::WorldQuery) item type for [`"]
-            #[doc = stringify!(#struct_name)]
-            #[doc = "`], returned when iterating over query results."]
-            #[automatically_derived]
-    );
+    let item_attrs = quote! {
+        #[doc = concat!(
+            "Automatically generated [`WorldQuery`](",
+            stringify!(#path),
+            "::query::WorldQuery) item type for [`",
+            stringify!(#struct_name),
+            "`], returned when iterating over query results."
+        )]
+        #[automatically_derived]
+    };
 
     match fields {
         Fields::Named(_) => quote! {

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -73,9 +73,13 @@ pub(crate) fn world_query_impl(
 ) -> proc_macro2::TokenStream {
     quote! {
         #[doc(hidden)]
-        #[doc = "Automatically generated internal [`WorldQuery`] fetch type for [`"]
-        #[doc = stringify!(#struct_name)]
-        #[doc = "`], used to define the world data accessed by this query."]
+        #[doc = concat!(
+            "Automatically generated internal [`WorldQuery`](",
+            stringify!(#path),
+            "::query::WorldQuery) fetch type for [`",
+            stringify!(#struct_name),
+            "`], used to define the world data accessed by this query."
+        )]
         #[automatically_derived]
         #visibility struct #fetch_struct_name #user_impl_generics_with_world #user_where_clauses_with_world {
             #(#named_field_idents: <#field_types as #path::query::WorldQuery>::Fetch<'__w>,)*


### PR DESCRIPTION
# Objective

Fixes #14972

## Solution

Uses the `concat!` macro to interpolate the `path` variable.

## Testing

* Run `cargo doc --workspace --open`
* Check functionality of `WorldQuery` links within `NodeQueryItem`, `NodeQueryReadOnly`, `NodeQueryReadOnlyItem` docs
