### PR TITLE
Implement `ReadOnlyQueryData` for `Parent` and `Children`

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -1265,9 +1265,9 @@ mod tests {
             .push_children(&[child])
             .id();
 
-        let mut query = world.query::<&Children>();
+        let mut query = world.query::<Children>();
         let children = query.get(&world, parent).unwrap();
-        assert_eq!(**children, [child]);
+        assert_eq!(children, [child]);
     }
 
     #[test]
@@ -1275,7 +1275,7 @@ mod tests {
         let mut world = World::new();
         let parent = world.spawn_empty().push_children(&[]).id();
 
-        let mut query = world.query::<&Children>();
+        let mut query = world.query::<Children>();
         let children = query.get(&world, parent);
         assert!(children.is_err());
     }

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -1,10 +1,13 @@
 #[cfg(feature = "reflect")]
 use bevy_ecs::reflect::{ReflectComponent, ReflectMapEntities};
 use bevy_ecs::{
-    component::Component,
+    archetype::Archetype,
+    component::{Component, ComponentId, Components, Tick},
     entity::{Entity, EntityMapper, MapEntities},
     prelude::FromWorld,
-    world::World,
+    query::{FilteredAccess, QueryData, ReadFetch, ReadOnlyQueryData, WorldQuery},
+    storage::{Table, TableRow},
+    world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 use core::slice;
 use smallvec::SmallVec;
@@ -162,3 +165,96 @@ impl<'a> IntoIterator for &'a Children {
         self.0.iter()
     }
 }
+
+#[allow(unsafe_code)]
+/// SAFETY:
+/// This implementation delegates to the existing implementation for &Children
+unsafe impl WorldQuery for Children
+where
+    Self: Component,
+{
+    type Item<'w> = &'w [Entity];
+    type Fetch<'w> = ReadFetch<'w, Self>;
+    type State = ComponentId;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
+        <&Self as WorldQuery>::shrink_fetch(fetch)
+    }
+
+    #[inline]
+    unsafe fn init_fetch<'w>(
+        world: UnsafeWorldCell<'w>,
+        state: &Self::State,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Self::Fetch<'w> {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::init_fetch(world, state, last_run, this_run) }
+    }
+
+    const IS_DENSE: bool = <&Self as WorldQuery>::IS_DENSE;
+
+    #[inline]
+    unsafe fn set_archetype<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype: &'w Archetype,
+        table: &'w Table,
+    ) {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::set_archetype(fetch, state, archetype, table) }
+    }
+
+    #[inline]
+    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table) {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::set_table(fetch, state, table) }
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe {
+            <&Self as WorldQuery>::fetch(fetch, entity, table_row)
+                .0
+                .as_ref()
+        }
+    }
+
+    fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+        <&Self as WorldQuery>::update_component_access(state, access);
+    }
+
+    fn init_state(world: &mut World) -> ComponentId {
+        <&Self as WorldQuery>::init_state(world)
+    }
+
+    fn get_state(components: &Components) -> Option<Self::State> {
+        <&Self as WorldQuery>::get_state(components)
+    }
+
+    fn matches_component_set(
+        state: &Self::State,
+        set_contains_id: &impl Fn(ComponentId) -> bool,
+    ) -> bool {
+        <&Self as WorldQuery>::matches_component_set(state, set_contains_id)
+    }
+}
+
+#[allow(unsafe_code)]
+/// SAFETY: `Self` is the same as `Self::ReadOnly`
+unsafe impl QueryData for Children {
+    type ReadOnly = Self;
+}
+
+#[allow(unsafe_code)]
+/// SAFETY: access is read only
+unsafe impl ReadOnlyQueryData for Children {}

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -1,10 +1,13 @@
 #[cfg(feature = "reflect")]
 use bevy_ecs::reflect::{ReflectComponent, ReflectMapEntities};
 use bevy_ecs::{
-    component::Component,
+    archetype::Archetype,
+    component::{Component, ComponentId, Components, Tick},
     entity::{Entity, EntityMapper, MapEntities},
+    query::{FilteredAccess, QueryData, ReadFetch, ReadOnlyQueryData, WorldQuery},
+    storage::{Table, TableRow},
     traversal::Traversal,
-    world::{FromWorld, World},
+    world::{unsafe_world_cell::UnsafeWorldCell, FromWorld, World},
 };
 use std::ops::Deref;
 
@@ -81,3 +84,92 @@ impl Traversal for Parent {
         Some(self.0)
     }
 }
+
+#[allow(unsafe_code)]
+/// SAFETY:
+/// This implementation delegates to the existing implementation for &Parent
+unsafe impl WorldQuery for Parent
+where
+    Self: Component,
+{
+    type Item<'w> = Entity;
+    type Fetch<'w> = ReadFetch<'w, Self>;
+    type State = ComponentId;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
+        <&Self as WorldQuery>::shrink_fetch(fetch)
+    }
+
+    #[inline]
+    unsafe fn init_fetch<'w>(
+        world: UnsafeWorldCell<'w>,
+        state: &Self::State,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Self::Fetch<'w> {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::init_fetch(world, state, last_run, this_run) }
+    }
+
+    const IS_DENSE: bool = <&Self as WorldQuery>::IS_DENSE;
+
+    #[inline]
+    unsafe fn set_archetype<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype: &'w Archetype,
+        table: &'w Table,
+    ) {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::set_archetype(fetch, state, archetype, table) }
+    }
+
+    #[inline]
+    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table) {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::set_table(fetch, state, table) }
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: This implementation delegates to the existing implementation for &Self
+        unsafe { <&Self as WorldQuery>::fetch(fetch, entity, table_row).get() }
+    }
+
+    fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+        <&Self as WorldQuery>::update_component_access(state, access);
+    }
+
+    fn init_state(world: &mut World) -> ComponentId {
+        <&Self as WorldQuery>::init_state(world)
+    }
+
+    fn get_state(components: &Components) -> Option<Self::State> {
+        <&Self as WorldQuery>::get_state(components)
+    }
+
+    fn matches_component_set(
+        state: &Self::State,
+        set_contains_id: &impl Fn(ComponentId) -> bool,
+    ) -> bool {
+        <&Self as WorldQuery>::matches_component_set(state, set_contains_id)
+    }
+}
+
+#[allow(unsafe_code)]
+/// SAFETY: `Self` is the same as `Self::ReadOnly`
+unsafe impl QueryData for Parent {
+    type ReadOnly = Self;
+}
+
+#[allow(unsafe_code)]
+/// SAFETY: access is read only
+unsafe impl ReadOnlyQueryData for Parent {}

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -54,14 +54,13 @@ impl<T> Default for ReportHierarchyIssue<T> {
 /// (See B0004 explanation linked in warning message)
 pub fn check_hierarchy_component_has_valid_parent<T: Component>(
     parent_query: Query<
-        (Entity, &Parent, Option<&bevy_core::Name>),
+        (Entity, Parent, Option<&bevy_core::Name>),
         (With<T>, Or<(Changed<Parent>, Added<T>)>),
     >,
     component_query: Query<(), With<T>>,
     mut already_diagnosed: Local<HashSet<Entity>>,
 ) {
     for (entity, parent, name) in &parent_query {
-        let parent = parent.get();
         if !component_query.contains(parent) && !already_diagnosed.contains(&entity) {
             already_diagnosed.insert(entity);
             bevy_utils::tracing::warn!(

--- a/crates/bevy_render/src/mesh/morph.rs
+++ b/crates/bevy_render/src/mesh/morph.rs
@@ -198,7 +198,7 @@ impl MeshMorphWeights {
 ///
 /// Only direct children are updated, to fulfill the expectations of glTF spec.
 pub fn inherit_weights(
-    morph_nodes: Query<(&Children, &MorphWeights), (Without<Handle<Mesh>>, Changed<MorphWeights>)>,
+    morph_nodes: Query<(Children, &MorphWeights), (Without<Handle<Mesh>>, Changed<MorphWeights>)>,
     mut morph_primitives: Query<&mut MeshMorphWeights, With<Handle<Mesh>>>,
 ) {
     for (children, parent_weights) in &morph_nodes {

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -344,11 +344,11 @@ pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
 
 fn visibility_propagate_system(
     changed: Query<
-        (Entity, &Visibility, Option<&Parent>, Option<&Children>),
+        (Entity, &Visibility, Option<Parent>, Option<Children>),
         (With<InheritedVisibility>, Changed<Visibility>),
     >,
     mut visibility_query: Query<(&Visibility, &mut InheritedVisibility)>,
-    children_query: Query<&Children, (With<Visibility>, With<InheritedVisibility>)>,
+    children_query: Query<Children, (With<Visibility>, With<InheritedVisibility>)>,
 ) {
     for (entity, visibility, parent, children) in &changed {
         let is_visible = match visibility {
@@ -356,7 +356,7 @@ fn visibility_propagate_system(
             Visibility::Hidden => false,
             // fall back to true if no parent is found or parent lacks components
             Visibility::Inherited => parent
-                .and_then(|p| visibility_query.get(p.get()).ok())
+                .and_then(|p| visibility_query.get(p).ok())
                 .map_or(true, |(_, x)| x.get()),
         };
         let (_, mut inherited_visibility) = visibility_query
@@ -382,7 +382,7 @@ fn propagate_recursive(
     parent_is_visible: bool,
     entity: Entity,
     visibility_query: &mut Query<(&Visibility, &mut InheritedVisibility)>,
-    children_query: &Query<&Children, (With<Visibility>, With<InheritedVisibility>)>,
+    children_query: &Query<Children, (With<Visibility>, With<InheritedVisibility>)>,
     // BLOCKED: https://github.com/rust-lang/rust/issues/31436
     // We use a result here to use the `?` operator. Ideally we'd use a try block instead
 ) -> Result<(), ()> {

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -48,11 +48,11 @@ pub fn sync_simple_transforms(
 /// Third party plugins should ensure that this is used in concert with [`sync_simple_transforms`].
 pub fn propagate_transforms(
     mut root_query: Query<
-        (Entity, &Children, Ref<Transform>, &mut GlobalTransform),
+        (Entity, Children, Ref<Transform>, &mut GlobalTransform),
         Without<Parent>,
     >,
     mut orphaned: RemovedComponents<Parent>,
-    transform_query: Query<(Ref<Transform>, &mut GlobalTransform, Option<&Children>), With<Parent>>,
+    transform_query: Query<(Ref<Transform>, &mut GlobalTransform, Option<Children>), With<Parent>>,
     parent_query: Query<(Entity, Ref<Parent>), With<GlobalTransform>>,
     mut orphaned_entities: Local<Vec<Entity>>,
 ) {
@@ -110,10 +110,7 @@ pub fn propagate_transforms(
 #[allow(unsafe_code)]
 unsafe fn propagate_recursive(
     parent: &GlobalTransform,
-    transform_query: &Query<
-        (Ref<Transform>, &mut GlobalTransform, Option<&Children>),
-        With<Parent>,
-    >,
+    transform_query: &Query<(Ref<Transform>, &mut GlobalTransform, Option<Children>), With<Parent>>,
     parent_query: &Query<(Entity, Ref<Parent>), With<GlobalTransform>>,
     entity: Entity,
     mut changed: bool,

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -19,7 +19,7 @@ use bevy_render::{camera::CameraUpdateSystem, prelude::Camera};
 use bevy_text::Text;
 use bevy_transform::prelude::GlobalTransform;
 
-fn calc_name(texts: &Query<&Text>, children: &Children) -> Option<Box<str>> {
+fn calc_name(texts: &Query<&Text>, children: &[Entity]) -> Option<Box<str>> {
     let mut name = None;
     for child in children {
         if let Ok(text) = texts.get(*child) {
@@ -59,7 +59,7 @@ fn calc_bounds(
 
 fn button_changed(
     mut commands: Commands,
-    mut query: Query<(Entity, &Children, Option<&mut AccessibilityNode>), Changed<Button>>,
+    mut query: Query<(Entity, Children, Option<&mut AccessibilityNode>), Changed<Button>>,
     texts: Query<&Text>,
 ) {
     for (entity, children, accessible) in &mut query {
@@ -86,7 +86,7 @@ fn button_changed(
 fn image_changed(
     mut commands: Commands,
     mut query: Query<
-        (Entity, &Children, Option<&mut AccessibilityNode>),
+        (Entity, Children, Option<&mut AccessibilityNode>),
         (Changed<UiImage>, Without<Button>),
     >,
     texts: Query<&Text>,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -110,7 +110,7 @@ pub fn ui_layout_system(
         With<Node>,
     >,
     children_query: Query<(Entity, Ref<Children>), With<Node>>,
-    just_children_query: Query<&Children>,
+    just_children_query: Query<Children>,
     mut removed_components: UiLayoutSystemRemovedComponentParam,
     mut node_transform_query: Query<(
         &mut Node,
@@ -293,7 +293,7 @@ pub fn ui_layout_system(
             Option<&BorderRadius>,
             Option<&Outline>,
         )>,
-        children_query: &Query<&Children>,
+        children_query: &Query<Children>,
         inverse_target_scale_factor: f32,
         parent_size: Vec2,
         mut absolute_location: Vec2,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -202,7 +202,7 @@ pub fn extract_uinode_background_colors(
             Option<&TargetCamera>,
             &BackgroundColor,
             &Style,
-            Option<&Parent>,
+            Option<Parent>,
         )>,
     >,
     node_query: Extract<Query<&Node>>,
@@ -241,7 +241,7 @@ pub fn extract_uinode_background_colors(
         // Both vertical and horizontal percentage border values are calculated based on the width of the parent node
         // <https://developer.mozilla.org/en-US/docs/Web/CSS/border-width>
         let parent_width = parent
-            .and_then(|parent| node_query.get(parent.get()).ok())
+            .and_then(|parent| node_query.get(parent).ok())
             .map(|parent_node| parent_node.size().x)
             .unwrap_or(ui_logical_viewport_size.x);
         let left =
@@ -305,7 +305,7 @@ pub fn extract_uinode_images(
                 Option<&TargetCamera>,
                 &UiImage,
                 Option<&TextureAtlas>,
-                Option<&Parent>,
+                Option<Parent>,
                 &Style,
             ),
             Without<ImageScaleMode>,
@@ -362,7 +362,7 @@ pub fn extract_uinode_images(
         // Both vertical and horizontal percentage border values are calculated based on the width of the parent node
         // <https://developer.mozilla.org/en-US/docs/Web/CSS/border-width>
         let parent_width = parent
-            .and_then(|parent| node_query.get(parent.get()).ok())
+            .and_then(|parent| node_query.get(parent).ok())
             .map(|parent_node| parent_node.size().x)
             .unwrap_or(ui_logical_viewport_size.x);
         let left =
@@ -452,7 +452,7 @@ pub fn extract_uinode_borders(
             &ViewVisibility,
             Option<&CalculatedClip>,
             Option<&TargetCamera>,
-            Option<&Parent>,
+            Option<Parent>,
             &Style,
             AnyOf<(&BorderColor, &Outline)>,
         )>,
@@ -500,7 +500,7 @@ pub fn extract_uinode_borders(
         // Both vertical and horizontal percentage border values are calculated based on the width of the parent node
         // <https://developer.mozilla.org/en-US/docs/Web/CSS/border-width>
         let parent_width = maybe_parent
-            .and_then(|parent| node_query.get(parent.get()).ok())
+            .and_then(|parent| node_query.get(parent).ok())
             .map(|parent_node| parent_node.size().x)
             .unwrap_or(ui_logical_viewport_size.x);
         let left =

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -54,7 +54,7 @@ pub(crate) fn ui_stack_system(
     mut ui_stack: ResMut<UiStack>,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     zindex_query: Query<&ZIndex, With<Node>>,
-    children_query: Query<&Children>,
+    children_query: Query<Children>,
     mut update_query: Query<&mut Node>,
 ) {
     // Generate `StackingContext` tree
@@ -90,7 +90,7 @@ pub(crate) fn ui_stack_system(
 fn insert_context_hierarchy(
     cache: &mut StackingContextCache,
     zindex_query: &Query<&ZIndex, With<Node>>,
-    children_query: &Query<&Children>,
+    children_query: &Query<Children>,
     entity: Entity,
     global_context: &mut StackingContext,
     parent_context: Option<&mut StackingContext>,

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -18,7 +18,7 @@ pub fn update_clipping_system(
     mut commands: Commands,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     mut node_query: Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
-    children_query: Query<&Children>,
+    children_query: Query<Children>,
 ) {
     for root_node in &root_node_query {
         update_clipping(
@@ -33,7 +33,7 @@ pub fn update_clipping_system(
 
 fn update_clipping(
     commands: &mut Commands,
-    children_query: &Query<&Children>,
+    children_query: &Query<Children>,
     node_query: &mut Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
     entity: Entity,
     mut maybe_inherited_clip: Option<Rect>,
@@ -106,7 +106,7 @@ pub fn update_target_camera_system(
         (With<Node>, Without<Parent>, Changed<TargetCamera>),
     >,
     changed_children_query: Query<(Entity, Option<&TargetCamera>), (With<Node>, Changed<Children>)>,
-    children_query: Query<&Children, With<Node>>,
+    children_query: Query<Children, With<Node>>,
     node_query: Query<Option<&TargetCamera>, With<Node>>,
 ) {
     // Track updated entities to prevent redundant updates, as `Commands` changes are deferred,
@@ -145,7 +145,7 @@ fn update_children_target_camera(
     entity: Entity,
     camera_to_set: Option<&TargetCamera>,
     node_query: &Query<Option<&TargetCamera>, With<Node>>,
-    children_query: &Query<&Children, With<Node>>,
+    children_query: &Query<Children, With<Node>>,
     commands: &mut Commands,
     updated_entities: &mut HashSet<Entity>,
 ) {

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -181,12 +181,7 @@ fn update_accessibility_nodes(
     mut adapters: NonSendMut<AccessKitAdapters>,
     focus: Res<Focus>,
     primary_window: Query<(Entity, &Window), With<PrimaryWindow>>,
-    nodes: Query<(
-        Entity,
-        &AccessibilityNode,
-        Option<&Children>,
-        Option<&Parent>,
-    )>,
+    nodes: Query<(Entity, &AccessibilityNode, Option<Children>, Option<Parent>)>,
     node_entities: Query<Entity, With<AccessibilityNode>>,
 ) {
     let Ok((primary_window_id, primary_window)) = primary_window.get_single() else {
@@ -209,12 +204,7 @@ fn update_accessibility_nodes(
 }
 
 fn update_adapter(
-    nodes: Query<(
-        Entity,
-        &AccessibilityNode,
-        Option<&Children>,
-        Option<&Parent>,
-    )>,
+    nodes: Query<(Entity, &AccessibilityNode, Option<Children>, Option<Parent>)>,
     node_entities: Query<Entity, With<AccessibilityNode>>,
     primary_window: &Window,
     primary_window_id: Entity,
@@ -250,12 +240,12 @@ fn update_adapter(
 #[inline]
 fn queue_node_for_update(
     node_entity: Entity,
-    parent: Option<&Parent>,
+    parent: Option<Entity>,
     node_entities: &Query<Entity, With<AccessibilityNode>>,
     window_children: &mut Vec<NodeId>,
 ) {
     let should_push = if let Some(parent) = parent {
-        !node_entities.contains(parent.get())
+        !node_entities.contains(parent)
     } else {
         true
     };
@@ -266,7 +256,7 @@ fn queue_node_for_update(
 
 #[inline]
 fn add_children_nodes(
-    children: Option<&Children>,
+    children: Option<&[Entity]>,
     node_entities: &Query<Entity, With<AccessibilityNode>>,
     node: &mut NodeBuilder,
 ) {

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -315,7 +315,7 @@ fn race_track_pos(offset: f32, t: f32) -> Vec2 {
 
 fn move_cars(
     time: Res<Time>,
-    mut movables: Query<(&mut Transform, &Moves, &Children)>,
+    mut movables: Query<(&mut Transform, &Moves, Children)>,
     mut spins: Query<&mut Transform, (Without<Moves>, With<Rotates>)>,
 ) {
     for (mut transform, moves, children) in &mut movables {
@@ -331,7 +331,7 @@ fn move_cars(
         transform.translation.y = -0.59;
         let delta = transform.translation - prev;
         transform.look_to(delta, Vec3::Y);
-        for child in children.iter() {
+        for child in children {
             let Ok(mut wheel) = spins.get_mut(*child) else {
                 continue;
             };

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -177,7 +177,7 @@ fn setup(
 fn set_visibility_ranges(
     mut commands: Commands,
     mut new_meshes: Query<Entity, Added<Handle<Mesh>>>,
-    parents: Query<(Option<&Parent>, Option<&MainModel>)>,
+    parents: Query<(Option<Parent>, Option<&MainModel>)>,
 ) {
     // Loop over each newly-added mesh.
     for new_mesh in new_meshes.iter_mut() {
@@ -189,7 +189,7 @@ fn set_visibility_ranges(
                 break;
             }
             match parent {
-                Some(parent) => current = **parent,
+                Some(parent) => current = parent,
                 None => break,
             }
         }

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -431,7 +431,7 @@ fn handle_weight_drag(
 fn update_ui(
     mut text_query: Query<&mut Text>,
     mut background_query: Query<&mut Style, Without<Text>>,
-    container_query: Query<(&Children, &ClipNode)>,
+    container_query: Query<(Children, &ClipNode)>,
     animation_weights_query: Query<&ExampleAnimationWeights, Changed<ExampleAnimationWeights>>,
 ) {
     for animation_weights in animation_weights_query.iter() {

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -298,7 +298,7 @@ fn handle_button_toggles(
             &Interaction,
             &mut MaskGroupControl,
             &mut BackgroundColor,
-            &Children,
+            Children,
         ),
         Changed<Interaction>,
     >,
@@ -325,7 +325,7 @@ fn handle_button_toggles(
         };
 
         // Update the text color of the button.
-        for &kid in children.iter() {
+        for &kid in children {
             if let Ok(mut text) = texts.get_mut(kid) {
                 for section in &mut text.sections {
                     section.style.color = if mask_group_control.enabled {

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -47,14 +47,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 /// It is similar to the animation defined in `models/SimpleSkin/SimpleSkin.gltf`.
 fn joint_animation(
     time: Res<Time>,
-    parent_query: Query<&Parent, With<SkinnedMesh>>,
-    children_query: Query<&Children>,
+    parent_query: Query<Parent, With<SkinnedMesh>>,
+    children_query: Query<Children>,
     mut transform_query: Query<&mut Transform>,
 ) {
     // Iter skinned mesh entity
-    for skinned_mesh_parent in &parent_query {
-        // Mesh node is the parent of the skinned mesh entity.
-        let mesh_node_entity = skinned_mesh_parent.get();
+    // Mesh node is the parent of the skinned mesh entity.
+    for mesh_node_entity in &parent_query {
         // Get `Children` in the mesh node.
         let mesh_node_children = children_query.get(mesh_node_entity).unwrap();
 

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -62,7 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 fn rotate(
     mut commands: Commands,
     time: Res<Time>,
-    mut parents_query: Query<(Entity, &Children), With<Sprite>>,
+    mut parents_query: Query<(Entity, Children), With<Sprite>>,
     mut transform_query: Query<&mut Transform, With<Sprite>>,
 ) {
     for (parent, children) in &mut parents_query {

--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -36,7 +36,7 @@ impl Clips {
 fn assign_clips(
     mut players: Query<&mut AnimationPlayer>,
     targets: Query<(Entity, &AnimationTarget)>,
-    parents: Query<&Parent>,
+    parents: Query<Parent>,
     scene_handle: Res<SceneHandle>,
     clips: Res<Assets<AnimationClip>>,
     gltf_assets: Res<Assets<Gltf>>,
@@ -108,7 +108,7 @@ fn assign_clips(
                 }
 
                 // Go to the next parent.
-                current = parents.get(entity).ok().map(Parent::get);
+                current = parents.get(entity).ok();
             }
         }
 

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -23,7 +23,7 @@ fn button_system(
             &Interaction,
             &mut BackgroundColor,
             &mut BorderColor,
-            &Children,
+            Children,
         ),
         (Changed<Interaction>, With<Button>),
     >,

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -433,7 +433,7 @@ where
 
 fn buttons_handler<T>(
     mut left_panel_query: Query<&mut <Target<T> as TargetUpdate>::TargetComponent>,
-    mut visibility_button_query: Query<(&Target<T>, &Interaction, &Children), Changed<Interaction>>,
+    mut visibility_button_query: Query<(&Target<T>, &Interaction, Children), Changed<Interaction>>,
     mut text_query: Query<&mut Text>,
 ) where
     T: Send + Sync,
@@ -459,7 +459,7 @@ fn buttons_handler<T>(
 }
 
 fn text_hover(
-    mut button_query: Query<(&Interaction, &mut BackgroundColor, &Children), Changed<Interaction>>,
+    mut button_query: Query<(&Interaction, &mut BackgroundColor, Children), Changed<Interaction>>,
     mut text_query: Query<&mut Text>,
 ) {
     for (interaction, mut color, children) in button_query.iter_mut() {

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -299,7 +299,7 @@ fn update_buttons(
     >,
     mut bar_query: Query<&mut Style, With<Bar>>,
     mut text_query: Query<&mut Text>,
-    children_query: Query<&Children>,
+    children_query: Query<Children>,
     mut button_activated_event: EventWriter<ButtonActivatedEvent>,
 ) {
     let mut style = bar_query.single_mut();
@@ -362,7 +362,7 @@ fn update_radio_buttons_colors(
     mut border_query: Query<&mut BorderColor>,
     mut color_query: Query<&mut BackgroundColor>,
     mut text_query: Query<&mut Text>,
-    children_query: Query<&Children>,
+    children_query: Query<Children>,
 ) {
     for &ButtonActivatedEvent(button_id) in event_reader.read() {
         let (_, target_constraint, _) = button_query.get(button_id).unwrap();

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -343,13 +343,13 @@ struct ScrollingList {
 
 fn mouse_scroll(
     mut mouse_wheel_events: EventReader<MouseWheel>,
-    mut query_list: Query<(&mut ScrollingList, &mut Style, &Parent, &Node)>,
+    mut query_list: Query<(&mut ScrollingList, &mut Style, Parent, &Node)>,
     query_node: Query<&Node>,
 ) {
     for mouse_wheel_event in mouse_wheel_events.read() {
         for (mut scrolling_list, mut style, parent, list_node) in &mut query_list {
             let items_height = list_node.size().y;
-            let container_height = query_node.get(parent.get()).unwrap().size().y;
+            let container_height = query_node.get(parent).unwrap().size().y;
 
             let max_scroll = (items_height - container_height).max(0.);
 

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -19,7 +19,7 @@ fn main() {
 
 fn button_system(
     mut interaction_query: Query<
-        (&Interaction, &mut TextureAtlas, &Children, &mut UiImage),
+        (&Interaction, &mut TextureAtlas, Children, &mut UiImage),
         (Changed<Interaction>, With<Button>),
     >,
     mut text_query: Query<&mut Text>,

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -19,7 +19,7 @@ fn main() {
 
 fn button_system(
     mut interaction_query: Query<
-        (&Interaction, &Children, &mut UiImage),
+        (&Interaction, Children, &mut UiImage),
         (Changed<Interaction>, With<Button>),
     >,
     mut text_query: Query<&mut Text>,


### PR DESCRIPTION
# Objective

- Improve the ergonomics of `Parent` and `Children` in queries.
- Act on a conversation had on [Discord](https://discord.com/channels/691052431525675048/749335865876021248/1281151648042848267) with @ItsDoot 

## Solution

Add an implementation of `ReadOnlyQueryData` (and the prerequisite traits) for `Parent` and `Children`. This does not conflict with the derived implementations from `Component`, allowing the wrapping types to still be accessed via `&T` and `&mut T` as currently.

## Testing

- CI passed locally.

---

## Showcase

<details>
  <summary>Before</summary>

```rust
fn foo(foo_query: Query<(&Foo, &Parent)>, bar_query: Query<&Bar>) {
    for (foo, parent) in foo_query.iter() {
        let parent = parent.get();
        let bar = bar_query.get(parent).unwrap();
        do_something(foo, bar);
    }
}
```

</details>

<details>
  <summary>After</summary>

```rust
fn foo(foo_query: Query<(&Foo, Parent)>, bar_query: Query<&Bar>) {
    for (foo, parent) in foo_query.iter() {
        let bar = bar_query.get(parent).unwrap();
        do_something(foo, bar);
    }
}
```

</details>

As can be seen above, the change in end-user code is minimal, but positive. It's unfortunate that it requires an `unsafe` implementation since we're able to delegate all the actually unsafe operations to the known-safe derived implementation from `Component`. But I think it's worth it for this (mild) improvement.
