### PR TITLE
Added `DelayedCommands`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -176,6 +176,15 @@ impl<'w, 's> Commands<'w, 's> {
         Self::new_from_entities(queue, &world.entities)
     }
 
+    /// Creates a new `Commands` instance from a [`CommandQueue`] and an existing `Commands`.
+    ///
+    /// It is not required to call this constructor when using `Commands` as a [system parameter].
+    ///
+    /// [system parameter]: crate::system::SystemParam
+    pub fn new_from_commands<'x>(queue: &'s mut CommandQueue, commands: &Commands<'w, 'x>) -> Self {
+        Self::new_from_entities(queue, commands.entities)
+    }
+
     /// Returns a new `Commands` instance from a [`CommandQueue`] and an [`Entities`] reference.
     ///
     /// It is not required to call this constructor when using `Commands` as a [system parameter].

--- a/crates/bevy_time/src/delayed_commands.rs
+++ b/crates/bevy_time/src/delayed_commands.rs
@@ -1,0 +1,179 @@
+use std::time::Duration;
+
+use bevy_ecs::{
+    entity::Entity,
+    system::{Commands, Query, Res},
+    world::CommandQueue,
+};
+
+use crate::{Time, Timer, TimerMode};
+use private::DelayedCommandQueue;
+
+/// A [`Commands`]-like type allowing for each queued [`Command`] to be delayed
+/// until a certain amount of time has elapsed.
+///
+/// [`Command`]: bevy_ecs::system::Command
+pub struct DelayedCommands<'w, 's> {
+    commands: Commands<'w, 's>,
+    delayed_queue: CommandQueue,
+    timer: Timer,
+}
+
+/// System responsible for applying delayed [`CommandQueues`](`CommandQueue`).
+pub fn apply_delayed_commands(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut DelayedCommandQueue)>,
+) {
+    for (entity, mut delayed_commands) in query.iter_mut() {
+        delayed_commands.timer.tick(time.delta());
+
+        if delayed_commands.timer.finished() {
+            commands.append(&mut delayed_commands.queue);
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+impl<'w, 's> Drop for DelayedCommands<'w, 's> {
+    fn drop(&mut self) {
+        let mut queue = CommandQueue::default();
+        queue.append(&mut self.delayed_queue);
+
+        let timer = self.timer.clone();
+
+        self.commands.spawn(DelayedCommandQueue { queue, timer });
+    }
+}
+
+impl<'w, 's> DelayedCommands<'w, 's> {
+    /// Get a [`Commands`] item which will delay all queued [commands].
+    ///
+    /// [commands]: bevy_ecs::system::Command
+    pub fn as_commands<'a>(&'a mut self) -> Commands<'w, 'a> {
+        Commands::new_from_commands(&mut self.delayed_queue, &self.commands)
+    }
+}
+
+/// Extension trait for the [`Commands`] type providing time-related functionality.
+pub trait CommandsExt<'w, 's>: private::Sealed {
+    /// Create a [`DelayedCommands`] from this [`Commands`] with a delay equal
+    /// to the provided [`Duration`].
+    /// You can then create a new [`Commands`] from this [`DelayedCommands`] which
+    /// will delay all provided [commands].
+    ///
+    /// Note: Commands which reserve [`entities`](`Entity`) will immediately allocate
+    /// their required [`Entity`] IDs, but all operations will still be delayed.
+    /// For example, `commands.spawn(MyBundle)` will spawn an [`Entity`] immediately,
+    /// but the bundle `MyBundle` will _not_ be inserted until the delay has elapsed.
+    ///
+    /// # Examples
+    ///
+    /// ## Despawn after 5 seconds
+    ///
+    /// ```rust
+    /// # use std::time::Duration;
+    /// # use bevy_time::*;
+    /// # use bevy_ecs::Commands;
+    /// #
+    /// fn spawn_temporary_entities(mut commands: Commands) {
+    ///     let entity = commands.spawn_empty().id();
+    ///
+    ///     commands
+    ///         .after(Duration::from_secs(5))
+    ///         .as_commands()
+    ///         .entity(entity)
+    ///         .despawn();
+    /// }
+    /// ```
+    ///
+    /// [commands]: bevy_ecs::system::Command
+    fn after<'a>(&'a mut self, duration: Duration) -> DelayedCommands<'w, 'a>;
+}
+
+impl<'w, 's> CommandsExt<'w, 's> for Commands<'w, 's> {
+    fn after<'a>(&'a mut self, duration: Duration) -> DelayedCommands<'w, 'a> {
+        let timer = Timer::new(duration, TimerMode::Once);
+        let delayed_queue = CommandQueue::default();
+
+        DelayedCommands {
+            commands: self.reborrow(),
+            delayed_queue,
+            timer,
+        }
+    }
+}
+
+mod private {
+    use bevy_ecs::{component::Component, world::CommandQueue};
+
+    use crate::Timer;
+
+    pub trait Sealed {}
+
+    impl<'w, 's> Sealed for bevy_ecs::system::Commands<'w, 's> {}
+
+    /// [`Component`] storing queued [commands] which have been delayed
+    /// until after [`timer`](Self::timer) has finished.
+    ///
+    /// [commands]: bevy_ecs::system::Command
+    #[derive(Component)]
+    pub struct DelayedCommandQueue {
+        pub queue: CommandQueue,
+        pub timer: Timer,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use bevy_app::{App, Startup, Update};
+    use bevy_ecs::{system::Resource, world::World};
+
+    use super::*;
+
+    #[test]
+    fn test() {
+        #[derive(Resource, PartialEq, Eq, Debug)]
+        struct Flag(bool);
+
+        let mut app = App::new();
+
+        app.insert_resource(Time::new(Instant::now()).as_generic());
+        app.insert_resource(Flag(false));
+        app.add_systems(Update, apply_delayed_commands);
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands
+                .after(Duration::from_secs(1000))
+                .as_commands()
+                .add(|world: &mut World| {
+                    *world.resource_mut::<Flag>() = Flag(true);
+                });
+
+            commands.spawn_empty();
+        });
+
+        assert_eq!(app.world().get_resource::<Flag>(), Some(&Flag(false)));
+
+        app.update();
+
+        assert_eq!(app.world().get_resource::<Flag>(), Some(&Flag(false)));
+
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_secs(999));
+
+        app.update();
+
+        assert_eq!(app.world().get_resource::<Flag>(), Some(&Flag(false)));
+
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_secs(1));
+
+        app.update();
+
+        assert_eq!(app.world().get_resource::<Flag>(), Some(&Flag(true)));
+    }
+}

--- a/crates/bevy_time/src/delayed_commands.rs
+++ b/crates/bevy_time/src/delayed_commands.rs
@@ -12,7 +12,7 @@ use private::DelayedCommandQueue;
 /// A [`Commands`]-like type allowing for each queued [`Command`] to be delayed
 /// until a certain amount of time has elapsed.
 ///
-/// [`Command`]: bevy_ecs::system::Command
+/// [`Command`]: bevy_ecs::world::Command
 pub struct DelayedCommands<'w, 's> {
     commands: Commands<'w, 's>,
     delayed_queue: CommandQueue,
@@ -49,7 +49,7 @@ impl<'w, 's> Drop for DelayedCommands<'w, 's> {
 impl<'w, 's> DelayedCommands<'w, 's> {
     /// Get a [`Commands`] item which will delay all queued [commands].
     ///
-    /// [commands]: bevy_ecs::system::Command
+    /// [commands]: bevy_ecs::world::Command
     pub fn as_commands<'a>(&'a mut self) -> Commands<'w, 'a> {
         Commands::new_from_commands(&mut self.delayed_queue, &self.commands)
     }
@@ -87,7 +87,7 @@ pub trait CommandsExt<'w, 's>: private::Sealed {
     /// }
     /// ```
     ///
-    /// [commands]: bevy_ecs::system::Command
+    /// [commands]: bevy_ecs::world::Command
     fn after<'a>(&'a mut self, duration: Duration) -> DelayedCommands<'w, 'a>;
 }
 
@@ -116,7 +116,7 @@ mod private {
     /// [`Component`] storing queued [commands] which have been delayed
     /// until after [`timer`](Self::timer) has finished.
     ///
-    /// [commands]: bevy_ecs::system::Command
+    /// [commands]: bevy_ecs::world::Command
     #[derive(Component)]
     pub struct DelayedCommandQueue {
         pub queue: CommandQueue,

--- a/crates/bevy_time/src/delayed_commands.rs
+++ b/crates/bevy_time/src/delayed_commands.rs
@@ -73,8 +73,8 @@ pub trait CommandsExt<'w, 's>: private::Sealed {
     ///
     /// ```rust
     /// # use std::time::Duration;
-    /// # use bevy_time::*;
-    /// # use bevy_ecs::Commands;
+    /// # use bevy_time::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     /// #
     /// fn spawn_temporary_entities(mut commands: Commands) {
     ///     let entity = commands.spawn_empty().id();

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -8,6 +8,7 @@
 
 /// Common run conditions
 pub mod common_conditions;
+mod delayed_commands;
 mod fixed;
 mod real;
 mod stopwatch;
@@ -16,6 +17,7 @@ mod time;
 mod timer;
 mod virt;
 
+pub use delayed_commands::*;
 pub use fixed::*;
 pub use real::*;
 pub use stopwatch::*;
@@ -75,6 +77,11 @@ impl Plugin for TimePlugin {
         .add_systems(
             RunFixedMainLoop,
             run_fixed_main_schedule.in_set(RunFixedMainLoopSystem::FixedMainLoop),
+        );
+
+        app.add_systems(
+            First,
+            apply_delayed_commands.in_set(TimeSystem).after(time_system),
         );
 
         // Ensure the events are not dropped until `FixedMain` systems can observe them

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -30,7 +30,7 @@ pub use virt::*;
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Fixed, Real, Time, Timer, TimerMode, Virtual};
+    pub use crate::{CommandsExt, Fixed, Real, Time, Timer, TimerMode, Virtual};
 }
 
 use bevy_app::{prelude::*, RunFixedMainLoop};
@@ -81,7 +81,10 @@ impl Plugin for TimePlugin {
 
         app.add_systems(
             First,
-            apply_delayed_commands.in_set(TimeSystem).after(time_system),
+            apply_delayed_commands
+                .in_set(TimeSystem)
+                .after(time_system)
+                .ambiguous_with(event_update_system),
         );
 
         // Ensure the events are not dropped until `FixedMain` systems can observe them


### PR DESCRIPTION
Allows for delaying `Commands` from being applied until an amount of time has elapsed.

# Objective

- Fixes #15129

## Solution

Added a new type, `DelayedCommands`, which will delay commands pushed to its `CommandQueue` until after its `Timer` has elapsed. This type allows for a standard `Commands` to be created from it, so all existing `Commands` APIs (including `EntityCommands`) work as `DelayedCommands`. Additionally, `DelayedCommands` itself can be created from a standard `Commands` system parameter via an extension method `after(...)` which accepts a `Duration`.

```rust
commands
    .spawn(MyBundle) // Applied at next sync-point
    .after(Duration::from_secs(1))
    .as_commands()
    .spawn(MyBundle); // Applied after 1 second
```

Unfortunately, I cannot find a way to implement `Deref` and `DerefMut` for `DelayedCommands` in a way which could return a usable `Commands`. As such, after calling `.after(...)` the user must then call `.as_commands()`. I believe the only workaround for this would be a self-referential type, or some `unsafe`, which I don't believe is worth the effort.

## Details

- `DelayedCommands` creates a new `CommandQueue` and holds a mutable reference to an existing `Commands` item. This required adding a method to `Commands` which allowed for the creation of a brand new `Commands` item referencing the existing `&Entities` reference. I don't like this addition, but the `bevy_ecs` / `bevy_time` crate boundary makes it tricky for me to see an alternative. 
- When calling `.as_commands()`, a new `Commands` is created using the `DelayedCommands`' `CommandQueue` and the existing `Commands`' `Entities` reference. This means that any `Entity` reservation/creation always occurs immediately, while `Command`'s are deferred until the `Timer` elapses. I don't believe this is unreasonable, since the current `Commands` parameter does this as well, just with a tighter timeframe between `Entity` creation and command execution.
- Once the `DelayedCommands` is dropped, it inserts a `Timer` and the `CommandQueue` onto a new `Entity` using its held `Commands` reference. This uses an implementation of `Drop` and allows us to only spawn a single `Entity` for all commands in the `CommandQueue`, instead of separate entities for each command being created on the fly. `Drop` also allows us to skip a `.done()` method, leaving a slightly cleaner API. I had considered using a `Resource` for this instead, but it would require some collection type (`Vec`, `HashMap`, etc.), so I opted to lean on the ECS instead.
- Finally, `apply_delayed_commands` is run in the `First` schedule _after_ `Time` has been updated to tick all `Timers`. If any `Timers` are elapsed, the `CommandQueue` is drained onto a `Commands` system parameter and the entity is despawned. This does mean that delayed commands may happen up to one frame _later_ than scheduled, which will disproportionately affect short delays. For tight timing, a dedicated system or even something leaning on the `async` runtime may be preferable.

## Testing

- Wrote a new unit test and CI passed locally.
