### PR TITLE
Add `EntityRefExcept` and `EntityMutExcept` world queries, in preparation for generalized animation.

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1", optional = true, default-features = false }
 thiserror = "1.0"
 nonmax = "0.5"
 arrayvec = { version = "0.7.4", optional = true }
+smallvec = "1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -499,6 +499,16 @@ impl Archetype {
         self.components.len()
     }
 
+    /// Gets an iterator of all of the components in the archetype, along with
+    /// their archetype component ID.
+    pub(crate) fn components_with_archetype_component_id(
+        &self,
+    ) -> impl Iterator<Item = (ComponentId, ArchetypeComponentId)> + '_ {
+        self.components
+            .iter()
+            .map(|(component_id, info)| (*component_id, info.archetype_component_id))
+    }
+
     /// Fetches an immutable reference to the archetype's [`Edges`], a cache of
     /// archetypal relationships.
     #[inline]

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -222,6 +222,13 @@ impl<T: SparseSetIndex> Access<T> {
     }
 
     /// Removes both read and write access to the component given by `index`.
+    ///
+    /// Because this method corresponds to the set difference operator ∖, it can
+    /// create complicated logical formulas that you should verify correctness
+    /// of. For example, A ∪ (B ∖ A) isn't equivalent to (A ∪ B) ∖ A, so you
+    /// can't replace a call to `remove_component_read` followed by a call to
+    /// `extend` with a call to `extend` followed by a call to
+    /// `remove_component_read`.
     pub fn remove_component_read(&mut self, index: T) {
         let sparse_set_index = index.sparse_set_index();
         self.remove_component_sparse_set_index_write(sparse_set_index);
@@ -229,6 +236,13 @@ impl<T: SparseSetIndex> Access<T> {
     }
 
     /// Removes write access to the component given by `index`.
+    ///
+    /// Because this method corresponds to the set difference operator ∖, it can
+    /// create complicated logical formulas that you should verify correctness
+    /// of. For example, A ∪ (B ∖ A) isn't equivalent to (A ∪ B) ∖ A, so you
+    /// can't replace a call to `remove_component_write` followed by a call to
+    /// `extend` with a call to `extend` followed by a call to
+    /// `remove_component_write`.
     pub fn remove_component_write(&mut self, index: T) {
         let sparse_set_index = index.sparse_set_index();
         self.remove_component_sparse_set_index_write(sparse_set_index);

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -49,20 +49,22 @@ impl<'a, T: SparseSetIndex + Debug> Debug for FormattedBitSet<'a, T> {
 /// See the [`is_compatible`](Access::is_compatible) and [`get_conflicts`](Access::get_conflicts) functions.
 #[derive(Eq, PartialEq)]
 pub struct Access<T: SparseSetIndex> {
-    /// All accessed components.
+    /// All accessed components, or forbidden components if
+    /// `Self::component_read_and_writes_inverted` is set.
     component_read_and_writes: FixedBitSet,
-    /// The exclusively-accessed components.
+    /// All exclusively-accessed components, or components that may not be
+    /// exclusively accessed if `Self::component_writes_inverted` is set.
     component_writes: FixedBitSet,
     /// All accessed resources.
     resource_read_and_writes: FixedBitSet,
     /// The exclusively-accessed resources.
     resource_writes: FixedBitSet,
-    /// Is `true` if this has access to all components.
-    /// (Note that this does not include `Resources`)
-    reads_all_components: bool,
-    /// Is `true` if this has mutable access to all components.
-    /// (Note that this does not include `Resources`)
-    writes_all_components: bool,
+    /// Is `true` if this component can read all components *except* those
+    /// present in `Self::component_read_and_writes`.
+    component_read_and_writes_inverted: bool,
+    /// Is `true` if this component can write to all components *except* those
+    /// present in `Self::component_writes`.
+    component_writes_inverted: bool,
     /// Is `true` if this has access to all resources.
     /// This field is a performance optimization for `&World` (also harder to mess up for soundness).
     reads_all_resources: bool,
@@ -82,8 +84,8 @@ impl<T: SparseSetIndex> Clone for Access<T> {
             component_writes: self.component_writes.clone(),
             resource_read_and_writes: self.resource_read_and_writes.clone(),
             resource_writes: self.resource_writes.clone(),
-            reads_all_components: self.reads_all_components,
-            writes_all_components: self.writes_all_components,
+            component_read_and_writes_inverted: self.component_read_and_writes_inverted,
+            component_writes_inverted: self.component_writes_inverted,
             reads_all_resources: self.reads_all_resources,
             writes_all_resources: self.writes_all_resources,
             archetypal: self.archetypal.clone(),
@@ -98,8 +100,8 @@ impl<T: SparseSetIndex> Clone for Access<T> {
         self.resource_read_and_writes
             .clone_from(&source.resource_read_and_writes);
         self.resource_writes.clone_from(&source.resource_writes);
-        self.reads_all_components = source.reads_all_components;
-        self.writes_all_components = source.writes_all_components;
+        self.component_read_and_writes_inverted = source.component_read_and_writes_inverted;
+        self.component_writes_inverted = source.component_writes_inverted;
         self.reads_all_resources = source.reads_all_resources;
         self.writes_all_resources = source.writes_all_resources;
         self.archetypal.clone_from(&source.archetypal);
@@ -125,8 +127,11 @@ impl<T: SparseSetIndex + Debug> Debug for Access<T> {
                 "resource_writes",
                 &FormattedBitSet::<T>::new(&self.resource_writes),
             )
-            .field("reads_all_components", &self.reads_all_components)
-            .field("writes_all_components", &self.writes_all_components)
+            .field(
+                "component_read_and_writes_inverted",
+                &self.component_read_and_writes_inverted,
+            )
+            .field("component_writes_inverted", &self.component_writes_inverted)
             .field("reads_all_resources", &self.reads_all_resources)
             .field("writes_all_resources", &self.writes_all_resources)
             .field("archetypal", &FormattedBitSet::<T>::new(&self.archetypal))
@@ -146,8 +151,8 @@ impl<T: SparseSetIndex> Access<T> {
         Self {
             reads_all_resources: false,
             writes_all_resources: false,
-            reads_all_components: false,
-            writes_all_components: false,
+            component_read_and_writes_inverted: false,
+            component_writes_inverted: false,
             component_read_and_writes: FixedBitSet::new(),
             component_writes: FixedBitSet::new(),
             resource_read_and_writes: FixedBitSet::new(),
@@ -157,18 +162,33 @@ impl<T: SparseSetIndex> Access<T> {
         }
     }
 
+    fn add_component_sparse_set_index_read(&mut self, index: usize) {
+        if !self.component_read_and_writes_inverted {
+            self.component_read_and_writes.grow_and_insert(index);
+        } else if index < self.component_read_and_writes.len() {
+            self.component_read_and_writes.remove(index);
+        }
+    }
+
+    fn add_component_sparse_set_index_write(&mut self, index: usize) {
+        if !self.component_writes_inverted {
+            self.component_writes.grow_and_insert(index);
+        } else if index < self.component_writes.len() {
+            self.component_writes.remove(index);
+        }
+    }
+
     /// Adds access to the component given by `index`.
     pub fn add_component_read(&mut self, index: T) {
-        self.component_read_and_writes
-            .grow_and_insert(index.sparse_set_index());
+        let sparse_set_index = index.sparse_set_index();
+        self.add_component_sparse_set_index_read(sparse_set_index);
     }
 
     /// Adds exclusive access to the component given by `index`.
     pub fn add_component_write(&mut self, index: T) {
-        self.component_read_and_writes
-            .grow_and_insert(index.sparse_set_index());
-        self.component_writes
-            .grow_and_insert(index.sparse_set_index());
+        let sparse_set_index = index.sparse_set_index();
+        self.add_component_sparse_set_index_read(sparse_set_index);
+        self.add_component_sparse_set_index_write(sparse_set_index);
     }
 
     /// Adds access to the resource given by `index`.
@@ -185,6 +205,35 @@ impl<T: SparseSetIndex> Access<T> {
             .grow_and_insert(index.sparse_set_index());
     }
 
+    fn remove_component_sparse_set_index_read(&mut self, index: usize) {
+        if self.component_read_and_writes_inverted {
+            self.component_read_and_writes.grow_and_insert(index);
+        } else if index < self.component_read_and_writes.len() {
+            self.component_read_and_writes.remove(index);
+        }
+    }
+
+    fn remove_component_sparse_set_index_write(&mut self, index: usize) {
+        if self.component_writes_inverted {
+            self.component_writes.grow_and_insert(index);
+        } else if index < self.component_writes.len() {
+            self.component_writes.remove(index);
+        }
+    }
+
+    /// Removes both read and write access to the component given by `index`.
+    pub fn remove_component_read(&mut self, index: T) {
+        let sparse_set_index = index.sparse_set_index();
+        self.remove_component_sparse_set_index_write(sparse_set_index);
+        self.remove_component_sparse_set_index_read(sparse_set_index);
+    }
+
+    /// Removes write access to the component given by `index`.
+    pub fn remove_component_write(&mut self, index: T) {
+        let sparse_set_index = index.sparse_set_index();
+        self.remove_component_sparse_set_index_write(sparse_set_index);
+    }
+
     /// Adds an archetypal (indirect) access to the component given by `index`.
     ///
     /// This is for components whose values are not accessed (and thus will never cause conflicts),
@@ -199,25 +248,25 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Returns `true` if this can access the component given by `index`.
     pub fn has_component_read(&self, index: T) -> bool {
-        self.reads_all_components
-            || self
+        self.component_read_and_writes_inverted
+            ^ self
                 .component_read_and_writes
                 .contains(index.sparse_set_index())
     }
 
     /// Returns `true` if this can access any component.
     pub fn has_any_component_read(&self) -> bool {
-        self.reads_all_components || !self.component_read_and_writes.is_clear()
+        self.component_read_and_writes_inverted || !self.component_read_and_writes.is_clear()
     }
 
     /// Returns `true` if this can exclusively access the component given by `index`.
     pub fn has_component_write(&self, index: T) -> bool {
-        self.writes_all_components || self.component_writes.contains(index.sparse_set_index())
+        self.component_writes_inverted ^ self.component_writes.contains(index.sparse_set_index())
     }
 
     /// Returns `true` if this accesses any component mutably.
     pub fn has_any_component_write(&self) -> bool {
-        self.writes_all_components || !self.component_writes.is_clear()
+        self.component_writes_inverted || !self.component_writes.is_clear()
     }
 
     /// Returns `true` if this can access the resource given by `index`.
@@ -258,14 +307,16 @@ impl<T: SparseSetIndex> Access<T> {
     /// Sets this as having access to all components (i.e. `EntityRef`).
     #[inline]
     pub fn read_all_components(&mut self) {
-        self.reads_all_components = true;
+        self.component_read_and_writes_inverted = true;
+        self.component_read_and_writes.clear();
     }
 
     /// Sets this as having mutable access to all components (i.e. `EntityMut`).
     #[inline]
     pub fn write_all_components(&mut self) {
-        self.reads_all_components = true;
-        self.writes_all_components = true;
+        self.read_all_components();
+        self.component_writes_inverted = true;
+        self.component_writes.clear();
     }
 
     /// Sets this as having access to all resources (i.e. `&World`).
@@ -298,13 +349,13 @@ impl<T: SparseSetIndex> Access<T> {
     /// Returns `true` if this has access to all components (i.e. `EntityRef`).
     #[inline]
     pub fn has_read_all_components(&self) -> bool {
-        self.reads_all_components
+        self.component_read_and_writes_inverted && self.component_read_and_writes.is_clear()
     }
 
     /// Returns `true` if this has write access to all components (i.e. `EntityMut`).
     #[inline]
     pub fn has_write_all_components(&self) -> bool {
-        self.writes_all_components
+        self.component_writes_inverted && self.component_writes.is_clear()
     }
 
     /// Returns `true` if this has access to all resources (i.e. `EntityRef`).
@@ -332,7 +383,7 @@ impl<T: SparseSetIndex> Access<T> {
     /// Removes all writes.
     pub fn clear_writes(&mut self) {
         self.writes_all_resources = false;
-        self.writes_all_components = false;
+        self.component_writes_inverted = false;
         self.component_writes.clear();
         self.resource_writes.clear();
     }
@@ -341,8 +392,8 @@ impl<T: SparseSetIndex> Access<T> {
     pub fn clear(&mut self) {
         self.reads_all_resources = false;
         self.writes_all_resources = false;
-        self.reads_all_components = false;
-        self.writes_all_components = false;
+        self.component_read_and_writes_inverted = false;
+        self.component_writes_inverted = false;
         self.component_read_and_writes.clear();
         self.component_writes.clear();
         self.resource_read_and_writes.clear();
@@ -351,13 +402,72 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Adds all access from `other`.
     pub fn extend(&mut self, other: &Access<T>) {
+        let component_read_and_writes_inverted =
+            self.component_read_and_writes_inverted || other.component_read_and_writes_inverted;
+        let component_writes_inverted =
+            self.component_writes_inverted || other.component_writes_inverted;
+
+        match (
+            self.component_read_and_writes_inverted,
+            other.component_read_and_writes_inverted,
+        ) {
+            (true, true) => {
+                self.component_read_and_writes
+                    .intersect_with(&other.component_read_and_writes);
+            }
+            (true, false) => {
+                self.component_read_and_writes
+                    .difference_with(&other.component_read_and_writes);
+            }
+            (false, true) => {
+                // We have to grow here because the new bits are going to get flipped to 1.
+                self.component_read_and_writes.grow(
+                    self.component_read_and_writes
+                        .len()
+                        .max(other.component_read_and_writes.len()),
+                );
+                self.component_read_and_writes.toggle_range(..);
+                self.component_read_and_writes
+                    .intersect_with(&other.component_read_and_writes);
+            }
+            (false, false) => {
+                self.component_read_and_writes
+                    .union_with(&other.component_read_and_writes);
+            }
+        }
+
+        match (
+            self.component_writes_inverted,
+            other.component_writes_inverted,
+        ) {
+            (true, true) => {
+                self.component_writes
+                    .intersect_with(&other.component_writes);
+            }
+            (true, false) => {
+                self.component_writes
+                    .difference_with(&other.component_writes);
+            }
+            (false, true) => {
+                // We have to grow here because the new bits are going to get flipped to 1.
+                self.component_writes.grow(
+                    self.component_writes
+                        .len()
+                        .max(other.component_writes.len()),
+                );
+                self.component_writes.toggle_range(..);
+                self.component_writes
+                    .intersect_with(&other.component_writes);
+            }
+            (false, false) => {
+                self.component_writes.union_with(&other.component_writes);
+            }
+        }
+
         self.reads_all_resources = self.reads_all_resources || other.reads_all_resources;
         self.writes_all_resources = self.writes_all_resources || other.writes_all_resources;
-        self.reads_all_components = self.reads_all_components || other.reads_all_components;
-        self.writes_all_components = self.writes_all_components || other.writes_all_components;
-        self.component_read_and_writes
-            .union_with(&other.component_read_and_writes);
-        self.component_writes.union_with(&other.component_writes);
+        self.component_read_and_writes_inverted = component_read_and_writes_inverted;
+        self.component_writes_inverted = component_writes_inverted;
         self.resource_read_and_writes
             .union_with(&other.resource_read_and_writes);
         self.resource_writes.union_with(&other.resource_writes);
@@ -369,27 +479,52 @@ impl<T: SparseSetIndex> Access<T> {
     /// [`Access`] instances are incompatible if one can write
     /// an element that the other can read or write.
     pub fn is_components_compatible(&self, other: &Access<T>) -> bool {
-        if self.writes_all_components {
-            return !other.has_any_component_read();
+        // We have a conflict if we write and they read or write, or if they
+        // write and we read or write.
+        for (
+            lhs_writes,
+            rhs_reads_and_writes,
+            rhs_reads_and_writes_inverted,
+            lhs_writes_inverted,
+        ) in [
+            (
+                &self.component_writes,
+                &other.component_read_and_writes,
+                other.component_read_and_writes_inverted,
+                self.component_writes_inverted,
+            ),
+            (
+                &other.component_writes,
+                &self.component_read_and_writes,
+                self.component_read_and_writes_inverted,
+                other.component_writes_inverted,
+            ),
+        ] {
+            match (rhs_reads_and_writes_inverted, lhs_writes_inverted) {
+                (true, true) => return false,
+                (true, false) => {
+                    if lhs_writes.difference(rhs_reads_and_writes).next().is_some() {
+                        return false;
+                    }
+                }
+                (false, true) => {
+                    if rhs_reads_and_writes.difference(lhs_writes).next().is_some() {
+                        return false;
+                    }
+                }
+                (false, false) => {
+                    if lhs_writes
+                        .intersection(rhs_reads_and_writes)
+                        .next()
+                        .is_some()
+                    {
+                        return false;
+                    }
+                }
+            }
         }
 
-        if other.writes_all_components {
-            return !self.has_any_component_read();
-        }
-
-        if self.reads_all_components {
-            return !other.has_any_component_write();
-        }
-
-        if other.reads_all_components {
-            return !self.has_any_component_write();
-        }
-
-        self.component_writes
-            .is_disjoint(&other.component_read_and_writes)
-            && other
-                .component_writes
-                .is_disjoint(&self.component_read_and_writes)
+        true
     }
 
     /// Returns `true` if the access and `other` can be active at the same time,
@@ -432,25 +567,52 @@ impl<T: SparseSetIndex> Access<T> {
     /// Returns `true` if the set's component access is a subset of another, i.e. `other`'s component access
     /// contains at least all the values in `self`.
     pub fn is_subset_components(&self, other: &Access<T>) -> bool {
-        if self.writes_all_components {
-            return other.writes_all_components;
+        for (
+            our_components,
+            their_components,
+            our_components_inverted,
+            their_components_inverted,
+        ) in [
+            (
+                &self.component_read_and_writes,
+                &other.component_read_and_writes,
+                self.component_read_and_writes_inverted,
+                other.component_read_and_writes_inverted,
+            ),
+            (
+                &self.component_writes,
+                &other.component_writes,
+                self.component_writes_inverted,
+                other.component_writes_inverted,
+            ),
+        ] {
+            match (our_components_inverted, their_components_inverted) {
+                (true, true) => {
+                    if their_components.difference(our_components).next().is_some() {
+                        return false;
+                    }
+                }
+                (true, false) => {
+                    return false;
+                }
+                (false, true) => {
+                    if our_components
+                        .intersection(their_components)
+                        .next()
+                        .is_some()
+                    {
+                        return false;
+                    }
+                }
+                (false, false) => {
+                    if our_components.difference(their_components).next().is_some() {
+                        return false;
+                    }
+                }
+            }
         }
 
-        if other.writes_all_components {
-            return true;
-        }
-
-        if self.reads_all_components {
-            return other.reads_all_components;
-        }
-
-        if other.reads_all_components {
-            return self.component_writes.is_subset(&other.component_writes);
-        }
-
-        self.component_read_and_writes
-            .is_subset(&other.component_read_and_writes)
-            && self.component_writes.is_subset(&other.component_writes)
+        true
     }
 
     /// Returns `true` if the set's resource access is a subset of another, i.e. `other`'s resource access
@@ -483,30 +645,52 @@ impl<T: SparseSetIndex> Access<T> {
         self.is_subset_components(other) && self.is_subset_resources(other)
     }
 
+    fn get_component_conflicts(&self, other: &Access<T>) -> AccessConflicts {
+        let mut conflicts = FixedBitSet::new();
+
+        // We have a conflict if we write and they read or write, or if they
+        // write and we read or write.
+        for (
+            lhs_writes,
+            rhs_reads_and_writes,
+            rhs_reads_and_writes_inverted,
+            lhs_writes_inverted,
+        ) in [
+            (
+                &self.component_writes,
+                &other.component_read_and_writes,
+                other.component_read_and_writes_inverted,
+                self.component_writes_inverted,
+            ),
+            (
+                &other.component_writes,
+                &self.component_read_and_writes,
+                self.component_read_and_writes_inverted,
+                other.component_writes_inverted,
+            ),
+        ] {
+            // There's no way that I can see to do this without a temporary.
+            // Neither CNF or DNF allows us to avoid one.
+            let temp_conflicts: FixedBitSet =
+                match (rhs_reads_and_writes_inverted, lhs_writes_inverted) {
+                    (true, true) => return AccessConflicts::All,
+                    (true, false) => lhs_writes.difference(rhs_reads_and_writes).collect(),
+                    (false, true) => rhs_reads_and_writes.difference(lhs_writes).collect(),
+                    (false, false) => lhs_writes.intersection(rhs_reads_and_writes).collect(),
+                };
+            conflicts.union_with(&temp_conflicts);
+        }
+
+        AccessConflicts::Individual(conflicts)
+    }
+
     /// Returns a vector of elements that the access and `other` cannot access at the same time.
     pub fn get_conflicts(&self, other: &Access<T>) -> AccessConflicts {
-        let mut conflicts = FixedBitSet::new();
-        if self.reads_all_components {
-            if other.writes_all_components {
-                return AccessConflicts::All;
-            }
-            conflicts.extend(other.component_writes.ones());
-        }
+        let mut conflicts = match self.get_component_conflicts(other) {
+            AccessConflicts::All => return AccessConflicts::All,
+            AccessConflicts::Individual(conflicts) => conflicts,
+        };
 
-        if other.reads_all_components {
-            if self.writes_all_components {
-                return AccessConflicts::All;
-            }
-            conflicts.extend(self.component_writes.ones());
-        }
-
-        if self.writes_all_components {
-            conflicts.extend(other.component_read_and_writes.ones());
-        }
-
-        if other.writes_all_components {
-            conflicts.extend(self.component_read_and_writes.ones());
-        }
         if self.reads_all_resources {
             if other.writes_all_resources {
                 return AccessConflicts::All;
@@ -529,14 +713,6 @@ impl<T: SparseSetIndex> Access<T> {
         }
 
         conflicts.extend(
-            self.component_writes
-                .intersection(&other.component_read_and_writes),
-        );
-        conflicts.extend(
-            self.component_read_and_writes
-                .intersection(&other.component_writes),
-        );
-        conflicts.extend(
             self.resource_writes
                 .intersection(&other.resource_read_and_writes),
         );
@@ -545,25 +721,6 @@ impl<T: SparseSetIndex> Access<T> {
                 .intersection(&other.resource_writes),
         );
         AccessConflicts::Individual(conflicts)
-    }
-
-    /// Returns the indices of the components this has access to.
-    pub fn component_reads_and_writes(&self) -> impl Iterator<Item = T> + '_ {
-        self.component_read_and_writes
-            .ones()
-            .map(T::get_sparse_set_index)
-    }
-
-    /// Returns the indices of the components this has non-exclusive access to.
-    pub fn component_reads(&self) -> impl Iterator<Item = T> + '_ {
-        self.component_read_and_writes
-            .difference(&self.component_writes)
-            .map(T::get_sparse_set_index)
-    }
-
-    /// Returns the indices of the components this has exclusive access to.
-    pub fn component_writes(&self) -> impl Iterator<Item = T> + '_ {
-        self.component_writes.ones().map(T::get_sparse_set_index)
     }
 
     /// Returns the indices of the components that this has an archetypal access to.
@@ -576,6 +733,33 @@ impl<T: SparseSetIndex> Access<T> {
     /// [`Has<T>`]: crate::query::Has
     pub fn archetypal(&self) -> impl Iterator<Item = T> + '_ {
         self.archetypal.ones().map(T::get_sparse_set_index)
+    }
+
+    /// Returns an iterator over the component IDs that this `Access` either
+    /// reads and writes or cannot read or write, depending on the value of
+    /// [`Access::component_reads_and_writes_inverted`].
+    ///
+    /// Because this method depends on internal implementation details of
+    /// `Access`, it's not recommended. Prefer to manage your own lists of
+    /// accessible components if your application needs to do that.
+    #[doc(hidden)]
+    pub fn component_reads_and_writes(&self) -> impl Iterator<Item = T> + '_ {
+        self.component_read_and_writes
+            .ones()
+            .map(T::get_sparse_set_index)
+    }
+
+    /// Returns true if [`Access::component_reads_and_writes`] returns IDs of
+    /// components that this [`Access`] does *not* allow access to, or false if
+    /// that method returns IDs of components that this [`Access`] *does* allow
+    /// access to.
+    ///
+    /// Because this method depends on internal implementation details of
+    /// `Access`, it's not recommended. Prefer to manage your own lists of
+    /// accessible components if your application needs to do that.
+    #[doc(hidden)]
+    pub fn component_reads_and_writes_inverted(&self) -> bool {
+        self.component_read_and_writes_inverted
     }
 }
 

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -79,10 +79,12 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
                 .map_or(false, |info| info.storage_type() == StorageType::Table)
         };
 
-        self.access
-            .access()
-            .component_reads_and_writes()
-            .all(is_dense)
+        !self.access.access().component_reads_and_writes_inverted()
+            && self
+                .access
+                .access()
+                .component_reads_and_writes()
+                .all(is_dense)
             && self.access.access().archetypal().all(is_dense)
             && !self.access.access().has_read_all_components()
             && self.access.with_filters().all(is_dense)

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -79,12 +79,14 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
                 .map_or(false, |info| info.storage_type() == StorageType::Table)
         };
 
-        !self.access.access().component_reads_and_writes_inverted()
-            && self
-                .access
-                .access()
-                .component_reads_and_writes()
-                .all(is_dense)
+        #[allow(deprecated)]
+        let (mut component_reads_and_writes, component_reads_and_writes_inverted) =
+            self.access.access().component_reads_and_writes();
+        if component_reads_and_writes_inverted {
+            return false;
+        }
+
+        component_reads_and_writes.all(is_dense)
             && self.access.access().archetypal().all(is_dense)
             && !self.access.access().has_read_all_components()
             && self.access.with_filters().all(is_dense)

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -813,7 +813,7 @@ unsafe impl<'a> QueryData for FilteredEntityMut<'a> {
     type ReadOnly = FilteredEntityRef<'a>;
 }
 
-/// SAFETY: `EntityRefExcept` guards access to all components in the list `CL`
+/// SAFETY: `EntityRefExcept` guards access to all components in the bundle `B`
 /// and populates `Access` values so that queries that conflict with this access
 /// are rejected.
 unsafe impl<'a, B> WorldQuery for EntityRefExcept<'a, B>
@@ -905,7 +905,7 @@ where
 /// components.
 unsafe impl<'a, B> ReadOnlyQueryData for EntityRefExcept<'a, B> where B: Bundle {}
 
-/// SAFETY: `EntityMutExcept` guards access to all components in the list `CL`
+/// SAFETY: `EntityMutExcept` guards access to all components in the bundle `B`
 /// and populates `Access` values so that queries that conflict with this access
 /// are rejected.
 unsafe impl<'a, B> WorldQuery for EntityMutExcept<'a, B>

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -845,7 +845,8 @@ where
         let access = filtered_access.access_mut();
         assert!(
             access.is_compatible(&my_access),
-            "`EntityRefExcept` conflicts with a previous access in this query."
+            "`EntityRefExcept<{}>` conflicts with a previous access in this query.",
+            std::any::type_name::<B>(),
         );
         access.extend(&my_access);
     }
@@ -943,7 +944,8 @@ where
         let access = filtered_access.access_mut();
         assert!(
             access.is_compatible(&my_access),
-            "`EntityMutExcept` conflicts with a previous access in this query."
+            "`EntityMutExcept<{}>` conflicts with a previous access in this query.",
+            std::any::type_name::<B>()
         );
         access.extend(&my_access);
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -509,11 +509,22 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         access: &mut Access<ArchetypeComponentId>,
     ) {
         for component_id in archetype.components() {
-            let Some(archetype_component_id) = archetype.get_archetype_component_id(component_id) else { continue };
-            if self.component_access.access.has_component_read(component_id) {
+            let Some(archetype_component_id) = archetype.get_archetype_component_id(component_id)
+            else {
+                continue;
+            };
+            if self
+                .component_access
+                .access
+                .has_component_read(component_id)
+            {
                 access.add_component_read(archetype_component_id);
             }
-            if self.component_access.access.has_component_write(component_id) {
+            if self
+                .component_access
+                .access
+                .has_component_write(component_id)
+            {
                 access.add_component_write(archetype_component_id);
             }
         }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -508,22 +508,15 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         archetype: &Archetype,
         access: &mut Access<ArchetypeComponentId>,
     ) {
-        self.component_access
-            .access
-            .component_reads()
-            .for_each(|id| {
-                if let Some(id) = archetype.get_archetype_component_id(id) {
-                    access.add_component_read(id);
-                }
-            });
-        self.component_access
-            .access
-            .component_writes()
-            .for_each(|id| {
-                if let Some(id) = archetype.get_archetype_component_id(id) {
-                    access.add_component_write(id);
-                }
-            });
+        for component_id in archetype.components() {
+            let Some(archetype_component_id) = archetype.get_archetype_component_id(component_id) else { continue };
+            if self.component_access.access.has_component_read(component_id) {
+                access.add_component_read(archetype_component_id);
+            }
+            if self.component_access.access.has_component_write(component_id) {
+                access.add_component_write(archetype_component_id);
+            }
+        }
     }
 
     /// Use this to transform a [`QueryState`] into a more generic [`QueryState`].

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -902,6 +902,11 @@ impl Table {
             column.clear();
         }
     }
+
+    /// Returns the component ID of every column in the [`Table`].
+    pub(crate) fn columns(&self) -> impl Iterator<Item = ComponentId> + '_ {
+        self.columns.indices()
+    }
 }
 
 /// A collection of [`Table`] storages, indexed by [`TableId`]

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -902,11 +902,6 @@ impl Table {
             column.clear();
         }
     }
-
-    /// Returns the component ID of every column in the [`Table`].
-    pub(crate) fn columns(&self) -> impl Iterator<Item = ComponentId> + '_ {
-        self.columns.indices()
-    }
 }
 
 /// A collection of [`Table`] storages, indexed by [`TableId`]

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1493,13 +1493,10 @@ mod tests {
         // set up system and verify its access is empty
         system.initialize(&mut world);
         system.update_archetype_component_access(world.as_unsafe_world_cell());
-        assert_eq!(
-            system
-                .archetype_component_access()
-                .component_reads()
-                .collect::<HashSet<_>>(),
-            expected_ids
-        );
+        let archetype_component_access = system.archetype_component_access();
+        assert!(expected_ids
+            .iter()
+            .all(|id| archetype_component_access.has_component_read(*id)));
 
         // add some entities with archetypes that should match and save their ids
         expected_ids.insert(
@@ -1523,13 +1520,10 @@ mod tests {
 
         // update system and verify its accesses are correct
         system.update_archetype_component_access(world.as_unsafe_world_cell());
-        assert_eq!(
-            system
-                .archetype_component_access()
-                .component_reads()
-                .collect::<HashSet<_>>(),
-            expected_ids
-        );
+        let archetype_component_access = system.archetype_component_access();
+        assert!(expected_ids
+            .iter()
+            .all(|id| archetype_component_access.has_component_read(*id)));
 
         // one more round
         expected_ids.insert(
@@ -1541,13 +1535,10 @@ mod tests {
         );
         world.spawn((A, B, D));
         system.update_archetype_component_access(world.as_unsafe_world_cell());
-        assert_eq!(
-            system
-                .archetype_component_access()
-                .component_reads()
-                .collect::<HashSet<_>>(),
-            expected_ids
-        );
+        let archetype_component_access = system.archetype_component_access();
+        assert!(expected_ids
+            .iter()
+            .all(|id| archetype_component_access.has_component_read(*id)));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2384,6 +2384,259 @@ pub enum TryFromFilteredError {
     MissingWriteAllAccess,
 }
 
+/// A type-level set of components.
+///
+/// This is used to name components in [`EntityRefExcept`] and
+/// [`EntityMutExcept`].
+pub trait ComponentList {
+    /// An array of component IDs, one for each component in the list.
+    type Ids: ComponentIdList;
+
+    /// Returns the component IDs of each component in the list.
+    fn get_ids(components: &Components) -> Self::Ids;
+
+    /// Returns true if the component `C` is a member of this list and false
+    /// otherwise.
+    fn contains<C>() -> bool
+    where
+        C: Component;
+}
+
+/// A fixed-length array of component IDs.
+///
+/// This is essentially an implementation detail of [`ComponentList`].
+pub trait ComponentIdList: Clone + Send + Sync {
+    /// Returns true if this list contains the given component ID and false
+    /// otherwise.
+    fn contains(&self, id: ComponentId) -> bool;
+}
+
+impl<C> ComponentList for C
+where
+    C: Component,
+{
+    type Ids = ComponentId;
+
+    #[inline]
+    fn get_ids(components: &Components) -> Self::Ids {
+        components.component_id::<C>().unwrap()
+    }
+
+    #[inline]
+    fn contains<K>() -> bool
+    where
+        K: Component,
+    {
+        TypeId::of::<K>() == TypeId::of::<C>()
+    }
+}
+
+// Replaces a token tree with a constant. This is a helper for
+// `impl_component_list_tuple!` below.
+//
+// https://veykril.github.io/tlborm/decl-macros/patterns/repetition-replacement.html
+macro_rules! replace_expr {
+    ($_t:tt $sub:expr) => {
+        $sub
+    };
+}
+
+// A helper macro to reduce internal boilerplate when for `ComponentList` tuple
+// implementations.
+macro_rules! impl_component_list_tuple {
+    ($($name: ident),*) => {
+        impl<$($name),*> ComponentList for ($($name,)*) where $($name: Component),* {
+            type Ids = [ComponentId; 0 $(+ replace_expr!($name 1))*];
+
+            #[inline]
+            fn get_ids(components: &Components) -> Self::Ids {
+                [$(components.component_id::<$name>().unwrap()),*]
+            }
+
+            #[inline]
+            fn contains<C>() -> bool where C: Component {
+                true $(|| TypeId::of::<C>() == TypeId::of::<$name>())*
+            }
+        }
+    }
+}
+
+impl_component_list_tuple!(C1);
+impl_component_list_tuple!(C1, C2);
+impl_component_list_tuple!(C1, C2, C3);
+impl_component_list_tuple!(C1, C2, C3, C4);
+impl_component_list_tuple!(C1, C2, C3, C4, C5);
+impl_component_list_tuple!(C1, C2, C3, C4, C5, C6);
+impl_component_list_tuple!(C1, C2, C3, C4, C5, C6, C7);
+impl_component_list_tuple!(C1, C2, C3, C4, C5, C6, C7, C8);
+
+impl ComponentIdList for ComponentId {
+    fn contains(&self, id: ComponentId) -> bool {
+        *self == id
+    }
+}
+
+impl<const N: usize> ComponentIdList for [ComponentId; N] {
+    fn contains(&self, query_id: ComponentId) -> bool {
+        self.iter().any(|id| *id == query_id)
+    }
+}
+
+/// Provides read-only access to a single entity and all its components, save
+/// for an explicitly-enumerated set.
+#[derive(Clone)]
+pub struct EntityRefExcept<'w, CL>
+where
+    CL: ComponentList,
+{
+    entity: UnsafeEntityCell<'w>,
+    phantom: PhantomData<CL>,
+}
+
+impl<'w, CL> EntityRefExcept<'w, CL>
+where
+    CL: ComponentList,
+{
+    pub(crate) unsafe fn new(entity: UnsafeEntityCell<'w>) -> Self {
+        Self {
+            entity,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Gets access to the component of type `C` for the current entity. Returns
+    /// `None` if the component doesn't have a component of that type or if the
+    /// type is one of the excluded components.
+    #[inline]
+    pub fn get<C>(&self) -> Option<&'w C>
+    where
+        C: Component,
+    {
+        if CL::contains::<C>() {
+            None
+        } else {
+            // SAFETY: We have read access for all components that weren't
+            // covered by the `contains` check above.
+            unsafe { self.entity.get() }
+        }
+    }
+
+    /// Gets access to the component of type `C` for the current entity,
+    /// including change detection information. Returns `None` if the component
+    /// doesn't have a component of that type or if the type is one of the
+    /// excluded components.
+    #[inline]
+    pub fn get_ref<C>(&self) -> Option<Ref<'w, C>>
+    where
+        C: Component,
+    {
+        if CL::contains::<C>() {
+            None
+        } else {
+            // SAFETY: We have read access for all components that weren't
+            // covered by the `contains` check above.
+            unsafe { self.entity.get_ref() }
+        }
+    }
+}
+
+impl<'a, CL> From<&'a EntityMutExcept<'_, CL>> for EntityRefExcept<'a, CL>
+where
+    CL: ComponentList,
+{
+    fn from(entity_mut: &'a EntityMutExcept<'_, CL>) -> Self {
+        // SAFETY: All accesses that `EntityRefExcept` provides are also
+        // accesses that `EntityMutExcept` provides.
+        unsafe { EntityRefExcept::new(entity_mut.entity) }
+    }
+}
+
+/// Provides mutable access to all components of an entity, with the exception
+/// of an explicit set.
+///
+/// This is a rather niche type that should only be used if you need access to
+/// *all* components of an entity, while still allowing you to consult other
+/// queries that might match entities that this query also matches. If you don't
+/// need access to all components, prefer a standard query with a
+/// [`crate::query::Without`] filter.
+#[derive(Clone)]
+pub struct EntityMutExcept<'w, CL>
+where
+    CL: ComponentList,
+{
+    entity: UnsafeEntityCell<'w>,
+    phantom: PhantomData<CL>,
+}
+
+impl<'w, CL> EntityMutExcept<'w, CL>
+where
+    CL: ComponentList,
+{
+    pub(crate) unsafe fn new(entity: UnsafeEntityCell<'w>) -> Self {
+        Self {
+            entity,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns a new instance with a shorter lifetime.
+    ///
+    /// This is useful if you have `&mut EntityMutExcept`, but you need
+    /// `EntityMutExcept`.
+    pub fn reborrow(&mut self) -> EntityMutExcept<'_, CL> {
+        // SAFETY: We have exclusive access to the entire entity and the
+        // applicable components.
+        unsafe { Self::new(self.entity) }
+    }
+
+    /// Gets read-only access to all of the entity's components, except for the
+    /// ones in `CL`.
+    #[inline]
+    pub fn as_readonly(&self) -> EntityRefExcept<'_, CL> {
+        EntityRefExcept::from(self)
+    }
+
+    /// Gets access to the component of type `C` for the current entity. Returns
+    /// `None` if the component doesn't have a component of that type or if the
+    /// type is one of the excluded components.
+    #[inline]
+    pub fn get<C>(&self) -> Option<&'_ C>
+    where
+        C: Component,
+    {
+        self.as_readonly().get()
+    }
+
+    /// Gets access to the component of type `C` for the current entity,
+    /// including change detection information. Returns `None` if the component
+    /// doesn't have a component of that type or if the type is one of the
+    /// excluded components.
+    #[inline]
+    pub fn get_ref<C>(&self) -> Option<Ref<'_, C>>
+    where
+        C: Component,
+    {
+        self.as_readonly().get_ref()
+    }
+
+    /// Gets mutable access to the component of type `C` for the current entity.
+    /// Returns `None` if the component doesn't have a component of that type or
+    /// if the type is one of the excluded components.
+    #[inline]
+    pub fn get_mut<C>(&self) -> Option<Mut<'_, C>>
+    where
+        C: Component,
+    {
+        if CL::contains::<C>() {
+            None
+        } else {
+            // SAFETY: We have write access for all components that weren't
+            // covered by the `contains` check above.
+            unsafe { self.entity.get_mut() }
+        }
+    }
+}
+
 /// Inserts a dynamic [`Bundle`] into the entity.
 ///
 /// # Safety
@@ -2603,8 +2856,11 @@ mod tests {
     use bevy_ptr::OwningPtr;
     use std::panic::AssertUnwindSafe;
 
+    use crate::system::{QueryParamBuilder, RunSystemOnce as _};
     use crate::world::{FilteredEntityMut, FilteredEntityRef};
     use crate::{self as bevy_ecs, component::ComponentId, prelude::*, system::assert_is_system};
+
+    use super::{EntityMutExcept, EntityRefExcept};
 
     #[test]
     fn sorted_remove() {
@@ -2996,6 +3252,187 @@ mod tests {
 
         // remove non-existent component does not panic
         world.spawn_empty().remove_by_id(test_component_id);
+    }
+
+    /// Tests that components can be accessed through an `EntityRefExcept`.
+    #[test]
+    fn entity_ref_except() {
+        let mut world = World::new();
+        world.init_component::<TestComponent>();
+        world.init_component::<TestComponent2>();
+
+        world.spawn(TestComponent(0)).insert(TestComponent2(0));
+
+        let mut query = world.query::<EntityRefExcept<TestComponent>>();
+
+        let mut found = false;
+        for entity_ref in query.iter_mut(&mut world) {
+            found = true;
+            assert!(entity_ref.get::<TestComponent>().is_none());
+            assert!(matches!(
+                entity_ref.get::<TestComponent2>(),
+                Some(TestComponent2(0))
+            ));
+        }
+
+        assert!(found);
+    }
+
+    // Test that an `EntityRefExcept` that doesn't include a component C among
+    // its exclusions can't coexist with a mutable query for that component.
+    #[test]
+    #[should_panic]
+    fn entity_ref_except_conflicts() {
+        let mut world = World::new();
+        world.init_component::<TestComponent>();
+        world.init_component::<TestComponent2>();
+
+        world.spawn(TestComponent(0)).insert(TestComponent2(0));
+
+        // This should panic, because we have a mutable borrow on
+        // `TestComponent` but have a simultaneous indirect immutable borrow on
+        // that component via `EntityRefExcept`.
+        let system = (
+            QueryParamBuilder::new(|builder| {
+                builder.data::<&mut TestComponent>();
+            }),
+            QueryParamBuilder::new(|builder| {
+                builder.data::<EntityRefExcept<TestComponent2>>();
+            }),
+        )
+            .build_state(&mut world)
+            .build_system(
+                |_: Query<&mut TestComponent>, _: Query<EntityRefExcept<TestComponent2>>| {},
+            );
+
+        world.run_system_once(system);
+    }
+
+    // Test that an `EntityRefExcept` with an exception for some component C can
+    // coexist with a query for that component C.
+    #[test]
+    fn entity_ref_except_doesnt_conflict() {
+        let mut world = World::new();
+        world.init_component::<TestComponent>();
+        world.init_component::<TestComponent2>();
+
+        world.spawn(TestComponent(0)).insert(TestComponent2(0));
+
+        let system = (
+            QueryParamBuilder::new(|builder| {
+                builder.data::<&mut TestComponent>();
+            }),
+            QueryParamBuilder::new(|builder| {
+                builder.data::<EntityRefExcept<TestComponent>>();
+            }),
+        )
+            .build_state(&mut world)
+            .build_system(
+                |_: Query<&mut TestComponent>, query: Query<EntityRefExcept<TestComponent>>| {
+                    for entity_ref in query.iter() {
+                        assert!(matches!(
+                            entity_ref.get::<TestComponent2>(),
+                            Some(TestComponent2(0))
+                        ));
+                    }
+                },
+            );
+
+        world.run_system_once(system);
+    }
+
+    /// Tests that components can be mutably accessed through an
+    /// `EntityMutExcept`.
+    #[test]
+    fn entity_mut_except() {
+        let mut world = World::new();
+        world.init_component::<TestComponent>();
+        world.init_component::<TestComponent2>();
+
+        world.spawn(TestComponent(0)).insert(TestComponent2(0));
+
+        let mut query = world.query::<EntityMutExcept<TestComponent>>();
+
+        let mut found = false;
+        for entity_mut in query.iter_mut(&mut world) {
+            found = true;
+            assert!(entity_mut.get::<TestComponent>().is_none());
+            assert!(matches!(
+                entity_mut.get::<TestComponent2>(),
+                Some(TestComponent2(0))
+            ));
+        }
+
+        assert!(found);
+    }
+
+    // Test that an `EntityMutExcept` that doesn't include a component C among
+    // its exclusions can't coexist with a query for that component.
+    #[test]
+    #[should_panic]
+    fn entity_mut_except_conflicts() {
+        let mut world = World::new();
+        world.init_component::<TestComponent>();
+        world.init_component::<TestComponent2>();
+
+        world.spawn(TestComponent(0)).insert(TestComponent2(0));
+
+        // This should panic, because we have a mutable borrow on
+        // `TestComponent` but have a simultaneous indirect immutable borrow on
+        // that component via `EntityRefExcept`.
+        let system = (
+            QueryParamBuilder::new(|builder| {
+                builder.data::<&mut TestComponent>();
+            }),
+            QueryParamBuilder::new(|builder| {
+                builder.data::<EntityMutExcept<TestComponent2>>();
+            }),
+        )
+            .build_state(&mut world)
+            .build_system(
+                |_: Query<&mut TestComponent>,
+                 mut query: Query<EntityMutExcept<TestComponent2>>| {
+                    for entity_mut in query.iter_mut() {
+                        assert!(entity_mut
+                            .get_mut::<TestComponent2>()
+                            .is_some_and(|component| component.0 == 0));
+                    }
+                },
+            );
+
+        world.run_system_once(system);
+    }
+
+    // Test that an `EntityMutExcept` with an exception for some component C can
+    // coexist with a query for that component C.
+    #[test]
+    fn entity_mut_except_doesnt_conflict() {
+        let mut world = World::new();
+        world.init_component::<TestComponent>();
+        world.init_component::<TestComponent2>();
+
+        world.spawn(TestComponent(0)).insert(TestComponent2(0));
+
+        let system = (
+            QueryParamBuilder::new(|builder| {
+                builder.data::<&mut TestComponent>();
+            }),
+            QueryParamBuilder::new(|builder| {
+                builder.data::<EntityMutExcept<TestComponent>>();
+            }),
+        )
+            .build_state(&mut world)
+            .build_system(
+                |_: Query<&mut TestComponent>, mut query: Query<EntityMutExcept<TestComponent>>| {
+                    for entity_mut in query.iter_mut() {
+                        assert!(entity_mut
+                            .get_mut::<TestComponent2>()
+                            .is_some_and(|component| component.0 == 0));
+                    }
+                },
+            );
+
+        world.run_system_once(system);
     }
 
     #[derive(Component)]

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2765,7 +2765,7 @@ mod tests {
     use bevy_ptr::OwningPtr;
     use std::panic::AssertUnwindSafe;
 
-    use crate::system::{QueryParamBuilder, RunSystemOnce as _};
+    use crate::system::RunSystemOnce as _;
     use crate::world::{FilteredEntityMut, FilteredEntityRef};
     use crate::{self as bevy_ecs, component::ComponentId, prelude::*, system::assert_is_system};
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -19,8 +19,8 @@ pub use crate::{
 pub use component_constants::*;
 pub use deferred_world::DeferredWorld;
 pub use entity_ref::{
-    ComponentIdList, ComponentList, EntityMut, EntityMutExcept, EntityRef, EntityRefExcept,
-    EntityWorldMut, Entry, FilteredEntityMut, FilteredEntityRef, OccupiedEntry, VacantEntry,
+    EntityMut, EntityMutExcept, EntityRef, EntityRefExcept, EntityWorldMut, Entry,
+    FilteredEntityMut, FilteredEntityRef, OccupiedEntry, VacantEntry,
 };
 pub use identifier::WorldId;
 pub use spawn_batch::*;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -19,8 +19,8 @@ pub use crate::{
 pub use component_constants::*;
 pub use deferred_world::DeferredWorld;
 pub use entity_ref::{
-    EntityMut, EntityRef, EntityWorldMut, Entry, FilteredEntityMut, FilteredEntityRef,
-    OccupiedEntry, VacantEntry,
+    ComponentIdList, ComponentList, EntityMut, EntityMutExcept, EntityRef, EntityRefExcept,
+    EntityWorldMut, Entry, FilteredEntityMut, FilteredEntityRef, OccupiedEntry, VacantEntry,
 };
 pub use identifier::WorldId;
 pub use spawn_batch::*;

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -151,7 +151,8 @@ fn main() {
 
                 query.iter_mut(&mut world).for_each(|filtered_entity| {
                     let terms = filtered_entity
-                        .accessed_components()
+                        .access()
+                        .component_reads_and_writes()
                         .map(|id| {
                             let ptr = filtered_entity.get_by_id(id).unwrap();
                             let info = component_info.get(&id).unwrap();

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -150,9 +150,11 @@ fn main() {
                 let mut query = builder.build();
 
                 query.iter_mut(&mut world).for_each(|filtered_entity| {
+                    #[allow(deprecated)]
                     let terms = filtered_entity
                         .access()
                         .component_reads_and_writes()
+                        .0
                         .map(|id| {
                             let ptr = filtered_entity.get_by_id(id).unwrap();
                             let info = component_info.get(&id).unwrap();


### PR DESCRIPTION
This commit adds two new `WorldQuery` types: `EntityRefExcept` and `EntityMutExcept`. These types work just like `EntityRef` and `EntityMut`, but they prevent access to a statically-specified list of components. For example, `EntityMutExcept<(AnimationPlayer, Handle<AnimationGraph>)>` provides mutable access to all components except for `AnimationPlayer` and `Handle<AnimationGraph>`. These types are useful when you need to be able to process arbitrary queries while iterating over the results of another `EntityMut` query.

The motivating use case is *generalized animation*, which is an upcoming feature that allows animation of any component property, not just rotation, translation, scaling, or morph weights. To implement this, we must change the current `AnyOf<(&mut Transform, &mut MorphWeights)>` to instead be `EntityMutExcept<(AnimationPlayer, Handle<AnimationGraph>)>`. It's possible to use `FilteredEntityMut` in conjunction with a dynamically-generated system instead, but `FilteredEntityMut` isn't optimized for the use case of a large number of allowed components coupled with a small set of disallowed components. No amount of optimization of `FilteredEntityMut` produced acceptable performance on the `many_foxes` benchmark. `Query<EntityMut, Without<AnimationPlayer>>` will not suffice either, as it's legal and idiomatic for an `AnimationTarget` and an `AnimationPlayer` to coexist on the same entity.

An alternate proposal was to implement a somewhat-more-general `Except<Q, CL>` feature, where Q is a `WorldQuery` and CL is a `ComponentList`. I wasn't able to implement that proposal in a reasonable way, because of the fact that methods like `EntityMut::get_mut` and `EntityRef::get` are inherent methods instead of methods on `WorldQuery`, and therefore there was no way to delegate methods like `get` and `get_mut` to the inner query in a generic way. Refactoring those methods into a trait would probably be possible. However, I didn't see a use case for a hypothetical `Except` with arbitrary queries: `Query<Except<(&Transform, &Visibility), Visibility>>` would just be a complicated equivalent to `Query<&Transform>`, for instance. So, out of a desire for simplicity, I omitted a generic `Except` mechanism.

I've tested the performance of generalized animation on `many_foxes` and found that, with this patch, `animate_targets` has a 7.4% slowdown over `main`. With `FilteredEntityMut` optimized to use `Arc<Access>`, the slowdown is 75.6%, due to contention on the reference count. Without `Arc<Access>`, the slowdown is even worse, over 2x.

## Testing

New tests have been added that check that `EntityRefExcept` and `EntityMutExcept` allow and disallow access to components properly and that the query engine can correctly reject conflicting queries involving those types.

A Tracy profile of `many_foxes` with 10,000 foxes showing generalized animation using `FilteredEntityMut` (red) vs. main (yellow) is as follows:

![Screenshot 2024-09-12 225914](https://github.com/user-attachments/assets/2993d74c-a513-4ba4-85bd-225672e7170a)

A Tracy profile of `many_foxes` with 10,000 foxes showing generalized animation using this `EntityMutExcept` (yellow) vs. main (red) is as follows:

![Screenshot 2024-09-14 205831](https://github.com/user-attachments/assets/4241015e-0c5d-44ef-835b-43f78a24e604)