### PR TITLE
Add a `TimedCommands` `SystemParam`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -205,6 +205,12 @@ impl<'w, 's> Commands<'w, 's> {
         }
     }
 
+    /// Returns a new [`Commands`] instance which uses the provided [`CommandQueue`],
+    /// reusing the [`Entities`] from the current [`Commands`] instance.
+    pub fn with_queue<'ns>(&self, queue: &'ns mut CommandQueue) -> Commands<'w, 'ns> {
+        Commands::new_from_entities(queue, self.entities)
+    }
+
     /// Returns a [`Commands`] with a smaller lifetime.
     /// This is useful if you have `&mut Commands` but need `Commands`.
     ///

--- a/crates/bevy_time/src/commands.rs
+++ b/crates/bevy_time/src/commands.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::TypeId,
     ops::{Deref, DerefMut},
     time::Duration,
 };
@@ -7,8 +8,9 @@ use bevy_ecs::{
     system::{Commands, Deferred, Res, ResMut, Resource, SystemBuffer, SystemMeta, SystemParam},
     world::{CommandQueue, World},
 };
+use bevy_utils::TypeIdMap;
 
-use crate::{Domain, Time, Timer, TimerMode};
+use crate::{Domain, Fixed, Generic, Time, Timer, TimerMode, Virtual};
 
 /// A [`SystemParam`] that allows you to queue commands to be
 /// executed after a certain duration has elapsed,
@@ -17,9 +19,12 @@ use crate::{Domain, Time, Timer, TimerMode};
 /// This type also derefs to [`Commands`], so you can still use it
 /// to queue commands to run at the next sync point.
 ///
-/// **Note**: By default, commands that have elapsed will be queued
-/// in the [`First`] and [`FixedFirst`] schedules for time domains
-/// `()` and [`Fixed`], respectively.
+/// # Deferred
+///
+/// - Commands queued during the [`Update`] schedules
+///   will be applied (if their timers have elapsed) during the [`First`] schedule.
+/// - Commands queued during the [`FixedUpdate`] schedules
+///   will be applied (if their timers have elapsed) during the [`FixedFirst`] schedule.
 ///
 /// # Usage
 ///
@@ -40,16 +45,23 @@ use crate::{Domain, Time, Timer, TimerMode};
 /// # bevy_ecs::system::assert_is_system(my_system);
 /// ```
 ///
+/// [`Update`]: bevy_app::Update
 /// [`First`]: bevy_app::First
+/// [`FixedUpdate`]: bevy_app::FixedUpdate
 /// [`FixedFirst`]: bevy_app::FixedFirst
-/// [`Fixed`]: crate::Fixed
 #[derive(SystemParam)]
-pub struct TimedCommands<'w, 's, T: Domain = ()> {
+pub struct TimedCommands<'w, 's, T: Domain = Generic>
+where
+    TimedCommandQueues<T>: SystemBuffer,
+{
     commands: Commands<'w, 's>,
     queues: Deferred<'s, TimedCommandQueues<T>>,
 }
 
-impl<'w, 's, T: Domain> TimedCommands<'w, 's, T> {
+impl<'w, 's, T: Domain> TimedCommands<'w, 's, T>
+where
+    TimedCommandQueues<T>: SystemBuffer,
+{
     /// Creates a new [`Commands`] instance that will have its commands queued
     /// after the specified duration has elapsed.
     ///
@@ -65,7 +77,7 @@ impl<'w, 's, T: Domain> TimedCommands<'w, 's, T> {
     /// }
     /// # bevy_ecs::system::assert_is_system(my_system);
     /// ```
-    #[must_use = "no commands are queued by this method itself, only by the returned Commands"]
+    #[must_use = "no commands are queued by this method itself, only through the returned Commands"]
     pub fn after(&mut self, duration: Duration) -> Commands<'w, '_> {
         let timer = Timer::new(duration, TimerMode::Once);
         let queue = CommandQueue::default();
@@ -79,7 +91,10 @@ impl<'w, 's, T: Domain> TimedCommands<'w, 's, T> {
     }
 }
 
-impl<'w, 's, T: Domain> Deref for TimedCommands<'w, 's, T> {
+impl<'w, 's, T: Domain> Deref for TimedCommands<'w, 's, T>
+where
+    TimedCommandQueues<T>: SystemBuffer,
+{
     type Target = Commands<'w, 's>;
 
     fn deref(&self) -> &Self::Target {
@@ -87,7 +102,10 @@ impl<'w, 's, T: Domain> Deref for TimedCommands<'w, 's, T> {
     }
 }
 
-impl<'w, 's, T: Domain> DerefMut for TimedCommands<'w, 's, T> {
+impl<'w, 's, T: Domain> DerefMut for TimedCommands<'w, 's, T>
+where
+    TimedCommandQueues<T>: SystemBuffer,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.commands
     }
@@ -96,35 +114,122 @@ impl<'w, 's, T: Domain> DerefMut for TimedCommands<'w, 's, T> {
 /// A [`SystemBuffer`] and [`Resource`] that holds a list of pairs of [`Timer`]s and [`CommandQueue`]s.
 ///
 /// Used by [`TimedCommands`] to hold queued commands.
-#[derive(Default, Resource)]
 pub struct TimedCommandQueues<T: Domain> {
     inner: Vec<(Timer, CommandQueue)>,
     _domain: std::marker::PhantomData<T>,
 }
 
-impl<T: Domain> SystemBuffer for TimedCommandQueues<T> {
+/// The [`Generic`] [`Time`] [`Domain`] is a special case that contextually changes
+/// based on what schedule is currently running:
+/// - When operating in the normal [`Update`] schedule, the actual domain is [`Virtual`].
+/// - When operating in the [`FixedUpdate`] schedule, the actual domain is [`Fixed`].
+///
+/// We use the "provenance" of the [`Generic`] [`Time`] to determine which domain to use,
+/// and append to the global queues accordingly.
+/// If the provenance is not set, we append to the [`Virtual`] domain.
+impl SystemBuffer for TimedCommandQueues<Generic> {
     fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
-        let Some(mut queues) = world.get_resource_mut::<Self>() else {
+        let provenance = world
+            .get_resource::<Time>()
+            .and_then(|t| t.context().provenance());
+
+        let Some(mut global) = world.get_resource_mut::<GlobalTimedCommandQueues>() else {
             return;
         };
 
-        queues.inner.append(&mut self.inner);
+        if let Some(provenance) = provenance {
+            global.append_to_dyn(provenance, self);
+        } else {
+            global.append_to::<_, Virtual>(self);
+        }
+    }
+}
+
+impl SystemBuffer for TimedCommandQueues<Virtual> {
+    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+        let Some(mut global) = world.get_resource_mut::<GlobalTimedCommandQueues>() else {
+            return;
+        };
+
+        global.append(self);
+    }
+}
+
+impl SystemBuffer for TimedCommandQueues<Fixed> {
+    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+        let Some(mut global) = world.get_resource_mut::<GlobalTimedCommandQueues>() else {
+            return;
+        };
+
+        global.append(self);
+    }
+}
+
+impl<T: Domain> Default for TimedCommandQueues<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            _domain: Default::default(),
+        }
+    }
+}
+
+/// [`Resource`] that holds separate queues of [`TimedCommandQueues`] for each [`Domain`].
+#[derive(Resource, Default)]
+pub struct GlobalTimedCommandQueues {
+    domains_to_queues: TypeIdMap<Vec<(Timer, CommandQueue)>>,
+}
+
+impl GlobalTimedCommandQueues {
+    /// Appends the queues from the given [`TimedCommandQueues`].
+    pub fn append<Current: Domain>(&mut self, queues: &mut TimedCommandQueues<Current>) {
+        self.append_to::<Current, Current>(queues);
+    }
+
+    /// Appends the queues from the given [`TimedCommandQueues`] to the target `Target` [`Domain`]
+    /// in the [`GlobalTimedCommandQueues`].
+    ///
+    /// Queuing to a different [`Domain`] than the current one is required to support
+    /// the special-case behavior of the [`Generic`] [`Time`] domain.
+    pub fn append_to<Current: Domain, Target: Domain>(
+        &mut self,
+        queues: &mut TimedCommandQueues<Current>,
+    ) {
+        self.append_to_dyn(TypeId::of::<Target>(), queues);
+    }
+
+    /// Appends the queues from the given [`TimedCommandQueues`] to the target [`Domain`] type
+    /// in the [`GlobalTimedCommandQueues`].
+    ///
+    /// Queuing to a different [`Domain`] than the current one is required to support
+    /// the special-case behavior of the [`Generic`] [`Time`] domain.
+    pub fn append_to_dyn<Current: Domain>(
+        &mut self,
+        target_domain: TypeId,
+        queues: &mut TimedCommandQueues<Current>,
+    ) {
+        let domain = self.domains_to_queues.entry(target_domain).or_default();
+        domain.append(&mut queues.inner);
     }
 }
 
 /// A system that ticks commands queued via [`TimedCommands`],
 /// which will be applied by default in the [`First`] and [`FixedFirst`] schedules
-/// for time domains `()` and [`Fixed`], respectively.
+/// for time domains [`Virtual`] and [`Fixed`], respectively.
 ///
 /// [`First`]: bevy_app::First
 /// [`FixedFirst`]: bevy_app::FixedFirst
 /// [`Fixed`]: crate::Fixed
-pub fn queue_delayed_commands<T: Domain>(
+pub fn queue_timed_commands<T: Domain>(
     mut commands: Commands,
-    mut queues: ResMut<TimedCommandQueues<T>>,
+    mut global: ResMut<GlobalTimedCommandQueues>,
     time: Res<Time<T>>,
 ) {
-    queues.inner.retain_mut(|(timer, queue)| {
+    let Some(queues) = global.domains_to_queues.get_mut(&TypeId::of::<T>()) else {
+        return;
+    };
+
+    queues.retain_mut(|(timer, queue)| {
         let finished = timer.tick(time.delta()).just_finished();
         if finished {
             commands.append(queue);
@@ -137,8 +242,10 @@ pub fn queue_delayed_commands<T: Domain>(
 mod tests {
     use std::time::Instant;
 
-    use bevy_app::{App, Startup, Update};
+    use bevy_app::{App, MainSchedulePlugin, Startup, Update};
     use bevy_ecs::{system::Resource, world::World};
+
+    use crate::TimePlugin;
 
     use super::*;
 
@@ -148,11 +255,8 @@ mod tests {
         struct Flag(bool);
 
         let mut app = App::new();
-
-        app.insert_resource(Time::new(Instant::now()).as_generic());
+        app.add_plugins(TimePlugin);
         app.insert_resource(Flag(false));
-        app.add_systems(Update, queue_delayed_commands::<()>);
-        app.init_resource::<TimedCommandQueues<()>>();
         app.add_systems(Startup, |mut commands: TimedCommands| {
             commands
                 .after(Duration::from_secs(1000))

--- a/crates/bevy_time/src/commands.rs
+++ b/crates/bevy_time/src/commands.rs
@@ -1,0 +1,67 @@
+use std::time::Duration;
+
+use bevy_ecs::{
+    entity::Entities,
+    system::{Commands, Deferred, Res, ResMut, Resource, SystemBuffer, SystemMeta, SystemParam},
+    world::{CommandQueue, World},
+};
+
+use crate::{Domain, Time, Timer, TimerMode};
+
+/// A [`SystemParam`] that allows you to queue commands to be
+/// executed after a certain duration has elapsed,
+/// rather than immediately at the next sync point.
+#[derive(SystemParam)]
+pub struct TimedCommands<'w, 's, T: Domain> {
+    entities: &'w Entities,
+    queues: Deferred<'s, TimedCommandQueues<T>>,
+}
+
+impl<'w, 's, T: Domain> TimedCommands<'w, 's, T> {
+    /// Creates a new [`Commands`] instance that will have its commands queued
+    /// after the specified duration has elapsed.
+    #[must_use]
+    pub fn after(&mut self, duration: Duration) -> Commands<'w, '_> {
+        let timer = Timer::new(duration, TimerMode::Once);
+        let queue = CommandQueue::default();
+        self.queues.inner.push((timer, queue));
+        let (_, queue) = self
+            .queues
+            .inner
+            .last_mut()
+            .unwrap_or_else(|| unreachable!("we just pushed a queue"));
+        Commands::new_from_entities(queue, self.entities)
+    }
+}
+
+/// A [`SystemBuffer`] and [`Resource`] that holds a list of pairs of [`Timer`]s and [`CommandQueue`]s.
+#[derive(Default, Resource)]
+pub struct TimedCommandQueues<T: Domain> {
+    inner: Vec<(Timer, CommandQueue)>,
+    _domain: std::marker::PhantomData<T>,
+}
+
+impl<T: Domain> SystemBuffer for TimedCommandQueues<T> {
+    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+        let Some(mut queues) = world.get_resource_mut::<Self>() else {
+            return;
+        };
+
+        queues.inner.append(&mut self.inner);
+    }
+}
+
+/// A system that ticks delayed commands, queuing them for the next sync point if their timers have finished.
+pub fn queue_delayed_commands<T: Domain>(
+    mut commands: Commands,
+    mut queues: ResMut<TimedCommandQueues<T>>,
+    time: Res<Time<T>>,
+) {
+    queues.inner.retain_mut(|(timer, queue)| {
+        let finished = timer.tick(time.delta()).just_finished();
+        if finished {
+            commands.append(queue);
+        }
+        !finished
+    });
+}

--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -4,7 +4,7 @@ use bevy_ecs::world::World;
 use bevy_reflect::Reflect;
 use bevy_utils::Duration;
 
-use crate::{time::Time, virt::Virtual};
+use crate::{time::Time, virt::Virtual, Domain};
 
 /// The fixed timestep game clock following virtual time.
 ///
@@ -231,6 +231,8 @@ impl Default for Fixed {
         }
     }
 }
+
+impl Domain for Fixed {}
 
 /// Runs [`FixedMain`] zero or more times based on delta of
 /// [`Time<Virtual>`](Virtual) and [`Time::overstep`].

--- a/crates/bevy_time/src/generic.rs
+++ b/crates/bevy_time/src/generic.rs
@@ -1,0 +1,35 @@
+use std::any::TypeId;
+
+use crate::{Domain, Time};
+
+/// Generic [`Time`] [`Domain`] representing the current time context.
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub struct Generic {
+    /// The domain promenance (i.e. which domain this generic one was created from).
+    provenance: Option<TypeId>,
+}
+
+impl Generic {
+    /// Constructs a new `Generic` based on the given `T` domain.
+    pub fn new_from<T: Domain>() -> Self {
+        Self {
+            provenance: Some(TypeId::of::<T>()),
+        }
+    }
+
+    /// Returns the provenance of this generic domain
+    /// (i.e. which domain this generic one was created from).
+    pub fn provenance(&self) -> Option<TypeId> {
+        self.provenance
+    }
+}
+
+impl Time<Generic> {
+    /// Constructs a new `Time<Generic>` based on the given `T` domain.
+    pub fn new_from<T: Domain>() -> Self {
+        Self::new_with(Generic::new_from::<T>())
+    }
+}
+
+impl Domain for Generic {}

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -10,6 +10,7 @@ mod commands;
 /// Common run conditions
 pub mod common_conditions;
 mod fixed;
+mod generic;
 mod real;
 mod stopwatch;
 #[allow(clippy::module_inception)]
@@ -19,6 +20,7 @@ mod virt;
 
 pub use commands::*;
 pub use fixed::*;
+pub use generic::*;
 pub use real::*;
 pub use stopwatch::*;
 pub use time::*;
@@ -58,8 +60,7 @@ impl Plugin for TimePlugin {
             .init_resource::<Time<Virtual>>()
             .init_resource::<Time<Fixed>>()
             .init_resource::<TimeUpdateStrategy>()
-            .init_resource::<TimedCommandQueues<()>>()
-            .init_resource::<TimedCommandQueues<Fixed>>();
+            .init_resource::<GlobalTimedCommandQueues>();
 
         #[cfg(feature = "bevy_reflect")]
         {
@@ -72,14 +73,14 @@ impl Plugin for TimePlugin {
 
         app.add_systems(
             First,
-            (time_system, queue_delayed_commands::<()>)
+            (time_system, queue_timed_commands::<Virtual>)
                 .chain()
                 .in_set(TimeSystem)
                 .ambiguous_with(event_update_system),
         )
         .add_systems(
             FixedFirst,
-            queue_delayed_commands::<Fixed>
+            queue_timed_commands::<Fixed>
                 .in_set(TimeSystem)
                 .ambiguous_with(event_update_system),
         )

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -6,6 +6,7 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 
+mod commands;
 /// Common run conditions
 pub mod common_conditions;
 mod fixed;
@@ -16,6 +17,7 @@ mod time;
 mod timer;
 mod virt;
 
+pub use commands::*;
 pub use fixed::*;
 pub use real::*;
 pub use stopwatch::*;
@@ -28,7 +30,7 @@ pub use virt::*;
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Fixed, Real, Time, Timer, TimerMode, Virtual};
+    pub use crate::{Fixed, Real, Time, TimedCommands, Timer, TimerMode, Virtual};
 }
 
 use bevy_app::{prelude::*, RunFixedMainLoop};
@@ -69,6 +71,17 @@ impl Plugin for TimePlugin {
         app.add_systems(
             First,
             time_system
+                .in_set(TimeSystem)
+                .ambiguous_with(event_update_system),
+        )
+        .add_systems(
+            First,
+            (
+                queue_delayed_commands::<()>,
+                queue_delayed_commands::<Real>,
+                queue_delayed_commands::<Virtual>,
+                queue_delayed_commands::<Fixed>,
+            )
                 .in_set(TimeSystem)
                 .ambiguous_with(event_update_system),
         )

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -57,7 +57,11 @@ impl Plugin for TimePlugin {
             .init_resource::<Time<Real>>()
             .init_resource::<Time<Virtual>>()
             .init_resource::<Time<Fixed>>()
-            .init_resource::<TimeUpdateStrategy>();
+            .init_resource::<TimeUpdateStrategy>()
+            .init_resource::<TimedCommandQueues<()>>()
+            .init_resource::<TimedCommandQueues<Real>>()
+            .init_resource::<TimedCommandQueues<Virtual>>()
+            .init_resource::<TimedCommandQueues<Fixed>>();
 
         #[cfg(feature = "bevy_reflect")]
         {

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -72,13 +72,8 @@ impl Plugin for TimePlugin {
 
         app.add_systems(
             First,
-            time_system
-                .in_set(TimeSystem)
-                .ambiguous_with(event_update_system),
-        )
-        .add_systems(
-            First,
-            queue_delayed_commands::<()>
+            (time_system, queue_delayed_commands::<()>)
+                .chain()
                 .in_set(TimeSystem)
                 .ambiguous_with(event_update_system),
         )

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -59,8 +59,6 @@ impl Plugin for TimePlugin {
             .init_resource::<Time<Fixed>>()
             .init_resource::<TimeUpdateStrategy>()
             .init_resource::<TimedCommandQueues<()>>()
-            .init_resource::<TimedCommandQueues<Real>>()
-            .init_resource::<TimedCommandQueues<Virtual>>()
             .init_resource::<TimedCommandQueues<Fixed>>();
 
         #[cfg(feature = "bevy_reflect")]
@@ -80,12 +78,13 @@ impl Plugin for TimePlugin {
         )
         .add_systems(
             First,
-            (
-                queue_delayed_commands::<()>,
-                queue_delayed_commands::<Real>,
-                queue_delayed_commands::<Virtual>,
-                queue_delayed_commands::<Fixed>,
-            )
+            queue_delayed_commands::<()>
+                .in_set(TimeSystem)
+                .ambiguous_with(event_update_system),
+        )
+        .add_systems(
+            FixedFirst,
+            queue_delayed_commands::<Fixed>
                 .in_set(TimeSystem)
                 .ambiguous_with(event_update_system),
         )

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -2,7 +2,7 @@
 use bevy_reflect::Reflect;
 use bevy_utils::{Duration, Instant};
 
-use crate::time::Time;
+use crate::{time::Time, Domain};
 
 /// Real time clock representing elapsed wall clock time.
 ///
@@ -123,6 +123,8 @@ impl Time<Real> {
         self.context().last_update
     }
 }
+
+impl Domain for Real {}
 
 #[cfg(test)]
 mod test {

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -396,7 +396,7 @@ fn duration_rem(dividend: Duration, divisor: Duration) -> Duration {
 /// A marker trait for the domain of a [`Time`] clock.
 ///
 /// Provided domains:
-/// - `()` (current time based on schedule processing)
+/// - `()` (contextually dependent on the current schedule that's running)
 /// - [`Real`](crate::real::Real)
 /// - [`Virtual`](crate::virt::Virtual)
 /// - [`Fixed`](crate::fixed::Fixed)

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -158,7 +158,7 @@ use bevy_utils::Duration;
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// # use bevy_time::prelude::*;
+/// # use bevy_time::{prelude::*, Domain};
 /// # use bevy_utils::Instant;
 /// #
 /// #[derive(Debug)]

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -392,6 +392,12 @@ fn duration_rem(dividend: Duration, divisor: Duration) -> Duration {
 }
 
 /// A marker trait for the domain of a [`Time`] clock.
+///
+/// Provided domains:
+/// - `()` (app update time)
+/// - [`Real`](crate::real::Real)
+/// - [`Virtual`](crate::virt::Virtual)
+/// - [`Fixed`](crate::fixed::Fixed)
 pub trait Domain: Default + Send + Sync + 'static {}
 
 impl Domain for () {}

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -174,6 +174,8 @@ use bevy_utils::Duration;
 ///     }
 /// }
 ///
+/// impl Domain for Custom {}
+///
 /// trait CustomTime {
 ///     fn update_from_external(&mut self, instant: Instant);
 /// }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -188,7 +188,7 @@ use bevy_utils::Duration;
 /// ```
 #[derive(Resource, Debug, Copy, Clone)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Resource, Default))]
-pub struct Time<T: Default = ()> {
+pub struct Time<T: Domain = ()> {
     context: T,
     wrap_period: Duration,
     delta: Duration,
@@ -202,7 +202,7 @@ pub struct Time<T: Default = ()> {
     elapsed_seconds_wrapped_f64: f64,
 }
 
-impl<T: Default> Time<T> {
+impl<T: Domain> Time<T> {
     const DEFAULT_WRAP_PERIOD: Duration = Duration::from_secs(3600); // 1 hour
 
     /// Create a new clock from context with [`Self::delta`] and [`Self::elapsed`] starting from
@@ -367,7 +367,7 @@ impl<T: Default> Time<T> {
     }
 }
 
-impl<T: Default> Default for Time<T> {
+impl<T: Domain> Default for Time<T> {
     fn default() -> Self {
         Self {
             context: Default::default(),
@@ -390,6 +390,11 @@ fn duration_rem(dividend: Duration, divisor: Duration) -> Duration {
     let quotient = (dividend.as_nanos() / divisor.as_nanos()) as u32;
     dividend - (quotient * divisor)
 }
+
+/// A marker trait for the domain of a [`Time`] clock.
+pub trait Domain: Default + Send + Sync + 'static {}
+
+impl Domain for () {}
 
 #[cfg(test)]
 mod test {

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -396,7 +396,7 @@ fn duration_rem(dividend: Duration, divisor: Duration) -> Duration {
 /// A marker trait for the domain of a [`Time`] clock.
 ///
 /// Provided domains:
-/// - `()` (app update time)
+/// - `()` (current time based on schedule processing)
 /// - [`Real`](crate::real::Real)
 /// - [`Virtual`](crate::virt::Virtual)
 /// - [`Fixed`](crate::fixed::Fixed)

--- a/crates/bevy_time/src/virt.rs
+++ b/crates/bevy_time/src/virt.rs
@@ -2,7 +2,7 @@
 use bevy_reflect::Reflect;
 use bevy_utils::{tracing::debug, Duration};
 
-use crate::{real::Real, time::Time};
+use crate::{real::Real, time::Time, Domain};
 
 /// The virtual game clock representing game time.
 ///
@@ -265,6 +265,8 @@ impl Default for Virtual {
         }
     }
 }
+
+impl Domain for Virtual {}
 
 /// Advances [`Time<Virtual>`] and [`Time`] based on the elapsed [`Time<Real>`].
 ///


### PR DESCRIPTION
# Objective

Closes #15129, as an alternative to #15136.

## Solution

Adds a new system parameter for queuing commands to be applied after a specific duration has elapsed, rather than at the immediate next sync point:

```rust
fn my_system(mut commands: TimedCommands) {
    // You can use any standard command that you're used to, because `after` returns `Commands`!
    commands.after(Duration::from_secs(5))
        .spawn_empty();
        
    // `TimedCommands` also derefs into `Commands`, so you can still use it to queue for the next sync point:
    commands.spawn_empty();
}

// Also supports specific time domains!
fn my_system(mut commands: TimedCommands<Fixed>) {
    // You can use any standard command that you're used to, because `after` returns `Commands`!
    commands.after(Duration::from_secs(5))
        .spawn_empty();
}
```

`Real` and `Virtual` are currently left out as there's some implications we would need to sort through.

## Testing

- Adapted the test from #15136

## Migration Guide

- The `Time<T: Default>` bound has been changed to `Time<T: Domain>`, where `trait Domain: Default + Send + Sync + 'static {}`.