### PR TITLE
Note on compiling on FreeBSD

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -205,3 +205,11 @@ sudo eopkg it wayland-devel libxkbcommon-devel
 ```
 
 Compiling with clang is also possible - replace the `g++` package with `llvm-clang`
+
+## [FreeBSD](https://www.freebsd.org/)
+
+It is necessary to have the hgame module loaded in order to satisfy gli-rs. It will still throw an error, but the program should run successfully. You can make sure the kernel module is loaded on start up by adding the following line to /boot/loader.conf:
+
+```sh
+hgame_load="YES"
+```


### PR DESCRIPTION
The hgame kernel module is necessary to load on start up, otherwise, Bevy will crash. Adding a note to the docs to help anyone struggling with this.