### PR TITLE
Register reflect type `CursorIcon`

### DIFF
--- a/crates/bevy_render/src/view/window/cursor.rs
+++ b/crates/bevy_render/src/view/window/cursor.rs
@@ -1,3 +1,4 @@
+use bevy_app::{App, Last, Plugin};
 use bevy_asset::{AssetId, Assets, Handle};
 use bevy_ecs::{
     change_detection::DetectChanges,
@@ -18,6 +19,16 @@ use bevy_winit::{
 use wgpu::TextureFormat;
 
 use crate::prelude::Image;
+
+pub struct CursorPlugin;
+
+impl Plugin for CursorPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<CursorIcon>()
+            .init_resource::<CustomCursorCache>()
+            .add_systems(Last, update_cursors);
+    }
+}
 
 /// Insert into a window entity to set the cursor for that window.
 #[derive(Component, Debug, Clone, Reflect, PartialEq, Eq)]

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     renderer::{RenderAdapter, RenderDevice, RenderInstance},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet, WgpuWrapper,
 };
-use bevy_app::{App, Last, Plugin};
+use bevy_app::{App, Plugin};
 use bevy_ecs::{entity::EntityHashMap, prelude::*};
 #[cfg(target_os = "linux")]
 use bevy_utils::warn_once;
@@ -11,7 +11,7 @@ use bevy_utils::{default, tracing::debug, HashSet};
 use bevy_window::{
     CompositeAlphaMode, PresentMode, PrimaryWindow, RawHandleWrapper, Window, WindowClosing,
 };
-use bevy_winit::CustomCursorCache;
+use cursor::CursorPlugin;
 use std::{
     num::NonZero,
     ops::{Deref, DerefMut},
@@ -23,16 +23,13 @@ use wgpu::{
 pub mod cursor;
 pub mod screenshot;
 
-use self::cursor::update_cursors;
 use screenshot::{ScreenshotPlugin, ScreenshotToScreenPipeline};
 
 pub struct WindowRenderPlugin;
 
 impl Plugin for WindowRenderPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(ScreenshotPlugin)
-            .init_resource::<CustomCursorCache>()
-            .add_systems(Last, update_cursors);
+        app.add_plugins((ScreenshotPlugin, CursorPlugin));
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app


### PR DESCRIPTION
# Objective

- `CursorIcon` had derived `Reflect`, but it wasn't registered

## Solution

- Use `register_type` on it
- I also moved the cursor code to it's own plugin because there was starting to be too much cursor code outside the cursor file.

## Testing

- window_settings example still works with the custom cursor