### PR TITLE
Remove OrthographicProjection.scale (adopted)

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1254,8 +1254,7 @@ fn load_node(
                     let orthographic_projection = OrthographicProjection {
                         near: orthographic.znear(),
                         far: orthographic.zfar(),
-                        scaling_mode: ScalingMode::FixedHorizontal(1.0),
-                        scale: xmag,
+                        scaling_mode: ScalingMode::FixedHorizontal(xmag),
                         ..OrthographicProjection::default_3d()
                     };
 

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -371,17 +371,6 @@ pub struct OrthographicProjection {
     ///
     /// Defaults to `ScalingMode::WindowSize(1.0)`
     pub scaling_mode: ScalingMode,
-    /// Scales the projection.
-    ///
-    /// As scale increases, the apparent size of objects decreases, and vice versa.
-    ///
-    /// Note: scaling can be set by [`scaling_mode`](Self::scaling_mode) as well.
-    /// This parameter scales on top of that.
-    ///
-    /// This property is particularly useful in implementing zoom functionality.
-    ///
-    /// Defaults to `1.0`.
-    pub scale: f32,
     /// The area that the projection covers relative to `viewport_origin`.
     ///
     /// Bevy's [`camera_system`](crate::camera::camera_system) automatically
@@ -454,10 +443,10 @@ impl CameraProjection for OrthographicProjection {
         }
 
         self.area = Rect::new(
-            self.scale * -origin_x,
-            self.scale * -origin_y,
-            self.scale * (projection_width - origin_x),
-            self.scale * (projection_height - origin_y),
+            -origin_x,
+            -origin_y,
+            projection_width - origin_x,
+            projection_height - origin_y,
         );
     }
 
@@ -505,7 +494,6 @@ impl OrthographicProjection {
     /// objects that are behind it.
     pub fn default_3d() -> Self {
         OrthographicProjection {
-            scale: 1.0,
             near: 0.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -12,6 +12,7 @@ use bevy::{
     sprite::MaterialMesh2dBundle,
     window::WindowResized,
 };
+use bevy_render::camera::ScalingMode;
 
 /// In-game resolution width.
 const RES_WIDTH: u32 = 160;
@@ -176,6 +177,6 @@ fn fit_canvas(
         let h_scale = event.width / RES_WIDTH as f32;
         let v_scale = event.height / RES_HEIGHT as f32;
         let mut projection = projections.single_mut();
-        projection.scale = 1. / h_scale.min(v_scale).round();
+        projection.scaling_mode = ScalingMode::WindowSize(h_scale.min(v_scale).round());
     }
 }

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,5 +1,6 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
+use bevy::render::camera::ScalingMode;
 use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
@@ -120,7 +121,7 @@ fn setup(
         Camera3dBundle {
             transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
             projection: OrthographicProjection {
-                scale: 0.01,
+                scaling_mode: ScalingMode::WindowSize(100.0),
                 ..OrthographicProjection::default_3d()
             }
             .into(),

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -36,7 +36,6 @@ const TRANSFORM_2D: Transform = Transform {
 const PROJECTION_2D: Projection = Projection::Orthographic(OrthographicProjection {
     near: -1.0,
     far: 10.0,
-    scale: 1.0,
     viewport_origin: Vec2::new(0.5, 0.5),
     scaling_mode: ScalingMode::AutoMax {
         max_width: 8.0,

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -94,8 +94,7 @@ fn setup(
     match std::env::args().nth(1).as_deref() {
         Some("orthographic") => commands.spawn(Camera3dBundle {
             projection: OrthographicProjection {
-                scale: 20.0,
-                scaling_mode: ScalingMode::FixedHorizontal(1.0),
+                scaling_mode: ScalingMode::FixedHorizontal(20.0),
                 ..OrthographicProjection::default_3d()
             }
             .into(),


### PR DESCRIPTION
# Objective

Hello! I am adopting #11022 to resolve conflicts with `main`. tldr: this removes `scale` in favour of `scaling_mode`. Please see the original PR for explanation/discussion.

Also relates to #2580.

## Migration Guide

Replace all uses of `scale` with `scaling_mode`, keeping in mind that `scale` is (was) a multiplier. For example, replace
```rust
    scale: 2.0,
    scaling_mode: ScalingMode::FixedHorizontal(4.0),

```
with
```rust
    scaling_mode: ScalingMode::FixedHorizontal(8.0),
```