### PR TITLE
Broaden "Check for bevy_internal imports" CI Task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,19 +419,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Check for bevy_internal imports
+      - name: Check for Bevy internal imports
         shell: bash
         run: |
           errors=""
           for file in $(find examples tests -name '*.rs'); do
-              if grep -q "use bevy_internal" "$file"; then
-                  errors+="ERROR: Detected 'use bevy_internal' in $file\n"
+              if grep -q "use bevy_" "$file"; then
+                  errors+="ERROR: Detected internal Bevy import in $file\n"
               fi
           done
           if [ -n "$errors" ]; then
               echo -e "$errors"
-              echo " Avoid importing bevy_internal, it should not be used directly"
-              echo " Fix the issue by replacing 'bevy_internal' with 'bevy'"
+              echo " Avoid importing internal Bevy crates, they should not be used directly"
+              echo " Fix the issue by replacing 'bevy_*' with 'bevy'"
               echo " Example: 'use bevy::sprite::MaterialMesh2dBundle;' instead of 'bevy_internal::sprite::MaterialMesh2dBundle;'"
               exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Check for Bevy internal imports
+      - name: Check for internal Bevy imports
         shell: bash
         run: |
           errors=""

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -3,7 +3,7 @@
 use bevy::{
     prelude::*,
     render::{
-        camera::RenderTarget,
+        camera::{RenderTarget, ScalingMode},
         render_resource::{
             Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
         },
@@ -12,7 +12,6 @@ use bevy::{
     sprite::MaterialMesh2dBundle,
     window::WindowResized,
 };
-use bevy_render::camera::ScalingMode;
 
 /// In-game resolution width.
 const RES_WIDTH: u32 = 160;

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -5,11 +5,11 @@ use std::f32::consts::PI;
 use bevy::{
     prelude::*,
     render::{
+        render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
         view::RenderLayers,
     },
 };
-use bevy_render::render_asset::RenderAssetUsages;
 
 fn main() {
     App::new()

--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -14,7 +14,7 @@ use bevy::core_pipeline::bloom::Bloom;
 use bevy::core_pipeline::experimental::taa::{TemporalAntiAliasBundle, TemporalAntiAliasPlugin};
 use bevy::pbr::{DirectionalLightShadowMap, FogVolume, VolumetricFog, VolumetricLight};
 use bevy::prelude::*;
-use bevy_render::texture::{
+use bevy::render::texture::{
     ImageAddressMode, ImageFilterMode, ImageLoaderSettings, ImageSampler, ImageSamplerDescriptor,
 };
 

--- a/examples/shader/storage_buffer.rs
+++ b/examples/shader/storage_buffer.rs
@@ -2,9 +2,11 @@
 use bevy::{
     prelude::*,
     reflect::TypePath,
-    render::render_resource::{AsBindGroup, ShaderRef},
+    render::{
+        render_resource::{AsBindGroup, ShaderRef},
+        storage::ShaderStorageBuffer,
+    },
 };
-use bevy_render::storage::ShaderStorageBuffer;
 
 const SHADER_ASSET_PATH: &str = "shaders/storage_buffer.wgsl";
 

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -7,10 +7,10 @@ use bevy::{
     prelude::*,
     render::{
         camera::RenderTarget,
+        render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
     },
 };
-use bevy_render::render_asset::RenderAssetUsages;
 
 fn main() {
     App::new()

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -1,9 +1,11 @@
 //! An example showing how to save screenshots to disk
 
 use bevy::prelude::*;
+use bevy::render::view::{
+    cursor::CursorIcon,
+    screenshot::{save_to_disk, Capturing, Screenshot},
+};
 use bevy::window::SystemCursorIcon;
-use bevy_render::view::cursor::CursorIcon;
-use bevy_render::view::screenshot::{save_to_disk, Capturing, Screenshot};
 
 fn main() {
     App::new()

--- a/tests/ecs/ambiguity_detection.rs
+++ b/tests/ecs/ambiguity_detection.rs
@@ -7,9 +7,9 @@
 use bevy::{
     ecs::schedule::{InternedScheduleLabel, LogLevel, ScheduleBuildSettings},
     prelude::*,
+    render::pipelined_rendering::RenderExtractApp,
     utils::HashMap,
 };
-use bevy_render::pipelined_rendering::RenderExtractApp;
 
 fn main() {
     let mut app = App::new();


### PR DESCRIPTION
# Objective

- Fixes #15319
- Fixes #15317

## Solution

- Updated CI task to check for _any_ `bevy_*` crates, rather than just `bevy_internal`
