### PR TITLE
Remove `ReceivedCharacter`

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -9,7 +9,6 @@ use bevy_input::{
 };
 use bevy_math::{IVec2, Vec2};
 use bevy_reflect::Reflect;
-use smol_str::SmolStr;
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use std::path::PathBuf;
 
 use bevy_ecs::{entity::Entity, event::Event};
@@ -190,22 +189,6 @@ pub struct CursorLeft {
     pub window: Entity,
 }
 
-/// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[deprecated(since = "0.14.0", note = "Use `KeyboardInput` instead.")]
-#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
-    reflect(Serialize, Deserialize)
-)]
-pub struct ReceivedCharacter {
-    /// Window that received the character.
-    pub window: Entity,
-    /// Received character.
-    pub char: SmolStr,
-}
-
 /// A Input Method Editor event.
 ///
 /// This event is the translated version of the `WindowEvent::Ime` from the `winit` crate.
@@ -239,8 +222,7 @@ pub enum Ime {
     },
     /// Notifies when the IME was enabled.
     ///
-    /// After this event, you will receive events `Ime::Preedit` and `Ime::Commit`,
-    /// and stop receiving events [`ReceivedCharacter`].
+    /// After this event, you will receive events `Ime::Preedit` and `Ime::Commit`.
     Enabled {
         /// Window that received the event.
         window: Entity,
@@ -440,7 +422,6 @@ pub enum WindowEvent {
     CursorMoved(CursorMoved),
     FileDragAndDrop(FileDragAndDrop),
     Ime(Ime),
-    ReceivedCharacter(ReceivedCharacter),
     RequestRedraw(RequestRedraw),
     WindowBackendScaleFactorChanged(WindowBackendScaleFactorChanged),
     WindowCloseRequested(WindowCloseRequested),
@@ -496,11 +477,6 @@ impl From<FileDragAndDrop> for WindowEvent {
 impl From<Ime> for WindowEvent {
     fn from(e: Ime) -> Self {
         Self::Ime(e)
-    }
-}
-impl From<ReceivedCharacter> for WindowEvent {
-    fn from(e: ReceivedCharacter) -> Self {
-        Self::ReceivedCharacter(e)
     }
 }
 impl From<RequestRedraw> for WindowEvent {

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -34,12 +34,10 @@ pub use window::*;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[allow(deprecated)]
     #[doc(hidden)]
     pub use crate::{
-        CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime, MonitorSelection,
-        ReceivedCharacter, Window, WindowMoved, WindowPlugin, WindowPosition,
-        WindowResizeConstraints,
+        CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime, MonitorSelection, Window,
+        WindowMoved, WindowPlugin, WindowPosition, WindowResizeConstraints,
     };
 }
 
@@ -92,7 +90,6 @@ pub struct WindowPlugin {
 impl Plugin for WindowPlugin {
     fn build(&self, app: &mut App) {
         // User convenience events
-        #[allow(deprecated)]
         app.add_event::<WindowEvent>()
             .add_event::<WindowResized>()
             .add_event::<WindowCreated>()
@@ -104,7 +101,6 @@ impl Plugin for WindowPlugin {
             .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()
             .add_event::<CursorLeft>()
-            .add_event::<ReceivedCharacter>()
             .add_event::<Ime>()
             .add_event::<WindowFocused>()
             .add_event::<WindowOccluded>()
@@ -145,7 +141,6 @@ impl Plugin for WindowPlugin {
         }
 
         // Register event types
-        #[allow(deprecated)]
         app.register_type::<WindowEvent>()
             .register_type::<WindowResized>()
             .register_type::<RequestRedraw>()
@@ -156,7 +151,6 @@ impl Plugin for WindowPlugin {
             .register_type::<CursorMoved>()
             .register_type::<CursorEntered>()
             .register_type::<CursorLeft>()
-            .register_type::<ReceivedCharacter>()
             .register_type::<WindowFocused>()
             .register_type::<WindowOccluded>()
             .register_type::<WindowScaleFactorChanged>()

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -227,7 +227,6 @@ pub struct Window {
     /// Should the window use Input Method Editor?
     ///
     /// If enabled, the window will receive [`Ime`](crate::Ime) events instead of
-    /// [`ReceivedCharacter`](crate::ReceivedCharacter) or
     /// `KeyboardInput` from `bevy_input`.
     ///
     /// IME should be enabled during text input, but not when you expect to get the exact key pressed.

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -22,7 +22,6 @@ pub use winit::platform::android::activity as android_activity;
 use bevy_a11y::AccessibilityRequested;
 use bevy_app::{App, Last, Plugin};
 use bevy_ecs::prelude::*;
-#[allow(deprecated)]
 use bevy_window::{exit_on_all_closed, Window, WindowCreated};
 pub use converters::convert_system_cursor_icon;
 pub use state::{CursorSource, CustomCursorCache, CustomCursorCacheKey, PendingCursor};

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -24,10 +24,9 @@ use winit::event::{DeviceEvent, DeviceId, StartCause, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::window::WindowId;
 
-#[allow(deprecated)]
 use bevy_window::{
-    AppLifecycle, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime, ReceivedCharacter,
-    RequestRedraw, Window, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowDestroyed,
+    AppLifecycle, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime, RequestRedraw,
+    Window, WindowBackendScaleFactorChanged, WindowCloseRequested, WindowDestroyed,
     WindowEvent as BevyWindowEvent, WindowFocused, WindowMoved, WindowOccluded, WindowResized,
     WindowScaleFactorChanged, WindowThemeChanged,
 };
@@ -272,14 +271,6 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 // properly releasing keys when the window loses focus.
                 if !(is_synthetic && event.state.is_pressed()) {
                     // Process the keyboard input event, as long as it's not a synthetic key press.
-                    if event.state.is_pressed() {
-                        if let Some(char) = &event.text {
-                            let char = char.clone();
-                            #[allow(deprecated)]
-                            self.bevy_window_events
-                                .send(ReceivedCharacter { window, char });
-                        }
-                    }
                     self.bevy_window_events
                         .send(converters::convert_keyboard_input(event, window));
                 }
@@ -714,9 +705,6 @@ impl<T: Event> WinitAppRunnerState<T> {
                     world.send_event(e);
                 }
                 BevyWindowEvent::Ime(e) => {
-                    world.send_event(e);
-                }
-                BevyWindowEvent::ReceivedCharacter(e) => {
                     world.send_event(e);
                 }
                 BevyWindowEvent::RequestRedraw(e) => {


### PR DESCRIPTION
# Objective

- Fixes #12639.
- `ReceivedCharacter` was deprecated in #12868 for 0.14, and should be removed for 0.15.

## Solution

- Remove all instances of `ReceivedCharacter`, including the relevant `#[allow(deprecated)]` lint attributes.

## Migration Guide

`ReceivedCharacter` was deprecated in 0.14 due to `winit` reworking their keyboard system. It has now been fully removed. Switch to using `KeyboardInput` instead.

```rust
// 0.14
fn listen_characters(events: EventReader<ReceivedCharacter>) {
    for event in events.read() {
        info!("{}", event.char);
    }
}

// 0.15
fn listen_characters(events: EventReader<KeyboardInput>) {
    for event in events.read() {
        // Only check for characters when the key is pressed.
        if !event.state.is_pressed() {
            continue;
        }

        // Note that some keys such as `Space` and `Tab` won't be detected as a character.
        // Instead, check for them as separate enum variants.
        match &event.logical_key {
            Key::Character(character) => {
                info!("{} pressed.", character);
            },
            Key::Space => {
                info!("Space pressed.");
            },
            _ => {},
        }
    }
}
```
