### PR TITLE
AssetServer LoadState API consistency

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1133,8 +1133,8 @@ mod tests {
             ));
 
             assert!(asset_server.is_loaded(a_id));
-            assert!(asset_server.is_loaded_with_dependencies(a_id));
-            assert!(!asset_server.is_loaded_with_recursive_dependencies(a_id));
+            assert!(asset_server.is_loaded_with_direct_dependencies(a_id));
+            assert!(!asset_server.is_loaded_with_dependencies(a_id));
 
             Some(())
         });

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -388,8 +388,10 @@ impl AssetInfos {
         loaded_asset.value.insert(loaded_asset_id, world);
         let mut loading_deps = loaded_asset.dependencies;
         let mut failed_deps = HashSet::new();
+        let mut dep_error = None;
         let mut loading_rec_deps = loading_deps.clone();
         let mut failed_rec_deps = HashSet::new();
+        let mut rec_dep_error = None;
         loading_deps.retain(|dep_id| {
             if let Some(dep_info) = self.get_mut(*dep_id) {
                 match dep_info.rec_dep_load_state {
@@ -404,7 +406,10 @@ impl AssetInfos {
                         // If dependency is loaded, reduce our count by one
                         loading_rec_deps.remove(dep_id);
                     }
-                    RecursiveDependencyLoadState::Failed => {
+                    RecursiveDependencyLoadState::Failed(ref error) => {
+                        if rec_dep_error.is_none() {
+                            rec_dep_error = Some(error.clone());
+                        }
                         failed_rec_deps.insert(*dep_id);
                         loading_rec_deps.remove(dep_id);
                     }
@@ -419,7 +424,10 @@ impl AssetInfos {
                         // If dependency is loaded, reduce our count by one
                         false
                     }
-                    LoadState::Failed(_) => {
+                    LoadState::Failed(ref error) => {
+                        if dep_error.is_none() {
+                            dep_error = Some(error.clone());
+                        }
                         failed_deps.insert(*dep_id);
                         false
                     }
@@ -437,7 +445,7 @@ impl AssetInfos {
         let dep_load_state = match (loading_deps.len(), failed_deps.len()) {
             (0, 0) => DependencyLoadState::Loaded,
             (_loading, 0) => DependencyLoadState::Loading,
-            (_loading, _failed) => DependencyLoadState::Failed,
+            (_loading, _failed) => DependencyLoadState::Failed(dep_error.unwrap()),
         };
 
         let rec_dep_load_state = match (loading_rec_deps.len(), failed_rec_deps.len()) {
@@ -450,7 +458,7 @@ impl AssetInfos {
                 RecursiveDependencyLoadState::Loaded
             }
             (_loading, 0) => RecursiveDependencyLoadState::Loading,
-            (_loading, _failed) => RecursiveDependencyLoadState::Failed,
+            (_loading, _failed) => RecursiveDependencyLoadState::Failed(rec_dep_error.unwrap()),
         };
 
         let (dependants_waiting_on_load, dependants_waiting_on_rec_load) = {
@@ -480,14 +488,14 @@ impl AssetInfos {
             info.failed_rec_dependencies = failed_rec_deps;
             info.load_state = LoadState::Loaded;
             info.dep_load_state = dep_load_state;
-            info.rec_dep_load_state = rec_dep_load_state;
+            info.rec_dep_load_state = rec_dep_load_state.clone();
             if watching_for_changes {
                 info.loader_dependencies = loaded_asset.loader_dependencies;
             }
 
             let dependants_waiting_on_rec_load = if matches!(
                 rec_dep_load_state,
-                RecursiveDependencyLoadState::Loaded | RecursiveDependencyLoadState::Failed
+                RecursiveDependencyLoadState::Loaded | RecursiveDependencyLoadState::Failed(_)
             ) {
                 Some(std::mem::take(
                     &mut info.dependants_waiting_on_recursive_dep_load,
@@ -505,7 +513,9 @@ impl AssetInfos {
         for id in dependants_waiting_on_load {
             if let Some(info) = self.get_mut(id) {
                 info.loading_dependencies.remove(&loaded_asset_id);
-                if info.loading_dependencies.is_empty() {
+                if info.loading_dependencies.is_empty()
+                    && !matches!(info.dep_load_state, DependencyLoadState::Failed(_))
+                {
                     // send dependencies loaded event
                     info.dep_load_state = DependencyLoadState::Loaded;
                 }
@@ -519,9 +529,9 @@ impl AssetInfos {
                         Self::propagate_loaded_state(self, loaded_asset_id, dep_id, sender);
                     }
                 }
-                RecursiveDependencyLoadState::Failed => {
+                RecursiveDependencyLoadState::Failed(ref error) => {
                     for dep_id in dependants_waiting_on_rec_load {
-                        Self::propagate_failed_state(self, loaded_asset_id, dep_id);
+                        Self::propagate_failed_state(self, loaded_asset_id, dep_id, error);
                     }
                 }
                 RecursiveDependencyLoadState::Loading | RecursiveDependencyLoadState::NotLoaded => {
@@ -570,11 +580,12 @@ impl AssetInfos {
         infos: &mut AssetInfos,
         failed_id: UntypedAssetId,
         waiting_id: UntypedAssetId,
+        error: &Arc<AssetLoadError>,
     ) {
         let dependants_waiting_on_rec_load = if let Some(info) = infos.get_mut(waiting_id) {
             info.loading_rec_dependencies.remove(&failed_id);
             info.failed_rec_dependencies.insert(failed_id);
-            info.rec_dep_load_state = RecursiveDependencyLoadState::Failed;
+            info.rec_dep_load_state = RecursiveDependencyLoadState::Failed(error.clone());
             Some(std::mem::take(
                 &mut info.dependants_waiting_on_recursive_dep_load,
             ))
@@ -584,7 +595,7 @@ impl AssetInfos {
 
         if let Some(dependants_waiting_on_rec_load) = dependants_waiting_on_rec_load {
             for dep_id in dependants_waiting_on_rec_load {
-                Self::propagate_failed_state(infos, waiting_id, dep_id);
+                Self::propagate_failed_state(infos, waiting_id, dep_id, error);
             }
         }
     }
@@ -595,14 +606,15 @@ impl AssetInfos {
             return;
         }
 
+        let error = Arc::new(error);
         let (dependants_waiting_on_load, dependants_waiting_on_rec_load) = {
             let Some(info) = self.get_mut(failed_id) else {
                 // The asset was already dropped.
                 return;
             };
-            info.load_state = LoadState::Failed(Box::new(error));
-            info.dep_load_state = DependencyLoadState::Failed;
-            info.rec_dep_load_state = RecursiveDependencyLoadState::Failed;
+            info.load_state = LoadState::Failed(error.clone());
+            info.dep_load_state = DependencyLoadState::Failed(error.clone());
+            info.rec_dep_load_state = RecursiveDependencyLoadState::Failed(error.clone());
             (
                 std::mem::take(&mut info.dependants_waiting_on_load),
                 std::mem::take(&mut info.dependants_waiting_on_recursive_dep_load),
@@ -613,12 +625,15 @@ impl AssetInfos {
             if let Some(info) = self.get_mut(waiting_id) {
                 info.loading_dependencies.remove(&failed_id);
                 info.failed_dependencies.insert(failed_id);
-                info.dep_load_state = DependencyLoadState::Failed;
+                // don't overwrite DependencyLoadState if already failed to preserve first error
+                if !(matches!(info.dep_load_state, DependencyLoadState::Failed(_))) {
+                    info.dep_load_state = DependencyLoadState::Failed(error.clone());
+                }
             }
         }
 
         for waiting_id in dependants_waiting_on_rec_load {
-            Self::propagate_failed_state(self, failed_id, waiting_id);
+            Self::propagate_failed_state(self, failed_id, waiting_id, &error);
         }
     }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -895,17 +895,20 @@ impl AssetServer {
         &self,
         id: impl Into<UntypedAssetId>,
     ) -> Option<(LoadState, DependencyLoadState, RecursiveDependencyLoadState)> {
-        self.data
-            .infos
-            .read()
-            .get(id.into())
-            .map(|i| (i.load_state.clone(), i.dep_load_state, i.rec_dep_load_state))
+        self.data.infos.read().get(id.into()).map(|i| {
+            (
+                i.load_state.clone(),
+                i.dep_load_state.clone(),
+                i.rec_dep_load_state.clone(),
+            )
+        })
     }
 
     /// Retrieves the main [`LoadState`] of a given asset `id`.
     ///
-    /// Note that this is "just" the root asset load state. To check if an asset _and_ its recursive
-    /// dependencies have loaded, see [`AssetServer::is_loaded_with_dependencies`].
+    /// Note that this is "just" the root asset load state. To get the load state of
+    /// its dependencies or recursive dependencies, see [`AssetServer::get_dependency_load_state`]
+    /// and [`AssetServer::get_recursive_dependency_load_state`] respectively.
     pub fn get_load_state(&self, id: impl Into<UntypedAssetId>) -> Option<LoadState> {
         self.data
             .infos
@@ -914,7 +917,27 @@ impl AssetServer {
             .map(|i| i.load_state.clone())
     }
 
-    /// Retrieves the [`RecursiveDependencyLoadState`] of a given asset `id`.
+    /// Retrieves the [`DependencyLoadState`] of a given asset `id`'s dependencies.
+    ///
+    /// Note that this is only the load state of direct dependencies of the root asset. To get
+    /// the load state of the root asset itself or its recursive dependencies, see
+    /// [`AssetServer::get_load_state`] and [`AssetServer::get_recursive_dependency_load_state`] respectively.
+    pub fn get_dependency_load_state(
+        &self,
+        id: impl Into<UntypedAssetId>,
+    ) -> Option<DependencyLoadState> {
+        self.data
+            .infos
+            .read()
+            .get(id.into())
+            .map(|i| i.dep_load_state.clone())
+    }
+
+    /// Retrieves the main [`RecursiveDependencyLoadState`] of a given asset `id`'s recursive dependencies.
+    ///
+    /// Note that this is only the load state of recursive dependencies of the root asset. To get
+    /// the load state of the root asset itself or its direct dependencies only, see
+    /// [`AssetServer::get_load_state`] and [`AssetServer::get_dependency_load_state`] respectively.
     pub fn get_recursive_dependency_load_state(
         &self,
         id: impl Into<UntypedAssetId>,
@@ -923,15 +946,30 @@ impl AssetServer {
             .infos
             .read()
             .get(id.into())
-            .map(|i| i.rec_dep_load_state)
+            .map(|i| i.rec_dep_load_state.clone())
     }
 
     /// Retrieves the main [`LoadState`] of a given asset `id`.
+    ///
+    /// This is the same as [`AssetServer::get_load_state`] except the result is unwrapped. If
+    /// the result is None, [`LoadState::NotLoaded`] is returned.
     pub fn load_state(&self, id: impl Into<UntypedAssetId>) -> LoadState {
         self.get_load_state(id).unwrap_or(LoadState::NotLoaded)
     }
 
+    /// Retrieves the [`DependencyLoadState`] of a given asset `id`.
+    ///
+    /// This is the same as [`AssetServer::get_dependency_load_state`] except the result is unwrapped. If
+    /// the result is None, [`DependencyLoadState::NotLoaded`] is returned.
+    pub fn dependency_load_state(&self, id: impl Into<UntypedAssetId>) -> DependencyLoadState {
+        self.get_dependency_load_state(id)
+            .unwrap_or(DependencyLoadState::NotLoaded)
+    }
+
     /// Retrieves the  [`RecursiveDependencyLoadState`] of a given asset `id`.
+    ///
+    /// This is the same as [`AssetServer::get_recursive_dependency_load_state`] except the result is unwrapped. If
+    /// the result is None, [`RecursiveDependencyLoadState::NotLoaded`] is returned.
     pub fn recursive_dependency_load_state(
         &self,
         id: impl Into<UntypedAssetId>,
@@ -940,11 +978,30 @@ impl AssetServer {
             .unwrap_or(RecursiveDependencyLoadState::NotLoaded)
     }
 
-    /// Returns true if the asset and all of its dependencies (recursive) have been loaded.
+    /// Convenience method that returns true if the asset has been loaded.
+    pub fn is_loaded(&self, id: impl Into<UntypedAssetId>) -> bool {
+        matches!(self.load_state(id), LoadState::Loaded)
+    }
+
+    /// Convenience method that returns true if the asset and all of its direct dependencies have been loaded.
     pub fn is_loaded_with_dependencies(&self, id: impl Into<UntypedAssetId>) -> bool {
-        let id = id.into();
-        self.load_state(id) == LoadState::Loaded
-            && self.recursive_dependency_load_state(id) == RecursiveDependencyLoadState::Loaded
+        matches!(
+            self.get_load_states(id),
+            Some((LoadState::Loaded, DependencyLoadState::Loaded, _))
+        )
+    }
+
+    /// Convenience method that returns true if the asset, all of its dependencies, and all of its recursive
+    /// dependencies have been loaded.
+    pub fn is_loaded_with_recursive_dependencies(&self, id: impl Into<UntypedAssetId>) -> bool {
+        matches!(
+            self.get_load_states(id),
+            Some((
+                LoadState::Loaded,
+                DependencyLoadState::Loaded,
+                RecursiveDependencyLoadState::Loaded
+            ))
+        )
     }
 
     /// Returns an active handle for the given path, if the asset at the given path has already started loading,
@@ -1360,12 +1417,14 @@ pub enum LoadState {
     Loading,
     /// The asset has been loaded and has been added to the [`World`]
     Loaded,
-    /// The asset failed to load.
-    Failed(Box<AssetLoadError>),
+    /// The asset failed to load. The underlying [`AssetLoadError`] is
+    /// referenced by [`Arc`] clones in all related [`DependencyLoadState`]s
+    /// and [`RecursiveDependencyLoadState`]s in the asset's dependency tree.
+    Failed(Arc<AssetLoadError>),
 }
 
 /// The load state of an asset's dependencies.
-#[derive(Component, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Component, Clone, Debug, Eq, PartialEq)]
 pub enum DependencyLoadState {
     /// The asset has not started loading yet
     NotLoaded,
@@ -1373,12 +1432,14 @@ pub enum DependencyLoadState {
     Loading,
     /// Dependencies have all loaded
     Loaded,
-    /// One or more dependencies have failed to load
-    Failed,
+    /// One or more dependencies have failed to load. The underlying [`AssetLoadError`]
+    /// is referenced by [`Arc`] clones in all related [`LoadState`] and
+    /// [`RecursiveDependencyLoadState`]s in the asset's dependency tree.
+    Failed(Arc<AssetLoadError>),
 }
 
 /// The recursive load state of an asset's dependencies.
-#[derive(Component, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Component, Clone, Debug, Eq, PartialEq)]
 pub enum RecursiveDependencyLoadState {
     /// The asset has not started loading yet
     NotLoaded,
@@ -1386,8 +1447,11 @@ pub enum RecursiveDependencyLoadState {
     Loading,
     /// Dependencies in this asset's dependency tree have all loaded
     Loaded,
-    /// One or more dependencies have failed to load in this asset's dependency tree
-    Failed,
+    /// One or more dependencies have failed to load in this asset's dependency
+    /// tree. The underlying [`AssetLoadError`] is referenced by [`Arc`] clones
+    /// in all related [`LoadState`]s and [`DependencyLoadState`]s in the asset's
+    /// dependency tree.
+    Failed(Arc<AssetLoadError>),
 }
 
 /// An error that occurs during an [`Asset`] load.

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -984,7 +984,7 @@ impl AssetServer {
     }
 
     /// Convenience method that returns true if the asset and all of its direct dependencies have been loaded.
-    pub fn is_loaded_with_dependencies(&self, id: impl Into<UntypedAssetId>) -> bool {
+    pub fn is_loaded_with_direct_dependencies(&self, id: impl Into<UntypedAssetId>) -> bool {
         matches!(
             self.get_load_states(id),
             Some((LoadState::Loaded, DependencyLoadState::Loaded, _))
@@ -993,7 +993,7 @@ impl AssetServer {
 
     /// Convenience method that returns true if the asset, all of its dependencies, and all of its recursive
     /// dependencies have been loaded.
-    pub fn is_loaded_with_recursive_dependencies(&self, id: impl Into<UntypedAssetId>) -> bool {
+    pub fn is_loaded_with_dependencies(&self, id: impl Into<UntypedAssetId>) -> bool {
         matches!(
             self.get_load_states(id),
             Some((


### PR DESCRIPTION
# Objective

- implements consistently named AssertServer methods for asset, dependency, and recursive dependency load states
- returns relevant LoadState when required, including error information for failed loads
- resolves #15098

## Solution

- implement consistently named LoadState accessor methods:
  - load_state, dependency_load_state, recursive_dependency_load_state (return unwrapped load states)
  - get_load_state, get_dependency_load_state, get_recursive_dependency_load_state (return Option)
  - is_loaded, is_loaded_with_dependencies, is_loaded_with_recursive_dependencies (return bool)
- adds AssetLoadError to DependencyLoadState::Failed and RecursiveDependencyLoadState::Failed

## Testing

- Added coverage to existing unit tests
