### PR TITLE
Finish enhancing `ReflectCommandExt` to work with Bundles

### DIFF
--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -22,7 +22,7 @@ pub trait ReflectCommandExt {
     ///
     /// - If the entity doesn't exist.
     /// - If [`AppTypeRegistry`] does not have the reflection data for the given
-    /// [`Component`](crate::component::Component) or [`Bundle`](crate::bundle::Bundle).
+    ///     [`Component`](crate::component::Component) or [`Bundle`](crate::bundle::Bundle).
     /// - If the component or bundle data is invalid. See [`PartialReflect::apply`] for further details.
     /// - If [`AppTypeRegistry`] is not present in the [`World`].
     ///

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -266,10 +266,11 @@ fn remove_reflect(
     let Some(type_registration) = type_registry.get_with_type_path(&component_type_path) else {
         return;
     };
-    let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
-        return;
-    };
-    reflect_component.remove(&mut entity);
+    if let Some(reflect_component) = type_registration.data::<ReflectComponent>() {
+        reflect_component.remove(&mut entity);
+    } else if let Some(reflect_bundle) = type_registration.data::<ReflectBundle>() {
+        reflect_bundle.remove(&mut entity);
+    }
 }
 
 /// A [`Command`] that removes the component of the same type as the given component type name from

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -39,7 +39,7 @@ pub trait ReflectCommandExt {
     /// // or write to the TypeRegistry directly to register all your components
     ///
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::reflect::ReflectCommandExt;
+    /// # use bevy_ecs::reflect::{ReflectCommandExt, ReflectBundle};
     /// # use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
     /// // A resource that can hold any component that implements reflect as a boxed reflect component
     /// #[derive(Resource)]
@@ -53,7 +53,7 @@ pub trait ReflectCommandExt {
     /// #[derive(Component, Reflect, Default)]
     /// #[reflect(Component)]
     /// struct ComponentB(String);
-    /// 
+    ///
     /// #[derive(Bundle, Reflect, Default)]
     /// #[reflect(Bundle)]
     /// struct BundleA {
@@ -72,7 +72,7 @@ pub trait ReflectCommandExt {
     ///         a: ComponentA(24),
     ///         b: ComponentB("Twenty-Four".to_string()),
     ///     });
-    /// 
+    ///
     ///     // You can overwrite the component in the resource with either ComponentA or ComponentB
     ///     prefab.data = boxed_reflect_component_a;
     ///     prefab.data = boxed_reflect_component_b;
@@ -106,7 +106,7 @@ pub trait ReflectCommandExt {
     ) -> &mut Self;
 
     /// Removes from the entity the component or bundle with the given type name registered in [`AppTypeRegistry`].
-    /// 
+    ///
     /// If the type is a bundle, it will remove any components in that bundle regardless if the entity
     /// contains all the components.
     ///
@@ -128,7 +128,7 @@ pub trait ReflectCommandExt {
     /// // or write to the TypeRegistry directly to register all your components and bundles
     ///
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::reflect::ReflectCommandExt;
+    /// # use bevy_ecs::reflect::{ReflectCommandExt, ReflectBundle};
     /// # use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
     ///
     /// // A resource that can hold any component or bundle that implements reflect as a boxed reflect
@@ -540,11 +540,11 @@ mod tests {
     #[test]
     fn insert_reflect_bundle_with_registry() {
         let mut world = World::new();
-        
+
         let mut type_registry = TypeRegistryResource {
             type_registry: TypeRegistry::new(),
         };
-        
+
         type_registry.type_registry.register::<BundleA>();
         type_registry
             .type_registry
@@ -559,8 +559,9 @@ mod tests {
             a: ComponentA(31),
             b: ComponentB(20),
         }) as Box<dyn PartialReflect>;
-        
-        commands.entity(entity)
+
+        commands
+            .entity(entity)
             .insert_reflect_with_registry::<TypeRegistryResource>(bundle);
         system_state.apply(&mut world);
 
@@ -583,10 +584,12 @@ mod tests {
         let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
         let mut commands = system_state.get_mut(&mut world);
 
-        let entity = commands.spawn(BundleA {
-            a: ComponentA(31),
-            b: ComponentB(20),
-        }).id();
+        let entity = commands
+            .spawn(BundleA {
+                a: ComponentA(31),
+                b: ComponentB(20),
+            })
+            .id();
 
         let boxed_reflect_bundle_a = Box::new(BundleA {
             a: ComponentA(1),
@@ -606,7 +609,6 @@ mod tests {
     fn remove_reflected_bundle_with_registry() {
         let mut world = World::new();
 
-
         let mut type_registry = TypeRegistryResource {
             type_registry: TypeRegistry::new(),
         };
@@ -620,10 +622,12 @@ mod tests {
         let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
         let mut commands = system_state.get_mut(&mut world);
 
-        let entity = commands.spawn(BundleA {
-            a: ComponentA(31),
-            b: ComponentB(20),
-        }).id();
+        let entity = commands
+            .spawn(BundleA {
+                a: ComponentA(31),
+                b: ComponentB(20),
+            })
+            .id();
 
         let boxed_reflect_bundle_a = Box::new(BundleA {
             a: ComponentA(1),
@@ -633,7 +637,7 @@ mod tests {
         commands
             .entity(entity)
             .remove_reflect_with_registry::<TypeRegistryResource>(
-                boxed_reflect_bundle_a.reflect_type_path().to_owned()
+                boxed_reflect_bundle_a.reflect_type_path().to_owned(),
             );
         system_state.apply(&mut world);
 


### PR DESCRIPTION
# Objective

- Finish resolving https://github.com/bevyengine/bevy/issues/15125
- Inserting bundles was implemented in https://github.com/bevyengine/bevy/pull/15128 but removing bundles still needed to be implemented.

## Solution

- Modified `bevy_ecs::reflect::entity_commands::remove_reflect` to handle both components and bundles
- Modified documentation of `ReflectCommandExt` methods to reflect that one can now use bundles with these commands.

## Testing

- Three tests were added to match the ones for inserting components.
