### PR TITLE
Add Transform Helper methods

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -288,6 +288,57 @@ impl Transform {
         self.local_z()
     }
 
+    /// Translates the entity in the local space using a given direction, speed, and delta time.
+    ///
+    /// The translation is applied directly to the entity's local position without considering
+    /// the entity's rotation. This means the entity moves along the provided direction in its
+    /// own local space.
+    ///
+    /// # Parameters
+    /// - `direction`: A `Vec3` representing the direction of movement in the entity's local space.
+    /// - `speed`: A `f32` representing the speed at which the entity should move.
+    /// - `delta_time_seconds`: A `f32` representing the time elapsed in seconds, typically
+    /// the time since the last frame.
+    ///
+    /// # Example
+    /// ```rust
+    /// transform.translate(Vec3::new(1.0, 0.0, 0.0), 5.0, delta_time);
+    /// ```
+    /// This example moves the entity 5 units per second along the positive X axis,
+    /// ignoring the entity's rotation.
+    pub fn translate(&mut self, direction: Vec3, speed: f32, delta_time_seconds: f32) {
+        self.translation += direction * speed * delta_time_seconds;
+    }
+
+    /// Translates the entity in local space, taking into account the entity's rotation, speed,
+    /// and delta time.
+    ///
+    /// The translation is relative to the entity's rotation. This means the movement will be in
+    /// the direction the entity is currently facing, which allows the entity to move "forward"
+    /// or in any rotated direction relative to its local orientation.
+    ///
+    /// # Parameters
+    /// - `direction`: A `Vec3` representing the direction of movement, relative to the entity's
+    /// local orientation.
+    /// - `speed`: A `f32` representing the speed at which the entity should move.
+    /// - `delta_time_seconds`: A `f32` representing the time elapsed in seconds, typically
+    /// the time since the last frame.
+    ///
+    /// # Example
+    /// ```rust
+    /// transform.translate_with_local_rotation(Vec3::new(0.0, 0.0, 1.0), 5.0, delta_time);
+    /// ```
+    /// This example moves the entity 5 units per second along its local forward (Z axis) direction,
+    /// relative to its current rotation.
+    pub fn translate_with_local_rotation(
+        &mut self,
+        direction: Vec3,
+        speed: f32,
+        delta_time_seconds: f32,
+    ) {
+        self.translation += self.rotation * direction * speed * delta_time_seconds;
+    }
+
     /// Rotates this [`Transform`] by the given rotation.
     ///
     /// If this [`Transform`] has a parent, the `rotation` is relative to the rotation of the parent.

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -68,7 +68,6 @@ fn move_cube(mut cubes: Query<(&mut Transform, &mut Movable)>, timer: Res<Time>)
         if (cube.spawn - transform.translation).length() > cube.max_distance {
             cube.speed *= -1.0;
         }
-        let direction = transform.local_x();
-        transform.translation += direction * cube.speed * timer.delta_seconds();
+        transform.translate(Vec3::X, cube.speed, timer.delta_seconds());
     }
 }


### PR DESCRIPTION
# Objective

- The objective of this PR reflects the idea of adding some helper methods to Transform to avoid cumbersome way of providing direction and moving an object. The issue taken in consideration is the following: [Helper methods on Transform](https://github.com/bevyengine/bevy/issues/14426)

## Solution

- I decided to add a basic translate method in the Transform class `translate(&mut self, direction: Vec3, speed: f32, delta_time_seconds: f32)`. This function simply provides a faster way of adding a translation to the Transform by providing a direction, a speed and a delta_seconds (or delta in general referring to time). This doesn't take in account the rotation of the Transform.
- I also added a second function `translate_with_local_rotation(&mut self, direction: Vec3, speed: f32, delta_time_seconds: f32)`. This function differs from the one above because it also utilizes the rotation of the Transform to provide a way of moving the object following a specific direction and taking in account also it's rotation.

## Testing

- I didn't test the new function, but I changed the example `translation.rs` using the newly implemented function `translate` to see if the result was the same.
- I also tried the second method `translate_with_local_rotation` by modifing the example `3d_rotation` and adding a new line just after the rotation. It moved as expected, but the addition of the line felt like out of scope of the example, so I removed it.
