### PR TITLE
Reccomend using `AssetPlugin.file_path` instead of CARGO_MANIFEST_DIR

### DIFF
--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -51,8 +51,7 @@ impl FileAssetReader {
     /// Returns the base path of the assets directory, which is normally the executable's parent
     /// directory.
     ///
-    /// If the `CARGO_MANIFEST_DIR` environment variable is set, then its value will be used
-    /// instead. It's set by cargo when running with `cargo run`.
+    /// To change this, set [`AssetPlugin.file_path`].
     pub fn get_base_path() -> PathBuf {
         get_base_path()
     }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -19,10 +19,7 @@ fn setup(
     // For example, the next line will load GltfAssetLabel::Primitive{mesh:0,primitive:0}.from_asset("ROOT/assets/models/cube/cube.gltf"),
     // where "ROOT" is the directory of the Application.
     //
-    // This can be overridden by setting the "CARGO_MANIFEST_DIR" environment variable (see
-    // https://doc.rust-lang.org/cargo/reference/environment-variables.html)
-    // to another directory. When the Application is run through Cargo, "CARGO_MANIFEST_DIR" is
-    // automatically set to your crate (workspace) root directory.
+    // This can be overridden by setting [`AssetPlugin.file_path`].
     let cube_handle = asset_server.load(
         GltfAssetLabel::Primitive {
             mesh: 0,


### PR DESCRIPTION
Fixes #15175.

One question I have: I see that the scene_viewer example uses the CARGO_MANIFEST_DIR. Should that line be removed, or would that break the tool?
https://github.com/bevyengine/bevy/blob/1fd478277e55f31df18d02023c003935579b3864/examples/tools/scene_viewer/main.rs#L40