### PR TITLE
Don't leak SEND resource, even if thread is panicking.

### DIFF
--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -25,7 +25,10 @@ pub struct ResourceData<const SEND: bool> {
 
 impl<const SEND: bool> Drop for ResourceData<SEND> {
     fn drop(&mut self) {
-        if self.is_present() {
+        // For Non Send resources we need to validate that correct thread
+        // is dropping the resource. This validation is not needed in case
+        // of SEND resources. Or if there is no data.
+        if !SEND && self.is_present() {
             // If this thread is already panicking, panicking again will cause
             // the entire process to abort. In this case we choose to avoid
             // dropping or checking this altogether and just leak the column.


### PR DESCRIPTION
# Objective
Currently the resource doesn't get dropped if thread panics. This is presumably to prevent !SEND resource from being dropped by wrong thread.
But, this logic is not needed for SEND resources. So we don't need this check for SEND resource.

Fixes #15144 

## Solution

We check if resource is !SEND before, validating that correct thread is dropping the resource.

## Testing

- Did you test these changes? If so, how?
I did run cargo test on bevy.
- Are there any parts that need more testing?
No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Nothing special
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
x86_64 desktop