### PR TITLE
Fix `bevy_ui` compile error when `bevy_picking` feature is disabled

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,6 +1,5 @@
 use crate::{
-    picking_backend::pick_rounded_rect, CalculatedClip, DefaultUiCamera, Node, TargetCamera,
-    UiScale, UiStack,
+    pick_rounded_rect, CalculatedClip, DefaultUiCamera, Node, TargetCamera, UiScale, UiStack,
 };
 use bevy_ecs::{
     change_detection::DetectChangesMut,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -21,7 +21,6 @@ pub mod widget;
 pub mod picking_backend;
 
 use bevy_derive::{Deref, DerefMut};
-use bevy_math::Vec2;
 use bevy_reflect::Reflect;
 #[cfg(feature = "bevy_text")]
 mod accessibility;
@@ -245,23 +244,4 @@ fn build_text_interop(app: &mut App) {
         PostUpdate,
         AmbiguousWithUpdateText2DLayout.ambiguous_with(bevy_text::update_text2d_layout),
     );
-}
-
-// Returns true if `point` (relative to the rectangle's center) is within the bounds of a rounded rectangle with
-// the given size and border radius.
-//
-// Matches the sdf function in `ui.wgsl` that is used by the UI renderer to draw rounded rectangles.
-fn pick_rounded_rect(point: Vec2, size: Vec2, border_radius: ResolvedBorderRadius) -> bool {
-    let s = point.signum();
-    let r = (border_radius.top_left * (1. - s.x) * (1. - s.y)
-        + border_radius.top_right * (1. + s.x) * (1. - s.y)
-        + border_radius.bottom_right * (1. + s.x) * (1. + s.y)
-        + border_radius.bottom_left * (1. - s.x) * (1. + s.y))
-        / 4.;
-
-    let corner_to_point = point.abs() - 0.5 * size;
-    let q = corner_to_point + r;
-    let l = q.max(Vec2::ZERO).length();
-    let m = q.max_element().min(0.);
-    l + m - r < 0.
 }

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -23,7 +23,7 @@
 #![allow(clippy::too_many_arguments)]
 #![deny(missing_docs)]
 
-use crate::{pick_rounded_rect, prelude::*, UiStack};
+use crate::{focus::pick_rounded_rect, prelude::*, UiStack};
 use bevy_app::prelude::*;
 use bevy_ecs::{prelude::*, query::QueryData};
 use bevy_math::Vec2;

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -23,7 +23,7 @@
 #![allow(clippy::too_many_arguments)]
 #![deny(missing_docs)]
 
-use crate::{prelude::*, UiStack};
+use crate::{pick_rounded_rect, prelude::*, UiStack};
 use bevy_app::prelude::*;
 use bevy_ecs::{prelude::*, query::QueryData};
 use bevy_math::Vec2;
@@ -216,27 +216,4 @@ pub fn ui_picking(
 
         output.send(PointerHits::new(*pointer, picks, order));
     }
-}
-
-// Returns true if `point` (relative to the rectangle's center) is within the bounds of a rounded rectangle with
-// the given size and border radius.
-//
-// Matches the sdf function in `ui.wgsl` that is used by the UI renderer to draw rounded rectangles.
-pub(crate) fn pick_rounded_rect(
-    point: Vec2,
-    size: Vec2,
-    border_radius: ResolvedBorderRadius,
-) -> bool {
-    let s = point.signum();
-    let r = (border_radius.top_left * (1. - s.x) * (1. - s.y)
-        + border_radius.top_right * (1. + s.x) * (1. - s.y)
-        + border_radius.bottom_right * (1. + s.x) * (1. + s.y)
-        + border_radius.bottom_left * (1. - s.x) * (1. + s.y))
-        / 4.;
-
-    let corner_to_point = point.abs() - 0.5 * size;
-    let q = corner_to_point + r;
-    let l = q.max(Vec2::ZERO).length();
-    let m = q.max_element().min(0.);
-    l + m - r < 0.
 }


### PR DESCRIPTION
# Objective

#14957 added the `pick_rounded_rect` function to `bevy_ui` in the `picking_backend` module, which is gated behind the `bevy_picking` feature. This function is used in that module, as well as in the `focus` module. The latter usage is not gated behind the `bevy_picking` feature, causing a compile error when the feature is disabled.

## Solution

Move the `pick_rounded_rect` function out of the `picking_backend` module, as it does not depend on anything defined in that module. I put it in `lib.rs` but it could reasonably be moved somewhere else instead.

## Testing

Encountered this compile error in a project and confirmed that this patch fixes it.
