### PR TITLE
Scalarize point/spot light loop

### DIFF
--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -278,6 +278,7 @@ impl<B: Material, E: MaterialExtension> Material for ExtendedMaterial<B, E> {
             material_layout,
             vertex_shader,
             fragment_shader,
+            subgroup_operations_supported,
             ..
         } = pipeline.clone();
         let base_pipeline = MaterialPipeline::<B> {
@@ -285,6 +286,7 @@ impl<B: Material, E: MaterialExtension> Material for ExtendedMaterial<B, E> {
             material_layout,
             vertex_shader,
             fragment_shader,
+            subgroup_operations_supported,
             marker: Default::default(),
         };
         let base_key = MaterialPipelineKey::<B> {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -371,7 +371,7 @@ impl<M: Material> Clone for MaterialPipeline<M> {
             material_layout: self.material_layout.clone(),
             vertex_shader: self.vertex_shader.clone(),
             fragment_shader: self.fragment_shader.clone(),
-            subgroup_operations_supported: self.subgroup_operations_supported.clone(),
+            subgroup_operations_supported: self.subgroup_operations_supported,
             marker: PhantomData,
         }
     }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -396,9 +396,12 @@ where
         if let Some(fragment_shader) = &self.fragment_shader {
             let fragment_state = descriptor.fragment.as_mut().unwrap();
             fragment_state.shader = fragment_shader.clone();
-            fragment_state
-                .shader_defs
-                .push("SUBGROUP_OPERATIONS_SUPPORTED".into());
+
+            if self.subgroup_operations_supported {
+                fragment_state
+                    .shader_defs
+                    .push("SUBGROUP_OPERATIONS_SUPPORTED".into());
+            }
         }
 
         descriptor.layout.insert(2, self.material_layout.clone());


### PR DESCRIPTION
# Objective

- Reduce vector register pressure in our PBR shader, increasing occupancy and therefore performance.

## Solution

- Implement strategy number two from https://flashypixels.wordpress.com/2018/11/10/intro-to-gpu-scalarization-part-2-scalarize-all-the-lights
- There's also some more advanced strategies we could look into from https://advances.realtimerendering.com/s2017/2017_Sig_Improved_Culling_final.pdf and https://themaister.net/blog/2020/01/10/clustered-shading-evolution-in-granite, but I didn't feel like changing all the clustering logic

## Testing
TODO

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?