### PR TITLE
Implement `enabled` flag for fps overlay

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -5,7 +5,7 @@ use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin};
 use bevy_ecs::{
-    change_detection::DetectChangesMut,
+    change_detection::{DetectChanges, DetectChangesMut},
     component::Component,
     query::With,
     schedule::{common_conditions::resource_changed, IntoSystemConfigs},
@@ -129,6 +129,9 @@ fn toggle_display(
     overlay_config: Res<FpsOverlayConfig>,
     mut query: Query<&mut Visibility, With<FpsText>>,
 ) {
+    if !overlay_config.is_changed() {
+        return;
+    }
     for mut visibility in &mut query {
         visibility.set_if_neq(match overlay_config.enabled {
             true => Visibility::Visible,

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -5,7 +5,7 @@ use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin};
 use bevy_ecs::{
-    change_detection::{DetectChanges, DetectChangesMut},
+    change_detection::DetectChangesMut,
     component::Component,
     query::With,
     schedule::{common_conditions::resource_changed, IntoSystemConfigs},
@@ -129,9 +129,6 @@ fn toggle_display(
     overlay_config: Res<FpsOverlayConfig>,
     mut query: Query<&mut Visibility, With<FpsText>>,
 ) {
-    if !overlay_config.is_changed() {
-        return;
-    }
     for mut visibility in &mut query {
         visibility.set_if_neq(match overlay_config.enabled {
             true => Visibility::Visible,

--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -19,6 +19,7 @@ fn main() {
                         // If we want, we can use a custom font
                         font: default(),
                     },
+                    enabled: true,
                 },
             },
         ))
@@ -47,7 +48,8 @@ fn setup(mut commands: Commands) {
             c.spawn(TextBundle::from_section(
                 concat!(
                     "Press 1 to change color of the overlay.\n",
-                    "Press 2 to change size of the overlay."
+                    "Press 2 to change size of the overlay.\n",
+                    "Press 3 to toggle the overlay."
                 ),
                 TextStyle {
                     font_size: 25.0,
@@ -64,5 +66,8 @@ fn customize_config(input: Res<ButtonInput<KeyCode>>, mut overlay: ResMut<FpsOve
     }
     if input.just_pressed(KeyCode::Digit2) {
         overlay.text_config.font_size -= 2.0;
+    }
+    if input.just_pressed(KeyCode::Digit3) {
+        overlay.enabled = !overlay.enabled;
     }
 }


### PR DESCRIPTION
# Objective

Fixes #15223 

## Solution

Adds an `enabled` flag to the `FpsOverlayConfig` resource with a system that detects it's change, and adjusts the visibility of the overlay text entity.

## Testing

I extended the `fps_overlay` example with the option to toggle the overlay. Run with:
```
cargo run --features="bevy_dev_tools" --example fps_overlay
```
