### PR TITLE
Fix `with_child` not inserting `Parent` component

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -585,7 +585,8 @@ impl BuildChildren for EntityWorldMut<'_> {
     }
 
     fn with_child<B: Bundle>(&mut self, bundle: B) -> &mut Self {
-        let child = self.world_scope(|world| world.spawn(bundle).id());
+        let parent = self.id();
+        let child = self.world_scope(|world| world.spawn((bundle, Parent(parent))).id());
         if let Some(mut children_component) = self.get_mut::<Children>() {
             children_component.0.retain(|value| child != *value);
             children_component.0.push(child);


### PR DESCRIPTION
# Objective

The `Parent` component holds a reference to the parent entity of the entity it is inserted onto. The `with_child` function erroneously forgets to insert this component onto the child entity that it spawns, causing buggy behaviour when the function is used instead of the other child-spawning functions.

## Solution

Ensure `with_child` inserts the `Parent` component, the same as all the other child-spawning functions.

## Testing

Checked before/after with a bevy_ui layout where this patch fixed buggy behaviour I was seeing in parent/child UI nodes.
