### PR TITLE
Optimize UI text measurement

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -240,6 +240,7 @@ impl TextPipeline {
     /// to measure the text area on demand.
     pub fn create_text_measure(
         &mut self,
+        entity: Entity,
         fonts: &Assets<Font>,
         sections: &[TextSection],
         scale_factor: f64,
@@ -270,9 +271,7 @@ impl TextPipeline {
         Ok(TextMeasureInfo {
             min: min_width_content_size,
             max: max_width_content_size,
-            // TODO: This clone feels wasteful, is there another way to structure TextMeasureInfo
-            // that it doesn't need to own a buffer? - bytemunch
-            buffer: buffer.0.clone(),
+            entity,
         })
     }
 
@@ -299,23 +298,14 @@ pub struct TextLayoutInfo {
 /// Size information for a corresponding [`Text`](crate::Text) component.
 ///
 /// Generated via [`TextPipeline::create_text_measure`].
+#[derive(Debug)]
 pub struct TextMeasureInfo {
     /// Minimum size for a text area in pixels, to be used when laying out widgets with taffy
     pub min: Vec2,
     /// Maximum size for a text area in pixels, to be used when laying out widgets with taffy
     pub max: Vec2,
-    buffer: Buffer,
-}
-
-impl std::fmt::Debug for TextMeasureInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TextMeasureInfo")
-            .field("min", &self.min)
-            .field("max", &self.max)
-            .field("buffer", &"_")
-            .field("font_system", &"_")
-            .finish()
-    }
+    /// The entity that is measured.
+    pub entity: Entity,
 }
 
 impl TextMeasureInfo {
@@ -323,11 +313,13 @@ impl TextMeasureInfo {
     pub fn compute_size(
         &mut self,
         bounds: TextBounds,
+        buffer: &mut cosmic_text::Buffer,
         font_system: &mut cosmic_text::FontSystem,
     ) -> Vec2 {
-        self.buffer
-            .set_size(font_system, bounds.width, bounds.height);
-        buffer_dimensions(&self.buffer)
+        // Note that this arbitrarily adjusts the buffer layout. We assume the buffer is always 'refreshed'
+        // whenever a canonical state is required.
+        buffer.set_size(font_system, bounds.width, bounds.height);
+        buffer_dimensions(&buffer)
     }
 }
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bevy_asset::{AssetId, Assets};
-use bevy_ecs::{component::Component, reflect::ReflectComponent, system::Resource};
+use bevy_ecs::{component::Component, entity::Entity, reflect::ReflectComponent, system::Resource};
 use bevy_math::{UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::texture::Image;
@@ -313,7 +313,7 @@ impl TextMeasureInfo {
     pub fn compute_size(
         &mut self,
         bounds: TextBounds,
-        buffer: &mut cosmic_text::Buffer,
+        buffer: &mut Buffer,
         font_system: &mut cosmic_text::FontSystem,
     ) -> Vec2 {
         // Note that this arbitrarily adjusts the buffer layout. We assume the buffer is always 'refreshed'

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -238,6 +238,7 @@ impl TextPipeline {
     ///
     /// Produces a [`TextMeasureInfo`] which can be used by a layout system
     /// to measure the text area on demand.
+    #[allow(clippy::too_many_arguments)]
     pub fn create_text_measure(
         &mut self,
         entity: Entity,
@@ -319,7 +320,7 @@ impl TextMeasureInfo {
         // Note that this arbitrarily adjusts the buffer layout. We assume the buffer is always 'refreshed'
         // whenever a canonical state is required.
         buffer.set_size(font_system, bounds.width, bounds.height);
-        buffer_dimensions(&buffer)
+        buffer_dimensions(buffer)
     }
 }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -95,6 +95,7 @@ pub fn ui_layout_system(
     just_children_query: Query<&Children>,
     mut removed_components: UiLayoutSystemRemovedComponentParam,
     mut node_transform_query: Query<(&mut Node, &mut Transform)>,
+    #[cfg(feature = "bevy_text")] mut buffer_query: Query<&mut CosmicBuffer>,
     #[cfg(feature = "bevy_text")] mut text_pipeline: ResMut<TextPipeline>,
 ) {
     struct CameraLayoutInfo {
@@ -218,6 +219,8 @@ pub fn ui_layout_system(
     });
 
     #[cfg(feature = "bevy_text")]
+    let text_buffers = &mut buffer_query;
+    #[cfg(feature = "bevy_text")]
     let font_system = text_pipeline.font_system_mut();
     // clean up removed nodes after syncing children to avoid potential panic (invalid SlotMap key used)
     ui_surface.remove_entities(removed_components.removed_nodes.read());
@@ -235,6 +238,8 @@ pub fn ui_layout_system(
         ui_surface.compute_camera_layout(
             *camera_id,
             camera.size,
+            #[cfg(feature = "bevy_text")]
+            text_buffers,
             #[cfg(feature = "bevy_text")]
             font_system,
         );

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -12,7 +12,7 @@ use bevy_hierarchy::{Children, Parent};
 use bevy_math::{UVec2, Vec2};
 use bevy_render::camera::{Camera, NormalizedRenderTarget};
 #[cfg(feature = "bevy_text")]
-use bevy_text::TextPipeline;
+use bevy_text::{CosmicBuffer, TextPipeline};
 use bevy_transform::components::Transform;
 use bevy_utils::tracing::warn;
 use bevy_utils::{HashMap, HashSet};

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -227,7 +227,14 @@ without UI components as a child of an entity with UI components, results may be
                         context
                             .map(|ctx| {
                                 #[cfg(feature = "bevy_text")]
-                                let buffer = get_text_buffer(ctx, buffer_query);
+                                let buffer = get_text_buffer(
+                                    crate::widget::TextMeasure::needs_buffer(
+                                        known_dimensions.height,
+                                        available_space.width,
+                                    ),
+                                    ctx,
+                                    buffer_query,
+                                );
                                 let size = ctx.measure(
                                     MeasureArgs {
                                         width: known_dimensions.width,
@@ -294,9 +301,14 @@ with UI components as a child of an entity without UI components, results may be
 
 #[cfg(feature = "bevy_text")]
 fn get_text_buffer<'a>(
+    needs_buffer: bool,
     ctx: &mut NodeMeasure,
     query: &'a mut bevy_ecs::prelude::Query<&mut bevy_text::CosmicBuffer>,
 ) -> Option<&'a mut bevy_text::cosmic_text::Buffer> {
+    // We avoid a query lookup whenever the buffer is not required.
+    if !needs_buffer {
+        return None;
+    }
     let NodeMeasure::Text(crate::widget::TextMeasure { info }) = ctx else {
         return None;
     };

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -23,6 +23,8 @@ pub struct MeasureArgs<'a> {
     pub available_height: AvailableSpace,
     #[cfg(feature = "bevy_text")]
     pub font_system: &'a mut bevy_text::cosmic_text::FontSystem,
+    #[cfg(feature = "bevy_text")]
+    pub buffer: Option<&'a mut bevy_text::cosmic_text::Buffer>,
     // When `bevy_text` is disabled, use `PhantomData` in order to keep lifetime in type signature.
     #[cfg(not(feature = "bevy_text"))]
     pub font_system: std::marker::PhantomData<&'a mut ()>,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -47,6 +47,13 @@ pub struct TextMeasure {
     pub info: TextMeasureInfo,
 }
 
+impl TextMeasure {
+    /// Checks if the cosmic text buffer is needed for measuring the text.
+    pub fn needs_buffer(height: Option<f32>, available_width: AvailableSpace) -> bool {
+        height.is_none() && matches!(available_width, AvailableSpace::Definite(_))
+    }
+}
+
 impl Measure for TextMeasure {
     fn measure(&mut self, measure_args: MeasureArgs, _style: &taffy::Style) -> Vec2 {
         let MeasureArgs {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -19,7 +19,7 @@ use bevy_text::{
     scale_value, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, JustifyText, Text, TextBounds,
     TextError, TextLayoutInfo, TextMeasureInfo, TextPipeline, YAxisOrientation,
 };
-use bevy_utils::Entry;
+use bevy_utils::{tracing::error, Entry};
 use taffy::style::AvailableSpace;
 
 /// Text system flags
@@ -74,14 +74,16 @@ impl Measure for TextMeasure {
                 || match available_width {
                     AvailableSpace::Definite(_) => {
                         if let Some(buffer) = buffer {
-                            self
-                                .info
-                                .compute_size(TextBounds::new_horizontal(x), buffer, font_system)
+                            self.info.compute_size(
+                                TextBounds::new_horizontal(x),
+                                buffer,
+                                font_system,
+                            )
                         } else {
                             error!("text measure failed, buffer is missing");
                             Vec2::default()
                         }
-                    },
+                    }
                     AvailableSpace::MinContent => Vec2::new(x, self.info.min.y),
                     AvailableSpace::MaxContent => Vec2::new(x, self.info.max.y),
                 },


### PR DESCRIPTION
# Objective

- Avoid cloning the `CosmicBuffer` every time you create a new text measurement.

## Solution

- Inject a buffer query when calculating layout so existing buffers can be reused.

## Testing

- I tested the `text`, `text_debug`, and `text_wrap_debug` examples.
- I did not do a performance test.
