### PR TITLE
Improve schedule note of .after/.before & encourage to use .chain ins…

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -311,7 +311,7 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`before_ignore_deferred`](Self::before_ignore_deferred) instead.
     ///
-    /// Usually, you'll want to use [`.chain`](Self::chain) instead.
+    /// Calling [`.chain`](Self::chain) is often more convenient and ensures that all systems are added to the schedule.
     /// Please check the [caveats section of `.after`](Self::after) for details.
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().before(set)

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -322,13 +322,13 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
-    /// # Notes
+    /// # Note
     ///
-    /// If you configure two groups of systems (let's call them 'Set A') in a Schedule, another group referencing `.after` or `.before` (let's call it 'Set B') will not be added automatically.
+    /// If you configure two groups of systems (e.g. 'Set A') in a schedule, and another group references `.after` or `.before` (e.g. 'Set B'), the systems in Set B will not be automatically scheduled.
     ///
-    /// It's safe and won't cause any problems or errors. But no dependencies are created: Adding Set A does not automatically create any connections or relationships with Set B. They remain independent of each other.
+    /// This means that Set A and Set B will run independently unless they are explicitly linked. So `.after`/`.before` will not provide the desired behaviour, so the Sets can run in parallel or in any order determined by the scheduler.
     ///
-    /// If you're adding systems in the same location, it's recommended that you use **`.chain`** for brevity and clarity. You can also add a set of systems. You may want to use `.after` or `.before` in association with a comment when the reasoning needs to be particularly clear.
+    /// If you're adding systems in the same location, it's recommended that you use [**`.chain`**](Self::chain) for brevity and clarity. You can also add a set of systems. You may want to use `.after` or `.before` in association with a comment when the reasoning needs to be particularly clear and the order of execution is important or not immediately obvious.
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -324,7 +324,7 @@ where
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
     /// Usually, you'll want to use [`.chain`](Self::chain) instead. 
-    /// # Note
+    /// # Caveats
     ///
     /// If you configure two [`SystemSet`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
     ///

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -337,6 +337,8 @@ where
     ///
     /// Another caveat is that if `GameSystem::B` is placed in a different schedule than `GameSystem::A`,
     /// any ordering calls between them—whether using `.before`, `.after`, or `.chain`—will be silently ignored.
+    ///
+    /// [`App::configure_sets`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.configure_sets
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -329,7 +329,7 @@ where
     ///
     /// If you configure two [`System`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
     ///
-    /// This means that the system `GameSystem::A` and the system or systems in `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`configure_sets`](bevy_app::App::configure_sets).
+    /// This means that the system `GameSystem::A` and the system or systems in `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`configure_sets`]
     /// If that is the case, `.after`/`.before` will not provide the desired behaviour
     /// and the systems can run in parallel or in any order determined by the scheduler.
     /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you,
@@ -338,6 +338,8 @@ where
     ///
     /// Another caveat is that if `GameSystem::B` is placed in a different schedule than `GameSystem::A`,
     /// any ordering calls between them—whether using `.before`, `.after`, or `.chain`—will be silently ignored.
+    ///
+    /// [`configure_sets`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.configure_sets
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -316,7 +316,6 @@ where
         self.into_configs().before(set)
     }
 
-    ///
     /// Run after all systems in `set`. If `set` has any systems that produce [`Commands`](crate::system::Commands)
     /// or other [`Deferred`](crate::system::Deferred) operations, all systems in `self` will see their effect.
     ///

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -323,23 +323,21 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
-    /// Usually, you'll want to use [`.chain`](Self::chain) instead.
+    /// Calling [`.chain`](Self::chain) is often more convenient and ensures that all systems are added to the schedule.
     ///
     /// # Caveats
     ///
-    /// If you configure two [`SystemSet`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
+    /// If you configure two [`System`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
     ///
-    /// This means that the systems in `GameSystem::A` and `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`App::configure_sets`].
+    /// This means that the system `GameSystem::A` and the system or systems in `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`App::configure_sets`].
     /// If that is the case, `.after`/`.before` will not provide the desired behaviour
-    /// and the sets can run in parallel or in any order determined by the scheduler.
+    /// and the systems can run in parallel or in any order determined by the scheduler.
     /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you,
     /// e.g. when it was provided by Bevy or a third-party dependency,
     /// or you manually scheduled it somewhere else in your app.
     ///
     /// Another caveat is that if `GameSystem::B` is placed in a different schedule than `GameSystem::A`,
     /// any ordering calls between them—whether using `.before`, `.after`, or `.chain`—will be silently ignored.
-    ///
-    /// [`App::configure_sets`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.configure_sets
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -324,6 +324,7 @@ where
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
     /// Usually, you'll want to use [`.chain`](Self::chain) instead.
+    ///
     /// # Caveats
     ///
     /// If you configure two [`SystemSet`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -311,7 +311,7 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`before_ignore_deferred`](Self::before_ignore_deferred) instead.
     ///
-    /// Note: please check the [Notes of after](Self::after)
+    /// Note: please check the [Notes of `after`](Self::after)
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().before(set)
     }
@@ -328,7 +328,7 @@ where
     ///
     /// It's safe and won't cause any problems or errors. But no dependencies are created: Adding Set A does not automatically create any connections or relationships with Set B. They remain independent of each other.
     ///
-    /// If you're adding systems in the same location, it's **recommended** that you use **`.chain`**. You can also add a set of systems. You may want to use `.after` or `.before` for advanced planning and perhaps exceptional cases.
+    /// If you're adding systems in the same location, it's recommended that you use **`.chain`** for brevity and clarity. You can also add a set of systems. You may want to use `.after` or `.before` in association with a comment when the reasoning needs to be particularly clear.
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -311,20 +311,25 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`before_ignore_deferred`](Self::before_ignore_deferred) instead.
     ///
-    /// Note: The given set is not implicitly added to the schedule when this system set is added.
-    /// It is safe, but no dependencies will be created.
+    /// Note: please check the [Notes of after](Self::after)
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().before(set)
     }
 
+    ///
     /// Run after all systems in `set`. If `set` has any systems that produce [`Commands`](crate::system::Commands)
     /// or other [`Deferred`](crate::system::Deferred) operations, all systems in `self` will see their effect.
     ///
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
-    /// Note: The given set is not implicitly added to the schedule when this system set is added.
-    /// It is safe, but no dependencies will be created.
+    /// # Notes
+    ///
+    /// If you configure two groups of systems (let's call them 'Set A') in a Schedule, another group referencing `.after` or `.before` (let's call it 'Set B') will not be added automatically.
+    ///
+    /// It's safe and won't cause any problems or errors. But no dependencies are created: Adding Set A does not automatically create any connections or relationships with Set B. They remain independent of each other.
+    ///
+    /// If you're adding systems in the same location, it's **recommended** that you use **`.chain`**. You can also add a set of systems. You may want to use `.after` or `.before` for advanced planning and perhaps exceptional cases.
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -323,6 +323,7 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
+    /// Usually, you'll want to use [`.chain`](Self::chain) instead. 
     /// # Note
     ///
     /// If you configure two groups of systems (e.g. 'Set A') in a schedule, and another group references `.after` or `.before` (e.g. 'Set B'), the systems in Set B will not be automatically scheduled.

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -311,7 +311,8 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`before_ignore_deferred`](Self::before_ignore_deferred) instead.
     ///
-    /// Note: please check the [Notes of `after`](Self::after)
+    /// Usually, you'll want to use [`.chain`](Self::chain) instead. 
+    /// Please check the [caveats section of `.after`](Self::after) for details.
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().before(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -335,7 +335,8 @@ where
     /// e.g. when it was provided by Bevy or a third-party dependency, 
     /// or you manually scheduled it somewhere else in your app.
     ///
-    /// If you're adding systems in the same location, it's recommended that you use [**`.chain`**](Self::chain) for brevity and clarity. You can also add a set of systems. You may want to use `.after` or `.before` in association with a comment when the reasoning needs to be particularly clear and the order of execution is important or not immediately obvious.
+    /// Another caveat is that if `GameSystem::B` is placed in a different schedule than `GameSystem::A`,
+    /// any ordering calls between them—whether using `.before`, `.after`, or `.chain`—will be silently ignored.
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().after(set)
     }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -329,7 +329,7 @@ where
     ///
     /// If you configure two [`System`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
     ///
-    /// This means that the system `GameSystem::A` and the system or systems in `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`App::configure_sets`].
+    /// This means that the system `GameSystem::A` and the system or systems in `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`configure_sets`](bevy_app::App::configure_sets).
     /// If that is the case, `.after`/`.before` will not provide the desired behaviour
     /// and the systems can run in parallel or in any order determined by the scheduler.
     /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you,

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -311,7 +311,7 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`before_ignore_deferred`](Self::before_ignore_deferred) instead.
     ///
-    /// Usually, you'll want to use [`.chain`](Self::chain) instead. 
+    /// Usually, you'll want to use [`.chain`](Self::chain) instead.
     /// Please check the [caveats section of `.after`](Self::after) for details.
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {
         self.into_configs().before(set)
@@ -323,7 +323,7 @@ where
     /// If automatically inserting [`apply_deferred`](crate::schedule::apply_deferred) like
     /// this isn't desired, use [`after_ignore_deferred`](Self::after_ignore_deferred) instead.
     ///
-    /// Usually, you'll want to use [`.chain`](Self::chain) instead. 
+    /// Usually, you'll want to use [`.chain`](Self::chain) instead.
     /// # Caveats
     ///
     /// If you configure two [`SystemSet`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
@@ -331,8 +331,8 @@ where
     /// This means that the systems in `GameSystem::A` and `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`App::configure_sets`].
     /// If that is the case, `.after`/`.before` will not provide the desired behaviour
     /// and the sets can run in parallel or in any order determined by the scheduler.
-    /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you, 
-    /// e.g. when it was provided by Bevy or a third-party dependency, 
+    /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you,
+    /// e.g. when it was provided by Bevy or a third-party dependency,
     /// or you manually scheduled it somewhere else in your app.
     ///
     /// Another caveat is that if `GameSystem::B` is placed in a different schedule than `GameSystem::A`,

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -326,7 +326,7 @@ where
     /// Usually, you'll want to use [`.chain`](Self::chain) instead. 
     /// # Note
     ///
-    /// If you configure two groups of systems (e.g. 'Set A') in a schedule, and another group references `.after` or `.before` (e.g. 'Set B'), the systems in Set B will not be automatically scheduled.
+    /// If you configure two [`SystemSet`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
     ///
     /// This means that the systems in `GameSystem::A` and `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`App::configure_sets`].
     /// If that is the case, `.after`/`.before` will not provide the desired behaviour

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -327,7 +327,12 @@ where
     ///
     /// If you configure two groups of systems (e.g. 'Set A') in a schedule, and another group references `.after` or `.before` (e.g. 'Set B'), the systems in Set B will not be automatically scheduled.
     ///
-    /// This means that Set A and Set B will run independently unless they are explicitly linked. So `.after`/`.before` will not provide the desired behaviour, so the Sets can run in parallel or in any order determined by the scheduler.
+    /// This means that the systems in `GameSystem::A` and `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`App::configure_sets`].
+    /// If that is the case, `.after`/`.before` will not provide the desired behaviour
+    /// and the sets can run in parallel or in any order determined by the scheduler.
+    /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you, 
+    /// e.g. when it was provided by Bevy or a third-party dependency, 
+    /// or you manually scheduled it somewhere else in your app.
     ///
     /// If you're adding systems in the same location, it's recommended that you use [**`.chain`**](Self::chain) for brevity and clarity. You can also add a set of systems. You may want to use `.after` or `.before` in association with a comment when the reasoning needs to be particularly clear and the order of execution is important or not immediately obvious.
     fn after<M>(self, set: impl IntoSystemSet<M>) -> SystemConfigs {


### PR DESCRIPTION
# Objective

- Fixes #14552 
- Make the current note of `before` and `after` understandable. 
    - > The given set is not implicitly added to the schedule when this system set is added.

## Solution

- Replace note in docs of [`after` and `before`](https://docs.rs/bevy/latest/bevy/ecs/prelude/trait.IntoSystemConfigs.html#method.before) 
- Note of after was removed completely, and links to `before`, because they notes would be identical.
- Also encourage to use `.chain`, which is much simpler and safer to use

## Testing

- Checked the docs after running `cargo doc` and `cargo run -p ci -- lints`
- Are there any parts that need more testing?
  - no need to test, but please review the text. If it is still including the intended message and especially if its understandable.  