### PR TITLE
Added Mesh::ATTRIBUTE_POSITION_2D (VertexFormat::Float32x2)

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -556,6 +556,10 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
         if layout.0.contains(Mesh::ATTRIBUTE_POSITION) {
             shader_defs.push("VERTEX_POSITIONS".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_POSITION.at_shader_location(0));
+        } else if layout.0.contains(Mesh::ATTRIBUTE_POSITION_2D) {
+            shader_defs.push("VERTEX_POSITIONS".into());
+            shader_defs.push("VERTEX_POSITIONS_2D".into());
+            vertex_attributes.push(Mesh::ATTRIBUTE_POSITION_2D.at_shader_location(0));
         }
 
         if layout.0.contains(Mesh::ATTRIBUTE_NORMAL) {

--- a/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
@@ -10,7 +10,9 @@
 
 struct Vertex {
     @builtin(instance_index) instance_index: u32,
-#ifdef VERTEX_POSITIONS
+#ifdef VERTEX_POSITIONS_2D
+    @location(0) position: vec2<f32>,
+#else ifdef VERTEX_POSITIONS
     @location(0) position: vec3<f32>,
 #endif
 #ifdef VERTEX_NORMALS
@@ -35,10 +37,15 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 #endif
 
 #ifdef VERTEX_POSITIONS
+#ifdef VERTEX_POSITIONS_2D
+    let vertex_position = vec4<f32>(vertex.position, 0.0, 1.0);
+#else
+    let vertex_position = vec4<f32>(vertex.position, 1.0);
+#endif
     var world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
     out.world_position = mesh_functions::mesh2d_position_local_to_world(
         world_from_local,
-        vec4<f32>(vertex.position, 1.0)
+        vertex_position
     );
     out.position = mesh_functions::mesh2d_position_world_to_clip(out.world_position);
 #endif


### PR DESCRIPTION
# Objective / Solution

This PR introduces support for 2D meshes without a dummy `0.0` z value (for a bit of memory savings) via a new attribute: `Mesh::ATTRIBUTE_POSITION_2D`.

## Testing

- I tested this on a local project. 

## Migration Guide

To make any custom 2D vertex shaders work with `Float32x2` meshes, you'll want to use the `VERTEX_POSITIONS_2D` flag like below. ***Note:** `VERTEX_POSITIONS` will still be defined (the two flags are not mutually exclusive).*

```wgsl
// Before
struct Vertex {
    ...
#ifdef VERTEX_POSITIONS
    @location(0) position: vec3<f32>,
#endif
    ...
}

// After
struct Vertex {
    ...
#ifdef VERTEX_POSITIONS_2D
    @location(0) position: vec2<f32>,
#else ifdef VERTEX_POSITIONS
    @location(0) position: vec3<f32>,
#endif
    ...
}
```

```wgsl
// Before
    var world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
    out.world_position = mesh_functions::mesh2d_position_local_to_world(
        world_from_local,
        vec4<f32>(vertex.position, 1.0)
    );

// After
#ifdef VERTEX_POSITIONS_2D
    let vertex_position = vec4<f32>(vertex.position, 0.0, 1.0);
#else
    let vertex_position = vec4<f32>(vertex.position, 1.0);
#endif

    var world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
    out.world_position = mesh_functions::mesh2d_position_local_to_world(
        world_from_local,
        vertex_position
    );
```


