### PR TITLE
Add various methods to get reflected components from `EntityRef` & friends

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -7,6 +7,7 @@ use crate::{
     event::Event,
     observer::{Observer, Observers},
     query::{Access, ReadOnlyQueryData},
+    reflect::AppTypeRegistry,
     removal_detection::RemovedComponentEvents,
     storage::Storages,
     system::IntoObserverSystem,
@@ -880,6 +881,42 @@ impl<'w> EntityWorldMut<'w> {
         // SAFETY:
         // consuming `self` ensures that no references exist to this entity's components.
         unsafe { self.into_unsafe_entity_cell().get_mut_by_id(component_id) }
+    }
+
+    /// TODO
+    pub fn get_reflect(&self, component_id: ComponentId) -> Option<&'_ dyn Reflect> {
+        let app_type_registry = self.world.get_resource::<AppTypeRegistry>()?;
+        let type_registry = &app_type_registry.read();
+        // SAFETY: TODO
+        unsafe {
+            self.as_unsafe_entity_cell_readonly()
+                .get_reflect(component_id, type_registry)
+        }
+    }
+
+    /// TODO
+    pub fn get_reflect_ref(&self, component_id: ComponentId) -> Option<Ref<'_, dyn Reflect>> {
+        let app_type_registry = self.world.get_resource::<AppTypeRegistry>()?;
+        let type_registry = &app_type_registry.read();
+        // SAFETY: TODO
+        unsafe {
+            self.as_unsafe_entity_cell_readonly()
+                .get_reflect_ref(component_id, type_registry)
+        }
+    }
+
+    /// TODO
+    pub fn get_reflect_mut(&mut self, component_id: ComponentId) -> Option<Mut<'_, dyn Reflect>> {
+        let app_type_registry = self.world.get_resource::<AppTypeRegistry>()?;
+        // SAFETY: as_unsafe_entity_cell mutably borrows self, but doesn't access any resource.
+        let app_type_registry = unsafe { &*core::ptr::from_ref(app_type_registry) };
+        let type_registry = &app_type_registry.read();
+
+        // SAFETY: TODO
+        unsafe {
+            self.as_unsafe_entity_cell()
+                .get_reflect_mut(component_id, type_registry)
+        }
     }
 
     /// Adds a [`Bundle`] of components to the entity.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -534,6 +534,36 @@ impl<'w> EntityMut<'w> {
         // consuming `self` ensures that no references exist to this entity's components.
         unsafe { self.0.get_mut_by_id(component_id) }
     }
+
+    /// TODO
+    pub fn get_reflect(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<&'_ dyn Reflect> {
+        // SAFETY: TODO
+        unsafe { self.0.get_reflect(component_id, type_registry) }
+    }
+
+    /// TODO
+    pub fn get_reflect_ref(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<Ref<'_, dyn Reflect>> {
+        // SAFETY: TODO
+        unsafe { self.0.get_reflect_ref(component_id, type_registry) }
+    }
+
+    /// TODO
+    pub fn get_reflect_mut(
+        &mut self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<Mut<'_, dyn Reflect>> {
+        // SAFETY: TODO
+        unsafe { self.0.get_reflect_mut(component_id, type_registry) }
+    }
 }
 
 impl<'w> From<&'w mut EntityMut<'_>> for EntityMut<'w> {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2465,6 +2465,45 @@ impl<'w> FilteredEntityMut<'w> {
             .then(|| unsafe { self.entity.get_mut_by_id(component_id) })
             .flatten()
     }
+
+    /// TODO
+    pub fn get_reflect(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<&'_ dyn Reflect> {
+        self.access
+            .has_component_read(component_id)
+            // SAFETY: TODO
+            .then(|| unsafe { self.entity.get_reflect(component_id, type_registry) })
+            .flatten()
+    }
+
+    /// TODO
+    pub fn get_reflect_ref(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<Ref<'_, dyn Reflect>> {
+        self.access
+            .has_component_read(component_id)
+            // SAFETY: TODO
+            .then(|| unsafe { self.entity.get_reflect_ref(component_id, type_registry) })
+            .flatten()
+    }
+
+    /// TODO
+    pub fn get_reflect_mut(
+        &mut self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<Mut<'_, dyn Reflect>> {
+        self.access
+            .has_component_write(component_id)
+            // SAFETY: TODO
+            .then(|| unsafe { self.entity.get_reflect_mut(component_id, type_registry) })
+            .flatten()
+    }
 }
 
 impl<'a> From<EntityMut<'a>> for FilteredEntityMut<'a> {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -13,6 +13,7 @@ use crate::{
     world::{DeferredWorld, Mut, World},
 };
 use bevy_ptr::{OwningPtr, Ptr};
+use bevy_reflect::{Reflect, TypeRegistry};
 use core::{any::TypeId, marker::PhantomData};
 use thiserror::Error;
 
@@ -177,6 +178,26 @@ impl<'w> EntityRef<'w> {
     pub fn get_components<Q: ReadOnlyQueryData>(&self) -> Option<Q::Item<'w>> {
         // SAFETY: We have read-only access to all components of this entity.
         unsafe { self.0.get_components::<Q>() }
+    }
+
+    /// TODO
+    pub fn get_reflect(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<&'w dyn Reflect> {
+        // SAFETY: TODO
+        unsafe { self.0.get_reflect(component_id, type_registry) }
+    }
+
+    /// TODO
+    pub fn get_reflect_ref(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<Ref<'w, dyn Reflect>> {
+        // SAFETY: TODO
+        unsafe { self.0.get_reflect_ref(component_id, type_registry) }
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1,7 +1,7 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleId, BundleInfo, BundleInserter, DynamicBundle, InsertMode},
-    change_detection::MutUntyped,
+    change_detection::{MutUntyped, RefUntyped},
     component::{Component, ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     event::Event,
@@ -155,6 +155,12 @@ impl<'w> EntityRef<'w> {
     pub fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'w>> {
         // SAFETY: We have read-only access to all components of this entity.
         unsafe { self.0.get_by_id(component_id) }
+    }
+
+    /// TODO
+    pub fn get_ref_by_id(&self, component_id: ComponentId) -> Option<RefUntyped<'w>> {
+        // SAFETY: We have read-only access to all components of this entity.
+        unsafe { self.0.get_ref_by_id(component_id) }
     }
 
     /// Returns read-only components for the current entity that match the query `Q`.
@@ -459,6 +465,11 @@ impl<'w> EntityMut<'w> {
     #[inline]
     pub fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
         self.as_readonly().get_by_id(component_id)
+    }
+
+    /// TODO
+    pub fn get_ref_by_id(&self, component_id: ComponentId) -> Option<RefUntyped<'_>> {
+        self.as_readonly().get_ref_by_id(component_id)
     }
 
     /// Consumes `self` and gets the component of the given [`ComponentId`] with
@@ -772,6 +783,11 @@ impl<'w> EntityWorldMut<'w> {
     #[inline]
     pub fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
         EntityRef::from(self).get_by_id(component_id)
+    }
+
+    /// TODO
+    pub fn get_ref_by_id(&self, component_id: ComponentId) -> Option<RefUntyped<'_>> {
+        EntityRef::from(self).get_ref_by_id(component_id)
     }
 
     /// Consumes `self` and gets the component of the given [`ComponentId`] with
@@ -2043,6 +2059,15 @@ impl<'w> FilteredEntityRef<'w> {
             .then(|| unsafe { self.entity.get_by_id(component_id) })
             .flatten()
     }
+
+    /// TODO
+    pub fn get_ref_by_id(&self, component_id: ComponentId) -> Option<RefUntyped<'w>> {
+        self.access
+            .has_component_read(component_id)
+            // SAFETY: We have read access
+            .then(|| unsafe { self.entity.get_ref_by_id(component_id) })
+            .flatten()
+    }
 }
 
 impl<'w> From<FilteredEntityMut<'w>> for FilteredEntityRef<'w> {
@@ -2299,6 +2324,15 @@ impl<'w> FilteredEntityMut<'w> {
     #[inline]
     pub fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
         self.as_readonly().get_by_id(component_id)
+    }
+
+    /// TODO
+    pub fn get_ref_by_id(&self, component_id: ComponentId) -> Option<RefUntyped<'_>> {
+        self.access
+            .has_component_read(component_id)
+            // SAFETY: We have read access
+            .then(|| unsafe { self.entity.get_ref_by_id(component_id) })
+            .flatten()
     }
 
     /// Gets a [`MutUntyped`] of the component of the given [`ComponentId`] from the entity.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -565,6 +565,16 @@ impl<'w> EntityMut<'w> {
         // SAFETY: TODO
         unsafe { self.0.get_reflect_mut(component_id, type_registry) }
     }
+
+    /// TODO
+    pub fn get_many_reflect_mut<const N: usize>(
+        &mut self,
+        component_ids: [ComponentId; N],
+        type_registry: &TypeRegistry,
+    ) -> Option<[Mut<'_, dyn Reflect>; N]> {
+        // SAFETY: TODO
+        unsafe { self.0.get_many_reflect_mut(component_ids, type_registry) }
+    }
 }
 
 impl<'w> From<&'w mut EntityMut<'_>> for EntityMut<'w> {
@@ -916,6 +926,23 @@ impl<'w> EntityWorldMut<'w> {
         unsafe {
             self.as_unsafe_entity_cell()
                 .get_reflect_mut(component_id, type_registry)
+        }
+    }
+
+    /// TODO
+    pub fn get_many_reflect_mut<const N: usize>(
+        &mut self,
+        component_ids: [ComponentId; N],
+    ) -> Option<[Mut<'_, dyn Reflect>; N]> {
+        let app_type_registry = self.world.get_resource::<AppTypeRegistry>()?;
+        // SAFETY: as_unsafe_entity_cell mutably borrows self, but doesn't access any resource.
+        let app_type_registry = unsafe { &*core::ptr::from_ref(app_type_registry) };
+        let type_registry = &app_type_registry.read();
+
+        // SAFETY: TODO
+        unsafe {
+            self.as_unsafe_entity_cell()
+                .get_many_reflect_mut(component_ids, type_registry)
         }
     }
 
@@ -2503,6 +2530,25 @@ impl<'w> FilteredEntityMut<'w> {
             // SAFETY: TODO
             .then(|| unsafe { self.entity.get_reflect_mut(component_id, type_registry) })
             .flatten()
+    }
+
+    /// TODO
+    pub fn get_many_reflect_mut<const N: usize>(
+        &mut self,
+        component_ids: [ComponentId; N],
+        type_registry: &TypeRegistry,
+    ) -> Option<[Mut<'_, dyn Reflect>; N]> {
+        for component_id in component_ids {
+            if !self.access.has_component_write(component_id) {
+                return None;
+            }
+        }
+
+        // SAFETY: TODO
+        unsafe {
+            self.entity
+                .get_many_reflect_mut(component_ids, type_registry)
+        }
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2156,6 +2156,32 @@ impl<'w> FilteredEntityRef<'w> {
             .then(|| unsafe { self.entity.get_ref_by_id(component_id) })
             .flatten()
     }
+
+    /// TODO
+    pub fn get_reflect(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<&'w dyn Reflect> {
+        self.access
+            .has_component_read(component_id)
+            // SAFETY: TODO
+            .then(|| unsafe { self.entity.get_reflect(component_id, type_registry) })
+            .flatten()
+    }
+
+    /// TODO
+    pub fn get_reflect_ref(
+        &self,
+        component_id: ComponentId,
+        type_registry: &TypeRegistry,
+    ) -> Option<Ref<'w, dyn Reflect>> {
+        self.access
+            .has_component_read(component_id)
+            // SAFETY: TODO
+            .then(|| unsafe { self.entity.get_reflect_ref(component_id, type_registry) })
+            .flatten()
+    }
 }
 
 impl<'w> From<FilteredEntityMut<'w>> for FilteredEntityRef<'w> {


### PR DESCRIPTION
# Objective

- #14416 added `World::get_reflect` and `World::get_reflect_mut`, but they require a world reference. Make them available on `EntityRef` and other similar types.
- Also add missing `_ref` variants of `get_by_id` methods and the above `get_reflect` methods.

## Solution
- Add `get_reflect`, `get_reflect_ref`, `get_reflect_mut` and `get_many_reflect_mut` methods to the types `UnsafeEntityCell`, `EntityRef`, `EntityMut`, `EntityWorldMut`, `FilteredEntityRef` and `FilteredEntityMut` (the `_mut` variants are missing for types that don't provide mutable access);
  - With the exception of `EntityWorldMut`, all these methods take a `&TypeRegistry` argument, since they can't fetch it from the `World`. `EntityWorldMut` instead fetches the `AppTypeRegistry` resource from the `World` reference it has access to;
  - Differently from the methods on `World` these methods take a `ComponentId`, which I think is more general and slightly more efficient.
- Add `get_ref_by_id` to those same types and a `RefUntyped` type to match `MutUntyped`.

## TODO

- Remove `World::get_reflect` and `World::get_reflect_mut`, since they can be replaced by the corresponding methods on `EntityRef` and `EntityMut`/`EntityWorldMut`
- Documentation and safety comments
- Proper errors instead of `Option`s
- Tests
- Showcase

---

## Showcase

TODO