### PR TITLE
Increase border_rect for TextureSlicer to match image

### DIFF
--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -55,7 +55,7 @@ fn setup(
     let atlas_layout_handle = texture_atlases.add(atlas_layout);
 
     let slicer = TextureSlicer {
-        border: BorderRect::square(22.0),
+        border: BorderRect::square(24.0),
         center_scale_mode: SliceScaleMode::Stretch,
         sides_scale_mode: SliceScaleMode::Stretch,
         max_corner_scale: 1.0,


### PR DESCRIPTION
# Objective

- Fixes #14550 

## Solution

Increased the _border_rect_ for _TextureSampler_ to match image.

## Testing

- Compiled main branch from source and made sure problem exists
- Applied fix and rebuild to make sure problem doesn't exist anymore

## Showcase

### main

After some clicking on the buttons problem exists on main branch:
![image](https://github.com/user-attachments/assets/29636390-f33d-495d-8068-e652c20c12f3)

### this PR
Can not get the problem with the fix:
![image](https://github.com/user-attachments/assets/b891f188-e025-49c0-8523-7a98cb784b19)

