### PR TITLE
Fix typo in bevy_reflect/src/reflect.rs

### DIFF
--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -142,7 +142,7 @@ pub enum ApplyError {
     },
 }
 
-/// A zero-sized enumuration of the "kinds" of a reflected type.
+/// A zero-sized enumeration of the "kinds" of a reflected type.
 ///
 /// A [`ReflectKind`] is obtained via [`PartialReflect::reflect_kind`],
 /// or via [`ReflectRef::kind`],[`ReflectMut::kind`] or [`ReflectOwned::kind`].


### PR DESCRIPTION
Corrected a typo "enumuration" to "enumeration".