### PR TITLE
Improve type inference in `DynSystemParam::downcast()` by making the type parameter match the return value.

### DIFF
--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -545,11 +545,11 @@ mod tests {
             .build_state(&mut world)
             .build_system(
                 |mut p0: DynSystemParam, mut p1: DynSystemParam, mut p2: DynSystemParam| {
+                    let local = *p0.downcast_mut::<Local<usize>>().unwrap();
+                    let query_count = p1.downcast_mut::<Query<()>>().unwrap().iter().count();
+                    let _entities = p2.downcast_mut::<&Entities>().unwrap();
                     assert!(p0.downcast_mut::<Query<()>>().is_none());
-                    let local: Local<usize> = p0.downcast_mut().unwrap();
-                    let query: Query<()> = p1.downcast_mut().unwrap();
-                    let _entities: &Entities = p2.downcast_mut().unwrap();
-                    *local + query.iter().count()
+                    local + query_count
                 },
             );
 

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -545,11 +545,11 @@ mod tests {
             .build_state(&mut world)
             .build_system(
                 |mut p0: DynSystemParam, mut p1: DynSystemParam, mut p2: DynSystemParam| {
-                    let local = *p0.downcast_mut::<Local<usize>>().unwrap();
-                    let query_count = p1.downcast_mut::<Query<()>>().unwrap().iter().count();
-                    let _entities = p2.downcast_mut::<&Entities>().unwrap();
                     assert!(p0.downcast_mut::<Query<()>>().is_none());
-                    local + query_count
+                    let local: Local<usize> = p0.downcast_mut().unwrap();
+                    let query: Query<()> = p1.downcast_mut().unwrap();
+                    let _entities: &Entities = p2.downcast_mut().unwrap();
+                    *local + query.iter().count()
                 },
             );
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1944,8 +1944,12 @@ impl<'w, 's> DynSystemParam<'w, 's> {
     }
 
     /// Returns `true` if the inner system param is the same as `T`.
-    pub fn is<T: SystemParam + 'static>(&self) -> bool {
-        self.state.is::<ParamState<T>>()
+    pub fn is<T: SystemParam>(&self) -> bool
+    // See downcast() function for an explanation of the where clause
+    where
+        T::Item<'static, 'static>: SystemParam<Item<'w, 's> = T> + 'static,
+    {
+        self.state.is::<ParamState<T::Item<'static, 'static>>>()
     }
 
     /// Returns the inner system param if it is the correct type.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1894,7 +1894,9 @@ unsafe impl<T: ?Sized> ReadOnlySystemParam for PhantomData<T> {}
 ///     assert!(param.is::<Res<A>>());
 ///     assert!(!param.is::<Res<B>>());
 ///     assert!(param.downcast_mut::<Res<B>>().is_none());
-///     let foo: Res<A> = param.downcast::<Res<A>>().unwrap();
+///     let res = param.downcast_mut::<Res<A>>().unwrap();
+///     // The type parameter can be left out if it can be determined from use.
+///     let res: Res<A> = param.downcast().unwrap();
 /// }
 ///
 /// let system = (
@@ -1948,7 +1950,10 @@ impl<'w, 's> DynSystemParam<'w, 's> {
 
     /// Returns the inner system param if it is the correct type.
     /// This consumes the dyn param, so the returned param can have its original world and state lifetimes.
-    pub fn downcast<T: SystemParam + 'static>(self) -> Option<T::Item<'w, 's>> {
+    pub fn downcast<T: SystemParam>(self) -> Option<T>
+    where
+        T::Item<'static, 'static>: SystemParam<Item<'w, 's> = T> + 'static,
+    {
         // SAFETY:
         // - `DynSystemParam::new()` ensures `state` is a `ParamState<T>`, that the world matches,
         //   and that it has access required by the inner system param.
@@ -1958,7 +1963,10 @@ impl<'w, 's> DynSystemParam<'w, 's> {
 
     /// Returns the inner system parameter if it is the correct type.
     /// This borrows the dyn param, so the returned param is only valid for the duration of that borrow.
-    pub fn downcast_mut<T: SystemParam + 'static>(&mut self) -> Option<T::Item<'_, '_>> {
+    pub fn downcast_mut<'a, T: SystemParam>(&'a mut self) -> Option<T>
+    where
+        T::Item<'static, 'static>: SystemParam<Item<'a, 'a> = T> + 'static,
+    {
         // SAFETY:
         // - `DynSystemParam::new()` ensures `state` is a `ParamState<T>`, that the world matches,
         //   and that it has access required by the inner system param.
@@ -1971,9 +1979,10 @@ impl<'w, 's> DynSystemParam<'w, 's> {
     /// but since it only performs read access it can keep the original world lifetime.
     /// This can be useful with methods like [`Query::iter_inner()`] or [`Res::into_inner()`]
     /// to obtain references with the original world lifetime.
-    pub fn downcast_mut_inner<T: ReadOnlySystemParam + 'static>(
-        &mut self,
-    ) -> Option<T::Item<'w, '_>> {
+    pub fn downcast_mut_inner<'a, T: ReadOnlySystemParam>(&'a mut self) -> Option<T>
+    where
+        T::Item<'static, 'static>: SystemParam<Item<'w, 'a> = T> + 'static,
+    {
         // SAFETY:
         // - `DynSystemParam::new()` ensures `state` is a `ParamState<T>`, that the world matches,
         //   and that it has access required by the inner system param.
@@ -1988,19 +1997,24 @@ impl<'w, 's> DynSystemParam<'w, 's> {
 ///   in [`init_state`](SystemParam::init_state) for the inner system param.
 /// - `world` must be the same `World` that was used to initialize
 ///   [`state`](SystemParam::init_state) for the inner system param.
-unsafe fn downcast<'w, 's, T: SystemParam + 'static>(
+unsafe fn downcast<'w, 's, T: SystemParam>(
     state: &'s mut dyn Any,
     system_meta: &SystemMeta,
     world: UnsafeWorldCell<'w>,
     change_tick: Tick,
-) -> Option<T::Item<'w, 's>> {
-    state.downcast_mut::<ParamState<T>>().map(|state| {
-        // SAFETY:
-        // - The caller ensures the world has access for the underlying system param,
-        //   and since the downcast succeeded, the underlying system param is T.
-        // - The caller ensures the `world` matches.
-        unsafe { T::get_param(&mut state.0, system_meta, world, change_tick) }
-    })
+) -> Option<T>
+where
+    T::Item<'static, 'static>: SystemParam<Item<'w, 's> = T> + 'static,
+{
+    state
+        .downcast_mut::<ParamState<T::Item<'static, 'static>>>()
+        .map(|state| {
+            // SAFETY:
+            // - The caller ensures the world has access for the underlying system param,
+            //   and since the downcast succeeded, the underlying system param is T.
+            // - The caller ensures the `world` matches.
+            unsafe { T::Item::get_param(&mut state.0, system_meta, world, change_tick) }
+        })
 }
 
 /// The [`SystemParam::State`] for a [`DynSystemParam`].

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2337,4 +2337,12 @@ mod tests {
         schedule.add_systems((non_send_param_set, non_send_param_set, non_send_param_set));
         schedule.run(&mut world);
     }
+
+    fn _dyn_system_param_type_inference(mut p: DynSystemParam) {
+        // Make sure the downcast() methods are able to infer their type parameters from the use of the return type.
+        // This is just a compilation test, so there is nothing to run.
+        let _query: Query<()> = p.downcast_mut().unwrap();
+        let _query: Query<()> = p.downcast_mut_inner().unwrap();
+        let _query: Query<()> = p.downcast().unwrap();
+    }
 }


### PR DESCRIPTION
# Objective

Right now, `DynSystemParam::downcast()` always requires the type parameter to be specified with a turbofish.  Make it so that it can be inferred from the use of the return value, like: 

```rust
fn expects_res_a(mut param: DynSystemParam) {
    let res: Res<A> = param.downcast().unwrap();
}
```

## Solution

The reason this doesn't currently work is that the type parameter is a `'static` version of the `SystemParam` so that it can be used with `Any::downcast_mut()`.  Change the method signature so that the type parameter matches the return type, and use `T::Item<'static, 'static>` to get the `'static` version.  That means we wind up returning a `T::Item<'static, 'static>::Item<'w, 's>`, so constrain that to be equal to `T`.  That works with every `SystemParam` implementation, since they have `T::Item == T` up to lifetimes.  