### PR TITLE
Clear view attachments before resizing window surfaces

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -121,6 +121,10 @@ impl Plugin for ViewPlugin {
             render_app.add_systems(
                 Render,
                 (
+                    // In DX12 backend, `TextureView`s need to be released before reconfiguring window surfaces.
+                    clear_view_attachments
+                        .in_set(RenderSet::ManageViews)
+                        .before(create_surfaces),
                     prepare_view_attachments
                         .in_set(RenderSet::ManageViews)
                         .before(prepare_view_targets)
@@ -817,7 +821,6 @@ pub fn prepare_view_attachments(
     cameras: Query<&ExtractedCamera>,
     mut view_target_attachments: ResMut<ViewTargetAttachments>,
 ) {
-    view_target_attachments.clear();
     for camera in cameras.iter() {
         let Some(target) = &camera.target else {
             continue;
@@ -840,6 +843,11 @@ pub fn prepare_view_attachments(
             }
         };
     }
+}
+
+/// Clears the view target [`OutputColorAttachment`]s.
+pub fn clear_view_attachments(mut view_target_attachments: ResMut<ViewTargetAttachments>) {
+    view_target_attachments.clear();
 }
 
 pub fn prepare_view_targets(

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -121,7 +121,7 @@ impl Plugin for ViewPlugin {
             render_app.add_systems(
                 Render,
                 (
-                    // In DX12 backend, `TextureView`s need to be released before reconfiguring window surfaces.
+                    // `TextureView`s need to be dropped before reconfiguring window surfaces.
                     clear_view_attachments
                         .in_set(RenderSet::ManageViews)
                         .before(create_surfaces),


### PR DESCRIPTION
# Objective

- Fixes #15077

## Solution

- Clears `ViewTargetAttachments` resource every frame before `create_surfaces` system instead, which was previously done after `extract_windows`.

## Testing

- Confirmed that examples no longer panic on window resizing with DX12 backend.
- `screenshot` example keeps working after this change.