### PR TITLE
Make more `Color` constructors `const fn`

### DIFF
--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -142,7 +142,7 @@ impl Color {
     /// Creates a new [`Color`] object storing a [`Srgba`] color from [`u8`] values.
     ///
     /// A value of 0 is interpreted as 0.0, and a value of 255 is interpreted as 1.0.
-    pub fn srgba_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Self {
+    pub const fn srgba_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Self {
         Self::Srgba(Srgba {
             red: red as f32 / 255.0,
             green: green as f32 / 255.0,
@@ -162,7 +162,7 @@ impl Color {
     /// Creates a new [`Color`] object storing a [`Srgba`] color from [`u8`] values with an alpha of 1.0.
     ///
     /// A value of 0 is interpreted as 0.0, and a value of 255 is interpreted as 1.0.
-    pub fn srgb_u8(red: u8, green: u8, blue: u8) -> Self {
+    pub const fn srgb_u8(red: u8, green: u8, blue: u8) -> Self {
         Self::Srgba(Srgba {
             red: red as f32 / 255.0,
             green: green as f32 / 255.0,


### PR DESCRIPTION
# Objective

I regularly copy-paste color codes to my game and try to use them in `const` values. These color codes are often in hex format, so converting them to floating points is annoying. `Color::srgb_u8()` provides a relative convenient alternative, except it's not a `const fn`.

## Solution

This PR makes the `Color::srgb_u8()` and `Color::srgba_u8()` constructors `const fn`s, making their use easier in constants.

## Testing

I think this is one of those cases where we can say, if it compiles, it works :)