### PR TITLE
Add ASCII art to custom mesh example (#15261)

### DIFF
--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -224,6 +224,14 @@ fn create_cube_mesh() -> Mesh {
     // should appear counter-clockwise from the front of the triangle, in this case from outside the cube).
     // Read more about how to correctly build a mesh manually in the Bevy documentation of a Mesh,
     // further examples and the implementation of the built-in shapes.
+    //
+    // The first two defined triangles look like (marked with the vertex indices),
+    // when looking down at the top (+y) of the cube:
+    // 0---1
+    // |  /|
+    // | / |
+    // |/  |
+    // 3---2
     .with_inserted_indices(Indices::U32(vec![
         0,3,1 , 1,3,2, // triangles making up the top (+y) facing side.
         4,5,7 , 5,6,7, // bottom (-y)

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -225,7 +225,7 @@ fn create_cube_mesh() -> Mesh {
     // Read more about how to correctly build a mesh manually in the Bevy documentation of a Mesh,
     // further examples and the implementation of the built-in shapes.
     //
-    // The first two defined triangles look like (marked with the vertex indices),
+    // The first two defined triangles look like this (marked with the vertex indices),
     // when looking down at the top (+y) of the cube:
     // 0---1
     // |  /|

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -225,13 +225,33 @@ fn create_cube_mesh() -> Mesh {
     // Read more about how to correctly build a mesh manually in the Bevy documentation of a Mesh,
     // further examples and the implementation of the built-in shapes.
     //
-    // The first two defined triangles look like this (marked with the vertex indices),
-    // when looking down at the top (+y) of the cube:
+    // The first two defined triangles look like this (marked with the vertex indices,
+    // and the axis), when looking down at the top (+y) of the cube:
+    //   -Z
+    //   ^
     // 0---1
     // |  /|
-    // | / |
+    // | / | -> +X
     // |/  |
     // 3---2
+    //
+    // The right face's (+x) triangles look like this, seen from the outside of the cube.
+    //   +Y
+    //   ^
+    // 10--11
+    // |  /|
+    // | / | -> -Z
+    // |/  |
+    // 9---8
+    //
+    // The back face's (+z) triangles look like this, seen from the outside of the cube.
+    //   +Y
+    //   ^
+    // 17--18
+    // |\  |
+    // | \ | -> +X
+    // |  \|
+    // 16--19
     .with_inserted_indices(Indices::U32(vec![
         0,3,1 , 1,3,2, // triangles making up the top (+y) facing side.
         4,5,7 , 5,6,7, // bottom (-y)


### PR DESCRIPTION
Added ASCII art to the custom mesh example, to clarify the ordering of the triangle indices.
Fixes #15261.