### PR TITLE
Stop using `Handle<Scene>` and `Handle<DynamicScene>` as components

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 /// To spawn a dynamic scene, you can use either:
 /// * [`SceneSpawner::spawn_dynamic`](crate::SceneSpawner::spawn_dynamic)
 /// * adding the [`DynamicSceneBundle`](crate::DynamicSceneBundle) to an entity
-/// * adding the [`Handle<DynamicScene>`](bevy_asset::Handle) to an entity (the scene will only be
+/// * adding the [`DynamicSceneHandle`](crate::DynamicSceneHandle) to an entity (the scene will only be
 ///     visible if the entity already has [`Transform`](bevy_transform::components::Transform) and
 ///     [`GlobalTransform`](bevy_transform::components::GlobalTransform) components)
 /// * using the [`DynamicSceneBuilder`] to construct a `DynamicScene` from `World`.

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -38,8 +38,8 @@ pub use scene_spawner::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        DynamicScene, DynamicSceneBuilder, DynamicSceneBundle, Scene, SceneBundle, SceneFilter,
-        SceneSpawner,
+        DynamicScene, DynamicSceneBuilder, DynamicSceneBundle, DynamicSceneHandle, Scene,
+        SceneBundle, SceneFilter, SceneHandle, SceneSpawner,
     };
 }
 

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -44,7 +44,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_asset::{AssetApp, Handle};
+use bevy_asset::AssetApp;
 
 /// Plugin that provides scene functionality to an [`App`].
 #[derive(Default)]
@@ -61,9 +61,9 @@ impl Plugin for ScenePlugin {
 
         // Register component hooks for DynamicScene
         app.world_mut()
-            .register_component_hooks::<Handle<DynamicScene>>()
+            .register_component_hooks::<DynamicSceneHandle>()
             .on_remove(|mut world, entity, _| {
-                let Some(handle) = world.get::<Handle<DynamicScene>>(entity) else {
+                let Some(handle) = world.get::<DynamicSceneHandle>(entity) else {
                     return;
                 };
                 let id = handle.id();
@@ -80,7 +80,7 @@ impl Plugin for ScenePlugin {
 
         // Register component hooks for Scene
         app.world_mut()
-            .register_component_hooks::<Handle<Scene>>()
+            .register_component_hooks::<SceneHandle>()
             .on_remove(|mut world, entity, _| {
                 if let Some(&SceneInstance(scene_instance)) = world.get::<SceneInstance>(entity) {
                     let Some(mut scene_spawner) = world.get_resource_mut::<SceneSpawner>() else {

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -10,7 +10,7 @@ use bevy_reflect::TypePath;
 /// To spawn a scene, you can use either:
 /// * [`SceneSpawner::spawn`](crate::SceneSpawner::spawn)
 /// * adding the [`SceneBundle`](crate::SceneBundle) to an entity
-/// * adding the [`Handle<Scene>`](bevy_asset::Handle) to an entity (the scene will only be
+/// * adding the [`SceneHandle`](crate::SceneHandle) to an entity (the scene will only be
 ///     visible if the entity already has [`Transform`](bevy_transform::components::Transform) and
 ///     [`GlobalTransform`](bevy_transform::components::GlobalTransform) components)
 #[derive(Asset, TypePath, Debug)]

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -482,7 +482,7 @@ mod tests {
     use bevy_ecs::{component::Component, system::Query};
     use bevy_reflect::Reflect;
 
-    use crate::{DynamicSceneBuilder, ScenePlugin};
+    use crate::{DynamicSceneBuilder, DynamicSceneHandle, ScenePlugin};
 
     use super::*;
 
@@ -711,7 +711,8 @@ mod tests {
 
         // Spawn scene.
         for _ in 0..count {
-            app.world_mut().spawn((ComponentA, scene.clone()));
+            app.world_mut()
+                .spawn((ComponentA, DynamicSceneHandle(scene.clone())));
         }
 
         app.update();

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -73,7 +73,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
     spawn_directional_light(&mut commands);
 
     commands.spawn(SceneBundle {
-        scene: asset_server.load("models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0"),
+        scene: asset_server
+            .load("models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0")
+            .into(),
         transform: Transform::from_xyz(0.0, 0.07, -0.13),
         ..default()
     });

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -280,7 +280,8 @@ fn setup(
     // Flight Helmet
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+            .into(),
         ..default()
     });
 

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -73,7 +73,8 @@ fn setup_terrain_scene(
     // Terrain
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/terrain/Mountains.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/terrain/Mountains.gltf"))
+            .into(),
         ..default()
     });
 

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -150,7 +150,8 @@ fn spawn_golf_ball(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn(SceneBundle {
             scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/GolfBall/GolfBall.glb")),
+                .load(GltfAssetLabel::Scene(0).from_asset("models/GolfBall/GolfBall.glb"))
+                .into(),
             transform: Transform::from_xyz(1.0, 1.0, 0.0).with_scale(Vec3::splat(SPHERE_SCALE)),
             ..default()
         })

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -382,16 +382,19 @@ fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading
 fn add_basic_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
-        ),
+        scene: asset_server
+            .load(
+                GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+            )
+            .into(),
         ..default()
     });
 
     // Spawn the flight helmet.
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+            .into(),
         transform: Transform::from_xyz(0.5, 0.0, -0.5)
             .with_rotation(Quat::from_rotation_y(-0.15 * PI)),
         ..default()

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -86,11 +86,11 @@ fn setup(
         .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
 
     commands.spawn(SceneBundle {
-        scene: helmet_scene.clone(),
+        scene: helmet_scene.clone().into(),
         ..default()
     });
     commands.spawn(SceneBundle {
-        scene: helmet_scene,
+        scene: helmet_scene.into(),
         transform: Transform::from_xyz(-4.0, 0.0, -3.0),
         ..default()
     });

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -89,10 +89,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
 
     // Spawn the scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0)
-                .from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
-        ),
+        scene: asset_server
+            .load(
+                GltfAssetLabel::Scene(0)
+                    .from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
+            )
+            .into(),
         ..default()
     });
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -13,7 +13,6 @@
 //!
 //! * Clicking anywhere moves the object.
 
-use bevy::color::palettes::css::*;
 use bevy::core_pipeline::Skybox;
 use bevy::math::{uvec3, vec3};
 use bevy::pbr::irradiance_volume::IrradianceVolume;
@@ -21,6 +20,7 @@ use bevy::pbr::{ExtendedMaterial, MaterialExtension, NotShadowCaster};
 use bevy::prelude::*;
 use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
 use bevy::window::PrimaryWindow;
+use bevy::{color::palettes::css::*, scene::SceneHandle};
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/irradiance_volume_voxel_visualization.wgsl";
@@ -225,7 +225,7 @@ fn setup(mut commands: Commands, assets: Res<ExampleAssets>, app_status: Res<App
 
 fn spawn_main_scene(commands: &mut Commands, assets: &ExampleAssets) {
     commands.spawn(SceneBundle {
-        scene: assets.main_scene.clone(),
+        scene: assets.main_scene.clone().into(),
         ..SceneBundle::default()
     });
 }
@@ -292,7 +292,7 @@ fn spawn_voxel_cube_parent(commands: &mut Commands) {
 fn spawn_fox(commands: &mut Commands, assets: &ExampleAssets) {
     commands
         .spawn(SceneBundle {
-            scene: assets.fox.clone(),
+            scene: assets.fox.clone().into(),
             visibility: Visibility::Hidden,
             transform: Transform::from_scale(Vec3::splat(FOX_SCALE)),
             ..default()
@@ -388,9 +388,9 @@ fn change_main_object(
     mut app_status: ResMut<AppStatus>,
     mut sphere_query: Query<
         &mut Visibility,
-        (With<MainObject>, With<Handle<Mesh>>, Without<Handle<Scene>>),
+        (With<MainObject>, With<Handle<Mesh>>, Without<SceneHandle>),
     >,
-    mut fox_query: Query<&mut Visibility, (With<MainObject>, With<Handle<Scene>>)>,
+    mut fox_query: Query<&mut Visibility, (With<MainObject>, With<SceneHandle>)>,
 ) {
     if !keyboard.just_pressed(KeyCode::Tab) {
         return;

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -13,6 +13,7 @@
 //!
 //! * Clicking anywhere moves the object.
 
+use bevy::color::palettes::css::*;
 use bevy::core_pipeline::Skybox;
 use bevy::math::{uvec3, vec3};
 use bevy::pbr::irradiance_volume::IrradianceVolume;
@@ -20,7 +21,6 @@ use bevy::pbr::{ExtendedMaterial, MaterialExtension, NotShadowCaster};
 use bevy::prelude::*;
 use bevy::render::render_resource::{AsBindGroup, ShaderRef, ShaderType};
 use bevy::window::PrimaryWindow;
-use bevy::{color::palettes::css::*, scene::SceneHandle};
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/irradiance_volume_voxel_visualization.wgsl";

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -15,7 +15,8 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/CornellBox/CornellBox.glb")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/CornellBox/CornellBox.glb"))
+            .into(),
         ..default()
     });
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -49,7 +49,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+            .into(),
         ..default()
     });
 }

--- a/examples/3d/load_gltf_extras.rs
+++ b/examples/3d/load_gltf_extras.rs
@@ -33,7 +33,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // a barebones scene containing one of each gltf_extra type
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb"))
+            .into(),
         ..default()
     });
 

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -94,16 +94,19 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
-        ),
+        scene: asset_server
+            .load(
+                GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+            )
+            .into(),
         ..default()
     });
 
     // Spawn the flight helmet.
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+            .into(),
         transform: Transform::from_xyz(0.5, 0.0, -0.5)
             .with_rotation(Quat::from_rotation_y(-0.15 * PI)),
         ..default()

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -98,7 +98,9 @@ fn setup(
 // Spawns the cubes, light, and camera.
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/cubes/Cubes.glb")),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset("models/cubes/Cubes.glb"))
+            .into(),
         ..SceneBundle::default()
     });
 }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -29,7 +29,9 @@ fn setup(
     });
 
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"))
+            .into(),
         ..default()
     });
 

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -167,7 +167,8 @@ fn spawn_flight_helmet(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn(SceneBundle {
             scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+                .into(),
             transform: Transform::from_scale(Vec3::splat(2.5)),
             ..default()
         })

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -97,9 +97,12 @@ fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Main scene
     commands
         .spawn(SceneBundle {
-            scene: asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
-            ),
+            scene: asset_server
+                .load(
+                    GltfAssetLabel::Scene(0)
+                        .from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+                )
+                .into(),
             ..default()
         })
         .insert(SceneNumber(1));
@@ -108,7 +111,8 @@ fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         SceneBundle {
             scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+                .into(),
             transform: Transform::from_xyz(0.5, 0.0, -0.5)
                 .with_rotation(Quat::from_rotation_y(-0.15 * PI)),
             ..default()

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -42,7 +42,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SceneBundle {
         transform: Transform::from_xyz(-1.0, 0.0, 0.0),
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+            .into(),
         ..default()
     });
 
@@ -50,7 +51,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         SceneBundle {
             scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+                .into(),
             ..default()
         },
         MovedScene,

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -105,17 +105,20 @@ fn setup(
     commands
         .spawn(SceneBundle {
             scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"))
+                .into(),
             ..default()
         })
         .insert(MainModel::HighPoly);
 
     commands
         .spawn(SceneBundle {
-            scene: asset_server.load(
-                GltfAssetLabel::Scene(0)
-                    .from_asset("models/FlightHelmetLowPoly/FlightHelmetLowPoly.gltf"),
-            ),
+            scene: asset_server
+                .load(
+                    GltfAssetLabel::Scene(0)
+                        .from_asset("models/FlightHelmetLowPoly/FlightHelmetLowPoly.gltf"),
+                )
+                .into(),
             ..default()
         })
         .insert(MainModel::LowPoly);

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -29,10 +29,12 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn the glTF scene.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(
-            GltfAssetLabel::Scene(0)
-                .from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
-        ),
+        scene: asset_server
+            .load(
+                GltfAssetLabel::Scene(0)
+                    .from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
+            )
+            .into(),
         ..default()
     });
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -84,7 +84,9 @@ fn setup(
 
     // Fox
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH)),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH))
+            .into(),
         ..default()
     });
 

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -236,7 +236,9 @@ fn setup_scene(
     });
 
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"))
+            .into(),
         transform: Transform::from_scale(Vec3::splat(0.07)),
         ..default()
     });

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -120,7 +120,9 @@ fn setup_scene(
 
     // Spawn the fox.
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"))
+            .into(),
         transform: Transform::from_scale(Vec3::splat(0.07)),
         ..default()
     });

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -28,7 +28,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawn the first scene in `models/SimpleSkin/SimpleSkin.gltf`
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/SimpleSkin/SimpleSkin.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/SimpleSkin/SimpleSkin.gltf"))
+            .into(),
         ..default()
     });
 }

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -48,7 +48,8 @@ fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
     });
     commands.spawn(SceneBundle {
         scene: asset_server
-            .load(GltfAssetLabel::Scene(0).from_asset("models/animated/MorphStressTest.gltf")),
+            .load(GltfAssetLabel::Scene(0).from_asset("models/animated/MorphStressTest.gltf"))
+            .into(),
         ..default()
     });
     commands.spawn(DirectionalLightBundle {

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -24,7 +24,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // mesh
     commands.spawn(SceneBundle {
-        scene: scene_handle,
+        scene: scene_handle.into(),
         ..default()
     });
     // light

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -265,7 +265,7 @@ fn wait_on_load(
             let position = Vec3::new(i as f32 - 5.0, 0.0, j as f32 - 5.0);
             // All gltfs must exist because this is guarded by the `AssetBarrier`.
             let gltf = gltfs.get(&foxes.0[index]).unwrap();
-            let scene = gltf.scenes.first().unwrap().clone();
+            let scene = gltf.scenes.first().unwrap().clone().into();
             commands.spawn(SceneBundle {
                 scene,
                 transform: Transform::from_translation(position),

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -142,7 +142,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                     let height = rng.gen_range(-0.1..0.1);
                     commands.spawn(SceneBundle {
                         transform: Transform::from_xyz(i as f32, height - 0.2, j as f32),
-                        scene: cell_scene.clone(),
+                        scene: cell_scene.clone().into(),
                         ..default()
                     });
                     Cell { height }
@@ -165,7 +165,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
                     ..default()
                 },
                 scene: asset_server
-                    .load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/alien.glb")),
+                    .load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/alien.glb"))
+                    .into(),
                 ..default()
             })
             .id(),
@@ -352,7 +353,7 @@ fn spawn_bonus(
                     game.board[game.bonus.j][game.bonus.i].height + 0.2,
                     game.bonus.j as f32,
                 ),
-                scene: game.bonus.handle.clone(),
+                scene: game.bonus.handle.clone().into(),
                 ..default()
             })
             .with_children(|children| {

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -155,7 +155,7 @@ fn load_level_1(
     // Spawn the fox.
     commands.spawn((
         SceneBundle {
-            scene: fox.clone(),
+            scene: fox.clone().into(),
             transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..default()
         },
@@ -199,7 +199,7 @@ fn load_level_2(
         .push(helmet_scene.clone().into());
     commands.spawn((
         SceneBundle {
-            scene: helmet_scene.clone(),
+            scene: helmet_scene.clone().into(),
             ..default()
         },
         LevelComponents,

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -69,7 +69,7 @@ fn load_scene_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     // of the given scene's entities as children of that entity.
     commands.spawn(DynamicSceneBundle {
         // Scenes are loaded just like any other asset.
-        scene: asset_server.load(SCENE_FILE_PATH),
+        scene: asset_server.load(SCENE_FILE_PATH).into(),
         ..default()
     });
 }

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -174,7 +174,7 @@ fn setup(
 
             commands.entity(ring_parent).with_children(|builder| {
                 builder.spawn(SceneBundle {
-                    scene: fox_handle.clone(),
+                    scene: fox_handle.clone().into(),
                     transform: Transform::from_xyz(x, 0.0, z)
                         .with_scale(Vec3::splat(0.01))
                         .with_rotation(base_rotation * Quat::from_rotation_y(-fox_angle)),

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -83,7 +83,8 @@ fn setup(
     commands.spawn((
         SceneBundle {
             scene: asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/ship/craft_speederD.gltf")),
+                .load(GltfAssetLabel::Scene(0).from_asset("models/ship/craft_speederD.gltf"))
+                .into(),
             ..default()
         },
         Ship {

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -13,7 +13,9 @@ fn main() {
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // add entities to the world
     commands.spawn(SceneBundle {
-        scene: asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf")),
+        scene: asset_server
+            .load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf"))
+            .into(),
         ..default()
     });
     // light


### PR DESCRIPTION
# Objective
Partially address #14124

## Solution

Replace `Handle<Scene>` and `Handle<DynamicScene>` with newtyped components `SceneHandle` and `DynamicSceneHandle`.

Currently all the added `.into()` makes spawning scenes this way a bit more icky/worsens formatting, but it would work quite nicely with required components – see the example below.

I still wonder if we will end up requiring `Transform` and `Visibility` for these components. It may make sense to not have those components for some scenes, though I think you can still avoid using these handle components altogether via `SceneSpawner` as a workaround for that.

Example:
```rust
// As of this PR
commands.spawn(SceneBundle {
    scene: asset_server
        .load(GltfAssetLabel::Scene(0).from_asset("models/../model.glb"))
        .into(),
    ..default()
});

// With required components
commands.spawn(SceneHandle(asset_server.load(
    GltfAssetLabel::Scene(0).from_asset("models/../model.glb"),
)));

// Alternatively, if Transform and Visibility won't be required for SceneHandle
commands.spawn((
    SceneHandle(asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/../model.glb"))),
    Transform::IDENTITY,
    Visibility::Inherited,
));
```

## Migration Guide
`Handle<Scene>` and `Handle<DynamicScene>` no longer act as components. Replace them with `SceneHandle` and `DynamicSceneHandle`.

