### PR TITLE
Migrate `#[allow(...)]` to `#[expect(...)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ semicolon_if_nothing_returned = "warn"
 type_complexity = "allow"
 undocumented_unsafe_blocks = "warn"
 unwrap_or_default = "warn"
+allow_attributes_without_reason = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 use thread_local::ThreadLocal;
 use uuid::Uuid;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -40,7 +40,6 @@ pub(crate) enum AppError {
     DuplicatePlugin { plugin_name: String },
 }
 
-#[allow(clippy::needless_doctest_main)]
 /// [`App`] is the primary API for writing user applications. It automates the setup of a
 /// [standard lifecycle](Main) and provides interface glue for [plugins](`Plugin`).
 ///

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -27,7 +27,7 @@ pub use sub_app::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use terminal_ctrl_c_handler::*;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -27,7 +27,7 @@ pub use sub_app::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use terminal_ctrl_c_handler::*;
 
-#[expect(missing_docs)]
+#[expect(missing_docs, reason = "Documentation is not useful for this prelude.")]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -169,7 +169,7 @@ mod sealed {
             {
                 // We use `allow` instead of `expect` here because the lint is not generated for all cases.
                 #[allow(non_snake_case, reason = "`all_tuples!()` generates non-snake-case variable names.")]
-                #[allow(unused_variables, reason = "`app` is unused when implemented for unit `()` type.")]
+                #[allow(unused_variables, reason = "`app` is unused when implemented for the unit type `()`.")]
                 #[track_caller]
                 fn add_to_app(self, app: &mut App) {
                     let ($($plugins,)*) = self;

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -167,7 +167,9 @@ mod sealed {
             where
                 $($plugins: Plugins<$param>),*
             {
-                #[allow(non_snake_case, unused_variables)]
+                // We use `allow` instead of `expect` here because the lint is not generated for all cases.
+                #[allow(non_snake_case, reason = "`all_tuples!()` generates non-snake-case variable names.")]
+                #[allow(unused_variables, reason = "`app` is unused when implemented for unit `()` type.")]
                 #[track_caller]
                 fn add_to_app(self, app: &mut App) {
                     let ($($plugins,)*) = self;

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -279,7 +279,10 @@ impl PluginGroupBuilder {
     /// Adds the plugin [`Plugin`] at the end of this [`PluginGroupBuilder`]. If the plugin was
     /// already in the group, it is removed from its previous place.
     // This is not confusing, clippy!
-    #[allow(clippy::should_implement_trait)]
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "This does not emulate the `+` operator, but is more akin to pushing to a stack."
+    )]
     pub fn add<T: Plugin>(mut self, plugin: T) -> Self {
         let target_index = self.order.len();
         self.order.push(TypeId::of::<T>());

--- a/crates/bevy_asset/macros/src/lib.rs
+++ b/crates/bevy_asset/macros/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_macro_utils::BevyManifest;

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -30,7 +30,13 @@ impl EmbeddedAssetRegistry {
     /// running in a non-rust file). `asset_path` is the path that will be used to identify the asset in the `embedded`
     /// [`AssetSource`]. `value` is the bytes that will be returned for the asset. This can be _either_ a `&'static [u8]`
     /// or a [`Vec<u8>`].
-    #[allow(unused)]
+    #[cfg_attr(
+        not(feature = "embedded_watcher"),
+        expect(
+            unused_variables,
+            reason = "The `full_path` argument is not used when `embedded_watcher` is disabled."
+        )
+    )]
     pub fn insert_asset(&self, full_path: PathBuf, asset_path: &Path, value: impl Into<Value>) {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
@@ -43,7 +49,13 @@ impl EmbeddedAssetRegistry {
     /// running in a non-rust file). `asset_path` is the path that will be used to identify the asset in the `embedded`
     /// [`AssetSource`]. `value` is the bytes that will be returned for the asset. This can be _either_ a `&'static [u8]`
     /// or a [`Vec<u8>`].
-    #[allow(unused)]
+    #[cfg_attr(
+        not(feature = "embedded_watcher"),
+        expect(
+            unused_variables,
+            reason = "The `full_path` argument is not used when `embedded_watcher` is disabled."
+        )
+    )]
     pub fn insert_meta(&self, full_path: &Path, asset_path: &Path, value: impl Into<Value>) {
         #[cfg(feature = "embedded_watcher")]
         self.root_paths
@@ -61,10 +73,17 @@ impl EmbeddedAssetRegistry {
 
     /// Registers a `embedded` [`AssetSource`] that uses this [`EmbeddedAssetRegistry`].
     // NOTE: unused_mut because embedded_watcher feature is the only mutable consumer of `let mut source`
-    #[allow(unused_mut)]
     pub fn register_source(&self, sources: &mut AssetSourceBuilders) {
         let dir = self.dir.clone();
         let processed_dir = self.dir.clone();
+
+        #[cfg_attr(
+            not(feature = "embedded_watcher"),
+            expect(
+                unused_mut,
+                reason = "Variable is only mutated when `embedded_watcher` feature is enabled."
+            )
+        )]
         let mut source = AssetSource::build()
             .with_reader(move || Box::new(MemoryAssetReader { root: dir.clone() }))
             .with_processed_reader(move || {

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -11,8 +11,7 @@ use thiserror::Error;
 
 use super::{ErasedAssetReader, ErasedAssetWriter};
 
-// Needed for doc strings.
-#[allow(unused_imports)]
+#[allow(unused_imports, reason = "Needed for documentation links.")]
 use crate::io::{AssetReader, AssetWriter};
 
 /// A reference to an "asset source", which maps to an [`AssetReader`] and/or [`AssetWriter`].
@@ -508,7 +507,17 @@ impl AssetSource {
     /// `file_debounce_time` is the amount of time to wait (and debounce duplicate events) before returning an event.
     /// Higher durations reduce duplicates but increase the amount of time before a change event is processed. If the
     /// duration is set too low, some systems might surface events _before_ their filesystem has the changes.
-    #[allow(unused)]
+    #[cfg_attr(
+        any(
+            not(feature = "file_watcher"),
+            target_arch = "wasm32",
+            target_os = "android"
+        ),
+        expect(
+            unused_variables,
+            reason = "The `path` and `file_debounce_wait_time` arguments are unused when on WASM, Android, or if the `file_watcher` feature is disabled."
+        )
+    )]
     pub fn get_default_watcher(
         path: String,
         file_debounce_wait_time: Duration,

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -252,7 +252,7 @@ impl ErasedLoadedAsset {
 
     /// Cast this loaded asset as the given type. If the type does not match,
     /// the original type-erased asset is returned.
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err, reason = "Function returns `Self` on error.")]
     pub fn downcast<A: Asset>(mut self) -> Result<LoadedAsset<A>, ErasedLoadedAsset> {
         match self.value.downcast::<A>() {
             Ok(value) => Ok(LoadedAsset {

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -37,7 +37,7 @@ use std::{
 use thiserror::Error;
 
 // Needed for doc strings
-#[allow(unused_imports)]
+#[allow(unused_imports, reason = "Needed for documentation links.")]
 use crate::io::{AssetReader, AssetWriter};
 
 /// A "background" asset processor that reads asset values from a source [`AssetSource`] (which corresponds to an [`AssetReader`] / [`AssetWriter`] pair),
@@ -516,7 +516,13 @@ impl AssetProcessor {
     /// This info will later be used to determine whether or not to re-process an asset
     ///
     /// This will validate transactions and recover failed transactions when necessary.
-    #[allow(unused)]
+    #[cfg_attr(
+        any(target_arch = "wasm32", not(feature = "multi_threaded")),
+        expect(
+            dead_code,
+            reason = "This function is only used when the `multi_threade` feature is enabled, and when not on WASM."
+        )
+    )]
     async fn initialize(&self) -> Result<(), InitializeError> {
         self.validate_transaction_log_and_recover().await;
         let mut asset_infos = self.data.asset_infos.write().await;

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -111,7 +111,10 @@ impl AssetInfos {
         .unwrap()
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Arguments needed so that both `create_loading_handle_untyped()` and `get_or_create_path_handle_internal()` may share code."
+    )]
     fn create_handle_internal(
         infos: &mut HashMap<UntypedAssetId, AssetInfo>,
         handle_providers: &TypeIdMap<AssetHandleProvider>,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -32,8 +32,7 @@ use std::{any::TypeId, path::Path, sync::Arc};
 use std::{future::Future, panic::AssertUnwindSafe};
 use thiserror::Error;
 
-// Needed for doc string
-#[allow(unused_imports)]
+#[allow(unused_imports, reason = "Needed for documentation links.")]
 use crate::io::{AssetReader, AssetWriter};
 
 /// Loads and tracks the state of [`Asset`] values from a configured [`AssetReader`]. This can be used to kick off new asset loads and
@@ -1335,7 +1334,6 @@ pub fn handle_internal_asset_events(world: &mut World) {
 }
 
 /// Internal events for asset load results
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum InternalAssetEvent {
     Loaded {
         id: UntypedAssetId,

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -33,7 +33,7 @@ mod audio_source;
 mod pitch;
 mod sinks;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(

--- a/crates/bevy_core_pipeline/src/skybox/prepass.rs
+++ b/crates/bevy_core_pipeline/src/skybox/prepass.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 //! Adds motion vector support to skyboxes. See [`SkyboxPrepassPipeline`] for details.
 
 use bevy_asset::Handle;

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![doc(

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate proc_macro;

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -104,7 +104,6 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
     let read_only_struct_name = if attributes.is_mutable {
         Ident::new(&format!("{struct_name}ReadOnly"), Span::call_site())
     } else {
-        #[allow(clippy::redundant_clone)]
         struct_name.clone()
     };
 
@@ -112,7 +111,6 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
     let read_only_item_struct_name = if attributes.is_mutable {
         Ident::new(&format!("{struct_name}ReadOnlyItem"), Span::call_site())
     } else {
-        #[allow(clippy::redundant_clone)]
         item_struct_name.clone()
     };
 
@@ -122,7 +120,6 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
         let new_ident = Ident::new(&format!("{struct_name}ReadOnlyFetch"), Span::call_site());
         ensure_no_collision(new_ident, tokens.clone())
     } else {
-        #[allow(clippy::redundant_clone)]
         fetch_struct_name.clone()
     };
 

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -2,7 +2,7 @@ use proc_macro2::Ident;
 use quote::quote;
 use syn::{Attribute, Fields, ImplGenerics, TypeGenerics, Visibility, WhereClause};
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments, reason = "Required to generate the entire item structure.")]
 pub(crate) fn item_struct(
     path: &syn::Path,
     fields: &Fields,
@@ -52,7 +52,7 @@ pub(crate) fn item_struct(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments, reason = "Required to generate the entire world query implementation.")]
 pub(crate) fn world_query_impl(
     path: &syn::Path,
     struct_name: &Ident,

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -2,7 +2,10 @@ use proc_macro2::Ident;
 use quote::quote;
 use syn::{Attribute, Fields, ImplGenerics, TypeGenerics, Visibility, WhereClause};
 
-#[expect(clippy::too_many_arguments, reason = "Required to generate the entire item structure.")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Required to generate the entire item structure."
+)]
 pub(crate) fn item_struct(
     path: &syn::Path,
     fields: &Fields,
@@ -52,7 +55,10 @@ pub(crate) fn item_struct(
     }
 }
 
-#[expect(clippy::too_many_arguments, reason = "Required to generate the entire world query implementation.")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Required to generate the entire world query implementation."
+)]
 pub(crate) fn world_query_impl(
     path: &syn::Path,
     struct_name: &Ident,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1893,7 +1893,7 @@ impl ScheduleGraph {
         &'a self,
         ambiguities: &'a [(NodeId, NodeId, Vec<ComponentId>)],
         components: &'a Components,
-    ) -> impl Iterator<Item = (String, String, Vec<&str>)> + 'a {
+    ) -> impl Iterator<Item = (String, String, Vec<&'a str>)> + 'a {
         ambiguities
             .iter()
             .map(move |(system_a, system_b, conflicts)| {

--- a/crates/bevy_encase_derive/src/lib.rs
+++ b/crates/bevy_encase_derive/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -65,7 +65,10 @@ use {bevy_ecs::system::Resource, bevy_utils::synccell::SyncCell};
 /// Wrapper resource for `tracing-chrome`'s flush guard.
 /// When the guard is dropped the chrome log is written to file.
 #[cfg(feature = "tracing-chrome")]
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "`FlushGuard` never needs to be read, it just needs to be kept alive for the `App`'s lifetime."
+)]
 #[derive(Resource)]
 pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 
@@ -185,7 +188,6 @@ impl Default for LogPlugin {
 }
 
 impl Plugin for LogPlugin {
-    #[cfg_attr(not(feature = "tracing-chrome"), allow(unused_variables))]
     fn build(&self, app: &mut App) {
         #[cfg(feature = "trace")]
         {

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -4,8 +4,7 @@
     clippy::undocumented_unsafe_blocks,
     clippy::ptr_cast_constness
 )]
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(unsafe_code)]
 #![doc(

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -82,7 +82,7 @@ pub struct PointerHits {
 }
 
 impl PointerHits {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(pointer: prelude::PointerId, picks: Vec<(Entity, HitData)>, order: f32) -> Self {
         Self {
             pointer,
@@ -110,7 +110,7 @@ pub struct HitData {
 }
 
 impl HitData {
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn new(camera: Entity, depth: f32, position: Option<Vec3>, normal: Option<Vec3>) -> Self {
         Self {
             camera,

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![allow(unsafe_code)]
+#![expect(unsafe_code, reason = "Raw pointers are inherently unsafe.")]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -312,7 +312,6 @@ impl<'a, A: IsAligned> Ptr<'a, A> {
     /// If possible, it is strongly encouraged to use [`deref`](Self::deref) over this function,
     /// as it retains the lifetime.
     #[inline]
-    #[allow(clippy::wrong_self_convention)]
     pub fn as_ptr(self) -> *mut u8 {
         self.0.as_ptr()
     }
@@ -368,7 +367,6 @@ impl<'a, A: IsAligned> PtrMut<'a, A> {
     /// If possible, it is strongly encouraged to use [`deref_mut`](Self::deref_mut) over
     /// this function, as it retains the lifetime.
     #[inline]
-    #[allow(clippy::wrong_self_convention)]
     pub fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }
@@ -455,7 +453,6 @@ impl<'a, A: IsAligned> OwningPtr<'a, A> {
     /// If possible, it is strongly encouraged to use the other more type-safe functions
     /// over this function.
     #[inline]
-    #[allow(clippy::wrong_self_convention)]
     pub fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }

--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -434,7 +434,10 @@ impl ContainerAttributes {
     }
 
     /// The `FromReflect` configuration found within `#[reflect(...)]` attributes on this type.
-    #[expect(clippy::wrong_self_convention, reason = "Method returns `FromReflectAttrs`, does not actually convert data.")]
+    #[expect(
+        clippy::wrong_self_convention,
+        reason = "Method returns `FromReflectAttrs`, does not actually convert data."
+    )]
     pub fn from_reflect_attrs(&self) -> &FromReflectAttrs {
         &self.from_reflect_attrs
     }

--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -434,7 +434,7 @@ impl ContainerAttributes {
     }
 
     /// The `FromReflect` configuration found within `#[reflect(...)]` attributes on this type.
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention, reason = "Method returns `FromReflectAttrs`, does not actually convert data.")]
     pub fn from_reflect_attrs(&self) -> &FromReflectAttrs {
         &self.from_reflect_attrs
     }

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -564,7 +564,7 @@ impl<'a> StructField<'a> {
         let ty = self.reflected_type();
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[expect(
+        #[allow(
             unused_mut,
             reason = "Needs to be mutable if `documentation` feature is enabled."
         )]
@@ -679,7 +679,7 @@ impl<'a> ReflectStruct<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[expect(
+        #[allow(
             unused_mut,
             reason = "Needs to be mutable if `documentation` feature is enabled."
         )]
@@ -779,7 +779,7 @@ impl<'a> ReflectEnum<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[expect(
+        #[allow(
             unused_mut,
             reason = "Needs to be mutable if `documentation` feature is enabled."
         )]
@@ -852,7 +852,7 @@ impl<'a> EnumVariant<'a> {
 
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[expect(
+        #[allow(
             unused_mut,
             reason = "Needs to be mutable if `documentation` feature is enabled."
         )]

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -121,10 +121,9 @@ pub(crate) struct EnumVariant<'a> {
     /// The fields within this variant.
     pub fields: EnumVariantFields<'a>,
     /// The reflection-based attributes on the variant.
-    #[allow(dead_code)]
     pub attrs: FieldAttributes,
     /// The index of this variant within the enum.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "TODO(MrGVSV): Why should this be kept?")]
     pub index: usize,
     /// The documentation for this variant, if any
     #[cfg(feature = "documentation")]
@@ -491,7 +490,7 @@ impl<'a> ReflectMeta<'a> {
     }
 
     /// The `FromReflect` attributes on this type.
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention, reason = "Method returns `FromReflectAttrs`, does not actually convert data.")]
     pub fn from_reflect(&self) -> &FromReflectAttrs {
         self.attrs.from_reflect_attrs()
     }
@@ -562,7 +561,7 @@ impl<'a> StructField<'a> {
         let ty = self.reflected_type();
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[allow(unused_mut)] // Needs mutability for the feature gate
+        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
         let mut info = quote! {
             #field_info::new::<#ty>(#name).with_custom_attributes(#custom_attributes)
         };
@@ -674,7 +673,7 @@ impl<'a> ReflectStruct<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[allow(unused_mut)] // Needs mutability for the feature gate
+        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new::<Self>(&[
                 #(#field_infos),*
@@ -771,7 +770,7 @@ impl<'a> ReflectEnum<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[allow(unused_mut)] // Needs mutability for the feature gate
+        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
         let mut info = quote! {
             #bevy_reflect_path::EnumInfo::new::<Self>(&[
                 #(#variants),*
@@ -802,7 +801,6 @@ impl<'a> EnumVariant<'a> {
     }
 
     /// The complete set of fields in this variant.
-    #[allow(dead_code)]
     pub fn fields(&self) -> &[StructField<'a>] {
         match &self.fields {
             EnumVariantFields::Named(fields) | EnumVariantFields::Unnamed(fields) => fields,
@@ -842,7 +840,7 @@ impl<'a> EnumVariant<'a> {
 
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[allow(unused_mut)] // Needs mutability for the feature gate
+        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new(#args)
                 .with_custom_attributes(#custom_attributes)
@@ -922,8 +920,7 @@ pub(crate) enum ReflectTypePath<'a> {
         generics: &'a Generics,
     },
     /// Any [`Type`] with only a defined `type_path` and `short_type_path`.
-    #[allow(dead_code)]
-    // Not currently used but may be useful in the future due to its generality.
+    #[expect(dead_code, reason = "Not current used but may be useful in the future due to its generality.")]
     Anonymous {
         qualified_type: Type,
         long_type_path: StringExpr,

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -564,9 +564,12 @@ impl<'a> StructField<'a> {
         let ty = self.reflected_type();
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[allow(
-            unused_mut,
-            reason = "Needs to be mutable if `documentation` feature is enabled."
+        #[cfg_attr(
+            not(feature = "documentation"),
+            expect(
+                unused_mut,
+                reason = "Needs to be mutable if `documentation` feature is enabled.",
+            )
         )]
         let mut info = quote! {
             #field_info::new::<#ty>(#name).with_custom_attributes(#custom_attributes)
@@ -679,9 +682,12 @@ impl<'a> ReflectStruct<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[allow(
-            unused_mut,
-            reason = "Needs to be mutable if `documentation` feature is enabled."
+        #[cfg_attr(
+            not(feature = "documentation"),
+            expect(
+                unused_mut,
+                reason = "Needs to be mutable if `documentation` feature is enabled.",
+            )
         )]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new::<Self>(&[
@@ -779,9 +785,12 @@ impl<'a> ReflectEnum<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[allow(
-            unused_mut,
-            reason = "Needs to be mutable if `documentation` feature is enabled."
+        #[cfg_attr(
+            not(feature = "documentation"),
+            expect(
+                unused_mut,
+                reason = "Needs to be mutable if `documentation` feature is enabled.",
+            )
         )]
         let mut info = quote! {
             #bevy_reflect_path::EnumInfo::new::<Self>(&[
@@ -852,9 +861,12 @@ impl<'a> EnumVariant<'a> {
 
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[allow(
-            unused_mut,
-            reason = "Needs to be mutable if `documentation` feature is enabled."
+        #[cfg_attr(
+            not(feature = "documentation"),
+            expect(
+                unused_mut,
+                reason = "Needs to be mutable if `documentation` feature is enabled.",
+            )
         )]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new(#args)

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -490,7 +490,10 @@ impl<'a> ReflectMeta<'a> {
     }
 
     /// The `FromReflect` attributes on this type.
-    #[expect(clippy::wrong_self_convention, reason = "Method returns `FromReflectAttrs`, does not actually convert data.")]
+    #[expect(
+        clippy::wrong_self_convention,
+        reason = "Method returns `FromReflectAttrs`, does not actually convert data."
+    )]
     pub fn from_reflect(&self) -> &FromReflectAttrs {
         self.attrs.from_reflect_attrs()
     }
@@ -561,7 +564,10 @@ impl<'a> StructField<'a> {
         let ty = self.reflected_type();
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
+        #[expect(
+            unused_mut,
+            reason = "Needs to be mutable if `documentation` feature is enabled."
+        )]
         let mut info = quote! {
             #field_info::new::<#ty>(#name).with_custom_attributes(#custom_attributes)
         };
@@ -673,7 +679,10 @@ impl<'a> ReflectStruct<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
+        #[expect(
+            unused_mut,
+            reason = "Needs to be mutable if `documentation` feature is enabled."
+        )]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new::<Self>(&[
                 #(#field_infos),*
@@ -770,7 +779,10 @@ impl<'a> ReflectEnum<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
+        #[expect(
+            unused_mut,
+            reason = "Needs to be mutable if `documentation` feature is enabled."
+        )]
         let mut info = quote! {
             #bevy_reflect_path::EnumInfo::new::<Self>(&[
                 #(#variants),*
@@ -840,7 +852,10 @@ impl<'a> EnumVariant<'a> {
 
         let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
 
-        #[expect(unused_mut, reason = "Needs to be mutable if `documentation` feature is enabled.")]
+        #[expect(
+            unused_mut,
+            reason = "Needs to be mutable if `documentation` feature is enabled."
+        )]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new(#args)
                 .with_custom_attributes(#custom_attributes)
@@ -920,7 +935,10 @@ pub(crate) enum ReflectTypePath<'a> {
         generics: &'a Generics,
     },
     /// Any [`Type`] with only a defined `type_path` and `short_type_path`.
-    #[expect(dead_code, reason = "Not current used but may be useful in the future due to its generality.")]
+    #[expect(
+        dead_code,
+        reason = "Not current used but may be useful in the future due to its generality."
+    )]
     Anonymous {
         qualified_type: Type,
         long_type_path: StringExpr,

--- a/crates/bevy_reflect/derive/src/reflect_value.rs
+++ b/crates/bevy_reflect/derive/src/reflect_value.rs
@@ -25,7 +25,7 @@ use syn::{parenthesized, Attribute, Generics, Path};
 /// (in my_crate::bar) Bar(TraitA, TraitB)
 /// ```
 pub(crate) struct ReflectValueDef {
-    #[expect(dead_code, reason = "TODO(MrGVSV): Why should this be kept?")]
+    #[allow(dead_code, reason = "The is used when the `documentation` feature is enabled.")]
     pub attrs: Vec<Attribute>,
     pub type_path: Path,
     pub generics: Generics,

--- a/crates/bevy_reflect/derive/src/reflect_value.rs
+++ b/crates/bevy_reflect/derive/src/reflect_value.rs
@@ -25,7 +25,7 @@ use syn::{parenthesized, Attribute, Generics, Path};
 /// (in my_crate::bar) Bar(TraitA, TraitB)
 /// ```
 pub(crate) struct ReflectValueDef {
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "TODO(MrGVSV): Why should this be kept?")]
     pub attrs: Vec<Attribute>,
     pub type_path: Path,
     pub generics: Generics,

--- a/crates/bevy_reflect/derive/src/reflect_value.rs
+++ b/crates/bevy_reflect/derive/src/reflect_value.rs
@@ -25,7 +25,13 @@ use syn::{parenthesized, Attribute, Generics, Path};
 /// (in my_crate::bar) Bar(TraitA, TraitB)
 /// ```
 pub(crate) struct ReflectValueDef {
-    #[allow(dead_code, reason = "The is used when the `documentation` feature is enabled.")]
+    #[cfg_attr(
+        not(feature = "documentation"),
+        expect(
+            dead_code,
+            reason = "The is used when the `documentation` feature is enabled.",
+        )
+    )]
     pub attrs: Vec<Attribute>,
     pub type_path: Path,
     pub generics: Generics,

--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -7,7 +7,6 @@ use quote::quote;
 use syn::Type;
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn impl_get_type_registration<'a>(
     meta: &ReflectMeta,
     where_clause_options: &WhereClauseOptions,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 // `rustdoc_internals` is needed for `#[doc(fake_variadics)]`
 #![allow(internal_features)]
 #![cfg_attr(any(docsrs, docsrs_dep), feature(doc_auto_cfg, rustdoc_internals))]

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod as_bind_group;

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![allow(unsafe_code)]
 // `rustdoc_internals` is needed for `#[doc(fake_variadics)]`
 #![allow(internal_features)]

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -34,7 +34,7 @@ pub use scene_filter::*;
 pub use scene_loader::*;
 pub use scene_spawner::*;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![doc(

--- a/crates/bevy_state/macros/src/lib.rs
+++ b/crates/bevy_state/macros/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate proc_macro;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -44,7 +44,7 @@ pub use iter::ParallelIterator;
 
 pub use futures_lite;
 
-#[expect(missing_docs)]
+#[expect(missing_docs, reason = "Documentation is not useful for this prelude.")]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -44,7 +44,7 @@ pub use iter::ParallelIterator;
 
 pub use futures_lite;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -68,7 +68,6 @@ impl TaskPool {
         TaskPoolBuilder::new().build()
     }
 
-    #[allow(unused_variables)]
     fn new_internal() -> Self {
         Self {}
     }
@@ -96,7 +95,7 @@ impl TaskPool {
     /// to spawn tasks. This function will await the completion of all tasks before returning.
     ///
     /// This is similar to `rayon::scope` and `crossbeam::scope`
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code, reason = "Required to transmute lifetimes.")]
     pub fn scope_with_executor<'env, F, T>(
         &self,
         _tick_task_pool_executor: bool,

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -330,7 +330,7 @@ impl TaskPool {
         })
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code, reason = "Required to transmute lifetimes.")]
     fn scope_with_executor_inner<'env, F, T>(
         &self,
         tick_task_pool_executor: bool,

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -11,7 +11,6 @@ pub mod common_conditions;
 mod fixed;
 mod real;
 mod stopwatch;
-#[allow(clippy::module_inception)]
 mod time;
 mod timer;
 mod virt;
@@ -42,9 +41,9 @@ use crossbeam_channel::{Receiver, Sender};
 #[derive(Default)]
 pub struct TimePlugin;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 /// Updates the elapsed time. Any system that interacts with [`Time`] component should run after
 /// this.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 pub struct TimeSystem;
 
 impl Plugin for TimePlugin {

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -79,7 +79,7 @@ pub fn propagate_transforms(
                 // - Since each root entity is unique and the hierarchy is consistent and forest-like,
                 //   other root entities' `propagate_recursive` calls will not conflict with this one.
                 // - Since this is the only place where `transform_query` gets used, there will be no conflicting fetches elsewhere.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code, reason = "`propagate_recursive() is unsafe due to its use of `Query::get_unchecked()`.")]
                 unsafe {
                     propagate_recursive(
                         &global_transform,
@@ -107,7 +107,10 @@ pub fn propagate_transforms(
 ///     nor any of its descendants.
 /// - The caller must ensure that the hierarchy leading to `entity`
 ///     is well-formed and must remain as a tree or a forest. Each entity must have at most one parent.
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "This function uses `Query::get_unchecked()`, which can result in multiple mutable references if the preconditions are not met."
+)]
 unsafe fn propagate_recursive(
     parent: &GlobalTransform,
     transform_query: &Query<

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",

--- a/crates/bevy_utils/macros/src/lib.rs
+++ b/crates/bevy_utils/macros/src/lib.rs
@@ -1,5 +1,4 @@
-// FIXME(3492): remove once docs are ready
-#![allow(missing_docs)]
+#![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use proc_macro::TokenStream;

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![allow(unsafe_code)]
+#![expect(
+    unsafe_code,
+    reason = "Some utilities, such as futures and cells, require unsafe code."
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -10,7 +13,7 @@
 //! [Bevy]: https://bevyengine.org/
 //!
 
-#[expect(missing_docs)]
+#[expect(missing_docs, reason = "Documentation is not useful for this prelude.")]
 pub mod prelude {
     pub use crate::default;
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -10,7 +10,7 @@
 //! [Bevy]: https://bevyengine.org/
 //!
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     pub use crate::default;
 }
@@ -54,7 +54,7 @@ mod conditional_send {
 }
 
 #[cfg(target_arch = "wasm32")]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 mod conditional_send {
     pub trait ConditionalSend {}
     impl<T> ConditionalSend for T {}

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -432,7 +432,7 @@ impl AppLifecycle {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum WindowEvent {
     AppLifecycle(AppLifecycle),
     CursorEntered(CursorEntered),

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -30,7 +30,7 @@ pub use system::*;
 pub use system_cursor::*;
 pub use window::*;
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod prelude {
     #[allow(deprecated)]
     #[doc(hidden)]


### PR DESCRIPTION
# Objective

- Rust 1.81 released the `#[expect(...)]` attribute, which works like `#[allow(...)]` but throws a warning if the lint _isn't_ raised. This is preferred to `#[allow(...)]` because it tells us when it can be removed.
- Closes #15059.

## Solution

Switch all applicable `#[allow(...)]` attributes to `#[expect(...)]` with a reason attribute.

### Progress

- [x] `bevy_ptr`
- [x] `bevy_utils`
- [x] `bevy_reflect`
- [x] `bevy_tasks`
- [x] `bevy_ecs`
- [x] `bevy_derive`
- [x] `bevy_app`
- [x] `bevy_reflect_derive`
- [x] `bevy_asset_macros`
- [x] `bevy_encase_derive`
- [x] `bevy_render_macros`
- [x] `bevy_state_macros`
- [x] `bevy_log`
- [x] `bevy_time`
- [x] `bevy_diagnostic`
- [x] `bevy_transform`
- [x] `bevy_asset`
- [ ] `bevy_input`
- [ ] `bevy_gilrs`
- [ ] `bevy_window`
- [ ] `bevy_winit`
- [ ] `bevy_state`
- [ ] `bevy_render`
- [ ] `bevy_picking`
- [ ] `bevy_core_pipeline`
- [ ] `bevy_sprite`
- [ ] `bevy_text`
- [ ] `bevy_pbr`
- [ ] `bevy_ui`
- [ ] `bevy_gltf`
- [ ] `bevy_gizmos`
- [ ] `bevy_dev_tools`
- [ ] `bevy_internal`
- [ ] `bevy_dylib`

## Testing

- `cargo clippy --workspace --all-features`
