### PR TITLE
Micro typo in `bevy_ecs`

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -740,7 +740,7 @@ impl Debug for ComponentDescriptor {
 impl ComponentDescriptor {
     /// # SAFETY
     ///
-    /// `x` must points to a valid value of type `T`.
+    /// `x` must point to a valid value of type `T`.
     unsafe fn drop_ptr<T>(x: OwningPtr<'_>) {
         // SAFETY: Contract is required to be upheld by the caller.
         unsafe {


### PR DESCRIPTION
I'm currently reading through the code and docs and found this.