### PR TITLE
Use of deprecated function in example for ButtonInput

### DIFF
--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -125,7 +125,7 @@ use std::hash::Hash;
 ///             Update,
 ///             something_used.run_if(
 ///                 input_just_pressed(KeyCode::KeyE)
-///                     .or_else(input_just_pressed(GamepadButton::new(
+///                     .or(input_just_pressed(GamepadButton::new(
 ///                         Gamepad::new(0),
 ///                         GamepadButtonType::West,
 ///                     ))),


### PR DESCRIPTION
The function `bevy_input::schedule::condition::Condition::or_else` has been deprecated in favor of `bevy_input::schedule::condition::Condition::or`. However the docs for `ButtonInput` were still using the deprecated function in their example.