### PR TITLE
Add `observer` to `Trigger`

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -60,6 +60,11 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
         self.trigger.entity
     }
 
+    /// Returns the entity that observed the triggered event.
+    pub fn observer(&self) -> Entity {
+        self.trigger.observer
+    }
+
     /// Enables or disables event propagation, allowing the same event to trigger observers on a chain of different entities.
     ///
     /// The path an event will propagate along is specified by its associated [`Traversal`] component. By default, events

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -55,12 +55,33 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
         Ptr::from(&self.event)
     }
 
-    /// Returns the entity that triggered the observer, could be [`Entity::PLACEHOLDER`].
+    /// Returns the [`Entity`] that triggered the observer, could be [`Entity::PLACEHOLDER`].
     pub fn entity(&self) -> Entity {
         self.trigger.entity
     }
 
-    /// Returns the entity that observed the triggered event.
+    /// Returns the [`Entity`] that observed the triggered event.
+    /// This allows you to despawn the observer, ceasing observation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bevy_ecs::prelude::{Commands, Trigger};
+    /// #
+    /// # struct MyEvent {
+    /// #   done: bool,
+    /// # }
+    /// #
+    /// /// Handle `MyEvent` and if it is done, stop observation.
+    /// fn my_observer(trigger: Trigger<MyEvent>, mut commands: Commands) {
+    ///     if trigger.event().done {
+    ///         commands.entity(trigger.observer()).despawn();
+    ///         return;
+    ///     }
+    ///
+    ///     // ...
+    /// }
+    /// ```
     pub fn observer(&self) -> Entity {
         self.trigger.observer
     }


### PR DESCRIPTION
# Objective

- Fixes  #15061

## Solution

- Added `observer` to `Trigger`, which returns the entity observing the triggered event.

## Testing

- CI passed locally.
