### PR TITLE
fix imports in example ui_texture_slice_flip_and_tile

### DIFF
--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -1,7 +1,10 @@
 //! This example illustrates how to how to flip and tile images with 9-slicing in the UI.
 
-use bevy::{prelude::*, winit::WinitSettings};
-use bevy_render::texture::{ImageLoaderSettings, ImageSampler};
+use bevy::{
+    prelude::*,
+    render::texture::{ImageLoaderSettings, ImageSampler},
+    winit::WinitSettings,
+};
 
 fn main() {
     App::new()


### PR DESCRIPTION
# Objective

- don't use a sub crate in an example

## Solution

- fix imports
