### PR TITLE
bevy_reflect: Function Overloading (Generic & Variadic Functions)

### DIFF
--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -84,11 +84,34 @@ fn overload(c: &mut Criterion) {
         a + b
     }
 
+    fn complex<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+        _: T0,
+        _: T1,
+        _: T2,
+        _: T3,
+        _: T4,
+        _: T5,
+        _: T6,
+        _: T7,
+        _: T8,
+        _: T9,
+    ) {
+    }
+
     c.benchmark_group("with_overload")
         .bench_function("01_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| func.with_overload(add::<i16>),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("01_complex_overload", |b| {
+            b.iter_batched(
+                || complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>.into_function(),
+                |func| {
+                    func.with_overload(complex::<i16, i32, i64, i128, u8, u16, u32, u64, u128, i8>)
+                },
                 BatchSize::SmallInput,
             );
         })
@@ -99,6 +122,17 @@ fn overload(c: &mut Criterion) {
                     func.with_overload(add::<i16>)
                         .with_overload(add::<i32>)
                         .with_overload(add::<i64>)
+                },
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("03_complex_overload", |b| {
+            b.iter_batched(
+                || complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>.into_function(),
+                |func| {
+                    func.with_overload(complex::<i16, i32, i64, i128, u8, u16, u32, u64, u128, i8>)
+                        .with_overload(complex::<i32, i64, i128, u8, u16, u32, u64, u128, i8, i16>)
+                        .with_overload(complex::<i64, i128, u8, u16, u32, u64, u128, i8, i16, i32>)
                 },
                 BatchSize::SmallInput,
             );
@@ -116,6 +150,23 @@ fn overload(c: &mut Criterion) {
                         .with_overload(add::<u32>)
                         .with_overload(add::<u64>)
                         .with_overload(add::<u128>)
+                },
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("10_complex_overload", |b| {
+            b.iter_batched(
+                || complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>.into_function(),
+                |func| {
+                    func.with_overload(complex::<i16, i32, i64, i128, u8, u16, u32, u64, u128, i8>)
+                        .with_overload(complex::<i32, i64, i128, u8, u16, u32, u64, u128, i8, i16>)
+                        .with_overload(complex::<i64, i128, u8, u16, u32, u64, u128, i8, i16, i32>)
+                        .with_overload(complex::<i128, u8, u16, u32, u64, u128, i8, i16, i32, i64>)
+                        .with_overload(complex::<u8, u16, u32, u64, u128, i8, i16, i32, i64, i128>)
+                        .with_overload(complex::<u16, u32, u64, u128, i8, i16, i32, i64, i128, u8>)
+                        .with_overload(complex::<u32, u64, u128, i8, i16, i32, i64, i128, u8, u16>)
+                        .with_overload(complex::<u64, u128, i8, i16, i32, i64, i128, u8, u16, u32>)
+                        .with_overload(complex::<u128, i8, i16, i32, i64, i128, u8, u16, u32, u64>)
                 },
                 BatchSize::SmallInput,
             );
@@ -181,6 +232,32 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
+        .bench_function("01_complex_overload", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>
+                            .into_function()
+                            .with_overload(
+                                complex::<i16, i32, i64, i128, u8, u16, u32, u64, u128, i8>,
+                            ),
+                        ArgList::new()
+                            .push_owned(1_i8)
+                            .push_owned(2_i16)
+                            .push_owned(3_i32)
+                            .push_owned(4_i64)
+                            .push_owned(5_i128)
+                            .push_owned(6_u8)
+                            .push_owned(7_u16)
+                            .push_owned(8_u32)
+                            .push_owned(9_u64)
+                            .push_owned(10_u128),
+                    )
+                },
+                |(func, args)| func.call(args),
+                BatchSize::SmallInput,
+            );
+        })
         .bench_function("03_overload", |b| {
             b.iter_batched(
                 || {
@@ -191,6 +268,38 @@ fn overload(c: &mut Criterion) {
                             .with_overload(add::<i32>)
                             .with_overload(add::<i64>),
                         ArgList::new().push_owned(75_i32).push_owned(25_i32),
+                    )
+                },
+                |(func, args)| func.call(args),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("03_complex_overload", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>
+                            .into_function()
+                            .with_overload(
+                                complex::<i16, i32, i64, i128, u8, u16, u32, u64, u128, i8>,
+                            )
+                            .with_overload(
+                                complex::<i32, i64, i128, u8, u16, u32, u64, u128, i8, i16>,
+                            )
+                            .with_overload(
+                                complex::<i64, i128, u8, u16, u32, u64, u128, i8, i16, i32>,
+                            ),
+                        ArgList::new()
+                            .push_owned(1_i32)
+                            .push_owned(2_i64)
+                            .push_owned(3_i128)
+                            .push_owned(4_u8)
+                            .push_owned(5_u16)
+                            .push_owned(6_u32)
+                            .push_owned(7_u64)
+                            .push_owned(8_u128)
+                            .push_owned(9_i8)
+                            .push_owned(10_i16),
                     )
                 },
                 |(func, args)| func.call(args),
@@ -213,6 +322,56 @@ fn overload(c: &mut Criterion) {
                             .with_overload(add::<u64>)
                             .with_overload(add::<u128>),
                         ArgList::new().push_owned(75_u8).push_owned(25_u8),
+                    )
+                },
+                |(func, args)| func.call(args),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("10_complex_overload", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>
+                            .into_function()
+                            .with_overload(
+                                complex::<i16, i32, i64, i128, u8, u16, u32, u64, u128, i8>,
+                            )
+                            .with_overload(
+                                complex::<i32, i64, i128, u8, u16, u32, u64, u128, i8, i16>,
+                            )
+                            .with_overload(
+                                complex::<i64, i128, u8, u16, u32, u64, u128, i8, i16, i32>,
+                            )
+                            .with_overload(
+                                complex::<i128, u8, u16, u32, u64, u128, i8, i16, i32, i64>,
+                            )
+                            .with_overload(
+                                complex::<u8, u16, u32, u64, u128, i8, i16, i32, i64, i128>,
+                            )
+                            .with_overload(
+                                complex::<u16, u32, u64, u128, i8, i16, i32, i64, i128, u8>,
+                            )
+                            .with_overload(
+                                complex::<u32, u64, u128, i8, i16, i32, i64, i128, u8, u16>,
+                            )
+                            .with_overload(
+                                complex::<u64, u128, i8, i16, i32, i64, i128, u8, u16, u32>,
+                            )
+                            .with_overload(
+                                complex::<u128, i8, i16, i32, i64, i128, u8, u16, u32, u64>,
+                            ),
+                        ArgList::new()
+                            .push_owned(1_u8)
+                            .push_owned(2_u16)
+                            .push_owned(3_u32)
+                            .push_owned(4_u64)
+                            .push_owned(5_u128)
+                            .push_owned(6_i8)
+                            .push_owned(7_i16)
+                            .push_owned(8_i32)
+                            .push_owned(9_i64)
+                            .push_owned(10_i128),
                     )
                 },
                 |(func, args)| func.call(args),

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -99,7 +99,7 @@ fn overload(c: &mut Criterion) {
     }
 
     c.benchmark_group("with_overload")
-        .bench_function("01_overload", |b| {
+        .bench_function("01_simple_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| func.with_overload(add::<i16>),
@@ -115,7 +115,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_overload", |b| {
+        .bench_function("03_simple_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -137,7 +137,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_overload", |b| {
+        .bench_function("10_simple_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -171,14 +171,14 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("01_nested_overload", |b| {
+        .bench_function("01_nested_simple_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| func.with_overload(add::<i16>),
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_nested_overload", |b| {
+        .bench_function("03_nested_simple_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -191,7 +191,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_nested_overload", |b| {
+        .bench_function("10_nested_simple_overload", |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -220,7 +220,7 @@ fn overload(c: &mut Criterion) {
         });
 
     c.benchmark_group("call_overload")
-        .bench_function("01_overload", |b| {
+        .bench_function("01_simple_overload", |b| {
             b.iter_batched(
                 || {
                     (
@@ -258,7 +258,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_overload", |b| {
+        .bench_function("03_simple_overload", |b| {
             b.iter_batched(
                 || {
                     (
@@ -306,7 +306,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_overload", |b| {
+        .bench_function("10_simple_overload", |b| {
             b.iter_batched(
                 || {
                     (

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -1,7 +1,7 @@
 use bevy_reflect::func::{ArgList, IntoFunction, IntoFunctionMut, TypedFunction};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
-criterion_group!(benches, typed, into, call, clone);
+criterion_group!(benches, typed, into, call, overload, clone);
 criterion_main!(benches);
 
 fn add(a: i32, b: i32) -> i32 {
@@ -74,6 +74,148 @@ fn call(c: &mut Criterion) {
             b.iter_batched(
                 || ArgList::new().push_owned(75_i32),
                 |args| add.call(args),
+                BatchSize::SmallInput,
+            );
+        });
+}
+
+fn overload(c: &mut Criterion) {
+    fn add<T: std::ops::Add<Output = T>>(a: T, b: T) -> T {
+        a + b
+    }
+
+    c.benchmark_group("with_overload")
+        .bench_function("01_overload", |b| {
+            b.iter_batched(
+                || add::<i8>.into_function(),
+                |func| func.with_overload(add::<i16>),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("03_overload", |b| {
+            b.iter_batched(
+                || add::<i8>.into_function(),
+                |func| {
+                    func.with_overload(add::<i16>)
+                        .with_overload(add::<i32>)
+                        .with_overload(add::<i64>)
+                },
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("10_overload", |b| {
+            b.iter_batched(
+                || add::<i8>.into_function(),
+                |func| {
+                    func.with_overload(add::<i16>)
+                        .with_overload(add::<i32>)
+                        .with_overload(add::<i64>)
+                        .with_overload(add::<i128>)
+                        .with_overload(add::<u8>)
+                        .with_overload(add::<u16>)
+                        .with_overload(add::<u32>)
+                        .with_overload(add::<u64>)
+                        .with_overload(add::<u128>)
+                },
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("01_nested_overload", |b| {
+            b.iter_batched(
+                || add::<i8>.into_function(),
+                |func| func.with_overload(add::<i16>),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("03_nested_overload", |b| {
+            b.iter_batched(
+                || add::<i8>.into_function(),
+                |func| {
+                    func.with_overload(
+                        add::<i16>
+                            .into_function()
+                            .with_overload(add::<i32>.into_function().with_overload(add::<i64>)),
+                    )
+                },
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("10_nested_overload", |b| {
+            b.iter_batched(
+                || add::<i8>.into_function(),
+                |func| {
+                    func.with_overload(
+                        add::<i16>.into_function().with_overload(
+                            add::<i32>.into_function().with_overload(
+                                add::<i64>.into_function().with_overload(
+                                    add::<i128>.into_function().with_overload(
+                                        add::<u8>.into_function().with_overload(
+                                            add::<u16>.into_function().with_overload(
+                                                add::<u32>.into_function().with_overload(
+                                                    add::<u64>
+                                                        .into_function()
+                                                        .with_overload(add::<u128>),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    )
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+    c.benchmark_group("call_overload")
+        .bench_function("01_overload", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        add::<i8>.into_function().with_overload(add::<i16>),
+                        ArgList::new().push_owned(75_i8).push_owned(25_i8),
+                    )
+                },
+                |(func, args)| func.call(args),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("03_overload", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        add::<i8>
+                            .into_function()
+                            .with_overload(add::<i16>)
+                            .with_overload(add::<i32>)
+                            .with_overload(add::<i64>),
+                        ArgList::new().push_owned(75_i32).push_owned(25_i32),
+                    )
+                },
+                |(func, args)| func.call(args),
+                BatchSize::SmallInput,
+            );
+        })
+        .bench_function("10_overload", |b| {
+            b.iter_batched(
+                || {
+                    (
+                        add::<i8>
+                            .into_function()
+                            .with_overload(add::<i16>)
+                            .with_overload(add::<i32>)
+                            .with_overload(add::<i64>)
+                            .with_overload(add::<i128>)
+                            .with_overload(add::<u8>)
+                            .with_overload(add::<u16>)
+                            .with_overload(add::<u32>)
+                            .with_overload(add::<u64>)
+                            .with_overload(add::<u128>),
+                        ArgList::new().push_owned(75_u8).push_owned(25_u8),
+                    )
+                },
+                |(func, args)| func.call(args),
                 BatchSize::SmallInput,
             );
         });

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -183,6 +183,14 @@ impl<'a> Arg<'a> {
             }
         }
     }
+
+    /// Returns `true` if the argument is of type `T`.
+    pub fn is<T: TypePath>(&self) -> bool {
+        self.value
+            .try_as_reflect()
+            .map(<dyn Reflect>::is::<T>)
+            .unwrap_or_default()
+    }
 }
 
 /// Represents an argument that can be passed to a [`DynamicFunction`] or [`DynamicFunctionMut`].

--- a/crates/bevy_reflect/src/func/args/count.rs
+++ b/crates/bevy_reflect/src/func/args/count.rs
@@ -1,0 +1,311 @@
+use crate::func::args::ArgCountOutOfBoundsError;
+use core::fmt::{Debug, Formatter};
+
+/// A container for zero or more argument counts for a function.
+///
+/// For most functions, this will contain a single count,
+/// however, overloaded functions may contain more.
+///
+/// # Maximum Argument Count
+///
+/// The maximum number of arguments that can be represented by this struct is 63,
+/// as given by [`ArgCount::MAX_COUNT`].
+/// The reason for this is that all counts are stored internally as a single `u64`
+/// with each bit representing a specific count based on its bit index.
+///
+/// This allows for a smaller memory footprint and faster lookups compared to a
+/// `HashSet` or `Vec` of possible counts.
+/// It's also more appropriate for representing the argument counts of a function
+/// given that most functions will not have more than a few arguments.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ArgCount {
+    /// The bits representing the argument counts.
+    ///
+    /// Each bit represents a specific count based on its bit index.
+    bits: u64,
+    /// The total number of argument counts.
+    len: u8,
+}
+
+impl ArgCount {
+    /// The maximum number of arguments that can be represented by this struct.
+    pub const MAX_COUNT: usize = u64::BITS as usize - 1;
+
+    /// Create a new [`ArgCount`] with the given count.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the count is greater than [`Self::MAX_COUNT`].
+    pub fn new(count: usize) -> Result<Self, ArgCountOutOfBoundsError> {
+        Ok(Self {
+            bits: 1 << Self::try_to_u8(count)?,
+            len: 1,
+        })
+    }
+
+    /// Adds the given count to this [`ArgCount`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the count is greater than [`Self::MAX_COUNT`].
+    pub fn add(&mut self, count: usize) {
+        self.try_add(count).unwrap();
+    }
+
+    /// Attempts to add the given count to this [`ArgCount`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the count is greater than [`Self::MAX_COUNT`].
+    pub fn try_add(&mut self, count: usize) -> Result<(), ArgCountOutOfBoundsError> {
+        let count = Self::try_to_u8(count)?;
+
+        if !self.contains_unchecked(count) {
+            self.len += 1;
+            self.bits |= 1 << count;
+        }
+
+        Ok(())
+    }
+
+    /// Removes the given count from this [`ArgCount`].
+    pub fn remove(&mut self, count: usize) {
+        self.try_remove(count).unwrap();
+    }
+
+    /// Attempts to remove the given count from this [`ArgCount`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the count is greater than [`Self::MAX_COUNT`].
+    pub fn try_remove(&mut self, count: usize) -> Result<(), ArgCountOutOfBoundsError> {
+        let count = Self::try_to_u8(count)?;
+
+        if self.contains_unchecked(count) {
+            self.len -= 1;
+            self.bits &= !(1 << count);
+        }
+
+        Ok(())
+    }
+
+    /// Checks if this [`ArgCount`] contains the given count.
+    pub fn contains(&self, count: usize) -> bool {
+        count < usize::BITS as usize && (self.bits >> count) & 1 == 1
+    }
+
+    /// Returns the total number of argument counts that this [`ArgCount`] contains.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Returns true if this [`ArgCount`] contains no argument counts.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns an iterator over the argument counts in this [`ArgCount`].
+    pub fn iter(&self) -> ArgCountIter {
+        ArgCountIter {
+            count: *self,
+            index: 0,
+            found: 0,
+        }
+    }
+
+    /// Checks if this [`ArgCount`] contains the given count without any bounds checking.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the count is greater than [`Self::MAX_COUNT`].
+    fn contains_unchecked(&self, count: u8) -> bool {
+        (self.bits >> count) & 1 == 1
+    }
+
+    /// Attempts to convert the given count to a `u8` within the bounds of the [maximum count].
+    ///
+    /// [maximum count]: Self::MAX_COUNT
+    fn try_to_u8(count: usize) -> Result<u8, ArgCountOutOfBoundsError> {
+        if count > Self::MAX_COUNT {
+            Err(ArgCountOutOfBoundsError(count))
+        } else {
+            Ok(count as u8)
+        }
+    }
+}
+
+/// Defaults this [`ArgCount`] to empty.
+///
+/// This means that it contains no argument counts, including zero.
+impl Default for ArgCount {
+    fn default() -> Self {
+        Self { bits: 0, len: 0 }
+    }
+}
+
+impl Debug for ArgCount {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+/// An iterator for the argument counts in an [`ArgCount`].
+pub struct ArgCountIter {
+    count: ArgCount,
+    index: u8,
+    found: u8,
+}
+
+impl Iterator for ArgCountIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.index as usize > ArgCount::MAX_COUNT {
+                return None;
+            }
+
+            if self.found == self.count.len {
+                // All counts have been found
+                return None;
+            }
+
+            if self.count.contains_unchecked(self.index) {
+                self.index += 1;
+                self.found += 1;
+                return Some(self.index as usize - 1);
+            }
+
+            self.index += 1;
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.count.len(), Some(self.count.len()))
+    }
+}
+
+impl ExactSizeIterator for ArgCountIter {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_default_to_empty() {
+        let count = ArgCount::default();
+
+        assert_eq!(count.len(), 0);
+        assert!(count.is_empty());
+
+        assert!(!count.contains(0));
+    }
+
+    #[test]
+    fn should_construct_with_count() {
+        let count = ArgCount::new(3).unwrap();
+
+        assert_eq!(count.len(), 1);
+        assert!(!count.is_empty());
+
+        assert!(count.contains(3));
+    }
+
+    #[test]
+    fn should_add_count() {
+        let mut count = ArgCount::default();
+        count.add(3);
+
+        assert_eq!(count.len(), 1);
+
+        assert!(count.contains(3));
+    }
+
+    #[test]
+    fn should_add_multiple_counts() {
+        let mut count = ArgCount::default();
+        count.add(3);
+        count.add(5);
+        count.add(7);
+
+        assert_eq!(count.len(), 3);
+
+        assert!(!count.contains(0));
+        assert!(!count.contains(1));
+        assert!(!count.contains(2));
+
+        assert!(count.contains(3));
+        assert!(count.contains(5));
+        assert!(count.contains(7));
+    }
+
+    #[test]
+    fn should_add_idempotently() {
+        let mut count = ArgCount::default();
+        count.add(3);
+        count.add(3);
+
+        assert_eq!(count.len(), 1);
+        assert!(count.contains(3));
+    }
+
+    #[test]
+    fn should_remove_count() {
+        let mut count = ArgCount::default();
+        count.add(3);
+
+        assert_eq!(count.len(), 1);
+        assert!(count.contains(3));
+
+        count.remove(3);
+
+        assert_eq!(count.len(), 0);
+        assert!(!count.contains(3));
+    }
+
+    #[test]
+    fn should_allow_removeting_nonexistent_count() {
+        let mut count = ArgCount::default();
+
+        assert_eq!(count.len(), 0);
+        assert!(!count.contains(3));
+
+        count.remove(3);
+
+        assert_eq!(count.len(), 0);
+        assert!(!count.contains(3));
+    }
+
+    #[test]
+    fn should_iterate_over_counts() {
+        let mut count = ArgCount::default();
+        count.add(3);
+        count.add(5);
+        count.add(7);
+
+        let mut iter = count.iter();
+
+        assert_eq!(iter.len(), 3);
+
+        assert_eq!(iter.next(), Some(3));
+        assert_eq!(iter.next(), Some(5));
+        assert_eq!(iter.next(), Some(7));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn should_return_error_for_out_of_bounds_count() {
+        let count = ArgCount::new(64);
+        assert_eq!(count, Err(ArgCountOutOfBoundsError(64)));
+
+        let mut count = ArgCount::default();
+        assert_eq!(count.try_add(64), Err(ArgCountOutOfBoundsError(64)));
+        assert_eq!(count.try_remove(64), Err(ArgCountOutOfBoundsError(64)));
+    }
+
+    #[test]
+    fn should_return_false_for_out_of_bounds_contains() {
+        let count = ArgCount::default();
+        assert!(!count.contains(64));
+    }
+}

--- a/crates/bevy_reflect/src/func/args/error.rs
+++ b/crates/bevy_reflect/src/func/args/error.rs
@@ -32,3 +32,8 @@ pub enum ArgError {
     #[error("expected an argument but received none")]
     EmptyArgList,
 }
+
+/// The given argument count is out of bounds.
+#[derive(Debug, Error, PartialEq)]
+#[error("argument count out of bounds: {0}")]
+pub struct ArgCountOutOfBoundsError(pub usize);

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -5,7 +5,10 @@ use crate::{
     },
     PartialReflect, Reflect, TypePath,
 };
-use alloc::{boxed::Box, collections::VecDeque};
+use alloc::{
+    boxed::Box,
+    collections::vec_deque::{Iter, VecDeque},
+};
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, vec};
@@ -284,6 +287,11 @@ impl<'a> ArgList<'a> {
     /// ```
     pub fn pop_mut<T: Reflect + TypePath>(&mut self) -> Result<&'a mut T, ArgError> {
         self.pop_arg()?.take_mut()
+    }
+
+    /// Returns an iterator over the arguments in the list.
+    pub fn iter(&self) -> Iter<'_, Arg<'a>> {
+        self.list.iter()
     }
 
     /// Returns the number of arguments in the list.

--- a/crates/bevy_reflect/src/func/args/mod.rs
+++ b/crates/bevy_reflect/src/func/args/mod.rs
@@ -4,6 +4,7 @@
 //! [`DynamicFunctionMut`]: crate::func::DynamicFunctionMut
 
 pub use arg::*;
+pub use count::*;
 pub use error::*;
 pub use from_arg::*;
 pub use info::*;
@@ -11,6 +12,7 @@ pub use list::*;
 pub use ownership::*;
 
 mod arg;
+mod count;
 mod error;
 mod from_arg;
 mod info;

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -299,9 +299,7 @@ impl<'env> DynamicFunction<'env> {
         let expected_arg_count = self.function_map.info().arg_count();
         let received_arg_count = args.len();
 
-        if matches!(self.function_map.info(), FunctionInfoType::Standard(_))
-            && expected_arg_count != received_arg_count
-        {
+        if !self.is_overloaded() && expected_arg_count != received_arg_count {
             Err(FunctionError::ArgCountMismatch {
                 expected: expected_arg_count,
                 received: received_arg_count,
@@ -333,6 +331,24 @@ impl<'env> DynamicFunction<'env> {
     /// [overloaded]: Self::with_overload
     pub fn name(&self) -> Option<&Cow<'static, str>> {
         self.name.as_ref()
+    }
+
+    /// Returns `true` if the function is [overloaded].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::func::IntoFunction;
+    /// let add = (|a: i32, b: i32| a + b).into_function();
+    /// assert!(!add.is_overloaded());
+    ///
+    /// let add = add.with_overload(|a: f32, b: f32| a + b);
+    /// assert!(add.is_overloaded());
+    /// ```
+    ///
+    /// [overloaded]: Self::with_overload
+    pub fn is_overloaded(&self) -> bool {
+        self.function_map.is_overloaded()
     }
 }
 

--- a/crates/bevy_reflect/src/func/dynamic_function_internal.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_internal.rs
@@ -1,9 +1,9 @@
+use crate::func::args::ArgCount;
 use crate::func::signature::{ArgListSignature, ArgumentSignature};
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionOverloadError};
 use alloc::borrow::Cow;
 use bevy_utils::hashbrown::HashMap;
 use core::fmt::{Debug, Formatter};
-use core::ops::RangeInclusive;
 
 /// An internal structure for storing a function and its corresponding [function information].
 ///
@@ -101,11 +101,9 @@ impl<F> DynamicFunctionInternal<F> {
 
     /// Returns the number of arguments the function expects.
     ///
-    /// For[overloaded functions that can have a variable number of arguments,
-    /// this will return the minimum and maximum number of arguments.
-    ///
-    /// Otherwise, the range will have the same start and end.
-    pub fn arg_count(&self) -> RangeInclusive<usize> {
+    /// For overloaded functions that can have a variable number of arguments,
+    /// this will contain the full set of counts for all signatures.
+    pub fn arg_count(&self) -> ArgCount {
         self.info.arg_count()
     }
 
@@ -117,7 +115,7 @@ impl<F> DynamicFunctionInternal<F> {
         let expected_arg_count = self.arg_count();
         let received_arg_count = args.len();
 
-        if !expected_arg_count.contains(&received_arg_count) {
+        if !expected_arg_count.contains(received_arg_count) {
             Err(FunctionError::ArgCountMismatch {
                 expected: expected_arg_count,
                 received: received_arg_count,

--- a/crates/bevy_reflect/src/func/dynamic_function_internal.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_internal.rs
@@ -1,8 +1,5 @@
 use crate::func::signature::ArgumentSignature;
-use crate::func::{
-    ArgList, FunctionError, FunctionInfo, FunctionInfoType, FunctionOverloadError,
-    PrettyPrintFunctionInfo,
-};
+use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionOverloadError};
 use alloc::borrow::Cow;
 use bevy_utils::hashbrown::HashMap;
 use core::fmt::{Debug, Formatter};
@@ -18,45 +15,40 @@ use core::ops::RangeInclusive;
 /// [`DynamicFunctionMut`]: crate::func::DynamicFunctionMut
 #[derive(Clone)]
 pub(super) struct DynamicFunctionInternal<F> {
-    name: Option<Cow<'static, str>>,
-    map: FunctionMap<F>,
+    functions: Vec<F>,
+    info: FunctionInfo,
+    arg_map: HashMap<ArgumentSignature, usize>,
 }
 
 impl<F> DynamicFunctionInternal<F> {
     /// Create a new instance of [`DynamicFunctionInternal`] with the given function
     /// and its corresponding information.
-    pub fn new(func: F, info: FunctionInfoType<'static>) -> Self {
+    pub fn new(func: F, info: FunctionInfo) -> Self {
+        let arg_map = info
+            .signatures()
+            .iter()
+            .map(|sig| (ArgumentSignature::from(sig), 0))
+            .collect();
+
         Self {
-            name: match &info {
-                FunctionInfoType::Standard(info) => info.name().cloned(),
-                FunctionInfoType::Overloaded(_) => None,
-            },
-            map: match info {
-                FunctionInfoType::Standard(info) => FunctionMap::Single(func, info.into_owned()),
-                FunctionInfoType::Overloaded(infos) => {
-                    let indices = infos
-                        .iter()
-                        .map(|info| (ArgumentSignature::from(info), 0))
-                        .collect();
-                    FunctionMap::Overloaded(vec![func], infos.into_owned(), indices)
-                }
-            },
+            functions: vec![func],
+            info,
+            arg_map,
         }
     }
-
-    /// Sets the name of the function.
-    pub fn set_name(&mut self, name: Option<Cow<'static, str>>) {
-        self.name = name;
+    pub fn with_name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.info = self.info.with_name(Some(name.into()));
+        self
     }
 
     /// The name of the function.
     pub fn name(&self) -> Option<&Cow<'static, str>> {
-        self.name.as_ref()
+        self.info.name()
     }
 
     /// Returns `true` if the function is overloaded.
     pub fn is_overloaded(&self) -> bool {
-        matches!(self.map, FunctionMap::Overloaded(..))
+        self.info.is_overloaded()
     }
 
     /// Get an immutable reference to the function.
@@ -66,52 +58,45 @@ impl<F> DynamicFunctionInternal<F> {
     ///
     /// If no overload matches the provided arguments, returns [`FunctionError::NoOverload`].
     pub fn get(&self, args: &ArgList) -> Result<&F, FunctionError> {
-        match &self.map {
-            FunctionMap::Single(function, _) => Ok(function),
-            FunctionMap::Overloaded(functions, _, indices) => {
-                let signature = ArgumentSignature::from(args);
-                indices
-                    .get(&signature)
-                    .map(|index| &functions[*index])
-                    .ok_or_else(|| FunctionError::NoOverload {
-                        expected: indices.keys().cloned().collect(),
-                        received: signature,
-                    })
-            }
+        if !self.info.is_overloaded() {
+            return Ok(&self.functions[0]);
         }
+
+        let signature = ArgumentSignature::from(args);
+        self.arg_map
+            .get(&signature)
+            .map(|index| &self.functions[*index])
+            .ok_or_else(|| FunctionError::NoOverload {
+                expected: self.arg_map.keys().cloned().collect(),
+                received: signature,
+            })
     }
 
-    /// Get an mutable reference to the function.
+    /// Get a mutable reference to the function.
     ///
     /// If the function is not overloaded, it will always be returned regardless of the arguments.
     /// Otherwise, the function will be selected based on the arguments provided.
     ///
     /// If no overload matches the provided arguments, returns [`FunctionError::NoOverload`].
     pub fn get_mut(&mut self, args: &ArgList) -> Result<&mut F, FunctionError> {
-        match &mut self.map {
-            FunctionMap::Single(function, _) => Ok(function),
-            FunctionMap::Overloaded(functions, _, indices) => {
-                let signature = ArgumentSignature::from(args);
-                indices
-                    .get(&signature)
-                    .map(|index| &mut functions[*index])
-                    .ok_or_else(|| FunctionError::NoOverload {
-                        expected: indices.keys().cloned().collect(),
-                        received: signature,
-                    })
-            }
+        if !self.info.is_overloaded() {
+            return Ok(&mut self.functions[0]);
         }
+
+        let signature = ArgumentSignature::from(args);
+        self.arg_map
+            .get(&signature)
+            .map(|index| &mut self.functions[*index])
+            .ok_or_else(|| FunctionError::NoOverload {
+                expected: self.arg_map.keys().cloned().collect(),
+                received: signature,
+            })
     }
 
     /// Returns the function information contained in the map.
     #[inline]
-    pub fn info(&self) -> FunctionInfoType {
-        match &self.map {
-            FunctionMap::Single(_, info) => FunctionInfoType::Standard(Cow::Borrowed(info)),
-            FunctionMap::Overloaded(_, info, _) => {
-                FunctionInfoType::Overloaded(Cow::Borrowed(info))
-            }
-        }
+    pub fn info(&self) -> &FunctionInfo {
+        &self.info
     }
 
     /// Returns the number of arguments the function expects.
@@ -121,7 +106,7 @@ impl<F> DynamicFunctionInternal<F> {
     ///
     /// Otherwise, the range will have the same start and end.
     pub fn arg_count(&self) -> RangeInclusive<usize> {
-        self.info().arg_count()
+        self.info.arg_count()
     }
 
     /// Helper method for validating that a given set of arguments are _potentially_ valid for this function.
@@ -155,215 +140,74 @@ impl<F> DynamicFunctionInternal<F> {
     /// `[func_a, func_b, func_c, func_d]`.
     /// And merging `[func_c, func_d]` (self) with `[func_a, func_b]` (other) should result in
     /// `[func_c, func_d, func_a, func_b]`.
-    pub fn merge(self, other: Self) -> Result<Self, (Box<Self>, FunctionOverloadError)> {
-        let map = self.map.merge(other.map).map_err(|(map, err)| {
-            (
-                Box::new(Self {
-                    name: self.name.clone(),
-                    map: *map,
-                }),
-                err,
-            )
-        })?;
+    pub fn merge(&mut self, mut other: Self) -> Result<(), FunctionOverloadError> {
+        // Keep a separate map of the new indices to avoid mutating the existing one
+        // until we can be sure the merge will be successful.
+        let mut new_signatures = HashMap::new();
 
-        Ok(Self {
-            name: self.name,
-            map,
-        })
+        for (sig, index) in other.arg_map {
+            if self.arg_map.contains_key(&sig) {
+                return Err(FunctionOverloadError::DuplicateSignature(sig));
+            }
+
+            new_signatures.insert_unique_unchecked(sig, self.functions.len() + index);
+        }
+
+        self.arg_map.reserve(new_signatures.len());
+        for (sig, index) in new_signatures {
+            self.arg_map.insert_unique_unchecked(sig, index);
+        }
+
+        self.functions.append(&mut other.functions);
+        self.info.extend_unchecked(other.info);
+
+        Ok(())
     }
 
-    /// Convert the inner [`FunctionMap`] from holding `F` to holding `G`.
-    pub fn convert<G>(self, f: fn(FunctionMap<F>) -> FunctionMap<G>) -> DynamicFunctionInternal<G> {
+    /// Maps the internally stored function(s) from type `F` to type `G`.
+    pub fn map_functions<G>(self, f: fn(F) -> G) -> DynamicFunctionInternal<G> {
         DynamicFunctionInternal {
-            name: self.name,
-            map: f(self.map),
+            functions: self.functions.into_iter().map(f).collect(),
+            info: self.info,
+            arg_map: self.arg_map,
         }
     }
 }
 
 impl<F> Debug for DynamicFunctionInternal<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        let name = self.name.as_deref().unwrap_or("_");
-        write!(f, "fn {name}")?;
-
-        match &self.map {
-            // `(arg0: i32, arg1: i32) -> ()`
-            FunctionMap::Single(_, info) => PrettyPrintFunctionInfo::new(info).fmt(f),
-            // `{(arg0: i32, arg1: i32) -> (), (arg0: f32, arg1: f32) -> ()}`
-            FunctionMap::Overloaded(_, infos, _) => {
-                let mut set = f.debug_set();
-                for info in infos.iter() {
-                    set.entry(&PrettyPrintFunctionInfo::new(info));
-                }
-                set.finish()
-            }
-        }
-    }
-}
-
-/// A helper type for storing a mapping of overloaded functions
-/// along with the corresponding [function information].
-///
-/// By using an enum, we can optimize the common case of a single function,
-/// while still allowing for multiple function overloads to be stored.
-///
-/// [function information]: FunctionInfo
-#[derive(Clone, Debug)]
-pub(super) enum FunctionMap<F> {
-    /// Represents a single, non-overloaded function.
-    Single(F, FunctionInfo),
-    /// Represents an overloaded function.
-    Overloaded(
-        /// The list of function overloads.
-        Vec<F>,
-        /// The information for each function.
-        ///
-        /// Note that some functions may have multiple `FunctionInfo` values (i.e. manually created overloads),
-        /// so this list may not always line up one-to-one with the functions list.
-        Vec<FunctionInfo>,
-        /// A mapping of argument signatures to the index of the corresponding function.
-        ///
-        /// Multiple signatures may point to the same function index (i.e. for manually created overloads).
-        HashMap<ArgumentSignature, usize>,
-    ),
-}
-
-impl<F> FunctionMap<F> {
-    /// Merge another [`FunctionMap`] into this one.
-    ///
-    /// If the other map contains any functions with the same signature as this one,
-    /// an error will be returned along with the original, unchanged map.
-    ///
-    /// Therefore, this method should always return `Ok(Self::Overloaded(..))` if the merge is successful.
-    ///
-    /// Additionally, if the merge succeeds, it should be guaranteed that the order
-    /// of the functions in the map will be preserved.
-    /// For example, merging `[func_a, func_b]` (self) with `[func_c, func_d]` (other) should result in
-    /// `[func_a, func_b, func_c, func_d]`.
-    /// And merging `[func_c, func_d]` (self) with `[func_a, func_b]` (other) should result in
-    /// `[func_c, func_d, func_a, func_b]`.
-    pub fn merge(self, other: Self) -> Result<Self, (Box<Self>, FunctionOverloadError)> {
-        match (self, other) {
-            (Self::Single(self_func, self_info), Self::Single(other_func, other_info)) => {
-                let self_sig = ArgumentSignature::from(&self_info);
-                let other_sig = ArgumentSignature::from(&other_info);
-                if self_sig == other_sig {
-                    return Err((
-                        Box::new(Self::Single(self_func, self_info)),
-                        FunctionOverloadError {
-                            signature: self_sig,
-                        },
-                    ));
-                }
-
-                let mut map = HashMap::new();
-                map.insert_unique_unchecked(self_sig, 0);
-                map.insert_unique_unchecked(other_sig, 1);
-
-                Ok(Self::Overloaded(
-                    vec![self_func, other_func],
-                    vec![self_info, other_info],
-                    map,
-                ))
-            }
-            (
-                Self::Single(self_func, self_info),
-                Self::Overloaded(mut other_funcs, mut other_infos, mut other_indices),
-            ) => {
-                let self_sig = ArgumentSignature::from(&self_info);
-                if other_indices.contains_key(&self_sig) {
-                    return Err((
-                        Box::new(Self::Single(self_func, self_info)),
-                        FunctionOverloadError {
-                            signature: self_sig,
-                        },
-                    ));
-                }
-
-                for index in other_indices.values_mut() {
-                    *index += 1;
-                }
-
-                other_funcs.insert(0, self_func);
-                other_infos.insert(0, self_info);
-                other_indices.insert_unique_unchecked(self_sig, 0);
-
-                Ok(Self::Overloaded(other_funcs, other_infos, other_indices))
-            }
-            (
-                Self::Overloaded(mut self_funcs, mut self_infos, mut self_indices),
-                Self::Single(other_func, other_info),
-            ) => {
-                let other_sig = ArgumentSignature::from(&other_info);
-                if self_indices.contains_key(&other_sig) {
-                    return Err((
-                        Box::new(Self::Overloaded(self_funcs, self_infos, self_indices)),
-                        FunctionOverloadError {
-                            signature: other_sig,
-                        },
-                    ));
-                }
-
-                let index = self_funcs.len();
-                self_funcs.push(other_func);
-                self_infos.push(other_info);
-                self_indices.insert_unique_unchecked(other_sig, index);
-
-                Ok(Self::Overloaded(self_funcs, self_infos, self_indices))
-            }
-            (
-                Self::Overloaded(mut self_funcs, mut self_infos, mut self_indices),
-                Self::Overloaded(mut other_funcs, mut other_infos, other_indices),
-            ) => {
-                // Keep a separate map of the new indices to avoid mutating the existing one
-                // until we can be sure the merge will be successful.
-                let mut new_indices = HashMap::new();
-
-                for (sig, index) in other_indices {
-                    if self_indices.contains_key(&sig) {
-                        return Err((
-                            Box::new(Self::Overloaded(self_funcs, self_infos, self_indices)),
-                            FunctionOverloadError { signature: sig },
-                        ));
-                    }
-
-                    new_indices.insert_unique_unchecked(sig, self_funcs.len() + index);
-                }
-
-                self_indices.reserve(new_indices.len());
-                for (sig, index) in new_indices {
-                    self_indices.insert_unique_unchecked(sig, index);
-                }
-
-                self_funcs.append(&mut other_funcs);
-                // The index map and `FunctionInfo` list should always be in sync,
-                // so we can simply append the new infos to the existing ones.
-                self_infos.append(&mut other_infos);
-
-                Ok(Self::Overloaded(self_funcs, self_infos, self_indices))
-            }
-        }
+        self.info
+            .pretty_printer()
+            .include_fn_token()
+            .include_name()
+            .fmt(f)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::func::FunctionInfo;
+    use crate::func::{FunctionInfo, SignatureInfo};
     use crate::Type;
 
     #[test]
     fn should_merge_single_into_single() {
-        let map_a = FunctionMap::Single('a', FunctionInfo::anonymous().with_arg::<i8>("arg0"));
-        let map_b = FunctionMap::Single('b', FunctionInfo::anonymous().with_arg::<u8>("arg0"));
+        let mut func_a = DynamicFunctionInternal::new(
+            'a',
+            FunctionInfo::new(SignatureInfo::anonymous().with_arg::<i8>("arg0")),
+        );
 
-        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
-            panic!("expected overloaded function");
-        };
-        assert_eq!(functions, vec!['a', 'b']);
-        assert_eq!(infos.len(), 2);
+        let func_b = DynamicFunctionInternal::new(
+            'b',
+            FunctionInfo::new(SignatureInfo::anonymous().with_arg::<u8>("arg0")),
+        );
+
+        func_a.merge(func_b).unwrap();
+
+        assert_eq!(func_a.functions, vec!['a', 'b']);
+        assert_eq!(func_a.info.signatures().len(), 2);
         assert_eq!(
-            indices,
+            func_a.arg_map,
             HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 1),
@@ -373,26 +217,28 @@ mod tests {
 
     #[test]
     fn should_merge_single_into_overloaded() {
-        let map_a = FunctionMap::Single('a', FunctionInfo::anonymous().with_arg::<i8>("arg0"));
-        let map_b = FunctionMap::Overloaded(
-            vec!['b', 'c'],
-            vec![
-                FunctionInfo::anonymous().with_arg::<u8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<u16>("arg0"),
-            ],
-            HashMap::from_iter([
+        let mut func_a = DynamicFunctionInternal::new(
+            'a',
+            FunctionInfo::new(SignatureInfo::anonymous().with_arg::<i8>("arg0")),
+        );
+
+        let func_b = DynamicFunctionInternal {
+            functions: vec!['b', 'c'],
+            info: FunctionInfo::new(SignatureInfo::anonymous().with_arg::<u8>("arg0"))
+                .with_overload(SignatureInfo::anonymous().with_arg::<u16>("arg0"))
+                .unwrap(),
+            arg_map: HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u16>()]), 1),
             ]),
-        );
-
-        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
-            panic!("expected overloaded function");
         };
-        assert_eq!(functions, vec!['a', 'b', 'c']);
-        assert_eq!(infos.len(), 3);
+
+        func_a.merge(func_b).unwrap();
+
+        assert_eq!(func_a.functions, vec!['a', 'b', 'c']);
+        assert_eq!(func_a.info.signatures().len(), 3);
         assert_eq!(
-            indices,
+            func_a.arg_map,
             HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 1),
@@ -403,26 +249,28 @@ mod tests {
 
     #[test]
     fn should_merge_overloaed_into_single() {
-        let map_a = FunctionMap::Overloaded(
-            vec!['a', 'b'],
-            vec![
-                FunctionInfo::anonymous().with_arg::<i8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
-            ],
-            HashMap::from_iter([
+        let mut func_a = DynamicFunctionInternal {
+            functions: vec!['a', 'b'],
+            info: FunctionInfo::new(SignatureInfo::anonymous().with_arg::<i8>("arg0"))
+                .with_overload(SignatureInfo::anonymous().with_arg::<i16>("arg0"))
+                .unwrap(),
+            arg_map: HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
             ]),
-        );
-        let map_b = FunctionMap::Single('c', FunctionInfo::anonymous().with_arg::<u8>("arg0"));
-
-        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
-            panic!("expected overloaded function");
         };
-        assert_eq!(functions, vec!['a', 'b', 'c']);
-        assert_eq!(infos.len(), 3);
+
+        let func_b = DynamicFunctionInternal::new(
+            'c',
+            FunctionInfo::new(SignatureInfo::anonymous().with_arg::<u8>("arg0")),
+        );
+
+        func_a.merge(func_b).unwrap();
+
+        assert_eq!(func_a.functions, vec!['a', 'b', 'c']);
+        assert_eq!(func_a.info.signatures().len(), 3);
         assert_eq!(
-            indices,
+            func_a.arg_map,
             HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
@@ -433,36 +281,34 @@ mod tests {
 
     #[test]
     fn should_merge_overloaded_into_overloaded() {
-        let map_a = FunctionMap::Overloaded(
-            vec!['a', 'b'],
-            vec![
-                FunctionInfo::anonymous().with_arg::<i8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
-            ],
-            HashMap::from_iter([
+        let mut func_a = DynamicFunctionInternal {
+            functions: vec!['a', 'b'],
+            info: FunctionInfo::new(SignatureInfo::anonymous().with_arg::<i8>("arg0"))
+                .with_overload(SignatureInfo::anonymous().with_arg::<i16>("arg0"))
+                .unwrap(),
+            arg_map: HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
             ]),
-        );
-        let map_b = FunctionMap::Overloaded(
-            vec!['c', 'd'],
-            vec![
-                FunctionInfo::anonymous().with_arg::<u8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<u16>("arg0"),
-            ],
-            HashMap::from_iter([
+        };
+
+        let func_b = DynamicFunctionInternal {
+            functions: vec!['c', 'd'],
+            info: FunctionInfo::new(SignatureInfo::anonymous().with_arg::<u8>("arg0"))
+                .with_overload(SignatureInfo::anonymous().with_arg::<u16>("arg0"))
+                .unwrap(),
+            arg_map: HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u16>()]), 1),
             ]),
-        );
-
-        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
-            panic!("expected overloaded function");
         };
-        assert_eq!(functions, vec!['a', 'b', 'c', 'd']);
-        assert_eq!(infos.len(), 4);
+
+        func_a.merge(func_b).unwrap();
+
+        assert_eq!(func_a.functions, vec!['a', 'b', 'c', 'd']);
+        assert_eq!(func_a.info.signatures().len(), 4);
         assert_eq!(
-            indices,
+            func_a.arg_map,
             HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
@@ -474,19 +320,29 @@ mod tests {
 
     #[test]
     fn should_return_error_on_duplicate_signature() {
-        let map_a = FunctionMap::Single(
+        let mut func_a = DynamicFunctionInternal::new(
             'a',
-            FunctionInfo::anonymous()
-                .with_arg::<i8>("arg0")
-                .with_arg::<i16>("arg1"),
+            FunctionInfo::new(
+                SignatureInfo::anonymous()
+                    .with_arg::<i8>("arg0")
+                    .with_arg::<i16>("arg1"),
+            ),
         );
-        let map_b = FunctionMap::Overloaded(
-            vec!['b', 'c'],
-            vec![
-                FunctionInfo::anonymous().with_arg::<u8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<u16>("arg1"),
-            ],
-            HashMap::from_iter([
+
+        let func_b = DynamicFunctionInternal {
+            functions: vec!['b', 'c'],
+            info: FunctionInfo::new(
+                SignatureInfo::anonymous()
+                    .with_arg::<u8>("arg0")
+                    .with_arg::<u16>("arg1"),
+            )
+            .with_overload(
+                SignatureInfo::anonymous()
+                    .with_arg::<i8>("arg0")
+                    .with_arg::<i16>("arg1"),
+            )
+            .unwrap(),
+            arg_map: HashMap::from_iter([
                 (
                     ArgumentSignature::from_iter([Type::of::<u8>(), Type::of::<u16>()]),
                     0,
@@ -496,23 +352,29 @@ mod tests {
                     1,
                 ),
             ]),
-        );
-
-        let (map, error) = map_a.merge(map_b).unwrap_err();
-        assert_eq!(
-            error.signature,
-            ArgumentSignature::from_iter([Type::of::<i8>(), Type::of::<i16>()])
-        );
-
-        // Assert the original map remains unchanged:
-        let FunctionMap::Single(function, info) = *map else {
-            panic!("expected single function");
         };
 
-        assert_eq!(function, 'a');
+        let FunctionOverloadError::DuplicateSignature(duplicate) =
+            func_a.merge(func_b).unwrap_err()
+        else {
+            panic!("Expected `FunctionOverloadError::DuplicateSignature`");
+        };
+
         assert_eq!(
-            ArgumentSignature::from(info),
+            duplicate,
             ArgumentSignature::from_iter([Type::of::<i8>(), Type::of::<i16>()])
+        );
+
+        // Assert the original remains unchanged:
+        assert!(!func_a.is_overloaded());
+        assert_eq!(func_a.functions, vec!['a']);
+        assert_eq!(func_a.info.signatures().len(), 1);
+        assert_eq!(
+            func_a.arg_map,
+            HashMap::from_iter([(
+                ArgumentSignature::from_iter([Type::of::<i8>(), Type::of::<i16>()]),
+                0
+            ),])
         );
     }
 }

--- a/crates/bevy_reflect/src/func/dynamic_function_internal.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_internal.rs
@@ -1,4 +1,4 @@
-use crate::func::signature::ArgumentSignature;
+use crate::func::signature::{ArgListSignature, ArgumentSignature};
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionOverloadError};
 use alloc::borrow::Cow;
 use bevy_utils::hashbrown::HashMap;
@@ -62,13 +62,13 @@ impl<F> DynamicFunctionInternal<F> {
             return Ok(&self.functions[0]);
         }
 
-        let signature = ArgumentSignature::from(args);
+        let signature = ArgListSignature::from(args);
         self.arg_map
             .get(&signature)
             .map(|index| &self.functions[*index])
             .ok_or_else(|| FunctionError::NoOverload {
                 expected: self.arg_map.keys().cloned().collect(),
-                received: signature,
+                received: ArgumentSignature::from(args),
             })
     }
 
@@ -83,13 +83,13 @@ impl<F> DynamicFunctionInternal<F> {
             return Ok(&mut self.functions[0]);
         }
 
-        let signature = ArgumentSignature::from(args);
+        let signature = ArgListSignature::from(args);
         self.arg_map
             .get(&signature)
             .map(|index| &mut self.functions[*index])
             .ok_or_else(|| FunctionError::NoOverload {
                 expected: self.arg_map.keys().cloned().collect(),
-                received: signature,
+                received: ArgumentSignature::from(args),
             })
     }
 

--- a/crates/bevy_reflect/src/func/dynamic_function_mut.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_mut.rs
@@ -6,7 +6,7 @@ use alloc::{boxed::Box, format, vec};
 
 use crate::func::{
     args::ArgList, function_map::FunctionMap, signature::ArgumentSignature, DynamicFunction,
-    FunctionError, FunctionInfoType, FunctionResult, IntoFunctionMut,
+    FunctionError, FunctionInfoType, FunctionOverloadError, FunctionResult, IntoFunctionMut,
 };
 use bevy_utils::HashMap;
 
@@ -158,6 +158,8 @@ impl<'env> DynamicFunctionMut<'env> {
     ///
     /// Panics if the function, `F`, contains a signature already found in this function.
     ///
+    /// For a non-panicking version, see [`try_with_overload`].
+    ///
     /// # Example
     ///
     /// ```
@@ -189,6 +191,7 @@ impl<'env> DynamicFunctionMut<'env> {
     ///
     /// [argument signature]: ArgumentSignature
     /// [name]: Self::name
+    /// [`try_with_overload`]: Self::try_with_overload
     pub fn with_overload<'a, F: IntoFunctionMut<'a, Marker>, Marker>(
         self,
         function: F,
@@ -199,12 +202,42 @@ impl<'env> DynamicFunctionMut<'env> {
         let function = function.into_function_mut();
 
         let name = self.name.clone();
-        let mut function_map = self.function_map;
-        function_map
+        let function_map = self
+            .function_map
             .merge(function.function_map)
-            .unwrap_or_else(|_| todo!());
+            .unwrap_or_else(|(_, err)| {
+                panic!("{}", err);
+            });
 
         DynamicFunctionMut { name, function_map }
+    }
+
+    /// Attempt to add an overload to this function.
+    ///
+    /// If the function, `F`, contains a signature already found in this function,
+    /// an error will be returned along with the original function.
+    ///
+    /// For a panicking version, see [`with_overload`].
+    ///
+    /// [`with_overload`]: Self::with_overload
+    pub fn try_with_overload<F: IntoFunctionMut<'env, Marker>, Marker>(
+        self,
+        function: F,
+    ) -> Result<Self, (Box<Self>, FunctionOverloadError)> {
+        let function = function.into_function_mut();
+
+        let name = self.name.clone();
+
+        match self.function_map.merge(function.function_map) {
+            Ok(function_map) => Ok(Self { name, function_map }),
+            Err((function_map, err)) => Err((
+                Box::new(Self {
+                    name,
+                    function_map: *function_map,
+                }),
+                err,
+            )),
+        }
     }
 
     /// Call the function with the given arguments.

--- a/crates/bevy_reflect/src/func/dynamic_function_mut.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_mut.rs
@@ -269,9 +269,7 @@ impl<'env> DynamicFunctionMut<'env> {
         let expected_arg_count = self.function_map.info().arg_count();
         let received_arg_count = args.len();
 
-        if matches!(self.function_map.info(), FunctionInfoType::Standard(_))
-            && expected_arg_count != received_arg_count
-        {
+        if !self.is_overloaded() && expected_arg_count != received_arg_count {
             Err(FunctionError::ArgCountMismatch {
                 expected: expected_arg_count,
                 received: received_arg_count,
@@ -332,6 +330,26 @@ impl<'env> DynamicFunctionMut<'env> {
     /// [`with_name`]: Self::with_name
     pub fn name(&self) -> Option<&Cow<'static, str>> {
         self.name.as_ref()
+    }
+
+    /// Returns `true` if the function is [overloaded].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::func::IntoFunctionMut;
+    /// let mut total_i32 = 0;
+    /// let increment = (|value: i32| total_i32 += value).into_function_mut();
+    /// assert!(!increment.is_overloaded());
+    ///
+    /// let mut total_f32 = 0.0;
+    /// let increment = increment.with_overload(|value: f32| total_f32 += value);
+    /// assert!(increment.is_overloaded());
+    /// ```
+    ///
+    /// [overloaded]: Self::with_overload
+    pub fn is_overloaded(&self) -> bool {
+        self.function_map.is_overloaded()
     }
 }
 

--- a/crates/bevy_reflect/src/func/dynamic_function_mut.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_mut.rs
@@ -382,30 +382,17 @@ impl<'env> DynamicFunctionMut<'env> {
 /// This takes the format: `DynamicFunctionMut(fn {name}({arg1}: {type1}, {arg2}: {type2}, ...) -> {return_type})`.
 ///
 /// Names for arguments and the function itself are optional and will default to `_` if not provided.
+///
+/// If the function is [overloaded], the output will include the signatures of all overloads as a set.
+/// For example, `DynamicFunctionMut(fn add{(_: i32, _: i32) -> i32, (_: f32, _: f32) -> f32})`.
+///
+/// [overloaded]: DynamicFunctionMut::with_overload
 impl<'env> Debug for DynamicFunctionMut<'env> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let name = self.name().unwrap_or(&Cow::Borrowed("_"));
-        write!(f, "DynamicFunctionMut(fn {name}(")?;
-
-        match self.info() {
-            FunctionInfoType::Standard(info) => {
-                for (index, arg) in info.args().iter().enumerate() {
-                    if index > 0 {
-                        write!(f, ", ")?;
-                    }
-
-                    let name = arg.name().unwrap_or("_");
-                    let ty = arg.type_path();
-                    write!(f, "{name}: {ty}")?;
-                }
-
-                let ret = info.return_info().type_path();
-                write!(f, ") -> {ret})")
-            }
-            FunctionInfoType::Overloaded(_) => {
-                todo!("overloaded functions are not yet debuggable");
-            }
-        }
+        write!(f, "DynamicFunctionMut(fn {name}")?;
+        self.function_map.debug(f)?;
+        write!(f, ")")
     }
 }
 

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -1,5 +1,7 @@
+use crate::func::signature::ArgumentSignature;
 use crate::func::{args::ArgError, Return};
 use alloc::borrow::Cow;
+use bevy_utils::HashSet;
 use thiserror::Error;
 
 #[cfg(not(feature = "std"))]
@@ -17,6 +19,12 @@ pub enum FunctionError {
     /// The number of arguments provided does not match the expected number.
     #[error("expected {expected} arguments but received {received}")]
     ArgCountMismatch { expected: usize, received: usize },
+    /// No overload was found for the given set of arguments.
+    #[error("no overload found for arguments with signature `{received:?}`, expected one of `{expected:?}`")]
+    NoOverload {
+        expected: HashSet<ArgumentSignature>,
+        received: ArgumentSignature,
+    },
 }
 
 /// The result of calling a [`DynamicFunction`] or [`DynamicFunctionMut`].

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -2,6 +2,7 @@ use crate::func::signature::ArgumentSignature;
 use crate::func::{args::ArgError, Return};
 use alloc::borrow::Cow;
 use bevy_utils::HashSet;
+use core::ops::RangeInclusive;
 use thiserror::Error;
 
 #[cfg(not(feature = "std"))]
@@ -17,8 +18,11 @@ pub enum FunctionError {
     #[error(transparent)]
     ArgError(#[from] ArgError),
     /// The number of arguments provided does not match the expected number.
-    #[error("expected {expected} arguments but received {received}")]
-    ArgCountMismatch { expected: usize, received: usize },
+    #[error("expected {expected:?} arguments but received {received}")]
+    ArgCountMismatch {
+        expected: RangeInclusive<usize>,
+        received: usize,
+    },
     /// No overload was found for the given set of arguments.
     #[error("no overload found for arguments with signature `{received:?}`, expected one of `{expected:?}`")]
     NoOverload {

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -1,8 +1,10 @@
 use crate::func::signature::ArgumentSignature;
-use crate::func::{args::ArgError, Return};
+use crate::func::{
+    args::{ArgCount, ArgError},
+    Return,
+};
 use alloc::borrow::Cow;
 use bevy_utils::HashSet;
-use core::ops::RangeInclusive;
 use thiserror::Error;
 
 #[cfg(not(feature = "std"))]
@@ -18,11 +20,8 @@ pub enum FunctionError {
     #[error(transparent)]
     ArgError(#[from] ArgError),
     /// The number of arguments provided does not match the expected number.
-    #[error("expected {expected:?} arguments but received {received}")]
-    ArgCountMismatch {
-        expected: RangeInclusive<usize>,
-        received: usize,
-    },
+    #[error("received {received} arguments but expected one of {expected:?}")]
+    ArgCountMismatch { expected: ArgCount, received: usize },
     /// No overload was found for the given set of arguments.
     #[error("no overload found for arguments with signature `{received:?}`, expected one of `{expected:?}`")]
     NoOverload {
@@ -51,6 +50,12 @@ pub enum FunctionOverloadError {
     /// An error that occurs when attempting to add a function overload with a duplicate signature.
     #[error("could not add function overload: duplicate found for signature `{0:?}`")]
     DuplicateSignature(ArgumentSignature),
+    #[error(
+        "argument signature `{:?}` has too many arguments (max {})",
+        0,
+        ArgCount::MAX_COUNT
+    )]
+    TooManyArguments(ArgumentSignature),
 }
 
 /// An error that occurs when registering a function into a [`FunctionRegistry`].

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -40,18 +40,17 @@ pub enum FunctionError {
 /// [`DynamicFunctionMut`]: crate::func::DynamicFunctionMut
 pub type FunctionResult<'a> = Result<Return<'a>, FunctionError>;
 
-/// A [`FunctionInfo`] was expected but none was found.
-///
-/// [`FunctionInfo`]: crate::func::FunctionInfo
+/// An error that occurs when attempting to add a function overload.
 #[derive(Debug, Error, PartialEq)]
-#[error("expected a `FunctionInfo` but found none")]
-pub struct MissingFunctionInfoError;
-
-/// An error that occurs when attempting to add a function overload with a duplicate signature.
-#[derive(Debug, Error, PartialEq)]
-#[error("could not add function overload: duplicate found for signature `{signature:?}`")]
-pub struct FunctionOverloadError {
-    pub signature: ArgumentSignature,
+pub enum FunctionOverloadError {
+    /// A [`SignatureInfo`] was expected, but none was found.
+    ///
+    /// [`SignatureInfo`]: crate::func::info::SignatureInfo
+    #[error("expected at least one `SignatureInfo` but found none")]
+    MissingSignature,
+    /// An error that occurs when attempting to add a function overload with a duplicate signature.
+    #[error("could not add function overload: duplicate found for signature `{0:?}`")]
+    DuplicateSignature(ArgumentSignature),
 }
 
 /// An error that occurs when registering a function into a [`FunctionRegistry`].

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -28,6 +28,13 @@ pub enum FunctionError {
 /// [`DynamicFunctionMut`]: crate::func::DynamicFunctionMut
 pub type FunctionResult<'a> = Result<Return<'a>, FunctionError>;
 
+/// A [`FunctionInfo`] was expected but none was found.
+///
+/// [`FunctionInfo`]: crate::func::FunctionInfo
+#[derive(Debug, Error, PartialEq)]
+#[error("expected a `FunctionInfo` but found none")]
+pub struct MissingFunctionInfoError;
+
 /// An error that occurs when registering a function into a [`FunctionRegistry`].
 ///
 /// [`FunctionRegistry`]: crate::func::FunctionRegistry

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -43,6 +43,13 @@ pub type FunctionResult<'a> = Result<Return<'a>, FunctionError>;
 #[error("expected a `FunctionInfo` but found none")]
 pub struct MissingFunctionInfoError;
 
+/// An error that occurs when attempting to add a function overload with a duplicate signature.
+#[derive(Debug, Error, PartialEq)]
+#[error("could not add function overload: duplicate found for signature `{signature:?}`")]
+pub struct FunctionOverloadError {
+    pub signature: ArgumentSignature,
+}
+
 /// An error that occurs when registering a function into a [`FunctionRegistry`].
 ///
 /// [`FunctionRegistry`]: crate::func::FunctionRegistry

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::fmt::Debug;
+use core::ops::RangeInclusive;
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, vec};
@@ -47,8 +48,15 @@ pub trait Function: PartialReflect + Debug {
     /// [`IntoFunction`]: crate::func::IntoFunction
     fn name(&self) -> Option<&Cow<'static, str>>;
 
-    /// The number of arguments this function accepts.
-    fn arg_count(&self) -> usize {
+    /// Returns the number of arguments the function expects.
+    ///
+    /// For [overloaded] functions that can have a variable number of arguments,
+    /// this will return the minimum and maximum number of arguments.
+    ///
+    /// Otherwise, the range will have the same start and end.
+    ///
+    /// [overloaded]: FunctionInfoType::Overloaded
+    fn arg_count(&self) -> RangeInclusive<usize> {
         self.info().arg_count()
     }
 

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -1,10 +1,12 @@
 use crate::{
-    func::{ArgList, DynamicFunction, FunctionInfo, FunctionResult},
+    func::{
+        args::{ArgCount, ArgList},
+        DynamicFunction, FunctionInfo, FunctionResult,
+    },
     PartialReflect,
 };
 use alloc::borrow::Cow;
 use core::fmt::Debug;
-use core::ops::RangeInclusive;
 
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, vec};
@@ -51,10 +53,8 @@ pub trait Function: PartialReflect + Debug {
     /// Returns the number of arguments the function expects.
     ///
     /// For overloaded functions that can have a variable number of arguments,
-    /// this will return the minimum and maximum number of arguments.
-    ///
-    /// Otherwise, the range will have the same start and end.
-    fn arg_count(&self) -> RangeInclusive<usize> {
+    /// this will contain the full set of counts for all signatures.
+    fn arg_count(&self) -> ArgCount {
         self.info().arg_count()
     }
 

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    func::{ArgList, DynamicFunction, FunctionInfoType, FunctionResult},
+    func::{ArgList, DynamicFunction, FunctionInfo, FunctionResult},
     PartialReflect,
 };
 use alloc::borrow::Cow;
@@ -50,18 +50,16 @@ pub trait Function: PartialReflect + Debug {
 
     /// Returns the number of arguments the function expects.
     ///
-    /// For [overloaded] functions that can have a variable number of arguments,
+    /// For overloaded functions that can have a variable number of arguments,
     /// this will return the minimum and maximum number of arguments.
     ///
     /// Otherwise, the range will have the same start and end.
-    ///
-    /// [overloaded]: FunctionInfoType::Overloaded
     fn arg_count(&self) -> RangeInclusive<usize> {
         self.info().arg_count()
     }
 
-    /// The [`FunctionInfoType`] for this function.
-    fn info(&self) -> FunctionInfoType;
+    /// The [`FunctionInfo`] for this function.
+    fn info(&self) -> &FunctionInfo;
 
     /// Call this function with the given arguments.
     fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a>;

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -53,7 +53,7 @@ pub trait Function: PartialReflect + Debug {
     }
 
     /// The [`FunctionInfoType`] for this function.
-    fn info(&self) -> &FunctionInfoType;
+    fn info(&self) -> FunctionInfoType;
 
     /// Call this function with the given arguments.
     fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a>;

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -52,8 +52,10 @@ pub trait Function: PartialReflect + Debug {
 
     /// Returns the number of arguments the function expects.
     ///
-    /// For overloaded functions that can have a variable number of arguments,
+    /// For [overloaded] functions that can have a variable number of arguments,
     /// this will contain the full set of counts for all signatures.
+    ///
+    /// [overloaded]: crate::func#overloading-functions
     fn arg_count(&self) -> ArgCount {
         self.info().arg_count()
     }

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    func::{ArgList, DynamicFunction, FunctionInfo, FunctionResult},
+    func::{ArgList, DynamicFunction, FunctionInfoType, FunctionResult},
     PartialReflect,
 };
 use alloc::borrow::Cow;
@@ -45,17 +45,15 @@ pub trait Function: PartialReflect + Debug {
     ///
     /// [`DynamicFunctions`]: crate::func::DynamicFunction
     /// [`IntoFunction`]: crate::func::IntoFunction
-    fn name(&self) -> Option<&Cow<'static, str>> {
-        self.info().name()
-    }
+    fn name(&self) -> Option<&Cow<'static, str>>;
 
     /// The number of arguments this function accepts.
     fn arg_count(&self) -> usize {
         self.info().arg_count()
     }
 
-    /// The [`FunctionInfo`] for this function.
-    fn info(&self) -> &FunctionInfo;
+    /// The [`FunctionInfoType`] for this function.
+    fn info(&self) -> &FunctionInfoType;
 
     /// Call this function with the given arguments.
     fn reflect_call<'a>(&self, args: ArgList<'a>) -> FunctionResult<'a>;

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -3,6 +3,7 @@ use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionInfoType, Functi
 use alloc::borrow::Cow;
 use bevy_utils::hashbrown::HashMap;
 use bevy_utils::NoOpHash;
+use core::ops::RangeInclusive;
 
 /// A helper type for storing a mapping of overloaded functions
 /// along with the corresponding [function information].
@@ -74,6 +75,18 @@ impl<F> FunctionMap<F> {
             Self::Single(_, info) => FunctionInfoType::Standard(Cow::Borrowed(info)),
             Self::Overloaded(_, info, _) => FunctionInfoType::Overloaded(Cow::Borrowed(info)),
         }
+    }
+
+    /// Returns the number of arguments the function expects.
+    ///
+    /// For [overloaded] functions that can have a variable number of arguments,
+    /// this will return the minimum and maximum number of arguments.
+    ///
+    /// Otherwise, the range will have the same start and end.
+    ///
+    /// [overloaded]: Self::Overloaded
+    pub fn arg_count(&self) -> RangeInclusive<usize> {
+        self.info().arg_count()
     }
 
     /// Merge another [`FunctionMap`] into this one.

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -1,7 +1,11 @@
 use crate::func::signature::ArgumentSignature;
-use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionInfoType, FunctionOverloadError};
+use crate::func::{
+    ArgList, FunctionError, FunctionInfo, FunctionInfoType, FunctionOverloadError,
+    PrettyPrintFunctionInfo,
+};
 use alloc::borrow::Cow;
 use bevy_utils::hashbrown::HashMap;
+use core::fmt::{Debug, Formatter};
 use core::ops::RangeInclusive;
 
 /// A helper type for storing a mapping of overloaded functions
@@ -213,6 +217,21 @@ impl<F> FunctionMap<F> {
                 self_infos.append(&mut other_infos);
 
                 Ok(Self::Overloaded(self_funcs, self_infos, self_indices))
+            }
+        }
+    }
+
+    pub fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            // `(arg0: i32, arg1: i32) -> ()`
+            Self::Single(_, info) => PrettyPrintFunctionInfo::new(info).fmt(f),
+            // `{(arg0: i32, arg1: i32) -> (), (arg0: f32, arg1: f32) -> ()}`
+            Self::Overloaded(_, infos, _) => {
+                let mut set = f.debug_set();
+                for info in infos.iter() {
+                    set.entry(&PrettyPrintFunctionInfo::new(info));
+                }
+                set.finish()
             }
         }
     }

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -1,0 +1,102 @@
+use crate::func::signature::ArgumentSignature;
+use crate::func::FunctionInfoType;
+use bevy_utils::HashMap;
+
+/// A helper type for storing either a single function or a mapping of overloaded functions.
+#[derive(Clone)]
+pub(super) enum FunctionMap<F> {
+    Standard(F),
+    Overloaded(HashMap<ArgumentSignature, F>),
+}
+
+/// Merges the given [`FunctionMap`]s and [`FunctionInfoType`]s into a new [`FunctionMap`] and [`FunctionInfoType`].
+///
+/// # Panics
+///
+/// Panics if a [`FunctionMap`]'s corresponding [`FunctionInfoType`] does not match its overload status.
+pub(super) fn merge_function_map<F>(
+    map_a: FunctionMap<F>,
+    info_a: FunctionInfoType,
+    map_b: FunctionMap<F>,
+    info_b: FunctionInfoType,
+) -> (FunctionMap<F>, FunctionInfoType) {
+    match (map_a, info_a, map_b, info_b) {
+        (
+            FunctionMap::Standard(old),
+            FunctionInfoType::Standard(info_a),
+            FunctionMap::Standard(new),
+            FunctionInfoType::Standard(info_b),
+        ) => {
+            let sig_a = ArgumentSignature::from(&info_a);
+            let sig_b = ArgumentSignature::from(&info_b);
+
+            if sig_a == sig_b {
+                (
+                    FunctionMap::Standard(new),
+                    FunctionInfoType::Standard(info_b),
+                )
+            } else {
+                (
+                    FunctionMap::Overloaded(HashMap::from([(sig_a, old), (sig_b, new)])),
+                    FunctionInfoType::Overloaded(Box::new([info_a, info_b])),
+                )
+            }
+        }
+        (
+            FunctionMap::Overloaded(old),
+            FunctionInfoType::Overloaded(info_a),
+            FunctionMap::Standard(new),
+            FunctionInfoType::Standard(info_b),
+        ) => {
+            let sig_b = ArgumentSignature::from(&info_b);
+            let mut map = old;
+            map.insert(sig_b, new);
+
+            let mut info = Vec::from_iter(info_a);
+            info.push(info_b);
+
+            (
+                FunctionMap::Overloaded(map),
+                FunctionInfoType::Overloaded(info.into_boxed_slice()),
+            )
+        }
+        (
+            FunctionMap::Standard(old),
+            FunctionInfoType::Standard(info_a),
+            FunctionMap::Overloaded(new),
+            FunctionInfoType::Overloaded(info_b),
+        ) => {
+            let sig_a = ArgumentSignature::from(&info_a);
+            let mut map = new;
+            map.insert(sig_a, old);
+
+            let mut info = vec![info_a];
+            info.extend(info_b);
+
+            (
+                FunctionMap::Overloaded(map),
+                FunctionInfoType::Overloaded(info.into_boxed_slice()),
+            )
+        }
+        (
+            FunctionMap::Overloaded(map1),
+            FunctionInfoType::Overloaded(info_a),
+            FunctionMap::Overloaded(map2),
+            FunctionInfoType::Overloaded(info_b),
+        ) => {
+            let mut map = map1;
+            map.extend(map2);
+
+            let mut info = Vec::from_iter(info_a);
+            info.extend(info_b);
+
+            (
+                FunctionMap::Overloaded(map),
+                FunctionInfoType::Overloaded(info.into_boxed_slice()),
+            )
+        }
+        _ => {
+            panic!("`FunctionMap` and `FunctionInfoType` mismatch");
+        }
+    }
+}

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -2,7 +2,6 @@ use crate::func::signature::ArgumentSignature;
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionInfoType, FunctionOverloadError};
 use alloc::borrow::Cow;
 use bevy_utils::hashbrown::HashMap;
-use bevy_utils::NoOpHash;
 use core::ops::RangeInclusive;
 
 /// A helper type for storing a mapping of overloaded functions
@@ -28,7 +27,7 @@ pub(super) enum FunctionMap<F> {
         /// A mapping of argument signatures to the index of the corresponding function.
         ///
         /// Multiple signatures may point to the same function index (i.e. for manually created overloads).
-        HashMap<ArgumentSignature, usize, NoOpHash>,
+        HashMap<ArgumentSignature, usize>,
     ),
 }
 

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -1,7 +1,8 @@
 use crate::func::signature::ArgumentSignature;
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionInfoType, FunctionOverloadError};
 use alloc::borrow::Cow;
-use bevy_utils::HashMap;
+use bevy_utils::hashbrown::HashMap;
+use bevy_utils::NoOpHash;
 
 /// A helper type for storing a mapping of overloaded functions
 /// along with the corresponding [function information].
@@ -10,7 +11,11 @@ use bevy_utils::HashMap;
 #[derive(Clone, Debug)]
 pub(super) enum FunctionMap<F> {
     Single(F, FunctionInfo),
-    Overloaded(Vec<F>, Vec<FunctionInfo>, HashMap<ArgumentSignature, usize>),
+    Overloaded(
+        Vec<F>,
+        Vec<FunctionInfo>,
+        HashMap<ArgumentSignature, usize, NoOpHash>,
+    ),
 }
 
 impl<F> FunctionMap<F> {
@@ -87,7 +92,7 @@ impl<F> FunctionMap<F> {
                 Ok(Self::Overloaded(
                     vec![self_func, other_func],
                     vec![self_info, other_info],
-                    HashMap::from([(self_sig, 0), (other_sig, 1)]),
+                    HashMap::from_iter([(self_sig, 0), (other_sig, 1)]),
                 ))
             }
             (
@@ -182,7 +187,7 @@ mod tests {
         assert_eq!(infos.len(), 2);
         assert_eq!(
             indices,
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 1),
             ])
@@ -198,7 +203,7 @@ mod tests {
                 FunctionInfo::anonymous().with_arg::<u8>("arg0"),
                 FunctionInfo::anonymous().with_arg::<u16>("arg0"),
             ],
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u16>()]), 1),
             ]),
@@ -211,7 +216,7 @@ mod tests {
         assert_eq!(infos.len(), 3);
         assert_eq!(
             indices,
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 1),
                 (ArgumentSignature::from_iter([Type::of::<u16>()]), 2),
@@ -227,7 +232,7 @@ mod tests {
                 FunctionInfo::anonymous().with_arg::<i8>("arg0"),
                 FunctionInfo::anonymous().with_arg::<i16>("arg0"),
             ],
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
             ]),
@@ -241,7 +246,7 @@ mod tests {
         assert_eq!(infos.len(), 3);
         assert_eq!(
             indices,
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 2),
@@ -257,7 +262,7 @@ mod tests {
                 FunctionInfo::anonymous().with_arg::<i8>("arg0"),
                 FunctionInfo::anonymous().with_arg::<i16>("arg0"),
             ],
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
             ]),
@@ -268,7 +273,7 @@ mod tests {
                 FunctionInfo::anonymous().with_arg::<u8>("arg0"),
                 FunctionInfo::anonymous().with_arg::<u16>("arg0"),
             ],
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u16>()]), 1),
             ]),
@@ -281,7 +286,7 @@ mod tests {
         assert_eq!(infos.len(), 4);
         assert_eq!(
             indices,
-            HashMap::from([
+            HashMap::from_iter([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 2),
@@ -304,7 +309,7 @@ mod tests {
                 FunctionInfo::anonymous().with_arg::<u8>("arg0"),
                 FunctionInfo::anonymous().with_arg::<u16>("arg1"),
             ],
-            HashMap::from([
+            HashMap::from_iter([
                 (
                     ArgumentSignature::from_iter([Type::of::<u8>(), Type::of::<u16>()]),
                     0,

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -128,10 +128,14 @@ impl<F> FunctionMap<F> {
                     ));
                 }
 
+                let mut map = HashMap::new();
+                map.insert_unique_unchecked(self_sig, 0);
+                map.insert_unique_unchecked(other_sig, 1);
+
                 Ok(Self::Overloaded(
                     vec![self_func, other_func],
                     vec![self_info, other_info],
-                    HashMap::from_iter([(self_sig, 0), (other_sig, 1)]),
+                    map,
                 ))
             }
             (
@@ -154,7 +158,7 @@ impl<F> FunctionMap<F> {
 
                 other_funcs.insert(0, self_func);
                 other_infos.insert(0, self_info);
-                other_indices.insert(self_sig, 0);
+                other_indices.insert_unique_unchecked(self_sig, 0);
 
                 Ok(Self::Overloaded(other_funcs, other_infos, other_indices))
             }
@@ -175,7 +179,7 @@ impl<F> FunctionMap<F> {
                 let index = self_funcs.len();
                 self_funcs.push(other_func);
                 self_infos.push(other_info);
-                self_indices.insert(other_sig, index);
+                self_indices.insert_unique_unchecked(other_sig, index);
 
                 Ok(Self::Overloaded(self_funcs, self_infos, self_indices))
             }
@@ -195,10 +199,14 @@ impl<F> FunctionMap<F> {
                         ));
                     }
 
-                    new_indices.insert(sig, self_funcs.len() + index);
+                    new_indices.insert_unique_unchecked(sig, self_funcs.len() + index);
                 }
 
-                self_indices.extend(new_indices);
+                self_indices.reserve(new_indices.len());
+                for (sig, index) in new_indices {
+                    self_indices.insert_unique_unchecked(sig, index);
+                }
+
                 self_funcs.append(&mut other_funcs);
                 // The index map and `FunctionInfo` list should always be in sync,
                 // so we can simply append the new infos to the existing ones.

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -1,16 +1,16 @@
 use crate::func::signature::ArgumentSignature;
-use crate::func::{ArgList, FunctionError, FunctionInfoType, FunctionOverloadError};
+use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionInfoType, FunctionOverloadError};
+use alloc::borrow::Cow;
 use bevy_utils::HashMap;
 
 /// A helper type for storing a mapping of overloaded functions
 /// along with the corresponding [function information].
 ///
-/// [function information]: FunctionInfoType
+/// [function information]: FunctionInfo
 #[derive(Clone, Debug)]
-pub(super) struct FunctionMap<F> {
-    pub info: FunctionInfoType,
-    pub functions: Vec<F>,
-    pub indices: HashMap<ArgumentSignature, usize>,
+pub(super) enum FunctionMap<F> {
+    Single(F, FunctionInfo),
+    Overloaded(Vec<F>, Vec<FunctionInfo>, HashMap<ArgumentSignature, usize>),
 }
 
 impl<F> FunctionMap<F> {
@@ -21,17 +21,18 @@ impl<F> FunctionMap<F> {
     ///
     /// If no overload matches the provided arguments, an error will be returned.
     pub fn get(&self, args: &ArgList) -> Result<&F, FunctionError> {
-        if self.functions.len() == 1 {
-            Ok(&self.functions[0])
-        } else {
-            let signature = ArgumentSignature::from(args);
-            self.indices
-                .get(&signature)
-                .map(|index| &self.functions[*index])
-                .ok_or_else(|| FunctionError::NoOverload {
-                    expected: self.indices.keys().cloned().collect(),
-                    received: signature,
-                })
+        match self {
+            Self::Single(function, _) => Ok(function),
+            Self::Overloaded(functions, _, indices) => {
+                let signature = ArgumentSignature::from(args);
+                indices
+                    .get(&signature)
+                    .map(|index| &functions[*index])
+                    .ok_or_else(|| FunctionError::NoOverload {
+                        expected: indices.keys().cloned().collect(),
+                        received: signature,
+                    })
+            }
         }
     }
 
@@ -42,17 +43,26 @@ impl<F> FunctionMap<F> {
     ///
     /// If no overload matches the provided arguments, an error will be returned.
     pub fn get_mut(&mut self, args: &ArgList) -> Result<&mut F, FunctionError> {
-        if self.functions.len() == 1 {
-            Ok(&mut self.functions[0])
-        } else {
-            let signature = ArgumentSignature::from(args);
-            self.indices
-                .get(&signature)
-                .map(|index| &mut self.functions[*index])
-                .ok_or_else(|| FunctionError::NoOverload {
-                    expected: self.indices.keys().cloned().collect(),
-                    received: signature,
-                })
+        match self {
+            Self::Single(function, _) => Ok(function),
+            Self::Overloaded(functions, _, indices) => {
+                let signature = ArgumentSignature::from(args);
+                indices
+                    .get(&signature)
+                    .map(|index| &mut functions[*index])
+                    .ok_or_else(|| FunctionError::NoOverload {
+                        expected: indices.keys().cloned().collect(),
+                        received: signature,
+                    })
+            }
+        }
+    }
+
+    /// Returns the function information contained in the map.
+    pub fn info(&self) -> FunctionInfoType {
+        match self {
+            Self::Single(_, info) => FunctionInfoType::Standard(Cow::Borrowed(info)),
+            Self::Overloaded(_, info, _) => FunctionInfoType::Overloaded(Cow::Borrowed(info)),
         }
     }
 
@@ -60,42 +70,97 @@ impl<F> FunctionMap<F> {
     ///
     /// If the other map contains any functions with the same signature as this one,
     /// an error will be returned along with the original, unchanged map.
-    pub fn merge(mut self, other: Self) -> Result<Self, (Box<Self>, FunctionOverloadError)> {
-        // === Function Map === //
-        let mut other_indices = HashMap::new();
+    pub fn merge(self, other: Self) -> Result<Self, (Box<Self>, FunctionOverloadError)> {
+        match (self, other) {
+            (Self::Single(self_func, self_info), Self::Single(other_func, other_info)) => {
+                let self_sig = ArgumentSignature::from(&self_info);
+                let other_sig = ArgumentSignature::from(&other_info);
+                if self_sig == other_sig {
+                    return Err((
+                        Box::new(Self::Single(self_func, self_info)),
+                        FunctionOverloadError {
+                            signature: self_sig,
+                        },
+                    ));
+                }
 
-        for (sig, index) in other.indices {
-            if self.indices.contains_key(&sig) {
-                return Err((Box::new(self), FunctionOverloadError { signature: sig }));
+                Ok(Self::Overloaded(
+                    vec![self_func, other_func],
+                    vec![self_info, other_info],
+                    HashMap::from([(self_sig, 0), (other_sig, 1)]),
+                ))
             }
+            (
+                Self::Single(self_func, self_info),
+                Self::Overloaded(mut other_funcs, mut other_infos, mut other_indices),
+            ) => {
+                let self_sig = ArgumentSignature::from(&self_info);
+                if other_indices.contains_key(&self_sig) {
+                    return Err((
+                        Box::new(Self::Single(self_func, self_info)),
+                        FunctionOverloadError {
+                            signature: self_sig,
+                        },
+                    ));
+                }
 
-            other_indices.insert(sig, self.functions.len() + index);
+                for index in other_indices.values_mut() {
+                    *index += 1;
+                }
+
+                other_funcs.insert(0, self_func);
+                other_infos.insert(0, self_info);
+                other_indices.insert(self_sig, 0);
+
+                Ok(Self::Overloaded(other_funcs, other_infos, other_indices))
+            }
+            (
+                Self::Overloaded(mut self_funcs, mut self_infos, mut self_indices),
+                Self::Single(other_func, other_info),
+            ) => {
+                let other_sig = ArgumentSignature::from(&other_info);
+                if self_indices.contains_key(&other_sig) {
+                    return Err((
+                        Box::new(Self::Overloaded(self_funcs, self_infos, self_indices)),
+                        FunctionOverloadError {
+                            signature: other_sig,
+                        },
+                    ));
+                }
+
+                let index = self_funcs.len();
+                self_funcs.push(other_func);
+                self_infos.push(other_info);
+                self_indices.insert(other_sig, index);
+
+                Ok(Self::Overloaded(self_funcs, self_infos, self_indices))
+            }
+            (
+                Self::Overloaded(mut self_funcs, mut self_infos, mut self_indices),
+                Self::Overloaded(mut other_funcs, mut other_infos, other_indices),
+            ) => {
+                let mut new_indices = HashMap::new();
+
+                for (sig, index) in other_indices {
+                    if self_indices.contains_key(&sig) {
+                        return Err((
+                            Box::new(Self::Overloaded(self_funcs, self_infos, self_indices)),
+                            FunctionOverloadError { signature: sig },
+                        ));
+                    }
+
+                    new_indices.insert(sig, self_funcs.len() + index);
+                }
+
+                self_indices.extend(new_indices);
+                self_funcs.append(&mut other_funcs);
+                // The index map and `FunctionInfo` list should always be in sync,
+                // so we can simply append the new infos to the existing ones.
+                self_infos.append(&mut other_infos);
+
+                Ok(Self::Overloaded(self_funcs, self_infos, self_indices))
+            }
         }
-
-        // === Function Info === //
-        let mut other_infos = Vec::new();
-
-        for info in other.info.into_iter() {
-            let sig = ArgumentSignature::from(&info);
-            if self.indices.contains_key(&sig) {
-                return Err((Box::new(self), FunctionOverloadError { signature: sig }));
-            }
-            other_infos.push(info);
-        }
-
-        // === Update === //
-        self.indices.extend(other_indices);
-        self.functions.extend(other.functions);
-        self.info = match self.info {
-            FunctionInfoType::Standard(info) => {
-                FunctionInfoType::Overloaded(std::iter::once(info).chain(other_infos).collect())
-            }
-            FunctionInfoType::Overloaded(infos) => FunctionInfoType::Overloaded(
-                IntoIterator::into_iter(infos).chain(other_infos).collect(),
-            ),
-        };
-
-        Ok(self)
     }
 }
 
@@ -106,100 +171,166 @@ mod tests {
     use crate::Type;
 
     #[test]
-    fn should_merge_function_maps() {
-        let map_a = FunctionMap {
-            info: FunctionInfoType::Overloaded(Box::new([
-                FunctionInfo::anonymous().with_arg::<i8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i32>("arg0"),
-            ])),
-            functions: vec!['a', 'b', 'c'],
-            indices: HashMap::from([
-                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
-                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
-                (ArgumentSignature::from_iter([Type::of::<i32>()]), 2),
-            ]),
-        };
+    fn should_merge_single_into_single() {
+        let map_a = FunctionMap::Single('a', FunctionInfo::anonymous().with_arg::<i8>("arg0"));
+        let map_b = FunctionMap::Single('b', FunctionInfo::anonymous().with_arg::<u8>("arg0"));
 
-        let map_b = FunctionMap {
-            info: FunctionInfoType::Overloaded(Box::new([
+        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
+            panic!("expected overloaded function");
+        };
+        assert_eq!(functions, vec!['a', 'b']);
+        assert_eq!(infos.len(), 2);
+        assert_eq!(
+            indices,
+            HashMap::from([
+                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
+                (ArgumentSignature::from_iter([Type::of::<u8>()]), 1),
+            ])
+        );
+    }
+
+    #[test]
+    fn should_merge_single_into_overloaded() {
+        let map_a = FunctionMap::Single('a', FunctionInfo::anonymous().with_arg::<i8>("arg0"));
+        let map_b = FunctionMap::Overloaded(
+            vec!['b', 'c'],
+            vec![
                 FunctionInfo::anonymous().with_arg::<u8>("arg0"),
                 FunctionInfo::anonymous().with_arg::<u16>("arg0"),
-                FunctionInfo::anonymous().with_arg::<u32>("arg0"),
-            ])),
-            functions: vec!['d', 'e', 'f'],
-            indices: HashMap::from([
+            ],
+            HashMap::from([
                 (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<u16>()]), 1),
-                (ArgumentSignature::from_iter([Type::of::<u32>()]), 2),
             ]),
+        );
+
+        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
+            panic!("expected overloaded function");
         };
-
-        let map = map_a.merge(map_b).unwrap();
-
-        assert_eq!(map.functions, vec!['a', 'b', 'c', 'd', 'e', 'f']);
+        assert_eq!(functions, vec!['a', 'b', 'c']);
+        assert_eq!(infos.len(), 3);
         assert_eq!(
-            map.indices,
+            indices,
+            HashMap::from([
+                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
+                (ArgumentSignature::from_iter([Type::of::<u8>()]), 1),
+                (ArgumentSignature::from_iter([Type::of::<u16>()]), 2),
+            ])
+        );
+    }
+
+    #[test]
+    fn should_merge_overloaed_into_single() {
+        let map_a = FunctionMap::Overloaded(
+            vec!['a', 'b'],
+            vec![
+                FunctionInfo::anonymous().with_arg::<i8>("arg0"),
+                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
+            ],
             HashMap::from([
                 (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
                 (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
-                (ArgumentSignature::from_iter([Type::of::<i32>()]), 2),
-                (ArgumentSignature::from_iter([Type::of::<u8>()]), 3),
-                (ArgumentSignature::from_iter([Type::of::<u16>()]), 4),
-                (ArgumentSignature::from_iter([Type::of::<u32>()]), 5),
+            ]),
+        );
+        let map_b = FunctionMap::Single('c', FunctionInfo::anonymous().with_arg::<u8>("arg0"));
+
+        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
+            panic!("expected overloaded function");
+        };
+        assert_eq!(functions, vec!['a', 'b', 'c']);
+        assert_eq!(infos.len(), 3);
+        assert_eq!(
+            indices,
+            HashMap::from([
+                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
+                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
+                (ArgumentSignature::from_iter([Type::of::<u8>()]), 2),
+            ])
+        );
+    }
+
+    #[test]
+    fn should_merge_overloaded_into_overloaded() {
+        let map_a = FunctionMap::Overloaded(
+            vec!['a', 'b'],
+            vec![
+                FunctionInfo::anonymous().with_arg::<i8>("arg0"),
+                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
+            ],
+            HashMap::from([
+                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
+                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
+            ]),
+        );
+        let map_b = FunctionMap::Overloaded(
+            vec!['c', 'd'],
+            vec![
+                FunctionInfo::anonymous().with_arg::<u8>("arg0"),
+                FunctionInfo::anonymous().with_arg::<u16>("arg0"),
+            ],
+            HashMap::from([
+                (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
+                (ArgumentSignature::from_iter([Type::of::<u16>()]), 1),
+            ]),
+        );
+
+        let FunctionMap::Overloaded(functions, infos, indices) = map_a.merge(map_b).unwrap() else {
+            panic!("expected overloaded function");
+        };
+        assert_eq!(functions, vec!['a', 'b', 'c', 'd']);
+        assert_eq!(infos.len(), 4);
+        assert_eq!(
+            indices,
+            HashMap::from([
+                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
+                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
+                (ArgumentSignature::from_iter([Type::of::<u8>()]), 2),
+                (ArgumentSignature::from_iter([Type::of::<u16>()]), 3),
             ])
         );
     }
 
     #[test]
     fn should_return_error_on_duplicate_signature() {
-        let map_a = FunctionMap {
-            info: FunctionInfoType::Overloaded(Box::new([
-                FunctionInfo::anonymous().with_arg::<i8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i32>("arg0"),
-            ])),
-            functions: vec!['a', 'b', 'c'],
-            indices: HashMap::from([
-                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
-                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
-                (ArgumentSignature::from_iter([Type::of::<i32>()]), 2),
-            ]),
-        };
-
-        let map_b = FunctionMap {
-            info: FunctionInfoType::Overloaded(Box::new([
+        let map_a = FunctionMap::Single(
+            'a',
+            FunctionInfo::anonymous()
+                .with_arg::<i8>("arg0")
+                .with_arg::<i16>("arg1"),
+        );
+        let map_b = FunctionMap::Overloaded(
+            vec!['b', 'c'],
+            vec![
                 FunctionInfo::anonymous().with_arg::<u8>("arg0"),
-                FunctionInfo::anonymous().with_arg::<i16>("arg0"),
-                FunctionInfo::anonymous().with_arg::<u32>("arg0"),
-            ])),
-            functions: vec!['d', 'e', 'f'],
-            indices: HashMap::from([
-                (ArgumentSignature::from_iter([Type::of::<u8>()]), 0),
-                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
-                (ArgumentSignature::from_iter([Type::of::<u32>()]), 2),
+                FunctionInfo::anonymous().with_arg::<u16>("arg1"),
+            ],
+            HashMap::from([
+                (
+                    ArgumentSignature::from_iter([Type::of::<u8>(), Type::of::<u16>()]),
+                    0,
+                ),
+                (
+                    ArgumentSignature::from_iter([Type::of::<i8>(), Type::of::<i16>()]),
+                    1,
+                ),
             ]),
-        };
-
-        let Err((map_a, error)) = map_a.merge(map_b) else {
-            panic!("expected an error");
-        };
-        assert_eq!(
-            error,
-            FunctionOverloadError {
-                signature: ArgumentSignature::from_iter([Type::of::<i16>()])
-            }
         );
 
-        // Assert that the original map remains unchanged:
-        assert_eq!(map_a.functions, vec!['a', 'b', 'c']);
+        let (map, error) = map_a.merge(map_b).unwrap_err();
         assert_eq!(
-            map_a.indices,
-            HashMap::from([
-                (ArgumentSignature::from_iter([Type::of::<i8>()]), 0),
-                (ArgumentSignature::from_iter([Type::of::<i16>()]), 1),
-                (ArgumentSignature::from_iter([Type::of::<i32>()]), 2),
-            ])
+            error.signature,
+            ArgumentSignature::from_iter([Type::of::<i8>(), Type::of::<i16>()])
+        );
+
+        // Assert the original map remains unchanged:
+        let FunctionMap::Single(function, info) = *map else {
+            panic!("expected single function");
+        };
+
+        assert_eq!(function, 'a');
+        assert_eq!(
+            ArgumentSignature::from(info),
+            ArgumentSignature::from_iter([Type::of::<i8>(), Type::of::<i16>()])
         );
     }
 }

--- a/crates/bevy_reflect/src/func/function_map.rs
+++ b/crates/bevy_reflect/src/func/function_map.rs
@@ -19,6 +19,11 @@ pub(super) enum FunctionMap<F> {
 }
 
 impl<F> FunctionMap<F> {
+    /// Returns `true` if the map contains an overloaded function.
+    pub fn is_overloaded(&self) -> bool {
+        matches!(self, Self::Overloaded(..))
+    }
+
     /// Get a reference to a function in the map.
     ///
     /// If there is only one function in the map, it will be returned.

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -47,6 +47,18 @@ impl TryFrom<Vec<FunctionInfo>> for FunctionInfoType {
     }
 }
 
+impl IntoIterator for FunctionInfoType {
+    type Item = FunctionInfo;
+    type IntoIter = vec::IntoIter<FunctionInfo>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            FunctionInfoType::Standard(info) => vec![info].into_iter(),
+            FunctionInfoType::Overloaded(infos) => infos.into_vec().into_iter(),
+        }
+    }
+}
+
 impl FunctionInfoType {
     pub fn arg_count(&self) -> usize {
         match self {

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -3,132 +3,230 @@ use alloc::{borrow::Cow, vec};
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, format, vec};
 
-use core::fmt::{Debug, Formatter};
-use core::ops::RangeInclusive;
-use variadics_please::all_tuples;
-
 use crate::{
-    func::{
-        args::{ArgInfo, GetOwnership, Ownership},
-        MissingFunctionInfoError,
-    },
+    func::args::{ArgInfo, GetOwnership, Ownership},
+    func::signature::ArgumentSignature,
+    func::FunctionOverloadError,
     type_info::impl_type_methods,
     Type, TypePath,
 };
 
-/// A wrapper around [`FunctionInfo`] used to represent either a standard function
-/// or an overloaded function.
-#[derive(Debug, Clone)]
-pub enum FunctionInfoType<'a> {
-    /// A standard function with a single set of arguments.
-    ///
-    /// This includes generic functions with a single set of monomorphized arguments.
-    Standard(Cow<'a, FunctionInfo>),
-    /// An overloaded function with multiple sets of arguments.
-    ///
-    /// This includes generic functions with multiple sets of monomorphized arguments,
-    /// as well as functions with a variable number of arguments (i.e. "variadic functions").
-    Overloaded(Cow<'a, [FunctionInfo]>),
-}
-
-impl From<FunctionInfo> for FunctionInfoType<'_> {
-    fn from(info: FunctionInfo) -> Self {
-        FunctionInfoType::Standard(Cow::Owned(info))
-    }
-}
-
-impl TryFrom<Vec<FunctionInfo>> for FunctionInfoType<'_> {
-    type Error = MissingFunctionInfoError;
-
-    fn try_from(mut infos: Vec<FunctionInfo>) -> Result<Self, Self::Error> {
-        match infos.len() {
-            0 => Err(MissingFunctionInfoError),
-            1 => Ok(Self::Standard(Cow::Owned(infos.pop().unwrap()))),
-            _ => Ok(Self::Overloaded(Cow::Owned(infos))),
-        }
-    }
-}
-
-impl IntoIterator for FunctionInfoType<'_> {
-    type Item = FunctionInfo;
-    type IntoIter = vec::IntoIter<FunctionInfo>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // Allow `.into_owned()` so that we can create a `std::vec::IntoIter`
-        #[allow(clippy::unnecessary_to_owned)]
-        match self {
-            FunctionInfoType::Standard(info) => vec![info.into_owned()].into_iter(),
-            FunctionInfoType::Overloaded(infos) => infos.into_owned().into_iter(),
-        }
-    }
-}
-
-impl FunctionInfoType<'_> {
-    /// Returns the number of arguments the function expects.
-    ///
-    /// For [overloaded] functions that can have a variable number of arguments,
-    /// this will return the minimum and maximum number of arguments.
-    ///
-    /// Otherwise, the range will have the same start and end.
-    ///
-    /// [overloaded]: Self::Overloaded
-    pub fn arg_count(&self) -> RangeInclusive<usize> {
-        match self {
-            Self::Standard(info) => RangeInclusive::new(info.arg_count(), info.arg_count()),
-            Self::Overloaded(infos) => infos.iter().map(FunctionInfo::arg_count).fold(
-                RangeInclusive::new(usize::MAX, usize::MIN),
-                |acc, count| {
-                    RangeInclusive::new((*acc.start()).min(count), (*acc.end()).max(count))
-                },
-            ),
-        }
-    }
-}
+use core::fmt::{Debug, Formatter};
+use core::ops::RangeInclusive;
+use variadics_please::all_tuples;
 
 /// Type information for a [`DynamicFunction`] or [`DynamicFunctionMut`].
 ///
 /// This information can be retrieved directly from certain functions and closures
 /// using the [`TypedFunction`] trait, and manually constructed otherwise.
 ///
+/// It is compromised of one or more [`SignatureInfo`] structs,
+/// allowing it to represent functions with multiple sets of arguments (i.e. "overloaded functions").
+///
 /// [`DynamicFunction`]: crate::func::DynamicFunction
 /// [`DynamicFunctionMut`]: crate::func::DynamicFunctionMut
 #[derive(Debug, Clone)]
 pub struct FunctionInfo {
     name: Option<Cow<'static, str>>,
-    args: Vec<ArgInfo>,
-    return_info: ReturnInfo,
+    signatures: Box<[SignatureInfo]>,
 }
 
 impl FunctionInfo {
-    /// Create a new [`FunctionInfo`] for a function with the given name.
+    /// Create a new [`FunctionInfo`] for a function with the given signature.
+    pub fn new(signature: SignatureInfo) -> Self {
+        Self {
+            name: signature.name.clone(),
+            signatures: vec![signature].into(),
+        }
+    }
+
+    /// Create a new [`FunctionInfo`] from a set of signatures.
+    ///
+    /// Returns an error if the given iterator is empty or contains duplicate signatures.
+    pub fn try_from_iter(
+        signatures: impl IntoIterator<Item = SignatureInfo>,
+    ) -> Result<Self, FunctionOverloadError> {
+        let mut iter = signatures.into_iter();
+
+        let mut info = Self::new(iter.next().ok_or(FunctionOverloadError::MissingSignature)?);
+
+        for signature in iter {
+            info = info.with_overload(signature).map_err(|sig| {
+                FunctionOverloadError::DuplicateSignature(ArgumentSignature::from(&sig))
+            })?;
+        }
+
+        Ok(info)
+    }
+
+    /// The base signature for this function.
+    ///
+    /// All functions—including overloaded functions—are guaranteed to have at least one signature.
+    /// The first signature used to define the [`FunctionInfo`] is considered the base signature.
+    pub fn base(&self) -> &SignatureInfo {
+        &self.signatures[0]
+    }
+
+    /// Whether this function is overloaded.
+    ///
+    /// This is determined by the existence of multiple signatures.
+    pub fn is_overloaded(&self) -> bool {
+        self.signatures.len() > 1
+    }
+
+    /// Set the name of the function.
+    pub fn with_name(mut self, name: Option<impl Into<Cow<'static, str>>>) -> Self {
+        self.name = name.map(Into::into);
+        self
+    }
+
+    /// The name of the function.
+    ///
+    /// For [`DynamicFunctions`] created using [`IntoFunction`] or [`DynamicFunctionMuts`] created using [`IntoFunctionMut`],
+    /// the default name will always be the full path to the function as returned by [`std::any::type_name`],
+    /// unless the function is a closure, anonymous function, or function pointer,
+    /// in which case the name will be `None`.
+    ///
+    /// For overloaded functions, this will be the name of the base signature,
+    /// unless manually overwritten using [`Self::with_name`].
+    ///
+    /// [`DynamicFunctions`]: crate::func::DynamicFunction
+    /// [`IntoFunction`]: crate::func::IntoFunction
+    /// [`DynamicFunctionMuts`]: crate::func::DynamicFunctionMut
+    /// [`IntoFunctionMut`]: crate::func::IntoFunctionMut
+    pub fn name(&self) -> Option<&Cow<'static, str>> {
+        self.name.as_ref()
+    }
+
+    /// Add a signature to this function.
+    ///
+    /// If a signature with the same [`ArgumentSignature`] already exists,
+    /// an error is returned with the given signature.
+    pub fn with_overload(mut self, signature: SignatureInfo) -> Result<Self, SignatureInfo> {
+        let is_duplicate = self.signatures.iter().any(|s| {
+            s.arg_count() == signature.arg_count()
+                && ArgumentSignature::from(s) == ArgumentSignature::from(&signature)
+        });
+
+        if is_duplicate {
+            return Err(signature);
+        }
+
+        self.signatures = IntoIterator::into_iter(self.signatures)
+            .chain(Some(signature))
+            .collect();
+        Ok(self)
+    }
+
+    /// Returns the number of arguments the function expects.
+    ///
+    /// For overloaded functions that can have a variable number of arguments,
+    /// this will return the minimum and maximum number of arguments.
+    ///
+    /// Otherwise, the range will have the same start and end.
+    pub fn arg_count(&self) -> RangeInclusive<usize> {
+        self.signatures
+            .iter()
+            .map(SignatureInfo::arg_count)
+            .fold(RangeInclusive::new(usize::MAX, usize::MIN), |acc, count| {
+                RangeInclusive::new((*acc.start()).min(count), (*acc.end()).max(count))
+            })
+    }
+
+    /// The signatures of the function.
+    ///
+    /// This is guaranteed to always contain at least one signature.
+    /// Overloaded functions will contain two or more.
+    pub fn signatures(&self) -> &[SignatureInfo] {
+        &self.signatures
+    }
+
+    /// Returns a wrapper around this info that implements [`Debug`] for pretty-printing the function.
+    ///
+    /// This can be useful for more readable debugging and logging.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::func::{FunctionInfo, TypedFunction};
+    /// #
+    /// fn add(a: i32, b: i32) -> i32 {
+    ///     a + b
+    /// }
+    ///
+    /// let info = add.get_function_info();
+    ///
+    /// let pretty = info.pretty_printer();
+    /// assert_eq!(format!("{:?}", pretty), "(_: i32, _: i32) -> i32");
+    /// ```
+    pub fn pretty_printer(&self) -> PrettyPrintFunctionInfo {
+        PrettyPrintFunctionInfo::new(self)
+    }
+
+    /// Extend this [`FunctionInfo`] with another without checking for duplicates.
+    pub(super) fn extend_unchecked(&mut self, other: FunctionInfo) {
+        if self.name.is_none() {
+            self.name = other.name;
+        }
+
+        let signatures = core::mem::take(&mut self.signatures);
+        self.signatures = IntoIterator::into_iter(signatures)
+            .chain(IntoIterator::into_iter(other.signatures))
+            .collect();
+    }
+}
+
+impl From<SignatureInfo> for FunctionInfo {
+    fn from(info: SignatureInfo) -> Self {
+        Self::new(info)
+    }
+}
+
+impl TryFrom<Vec<SignatureInfo>> for FunctionInfo {
+    type Error = FunctionOverloadError;
+
+    fn try_from(signatures: Vec<SignatureInfo>) -> Result<Self, Self::Error> {
+        Self::try_from_iter(signatures)
+    }
+}
+
+impl<const N: usize> TryFrom<[SignatureInfo; N]> for FunctionInfo {
+    type Error = FunctionOverloadError;
+
+    fn try_from(signatures: [SignatureInfo; N]) -> Result<Self, Self::Error> {
+        Self::try_from_iter(signatures)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SignatureInfo {
+    name: Option<Cow<'static, str>>,
+    args: Box<[ArgInfo]>,
+    return_info: ReturnInfo,
+}
+
+impl SignatureInfo {
+    /// Create a new [`SignatureInfo`] for a function with the given name.
     pub fn named(name: impl Into<Cow<'static, str>>) -> Self {
         Self {
             name: Some(name.into()),
-            args: Vec::new(),
+            args: Box::new([]),
             return_info: ReturnInfo::new::<()>(),
         }
     }
 
-    /// Create a new [`FunctionInfo`] with no name.
+    /// Create a new [`SignatureInfo`] with no name.
     ///
     /// For the purposes of debugging and [registration],
-    /// it's recommended to use [`FunctionInfo::named`] instead.
+    /// it's recommended to use [`Self::named`] instead.
     ///
     /// [registration]: crate::func::FunctionRegistry
     pub fn anonymous() -> Self {
         Self {
             name: None,
-            args: Vec::new(),
+            args: Box::new([]),
             return_info: ReturnInfo::new::<()>(),
         }
-    }
-
-    /// Create a new [`FunctionInfo`] from the given function.
-    pub fn from<F, Marker>(function: &F) -> Self
-    where
-        F: TypedFunction<Marker>,
-    {
-        function.get_function_info()
     }
 
     /// Set the name of the function.
@@ -146,7 +244,9 @@ impl FunctionInfo {
         name: impl Into<Cow<'static, str>>,
     ) -> Self {
         let index = self.args.len();
-        self.args.push(ArgInfo::new::<T>(index).with_name(name));
+        self.args = IntoIterator::into_iter(self.args)
+            .chain(Some(ArgInfo::new::<T>(index).with_name(name)))
+            .collect();
         self
     }
 
@@ -157,7 +257,7 @@ impl FunctionInfo {
     /// It's preferable to use [`Self::with_arg`] to add arguments to the function
     /// as it will automatically set the index of the argument.
     pub fn with_args(mut self, args: Vec<ArgInfo>) -> Self {
-        self.args = args;
+        self.args = IntoIterator::into_iter(self.args).chain(args).collect();
         self
     }
 
@@ -211,28 +311,6 @@ impl FunctionInfo {
     /// The return information of the function.
     pub fn return_info(&self) -> &ReturnInfo {
         &self.return_info
-    }
-
-    /// Returns a wrapper around this info that implements [`Debug`] for pretty-printing the function.
-    ///
-    /// This can be useful for more readable debugging and logging.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_reflect::func::{FunctionInfo, TypedFunction};
-    /// #
-    /// fn add(a: i32, b: i32) -> i32 {
-    ///     a + b
-    /// }
-    ///
-    /// let info = add.get_function_info();
-    ///
-    /// let pretty = info.pretty_printer();
-    /// assert_eq!(format!("{:?}", pretty), "(_: i32, _: i32) -> i32");
-    /// ```
-    pub fn pretty_printer(&self) -> PrettyPrintFunctionInfo {
-        PrettyPrintFunctionInfo::new(self)
     }
 }
 
@@ -324,6 +402,81 @@ impl<'a> Debug for PrettyPrintFunctionInfo<'a> {
             _ => {}
         }
 
+        if self.info.is_overloaded() {
+            // `{(arg0: i32, arg1: i32) -> (), (arg0: f32, arg1: f32) -> ()}`
+            let mut set = f.debug_set();
+            for signature in self.info.signatures() {
+                set.entry(&PrettyPrintSignatureInfo::new(signature));
+            }
+            set.finish()
+        } else {
+            // `(arg0: i32, arg1: i32) -> ()`
+            PrettyPrintSignatureInfo::new(self.info.base()).fmt(f)
+        }
+    }
+}
+
+/// A wrapper around [`SignatureInfo`] that implements [`Debug`] for pretty-printing function signature information.
+///
+/// # Example
+///
+/// ```
+/// # use bevy_reflect::func::{FunctionInfo, PrettyPrintSignatureInfo, TypedFunction};
+/// #
+/// fn add(a: i32, b: i32) -> i32 {
+///     a + b
+/// }
+///
+/// let info = add.get_function_info();
+///
+/// let pretty = PrettyPrintSignatureInfo::new(info.base());
+/// assert_eq!(format!("{:?}", pretty), "(_: i32, _: i32) -> i32");
+/// ```
+pub struct PrettyPrintSignatureInfo<'a> {
+    info: &'a SignatureInfo,
+    include_fn_token: bool,
+    include_name: bool,
+}
+
+impl<'a> PrettyPrintSignatureInfo<'a> {
+    /// Create a new pretty-printer for the given [`SignatureInfo`].
+    pub fn new(info: &'a SignatureInfo) -> Self {
+        Self {
+            info,
+            include_fn_token: false,
+            include_name: false,
+        }
+    }
+
+    /// Include the function name in the pretty-printed output.
+    pub fn include_name(mut self) -> Self {
+        self.include_name = true;
+        self
+    }
+
+    /// Include the `fn` token in the pretty-printed output.
+    pub fn include_fn_token(mut self) -> Self {
+        self.include_fn_token = true;
+        self
+    }
+}
+
+impl<'a> Debug for PrettyPrintSignatureInfo<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        if self.include_fn_token {
+            write!(f, "fn")?;
+
+            if self.include_name {
+                write!(f, " ")?;
+            }
+        }
+
+        match (self.include_name, self.info.name()) {
+            (true, Some(name)) => write!(f, "{}", name)?,
+            (true, None) => write!(f, "_")?,
+            _ => {}
+        }
+
         write!(f, "(")?;
 
         // We manually write the args instead of using `DebugTuple` to avoid trailing commas
@@ -370,7 +523,7 @@ impl<'a> Debug for PrettyPrintFunctionInfo<'a> {
 /// # Example
 ///
 /// ```
-/// # use bevy_reflect::func::{ArgList, FunctionInfo, ReflectFnMut, TypedFunction};
+/// # use bevy_reflect::func::{ArgList, ReflectFnMut, TypedFunction};
 /// #
 /// fn print(value: String) {
 ///   println!("{}", value);
@@ -378,9 +531,9 @@ impl<'a> Debug for PrettyPrintFunctionInfo<'a> {
 ///
 /// let info = print.get_function_info();
 /// assert!(info.name().unwrap().ends_with("print"));
-/// assert_eq!(info.arg_count(), 1);
-/// assert_eq!(info.args()[0].type_path(), "alloc::string::String");
-/// assert_eq!(info.return_info().type_path(), "()");
+/// assert!(info.arg_count().contains(&1));
+/// assert_eq!(info.base().args()[0].type_path(), "alloc::string::String");
+/// assert_eq!(info.base().return_info().type_path(), "()");
 /// ```
 ///
 /// # Trait Parameters
@@ -419,18 +572,20 @@ macro_rules! impl_typed_function {
             Function: FnMut($($Arg),*) -> ReturnType,
         {
             fn function_info() -> FunctionInfo {
-                create_info::<Function>()
-                    .with_args({
-                        #[allow(unused_mut)]
-                        let mut _index = 0;
-                        vec![
-                            $(ArgInfo::new::<$Arg>({
-                                _index += 1;
-                                _index - 1
-                            }),)*
-                        ]
-                    })
-                    .with_return_info(ReturnInfo::new::<ReturnType>())
+                FunctionInfo::new(
+                    create_info::<Function>()
+                        .with_args({
+                            #[allow(unused_mut)]
+                            let mut _index = 0;
+                            vec![
+                                $(ArgInfo::new::<$Arg>({
+                                    _index += 1;
+                                    _index - 1
+                                }),)*
+                            ]
+                        })
+                        .with_return_info(ReturnInfo::new::<ReturnType>())
+                )
             }
         }
 
@@ -442,20 +597,22 @@ macro_rules! impl_typed_function {
             for<'a> &'a ReturnType: TypePath + GetOwnership,
             Function: for<'a> FnMut(&'a Receiver, $($Arg),*) -> &'a ReturnType,
         {
-            fn function_info() -> $crate::func::FunctionInfo {
-                create_info::<Function>()
-                    .with_args({
-                        #[allow(unused_mut)]
-                        let mut _index = 1;
-                        vec![
-                            ArgInfo::new::<&Receiver>(0),
-                            $($crate::func::args::ArgInfo::new::<$Arg>({
-                                _index += 1;
-                                _index - 1
-                            }),)*
-                        ]
-                    })
-                    .with_return_info(ReturnInfo::new::<&ReturnType>())
+            fn function_info() -> FunctionInfo {
+                FunctionInfo::new(
+                    create_info::<Function>()
+                        .with_args({
+                            #[allow(unused_mut)]
+                            let mut _index = 1;
+                            vec![
+                                ArgInfo::new::<&Receiver>(0),
+                                $($crate::func::args::ArgInfo::new::<$Arg>({
+                                    _index += 1;
+                                    _index - 1
+                                }),)*
+                            ]
+                        })
+                        .with_return_info(ReturnInfo::new::<&ReturnType>())
+                )
             }
         }
 
@@ -468,19 +625,21 @@ macro_rules! impl_typed_function {
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg),*) -> &'a mut ReturnType,
         {
             fn function_info() -> FunctionInfo {
-                create_info::<Function>()
-                    .with_args({
-                        #[allow(unused_mut)]
-                        let mut _index = 1;
-                        vec![
-                            ArgInfo::new::<&mut Receiver>(0),
-                            $(ArgInfo::new::<$Arg>({
-                                _index += 1;
-                                _index - 1
-                            }),)*
-                        ]
-                    })
-                    .with_return_info(ReturnInfo::new::<&mut ReturnType>())
+                FunctionInfo::new(
+                    create_info::<Function>()
+                        .with_args({
+                            #[allow(unused_mut)]
+                            let mut _index = 1;
+                            vec![
+                                ArgInfo::new::<&mut Receiver>(0),
+                                $(ArgInfo::new::<$Arg>({
+                                    _index += 1;
+                                    _index - 1
+                                }),)*
+                            ]
+                        })
+                        .with_return_info(ReturnInfo::new::<&mut ReturnType>())
+                )
             }
         }
 
@@ -493,19 +652,21 @@ macro_rules! impl_typed_function {
             Function: for<'a> FnMut(&'a mut Receiver, $($Arg),*) -> &'a ReturnType,
         {
             fn function_info() -> FunctionInfo {
-                create_info::<Function>()
-                    .with_args({
-                        #[allow(unused_mut)]
-                        let mut _index = 1;
-                        vec![
-                            ArgInfo::new::<&mut Receiver>(0),
-                            $(ArgInfo::new::<$Arg>({
-                                _index += 1;
-                                _index - 1
-                            }),)*
-                        ]
-                    })
-                    .with_return_info(ReturnInfo::new::<&ReturnType>())
+                FunctionInfo::new(
+                    create_info::<Function>()
+                        .with_args({
+                            #[allow(unused_mut)]
+                            let mut _index = 1;
+                            vec![
+                                ArgInfo::new::<&mut Receiver>(0),
+                                $(ArgInfo::new::<$Arg>({
+                                    _index += 1;
+                                    _index - 1
+                                }),)*
+                            ]
+                        })
+                        .with_return_info(ReturnInfo::new::<&ReturnType>())
+                )
             }
         }
     };
@@ -531,13 +692,13 @@ all_tuples!(impl_typed_function, 0, 15, Arg, arg);
 /// | Function pointer   | `fn() -> String`        | `None`                  |
 ///
 /// [`type_name`]: core::any::type_name
-fn create_info<F>() -> FunctionInfo {
+fn create_info<F>() -> SignatureInfo {
     let name = core::any::type_name::<F>();
 
     if name.ends_with("{{closure}}") || name.starts_with("fn(") {
-        FunctionInfo::anonymous()
+        SignatureInfo::anonymous()
     } else {
-        FunctionInfo::named(name)
+        SignatureInfo::named(name)
     }
 }
 
@@ -562,10 +723,10 @@ mod tests {
             info.name().unwrap(),
             "bevy_reflect::func::info::tests::should_create_function_info::add"
         );
-        assert_eq!(info.arg_count(), 2);
-        assert_eq!(info.args()[0].type_path(), "i32");
-        assert_eq!(info.args()[1].type_path(), "i32");
-        assert_eq!(info.return_info().type_path(), "i32");
+        assert_eq!(info.base().arg_count(), 2);
+        assert_eq!(info.base().args()[0].type_path(), "i32");
+        assert_eq!(info.base().args()[1].type_path(), "i32");
+        assert_eq!(info.base().return_info().type_path(), "i32");
     }
 
     #[test]
@@ -581,10 +742,10 @@ mod tests {
 
         let info = add.get_function_info();
         assert!(info.name().is_none());
-        assert_eq!(info.arg_count(), 2);
-        assert_eq!(info.args()[0].type_path(), "i32");
-        assert_eq!(info.args()[1].type_path(), "i32");
-        assert_eq!(info.return_info().type_path(), "i32");
+        assert_eq!(info.base().arg_count(), 2);
+        assert_eq!(info.base().args()[0].type_path(), "i32");
+        assert_eq!(info.base().args()[1].type_path(), "i32");
+        assert_eq!(info.base().return_info().type_path(), "i32");
     }
 
     #[test]
@@ -599,10 +760,10 @@ mod tests {
 
         let info = add.get_function_info();
         assert!(info.name().is_none());
-        assert_eq!(info.arg_count(), 2);
-        assert_eq!(info.args()[0].type_path(), "i32");
-        assert_eq!(info.args()[1].type_path(), "i32");
-        assert_eq!(info.return_info().type_path(), "i32");
+        assert_eq!(info.base().arg_count(), 2);
+        assert_eq!(info.base().args()[0].type_path(), "i32");
+        assert_eq!(info.base().args()[1].type_path(), "i32");
+        assert_eq!(info.base().return_info().type_path(), "i32");
     }
 
     #[test]
@@ -618,30 +779,30 @@ mod tests {
 
         let info = add.get_function_info();
         assert!(info.name().is_none());
-        assert_eq!(info.arg_count(), 2);
-        assert_eq!(info.args()[0].type_path(), "i32");
-        assert_eq!(info.args()[1].type_path(), "i32");
-        assert_eq!(info.return_info().type_path(), "()");
+        assert_eq!(info.base().arg_count(), 2);
+        assert_eq!(info.base().args()[0].type_path(), "i32");
+        assert_eq!(info.base().args()[1].type_path(), "i32");
+        assert_eq!(info.base().return_info().type_path(), "()");
     }
 
     #[test]
     fn should_pretty_print_info() {
-        fn add(a: i32, b: i32) -> i32 {
-            a + b
-        }
-
-        let info = add.get_function_info().with_name("add");
-
-        let pretty = info.pretty_printer();
-        assert_eq!(format!("{:?}", pretty), "(_: i32, _: i32) -> i32");
-
-        let pretty = info.pretty_printer().include_fn_token();
-        assert_eq!(format!("{:?}", pretty), "fn(_: i32, _: i32) -> i32");
-
-        let pretty = info.pretty_printer().include_name();
-        assert_eq!(format!("{:?}", pretty), "add(_: i32, _: i32) -> i32");
-
-        let pretty = info.pretty_printer().include_fn_token().include_name();
-        assert_eq!(format!("{:?}", pretty), "fn add(_: i32, _: i32) -> i32");
+        // fn add(a: i32, b: i32) -> i32 {
+        //     a + b
+        // }
+        //
+        // let info = add.get_function_info().with_name("add");
+        //
+        // let pretty = info.pretty_printer();
+        // assert_eq!(format!("{:?}", pretty), "(_: i32, _: i32) -> i32");
+        //
+        // let pretty = info.pretty_printer().include_fn_token();
+        // assert_eq!(format!("{:?}", pretty), "fn(_: i32, _: i32) -> i32");
+        //
+        // let pretty = info.pretty_printer().include_name();
+        // assert_eq!(format!("{:?}", pretty), "add(_: i32, _: i32) -> i32");
+        //
+        // let pretty = info.pretty_printer().include_fn_token().include_name();
+        // assert_eq!(format!("{:?}", pretty), "fn add(_: i32, _: i32) -> i32");
     }
 }

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -146,8 +146,10 @@ impl FunctionInfo {
 
     /// Returns the number of arguments the function expects.
     ///
-    /// For overloaded functions that can have a variable number of arguments,
+    /// For [overloaded] functions that can have a variable number of arguments,
     /// this will contain the full set of counts for all signatures.
+    ///
+    /// [overloaded]: crate::func#overloading-functions
     pub fn arg_count(&self) -> ArgCount {
         self.arg_count
     }

--- a/crates/bevy_reflect/src/func/into_function.rs
+++ b/crates/bevy_reflect/src/func/into_function.rs
@@ -66,6 +66,6 @@ mod tests {
     fn should_default_closure_name_to_none() {
         let c = 23;
         let func = (|a: i32, b: i32| a + b + c).into_function();
-        assert_eq!(func.info().name(), None);
+        assert!(func.name().is_none());
     }
 }

--- a/crates/bevy_reflect/src/func/into_function_mut.rs
+++ b/crates/bevy_reflect/src/func/into_function_mut.rs
@@ -81,6 +81,6 @@ mod tests {
     fn should_default_closure_name_to_none() {
         let mut total = 0;
         let func = (|a: i32, b: i32| total = a + b).into_function_mut();
-        assert_eq!(func.info().name(), None);
+        assert!(func.name().is_none());
     }
 }

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -94,6 +94,32 @@
 //! For other functions that don't conform to one of the above signatures,
 //! [`DynamicFunction`] and [`DynamicFunctionMut`] can instead be created manually.
 //!
+//! # Generic Functions
+//!
+//! In Rust, generic functions are [monomophized] by the compiler,
+//! which means that a separate copy of the function is generated for each concrete set of type parameters.
+//!
+//! When converting a generic function to a [`DynamicFunction`] or [`DynamicFunctionMut`],
+//! the function must be manually monomorphized with concrete types.
+//! In other words, you cannot write `add<T>.into_function()`.
+//! Instead, you will need to write `add::<i32>.into_function()`.
+//!
+//! This means that reflected functions cannot be generic themselves.
+//! To get around this limitation, you can consider [overloading] your function with multiple concrete types.
+//!
+//! # Overloading Functions
+//!
+//! Both [`DynamicFunction`] and [`DynamicFunctionMut`] support [function overloading].
+//!
+//! Function overloading allows one function to handle multiple types of arguments.
+//! This is useful for simulating generic functions by having an overload for each known concrete type.
+//! Additionally, it can also simulate [variadic functions]: functions that can be called with a variable number of arguments.
+//!
+//! Internally, this works by storing multiple functions in a map,
+//! where each function is associated with a specific argument signature.
+//!
+//! To learn more, see the docs on [`DynamicFunction::with_overload`].
+//!
 //! # Function Registration
 //!
 //! This module also provides a [`FunctionRegistry`] that can be used to register functions and closures
@@ -127,6 +153,10 @@
 //! [`Reflect`]: crate::Reflect
 //! [lack of variadic generics]: https://poignardazur.github.io/2024/05/25/report-on-rustnl-variadics/
 //! [coherence issues]: https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#coherence-leak-check
+//! [monomophized]: https://en.wikipedia.org/wiki/Monomorphization
+//! [overloading]: #overloading-functions
+//! [function overloading]: https://en.wikipedia.org/wiki/Function_overloading
+//! [variadic functions]: https://en.wikipedia.org/wiki/Variadic_function
 
 pub use args::{ArgError, ArgList, ArgValue};
 pub use dynamic_function::*;

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -154,6 +154,7 @@ mod reflect_fn;
 mod reflect_fn_mut;
 mod registry;
 mod return_type;
+pub mod signature;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             FunctionError::ArgCountMismatch {
-                expected: 1,
+                expected: 1..=1,
                 received: 0
             }
         );
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             FunctionError::ArgCountMismatch {
-                expected: 0,
+                expected: 0..=0,
                 received: 1
             }
         );

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -191,12 +191,12 @@ pub mod signature;
 mod tests {
     use alloc::borrow::Cow;
 
+    use super::*;
+    use crate::func::args::ArgCount;
     use crate::{
         func::args::{ArgError, ArgList, Ownership},
         TypePath,
     };
-
-    use super::*;
 
     #[test]
     fn should_error_on_missing_args() {
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             FunctionError::ArgCountMismatch {
-                expected: 1..=1,
+                expected: ArgCount::new(1).unwrap(),
                 received: 0
             }
         );
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             FunctionError::ArgCountMismatch {
-                expected: 0..=0,
+                expected: ArgCount::new(0).unwrap(),
                 received: 1
             }
         );

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -146,6 +146,7 @@ mod dynamic_function;
 mod dynamic_function_mut;
 mod error;
 mod function;
+mod function_map;
 mod info;
 mod into_function;
 mod into_function_mut;

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -173,10 +173,10 @@ pub use return_type::*;
 
 pub mod args;
 mod dynamic_function;
+mod dynamic_function_internal;
 mod dynamic_function_mut;
 mod error;
 mod function;
-mod function_map;
 mod info;
 mod into_function;
 mod into_function_mut;

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -96,7 +96,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }
@@ -125,7 +125,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }
@@ -155,7 +155,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }
@@ -185,7 +185,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -5,8 +5,9 @@ use alloc::{boxed::Box, format, vec};
 
 use crate::{
     func::{
-        args::FromArg, macros::count_tokens, ArgList, FunctionError, FunctionResult, IntoReturn,
-        ReflectFnMut,
+        args::{ArgCount, FromArg},
+        macros::count_tokens,
+        ArgList, FunctionError, FunctionResult, IntoReturn, ReflectFnMut,
     },
     Reflect, TypePath,
 };
@@ -96,7 +97,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }
@@ -125,7 +126,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }
@@ -155,7 +156,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }
@@ -185,7 +186,7 @@ macro_rules! impl_reflect_fn {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -5,7 +5,9 @@ use alloc::{boxed::Box, format, vec};
 
 use crate::{
     func::{
-        args::FromArg, macros::count_tokens, ArgList, FunctionError, FunctionResult, IntoReturn,
+        args::{ArgCount, FromArg},
+        macros::count_tokens,
+        ArgList, FunctionError, FunctionResult, IntoReturn,
     },
     Reflect, TypePath,
 };
@@ -102,7 +104,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }
@@ -131,7 +133,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }
@@ -161,7 +163,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }
@@ -191,7 +193,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT..=COUNT,
+                        expected: ArgCount::new(COUNT).unwrap(),
                         received: args.len(),
                     });
                 }

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -102,7 +102,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }
@@ -131,7 +131,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }
@@ -161,7 +161,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }
@@ -191,7 +191,7 @@ macro_rules! impl_reflect_fn_mut {
 
                 if args.len() != COUNT {
                     return Err(FunctionError::ArgCountMismatch {
-                        expected: COUNT,
+                        expected: COUNT..=COUNT,
                         received: args.len(),
                     });
                 }

--- a/crates/bevy_reflect/src/func/signature.rs
+++ b/crates/bevy_reflect/src/func/signature.rs
@@ -1,0 +1,142 @@
+//! Function signature types.
+//!
+//! Function signatures differ from [`FunctionInfo`] in that they are only concerned
+//! about the types and order of the arguments and return type of a function.
+//!
+//! The names of arguments do not matter,
+//! nor does any other information about the function such as its name or other attributes.
+//!
+//! This makes signatures useful for comparing or hashing functions strictly based on their
+//! arguments and return type.
+
+use crate::func::args::ArgInfo;
+use crate::func::FunctionInfo;
+use crate::Type;
+use core::borrow::Borrow;
+use core::fmt::{Debug, Formatter};
+use core::ops::{Deref, DerefMut};
+
+/// The signature of a function.
+///
+/// This can be used as a way to compare or hash functions based on their arguments and return type.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Signature {
+    args: ArgumentSignature,
+    ret: Type,
+}
+
+impl Signature {
+    /// Create a new function signature with the given argument signature and return type.
+    pub fn new(args: ArgumentSignature, ret: Type) -> Self {
+        Self { args, ret }
+    }
+
+    /// Get the argument signature of the function.
+    pub fn args(&self) -> &ArgumentSignature {
+        &self.args
+    }
+
+    /// Get the return type of the function.
+    pub fn return_type(&self) -> &Type {
+        &self.ret
+    }
+}
+
+impl Debug for Signature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?} -> {:?}", self.args, self.ret)
+    }
+}
+
+impl<T: Borrow<FunctionInfo>> From<T> for Signature {
+    fn from(info: T) -> Self {
+        let info = info.borrow();
+        Self::new(ArgumentSignature::from(info), *info.return_info().ty())
+    }
+}
+
+/// The argument-portion of a function signature.
+///
+/// For example, given a function signature `(a: i32, b: f32) -> u32`,
+/// the argument signature would be `(i32, f32)`.
+///
+/// This can be used as a way to compare or hash functions based on their arguments.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ArgumentSignature(Box<[Type]>);
+
+impl Debug for ArgumentSignature {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut tuple = f.debug_tuple("");
+        for ty in self.0.iter() {
+            tuple.field(ty);
+        }
+        tuple.finish()
+    }
+}
+
+impl Deref for ArgumentSignature {
+    type Target = [Type];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ArgumentSignature {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromIterator<Type> for ArgumentSignature {
+    fn from_iter<T: IntoIterator<Item = Type>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<T: Borrow<FunctionInfo>> From<T> for ArgumentSignature {
+    fn from(info: T) -> Self {
+        Self(
+            info.borrow()
+                .args()
+                .iter()
+                .map(ArgInfo::ty)
+                .copied()
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::func::TypedFunction;
+
+    #[test]
+    fn should_generate_signature_from_function_info() {
+        fn add(a: i32, b: f32) -> u32 {
+            (a as f32 + b).round() as u32
+        }
+
+        let info = add.get_function_info();
+        let signature = Signature::from(&info);
+
+        assert_eq!(signature.args().0.len(), 2);
+        assert_eq!(signature.args().0[0], Type::of::<i32>());
+        assert_eq!(signature.args().0[1], Type::of::<f32>());
+        assert_eq!(*signature.return_type(), Type::of::<u32>());
+    }
+
+    #[test]
+    fn should_debug_signature() {
+        let signature = Signature::new(
+            ArgumentSignature::from_iter(vec![Type::of::<&mut String>(), Type::of::<i32>()]),
+            Type::of::<()>(),
+        );
+
+        assert_eq!(
+            format!("{:?}", signature),
+            "(&mut alloc::string::String, i32) -> ()"
+        );
+    }
+}

--- a/crates/bevy_reflect/src/func/signature.rs
+++ b/crates/bevy_reflect/src/func/signature.rs
@@ -10,7 +10,7 @@
 //! arguments and return type.
 
 use crate::func::args::ArgInfo;
-use crate::func::FunctionInfo;
+use crate::func::{ArgList, FunctionInfo};
 use crate::Type;
 use core::borrow::Borrow;
 use core::fmt::{Debug, Formatter};
@@ -101,6 +101,24 @@ impl<T: Borrow<FunctionInfo>> From<T> for ArgumentSignature {
                 .args()
                 .iter()
                 .map(ArgInfo::ty)
+                .copied()
+                .collect(),
+        )
+    }
+}
+
+impl From<&ArgList<'_>> for ArgumentSignature {
+    fn from(args: &ArgList) -> Self {
+        Self(
+            args.iter()
+                .map(|arg| {
+                    arg.value()
+                        .get_represented_type_info()
+                        .unwrap_or_else(|| {
+                            panic!("no `TypeInfo` found for argument: {:?}", arg);
+                        })
+                        .ty()
+                })
                 .copied()
                 .collect(),
         )

--- a/crates/bevy_reflect/src/func/signature.rs
+++ b/crates/bevy_reflect/src/func/signature.rs
@@ -1,16 +1,18 @@
 //! Function signature types.
 //!
-//! Function signatures differ from [`FunctionInfo`] in that they are only concerned
-//! about the types and order of the arguments and return type of a function.
+//! Function signatures differ from [`FunctionInfo`] and [`SignatureInfo`] in that they
+//! are only concerned about the types and order of the arguments and return type of a function.
 //!
 //! The names of arguments do not matter,
 //! nor does any other information about the function such as its name or other attributes.
 //!
 //! This makes signatures useful for comparing or hashing functions strictly based on their
 //! arguments and return type.
+//!
+//! [`FunctionInfo`]: crate::func::info::FunctionInfo
 
 use crate::func::args::ArgInfo;
-use crate::func::{ArgList, FunctionInfo};
+use crate::func::{ArgList, SignatureInfo};
 use crate::Type;
 use core::borrow::Borrow;
 use core::fmt::{Debug, Formatter};
@@ -48,7 +50,7 @@ impl Debug for Signature {
     }
 }
 
-impl<T: Borrow<FunctionInfo>> From<T> for Signature {
+impl<T: Borrow<SignatureInfo>> From<T> for Signature {
     fn from(info: T) -> Self {
         let info = info.borrow();
         Self::new(ArgumentSignature::from(info), *info.return_info().ty())
@@ -94,7 +96,7 @@ impl FromIterator<Type> for ArgumentSignature {
     }
 }
 
-impl<T: Borrow<FunctionInfo>> From<T> for ArgumentSignature {
+impl<T: Borrow<SignatureInfo>> From<T> for ArgumentSignature {
     fn from(info: T) -> Self {
         Self(
             info.borrow()
@@ -137,7 +139,7 @@ mod tests {
         }
 
         let info = add.get_function_info();
-        let signature = Signature::from(&info);
+        let signature = Signature::from(info.base());
 
         assert_eq!(signature.args().0.len(), 2);
         assert_eq!(signature.args().0[0], Type::of::<i32>());

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -83,7 +83,50 @@ fn main() {
     dbg!(closure.call_once(args).unwrap());
     assert_eq!(count, 5);
 
-    // As stated before, this works for many kinds of simple functions.
+    // Generic functions can also be converted into a `DynamicFunction`,
+    // however, they will need to be manually monomorphized first.
+    fn stringify<T: ToString>(value: T) -> String {
+        value.to_string()
+    }
+
+    // We have to manually specify the concrete generic type we want to use.
+    let function = stringify::<i32>.into_function();
+
+    let args = ArgList::new().push_owned(123_i32);
+    let return_value = function.call(args).unwrap();
+    let value: Box<dyn PartialReflect> = return_value.unwrap_owned();
+    assert_eq!(value.try_take::<String>().unwrap(), "123");
+
+    // To make things a little easier, we can also "overload" functions.
+    // This makes it so that a single `DynamicFunction` can represent multiple functions,
+    // and the correct one is chosen based on the types of the arguments.
+    // Each function overload must have a unique argument signature.
+    let function = stringify::<i32>
+        .into_function()
+        .with_overload(stringify::<f32>);
+
+    // Now our `function` accepts both `i32` and `f32` arguments.
+    let args = ArgList::new().push_owned(1.23_f32);
+    let return_value = function.call(args).unwrap();
+    let value: Box<dyn PartialReflect> = return_value.unwrap_owned();
+    assert_eq!(value.try_take::<String>().unwrap(), "1.23");
+
+    // Function overloading even allows us to have a variable number of arguments.
+    let function = (|| 0)
+        .into_function()
+        .with_overload(|a: i32| a)
+        .with_overload(|a: i32, b: i32| a + b)
+        .with_overload(|a: i32, b: i32, c: i32| a + b + c);
+
+    let args = ArgList::new()
+        .push_owned(1_i32)
+        .push_owned(2_i32)
+        .push_owned(3_i32);
+    let return_value = function.call(args).unwrap();
+    let value: Box<dyn PartialReflect> = return_value.unwrap_owned();
+    assert_eq!(value.try_take::<i32>().unwrap(), 6);
+
+    // As stated earlier, `IntoFunction` works for many kinds of simple functions.
     // Functions with non-reflectable arguments or return values may not be able to be converted.
     // Generic functions are also not supported (unless manually monomorphized like `foo::<i32>.into_function()`).
     // Additionally, the lifetime of the return value is tied to the lifetime of the first argument.
@@ -118,7 +161,7 @@ fn main() {
     let value: &dyn PartialReflect = return_value.unwrap_ref();
     assert_eq!(value.try_downcast_ref::<String>().unwrap(), "Hello, world!");
 
-    // Lastly, for more complex use cases, you can always create a custom `DynamicFunction` manually.
+    // For more complex use cases, you can always create a custom `DynamicFunction` manually.
     // This is useful for functions that can't be converted via the `IntoFunction` trait.
     // For example, this function doesn't implement `IntoFunction` due to the fact that
     // the lifetime of the return value is not tied to the lifetime of the first argument.

--- a/examples/reflection/function_reflection.rs
+++ b/examples/reflection/function_reflection.rs
@@ -8,8 +8,8 @@
 
 use bevy::reflect::{
     func::{
-        ArgList, DynamicFunction, DynamicFunctionMut, FunctionInfo, FunctionResult, IntoFunction,
-        IntoFunctionMut, Return,
+        ArgList, DynamicFunction, DynamicFunctionMut, FunctionResult, IntoFunction,
+        IntoFunctionMut, Return, SignatureInfo,
     },
     PartialReflect, Reflect,
 };
@@ -193,7 +193,7 @@ fn main() {
         // This makes it easier to debug and is also required for function registration.
         // We can either give it a custom name or use the function's type name as
         // derived from `std::any::type_name_of_val`.
-        FunctionInfo::named(std::any::type_name_of_val(&get_or_insert))
+        SignatureInfo::named(std::any::type_name_of_val(&get_or_insert))
             // We can always change the name if needed.
             // It's a good idea to also ensure that the name is unique,
             // such as by using its type name or by prefixing it with your crate name.


### PR DESCRIPTION
# Objective

Currently function reflection requires users to manually monomorphize their generic functions. For example:

```rust
fn add<T: Add<Output=T>>(a: T, b: T) -> T {
    a + b
}

// We have to specify the type of `T`:
let reflect_add = add::<i32>.into_function();
```

This PR doesn't aim to solve that problem—this is just a limitation in Rust. However, it also means that reflected functions can only ever work for a single monomorphization. If we wanted to support other types for `T`, we'd have to create a separate function for each one:

```rust
let reflect_add_i32 = add::<i32>.into_function();
let reflect_add_u32 = add::<u32>.into_function();
let reflect_add_f32 = add::<f32>.into_function();
// ...
```

So in addition to requiring manual monomorphization, we also lose the benefit of having a single function handle multiple argument types.

If a user wanted to create a small modding script that utilized function reflection, they'd have to either:
- Store all sets of supported monomorphizations and require users to call the correct one
- Write out some logic to find the correct function based on the given arguments

While the first option would work, it wouldn't be very ergonomic. The second option is better, but it adds additional complexity to the user's logic—complexity that `bevy_reflect` could instead take on.

## Solution

Introduce [function overloading](https://en.wikipedia.org/wiki/Function_overloading).

A `DynamicFunction` can now be overloaded with other `DynamicFunction`s. We can rewrite the above code like so:

```rust
let reflect_add = add::<i32>
    .into_function()
    .with_overload(add::<u32>)
    .with_overload(add::<f32>);
```

When invoked, the `DynamicFunction` will attempt to find a matching overload for the given set of arguments.

And while I went into this PR only looking to improve generic function reflection, I accidentally added support for variadic functions as well (hence why I use the broader term "overload" over "generic").

```rust
// Supports 1 to 4 arguments
let multiply_all = (|a: i32| a)
    .into_function()
    .with_overload(|a: i32, b: i32| a * b)
    .with_overload(|a: i32, b: i32, c: i32| a * b * c)
    .with_overload(|a: i32, b: i32, c: i32, d: i32| a * b * c * d);
```

This is simply an added bonus to this particular implementation. ~~Full variadic support (i.e. allowing for an indefinite number of arguments) will be added in a later PR.~~ I actually decided to limit the maximum number of arguments to 63 to supplement faster lookups, a reduced memory footprint, and faster cloning.

### Alternatives & Rationale

I explored a few options for handling generic functions. This PR is the one I feel the most confident in, but I feel I should mention the others and why I ultimately didn't move forward with them.

#### Adding `GenericDynamicFunction`

**TL;DR:** Adding a distinct `GenericDynamicFunction` type unnecessarily splits and complicates the API.

<details>
<summary>Details</summary>

My initial explorations involved a dedicated `GenericDynamicFunction` to contain and handle the mappings.

This was initially started back when `DynamicFunction` was distinct from `DynamicClosure`. My goal was to not prevent us from being able to somehow make `DynamicFunction` implement `Copy`. But once we reverted back to a single `DynamicFunction`, that became a non-issue.

But that aside, the real problem was that it created a split in the API. If I'm using a third-party library that uses function reflection, I have to know whether to request a `DynamicFunction` or a `GenericDynamicFunction`. I might not even know ahead of time which one I want. It might need to be determined at runtime.

And if I'm creating a library, I might want a type to contain both `DynamicFunction` and `GenericDynamicFunction`. This might not be possible if, for example, I need to store the function in a `HashMap`.

The other concern is with `IntoFunction`. Right now `DynamicFunction` trivially implements `IntoFunction` since it can just return itself. But what should `GenericDynamicFunction` do? It could return itself wrapped into a `DynamicFunction`, but then the API for `DynamicFunction` would have to account for this. So then what was the point of having a separate `GenericDynamicFunction` anyways?

And even apart from `IntoFunction`, there's nothing stopping someone from manually creating a generic `DynamicFunction` through lying about its `FunctionInfo` and wrapping a `GenericDynamicFunction`.

That being said, this is probably the "best" alternative if we added a `Function` trait and stored functions as `Box<dyn Function>`. 

However, I'm not convinced we gain much from this. Sure, we could keep the API for `DynamicFunction` the same, but consumers of `Function` will need to account for `GenericDynamicFunction` regardless (e.g. handling multiple `FunctionInfo`, a ranged argument count, etc.). And for all cases, except where using `DynamicFunction` directly, you end up treating them all like `GenericDynamicFunction`.

Right now, if we did go with `GenericDynamicFunction`, the only major benefit we'd gain would be saving 24 bytes. If memory ever does become an issue here, we could swap over. But I think for the time being it's better for us to pursue a clearer mental model and end-user ergonomics through unification.

</details>

##### Using the `FunctionRegistry`

**TL;DR:** Having overloads only exist in the `FunctionRegistry` unnecessarily splits and complicates the API.

<details>
<summary>Details</summary>

Another idea was to store the overloads in the `FunctionRegistry`. Users would then just call functions directly through the registry (i.e. `registry.call("my_func", my_args)`).

I didn't go with this option because of how it specifically relies on the functions being registered. You'd not only always need access to the registry, but you'd need to ensure that the functions you want to call are even registered.

It also means you can't just store a generic `DynamicFunction` on a type. Instead, you'll need to store the function's name and use that to look up the function in the registry—even if it's only ever used by that type.

Doing so also removes all the benefits of `DynamicFunction`, such as the ability to pass it to functions accepting `IntoFunction`, modify it if needed, and so on.

Like `GenericDynamicFunction` this introduces a split in the ecosystem: you either store `DynamicFunction`, store a string to look up the function, or force `DynamicFunction` to wrap your generic function anyways. Or worse yet: have `DynamicFunction` wrap the lookup function using `FunctionRegistryArc`.

</details>

#### Generic `ArgInfo`

**TL;DR:** Allowing `ArgInfo` and `ReturnInfo` to store the generic information introduces a footgun when interpreting `FunctionInfo`.

<details>
<summary>Details</summary>

Regardless of how we represent a generic function, one thing is clear: we need to be able to represent the information for such a function.

This PR does so by introducing a `FunctionInfoType` enum to wrap one or more `FunctionInfo` values.

Originally, I didn't do this. I had `ArgInfo` and `ReturnInfo` allow for generic types. This allowed us to have a single `FunctionInfo` to represent our function, but then I realized that it actually lies about our function.

If we have two `ArgInfo` that both allow for either `i32` or `u32`, what does this tell us about our function? It turns out: nothing! We can't know whether our function takes `(i32, i32)`, `(u32, u32)`, `(i32, u32)`, or `(u32, i32)`.

It therefore makes more sense to just represent a function with multiple `FunctionInfo` since that's really what it's made up of.

</details>

#### Flatten `FunctionInfo`

**TL;DR:** Flattening removes additional per-overload information some users may desire and prevents us from adding more information in the future.

<details>
<summary>Details</summary>

Why don't we just flatten multiple `FunctionInfo` into just one that can contain multiple signatures?

This is something we could do, but I decided against it for a few reasons:
- The only thing we'd be able to get rid of for each signature would be the `name`. While not enough to not do it, it doesn't really suggest we *have* to either.
- Some consumers may want access to the names of the functions that make up the overloaded function. For example, to track a bug where an undesirable function is being added as an overload. Or to more easily locate the original function of an overload.
- We may eventually allow for more information to be stored on `FunctionInfo`. For example, we may allow for documentation to be stored like we do for `TypeInfo`. Consumers of this documentation may want access to the documentation of each overload as they may provide documentation specific to that overload.

</details>

## Testing

This PR adds lots of tests and benchmarks, and also adds to the example.

To run the tests:

```
cargo test --package bevy_reflect --all-features
```

To run the benchmarks:

```
cargo bench --bench reflect_function --all-features
```

To run the example:

```
cargo run --package bevy --example function_reflection --all-features
```

### Benchmarks

One of my goals with this PR was to leave the typical case of non-overloaded functions largely unaffected by the changes introduced in this PR. ~~And while the static size of `DynamicFunction` has increased by 17% (from 136 to 160 bytes), the performance has generally stayed the same~~ The static size of `DynamicFunction` has decreased from 136 to 112 bytes, while calling performance has generally stayed the same:

|                                     | `main` | 7d293ab | 252f3897d |
|-------------------------------------|--------|---------|-----------|
| `into/function`                     | 37 ns  | 46 ns   | 142 ns    |
| `with_overload/01_simple_overload`  | -      | 149 ns  | 268 ns    |
| `with_overload/01_complex_overload` | -      | 332 ns  | 431 ns    |
| `with_overload/10_simple_overload`  | -      | 1266 ns | 2618 ns   |
| `with_overload/10_complex_overload` | -      | 2544 ns | 4170 ns   |
| `call/function`                     | 57 ns  | 58 ns   | 61 ns     |
| `call/01_simple_overload`           | -      | 255 ns  | 242 ns    |
| `call/01_complex_overload`          | -      | 595 ns  | 431 ns    |
| `call/10_simple_overload`           | -      | 740 ns  | 699 ns    |
| `call/10_complex_overload`          | -      | 1824 ns | 1618 ns   |

For the overloaded function tests, the leading number indicates how many overloads there are: `01` indicates 1 overload, `10` indicates 10 overloads. The `complex` cases have 10 unique generic types and 10 arguments, compared to the `simple` 1 generic type and 2 arguments.

I aimed to prioritize the performance of calling the functions over creating them, hence creation speed tends to be a bit slower.

There may be other optimizations we can look into but that's probably best saved for a future PR.

The important bit is that the standard ~~`into/function`~~ and `call/function` benchmarks show minimal regressions. Since the latest changes, `into/function` does have some regressions, but again the priority was `call/function`. We can probably optimize `into/function` if needed in the future.

---

## Showcase

Function reflection now supports [function overloading](https://en.wikipedia.org/wiki/Function_overloading)! This can be used to simulate generic functions:

```rust
fn add<T: Add<Output=T>>(a: T, b: T) -> T {
    a + b
}

let reflect_add = add::<i32>
    .into_function()
    .with_overload(add::<u32>)
    .with_overload(add::<f32>);

let args = ArgList::default().push_owned(25_i32).push_owned(75_i32);  
let result = func.call(args).unwrap().unwrap_owned();  
assert_eq!(result.try_take::<i32>().unwrap(), 100);  
  
let args = ArgList::default().push_owned(25.0_f32).push_owned(75.0_f32);  
let result = func.call(args).unwrap().unwrap_owned();  
assert_eq!(result.try_take::<f32>().unwrap(), 100.0);
```

You can also simulate variadic functions:

```rust
#[derive(Reflect, PartialEq, Debug)]
struct Player {
    name: Option<String>,
    health: u32,
}

// Creates a `Player` with one of the following:  
// - No name and 100 health  
// - A name and 100 health  
// - No name and custom health  
// - A name and custom health
let create_player = (|| Player {
        name: None,
        health: 100,
    })
    .into_function()
    .with_overload(|name: String| Player {
        name: Some(name),
        health: 100,
    })
    .with_overload(|health: u32| Player {
        name: None,
        health
    })
    .with_overload(|name: String, health: u32| Player {
        name: Some(name),
        health,
    });

let args = ArgList::default()
    .push_owned(String::from("Urist"))
    .push_owned(55_u32);
    
let player = create_player
    .call(args)
    .unwrap()
    .unwrap_owned()
    .try_take::<Player>()
    .unwrap();
	
assert_eq!(
    player,
    Player {
        name: Some(String::from("Urist")),
        health: 55
    }
);
```