### PR TITLE
Fix bevy_picking sprite backend panic in out of bounds atlas index

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -86,7 +86,7 @@ pub fn sprite_picking(
 
                     // Hit box in sprite coordinate system
                     let extents = match (sprite.custom_size, atlas) {
-                        (Some(size), _) => size,
+                        (Some(custom_size), _) => custom_size,
                         (None, None) => images.get(image)?.size().as_vec2(),
                         (None, Some(atlas)) => texture_atlas_layout
                             .get(&atlas.layout)


### PR DESCRIPTION
# Objective

- Fix panic when atlas index is out of bounds
- Took the chance to clean it up a bit

## Solution

- Use texture dimensions like rendering pipeline. Dropped atlas layouts and indexes out of bounds are shown as a sprite.

## Testing

Used sprite_picking example, drop layout and/or use indexes out of bounds.


