### PR TITLE
Bump crate-ci/typos from 1.24.1 to 1.24.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.24.1
+        uses: crate-ci/typos@v1.24.3
       - name: Typos info
         if: failure()
         run: |

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -261,7 +261,7 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
 
     /// Create a [`QueryState`] with the accesses of the builder.
     ///
-    /// Takes `&mut self` to access the innner world reference while initializing
+    /// Takes `&mut self` to access the inner world reference while initializing
     /// state for the new [`QueryState`]
     pub fn build(&mut self) -> QueryState<D, F> {
         QueryState::<D, F>::from_builder(self)


### PR DESCRIPTION
# Objective

- Adopts #15015

## Solution

- Fixed a typo that broke the build and prevented updating `crate-ci/typos`.