### PR TITLE
`Reflect` for `TextureFormat`

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -17,6 +17,7 @@ glam = ["dep:glam"]
 petgraph = ["dep:petgraph"]
 smallvec = ["dep:smallvec"]
 uuid = ["dep:uuid"]
+wgpu-types = ["dep:wgpu-types"]
 # Enables features useful for debugging reflection
 debug = ["debug_stack"]
 # When enabled, keeps track of the current serialization/deserialization context for better error messages
@@ -43,6 +44,7 @@ glam = { version = "0.28", features = ["serde"], optional = true }
 petgraph = { version = "0.6", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", features = ["serde"], optional = true }
 uuid = { version = "1.0", optional = true, features = ["v4", "serde"] }
+wgpu-types = { version = "22", features = ["serde"], optional = true }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/src/impls/wgpu_types.rs
+++ b/crates/bevy_reflect/src/impls/wgpu_types.rs
@@ -1,0 +1,8 @@
+use crate::{self as bevy_reflect, impl_reflect_value, ReflectDeserialize, ReflectSerialize};
+impl_reflect_value!(::wgpu_types::TextureFormat(
+    Debug,
+    Hash,
+    PartialEq,
+    Deserialize,
+    Serialize,
+));

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -557,6 +557,8 @@ mod type_path;
 mod type_registry;
 
 mod impls {
+    mod std;
+
     #[cfg(feature = "glam")]
     mod glam;
     #[cfg(feature = "petgraph")]
@@ -565,10 +567,10 @@ mod impls {
     mod smallvec;
     #[cfg(feature = "smol_str")]
     mod smol_str;
-
-    mod std;
     #[cfg(feature = "uuid")]
     mod uuid;
+    #[cfg(feature = "wgpu-types")]
+    mod wgpu_types;
 }
 
 pub mod attributes;


### PR DESCRIPTION
# Objective

In order to derive `Reflect`, all of a struct's fields must implement `FromReflect`. [As part of looking into some of the work mentioned here](https://github.com/bevyengine/bevy/issues/13713#issuecomment-2364786694), I noticed that `TextureFormat` doesn't implement `Reflect`, and decided to split that into a separate PR.

## Solution

I decided that `TextureFormat` should be a `reflect_value` since, although one variant has fields, most users will treat this as an opaque value set explicitly. It also substantially reduces the complexity of the implementation.

For now, this implementation isn't actually used by any crates, so, I decided to not preemptively enable the feature on anything. But it's technically an option, now, and more `wgpu` types can be added in the future.

## Testing

Everything compiles okay, and I can't really see how this could be done incorrectly given the above constraints.