### PR TITLE
`Node::is_empty`

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -474,11 +474,7 @@ pub fn extract_uinode_borders(
         };
 
         // Skip invisible borders
-        if !view_visibility.get()
-            || border_color.0.is_fully_transparent()
-            || uinode.size().x <= 0.
-            || uinode.size().y <= 0.
-        {
+        if !view_visibility.get() || border_color.0.is_fully_transparent() || uinode.is_empty() {
             continue;
         }
 
@@ -756,7 +752,7 @@ pub fn extract_uinode_text(
         };
 
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
-        if !view_visibility.get() || uinode.size().x == 0. || uinode.size().y == 0. {
+        if !view_visibility.get() || uinode.is_empty() {
             continue;
         }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -63,6 +63,14 @@ impl Node {
         self.calculated_size
     }
 
+    /// Check if the node is empty.
+    /// A node is considered empty if it has a zero or negative extent along either of its axes.
+    ///
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.size().cmple(Vec2::ZERO).any()
+    }
+
     /// The order of the node in the UI layout.
     /// Nodes with a higher stack index are drawn on top of and receive interactions before nodes with lower stack indices.
     pub const fn stack_index(&self) -> u32 {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -65,7 +65,6 @@ impl Node {
 
     /// Check if the node is empty.
     /// A node is considered empty if it has a zero or negative extent along either of its axes.
-    ///
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.size().cmple(Vec2::ZERO).any()


### PR DESCRIPTION
# Objective

Add a `Node::is_empty` method to replace the `uinode.size().x() <= 0. || uinode.size.y() <= 0.` checks.