### PR TITLE
Fix `AsBindGroup` sampler validation.

### DIFF
--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -366,7 +366,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                                 if let Some(handle) = handle {
                                     let image = images.get(handle).ok_or_else(|| #render_path::render_resource::AsBindGroupError::RetryNextUpdate)?;
 
-                                    let Some(sample_type) = image.texture_format.sample_type(None, None) else {
+                                    let Some(sample_type) = image.texture_format.sample_type(None, Some(render_device.features())) else {
                                         return Err(#render_path::render_resource::AsBindGroupError::InvalidSamplerType(
                                             #binding_index,
                                             "None".to_string(),


### PR DESCRIPTION
Kind of confused why this wasn't breaking for me pre-`0.15-dev` since nothing obvious seems to have changed in `wgpu` upstream, but this fixes it and ensures that we return the correct sample type re: the actual device.