### PR TITLE
Reflect auto registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,6 +350,9 @@ track_change_detection = ["bevy_internal/track_change_detection"]
 # Enable function reflection
 reflect_functions = ["bevy_internal/reflect_functions"]
 
+# Enables automatic registration of types annotated with #[derive(Reflect)]
+reflect_auto_register = ["bevy_internal/reflect_auto_register"]
+
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.15.0-dev", default-features = false }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -92,7 +92,11 @@ impl Debug for App {
 impl Default for App {
     fn default() -> Self {
         let mut app = App::empty();
+
         app.sub_apps.main.update_schedule = Some(Main.intern());
+
+        #[cfg(feature = "bevy_reflect")]
+        bevy_reflect::wasm_init::wasm_init();
 
         #[cfg(feature = "bevy_reflect")]
         app.init_resource::<AppTypeRegistry>();

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -96,9 +96,6 @@ impl Default for App {
         app.sub_apps.main.update_schedule = Some(Main.intern());
 
         #[cfg(feature = "bevy_reflect")]
-        bevy_reflect::wasm_init::wasm_init();
-
-        #[cfg(feature = "bevy_reflect")]
         app.init_resource::<AppTypeRegistry>();
 
         #[cfg(feature = "reflect_functions")]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -212,6 +212,9 @@ reflect_functions = [
   "bevy_ecs/reflect_functions",
 ]
 
+# Enables automatic registration of types annotated with #[derive(Reflect)]
+reflect_auto_register = ["bevy_reflect/auto_register_derives"]
+
 [dependencies]
 # bevy
 bevy_a11y = { path = "../bevy_a11y", version = "0.15.0-dev" }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -21,6 +21,12 @@ uuid = ["dep:uuid"]
 documentation = ["bevy_reflect_derive/documentation"]
 # Enables function reflection
 functions = ["bevy_reflect_derive/functions"]
+# Enables automatic registration of types annotated with #[derive(Reflect)]
+auto_register_derives = [
+    "bevy_reflect_derive/auto_register_derives",
+    "dep:inventory",
+    "dep:wasm-init",
+]
 
 [dependencies]
 # bevy
@@ -39,8 +45,8 @@ glam = { version = "0.28", features = ["serde"], optional = true }
 petgraph = { version = "0.6", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 uuid = { version = "1.0", optional = true, features = ["v4", "serde"] }
-inventory = "0.3"
-wasm-init = "0.2"
+inventory = { version = "0.3", optional = true }
+wasm-init = { version = "0.2", optional = true }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -39,6 +39,8 @@ glam = { version = "0.28", features = ["serde"], optional = true }
 petgraph = { version = "0.6", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 uuid = { version = "1.0", optional = true, features = ["v4", "serde"] }
+inventory = "0.3"
+wasm-init = "0.2"
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -17,6 +17,8 @@ default = []
 documentation = []
 # Enables macro logic related to function reflection
 functions = []
+# Enables automatic registration of types annotated with #[derive(Reflect)]
+auto_register_derives = []
 
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.15.0-dev" }

--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -24,6 +24,7 @@ mod kw {
     syn::custom_keyword!(PartialEq);
     syn::custom_keyword!(Hash);
     syn::custom_keyword!(no_field_bounds);
+    syn::custom_keyword!(no_auto_register);
 }
 
 // The "special" trait idents that are used internally for reflection.
@@ -188,6 +189,7 @@ pub(crate) struct ContainerAttributes {
     type_path_attrs: TypePathAttrs,
     custom_where: Option<WhereClause>,
     no_field_bounds: bool,
+    no_auto_register: bool,
     custom_attributes: CustomAttributes,
     idents: Vec<Ident>,
 }
@@ -239,6 +241,8 @@ impl ContainerAttributes {
             self.parse_type_path(input, trait_)
         } else if lookahead.peek(kw::no_field_bounds) {
             self.parse_no_field_bounds(input)
+        } else if lookahead.peek(kw::no_auto_register) {
+            self.parse_no_auto_register(input)
         } else if lookahead.peek(kw::Debug) {
             self.parse_debug(input)
         } else if lookahead.peek(kw::PartialEq) {
@@ -344,6 +348,16 @@ impl ContainerAttributes {
     fn parse_no_field_bounds(&mut self, input: ParseStream) -> syn::Result<()> {
         input.parse::<kw::no_field_bounds>()?;
         self.no_field_bounds = true;
+        Ok(())
+    }
+
+    /// Parse `no_auto_register` attribute.
+    ///
+    /// Examples:
+    /// - `#[reflect(no_auto_register)]`
+    fn parse_no_auto_register(&mut self, input: ParseStream) -> syn::Result<()> {
+        input.parse::<kw::no_auto_register>()?;
+        self.no_auto_register = true;
         Ok(())
     }
 
@@ -525,6 +539,11 @@ impl ContainerAttributes {
     /// Returns true if the `no_field_bounds` attribute was found on this type.
     pub fn no_field_bounds(&self) -> bool {
         self.no_field_bounds
+    }
+
+    /// Returns true if the `no_auto_register` attribute was found on this type.
+    pub fn no_auto_register(&self) -> bool {
+        self.no_auto_register
     }
 }
 

--- a/crates/bevy_reflect/derive/src/impls/common.rs
+++ b/crates/bevy_reflect/derive/src/impls/common.rs
@@ -158,6 +158,10 @@ pub fn common_partial_reflect_methods(
 }
 
 pub fn reflect_auto_registration(meta: &ReflectMeta) -> Option<proc_macro2::TokenStream> {
+    if meta.attrs().no_auto_register() {
+        return None;
+    }
+
     let bevy_reflect_path = meta.bevy_reflect_path();
     let type_path = meta.type_path();
     let (_, ty_generics, _) = meta.type_path().generics().split_for_impl();

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -1,6 +1,9 @@
 use crate::derive_data::{EnumVariantFields, ReflectEnum, StructField};
 use crate::enum_utility::{EnumVariantOutputData, TryApplyVariantBuilder, VariantBuilder};
-use crate::impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed};
+use crate::impls::{
+    common_partial_reflect_methods, impl_full_reflect, reflect_auto_registration,
+    impl_type_path, impl_typed,
+};
 use bevy_macro_utils::fq_std::{FQBox, FQOption, FQResult};
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -80,6 +83,8 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     let (impl_generics, ty_generics, where_clause) =
         reflect_enum.meta().type_path().generics().split_for_impl();
 
+    let auto_register = reflect_auto_registration(&reflect_enum.meta());
+
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
 
     quote! {
@@ -92,6 +97,8 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         #full_reflect_impl
 
         #function_impls
+
+        #auto_register
 
         impl #impl_generics #bevy_reflect_path::Enum for #enum_path #ty_generics #where_reflect_clause {
             fn field(&self, #ref_name: &str) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -1,8 +1,8 @@
 use crate::derive_data::{EnumVariantFields, ReflectEnum, StructField};
 use crate::enum_utility::{EnumVariantOutputData, TryApplyVariantBuilder, VariantBuilder};
 use crate::impls::{
-    common_partial_reflect_methods, impl_full_reflect, reflect_auto_registration,
-    impl_type_path, impl_typed,
+    common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed,
+    reflect_auto_registration,
 };
 use bevy_macro_utils::fq_std::{FQBox, FQOption, FQResult};
 use proc_macro2::{Ident, Span};
@@ -83,6 +83,9 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
     let (impl_generics, ty_generics, where_clause) =
         reflect_enum.meta().type_path().generics().split_for_impl();
 
+    #[cfg(not(feature = "auto_register_derives"))]
+    let auto_register = None::<proc_macro2::TokenStream>;
+    #[cfg(feature = "auto_register_derives")]
     let auto_register = reflect_auto_registration(&reflect_enum.meta());
 
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);

--- a/crates/bevy_reflect/derive/src/impls/mod.rs
+++ b/crates/bevy_reflect/derive/src/impls/mod.rs
@@ -9,7 +9,9 @@ mod typed;
 mod values;
 
 pub(crate) use assertions::impl_assertions;
-pub(crate) use common::{common_partial_reflect_methods, impl_full_reflect};
+pub(crate) use common::{
+    common_partial_reflect_methods, impl_full_reflect, reflect_auto_registration,
+};
 pub(crate) use enums::impl_enum;
 #[cfg(feature = "functions")]
 pub(crate) use func::impl_function_traits;

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -63,6 +63,9 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         .generics()
         .split_for_impl();
 
+    #[cfg(not(feature = "auto_register_derives"))]
+    let auto_register = None::<proc_macro2::TokenStream>;
+    #[cfg(feature = "auto_register_derives")]
     let auto_register = reflect_auto_registration(&reflect_struct.meta());
 
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -1,4 +1,7 @@
-use crate::impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed};
+use crate::impls::{
+    common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed,
+    reflect_auto_registration,
+};
 use crate::struct_utility::FieldAccessors;
 use crate::ReflectStruct;
 use bevy_macro_utils::fq_std::{FQBox, FQDefault, FQOption, FQResult};
@@ -60,21 +63,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         .generics()
         .split_for_impl();
 
-    let auto_reflect = if ty_generics.clone().into_token_stream().is_empty() {
-        quote! {
-            #[cfg(target_arch = "wasm32")]
-            #bevy_reflect_path::wasm_init::wasm_init!{
-                #bevy_reflect_path::AUTOMATIC_REFLECT_TYPES
-                    .write()
-                    .unwrap()
-                    .push(|reg: &mut #bevy_reflect_path::TypeRegistry| reg.register::<#struct_path>());
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            #bevy_reflect_path::inventory::submit!(#bevy_reflect_path::AUTOMATIC_REFLECT_TYPES(|reg: &mut #bevy_reflect_path::TypeRegistry| reg.register::<#struct_path>()));
-        }
-    } else {
-        quote! {}
-    };
+    let auto_register = reflect_auto_registration(&reflect_struct.meta());
 
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
 
@@ -89,7 +78,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
 
         #function_impls
 
-        #auto_reflect
+        #auto_register
 
         impl #impl_generics #bevy_reflect_path::Struct for #struct_path #ty_generics #where_reflect_clause {
             fn field(&self, name: &str) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -1,4 +1,7 @@
-use crate::impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed};
+use crate::impls::{
+    common_partial_reflect_methods, impl_full_reflect, reflect_auto_registration,
+    impl_type_path, impl_typed,
+};
 use crate::struct_utility::FieldAccessors;
 use crate::ReflectStruct;
 use bevy_macro_utils::fq_std::{FQBox, FQDefault, FQOption, FQResult};
@@ -48,6 +51,8 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
         .generics()
         .split_for_impl();
 
+    let auto_register = reflect_auto_registration(&reflect_struct.meta());
+
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
 
     quote! {
@@ -60,6 +65,8 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
         #full_reflect_impl
 
         #function_impls
+
+        #auto_register
 
         impl #impl_generics #bevy_reflect_path::TupleStruct for #struct_path #ty_generics #where_reflect_clause {
             fn field(&self, index: usize) -> #FQOption<&dyn #bevy_reflect_path::PartialReflect> {

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -1,6 +1,6 @@
 use crate::impls::{
-    common_partial_reflect_methods, impl_full_reflect, reflect_auto_registration,
-    impl_type_path, impl_typed,
+    common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed,
+    reflect_auto_registration,
 };
 use crate::struct_utility::FieldAccessors;
 use crate::ReflectStruct;
@@ -51,6 +51,9 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
         .generics()
         .split_for_impl();
 
+    #[cfg(not(feature = "auto_register_derives"))]
+    let auto_register = None::<proc_macro2::TokenStream>;
+    #[cfg(feature = "auto_register_derives")]
     let auto_register = reflect_auto_registration(&reflect_struct.meta());
 
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);

--- a/crates/bevy_reflect/derive/src/impls/values.rs
+++ b/crates/bevy_reflect/derive/src/impls/values.rs
@@ -1,4 +1,7 @@
-use crate::impls::{common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed};
+use crate::impls::{
+    common_partial_reflect_methods, impl_full_reflect, impl_type_path, impl_typed,
+    reflect_auto_registration,
+};
 use crate::utility::WhereClauseOptions;
 use crate::ReflectMeta;
 use bevy_macro_utils::fq_std::{FQBox, FQClone, FQOption, FQResult};
@@ -57,6 +60,8 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
     let get_type_registration_impl = meta.get_type_registration(&where_clause_options);
 
+    let auto_register = reflect_auto_registration(meta);
+
     quote! {
         #get_type_registration_impl
 
@@ -67,6 +72,8 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
         #full_reflect_impl
 
         #function_impls
+
+        #auto_register
 
         impl #impl_generics #bevy_reflect_path::PartialReflect for #type_path #ty_generics #where_reflect_clause  {
             #[inline]

--- a/crates/bevy_reflect/derive/src/impls/values.rs
+++ b/crates/bevy_reflect/derive/src/impls/values.rs
@@ -60,6 +60,9 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
     let get_type_registration_impl = meta.get_type_registration(&where_clause_options);
 
+    #[cfg(not(feature = "auto_register_derives"))]
+    let auto_register = None::<proc_macro2::TokenStream>;
+    #[cfg(feature = "auto_register_derives")]
     let auto_register = reflect_auto_registration(meta);
 
     quote! {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -597,6 +597,9 @@ pub use type_registry::*;
 pub use bevy_reflect_derive::*;
 pub use erased_serde;
 
+pub extern crate inventory;
+pub extern crate wasm_init;
+
 extern crate alloc;
 
 /// Exports used by the reflection macros.

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -597,7 +597,9 @@ pub use type_registry::*;
 pub use bevy_reflect_derive::*;
 pub use erased_serde;
 
+#[cfg(feature = "auto_register_derives")]
 pub extern crate inventory;
+#[cfg(feature = "auto_register_derives")]
 pub extern crate wasm_init;
 
 extern crate alloc;

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -9,12 +9,13 @@ use std::{
     sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-#[cfg(target_arch = "wasm32")]
-pub static AUTOMATIC_REFLECT_TYPES: RwLock<Vec<fn(&mut TypeRegistry)>> = RwLock::new(Vec::new());
-#[cfg(not(target_arch = "wasm32"))]
-pub struct AUTOMATIC_REFLECT_TYPES(pub fn(&mut TypeRegistry));
-#[cfg(not(target_arch = "wasm32"))]
-inventory::collect!(AUTOMATIC_REFLECT_TYPES);
+#[cfg(target_family = "wasm")]
+pub static DERIVED_REFLECT_TYPES: RwLock<Vec<fn(&mut TypeRegistry)>> = RwLock::new(Vec::new());
+#[cfg(not(target_family = "wasm"))]
+#[allow(non_camel_case_types)]
+pub struct DERIVED_REFLECT_TYPES(pub fn(&mut TypeRegistry));
+#[cfg(not(target_family = "wasm"))]
+inventory::collect!(DERIVED_REFLECT_TYPES);
 
 /// A registry of [reflected] types.
 ///
@@ -115,15 +116,24 @@ impl TypeRegistry {
         registry.register::<f32>();
         registry.register::<f64>();
         registry.register::<String>();
-        #[cfg(target_arch = "wasm32")]
-        for f in AUTOMATIC_REFLECT_TYPES.read().unwrap().iter() {
-            f(&mut registry)
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        for f in inventory::iter::<AUTOMATIC_REFLECT_TYPES> {
-            f.0(&mut registry)
-        }
+        registry.register_derived_types();
         registry
+    }
+
+    pub fn register_derived_types(&mut self) {
+        // wasm_init must be called at least once to run all init code.
+        // Calling it multiple times is ok and doesn't do anything.
+        #[cfg(target_family = "wasm")]
+        wasm_init::wasm_init();
+
+        #[cfg(target_family = "wasm")]
+        for ty in DERIVED_REFLECT_TYPES.read().unwrap().iter() {
+            ty(self)
+        }
+        #[cfg(not(target_family = "wasm"))]
+        for ty in inventory::iter::<DERIVED_REFLECT_TYPES> {
+            ty.0(self)
+        }
     }
 
     /// Attempts to register the type `T` if it has not yet been registered already.

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -4,6 +4,8 @@
 //! by their string name. Reflection is a core part of Bevy and enables a number of interesting
 //! features (like scenes).
 
+use std::any::Any;
+
 use bevy::{
     prelude::*,
     reflect::{
@@ -17,7 +19,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // Bar will be automatically registered as it's a dependency of Foo
-        .register_type::<Foo>()
+        // .register_type::<Foo>()
         .add_systems(Startup, setup)
         .run();
 }
@@ -101,6 +103,8 @@ fn setup(type_registry: Res<AppTypeRegistry>) {
     let mut deserializer = ron::de::Deserializer::from_str(&ron_string).unwrap();
     let reflect_value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
+    assert!(type_registry.contains(value.type_id()));
+
     // Deserializing returns a `Box<dyn PartialReflect>` value.
     // Generally, deserializing a value will return the "dynamic" variant of a type.
     // For example, deserializing a struct will return the DynamicStruct type.
@@ -118,4 +122,6 @@ fn setup(type_registry: Res<AppTypeRegistry>) {
     // By "patching" `Foo` with the deserialized DynamicStruct, we can "Deserialize" Foo.
     // This means we can serialize and deserialize with a single `Reflect` derive!
     value.apply(&*reflect_value);
+
+    info!("{}", type_registry.iter().collect::<Vec<_>>().len());
 }


### PR DESCRIPTION
# Objective
This PR adds automatic registration of non-generic types annotated with `#[derive(Reflect)]`.
Manually registering all reflect types can be error-prone, failing to reflect during runtime if some type is not registered.  #5781 fixed this for nested types, improving ergonomics of using reflection dramatically, but top-level types still need to be registered manually.
```rs
// from #5781
#[derive(Reflect)]
struct Foo(Bar);

#[derive(Reflect)]
struct Bar(Baz);

#[derive(Reflect)]
struct Baz(usize);

fn main() {
  // ...
  app.register_type::<Foo>() // <- can still forget to add this
  // ...
}
```

## Solution
Automatically register all types that derive Reflect. This works for all non-generic types, allowing users to just add `#[derive(Reflect)]` to a type and not think about where to register it.
```rs
fn main() {
    // No need to manually call .register<Foo>()
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

#[derive(Reflect)]
pub struct Foo {
    a: usize,
}

fn setup(type_registry: Res<AppTypeRegistry>) {
    let type_registry = type_registry.read();
    assert!(type_registry.contains(TypeId::of::<Foo>()));
}
```

Automatic registration can be opted-out of by adding `#[reflect(no_auto_register)]` reflect attribute to a type:
```rs
#[derive(Reflect)]
#[reflect(no_auto_register)]
struct Foo{
  field: i32,
}
```

All functionality is currently feature-gated behind `reflect_auto_register` for reasons explained in **considerations**. 

## Testing
Tested by running `reflect` example and removing explicit type registration, both native and on wasm32-unknown-unknown.

<details>
  <summary>Wasm bundle size comparison</summary>
All sizes are in KB as reported by `du` on `reflection` example

|                        | wasm-release && wasm-bindgen | wasm-opt -Oz | wasm-opt -Os | wasm-opt -Oz && gzip -c |
| ---------------------- | ---------------------------- | ------------ | ------------ | ----------------------- |
| +reflect_auto_register | 24364                        | 14940        | 16136        | 5184                    |
| default                | 21716                        | 13968        | 14896        | 4944                    |
| diff                   | +10.9%                       | +6.5%        | +7.7%        | +4.6%                   |

</details>


## Considerations
While automatic type registration improves ergonomics quite a bit for projects that make heavy use of it, there are also some problems:
- Generic types can't be automatically registered.
- Wasm bundle size increase is not insignificant, and would likely increase even further as more types are added.
