### PR TITLE
Fix typo in sprite_picking.rs example

### DIFF
--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -1,5 +1,5 @@
 //! Demonstrates picking for sprites and sprite atlases. The picking backend only tests against the
-//! sprite bounds, so the sprite atlas can be picked by clicking on its trnasparent areas.
+//! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
 
 use bevy::{prelude::*, sprite::Anchor};
 use std::fmt::Debug;


### PR DESCRIPTION
Simple typo I noticed while reading example.