### PR TITLE
UI Scrolling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2847,7 +2847,17 @@ doc-scrape-examples = true
 [package.metadata.example.grid]
 name = "CSS Grid"
 description = "An example for CSS Grid layout"
+category = "UI (User Interface)"
+wasm = true
 
+[[example]]
+name = "scroll"
+path = "examples/ui/scroll.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.scroll]
+name = "Scroll"
+description = "Demonstrates scrolling UI containers"
 category = "UI (User Interface)"
 wasm = true
 

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -258,6 +258,7 @@ impl From<OverflowAxis> for taffy::style::Overflow {
             OverflowAxis::Visible => taffy::style::Overflow::Visible,
             OverflowAxis::Clip => taffy::style::Overflow::Clip,
             OverflowAxis::Hidden => taffy::style::Overflow::Hidden,
+            OverflowAxis::Scroll => taffy::style::Overflow::Scroll,
         }
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -311,7 +311,7 @@ pub fn ui_layout_system(
         parent_scroll_position: Vec2,
         mut absolute_location: Vec2,
     ) -> Vec2 {
-        if let Ok((
+        let Ok((
             mut node,
             mut transform,
             style,
@@ -319,155 +319,136 @@ pub fn ui_layout_system(
             maybe_outline,
             maybe_scroll_position,
         )) = node_transform_query.get_mut(entity)
-        {
-            let overflow = style.overflow;
+        else {
+            return Vec2::ZERO;
+        };
 
-            let Ok(layout) = ui_surface.get_layout(entity) else {
-                return Vec2::ZERO;
-            };
-            let layout_size =
-                inverse_target_scale_factor * Vec2::new(layout.size.width, layout.size.height);
-            let layout_location =
-                inverse_target_scale_factor * Vec2::new(layout.location.x, layout.location.y);
+        let Ok(layout) = ui_surface.get_layout(entity) else {
+            return Vec2::ZERO;
+        };
 
-            absolute_location += layout_location;
+        let layout_size =
+            inverse_target_scale_factor * Vec2::new(layout.size.width, layout.size.height);
+        let layout_location =
+            inverse_target_scale_factor * Vec2::new(layout.location.x, layout.location.y);
 
-            let rounded_size = approx_round_layout_coords(absolute_location + layout_size)
-                - approx_round_layout_coords(absolute_location);
+        absolute_location += layout_location;
 
-            let rounded_location =
-                approx_round_layout_coords(layout_location - parent_scroll_position)
-                    + 0.5 * (rounded_size - parent_size);
+        let rounded_size = approx_round_layout_coords(absolute_location + layout_size)
+            - approx_round_layout_coords(absolute_location);
 
-            // only trigger change detection when the new values are different
-            if node.calculated_size != rounded_size || node.unrounded_size != layout_size {
-                node.calculated_size = rounded_size;
-                node.unrounded_size = layout_size;
-            }
+        let rounded_location = approx_round_layout_coords(layout_location - parent_scroll_position)
+            + 0.5 * (rounded_size - parent_size);
 
-            let viewport_size = root_size.unwrap_or(node.calculated_size);
+        // only trigger change detection when the new values are different
+        if node.calculated_size != rounded_size || node.unrounded_size != layout_size {
+            node.calculated_size = rounded_size;
+            node.unrounded_size = layout_size;
+        }
 
-            if let Some(border_radius) = maybe_border_radius {
-                // We don't trigger change detection for changes to border radius
-                node.bypass_change_detection().border_radius =
-                    border_radius.resolve(node.calculated_size, viewport_size);
-            }
+        let viewport_size = root_size.unwrap_or(node.calculated_size);
 
-            if let Some(outline) = maybe_outline {
-                // don't trigger change detection when only outlines are changed
-                let node = node.bypass_change_detection();
-                node.outline_width = outline
-                    .width
-                    .resolve(node.size().x, viewport_size)
-                    .unwrap_or(0.)
-                    .max(0.);
+        if let Some(border_radius) = maybe_border_radius {
+            // We don't trigger change detection for changes to border radius
+            node.bypass_change_detection().border_radius =
+                border_radius.resolve(node.calculated_size, viewport_size);
+        }
 
-                node.outline_offset = outline
-                    .offset
-                    .resolve(node.size().x, viewport_size)
-                    .unwrap_or(0.)
-                    .max(0.);
-            }
+        if let Some(outline) = maybe_outline {
+            // don't trigger change detection when only outlines are changed
+            let node = node.bypass_change_detection();
+            node.outline_width = outline
+                .width
+                .resolve(node.size().x, viewport_size)
+                .unwrap_or(0.)
+                .max(0.);
 
-            if transform.translation.truncate() != rounded_location {
-                transform.translation = rounded_location.extend(0.);
-            }
+            node.outline_offset = outline
+                .offset
+                .resolve(node.size().x, viewport_size)
+                .unwrap_or(0.)
+                .max(0.);
+        }
 
-            let scroll_position: Vec2 = maybe_scroll_position
-                .map(|scroll_pos| {
-                    Vec2::new(
-                        if overflow.x == OverflowAxis::Scroll {
-                            scroll_pos.offset_x
-                        } else {
-                            0.0
-                        },
-                        if overflow.y == OverflowAxis::Scroll {
-                            scroll_pos.offset_y
-                        } else {
-                            0.0
-                        },
+        if transform.translation.truncate() != rounded_location {
+            transform.translation = rounded_location.extend(0.);
+        }
+
+        let scroll_position: Vec2 = maybe_scroll_position
+            .map(|scroll_pos| {
+                Vec2::new(
+                    if style.overflow.x == OverflowAxis::Scroll {
+                        scroll_pos.offset_x
+                    } else {
+                        0.0
+                    },
+                    if style.overflow.y == OverflowAxis::Scroll {
+                        scroll_pos.offset_y
+                    } else {
+                        0.0
+                    },
+                )
+            })
+            .unwrap_or_default();
+
+        let node_scrollable_bounds = rounded_size + approx_round_layout_coords(layout_location);
+
+        if let Ok(children) = children_query.get(entity) {
+            let mut children_bounding_box = children
+                .iter()
+                .map(|child_uinode| {
+                    update_uinode_geometry_recursive(
+                        commands,
+                        *child_uinode,
+                        ui_surface,
+                        Some(viewport_size),
+                        node_transform_query,
+                        children_query,
+                        inverse_target_scale_factor,
+                        rounded_size,
+                        scroll_position,
+                        absolute_location,
                     )
                 })
-                .unwrap_or_default();
+                .fold(scroll_position, Vec2::max);
 
-            let mut node_scrollable_bounds =
-                rounded_size + approx_round_layout_coords(layout_location);
+            if children_bounding_box != Vec2::ZERO && scroll_position != Vec2::ZERO {
+                // Cannot scroll further than the edge of the furthest child
+                let max_possible_offset = (children_bounding_box - rounded_size).max(Vec2::ZERO);
+                let clamped_scroll_position =
+                    scroll_position.clamp(Vec2::ZERO, max_possible_offset);
 
-            if let Ok(children) = children_query.get(entity) {
-                let mut children_bounding_box = children
-                    .iter()
-                    .map(|child_uinode| {
-                        update_uinode_geometry_recursive(
-                            commands,
-                            *child_uinode,
-                            ui_surface,
-                            Some(viewport_size),
-                            node_transform_query,
-                            children_query,
-                            inverse_target_scale_factor,
-                            rounded_size,
-                            scroll_position,
-                            absolute_location,
-                        )
-                    })
-                    .fold(scroll_position, |acc, size| {
-                        Vec2::new(acc.x.max(size.x), acc.y.max(size.y))
-                    });
+                // If the size of the bounding box containing all children changed in a way that impacts the scroll position of the parent
+                // Re-run the layout for all children
+                if clamped_scroll_position != scroll_position {
+                    commands
+                        .entity(entity)
+                        .insert(ScrollPosition::from(&clamped_scroll_position));
 
-                if children_bounding_box != Vec2::ZERO && scroll_position != Vec2::ZERO {
-                    // Cannot scroll further than the edge of the furthest child
-                    let max_possible_offset =
-                        (children_bounding_box - rounded_size).max(Vec2::ZERO);
-                    let clamped_scroll_position =
-                        scroll_position.clamp(Vec2::ZERO, max_possible_offset);
-
-                    // If the size of the bounding box containing all children changed in a way that impacts the scroll position of the parent
-                    // Re-run the layout for all children
-                    if clamped_scroll_position != scroll_position {
-                        commands
-                            .entity(entity)
-                            .insert(ScrollPosition::from(&clamped_scroll_position));
-
-                        children_bounding_box = children
-                            .iter()
-                            .map(|child_uinode| {
-                                update_uinode_geometry_recursive(
-                                    commands,
-                                    *child_uinode,
-                                    ui_surface,
-                                    Some(viewport_size),
-                                    node_transform_query,
-                                    children_query,
-                                    inverse_target_scale_factor,
-                                    rounded_size,
-                                    clamped_scroll_position,
-                                    absolute_location,
-                                )
-                            })
-                            .fold(scroll_position, |acc, size| {
-                                Vec2::new(acc.x.max(size.x), acc.y.max(size.y))
-                            });
-                    }
+                    children_bounding_box = children
+                        .iter()
+                        .map(|child_uinode| {
+                            update_uinode_geometry_recursive(
+                                commands,
+                                *child_uinode,
+                                ui_surface,
+                                Some(viewport_size),
+                                node_transform_query,
+                                children_query,
+                                inverse_target_scale_factor,
+                                rounded_size,
+                                clamped_scroll_position,
+                                absolute_location,
+                            )
+                        })
+                        .fold(scroll_position, Vec2::max);
                 }
-
-                // If overflow is visible, the bounds of the children must be considered.
-                // A parent of this node could scroll the overflowing children.
-                if overflow.x.is_visible() {
-                    node_scrollable_bounds.x =
-                        node_scrollable_bounds.x.max(children_bounding_box.x);
-                }
-
-                if overflow.y.is_visible() {
-                    node_scrollable_bounds.y =
-                        node_scrollable_bounds.y.max(children_bounding_box.y);
-                }
-
-                node_scrollable_bounds
-            } else {
-                node_scrollable_bounds
             }
+
+            // The scrollable area of this node may also include overflowing children.
+            node_scrollable_bounds.max(children_bounding_box)
         } else {
-            Vec2::ZERO
+            node_scrollable_bounds
         }
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -389,9 +389,8 @@ pub fn ui_layout_system(
                 })
                 .unwrap_or_default();
 
-            let node_content_size = ui_surface.get_layout(entity).unwrap().content_size;
             let round_content_size = approx_round_layout_coords(
-                Vec2::new(node_content_size.width, node_content_size.height)
+                Vec2::new(layout.content_size.width, layout.content_size.height)
                     * inverse_target_scale_factor,
             );
             let max_possible_offset = (round_content_size - rounded_size).max(Vec2::ZERO);

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -80,10 +80,6 @@ pub enum UiSystem {
     ///
     /// Runs in [`PreUpdate`].
     Focus,
-    /// After this label, scroll positions will have been updated for UI entities.
-    ///
-    /// Runs in [`PreUpdate`].
-    Scroll,
     /// All UI systems in [`PostUpdate`] will run in or after this label.
     Prepare,
     /// After this label, the ui layout state has been updated.

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -80,6 +80,10 @@ pub enum UiSystem {
     ///
     /// Runs in [`PreUpdate`].
     Focus,
+    /// After this label, scroll positions will have been updated for UI entities.
+    ///
+    /// Runs in [`PreUpdate`].
+    Scroll,
     /// All UI systems in [`PostUpdate`] will run in or after this label.
     Prepare,
     /// After this label, the ui layout state has been updated.
@@ -158,7 +162,7 @@ impl Plugin for UiPlugin {
             )
             .add_systems(
                 PreUpdate,
-                ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),
+                (ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),),
             );
 
         app.add_systems(

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -158,7 +158,7 @@ impl Plugin for UiPlugin {
             )
             .add_systems(
                 PreUpdate,
-                (ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),),
+                ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),
             );
 
         app.add_systems(

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -4,8 +4,8 @@
 use crate::widget::TextFlags;
 use crate::{
     widget::{Button, UiImageSize},
-    BackgroundColor, BorderColor, BorderRadius, ContentSize, FocusPolicy, Interaction, Node, Style,
-    UiImage, UiMaterial, ZIndex,
+    BackgroundColor, BorderColor, BorderRadius, ContentSize, FocusPolicy, Interaction, Node,
+    ScrollPosition, Style, UiImage, UiMaterial, ZIndex,
 };
 use bevy_asset::Handle;
 #[cfg(feature = "bevy_text")]
@@ -38,6 +38,8 @@ pub struct NodeBundle {
     pub border_radius: BorderRadius,
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
+    /// The scroll position of the node,
+    pub scroll_position: ScrollPosition,
     /// The transform of the node
     ///
     /// This component is automatically managed by the UI layout system.

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -150,6 +150,44 @@ impl Default for Node {
     }
 }
 
+/// The scroll position on the node
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component, Default)]
+pub struct ScrollPosition {
+    /// How far across the node is scrolled (0 = not scrolled / scrolled to right)
+    pub offset_x: f32,
+    /// How far down the node is scrolled (0 = not scrolled / scrolled to top)
+    pub offset_y: f32,
+}
+
+impl ScrollPosition {
+    pub const DEFAULT: Self = Self {
+        offset_x: 0.0,
+        offset_y: 0.0,
+    };
+}
+
+impl Default for ScrollPosition {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl From<&ScrollPosition> for Vec2 {
+    fn from(scroll_pos: &ScrollPosition) -> Self {
+        Vec2::new(scroll_pos.offset_x, scroll_pos.offset_y)
+    }
+}
+
+impl From<&Vec2> for ScrollPosition {
+    fn from(vec: &Vec2) -> Self {
+        ScrollPosition {
+            offset_x: vec.x,
+            offset_y: vec.y,
+        }
+    }
+}
+
 /// Describes the style of a UI container node
 ///
 /// Nodes can be laid out using either Flexbox or CSS Grid Layout.
@@ -865,6 +903,29 @@ impl Overflow {
     pub const fn is_visible(&self) -> bool {
         self.x.is_visible() && self.y.is_visible()
     }
+
+    pub const fn scroll() -> Self {
+        Self {
+            x: OverflowAxis::Scroll,
+            y: OverflowAxis::Scroll,
+        }
+    }
+
+    /// Scroll overflowing items on the x axis
+    pub const fn scroll_x() -> Self {
+        Self {
+            x: OverflowAxis::Scroll,
+            y: OverflowAxis::Visible,
+        }
+    }
+
+    /// Scroll overflowing items on the y axis
+    pub const fn scroll_y() -> Self {
+        Self {
+            x: OverflowAxis::Visible,
+            y: OverflowAxis::Scroll,
+        }
+    }
 }
 
 impl Default for Overflow {
@@ -888,6 +949,8 @@ pub enum OverflowAxis {
     Clip,
     /// Hide overflowing items by influencing layout and then clipping.
     Hidden,
+    /// Scroll overflowing items.
+    Scroll,
 }
 
 impl OverflowAxis {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -150,13 +150,16 @@ impl Default for Node {
     }
 }
 
-/// The scroll position on the node
+/// The scroll position of the node.
+/// Updating the values of `ScrollPosition` will reposition the children of the node by the offset amount.
+/// `ScrollPosition` may be updated by the layout system when a layout change makes a previously valid `ScrollPosition` invalid.
+/// Changing this does nothing on a `Node` without a `Style` setting at least one `OverflowAxis` to `OverflowAxis::Scroll`.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct ScrollPosition {
-    /// How far across the node is scrolled (0 = not scrolled / scrolled to right)
+    /// How far across the node is scrolled, in pixels. (0 = not scrolled / scrolled to right)
     pub offset_x: f32,
-    /// How far down the node is scrolled (0 = not scrolled / scrolled to top)
+    /// How far down the node is scrolled, in pixels. (0 = not scrolled / scrolled to top)
     pub offset_y: f32,
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -482,6 +482,7 @@ Example | Description
 [Overflow and Clipping Debug](../examples/ui/overflow_debug.rs) | An example to debug overflow and clipping behavior
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Render UI to Texture](../examples/ui/render_ui_to_texture.rs) | An example of rendering UI as a part of a 3D world
+[Scroll](../examples/ui/scroll.rs) | Demonstrates scrolling UI containers
 [Size Constraints](../examples/ui/size_constraints.rs) | Demonstrates how the to use the size constraints to control the size of a UI node.
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -21,6 +21,9 @@ fn main() {
     app.run();
 }
 
+const FONT_SIZE: f32 = 20.;
+const LINE_HEIGHT: f32 = 21.;
+
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Camera
     commands.spawn((Camera2dBundle::default(), IsDefaultUiCamera));
@@ -56,7 +59,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             "Horizontally Scrolling list (Shift + Mousewheel)",
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: LINE_HEIGHT,
+                                font_size: FONT_SIZE,
                                 ..default()
                             },
                         ),
@@ -143,7 +146,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Vertically Scrolling List",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: LINE_HEIGHT,
+                                        font_size: FONT_SIZE,
                                         ..default()
                                     },
                                 ),
@@ -168,7 +171,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         parent
                                             .spawn(NodeBundle {
                                                 style: Style {
-                                                    height: Val::Px(LINE_HEIGHT),
+                                                    min_height: Val::Px(LINE_HEIGHT),
                                                     max_height: Val::Px(LINE_HEIGHT),
                                                     ..default()
                                                 },
@@ -223,7 +226,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Bidirectionally Scrolling List",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: LINE_HEIGHT,
+                                        font_size: FONT_SIZE,
                                         ..default()
                                     },
                                 ),
@@ -302,7 +305,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Nested Scrolling Lists",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: LINE_HEIGHT,
+                                        font_size: FONT_SIZE,
                                         ..default()
                                     },
                                 ),
@@ -372,7 +375,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-const LINE_HEIGHT: f32 = 20.;
 /// Updates the scroll position of scrollable nodes in response to mouse input
 pub fn update_scroll_position(
     mut mouse_wheel_events: EventReader<MouseWheel>,

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -1,5 +1,5 @@
 //! This example illustrates scrolling in Bevy UI.
-//!
+
 use bevy::{
     a11y::{
         accesskit::{NodeBuilder, Role},
@@ -56,7 +56,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             "Horizontally Scrolling list (Shift + Mousewheel)",
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: 25.,
+                                font_size: LINE_HEIGHT,
                                 ..default()
                             },
                         ),
@@ -143,7 +143,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Vertically Scrolling List",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 25.,
+                                        font_size: LINE_HEIGHT,
                                         ..default()
                                     },
                                 ),
@@ -166,21 +166,39 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     // List items
                                     for i in 0..25 {
                                         parent
-                                            .spawn((
-                                                TextBundle::from_section(
-                                                    format!("Item {i}"),
-                                                    TextStyle {
-                                                        font: asset_server
-                                                            .load("fonts/FiraSans-Bold.ttf"),
-                                                        ..default()
-                                                    },
-                                                ),
-                                                Label,
-                                                AccessibilityNode(NodeBuilder::new(Role::ListItem)),
-                                            ))
+                                            .spawn(NodeBundle {
+                                                style: Style {
+                                                    height: Val::Px(LINE_HEIGHT),
+                                                    max_height: Val::Px(LINE_HEIGHT),
+                                                    ..default()
+                                                },
+                                                ..default()
+                                            })
                                             .insert(Pickable {
                                                 should_block_lower: false,
                                                 ..default()
+                                            })
+                                            .with_children(|parent| {
+                                                parent
+                                                    .spawn((
+                                                        TextBundle::from_section(
+                                                            format!("Item {i}"),
+                                                            TextStyle {
+                                                                font: asset_server.load(
+                                                                    "fonts/FiraSans-Bold.ttf",
+                                                                ),
+                                                                ..default()
+                                                            },
+                                                        ),
+                                                        Label,
+                                                        AccessibilityNode(NodeBuilder::new(
+                                                            Role::ListItem,
+                                                        )),
+                                                    ))
+                                                    .insert(Pickable {
+                                                        should_block_lower: false,
+                                                        ..default()
+                                                    });
                                             });
                                     }
                                 });
@@ -205,7 +223,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Bidirectionally Scrolling List",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 25.,
+                                        font_size: LINE_HEIGHT,
                                         ..default()
                                     },
                                 ),
@@ -284,7 +302,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     "Nested Scrolling Lists",
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 25.,
+                                        font_size: LINE_HEIGHT,
                                         ..default()
                                     },
                                 ),
@@ -354,6 +372,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
+const LINE_HEIGHT: f32 = 20.;
 /// Updates the scroll position of scrollable nodes in response to mouse input
 pub fn update_scroll_position(
     mut mouse_wheel_events: EventReader<MouseWheel>,
@@ -363,7 +382,10 @@ pub fn update_scroll_position(
 ) {
     for mouse_wheel_event in mouse_wheel_events.read() {
         let (mut dx, mut dy) = match mouse_wheel_event.unit {
-            MouseScrollUnit::Line => (mouse_wheel_event.x * 20., mouse_wheel_event.y * 20.),
+            MouseScrollUnit::Line => (
+                mouse_wheel_event.x * LINE_HEIGHT,
+                mouse_wheel_event.y * LINE_HEIGHT,
+            ),
             MouseScrollUnit::Pixel => (mouse_wheel_event.x, mouse_wheel_event.y),
         };
 

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -1,0 +1,388 @@
+//! This example illustrates scrolling in Bevy UI.
+//!
+use bevy::{
+    a11y::{
+        accesskit::{NodeBuilder, Role},
+        AccessibilityNode,
+    },
+    input::mouse::{MouseScrollUnit, MouseWheel},
+    picking::focus::HoverMap,
+    prelude::*,
+    winit::WinitSettings,
+};
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins)
+        .insert_resource(WinitSettings::desktop_app())
+        .add_systems(Startup, setup)
+        .add_systems(Update, update_scroll_position);
+
+    app.run();
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Camera
+    commands.spawn((Camera2dBundle::default(), IsDefaultUiCamera));
+
+    //root node
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                justify_content: JustifyContent::SpaceBetween,
+                flex_direction: FlexDirection::Column,
+                ..default()
+            },
+            ..default()
+        })
+        .insert(Pickable::IGNORE)
+        .with_children(|parent| {
+            // horizontal scroll example
+            parent
+                .spawn(NodeBundle {
+                    style: Style {
+                        width: Val::Percent(100.),
+                        flex_direction: FlexDirection::Column,
+                        ..default()
+                    },
+                    ..default()
+                })
+                .with_children(|parent| {
+                    // header
+                    parent.spawn((
+                        TextBundle::from_section(
+                            "Horizontally Scrolling list (Shift + Mousewheel)",
+                            TextStyle {
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font_size: 25.,
+                                ..default()
+                            },
+                        ),
+                        Label,
+                    ));
+
+                    // horizontal scroll container
+                    parent
+                        .spawn(NodeBundle {
+                            style: Style {
+                                width: Val::Percent(80.),
+                                margin: UiRect::all(Val::Px(10.)),
+                                flex_direction: FlexDirection::Row,
+                                overflow: Overflow::scroll_x(), // n.b.
+                                ..default()
+                            },
+                            background_color: Color::srgb(0.10, 0.10, 0.10).into(),
+                            ..default()
+                        })
+                        .with_children(|parent| {
+                            for i in 0..100 {
+                                parent.spawn((
+                                    TextBundle::from_section(
+                                        format!("Item {i}"),
+                                        TextStyle {
+                                            font: asset_server
+                                                .load("fonts/FiraSans-Bold.ttf"),
+                                            ..default()
+                                        },
+                                    ),
+                                    Label,
+                                    AccessibilityNode(NodeBuilder::new(Role::ListItem)),
+                                ))
+                                .insert(Style {
+                                    min_width: Val::Px(200.),
+                                    align_content: AlignContent::Center,
+                                    ..default()
+                                })
+                                .insert(Pickable {
+                                    should_block_lower: false,
+                                    ..default()
+                                })
+                                .observe(|
+                                    trigger: Trigger<Pointer<Down>>,
+                                    mut commands: Commands
+                                | {
+                                    if trigger.event().button == PointerButton::Primary {
+                                        commands.entity(trigger.entity()).despawn_recursive();
+                                    }
+                                });
+                            }
+                        });
+                });
+
+            // container for all other examples
+            parent
+                .spawn(NodeBundle {
+                    style: Style {
+                        width: Val::Percent(100.),
+                        height: Val::Percent(100.),
+                        flex_direction: FlexDirection::Row,
+                        justify_content: JustifyContent::SpaceBetween,
+                        ..default()
+                    },
+                    ..default()
+                })
+                .with_children(|parent| {
+                    // vertical scroll example
+                    parent
+                        .spawn(NodeBundle {
+                            style: Style {
+                                flex_direction: FlexDirection::Column,
+                                justify_content: JustifyContent::Center,
+                                align_items: AlignItems::Center,
+                                width: Val::Px(200.),
+                                ..default()
+                            },
+                            ..default()
+                        })
+                        .with_children(|parent| {
+                            // Title
+                            parent.spawn((
+                                TextBundle::from_section(
+                                    "Vertically Scrolling List",
+                                    TextStyle {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font_size: 25.,
+                                        ..default()
+                                    },
+                                ),
+                                Label,
+                            ));
+                            // Scrolling list
+                            parent
+                                .spawn(NodeBundle {
+                                    style: Style {
+                                        flex_direction: FlexDirection::Column,
+                                        align_self: AlignSelf::Stretch,
+                                        height: Val::Percent(50.),
+                                        overflow: Overflow::scroll_y(), // n.b.
+                                        ..default()
+                                    },
+                                    background_color: Color::srgb(0.10, 0.10, 0.10).into(),
+                                    ..default()
+                                })
+                                .with_children(|parent| {
+                                    // List items
+                                    for i in 0..25 {
+                                        parent
+                                            .spawn((
+                                                TextBundle::from_section(
+                                                    format!("Item {i}"),
+                                                    TextStyle {
+                                                        font: asset_server
+                                                            .load("fonts/FiraSans-Bold.ttf"),
+                                                        ..default()
+                                                    },
+                                                ),
+                                                Label,
+                                                AccessibilityNode(NodeBuilder::new(Role::ListItem)),
+                                            ))
+                                            .insert(Pickable {
+                                                should_block_lower: false,
+                                                ..default()
+                                            });
+                                    }
+                                });
+                        });
+
+                    // Bidirectional scroll example
+                    parent
+                        .spawn(NodeBundle {
+                            style: Style {
+                                flex_direction: FlexDirection::Column,
+                                justify_content: JustifyContent::Center,
+                                align_items: AlignItems::Center,
+                                width: Val::Px(200.),
+                                ..default()
+                            },
+                            ..default()
+                        })
+                        .with_children(|parent| {
+                            // Title
+                            parent.spawn((
+                                TextBundle::from_section(
+                                    "Bidirectionally Scrolling List",
+                                    TextStyle {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font_size: 25.,
+                                        ..default()
+                                    },
+                                ),
+                                Label,
+                            ));
+                            // Scrolling list
+                            parent
+                                .spawn(NodeBundle {
+                                    style: Style {
+                                        flex_direction: FlexDirection::Column,
+                                        align_self: AlignSelf::Stretch,
+                                        height: Val::Percent(50.),
+                                        overflow: Overflow::scroll(), // n.b.
+                                        ..default()
+                                    },
+                                    background_color: Color::srgb(0.10, 0.10, 0.10).into(),
+                                    ..default()
+                                })
+                                .with_children(|parent| {
+                                    // Rows in each column
+                                    for oi in 0..10 {
+                                        parent
+                                            .spawn(NodeBundle {
+                                                style: Style {
+                                                    flex_direction: FlexDirection::Row,
+                                                    ..default()
+                                                },
+                                                ..default()
+                                            })
+                                            .insert(Pickable::IGNORE)
+                                            .with_children(|parent| {
+                                                // Elements in each row
+                                                for i in 0..25 {
+                                                    parent
+                                                        .spawn((
+                                                            TextBundle::from_section(
+                                                                format!("Item {}", (oi * 25) + i),
+                                                                TextStyle {
+                                                                    font: asset_server.load(
+                                                                        "fonts/FiraSans-Bold.ttf",
+                                                                    ),
+                                                                    ..default()
+                                                                },
+                                                            ),
+                                                            Label,
+                                                            AccessibilityNode(NodeBuilder::new(
+                                                                Role::ListItem,
+                                                            )),
+                                                        ))
+                                                        .insert(Pickable {
+                                                            should_block_lower: false,
+                                                            ..default()
+                                                        });
+                                                }
+                                            });
+                                    }
+                                });
+                        });
+
+                    //Nested scrolls example
+                    parent
+                        .spawn(NodeBundle {
+                            style: Style {
+                                flex_direction: FlexDirection::Column,
+                                justify_content: JustifyContent::Center,
+                                align_items: AlignItems::Center,
+                                width: Val::Px(200.),
+                                ..default()
+                            },
+                            ..default()
+                        })
+                        .with_children(|parent| {
+                            // Title
+                            parent.spawn((
+                                TextBundle::from_section(
+                                    "Nested Scrolling Lists",
+                                    TextStyle {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font_size: 25.,
+                                        ..default()
+                                    },
+                                ),
+                                Label,
+                            ));
+                            // Outer, horizontal scrolling container
+                            parent
+                                .spawn(NodeBundle {
+                                    style: Style {
+                                        column_gap: Val::Px(20.),
+                                        flex_direction: FlexDirection::Row,
+                                        align_self: AlignSelf::Stretch,
+                                        height: Val::Percent(50.),
+                                        overflow: Overflow::scroll_x(), // n.b.
+                                        ..default()
+                                    },
+                                    background_color: Color::srgb(0.10, 0.10, 0.10).into(),
+                                    ..default()
+                                })
+                                .with_children(|parent| {
+                                    // Inner, scrolling columns
+                                    for oi in 0..30 {
+                                        parent
+                                            .spawn(NodeBundle {
+                                                style: Style {
+                                                    flex_direction: FlexDirection::Column,
+                                                    align_self: AlignSelf::Stretch,
+                                                    overflow: Overflow::scroll_y(),
+                                                    ..default()
+                                                },
+                                                background_color: Color::srgb(0.05, 0.05, 0.05)
+                                                    .into(),
+                                                ..default()
+                                            })
+                                            .insert(Pickable {
+                                                should_block_lower: false,
+                                                ..default()
+                                            })
+                                            .with_children(|parent| {
+                                                for i in 0..25 {
+                                                    parent
+                                                        .spawn((
+                                                            TextBundle::from_section(
+                                                                format!("Item {}", (oi * 25) + i),
+                                                                TextStyle {
+                                                                    font: asset_server.load(
+                                                                        "fonts/FiraSans-Bold.ttf",
+                                                                    ),
+                                                                    ..default()
+                                                                },
+                                                            ),
+                                                            Label,
+                                                            AccessibilityNode(NodeBuilder::new(
+                                                                Role::ListItem,
+                                                            )),
+                                                        ))
+                                                        .insert(Pickable {
+                                                            should_block_lower: false,
+                                                            ..default()
+                                                        });
+                                                }
+                                            });
+                                    }
+                                });
+                        });
+                });
+        });
+}
+
+/// Updates the scroll position of scrollable nodes in response to mouse input
+pub fn update_scroll_position(
+    mut mouse_wheel_events: EventReader<MouseWheel>,
+    hover_map: Res<HoverMap>,
+    mut scrolled_node_query: Query<(&mut ScrollPosition, &Style)>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    for mouse_wheel_event in mouse_wheel_events.read() {
+        let (mut dx, mut dy) = match mouse_wheel_event.unit {
+            MouseScrollUnit::Line => (mouse_wheel_event.x * 20., mouse_wheel_event.y * 20.),
+            MouseScrollUnit::Pixel => (mouse_wheel_event.x, mouse_wheel_event.y),
+        };
+
+        if keyboard_input.pressed(KeyCode::ShiftLeft) || keyboard_input.pressed(KeyCode::ShiftRight)
+        {
+            std::mem::swap(&mut dx, &mut dy);
+        }
+
+        for (_pointer, pointer_map) in hover_map.iter() {
+            for (entity, _hit) in pointer_map.iter() {
+                if let Ok((mut scroll_position, style)) = scrolled_node_query.get_mut(*entity) {
+                    if style.overflow.x == OverflowAxis::Scroll {
+                        scroll_position.offset_x -= dx;
+                    }
+                    if style.overflow.y == OverflowAxis::Scroll {
+                        scroll_position.offset_y -= dy;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -377,7 +377,7 @@ const LINE_HEIGHT: f32 = 20.;
 pub fn update_scroll_position(
     mut mouse_wheel_events: EventReader<MouseWheel>,
     hover_map: Res<HoverMap>,
-    mut scrolled_node_query: Query<(&mut ScrollPosition, &Style)>,
+    mut scrolled_node_query: Query<&mut ScrollPosition>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     for mouse_wheel_event in mouse_wheel_events.read() {
@@ -396,13 +396,9 @@ pub fn update_scroll_position(
 
         for (_pointer, pointer_map) in hover_map.iter() {
             for (entity, _hit) in pointer_map.iter() {
-                if let Ok((mut scroll_position, style)) = scrolled_node_query.get_mut(*entity) {
-                    if style.overflow.x == OverflowAxis::Scroll {
-                        scroll_position.offset_x -= dx;
-                    }
-                    if style.overflow.y == OverflowAxis::Scroll {
-                        scroll_position.offset_y -= dy;
-                    }
+                if let Ok(mut scroll_position) = scrolled_node_query.get_mut(*entity) {
+                    scroll_position.offset_x -= dx;
+                    scroll_position.offset_y -= dy;
                 }
             }
         }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -7,6 +7,7 @@ use bevy::{
     },
     color::palettes::basic::LIME,
     input::mouse::{MouseScrollUnit, MouseWheel},
+    picking::focus::HoverMap,
     prelude::*,
     winit::WinitSettings,
 };
@@ -17,7 +18,7 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
-        .add_systems(Update, mouse_scroll);
+        .add_systems(Update, update_scroll_position);
 
     #[cfg(feature = "bevy_dev_tools")]
     {
@@ -43,6 +44,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             ..default()
         })
+        .insert(Pickable::IGNORE)
         .with_children(|parent| {
             // left vertical fill (border)
             parent
@@ -122,7 +124,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         width: Val::Px(200.),
                         ..default()
                     },
-                    background_color: Color::srgb(0.15, 0.15, 0.15).into(),
                     ..default()
                 })
                 .with_children(|parent| {
@@ -138,53 +139,42 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ),
                         Label,
                     ));
-                    // List with hidden overflow
+                    // Scrolling list
                     parent
                         .spawn(NodeBundle {
                             style: Style {
                                 flex_direction: FlexDirection::Column,
                                 align_self: AlignSelf::Stretch,
                                 height: Val::Percent(50.),
-                                overflow: Overflow::clip_y(),
+                                overflow: Overflow::scroll_y(),
                                 ..default()
                             },
                             background_color: Color::srgb(0.10, 0.10, 0.10).into(),
                             ..default()
                         })
                         .with_children(|parent| {
-                            // Moving panel
-                            parent
-                                .spawn((
-                                    NodeBundle {
-                                        style: Style {
-                                            flex_direction: FlexDirection::Column,
-                                            align_items: AlignItems::Center,
-                                            ..default()
-                                        },
+                            // List items
+                            for i in 0..25 {
+                                parent
+                                    .spawn((
+                                        TextBundle::from_section(
+                                            format!("Item {i}"),
+                                            TextStyle {
+                                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                                ..default()
+                                            },
+                                        ),
+                                        Label,
+                                        AccessibilityNode(NodeBuilder::new(Role::ListItem)),
+                                    ))
+                                    .insert(Pickable {
+                                        should_block_lower: false,
                                         ..default()
-                                    },
-                                    ScrollingList::default(),
-                                    AccessibilityNode(NodeBuilder::new(Role::List)),
-                                ))
-                                .with_children(|parent| {
-                                    // List items
-                                    for i in 0..30 {
-                                        parent.spawn((
-                                            TextBundle::from_section(
-                                                format!("Item {i}"),
-                                                TextStyle {
-                                                    font: asset_server
-                                                        .load("fonts/FiraSans-Bold.ttf"),
-                                                    ..default()
-                                                },
-                                            ),
-                                            Label,
-                                            AccessibilityNode(NodeBuilder::new(Role::ListItem)),
-                                        ));
-                                    }
-                                });
+                                    });
+                            }
                         });
                 });
+
             parent
                 .spawn(NodeBundle {
                     style: Style {
@@ -224,6 +214,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     ..default()
                 })
+                .insert(Pickable::IGNORE)
                 .with_children(|parent| {
                     parent
                         .spawn(NodeBundle {
@@ -336,35 +327,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-#[derive(Component, Default)]
-struct ScrollingList {
-    position: f32,
-}
-
-fn mouse_scroll(
-    mut mouse_wheel_events: EventReader<MouseWheel>,
-    mut query_list: Query<(&mut ScrollingList, &mut Style, &Parent, &Node)>,
-    query_node: Query<&Node>,
-) {
-    for mouse_wheel_event in mouse_wheel_events.read() {
-        for (mut scrolling_list, mut style, parent, list_node) in &mut query_list {
-            let items_height = list_node.size().y;
-            let container_height = query_node.get(parent.get()).unwrap().size().y;
-
-            let max_scroll = (items_height - container_height).max(0.);
-
-            let dy = match mouse_wheel_event.unit {
-                MouseScrollUnit::Line => mouse_wheel_event.y * 20.,
-                MouseScrollUnit::Pixel => mouse_wheel_event.y,
-            };
-
-            scrolling_list.position += dy;
-            scrolling_list.position = scrolling_list.position.clamp(-max_scroll, 0.);
-            style.top = Val::Px(scrolling_list.position);
-        }
-    }
-}
-
 #[cfg(feature = "bevy_dev_tools")]
 // The system that will enable/disable the debug outlines around the nodes
 fn toggle_overlay(
@@ -375,5 +337,38 @@ fn toggle_overlay(
     if input.just_pressed(KeyCode::Space) {
         // The toggle method will enable the debug_overlay if disabled and disable if enabled
         options.toggle();
+    }
+}
+
+/// Updates the scroll position of scrollable nodes in response to mouse input
+pub fn update_scroll_position(
+    mut mouse_wheel_events: EventReader<MouseWheel>,
+    hover_map: Res<HoverMap>,
+    mut scrolled_node_query: Query<(&mut ScrollPosition, &Style)>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    for mouse_wheel_event in mouse_wheel_events.read() {
+        let (mut dx, mut dy) = match mouse_wheel_event.unit {
+            MouseScrollUnit::Line => (mouse_wheel_event.x * 20., mouse_wheel_event.y * 20.),
+            MouseScrollUnit::Pixel => (mouse_wheel_event.x, mouse_wheel_event.y),
+        };
+
+        if keyboard_input.pressed(KeyCode::ShiftLeft) || keyboard_input.pressed(KeyCode::ShiftRight)
+        {
+            std::mem::swap(&mut dx, &mut dy);
+        }
+
+        for (_pointer, pointer_map) in hover_map.iter() {
+            for (entity, _hit) in pointer_map.iter() {
+                if let Ok((mut scroll_position, style)) = scrolled_node_query.get_mut(*entity) {
+                    if style.overflow.x == OverflowAxis::Scroll {
+                        scroll_position.offset_x -= dx;
+                    }
+                    if style.overflow.y == OverflowAxis::Scroll {
+                        scroll_position.offset_y -= dy;
+                    }
+                }
+            }
+        }
     }
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -344,7 +344,7 @@ fn toggle_overlay(
 pub fn update_scroll_position(
     mut mouse_wheel_events: EventReader<MouseWheel>,
     hover_map: Res<HoverMap>,
-    mut scrolled_node_query: Query<(&mut ScrollPosition, &Style)>,
+    mut scrolled_node_query: Query<&mut ScrollPosition>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     for mouse_wheel_event in mouse_wheel_events.read() {
@@ -360,13 +360,9 @@ pub fn update_scroll_position(
 
         for (_pointer, pointer_map) in hover_map.iter() {
             for (entity, _hit) in pointer_map.iter() {
-                if let Ok((mut scroll_position, style)) = scrolled_node_query.get_mut(*entity) {
-                    if style.overflow.x == OverflowAxis::Scroll {
-                        scroll_position.offset_x -= dx;
-                    }
-                    if style.overflow.y == OverflowAxis::Scroll {
-                        scroll_position.offset_y -= dy;
-                    }
+                if let Ok(mut scroll_position) = scrolled_node_query.get_mut(*entity) {
+                    scroll_position.offset_x -= dx;
+                    scroll_position.offset_y -= dy;
                 }
             }
         }


### PR DESCRIPTION
# Objective

- Fixes #8074 
- Adopts / Supersedes #8104

## Solution

Adapted from #8104 and affords the same benefits.

**Additions**
- [x] Update scrolling on relayout (height of node or contents may have changed)
- [x] Make ScrollPosition component optional for ui nodes to avoid checking every node on scroll
- [x] Nested scrollviews

**Omissions**
- Removed input handling for scrolling from `bevy_ui`. Users should update `ScrollPosition` directly.

### Implementation

Adds a new `ScrollPosition` component. Updating this component on a `Node` with an overflow axis set to `OverflowAxis::Scroll` will reposition its children by that amount when calculating node transforms. As before, no impact on the underlying Taffy layout.

Calculating this correctly is trickier than it was in #8104 due to `"Update scrolling on relayout"`. 

**Background**

When `ScrollPosition` is updated directly by the user, it can be trivially handled in-engine by adding the parent's scroll position to the final location of each child node. However, _other layout actions_ may result in a situation where `ScrollPosition` needs to be updated. Consider a 1000 pixel tall vertically scrolling list of 100 elements, each 100 pixels tall. Scrolled to the bottom, the `ScrollPosition.offset_y` is 9000, just enough to display the last element in the list. When removing an element from that list, the new desired `ScrollPosition.offset_y` is 8900, but, critically, that is not known until after the sizes and positions of the children of the scrollable node are resolved.

All user scrolling code today handles this by delaying the resolution by one frame. One notable disadvantage of this is the inability to support `WinitSettings::desktop_app()`, since there would need to be an input AFTER the layout change that caused the scroll position to update for the results of the scroll position update to render visually.

I propose the alternative in this PR, which allows for same-frame resolution of scrolling layout. 

**Resolution**

_Edit: Below resolution is outdated, and replaced with the simpler usage of taffy's `Layout::content_size`._

When recursively iterating the children of a node, each child now returns a `Vec2` representing the location of their own bottom right corner. Then, `[[0,0, [x,y]]` represents a bounding box containing the scrollable area filled by that child. Scrollable parents aggregate those areas into the bounding box of _all_ children, then consider that result against `ScrollPosition` to ensure its validity. 

In the event that resolution of the layout of the children invalidates the `ScrollPosition` (e.g. scrolled further than there were children to scroll to), _all_ children of that node must be recursively repositioned. The position of each child must change as a result of the change in scroll position.

Therefore, this implementation takes care to only spend the cost of the "second layout pass" when a specific node actually had a `ScrollPosition` forcibly updated by the layout of its children.


## Testing

Examples in `ui/scroll.rs`. There may be more complex node/style interactions that were unconsidered.

---

## Showcase


![scroll](https://github.com/user-attachments/assets/1331138f-93aa-4a8f-959c-6be18a04ff03)

## Alternatives

- `bevy_ui` doesn't support scrolling.
- `bevy_ui` implements scrolling with a one-frame delay on reactions to layout changes.