### PR TITLE
ParsedPath::try_from<&str>

### DIFF
--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -478,6 +478,13 @@ impl<const N: usize> From<[Access<'static>; N]> for ParsedPath {
     }
 }
 
+impl<'a> TryFrom<&'a str> for ParsedPath {
+    type Error = ReflectPathError<'a>;
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        ParsedPath::parse(value)
+    }
+}
+
 impl fmt::Display for ParsedPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for OffsetAccess { access, .. } in &self.0 {
@@ -583,6 +590,21 @@ mod tests {
             access: ParsedPath::parse_static(access).unwrap()[1].access.clone(),
             offset: Some(offset),
         })
+    }
+
+    #[test]
+    fn try_from() {
+        assert_eq!(
+            ParsedPath::try_from("w").unwrap().0,
+            &[offset(access_field("w"), 1)]
+        );
+
+        let r = ParsedPath::try_from("w[");
+        let matches = matches!(r, Err(ReflectPathError::ParseError { .. }));
+        assert!(
+            matches,
+            "ParsedPath::try_from did not return a ParseError for \"w[\""
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

- implements ParsedPath::try_from<&str>
- resolves #14438

## Testing

- Added unit test for ParsedPath::try_from<&str>

Note: I don't claim to be an expert on lifetimes! That said I think it makes sense that the error shares a lifetime with input string as deeper down it is used to construct it.