### PR TITLE
Fix comment in example

### DIFF
--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -40,7 +40,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // Store parent entity for next sections
         .id();
 
-    // Another way is to use the push_children function to add children after the parent
+    // Another way is to use the add_child function to add children after the parent
     // entity has already been spawned.
     let child = commands
         .spawn(SpriteBundle {


### PR DESCRIPTION
Commit 65252bb87 (Consistently use `PI` to specify angles in examples. (#5825)) changed from using push_children to add_child without adjusting the comment

# Objective

- Fix the comments to align with the code
