### PR TITLE
Use `HashTable` in `DynamicMap` and fix bug in `remove`

### DIFF
--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -241,7 +241,7 @@ impl DynamicMap {
         |&index| {
             value
             .reflect_partial_eq(&*values[index].0)
-            .expect("Underlying type does not reflect `PartialEq` and hence doesn't support equality checks")
+            .expect("underlying type does not reflect `PartialEq` and hence doesn't support equality checks")
         }
     }
 }
@@ -310,7 +310,7 @@ impl Map for DynamicMap {
         assert_eq!(
             key.reflect_partial_eq(&*key),
             Some(true),
-            "Keys inserted in `Map` like types are expected to reflect `PartialEq`"
+            "keys inserted in `Map`-like types are expected to reflect `PartialEq`"
         );
 
         let hash = Self::internal_hash(&*key);
@@ -351,7 +351,7 @@ impl Map for DynamicMap {
                     let moved_index = self
                         .indices
                         .find_mut(hash, |&moved_index| moved_index == self.values.len())
-                        .expect("Key inserted in a `DynamicMap` is no longer present, this means its reflected `Hash` might be incorrect");
+                        .expect("key inserted in a `DynamicMap` is no longer present, this means its reflected `Hash` might be incorrect");
                     *moved_index = index;
                 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -11,7 +11,7 @@ use crate::{
 /// A trait used to power [map-like] operations via [reflection].
 ///
 /// Maps contain zero or more entries of a key and its associated value,
-/// and correspond to types like [`HashMap`].
+/// and correspond to types like [`HashMap`] and [`BTreeMap`].
 /// The order of these entries is not guaranteed by this trait.
 ///
 /// # Hashing
@@ -37,6 +37,8 @@ use crate::{
 /// assert_eq!(field.try_downcast_ref::<bool>(), Some(&true));
 /// ```
 ///
+/// [`HashMap`]: std::collections::HashMap
+/// [`BTreeMap`]: std::collections::BTreeMap
 /// [map-like]: https://doc.rust-lang.org/book/ch08-03-hash-maps.html
 /// [reflection]: crate
 pub trait Map: PartialReflect {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -14,12 +14,14 @@ use crate::{
 /// and correspond to types like [`HashMap`] and [`BTreeMap`].
 /// The order of these entries is not guaranteed by this trait.
 ///
-/// # Hashing
+/// # Hashing and equality
 ///
-/// All keys are expected to return a valid hash value from [`PartialReflect::reflect_hash`].
-/// If using the [`#[derive(Reflect)]`](derive@crate::Reflect) macro, this can be done by adding `#[reflect(Hash)]`
-/// to the entire struct or enum.
-/// This is true even for manual implementors who do not use the hashed value,
+/// All keys are expected to return a valid hash value from [`PartialReflect::reflect_hash`] and be
+/// comparable using [`PartialReflect::reflect_partial_eq`].
+/// If using the [`#[derive(Reflect)]`](derive@crate::Reflect) macro, this can be done by adding
+/// `#[reflect(Hash, PartialEq)]` to the entire struct or enum.
+/// The ordering is expected to be total, that is as if the reflected type implements the [`Eq`] trait.
+/// This is true even for manual implementors who do not hash or compare values,
 /// as it is still relied on by [`DynamicMap`].
 ///
 /// # Example

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -714,4 +714,14 @@ mod tests {
             assert_eq!(size, iter.index);
         }
     }
+
+    #[test]
+    fn remove() {
+        let mut map = DynamicMap::default();
+        map.insert(0, 0);
+        map.insert(1, 1);
+
+        map.remove(&0);
+        assert!(map.get(&1).is_some());
+    }
 }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -725,7 +725,14 @@ mod tests {
         map.insert(0, 0);
         map.insert(1, 1);
 
-        map.remove(&0);
-        assert!(map.get(&1).is_some());
+        assert_eq!(map.remove(&0).unwrap().try_downcast_ref(), Some(&0));
+        assert!(map.get(&0).is_none());
+        assert_eq!(map.get(&1).unwrap().try_downcast_ref(), Some(&1));
+
+        assert_eq!(map.remove(&1).unwrap().try_downcast_ref(), Some(&1));
+        assert!(map.get(&1).is_none());
+
+        assert!(map.remove(&1).is_none());
+        assert!(map.get(&1).is_none());
     }
 }

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -10,15 +10,18 @@ use crate::{
 
 /// A trait used to power [set-like] operations via [reflection].
 ///
-/// Sets contain zero or more entries of a fixed type, and correspond to types like [`HashSet`](std::collections::HashSet). The
-/// order of these entries is not guaranteed by this trait.
+/// Sets contain zero or more entries of a fixed type, and correspond to types
+/// like [`HashSet`] and [`BTreeSet`].
+/// The order of these entries is not guaranteed by this trait.
 ///
-/// # Hashing
+/// # Hashing and equality
 ///
-/// All values are expected to return a valid hash value from [`PartialReflect::reflect_hash`].
-/// If using the [`#[derive(Reflect)]`](derive@crate::Reflect) macro, this can be done by adding `#[reflect(Hash)]`
-/// to the entire struct or enum.
-/// This is true even for manual implementors who do not use the hashed value,
+/// All values are expected to return a valid hash value from [`PartialReflect::reflect_hash`] and be
+/// comparable using [`PartialReflect::reflect_partial_eq`].
+/// If using the [`#[derive(Reflect)]`](derive@crate::Reflect) macro, this can be done by adding
+/// `#[reflect(Hash, PartialEq)]` to the entire struct or enum.
+/// The ordering is expected to be total, that is as if the reflected type implements the [`Eq`] trait.
+/// This is true even for manual implementors who do not hash or compare values,
 /// as it is still relied on by [`DynamicSet`].
 ///
 /// # Example
@@ -36,6 +39,8 @@ use crate::{
 /// assert_eq!(field.try_downcast_ref::<u32>(), Some(&123_u32));
 /// ```
 ///
+/// [`HashSet`]: std::collections::HashSet
+/// [`BTreeSet`]: std::collections::BTreeSet
 /// [set-like]: https://doc.rust-lang.org/stable/std/collections/struct.HashSet.html
 /// [reflection]: crate
 pub trait Set: PartialReflect {


### PR DESCRIPTION
# Objective

- `DynamicMap` currently uses an `HashMap` from a `u64` hash to the entry index in a `Vec`. This is incorrect in the presence of hash collisions, so let's fix it;
- `DynamicMap::remove` was also buggy, as it didn't fix up the indexes of the other elements after removal. Fix that up as well and add a regression test.

## Solution

- Use `HashTable` in `DynamicMap` to distinguish entries that have the same hash by using `reflect_partial_eq`, bringing it more in line with what `DynamicSet` does;
- Reimplement `DynamicMap::remove` to properly fix up the index of moved elements after the removal.

## Testing

- A regression test was added for the `DynamicMap::remove` issue.

---

Some kinda related considerations: the use of a separate `Vec` for storing the entries adds some complications that I'm not sure are worth. This is mainly used to implement an efficient `get_at`, which is relied upon by `MapIter`. However both `HashMap` and `BTreeMap` implement `get_at` inefficiently (and cannot do so efficiently), leading to a `O(N^2)` complexity for iterating them. This could be removed in favor of a `Box<dyn Iterator>` like it's done in `DynamicSet`.