### PR TITLE
Fix some examples having different instruction text positions

### DIFF
--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -90,8 +90,8 @@ fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
         }
         .with_style(Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            left: Val::Px(10.0),
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
             ..default()
         }),
     );

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -150,8 +150,8 @@ fn setup(
     commands.spawn((
         TextBundle::from_section("", text_style).with_style(Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            right: Val::Px(10.0),
+            top: Val::Px(12.0),
+            right: Val::Px(12.0),
             ..default()
         }),
         ExampleDisplay,

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -143,8 +143,8 @@ fn add_buttons(commands: &mut Commands, font: &Handle<Font>, color_grading: &Col
                 flex_direction: FlexDirection::Column,
                 position_type: PositionType::Absolute,
                 row_gap: Val::Px(6.0),
-                left: Val::Px(10.0),
-                bottom: Val::Px(10.0),
+                left: Val::Px(12.0),
+                bottom: Val::Px(12.0),
                 ..default()
             },
             ..default()
@@ -318,8 +318,8 @@ fn add_help_text(
         .spawn(TextBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                left: Val::Px(10.0),
-                top: Val::Px(10.0),
+                left: Val::Px(12.0),
+                top: Val::Px(12.0),
                 ..default()
             },
             ..TextBundle::from_section(

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -144,8 +144,8 @@ fn setup_ui(mut commands: Commands) {
         )
         .with_style(Style {
             position_type: PositionType::Absolute,
-            left: Val::Px(10.0),
-            top: Val::Px(10.0),
+            left: Val::Px(12.0),
+            top: Val::Px(12.0),
             ..default()
         }),
     );
@@ -157,8 +157,8 @@ fn setup_ui(mut commands: Commands) {
                 flex_direction: FlexDirection::Column,
                 position_type: PositionType::Absolute,
                 row_gap: Val::Px(6.0),
-                left: Val::Px(10.0),
-                bottom: Val::Px(10.0),
+                left: Val::Px(12.0),
+                bottom: Val::Px(12.0),
                 ..default()
             },
             ..default()

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -23,8 +23,8 @@ fn setup(
                 text: Text::from_section("Click Me to get a box", TextStyle::default()),
                 style: Style {
                     position_type: PositionType::Absolute,
-                    top: Val::Percent(10.0),
-                    left: Val::Percent(10.0),
+                    top: Val::Percent(12.0),
+                    left: Val::Percent(12.0),
                     ..default()
                 },
                 ..Default::default()


### PR DESCRIPTION
# Objective

Thought I had found all of these... noticed some `10px` in #15013 and did another sweep.

Continuation of #8478, #13583.

## Solution

- Position example text (and other elements) 12px from the edge of the screen