### PR TITLE
Honor mesh-light interaction mediation for “low” render layers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -906,6 +906,17 @@ category = "3D Rendering"
 wasm = true
 
 [[example]]
+name = "render_layers"
+path = "examples/3d/render_layers.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.render_layers]
+name = "Render Layers"
+description = "A 3D scene showcasing the use of render layers"
+category = "3D Rendering"
+wasm = true
+
+[[example]]
 name = "render_to_texture"
 path = "examples/3d/render_to_texture.rs"
 doc-scrape-examples = true

--- a/crates/bevy_pbr/src/meshlet/instance_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/instance_manager.rs
@@ -103,7 +103,7 @@ impl InstanceManager {
             previous_world_from_local: (&previous_transform).into(),
             flags: flags.bits(),
         };
-        let mesh_uniform = MeshUniform::new(&transforms, 0, None);
+        let mesh_uniform = MeshUniform::new(&transforms, 0, None, render_layers.cloned());
 
         // Append instance data
         self.instances.push((

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -38,6 +38,7 @@ pub struct ExtractedPointLight {
     pub shadow_depth_bias: f32,
     pub shadow_normal_bias: f32,
     pub spot_light_angles: Option<(f32, f32)>,
+    pub render_layers: RenderLayers,
 }
 
 #[derive(Component, Debug)]
@@ -64,6 +65,10 @@ bitflags::bitflags! {
         const NONE                       = 0;
         const UNINITIALIZED              = 0xFFFF;
     }
+}
+
+impl PointLightFlags {
+    pub const RENDER_LAYERS_SHIFT_BITS: usize = 16;
 }
 
 #[derive(Copy, Clone, ShaderType, Default, Debug)]
@@ -96,6 +101,10 @@ bitflags::bitflags! {
         const NONE                       = 0;
         const UNINITIALIZED              = 0xFFFF;
     }
+}
+
+impl DirectionalLightFlags {
+    pub const RENDER_LAYERS_SHIFT_BITS: usize = 16;
 }
 
 #[derive(Copy, Clone, Debug, ShaderType)]
@@ -181,6 +190,7 @@ pub fn extract_lights(
             &GlobalTransform,
             &ViewVisibility,
             &CubemapFrusta,
+            Option<&RenderLayers>,
         )>,
     >,
     spot_lights: Extract<
@@ -190,6 +200,7 @@ pub fn extract_lights(
             &GlobalTransform,
             &ViewVisibility,
             &Frustum,
+            Option<&RenderLayers>,
         )>,
     >,
     directional_lights: Extract<
@@ -231,8 +242,14 @@ pub fn extract_lights(
 
     let mut point_lights_values = Vec::with_capacity(*previous_point_lights_len);
     for entity in global_point_lights.iter().copied() {
-        let Ok((point_light, cubemap_visible_entities, transform, view_visibility, frusta)) =
-            point_lights.get(entity)
+        let Ok((
+            point_light,
+            cubemap_visible_entities,
+            transform,
+            view_visibility,
+            frusta,
+            render_layers,
+        )) = point_lights.get(entity)
         else {
             continue;
         };
@@ -258,6 +275,7 @@ pub fn extract_lights(
                 * point_light_texel_size
                 * std::f32::consts::SQRT_2,
             spot_light_angles: None,
+            render_layers: render_layers.unwrap_or_default().clone(),
         };
         point_lights_values.push((
             entity,
@@ -273,8 +291,14 @@ pub fn extract_lights(
 
     let mut spot_lights_values = Vec::with_capacity(*previous_spot_lights_len);
     for entity in global_point_lights.iter().copied() {
-        if let Ok((spot_light, visible_entities, transform, view_visibility, frustum)) =
-            spot_lights.get(entity)
+        if let Ok((
+            spot_light,
+            visible_entities,
+            transform,
+            view_visibility,
+            frustum,
+            render_layers,
+        )) = spot_lights.get(entity)
         {
             if !view_visibility.get() {
                 continue;
@@ -307,6 +331,7 @@ pub fn extract_lights(
                             * texel_size
                             * std::f32::consts::SQRT_2,
                         spot_light_angles: Some((spot_light.inner_angle, spot_light.outer_angle)),
+                        render_layers: render_layers.unwrap_or_default().clone(),
                     },
                     render_visible_entities,
                     *frustum,
@@ -726,7 +751,9 @@ pub fn prepare_lights(
                 .xyz()
                 .extend(1.0 / (light.range * light.range)),
             position_radius: light.transform.translation().extend(light.radius),
-            flags: flags.bits(),
+            flags: flags.bits()
+                | (light.render_layers.bits_u16() as u32)
+                    << PointLightFlags::RENDER_LAYERS_SHIFT_BITS,
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,
             spot_light_tan_angle,
@@ -770,7 +797,9 @@ pub fn prepare_lights(
             color: Vec4::from_slice(&light.color.to_f32_array()) * light.illuminance,
             // direction is negated to be ready for N.L
             dir_to_light: light.transform.back().into(),
-            flags: flags.bits(),
+            flags: flags.bits()
+                | (light.render_layers.bits_u16() as u32)
+                    << DirectionalLightFlags::RENDER_LAYERS_SHIFT_BITS,
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,
             num_cascades: num_cascades as u32,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -752,7 +752,7 @@ pub fn prepare_lights(
                 .extend(1.0 / (light.range * light.range)),
             position_radius: light.transform.translation().extend(light.radius),
             flags: flags.bits()
-                | (light.render_layers.bits_u16() as u32)
+                | (light.render_layers.bits_u16_lossy() as u32)
                     << PointLightFlags::RENDER_LAYERS_SHIFT_BITS,
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,
@@ -798,7 +798,7 @@ pub fn prepare_lights(
             // direction is negated to be ready for N.L
             dir_to_light: light.transform.back().into(),
             flags: flags.bits()
-                | (light.render_layers.bits_u16() as u32)
+                | (light.render_layers.bits_u16_lossy() as u32)
                     << DirectionalLightFlags::RENDER_LAYERS_SHIFT_BITS,
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -752,7 +752,7 @@ pub fn prepare_lights(
                 .extend(1.0 / (light.range * light.range)),
             position_radius: light.transform.translation().extend(light.radius),
             flags: flags.bits()
-                | (light.render_layers.bits_u16_lossy() as u32)
+                | (light.render_layers.bits_compact_lossy() as u32)
                     << PointLightFlags::RENDER_LAYERS_SHIFT_BITS,
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,
@@ -798,7 +798,7 @@ pub fn prepare_lights(
             // direction is negated to be ready for N.L
             dir_to_light: light.transform.back().into(),
             flags: flags.bits()
-                | (light.render_layers.bits_u16_lossy() as u32)
+                | (light.render_layers.bits_compact_lossy() as u32)
                     << DirectionalLightFlags::RENDER_LAYERS_SHIFT_BITS,
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -753,7 +753,7 @@ pub fn prepare_lights(
             position_radius: light.transform.translation().extend(light.radius),
             flags: flags.bits()
                 | (light.render_layers.bits_compact_lossy() as u32)
-                    << PointLightFlags::RENDER_LAYERS_SHIFT_BITS,
+                    << PointLightFlags::RENDER_LAYERS_SHIFT_BITS, // pack render layers into the high bits of the flags
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,
             spot_light_tan_angle,
@@ -799,7 +799,7 @@ pub fn prepare_lights(
             dir_to_light: light.transform.back().into(),
             flags: flags.bits()
                 | (light.render_layers.bits_compact_lossy() as u32)
-                    << DirectionalLightFlags::RENDER_LAYERS_SHIFT_BITS,
+                    << DirectionalLightFlags::RENDER_LAYERS_SHIFT_BITS, // pack render layers into the high bits of the flags
             shadow_depth_bias: light.shadow_depth_bias,
             shadow_normal_bias: light.shadow_normal_bias,
             num_cascades: num_cascades as u32,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -376,7 +376,7 @@ impl MeshUniform {
             local_from_world_transpose_b,
             flags: mesh_transforms.flags,
             first_vertex_index,
-            render_layers_bits: render_layers.unwrap_or_default().bits_u16_lossy() as u32,
+            render_layers_bits: render_layers.unwrap_or_default().bits_compact_lossy() as u32,
             pad_a: 0,
             pad_b: 0,
         }
@@ -791,7 +791,7 @@ impl RenderMeshInstanceGpuBuilder {
                 .render_layers
                 .as_ref()
                 .unwrap_or_default()
-                .bits_u16_lossy() as u32,
+                .bits_compact_lossy() as u32,
             pad_a: 0,
             pad_b: 0,
         });

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -922,7 +922,7 @@ pub fn extract_meshes_for_cpu_building(
                 handle,
                 not_shadow_caster,
                 no_automatic_batching,
-                render_layers.map(|render_layers| render_layers.clone()),
+                render_layers.cloned(),
             );
 
             let world_from_local = transform.affine();
@@ -1041,7 +1041,7 @@ pub fn extract_meshes_for_gpu_building(
                 handle,
                 not_shadow_caster,
                 no_automatic_batching,
-                render_layers.map(|render_layers| render_layers.clone()),
+                render_layers.cloned(),
             );
 
             let lightmap_uv_rect = pack_lightmap_uv_rect(lightmap.map(|lightmap| lightmap.uv_rect));

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -376,7 +376,7 @@ impl MeshUniform {
             local_from_world_transpose_b,
             flags: mesh_transforms.flags,
             first_vertex_index,
-            render_layers_bits: render_layers.unwrap_or_default().bits_u16() as u32,
+            render_layers_bits: render_layers.unwrap_or_default().bits_u16_lossy() as u32,
             pad_a: 0,
             pad_b: 0,
         }
@@ -791,7 +791,7 @@ impl RenderMeshInstanceGpuBuilder {
                 .render_layers
                 .as_ref()
                 .unwrap_or_default()
-                .bits_u16() as u32,
+                .bits_u16_lossy() as u32,
             pad_a: 0,
             pad_b: 0,
         });

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -23,9 +23,11 @@ struct MeshInput {
     // applicable. If not present, this is `u32::MAX`.
     previous_input_index: u32,
     first_vertex_index: u32,
+    // Only the first 16 bits are actually used, since we want to match
+    // the light render layers bits, and those are packed along with flags
+    render_layers_bits: u32,
     pad_a: u32,
     pad_b: u32,
-    pad_c: u32,
 }
 
 // Information about each mesh instance needed to cull it on GPU.
@@ -191,4 +193,5 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     output[mesh_output_index].flags = current_input[input_index].flags;
     output[mesh_output_index].lightmap_uv_rect = current_input[input_index].lightmap_uv_rect;
     output[mesh_output_index].first_vertex_index = current_input[input_index].first_vertex_index;
+    output[mesh_output_index].render_layers_bits = current_input[input_index].render_layers_bits;
 }

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -17,9 +17,11 @@ struct Mesh {
     lightmap_uv_rect: vec2<u32>,
     // The index of the mesh's first vertex in the vertex buffer.
     first_vertex_index: u32,
+    // Only the first 16 bits are actually used, since we want to match
+    // the light render layers bits, and those are packed along with flags
+    render_layers_bits: u32,
     pad_a: u32,
     pad_b: u32,
-    pad_c: u32,
 };
 
 #ifdef SKINNED

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -15,6 +15,7 @@ struct ClusterableObject {
 
 const POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT: u32   = 1u;
 const POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE: u32 = 2u;
+const POINT_LIGHT_FLAGS_RENDER_LAYERS_SHIFT_BITS: u32 = 16u;
 
 struct DirectionalCascade {
     clip_from_world: mat4x4<f32>,
@@ -38,6 +39,7 @@ struct DirectionalLight {
 
 const DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT: u32 = 1u;
 const DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT: u32      = 2u;
+const DIRECTIONAL_LIGHT_FLAGS_RENDER_LAYERS_SHIFT_BITS: u32 = 16u;
 
 struct Lights {
     // NOTE: this array size must be kept in sync with the constants defined in bevy_pbr/src/render/light.rs

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -38,6 +38,7 @@ fn pbr_input_from_vertex_output(
     pbr_input.flags = in.mesh_flags;
 #else
     pbr_input.flags = mesh[in.instance_index].flags;
+    pbr_input.render_layers_bits = mesh[in.instance_index].render_layers_bits;
 #endif
 
     pbr_input.is_orthographic = view.clip_from_view[3].w == 1.0;

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -410,6 +410,11 @@ fn apply_pbr_lighting(
     // Point lights (direct)
     for (var i: u32 = offset_and_counts[0]; i < offset_and_counts[0] + offset_and_counts[1]; i = i + 1u) {
         let light_id = clustering::get_clusterable_object_id(i);
+
+        if (view_bindings::clusterable_objects.data[light_id].flags >> mesh_view_types::POINT_LIGHT_FLAGS_RENDER_LAYERS_SHIFT_BITS & in.render_layers_bits) == 0u {
+            continue;
+        }
+
         var shadow: f32 = 1.0;
         if ((in.flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
                 && (view_bindings::clusterable_objects.data[light_id].flags & mesh_view_types::POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
@@ -444,6 +449,10 @@ fn apply_pbr_lighting(
     // Spot lights (direct)
     for (var i: u32 = offset_and_counts[0] + offset_and_counts[1]; i < offset_and_counts[0] + offset_and_counts[1] + offset_and_counts[2]; i = i + 1u) {
         let light_id = clustering::get_clusterable_object_id(i);
+
+        if (view_bindings::clusterable_objects.data[light_id].flags >> mesh_view_types::POINT_LIGHT_FLAGS_RENDER_LAYERS_SHIFT_BITS & in.render_layers_bits) == 0u {
+            continue;
+        }
 
         var shadow: f32 = 1.0;
         if ((in.flags & MESH_FLAGS_SHADOW_RECEIVER_BIT) != 0u
@@ -483,6 +492,10 @@ fn apply_pbr_lighting(
         // note point and spot lights aren't skippable, as the relevant lights are filtered in `assign_lights_to_clusters`
         let light = &view_bindings::lights.directional_lights[i];
         if (*light).skip != 0u {
+            continue;
+        }
+
+        if ((*light).flags >> mesh_view_types::DIRECTIONAL_LIGHT_FLAGS_RENDER_LAYERS_SHIFT_BITS & in.render_layers_bits) == 0u {
             continue;
         }
 

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -119,6 +119,7 @@ struct PbrInput {
     anisotropy_B: vec3<f32>,
     is_orthographic: bool,
     flags: u32,
+    render_layers_bits: u32,
 };
 
 // Creates a PbrInput with default values
@@ -146,6 +147,7 @@ fn pbr_input_new() -> PbrInput {
     pbr_input.lightmap_light = vec3<f32>(0.0);
 
     pbr_input.flags = 0u;
+    pbr_input.render_layers_bits = 65535u; // 0xFFFF
 
     return pbr_input;
 }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -175,7 +175,7 @@ impl RenderLayers {
     /// lower 15 bits, while the last bit is used as a special flag to indicate
     /// the presence of any other higher layer. This is so that bitwise operations
     /// can produce false positives but not false negatives for higher layers
-    pub fn bits_u16(&self) -> u16 {
+    pub fn bits_u16_lossy(&self) -> u16 {
         let has_higher_bits_set =
             (self.0[0] & (!0b0111_1111_1111_1111) != 0) || self.0[1..].iter().any(|&x| x != 0);
         if has_higher_bits_set {

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -191,7 +191,7 @@ impl RenderLayers {
     /// lower 15 bits, while the last bit is used as a special flag to indicate
     /// the presence of any other higher layer. This is so that bitwise operations
     /// can produce false positives but not false negatives for higher layers
-    pub fn bits_u16_lossy(&self) -> u16 {
+    pub fn bits_compact_lossy(&self) -> u16 {
         let has_higher_bits_set =
             (self.0[0] & (!0b0111_1111_1111_1111) != 0) || self.0[1..].iter().any(|&x| x != 0);
         if has_higher_bits_set {
@@ -430,7 +430,7 @@ mod rendering_mask_tests {
     #[test]
     fn mesh_light_interaction_max() {
         let layers = RenderLayers::default();
-        let bits = layers.bits_u16_lossy();
+        let bits = layers.bits_compact_lossy();
 
         assert_eq!(
             RenderLayers::MESH_LIGHT_INTERACTION_MAX + 1, // Extra bit for all higher layers

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -426,4 +426,15 @@ mod rendering_mask_tests {
         let layers = RenderLayers::from_layers(&[63]);
         layers.iter().count();
     }
+
+    #[test]
+    fn mesh_light_interaction_max() {
+        let layers = RenderLayers::default();
+        let bits = layers.bits_u16_lossy();
+
+        assert_eq!(
+            RenderLayers::MESH_LIGHT_INTERACTION_MAX + 1, // Extra bit for all higher layers
+            std::mem::size_of_val(&bits) * 8 - 1
+        );
+    }
 }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -23,7 +23,7 @@ pub type Layer = usize;
 ///
 /// ## Mesh-Light interactions
 ///
-/// Layers from `0` to `MESH_LIGHT_INTERACTION_MAX` (inclusive) are special in that besides
+/// Layers from `0` to [`RenderLayers::MESH_LIGHT_INTERACTION_MAX`] (inclusive) are special in that besides
 /// mediating light-camera and mesh-camera interactions, they also mediate mesh-light
 /// interaction for forward rendered meshes.
 ///

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -309,6 +309,7 @@ impl std::ops::BitXor for RenderLayers {
 mod rendering_mask_tests {
     use super::{Layer, RenderLayers};
     use smallvec::SmallVec;
+    use std::mem::size_of_val;
 
     #[test]
     fn rendering_mask_sanity() {
@@ -434,7 +435,7 @@ mod rendering_mask_tests {
 
         assert_eq!(
             RenderLayers::MESH_LIGHT_INTERACTION_MAX + 1, // Extra bit for all higher layers
-            std::mem::size_of_val(&bits) * 8 - 1
+            size_of_val(&bits) * 8 - 1
         );
     }
 }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -23,19 +23,23 @@ pub type Layer = usize;
 ///
 /// ## Mesh-Light interactions
 ///
-/// The first 15 layers (0–14) are special in that besides controlling light-camera
-/// and mesh-camera interactions, they also control mesh-light interactions for forward
-/// rendered entities.
+/// Layers from `0` to `MESH_LIGHT_INTERACTION_MAX` (inclusive) are special in that besides
+/// mediating light-camera and mesh-camera interactions, they also mediate mesh-light
+/// interaction for forward rendered meshes.
 ///
-/// For example, if you have the following setup:
+/// For example, if you have the following setup with two layers:
 ///
-/// - Mesh A (Layer 0)
-/// - Mesh B (Layer 1)
-/// - Light X (Layer 0)
-/// - Light Y (Layer 1)
-/// - Camera (Layers 0 and 1)
+/// - On layer 0:
+///   - Light I
+///   - Mesh A
+/// - On layer 1:
+///   - Light II
+///   - Mesh B
+/// - On both layers:
+///   - Mesh C
+///   - Camera
 ///
-/// Light X will only illuminate Mesh A, while Light Y will only illuminate mesh B,
+/// Light I will illuminate Mesh A and C, while Light II will illuminate mesh B and C,
 /// and both meshes will be visible by the camera.
 ///
 /// This behavior is useful, for example, when manually crafting a scene where you want
@@ -83,6 +87,18 @@ impl Default for RenderLayers {
 }
 
 impl RenderLayers {
+    /// The index of the highest layer that still mediates mesh-light interactions.
+    ///
+    /// Meshes and lights on layers `MESH_LIGHT_INTERACTION_MAX + 1` and onwards will all
+    /// interact with each other as if they were on the same layer, as long as they're on
+    /// the same layer as the camera.
+    ///
+    /// Meshes rendered via deferred rendering will always interact with all lights.
+    /// as long as both are on the same layer as the camera.
+    ///
+    /// Shadow casting is not affected by this limit.
+    pub const MESH_LIGHT_INTERACTION_MAX: usize = 14;
+
     /// Create a new `RenderLayers` belonging to the given layer.
     ///
     /// This `const` constructor is limited to `size_of::<usize>()` layers.

--- a/examples/3d/render_layers.rs
+++ b/examples/3d/render_layers.rs
@@ -1,0 +1,116 @@
+//! A 3D scene showcasing the use of render layers.
+
+use bevy::{
+    color::palettes::css::{BLUE, RED},
+    prelude::*,
+};
+use bevy_render::view::RenderLayers;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, orbit)
+        .run();
+}
+
+const LAYER_A: RenderLayers = RenderLayers::layer(0);
+const LAYER_B: RenderLayers = RenderLayers::layer(1);
+
+#[derive(Component)]
+struct Orbit;
+
+/// set up a scene using render layers
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // -------------------
+    // both layers
+    // -------------------
+
+    // circular base
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Circle::new(4.0)),
+            material: materials.add(Color::WHITE),
+            transform: Transform::from_rotation(Quat::from_rotation_x(
+                -std::f32::consts::FRAC_PI_2,
+            )),
+            ..default()
+        })
+        .insert(LAYER_A | LAYER_B);
+
+    // camera
+    commands
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 9.0, 0.0).looking_at(Vec3::ZERO, -Vec3::Z),
+            ..default()
+        })
+        .insert(LAYER_A | LAYER_B);
+
+    // -------------------
+    // layer A
+    // -------------------
+
+    // sphere
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Sphere::new(0.75)),
+            material: materials.add(Color::from(RED)),
+            transform: Transform::from_xyz(-1.0, 0.5, 0.0),
+            ..default()
+        })
+        .insert(LAYER_A);
+
+    // light
+    commands
+        .spawn(PointLightBundle {
+            point_light: PointLight {
+                shadows_enabled: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(4.0, 6.0, -4.0),
+            ..default()
+        })
+        .insert(Orbit)
+        .insert(LAYER_A);
+
+    // -------------------
+    // layer B
+    // -------------------
+
+    // sphere
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Sphere::new(0.75)),
+            material: materials.add(Color::from(BLUE)),
+            transform: Transform::from_xyz(1.0, 0.5, 0.0),
+            ..default()
+        })
+        .insert(LAYER_B);
+
+    // light
+    commands
+        .spawn(PointLightBundle {
+            point_light: PointLight {
+                shadows_enabled: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(4.0, 6.0, -4.0),
+            ..default()
+        })
+        .insert(LAYER_B);
+}
+
+/// make the entity orbit around the origin
+fn orbit(time: Res<Time>, mut query: Query<&mut Transform, With<Orbit>>) {
+    for mut transform in &mut query {
+        transform.translation = Vec3::new(
+            5.65 * time.elapsed_seconds().cos(),
+            6.0,
+            5.65 * time.elapsed_seconds().sin(),
+        );
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -158,6 +158,7 @@ Example | Description
 [Parenting](../examples/3d/parenting.rs) | Demonstrates parent->child relationships and relative transformations
 [Physically Based Rendering](../examples/3d/pbr.rs) | Demonstrates use of Physically Based Rendering (PBR) properties
 [Reflection Probes](../examples/3d/reflection_probes.rs) | Demonstrates reflection probes
+[Render Layers](../examples/3d/render_layers.rs) | A 3D scene showcasing the use of render layers
 [Render to Texture](../examples/3d/render_to_texture.rs) | Shows how to render to a texture, useful for mirrors, UI, or exporting images
 [Rotate Environment Map](../examples/3d/rotate_environment_map.rs) | Demonstrates how to rotate the skybox and the environment map simultaneously
 [Screen Space Ambient Occlusion](../examples/3d/ssao.rs) | A scene showcasing screen space ambient occlusion


### PR DESCRIPTION
Based on [this Discord conversation](https://discord.com/channels/691052431525675048/866787577687310356/1280316150135259157).

# Objective

Allow mesh-light interactions to be mediated by (a subset of) render layers, with minimal changes to existing shaders and light/mesh extraction systems.

This addresses the limitation originally described on #10742:

> potential issue: when mesh/light layers are smaller than the view layers weird results can occur. e.g:
> camera = layers 1+2
> light = layers 1
> mesh = layers 2
>
> the mesh does not cast shadows wrt the light as (1 & 2) == 0.
> the light affects the view as (1+2 & 1) != 0.
> the view renders the mesh as (1+2 & 2) != 0.
>
> so the mesh is rendered and lit, but does not cast a shadow.

## Solution

- “Low” render layers (from `0` to `RenderLayers::MESH_LIGHT_INTERACTION_MAX`) are treated specially, in that they now mediate mesh-light interaction in addition to mesh-camera and light-camera interaction
- "High" render layers (from `RenderLayers::MESH_LIGHT_INTERACTION_MAX + 1` onwards) retain the current behavior of mediating only light-camera and mesh-camera interactions.
- A `bits_compact_lossy()` method is introduced to lossily pack the unlimited render layers into a single `u16`
  - Layers 0–14 are sent verbatim, as a the lower 15 bits of the `u16`
  - The presence of any layers higher than 14 is signalled by the highest bit of the `u16`

<img width="521" alt="image" src="https://github.com/user-attachments/assets/3335883d-f84f-4799-bee5-6fcdf75f6c11">

- On the shader side, we reuse the higher half of the light flags, as well as one of the pad values in the mesh uniform, so that no changes to existing sizes take place
- Set mesh/light layer is verified by bitwise and operations

This is a compromise solution that:

- Preserves the ability to have unlimited layers, without regressing with current capabilities (especially for configurable, multi-viewport editor scenarios)
- Allows us to have mesh-light interactions mediated by (at least some) render layers
- Doesn't make the shaders overly complex, or take up additional space in the uniforms
- Produces more intuitive/useful behavior for hand crafted render layer scenarios (see my comment below)

## Testing

- Added a unit test to enforce `RenderLayers::MESH_LIGHT_INTERACTION_MAX` stays in sync with the return type of `bits_compact_lossy()`
- Added a `render_layers` example so that we can visually validate the effect. (See video below)
- Verified that the `first_person_view_model` example is unaffected by this change

---

## Showcase

https://github.com/user-attachments/assets/4db9bfca-4276-4ccd-8554-6c0b2771417d

https://github.com/user-attachments/assets/1e0086dc-4827-4c2c-84d7-5e1e8cafddb5

## Migration Guide

- `RenderLayers` from `0` to `RenderLayers::MESH_LIGHT_INTERACTION_MAX` now also mediate mesh-light interactions. For many common scenarios, including first person view models, this should not produce any changes in existing behavior. If your scene is affected, and you'd like to retain the old behavior of all lights affecting all meshes, regardless of layers, you can add a layer value of `RenderLayers::MESH_LIGHT_INTERACTION_MAX + 1` or higher to all affected lights/meshes.