### PR TITLE
Fix compile error caused by incorrect feature flag in `bevy_state`

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -54,7 +54,7 @@ pub mod prelude {
     pub use crate::app::AppExtStates;
     #[doc(hidden)]
     pub use crate::condition::*;
-    #[cfg(feature = "bevy_app")]
+    #[cfg(feature = "bevy_reflect")]
     #[doc(hidden)]
     pub use crate::reflect::{ReflectFreelyMutableState, ReflectState};
     #[doc(hidden)]


### PR DESCRIPTION
# Objective

The `reflect` module in `bevy_state` is gated behind the `bevy_reflect` feature, but the type exports from that module in the crate prelude are erroneously gated behind the `bevy_app` feature, causing a compile error when the `bevy_reflect` feature is disabled, but the `bevy_app` feature is enabled.

## Solution

Change the feature gate to `bevy_reflect`.

## Testing

- Discovered by depending on `bevy_state` with `default-features = false, features = ["bevy_app"]`
- Tested by running `cargo check -p bevy_state --no-default-features --features bevy_app`