### PR TITLE
Trim cosmic-text's shape run cache

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -30,7 +30,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
 cosmic-text = { version = "0.12", features = ["shape-run-cache"] }
-#cosmic-text = { version = "0.12" }
 thiserror = "1.0"
 serde = { version = "1", features = ["derive"] }
 unicode-bidi = "0.3.13"

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -30,6 +30,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
 cosmic-text = { version = "0.12", features = ["shape-run-cache"] }
+#cosmic-text = { version = "0.12" }
 thiserror = "1.0"
 serde = { version = "1", features = ["derive"] }
 unicode-bidi = "0.3.13"

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -121,7 +121,8 @@ impl Plugin for TextPlugin {
                         .ambiguous_with(CameraUpdateSystem),
                     remove_dropped_font_atlas_sets,
                 ),
-            );
+            )
+            .add_systems(Last, trim_cosmic_cache);
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -413,10 +413,12 @@ fn buffer_dimensions(buffer: &Buffer) -> Vec2 {
     Vec2::new(width.ceil(), height).ceil()
 }
 
-/// Discards cached shaped older than one tick.
-///
-/// We assume only text updated every tick benefits from the shape cache (e.g. animated text, or
-/// text that is dynamically measured for UI).
+/// Discards stale data cached in `FontSystem`.
 pub(crate) fn trim_cosmic_cache(mut pipeline: ResMut<TextPipeline>) {
+    // A trim age of 2 was found to reduce frame time variance vs age of 1 when tested with dynamic text.
+    // See https://github.com/bevyengine/bevy/pull/15037
+    //
+    // We assume only text updated frequently benefits from the shape cache (e.g. animated text, or
+    // text that is dynamically measured for UI).
     pipeline.font_system_mut().shape_run_cache.trim(2);
 }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,7 +1,12 @@
 use std::sync::Arc;
 
 use bevy_asset::{AssetId, Assets};
-use bevy_ecs::{component::Component, entity::Entity, reflect::ReflectComponent, system::Resource};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    reflect::ReflectComponent,
+    system::{ResMut, Resource},
+};
 use bevy_math::{UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::texture::Image;
@@ -406,4 +411,13 @@ fn buffer_dimensions(buffer: &Buffer) -> Vec2 {
     let height = buffer.layout_runs().count() as f32 * line_height;
 
     Vec2::new(width.ceil(), height).ceil()
+}
+
+/// Discards cached shaped older than one tick.
+///
+/// We assume only text updated every tick benefits from the shape cache (e.g. animated text, or
+/// text that is dynamically measured for UI).
+pub(crate) fn trim_cosmic_cache(mut pipeline: ResMut<TextPipeline>) {
+    // Use a large age to be very optimistic about reusability of cached shapes.
+    pipeline.font_system_mut().shape_run_cache.trim(2000);
 }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -418,6 +418,5 @@ fn buffer_dimensions(buffer: &Buffer) -> Vec2 {
 /// We assume only text updated every tick benefits from the shape cache (e.g. animated text, or
 /// text that is dynamically measured for UI).
 pub(crate) fn trim_cosmic_cache(mut pipeline: ResMut<TextPipeline>) {
-    // Use a large age to be very optimistic about reusability of cached shapes.
-    pipeline.font_system_mut().shape_run_cache.trim(2000);
+    pipeline.font_system_mut().shape_run_cache.trim(2);
 }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/pull/14991. The `cosmic-text` shape run cache requires manual cleanup for old text that no longer needs to be cached.

## Solution

- Add a system to trim the cache.
- Add an `average fps` indicator to the `text_debug` example.

## Testing

Tested with `cargo run --example text_debug`.
- **No shape run cache**: 82fps with ~1fps variance.
- **Shape run cache no trim**: 90-100fps with ~2-4fps variance
- **Shape run cache trim age = 1**: 90-100fps with ~2-8fps variance
- **Shape run cache trim age = 2**: 90-100fps with ~2-4fps variance
- **Shape run cache trim age = 2000**: 80-120fps with ~2-6fps variance

The shape run cache seems to increase average FPS but also increases frame time variance (when there is dynamic text).