### PR TITLE
Enable/disable UI anti-aliasing

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -47,7 +47,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         geometry::*, node_bundles::*, ui_material::*, ui_node::*, widget::Button, widget::Label,
-        Interaction, UiAntialias, UiMaterialPlugin, UiScale,
+        Interaction, UiMaterialPlugin, UiScale,
     };
     // `bevy_sprite` re-exports for texture slicing
     #[doc(hidden)]
@@ -59,7 +59,6 @@ use bevy_ecs::prelude::*;
 use bevy_input::InputSystem;
 use bevy_render::{
     camera::CameraUpdateSystem,
-    extract_resource::{ExtractResource, ExtractResourcePlugin},
     view::{check_visibility, VisibilitySystems},
     RenderApp,
 };
@@ -109,16 +108,6 @@ impl Default for UiScale {
     }
 }
 
-/// Configuration resource for controlling the UI's anti-aliasing
-#[derive(Debug, Reflect, Resource, Default, PartialEq, Eq, Clone, ExtractResource)]
-pub enum UiAntialias {
-    /// UI will render with anti-aliasing
-    #[default]
-    On,
-    /// UI will render without anti-aliasing
-    Off,
-}
-
 // Marks systems that can be ambiguous with [`widget::text_system`] if the `bevy_text` feature is enabled.
 // See https://github.com/bevyengine/bevy/pull/11391 for more details.
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
@@ -136,7 +125,6 @@ impl Plugin for UiPlugin {
         app.init_resource::<UiSurface>()
             .init_resource::<UiScale>()
             .init_resource::<UiStack>()
-            .init_resource::<UiAntialias>()
             .register_type::<BackgroundColor>()
             .register_type::<CalculatedClip>()
             .register_type::<ContentSize>()
@@ -156,7 +144,6 @@ impl Plugin for UiPlugin {
             .register_type::<widget::Label>()
             .register_type::<ZIndex>()
             .register_type::<Outline>()
-            .add_plugins(ExtractResourcePlugin::<UiAntialias>::default())
             .configure_sets(
                 PostUpdate,
                 (

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -108,6 +108,16 @@ impl Default for UiScale {
     }
 }
 
+/// Configuration resource for controlling the UI's anti-aliasing
+#[derive(Debug, Reflect, Resource, Default)]
+pub enum UiAntialias {
+    /// UI will render with anti-aliasing
+    #[default]
+    On,
+    /// UI will render without anti-aliasing
+    Off,
+}
+
 // Marks systems that can be ambiguous with [`widget::text_system`] if the `bevy_text` feature is enabled.
 // See https://github.com/bevyengine/bevy/pull/11391 for more details.
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
@@ -125,6 +135,7 @@ impl Plugin for UiPlugin {
         app.init_resource::<UiSurface>()
             .init_resource::<UiScale>()
             .init_resource::<UiStack>()
+            .init_resource::<UiAntialias>()
             .register_type::<BackgroundColor>()
             .register_type::<CalculatedClip>()
             .register_type::<ContentSize>()

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -47,7 +47,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         geometry::*, node_bundles::*, ui_material::*, ui_node::*, widget::Button, widget::Label,
-        Interaction, UiMaterialPlugin, UiScale,
+        Interaction, UiAntialias, UiMaterialPlugin, UiScale,
     };
     // `bevy_sprite` re-exports for texture slicing
     #[doc(hidden)]

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -59,6 +59,7 @@ use bevy_ecs::prelude::*;
 use bevy_input::InputSystem;
 use bevy_render::{
     camera::CameraUpdateSystem,
+    extract_resource::{ExtractResource, ExtractResourcePlugin},
     view::{check_visibility, VisibilitySystems},
     RenderApp,
 };
@@ -109,7 +110,7 @@ impl Default for UiScale {
 }
 
 /// Configuration resource for controlling the UI's anti-aliasing
-#[derive(Debug, Reflect, Resource, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Reflect, Resource, Default, PartialEq, Eq, Clone, ExtractResource)]
 pub enum UiAntialias {
     /// UI will render with anti-aliasing
     #[default]
@@ -155,6 +156,7 @@ impl Plugin for UiPlugin {
             .register_type::<widget::Label>()
             .register_type::<ZIndex>()
             .register_type::<Outline>()
+            .add_plugins(ExtractResourcePlugin::<UiAntialias>::default())
             .configure_sets(
                 PostUpdate,
                 (

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -109,7 +109,7 @@ impl Default for UiScale {
 }
 
 /// Configuration resource for controlling the UI's anti-aliasing
-#[derive(Debug, Reflect, Resource, Default)]
+#[derive(Debug, Reflect, Resource, Default, PartialEq, Eq, Clone)]
 pub enum UiAntialias {
     /// UI will render with anti-aliasing
     #[default]

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -860,6 +860,7 @@ pub mod shader_flags {
 #[allow(clippy::too_many_arguments)]
 pub fn queue_uinodes(
     extracted_uinodes: Res<ExtractedUiNodes>,
+    extracted_ui_antialias: Res<ExtractedUiAntialias>,
     ui_pipeline: Res<UiPipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
@@ -880,7 +881,13 @@ pub fn queue_uinodes(
         let pipeline = pipelines.specialize(
             &pipeline_cache,
             &ui_pipeline,
-            UiPipelineKey { hdr: view.hdr },
+            UiPipelineKey {
+                hdr: view.hdr,
+                antialias: match extracted_ui_antialias.as_ref() {
+                    ExtractedUiAntialias::On => true,
+                    ExtractedUiAntialias::Off => false,
+                },
+            },
         );
         transparent_phase.add(TransparentUi {
             draw_function,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -855,7 +855,6 @@ pub mod shader_flags {
     /// Ordering: top left, top right, bottom right, bottom left.
     pub const CORNERS: [u32; 4] = [0, 2, 2 | 4, 4];
     pub const BORDER: u32 = 8;
-    pub const ANTIALIAS: u32 = 16;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -910,7 +909,6 @@ pub fn prepare_uinodes(
     render_queue: Res<RenderQueue>,
     mut ui_meta: ResMut<UiMeta>,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
-    extracted_ui_antialias: Res<ExtractedUiAntialias>,
     view_uniforms: Res<ViewUniforms>,
     ui_pipeline: Res<UiPipeline>,
     mut image_bind_groups: ResMut<UiImageBindGroups>,
@@ -1132,10 +1130,6 @@ pub fn prepare_uinodes(
                     let color = extracted_uinode.color.to_f32_array();
                     if extracted_uinode.node_type == NodeType::Border {
                         flags |= shader_flags::BORDER;
-                    }
-
-                    if matches!(extracted_ui_antialias.as_ref(), ExtractedUiAntialias::On) {
-                        flags |= shader_flags::ANTIALIAS;
                     }
 
                     for i in 0..4 {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -466,7 +466,6 @@ fn clamp_radius(
     ]
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn extract_uinode_borders(
     mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
@@ -698,7 +697,6 @@ pub fn extract_default_ui_camera_view(
 }
 
 #[cfg(feature = "bevy_text")]
-#[allow(clippy::too_many_arguments)]
 pub fn extract_uinode_text(
     mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -881,10 +881,7 @@ pub fn queue_uinodes(
             &ui_pipeline,
             UiPipelineKey {
                 hdr: view.hdr,
-                antialias: match extracted_ui_antialias.as_ref() {
-                    ExtractedUiAntialias::On => true,
-                    ExtractedUiAntialias::Off => false,
-                },
+                antialias: matches!(*extracted_ui_antialias, ExtractedUiAntialias::On),
             },
         );
         transparent_phase.add(TransparentUi {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -837,7 +837,6 @@ pub mod shader_flags {
 #[allow(clippy::too_many_arguments)]
 pub fn queue_uinodes(
     extracted_uinodes: Res<ExtractedUiNodes>,
-    extracted_ui_antialias: Res<UiAntialias>,
     ui_pipeline: Res<UiPipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
@@ -860,7 +859,7 @@ pub fn queue_uinodes(
             &ui_pipeline,
             UiPipelineKey {
                 hdr: view.hdr,
-                antialias: matches!(*extracted_ui_antialias, UiAntialias::On),
+                antialias: true,
             },
         );
         transparent_phase.add(TransparentUi {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -665,11 +665,11 @@ pub fn extract_default_ui_camera_view(
                     color_grading: Default::default(),
                 })
                 .id();
-            commands
+            let entity_commands = commands
                 .get_or_spawn(entity)
                 .insert(DefaultCameraView(default_camera_view));
             if let Some(ui_anti_alias) = ui_anti_alias {
-                commands.get_or_spawn(entity).insert(*ui_anti_alias);
+                entity_commands.insert(*ui_anti_alias);
             }
             transparent_render_phases.insert_or_clear(entity);
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -25,7 +25,7 @@ use ui_texture_slice_pipeline::UiTextureSlicerPlugin;
 use crate::graph::{NodeUi, SubGraphUi};
 use crate::{
     BackgroundColor, BorderColor, CalculatedClip, DefaultUiCamera, Display, Node, Outline, Style,
-    TargetCamera, UiAntialias, UiImage, UiScale, Val,
+    TargetCamera, UiAntiAlias, UiImage, UiScale, Val,
 };
 
 use bevy_app::prelude::*;
@@ -612,14 +612,14 @@ pub fn extract_default_ui_camera_view(
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
     ui_scale: Extract<Res<UiScale>>,
     query: Extract<
-        Query<(Entity, &Camera, Option<&UiAntialias>), Or<(With<Camera2d>, With<Camera3d>)>>,
+        Query<(Entity, &Camera, Option<&UiAntiAlias>), Or<(With<Camera2d>, With<Camera3d>)>>,
     >,
     mut live_entities: Local<EntityHashSet>,
 ) {
     live_entities.clear();
 
     let scale = ui_scale.0.recip();
-    for (entity, camera, ui_antialias) in &query {
+    for (entity, camera, ui_anti_alias) in &query {
         // ignore inactive cameras
         if !camera.is_active {
             continue;
@@ -668,8 +668,8 @@ pub fn extract_default_ui_camera_view(
             commands
                 .get_or_spawn(entity)
                 .insert(DefaultCameraView(default_camera_view));
-            if let Some(ui_antialias) = ui_antialias {
-                commands.get_or_spawn(entity).insert(*ui_antialias);
+            if let Some(ui_anti_alias) = ui_anti_alias {
+                commands.get_or_spawn(entity).insert(*ui_anti_alias);
             }
             transparent_render_phases.insert_or_clear(entity);
 
@@ -845,13 +845,13 @@ pub fn queue_uinodes(
     ui_pipeline: Res<UiPipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
-    mut views: Query<(Entity, &ExtractedView, Option<&UiAntialias>)>,
+    mut views: Query<(Entity, &ExtractedView, Option<&UiAntiAlias>)>,
     pipeline_cache: Res<PipelineCache>,
     draw_functions: Res<DrawFunctions<TransparentUi>>,
 ) {
     let draw_function = draw_functions.read().id::<DrawUi>();
     for (entity, extracted_uinode) in extracted_uinodes.uinodes.iter() {
-        let Ok((view_entity, view, ui_antialias)) = views.get_mut(extracted_uinode.camera_entity)
+        let Ok((view_entity, view, ui_anti_alias)) = views.get_mut(extracted_uinode.camera_entity)
         else {
             continue;
         };
@@ -865,7 +865,7 @@ pub fn queue_uinodes(
             &ui_pipeline,
             UiPipelineKey {
                 hdr: view.hdr,
-                antialias: matches!(ui_antialias, None | Some(UiAntialias::On)),
+                anti_alias: matches!(ui_anti_alias, None | Some(UiAntiAlias::On)),
             },
         );
         transparent_phase.add(TransparentUi {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -456,6 +456,7 @@ fn clamp_radius(
     ]
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn extract_uinode_borders(
     mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
@@ -696,6 +697,7 @@ pub fn extract_default_ui_camera_view(
 }
 
 #[cfg(feature = "bevy_text")]
+#[allow(clippy::too_many_arguments)]
 pub fn extract_uinode_text(
     mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -48,6 +48,7 @@ impl FromWorld for UiPipeline {
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub hdr: bool,
+    pub antialias: bool,
 }
 
 impl SpecializedRenderPipeline for UiPipeline {
@@ -73,7 +74,11 @@ impl SpecializedRenderPipeline for UiPipeline {
                 VertexFormat::Float32x2,
             ],
         );
-        let shader_defs = Vec::new();
+        let shader_defs = if key.antialias {
+            vec!["ANTIALIAS".into()]
+        } else {
+            Vec::new()
+        };
 
         RenderPipelineDescriptor {
             vertex: VertexState {

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -48,7 +48,7 @@ impl FromWorld for UiPipeline {
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub hdr: bool,
-    pub antialias: bool,
+    pub anti_alias: bool,
 }
 
 impl SpecializedRenderPipeline for UiPipeline {
@@ -74,8 +74,8 @@ impl SpecializedRenderPipeline for UiPipeline {
                 VertexFormat::Float32x2,
             ],
         );
-        let shader_defs = if key.antialias {
-            vec!["ANTIALIAS".into()]
+        let shader_defs = if key.anti_alias {
+            vec!["ANTI_ALIAS".into()]
         } else {
             Vec::new()
         };

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -150,11 +150,11 @@ fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // outside the outside edge, or inside the inner edge have positive signed distance.
     let border_distance = max(external_distance, -internal_distance);
 
+    #ifdef ANTIALIAS
     // At external edges with no border, `border_distance` is equal to zero. 
     // This select statement ensures we only perform anti-aliasing where a non-zero width border 
-    // is present and if the `ANTIALIAS` flag is enabled, otherwise an outline about the external
-    // boundary would be drawn even without a border.
-    #ifdef ANTIALIAS
+    // is present, otherwise an outline about the external boundary would be drawn even without 
+    // a border.
     let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance);
     #else
     let t = 1.0 - step(0.0, border_distance);
@@ -170,7 +170,6 @@ fn draw_background(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // When drawing the background only draw the internal area and not the border.
     let internal_distance = sd_inset_rounded_box(in.point, in.size, in.radius, in.border);
 
-    // Only use anti-aliasing if the `ANTIALIAS` flag is enabled. 
     #ifdef ANTIALIAS
     let t = antialias(internal_distance);
     #else

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -4,7 +4,6 @@ const TEXTURED = 1u;
 const RIGHT_VERTEX = 2u;
 const BOTTOM_VERTEX = 4u;
 const BORDER: u32 = 8u;
-const ANTIALIAS: u32 = 16u;
 
 fn enabled(flags: u32, mask: u32) -> bool {
     return (flags & mask) != 0u;
@@ -155,7 +154,7 @@ fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // This select statement ensures we only perform anti-aliasing where a non-zero width border 
     // is present and if the `ANTIALIAS` flag is enabled, otherwise an outline about the external
     // boundary would be drawn even without a border.
-    let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance && enabled(in.flags, ANTIALIAS));
+    let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance);
 
     // Blend mode ALPHA_BLENDING is used for UI elements, so we don't premultiply alpha here.
     return vec4(color.rgb, saturate(color.a * t));
@@ -168,7 +167,7 @@ fn draw_background(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     let internal_distance = sd_inset_rounded_box(in.point, in.size, in.radius, in.border);
 
     // Only use anti-aliasing if the `ANTIALIAS` flag is enabled. 
-    let t = select(1.0 - step(0.0, internal_distance), antialias(internal_distance), enabled(in.flags, ANTIALIAS));
+    let t = antialias(internal_distance);
 
     return vec4(color.rgb, saturate(color.a * t));
 }

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -4,6 +4,7 @@ const TEXTURED = 1u;
 const RIGHT_VERTEX = 2u;
 const BOTTOM_VERTEX = 4u;
 const BORDER: u32 = 8u;
+const ANTIALIAS: u32 = 16u;
 
 fn enabled(flags: u32, mask: u32) -> bool {
     return (flags & mask) != 0u;
@@ -152,9 +153,9 @@ fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
 
     // At external edges with no border, `border_distance` is equal to zero. 
     // This select statement ensures we only perform anti-aliasing where a non-zero width border 
-    // is present, otherwise an outline about the external boundary would be drawn even without 
-    // a border.
-    let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance);
+    // is present and if the `ANTIALIAS` flag is enabled, otherwise an outline about the external
+    // boundary would be drawn even without a border.
+    let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance && enabled(in.flags, ANTIALIAS));
 
     // Blend mode ALPHA_BLENDING is used for UI elements, so we don't premultiply alpha here.
     return vec4(color.rgb, saturate(color.a * t));
@@ -165,7 +166,10 @@ fn draw_background(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
 
     // When drawing the background only draw the internal area and not the border.
     let internal_distance = sd_inset_rounded_box(in.point, in.size, in.radius, in.border);
-    let t = antialias(internal_distance);
+
+    // Only use anti-aliasing if the `ANTIALIAS` flag is enabled. 
+    let t = select(1.0 - step(0.0, internal_distance), antialias(internal_distance), enabled(in.flags, ANTIALIAS));
+
     return vec4(color.rgb, saturate(color.a * t));
 }
 

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -154,7 +154,11 @@ fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // This select statement ensures we only perform anti-aliasing where a non-zero width border 
     // is present and if the `ANTIALIAS` flag is enabled, otherwise an outline about the external
     // boundary would be drawn even without a border.
+    #ifdef ANTIALIAS
     let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance);
+    #else
+    let t = 1.0 - step(0.0, border_distance);
+    #endif
 
     // Blend mode ALPHA_BLENDING is used for UI elements, so we don't premultiply alpha here.
     return vec4(color.rgb, saturate(color.a * t));
@@ -167,7 +171,11 @@ fn draw_background(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     let internal_distance = sd_inset_rounded_box(in.point, in.size, in.radius, in.border);
 
     // Only use anti-aliasing if the `ANTIALIAS` flag is enabled. 
+    #ifdef ANTIALIAS
     let t = antialias(internal_distance);
+    #else
+    let t = 1.0 - step(0.0, internal_distance);
+    #endif
 
     return vec4(color.rgb, saturate(color.a * t));
 }

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -150,15 +150,15 @@ fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // outside the outside edge, or inside the inner edge have positive signed distance.
     let border_distance = max(external_distance, -internal_distance);
 
-    #ifdef ANTIALIAS
+#ifdef ANTI_ALIAS
     // At external edges with no border, `border_distance` is equal to zero. 
     // This select statement ensures we only perform anti-aliasing where a non-zero width border 
     // is present, otherwise an outline about the external boundary would be drawn even without 
     // a border.
     let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance);
-    #else
+#else
     let t = 1.0 - step(0.0, border_distance);
-    #endif
+#endif
 
     // Blend mode ALPHA_BLENDING is used for UI elements, so we don't premultiply alpha here.
     return vec4(color.rgb, saturate(color.a * t));
@@ -170,11 +170,11 @@ fn draw_background(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {
     // When drawing the background only draw the internal area and not the border.
     let internal_distance = sd_inset_rounded_box(in.point, in.size, in.radius, in.border);
 
-    #ifdef ANTIALIAS
+#ifdef ANTI_ALIAS
     let t = antialias(internal_distance);
-    #else
+#else
     let t = 1.0 - step(0.0, internal_distance);
-    #endif
+#endif
 
     return vec4(color.rgb, saturate(color.a * t));
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2394,12 +2394,12 @@ impl<'w, 's> DefaultUiCamera<'w, 's> {
 ///         Camera2dBundle::default(),
 ///         // This will cause all Ui in this camera to be rendered without
 ///         // anti-aliasing
-///         UiAntialias::Off,
+///         UiAntiAlias::Off,
 ///     ));
 /// }
 /// ```
 #[derive(Component, Clone, Copy, Default, Debug, Reflect, Eq, PartialEq)]
-pub enum UiAntialias {
+pub enum UiAntiAlias {
     /// UI will render with anti-aliasing
     #[default]
     On,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2380,3 +2380,28 @@ impl<'w, 's> DefaultUiCamera<'w, 's> {
         })
     }
 }
+
+/// Marker for controlling whether Ui is rendered with or without anti-aliasing
+/// in a camera. By default, Ui is always anti-aliased.
+///
+/// ```
+/// use bevy_ui::prelude::*;
+/// use bevy_core_pipeline::prelude::*;
+///
+/// fn spawn_camera(mut commands: Commands) {
+///     commands.spawn((
+///         Camera2dBundle::default(),
+///         // This will cause all Ui in this camera to be rendered without
+///         // anti-aliasing
+///         UiAntialias::Off
+///     ));
+/// }
+/// ```
+#[derive(Component, Clone, Copy, Default, Debug, Reflect, Eq, PartialEq)]
+pub enum UiAntialias {
+    /// UI will render with anti-aliasing
+    #[default]
+    On,
+    /// UI will render without anti-aliasing
+    Off,
+}

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2385,15 +2385,16 @@ impl<'w, 's> DefaultUiCamera<'w, 's> {
 /// in a camera. By default, Ui is always anti-aliased.
 ///
 /// ```
-/// use bevy_ui::prelude::*;
 /// use bevy_core_pipeline::prelude::*;
+/// use bevy_ecs::prelude::*;
+/// use bevy_ui::prelude::*;
 ///
 /// fn spawn_camera(mut commands: Commands) {
 ///     commands.spawn((
 ///         Camera2dBundle::default(),
 ///         // This will cause all Ui in this camera to be rendered without
 ///         // anti-aliasing
-///         UiAntialias::Off
+///         UiAntialias::Off,
 ///     ));
 /// }
 /// ```


### PR DESCRIPTION
# Objective

Currently, UI is always rendered with anti-aliasing. This makes bevy's UI completely unsuitable for art-styles that demands hard pixelated edges, such as retro-style games.

## Solution

Add a component for disabling anti-aliasing in UI.

## Testing

In [`examples/ui/button.rs`](https://github.com/bevyengine/bevy/blob/15e246eff8ccc87c290b9763cb66c9885c084950/examples/ui/button.rs), add the component to the camera like this:

```rust
use bevy::{prelude::*, ui::prelude::*};

commands.spawn((Camera2dBundle::default(), UiAntiAlias::Off));
```

The rounded button will now render without anti-aliasing.

## Showcase

An example of a rounded UI node rendered without anti-aliasing, with and without borders:

![image](https://github.com/user-attachments/assets/ea797e40-bdaa-4ede-a0d3-c9a7eab95b6e)


