### PR TITLE
Fix memory leak in world's command queue

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -162,6 +162,8 @@ impl Drop for World {
         drop(unsafe { Box::from_raw(self.command_queue.bytes.as_ptr()) });
         // SAFETY: Pointers in internal command queue are only invalidated here
         drop(unsafe { Box::from_raw(self.command_queue.cursor.as_ptr()) });
+        // SAFETY: Pointers in internal command queue are only invalidated here
+        drop(unsafe { Box::from_raw(self.command_queue.panic_recovery.as_ptr()) });
     }
 }
 


### PR DESCRIPTION
# Objective

- I was running miri locally to check the UB in #15276 and it detected an unrelated memory leak, due to the `RawCommandQueue` changes. (I probably should have turned the leak detection off because we do purposely leak interned string labels and I assume that's why CI didn't detect it.)

## Solution

- The memory allocated to `RawCommandQueue` needs to be manually dropped. This was being done for `bytes` and `cursor`, but was missed for `panic_recovery`.

## Testing

- Ran miri locally and the related memory leaks errors when away.
