### PR TITLE
Fix `Capsule2d::sample_interior`

### DIFF
--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -450,7 +450,7 @@ impl ShapeSample for Capsule2d {
         if capsule_area > 0.0 {
             // Check if the random point should be inside the rectangle
             if rng.gen_bool((rectangle_area / capsule_area) as f64) {
-                let rectangle = Rectangle::new(self.radius, self.half_length * 2.0);
+                let rectangle = Rectangle::new(self.radius * 2.0, self.half_length * 2.0);
                 rectangle.sample_interior(rng)
             } else {
                 let circle = Circle::new(self.radius);


### PR DESCRIPTION
# Objective

`Capsule2d::sample_interior` uses the radius of the capsule for the width of its rectangular section. It should be using two times the radius for the full width!

I noticed this as I was getting incorrect results for angular inertia approximated from a point cloud of points sampled on the capsule. This hinted that something was wrong with the sampling.

## Solution

Multiply the radius by two to get the full width of the rectangular section. With this, the sampling produces the correct result in my tests.