### PR TITLE
Add `many_entities_mut` function variants to `DeferredWorld`

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -553,3 +553,68 @@ impl<'w> DeferredWorld<'w> {
         self.world
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        entity::EntityHashSet,
+        world::{DeferredWorld, World},
+    };
+
+    #[test]
+    fn test_many_entities() {
+        let mut world = World::new();
+        let entity1 = world.spawn_empty().id();
+        let entity2 = world.spawn_empty().id();
+        let mut world = DeferredWorld::from(&mut world);
+
+        assert!(world.get_many_entities([entity1, entity1]).is_ok());
+        assert!(world.get_many_entities([entity1, entity2]).is_ok());
+        assert!(world.get_many_entities_mut([entity1, entity1]).is_err());
+        assert!(world.get_many_entities_mut([entity1, entity2]).is_ok());
+        assert!(world
+            .get_many_entities_mut([entity1, entity1, entity2])
+            .is_err());
+    }
+
+    #[test]
+    fn test_many_entities_dynamic() {
+        let mut world = World::new();
+        let entity1 = world.spawn_empty().id();
+        let entity2 = world.spawn_empty().id();
+        let mut world = DeferredWorld::from(&mut world);
+
+        assert!(world.get_many_entities_dynamic(&[entity1, entity1]).is_ok());
+        assert!(world.get_many_entities_dynamic(&[entity1, entity2]).is_ok());
+        assert!(world
+            .get_many_entities_dynamic_mut(&[entity1, entity1])
+            .is_err());
+        assert!(world
+            .get_many_entities_dynamic_mut(&[entity1, entity2])
+            .is_ok());
+        assert!(world
+            .get_many_entities_dynamic_mut(&[entity1, entity1, entity2])
+            .is_err());
+    }
+
+    #[test]
+    fn test_many_entities_from_set() {
+        let mut world = World::new();
+        let entity1 = world.spawn_empty().id();
+        let entity2 = world.spawn_empty().id();
+        let mut world = DeferredWorld::from(&mut world);
+
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity1]))
+            .is_ok());
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity2]))
+            .is_ok());
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity2]))
+            .is_ok());
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity1, entity2]))
+            .is_ok());
+    }
+}

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -427,17 +427,7 @@ impl World {
     /// world.many_entities([id1, id2]);
     /// ```
     pub fn many_entities<const N: usize>(&mut self, entities: [Entity; N]) -> [EntityRef<'_>; N] {
-        #[inline(never)]
-        #[cold]
-        #[track_caller]
-        fn panic_on_err(e: QueryEntityError) -> ! {
-            panic!("{e}");
-        }
-
-        match self.get_many_entities(entities) {
-            Ok(refs) => refs,
-            Err(e) => panic_on_err(e),
-        }
+        self.get_many_entities(entities).unwrap()
     }
 
     /// Gets mutable access to multiple entities at once.
@@ -472,17 +462,7 @@ impl World {
         &mut self,
         entities: [Entity; N],
     ) -> [EntityMut<'_>; N] {
-        #[inline(never)]
-        #[cold]
-        #[track_caller]
-        fn panic_on_err(e: QueryEntityError) -> ! {
-            panic!("{e}");
-        }
-
-        match self.get_many_entities_mut(entities) {
-            Ok(borrows) => borrows,
-            Err(e) => panic_on_err(e),
-        }
+        self.get_many_entities_mut(entities).unwrap()
     }
 
     /// Returns the components of an [`Entity`] through [`ComponentInfo`].

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2952,6 +2952,7 @@ mod tests {
     use crate::{
         change_detection::DetectChangesMut,
         component::{ComponentDescriptor, ComponentInfo, StorageType},
+        entity::EntityHashSet,
         ptr::OwningPtr,
         system::Resource,
     };
@@ -3476,5 +3477,59 @@ mod tests {
             entity1, entity2, entity3, entity4, entity5, entity1
         ])
         .is_err());
+    }
+
+    #[test]
+    fn test_many_entities() {
+        let mut world = World::new();
+        let entity1 = world.spawn_empty().id();
+        let entity2 = world.spawn_empty().id();
+
+        assert!(world.get_many_entities([entity1, entity1]).is_ok());
+        assert!(world.get_many_entities([entity1, entity2]).is_ok());
+        assert!(world.get_many_entities_mut([entity1, entity1]).is_err());
+        assert!(world.get_many_entities_mut([entity1, entity2]).is_ok());
+        assert!(world
+            .get_many_entities_mut([entity1, entity1, entity2])
+            .is_err());
+    }
+
+    #[test]
+    fn test_many_entities_dynamic() {
+        let mut world = World::new();
+        let entity1 = world.spawn_empty().id();
+        let entity2 = world.spawn_empty().id();
+
+        assert!(world.get_many_entities_dynamic(&[entity1, entity1]).is_ok());
+        assert!(world.get_many_entities_dynamic(&[entity1, entity2]).is_ok());
+        assert!(world
+            .get_many_entities_dynamic_mut(&[entity1, entity1])
+            .is_err());
+        assert!(world
+            .get_many_entities_dynamic_mut(&[entity1, entity2])
+            .is_ok());
+        assert!(world
+            .get_many_entities_dynamic_mut(&[entity1, entity1, entity2])
+            .is_err());
+    }
+
+    #[test]
+    fn test_many_entities_from_set() {
+        let mut world = World::new();
+        let entity1 = world.spawn_empty().id();
+        let entity2 = world.spawn_empty().id();
+
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity1]))
+            .is_ok());
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity2]))
+            .is_ok());
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity2]))
+            .is_ok());
+        assert!(world
+            .get_many_entities_from_set_mut(&EntityHashSet::from_iter([entity1, entity1, entity2]))
+            .is_ok());
     }
 }


### PR DESCRIPTION
# Objective

Closes #15038.

## Solution

Added:
- `DeferredWorld::get_many_entities_mut`
- `DeferredWorld::many_entities_mut`
- `DeferredWorld::get_many_entities_dynamic_mut`
- `DeferredWorld::get_many_entities_from_set_mut`
- `UnsafeWorldCell::get_entities` (used by the above functions)
- `UnsafeWorldCell::get_entities_dynamic` (used by the above functions)

Changed:
- Made equivalent functions on `World` reuse the newly introduced methods on `UnsafeWorldCell` for their implementations.
- Fixed the safety comment on `DeferredWorld::get_entity_mut`.

## Testing

- Added 3 tests for the `World` functions since they were previously missing.
- Added 3 tests for the `DeferredWorld` functions.

---

## Migration Guide

- `World::get_many_entities` and `World::get_many_entities_dynamic` now return `QueryEntityError` instead of `Entity` in the `Err` path to match the signatures of their `_mut` counterparts.