### PR TITLE
Fix transparent_window example on wayland

### DIFF
--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -5,7 +5,7 @@
 //! for more details.
 
 use bevy::prelude::*;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use bevy::window::CompositeAlphaMode;
 
 fn main() {
@@ -18,6 +18,8 @@ fn main() {
                 decorations: false,
                 #[cfg(target_os = "macos")]
                 composite_alpha_mode: CompositeAlphaMode::PostMultiplied,
+                #[cfg(target_os = "linux")]
+                composite_alpha_mode: CompositeAlphaMode::PreMultiplied,
                 ..default()
             }),
             ..default()


### PR DESCRIPTION
Wayland only supports pre-multiplied alpha. Behavior on X11 seems unchanged.

# Objective

- Fix #10929 on wayland.

## Solution

- Request pre-multiplied alpha.

## Testing

- Ran the example locally.