### PR TITLE
Remove deprecated `SpriteSheetBundle` and `AtlasImageBundle`

### DIFF
--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -1,4 +1,4 @@
-use crate::{Sprite, TextureAtlas};
+use crate::Sprite;
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use crate::{Sprite, TextureAtlas};
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -34,36 +32,3 @@ pub struct SpriteBundle {
     pub view_visibility: ViewVisibility,
 }
 
-/// A [`Bundle`] of components for drawing a single sprite from a sprite sheet (also referred
-/// to as a `TextureAtlas`) or for animated sprites.
-///
-/// Note:
-/// This bundle is identical to [`SpriteBundle`] with an additional [`TextureAtlas`] component.
-///
-/// Check the following examples for usage:
-/// - [`animated sprite sheet example`](https://github.com/bevyengine/bevy/blob/latest/examples/2d/sprite_sheet.rs)
-/// - [`sprite animation event example`](https://github.com/bevyengine/bevy/blob/latest/examples/2d/sprite_animation.rs)
-/// - [`texture atlas example`](https://github.com/bevyengine/bevy/blob/latest/examples/2d/texture_atlas.rs)
-#[deprecated(
-    since = "0.14.0",
-    note = "Use `TextureAtlas` alongside a `SpriteBundle` instead"
-)]
-#[derive(Bundle, Clone, Debug, Default)]
-pub struct SpriteSheetBundle {
-    /// Specifies the rendering properties of the sprite, such as color tint and flip.
-    pub sprite: Sprite,
-    /// The local transform of the sprite, relative to its parent.
-    pub transform: Transform,
-    /// The absolute transform of the sprite. This should generally not be written to directly.
-    pub global_transform: GlobalTransform,
-    /// The sprite sheet base texture
-    pub texture: Handle<Image>,
-    /// The sprite sheet texture atlas, allowing to draw a custom section of `texture`.
-    pub atlas: TextureAtlas,
-    /// User indication of whether an entity is visible
-    pub visibility: Visibility,
-    /// Inherited visibility of an entity.
-    pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub view_visibility: ViewVisibility,
-}

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -13,7 +13,7 @@ use bevy_transform::components::{GlobalTransform, Transform};
 ///
 /// You may add one or both of the following components to enable additional behaviours:
 /// - [`ImageScaleMode`](crate::ImageScaleMode) to enable either slicing or tiling of the texture
-/// - [`TextureAtlas`] to draw a specific section of the texture
+/// - [`TextureAtlas`](crate::TextureAtlas) to draw a specific section of the texture
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct SpriteBundle {
     /// Specifies the rendering properties of the sprite, such as color tint and flip.

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -31,4 +31,3 @@ pub struct SpriteBundle {
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
 }
-

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -20,10 +20,6 @@ mod texture_atlas_builder;
 mod texture_slice;
 
 pub mod prelude {
-    #[allow(deprecated)]
-    #[doc(hidden)]
-    pub use crate::bundle::SpriteSheetBundle;
-
     #[doc(hidden)]
     pub use crate::{
         bundle::SpriteBundle,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -64,7 +64,7 @@ pub struct NodeBundle {
 ///
 /// You may add one or both of the following components to enable additional behaviours:
 /// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
-/// - [`TextureAtlas`] to draw a specific section of the texture
+/// - [`TextureAtlas`](bevy_sprite::TextureAtlas) to draw a specific section of the texture
 #[derive(Bundle, Debug, Default)]
 pub struct ImageBundle {
     /// Describes the logical size of the node
@@ -216,7 +216,7 @@ where
 ///
 /// You may add one or both of the following components to enable additional behaviours:
 /// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
-/// - [`TextureAtlas`] to draw a specific section of the texture
+/// - [`TextureAtlas`](bevy_sprite::TextureAtlas) to draw a specific section of the texture
 #[derive(Bundle, Clone, Debug)]
 pub struct ButtonBundle {
     /// Describes the logical size of the node

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 //! This module contains basic node bundles used to build UIs
 
 #[cfg(feature = "bevy_text")]
@@ -95,56 +93,6 @@ pub struct ImageBundle {
     ///
     /// This component is automatically managed by the UI layout system.
     /// To alter the position of the `ImageBundle`, use the properties of the [`Style`] component.
-    pub transform: Transform,
-    /// The global transform of the node
-    ///
-    /// This component is automatically updated by the [`TransformPropagate`](`bevy_transform::TransformSystem::TransformPropagate`) systems.
-    pub global_transform: GlobalTransform,
-    /// Describes the visibility properties of the node
-    pub visibility: Visibility,
-    /// Inherited visibility of an entity.
-    pub inherited_visibility: InheritedVisibility,
-    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
-    pub view_visibility: ViewVisibility,
-    /// Indicates the depth at which the node should appear in the UI
-    pub z_index: ZIndex,
-}
-
-/// A UI node that is a texture atlas sprite
-///
-/// # Extra behaviours
-///
-/// You may add the following components to enable additional behaviours
-/// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
-///
-/// This bundle is identical to [`ImageBundle`] with an additional [`TextureAtlas`] component.
-#[deprecated(
-    since = "0.14.0",
-    note = "Use `TextureAtlas` alongside `ImageBundle` instead"
-)]
-#[derive(Bundle, Debug, Default)]
-pub struct AtlasImageBundle {
-    /// Describes the logical size of the node
-    pub node: Node,
-    /// Styles which control the layout (size and position) of the node and its children
-    /// In some cases these styles also affect how the node drawn/painted.
-    pub style: Style,
-    /// The calculated size based on the given image
-    pub calculated_size: ContentSize,
-    /// The image of the node
-    pub image: UiImage,
-    /// A handle to the texture atlas to use for this Ui Node
-    pub texture_atlas: TextureAtlas,
-    /// Whether this node should block interaction with lower nodes
-    pub focus_policy: FocusPolicy,
-    /// The size of the image in pixels
-    ///
-    /// This component is set automatically
-    pub image_size: UiImageSize,
-    /// The transform of the node
-    ///
-    /// This component is automatically managed by the UI layout system.
-    /// To alter the position of the `AtlasImageBundle`, use the properties of the [`Style`] component.
     pub transform: Transform,
     /// The global transform of the node
     ///

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -12,7 +12,6 @@ use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_ecs::bundle::Bundle;
 use bevy_render::view::{InheritedVisibility, ViewVisibility, Visibility};
-use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
 use bevy_text::{
     BreakLineOn, CosmicBuffer, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle,


### PR DESCRIPTION
# Objective

Remove bundles that were deprecated in 0.14.

## Testing

`rg SpriteSheetBundle` and `rg AtlasImageBundle` show no results.