### PR TITLE
Implement volumetric fog support for both point lights and spotlights

### DIFF
--- a/crates/bevy_pbr/src/cluster/assign.rs
+++ b/crates/bevy_pbr/src/cluster/assign.rs
@@ -21,6 +21,8 @@ use crate::{
     CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT, MAX_UNIFORM_BUFFER_CLUSTERABLE_OBJECTS,
 };
 
+use super::ClusterableObjectOrderData;
+
 const NDC_MIN: Vec2 = Vec2::NEG_ONE;
 const NDC_MAX: Vec2 = Vec2::ONE;
 
@@ -139,18 +141,18 @@ pub(crate) fn assign_objects_to_clusters(
     {
         clusterable_objects.sort_by(|clusterable_object_1, clusterable_object_2| {
             crate::clusterable_object_order(
-                (
-                    &clusterable_object_1.entity,
-                    &clusterable_object_1.shadows_enabled,
-                    &clusterable_object_1.volumetric,
-                    &clusterable_object_1.spot_light_angle.is_some(),
-                ),
-                (
-                    &clusterable_object_2.entity,
-                    &clusterable_object_2.shadows_enabled,
-                    &clusterable_object_2.volumetric,
-                    &clusterable_object_2.spot_light_angle.is_some(),
-                ),
+                ClusterableObjectOrderData {
+                    entity: &clusterable_object_1.entity,
+                    shadows_enabled: &clusterable_object_1.shadows_enabled,
+                    is_volumetric_light: &clusterable_object_1.volumetric,
+                    is_spot_light: &clusterable_object_1.spot_light_angle.is_some(),
+                },
+                ClusterableObjectOrderData {
+                    entity: &clusterable_object_2.entity,
+                    shadows_enabled: &clusterable_object_2.shadows_enabled,
+                    is_volumetric_light: &clusterable_object_2.volumetric,
+                    is_spot_light: &clusterable_object_2.spot_light_angle.is_some(),
+                },
             )
         });
 

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -491,6 +491,13 @@ impl Default for GpuClusterableObjectsUniform {
     }
 }
 
+pub(crate) struct ClusterableObjectOrderData<'a> {
+    pub(crate) entity: &'a Entity,
+    pub(crate) shadows_enabled: &'a bool,
+    pub(crate) is_volumetric_light: &'a bool,
+    pub(crate) is_spot_light: &'a bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 // Sort clusterable objects by:
 //
@@ -505,24 +512,14 @@ impl Default for GpuClusterableObjectsUniform {
 //   clusterable objects are chosen if the clusterable object count limit is
 //   exceeded.
 pub(crate) fn clusterable_object_order(
-    (entity_1, shadows_enabled_1, is_volumetric_light_1, is_spot_light_1): (
-        &Entity,
-        &bool,
-        &bool,
-        &bool,
-    ),
-    (entity_2, shadows_enabled_2, is_volumetric_light_2, is_spot_light_2): (
-        &Entity,
-        &bool,
-        &bool,
-        &bool,
-    ),
+    a: ClusterableObjectOrderData,
+    b: ClusterableObjectOrderData,
 ) -> std::cmp::Ordering {
-    is_spot_light_1
-        .cmp(is_spot_light_2) // pointlights before spot lights
-        .then_with(|| shadows_enabled_2.cmp(shadows_enabled_1)) // shadow casters before non-casters
-        .then_with(|| is_volumetric_light_2.cmp(is_volumetric_light_1)) // volumetric lights before non-volumetric lights
-        .then_with(|| entity_1.cmp(entity_2)) // stable
+    a.is_spot_light
+        .cmp(b.is_spot_light) // pointlights before spot lights
+        .then_with(|| b.shadows_enabled.cmp(a.shadows_enabled)) // shadow casters before non-casters
+        .then_with(|| b.is_volumetric_light.cmp(a.is_volumetric_light)) // volumetric lights before non-volumetric lights
+        .then_with(|| a.entity.cmp(b.entity)) // stable
 }
 
 /// Extracts clusters from the main world from the render world.

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -514,7 +514,7 @@ pub(crate) struct ClusterableObjectOrderData<'a> {
 pub(crate) fn clusterable_object_order(
     a: ClusterableObjectOrderData,
     b: ClusterableObjectOrderData,
-) -> std::cmp::Ordering {
+) -> core::cmp::Ordering {
     a.is_spot_light
         .cmp(b.is_spot_light) // pointlights before spot lights
         .then_with(|| b.shadows_enabled.cmp(a.shadows_enabled)) // shadow casters before non-casters

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -505,12 +505,23 @@ impl Default for GpuClusterableObjectsUniform {
 //   clusterable objects are chosen if the clusterable object count limit is
 //   exceeded.
 pub(crate) fn clusterable_object_order(
-    (entity_1, shadows_enabled_1, is_spot_light_1): (&Entity, &bool, &bool),
-    (entity_2, shadows_enabled_2, is_spot_light_2): (&Entity, &bool, &bool),
-) -> core::cmp::Ordering {
+    (entity_1, shadows_enabled_1, is_volumetric_light_1, is_spot_light_1): (
+        &Entity,
+        &bool,
+        &bool,
+        &bool,
+    ),
+    (entity_2, shadows_enabled_2, is_volumetric_light_2, is_spot_light_2): (
+        &Entity,
+        &bool,
+        &bool,
+        &bool,
+    ),
+) -> std::cmp::Ordering {
     is_spot_light_1
         .cmp(is_spot_light_2) // pointlights before spot lights
         .then_with(|| shadows_enabled_2.cmp(shadows_enabled_1)) // shadow casters before non-casters
+        .then_with(|| is_volumetric_light_2.cmp(is_volumetric_light_1)) // volumetric lights before non-volumetric lights
         .then_with(|| entity_1.cmp(entity_2)) // stable
 }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -686,18 +686,18 @@ pub fn prepare_lights(
     // - then by entity as a stable key to ensure that a consistent set of lights are chosen if the light count limit is exceeded.
     point_lights.sort_by(|(entity_1, light_1, _), (entity_2, light_2, _)| {
         clusterable_object_order(
-            (
-                entity_1,
-                &light_1.shadows_enabled,
-                &light_1.volumetric,
-                &light_1.spot_light_angles.is_some(),
-            ),
-            (
-                entity_2,
-                &light_2.shadows_enabled,
-                &light_2.volumetric,
-                &light_2.spot_light_angles.is_some(),
-            ),
+            ClusterableObjectOrderData {
+                entity: entity_1,
+                shadows_enabled: &light_1.shadows_enabled,
+                is_volumetric_light: &light_1.volumetric,
+                is_spot_light: &light_1.spot_light_angles.is_some(),
+            },
+            ClusterableObjectOrderData {
+                entity: entity_2,
+                shadows_enabled: &light_2.shadows_enabled,
+                is_volumetric_light: &light_2.volumetric,
+                is_spot_light: &light_2.spot_light_angles.is_some(),
+            },
         )
     });
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -45,6 +45,7 @@ pub struct ExtractedPointLight {
     pub shadow_normal_bias: f32,
     pub shadow_map_near_z: f32,
     pub spot_light_angles: Option<(f32, f32)>,
+    pub volumetric: bool,
 }
 
 #[derive(Component, Debug)]
@@ -69,6 +70,7 @@ bitflags::bitflags! {
     struct PointLightFlags: u32 {
         const SHADOWS_ENABLED            = 1 << 0;
         const SPOT_LIGHT_Y_NEGATIVE      = 1 << 1;
+        const VOLUMETRIC                 = 1 << 2;
         const NONE                       = 0;
         const UNINITIALIZED              = 0xFFFF;
     }
@@ -195,6 +197,7 @@ pub fn extract_lights(
             &GlobalTransform,
             &ViewVisibility,
             &CubemapFrusta,
+            Option<&VolumetricLight>,
         )>,
     >,
     spot_lights: Extract<
@@ -204,6 +207,7 @@ pub fn extract_lights(
             &GlobalTransform,
             &ViewVisibility,
             &Frustum,
+            Option<&VolumetricLight>,
         )>,
     >,
     directional_lights: Extract<
@@ -245,8 +249,14 @@ pub fn extract_lights(
 
     let mut point_lights_values = Vec::with_capacity(*previous_point_lights_len);
     for entity in global_point_lights.iter().copied() {
-        let Ok((point_light, cubemap_visible_entities, transform, view_visibility, frusta)) =
-            point_lights.get(entity)
+        let Ok((
+            point_light,
+            cubemap_visible_entities,
+            transform,
+            view_visibility,
+            frusta,
+            volumetric_light,
+        )) = point_lights.get(entity)
         else {
             continue;
         };
@@ -274,6 +284,7 @@ pub fn extract_lights(
                 * core::f32::consts::SQRT_2,
             shadow_map_near_z: point_light.shadow_map_near_z,
             spot_light_angles: None,
+            volumetric: volumetric_light.is_some(),
         };
         point_lights_values.push((
             entity,
@@ -289,8 +300,14 @@ pub fn extract_lights(
 
     let mut spot_lights_values = Vec::with_capacity(*previous_spot_lights_len);
     for entity in global_point_lights.iter().copied() {
-        if let Ok((spot_light, visible_entities, transform, view_visibility, frustum)) =
-            spot_lights.get(entity)
+        if let Ok((
+            spot_light,
+            visible_entities,
+            transform,
+            view_visibility,
+            frustum,
+            volumetric_light,
+        )) = spot_lights.get(entity)
         {
             if !view_visibility.get() {
                 continue;
@@ -325,6 +342,7 @@ pub fn extract_lights(
                             * core::f32::consts::SQRT_2,
                         shadow_map_near_z: spot_light.shadow_map_near_z,
                         spot_light_angles: Some((spot_light.inner_angle, spot_light.outer_angle)),
+                        volumetric: volumetric_light.is_some(),
                     },
                     render_visible_entities,
                     *frustum,
@@ -621,6 +639,14 @@ pub fn prepare_lights(
         .filter(|light| light.1.spot_light_angles.is_none())
         .count();
 
+    let point_light_volumetric_enabled_count = point_lights
+        .iter()
+        .filter(|(_, light, _)| {
+            (light.volumetric || light.shadows_enabled) && light.spot_light_angles.is_none()
+        })
+        .count()
+        .min(max_texture_cubes);
+
     let point_light_shadow_maps_count = point_lights
         .iter()
         .filter(|light| light.1.shadows_enabled && light.1.spot_light_angles.is_none())
@@ -641,6 +667,12 @@ pub fn prepare_lights(
         .count()
         .min(max_texture_array_layers / MAX_CASCADES_PER_LIGHT);
 
+    let spot_light_volumetric_enabled_count = point_lights
+        .iter()
+        .filter(|(_, light, _)| (light.volumetric) && light.spot_light_angles.is_some())
+        .count()
+        .min(max_texture_array_layers - directional_shadow_enabled_count * MAX_CASCADES_PER_LIGHT);
+
     let spot_light_shadow_maps_count = point_lights
         .iter()
         .filter(|(_, light, _)| light.shadows_enabled && light.spot_light_angles.is_some())
@@ -657,11 +689,13 @@ pub fn prepare_lights(
             (
                 entity_1,
                 &light_1.shadows_enabled,
+                &light_1.volumetric,
                 &light_1.spot_light_angles.is_some(),
             ),
             (
                 entity_2,
                 &light_2.shadows_enabled,
+                &light_2.volumetric,
                 &light_2.spot_light_angles.is_some(),
             ),
         )
@@ -706,6 +740,15 @@ pub fn prepare_lights(
             1.0,
             light.shadow_map_near_z,
         );
+        if light.shadows_enabled
+            && light.volumetric
+            && (index < point_light_volumetric_enabled_count
+                || (light.spot_light_angles.is_some()
+                    && index - point_light_volumetric_enabled_count
+                        < spot_light_volumetric_enabled_count))
+        {
+            flags |= PointLightFlags::VOLUMETRIC;
+        }
 
         let (light_custom_data, spot_light_tan_angle) = match light.spot_light_angles {
             Some((inner, outer)) => {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -641,9 +641,7 @@ pub fn prepare_lights(
 
     let point_light_volumetric_enabled_count = point_lights
         .iter()
-        .filter(|(_, light, _)| {
-            (light.volumetric || light.shadows_enabled) && light.spot_light_angles.is_none()
-        })
+        .filter(|(_, light, _)| light.volumetric && light.spot_light_angles.is_none())
         .count()
         .min(max_texture_cubes);
 
@@ -669,7 +667,7 @@ pub fn prepare_lights(
 
     let spot_light_volumetric_enabled_count = point_lights
         .iter()
-        .filter(|(_, light, _)| (light.volumetric) && light.spot_light_angles.is_some())
+        .filter(|(_, light, _)| light.volumetric && light.spot_light_angles.is_some())
         .count()
         .min(max_texture_array_layers - directional_shadow_enabled_count * MAX_CASCADES_PER_LIGHT);
 
@@ -744,8 +742,7 @@ pub fn prepare_lights(
             && light.volumetric
             && (index < point_light_volumetric_enabled_count
                 || (light.spot_light_angles.is_some()
-                    && index - point_light_volumetric_enabled_count
-                        < spot_light_volumetric_enabled_count))
+                    && index - point_light_count < spot_light_volumetric_enabled_count))
         {
             flags |= PointLightFlags::VOLUMETRIC;
         }

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -19,6 +19,7 @@ struct ClusterableObject {
 
 const POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT: u32   = 1u;
 const POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE: u32 = 2u;
+const POINT_LIGHT_FLAGS_VOLUMETRIC_BIT: u32        = 4u;
 
 struct DirectionalCascade {
     clip_from_world: mat4x4<f32>,

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wgsl
@@ -15,9 +15,20 @@
 
 #import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 #import bevy_pbr::mesh_functions::{get_world_from_local, mesh_position_local_to_clip}
-#import bevy_pbr::mesh_view_bindings::{globals, lights, view}
-#import bevy_pbr::mesh_view_types::DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT
-#import bevy_pbr::shadow_sampling::sample_shadow_map_hardware
+#import bevy_pbr::mesh_view_bindings::{globals, lights, view, clusterable_objects}
+#import bevy_pbr::mesh_view_types::{
+    DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT, 
+    POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT, 
+    POINT_LIGHT_FLAGS_VOLUMETRIC_BIT,
+    POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
+    ClusterableObject
+}
+#import bevy_pbr::shadow_sampling::{
+    sample_shadow_map_hardware, 
+    sample_shadow_cubemap,
+    sample_shadow_map,
+    SPOT_SHADOW_TEXEL_SIZE
+}
 #import bevy_pbr::shadows::{get_cascade_index, world_to_directional_light_local}
 #import bevy_pbr::utils::interleaved_gradient_noise
 #import bevy_pbr::view_transformations::{
@@ -27,6 +38,8 @@
     position_ndc_to_world,
     position_view_to_world
 }
+#import bevy_pbr::clustered_forward as clustering
+#import bevy_pbr::lighting::getDistanceAttenuation;
 
 // The GPU version of [`VolumetricFog`]. See the comments in
 // `volumetric_fog/mod.rs` for descriptions of the fields here.
@@ -292,7 +305,180 @@ fn fragment(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
         }
     }
 
+    // Point lights and Spot lights
+    let view_z = view_start_pos.z;
+    let is_orthographic = view.clip_from_view[3].w == 1.0;
+    let cluster_index = clustering::fragment_cluster_index(frag_coord.xy, view_z, is_orthographic);
+    let offset_and_counts = clustering::unpack_offset_and_counts(cluster_index);
+    let spot_light_start_index = offset_and_counts[0] + offset_and_counts[1];
+    for (var i: u32 = offset_and_counts[0]; i < offset_and_counts[0] + offset_and_counts[1] + offset_and_counts[2]; i = i + 1u) {
+        let light_id = clustering::get_clusterable_object_id(i);
+        let light = &clusterable_objects.data[light_id];
+        if (((*light).flags & POINT_LIGHT_FLAGS_VOLUMETRIC_BIT) == 0) {
+            continue;
+        }
+
+        // Reset `background_alpha` for a new raymarch.
+        background_alpha = 1.0;
+
+        // Start raymarching.
+        for (var step = 0u; step < step_count; step += 1u) {
+            // As an optimization, break if we've gotten too dark.
+            if (background_alpha < 0.001) {
+                break;
+            }
+
+            // Calculate where we are in the ray.
+            let P_world = Ro_world + Rd_world * f32(step) * step_size_world;
+            let P_view = Rd_view * f32(step) * step_size_world;
+
+            var density = density_factor;
+
+            let light_to_frag = (*light).position_radius.xyz - P_world;
+            let V = Rd_world;
+            let L = normalize(light_to_frag);
+            let distance_square = dot(light_to_frag, light_to_frag);
+            let distance_atten = getDistanceAttenuation(distance_square, (*light).color_inverse_square_range.w);
+            var local_light_attenuation = distance_atten;
+            if (i < spot_light_start_index) {
+                var shadow: f32 = 1.0;
+                if (((*light).flags & POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
+                    shadow = fetch_point_shadow_without_normal(light_id, vec4(P_world, 1.0));
+                }
+                local_light_attenuation *= shadow;
+            } else {
+                // spot light attenuation
+                // reconstruct spot dir from x/z and y-direction flag
+                var spot_dir = vec3<f32>((*light).light_custom_data.x, 0.0, (*light).light_custom_data.y);
+                spot_dir.y = sqrt(max(0.0, 1.0 - spot_dir.x * spot_dir.x - spot_dir.z * spot_dir.z));
+                if ((*light).flags & POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE) != 0u {
+                    spot_dir.y = -spot_dir.y;
+                }
+                let light_to_frag = (*light).position_radius.xyz - P_world;
+
+                // calculate attenuation based on filament formula https://google.github.io/filament/Filament.html#listing_glslpunctuallight
+                // spot_scale and spot_offset have been precomputed
+                // note we normalize here to get "l" from the filament listing. spot_dir is already normalized
+                let cd = dot(-spot_dir, normalize(light_to_frag));
+                let attenuation = saturate(cd * (*light).light_custom_data.z + (*light).light_custom_data.w);
+                let spot_attenuation = attenuation * attenuation;
+
+                var shadow: f32 = 1.0;
+                if (((*light).flags & POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u) {
+                    shadow = fetch_spot_shadow_without_normal(light_id, vec4(P_world, 1.0));
+                }
+                local_light_attenuation *= spot_attenuation * shadow;
+            }
+            
+            // Calculate absorption (amount of light absorbed by the fog) and
+            // out-scattering (amount of light the fog scattered away).
+            let sample_attenuation = exp(-step_size_world * density * (absorption + scattering));
+
+            // Process absorption and out-scattering.
+            background_alpha *= sample_attenuation;
+
+            let light_attenuation = exp(-density * bounding_radius * (absorption + scattering));
+            let light_factors_per_step = fog_color * light_tint * light_attenuation *
+                scattering * density * step_size_world * light_intensity * 0.1;
+
+            // Modulate the factor we calculated above by the phase, fog color,
+            // light color, light tint.
+            let light_color_per_step = (*light).color_inverse_square_range.rgb * light_factors_per_step;
+
+            // Accumulate the light.
+            accumulated_color += light_color_per_step * local_light_attenuation *
+                background_alpha;
+        }
+    }
+
     // We're done! Return the color with alpha so it can be blended onto the
     // render target.
     return vec4(accumulated_color, 1.0 - background_alpha);
+}
+
+fn fetch_point_shadow_without_normal(light_id: u32, frag_position: vec4<f32>) -> f32 {
+    let light = &clusterable_objects.data[light_id];
+
+    // because the shadow maps align with the axes and the frustum planes are at 45 degrees
+    // we can get the worldspace depth by taking the largest absolute axis
+    let surface_to_light = (*light).position_radius.xyz - frag_position.xyz;
+    let surface_to_light_abs = abs(surface_to_light);
+    let distance_to_light = max(surface_to_light_abs.x, max(surface_to_light_abs.y, surface_to_light_abs.z));
+
+    // The normal bias here is already scaled by the texel size at 1 world unit from the light.
+    // The texel size increases proportionally with distance from the light so multiplying by
+    // distance to light scales the normal bias to the texel size at the fragment distance.
+    let depth_offset = (*light).shadow_depth_bias * normalize(surface_to_light.xyz);
+    let offset_position = frag_position.xyz + depth_offset;
+
+    // similar largest-absolute-axis trick as above, but now with the offset fragment position
+    let frag_ls = offset_position.xyz - (*light).position_radius.xyz ;
+    let abs_position_ls = abs(frag_ls);
+    let major_axis_magnitude = max(abs_position_ls.x, max(abs_position_ls.y, abs_position_ls.z));
+
+    // NOTE: These simplifications come from multiplying:
+    // projection * vec4(0, 0, -major_axis_magnitude, 1.0)
+    // and keeping only the terms that have any impact on the depth.
+    // Projection-agnostic approach:
+    let zw = -major_axis_magnitude * (*light).light_custom_data.xy + (*light).light_custom_data.zw;
+    let depth = zw.x / zw.y;
+
+    // Do the lookup, using HW PCF and comparison. Cubemaps assume a left-handed coordinate space,
+    // so we have to flip the z-axis when sampling.
+    let flip_z = vec3(1.0, 1.0, -1.0);
+    return sample_shadow_cubemap(frag_ls * flip_z, distance_to_light, depth, light_id);
+}
+
+fn fetch_spot_shadow_without_normal(light_id: u32, frag_position: vec4<f32>) -> f32 {
+    let light = &clusterable_objects.data[light_id];
+
+    let surface_to_light = (*light).position_radius.xyz - frag_position.xyz;
+
+    // construct the light view matrix
+    var spot_dir = vec3<f32>((*light).light_custom_data.x, 0.0, (*light).light_custom_data.y);
+    // reconstruct spot dir from x/z and y-direction flag
+    spot_dir.y = sqrt(max(0.0, 1.0 - spot_dir.x * spot_dir.x - spot_dir.z * spot_dir.z));
+    if (((*light).flags & POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE) != 0u) {
+        spot_dir.y = -spot_dir.y;
+    }
+
+    // view matrix z_axis is the reverse of transform.forward()
+    let fwd = -spot_dir;
+    let offset_position =
+        -surface_to_light
+        + ((*light).shadow_depth_bias * normalize(surface_to_light));
+
+    // the construction of the up and right vectors needs to precisely mirror the code
+    // in render/light.rs:spot_light_view_matrix
+    var sign = -1.0;
+    if (fwd.z >= 0.0) {
+        sign = 1.0;
+    }
+    let a = -1.0 / (fwd.z + sign);
+    let b = fwd.x * fwd.y * a;
+    let up_dir = vec3<f32>(1.0 + sign * fwd.x * fwd.x * a, sign * b, -sign * fwd.x);
+    let right_dir = vec3<f32>(-b, -sign - fwd.y * fwd.y * a, fwd.y);
+    let light_inv_rot = mat3x3<f32>(right_dir, up_dir, fwd);
+
+    // because the matrix is a pure rotation matrix, the inverse is just the transpose, and to calculate
+    // the product of the transpose with a vector we can just post-multiply instead of pre-multiplying.
+    // this allows us to keep the matrix construction code identical between CPU and GPU.
+    let projected_position = offset_position * light_inv_rot;
+
+    // divide xy by perspective matrix "f" and by -projected.z (projected.z is -projection matrix's w)
+    // to get ndc coordinates
+    let f_div_minus_z = 1.0 / ((*light).spot_light_tan_angle * -projected_position.z);
+    let shadow_xy_ndc = projected_position.xy * f_div_minus_z;
+    // convert to uv coordinates
+    let shadow_uv = shadow_xy_ndc * vec2<f32>(0.5, -0.5) + vec2<f32>(0.5, 0.5);
+
+    // 0.1 must match POINT_LIGHT_NEAR_Z
+    let depth = 0.1 / -projected_position.z;
+
+    return sample_shadow_map(
+        shadow_uv,
+        depth,
+        i32(light_id) + lights.spot_light_shadowmap_offset,
+        SPOT_SHADOW_TEXEL_SIZE
+    );
 }

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -1,6 +1,7 @@
 //! Demonstrates volumetric fog and lighting (light shafts or god rays).
 
 use bevy::{
+    color::palettes::css::RED,
     core_pipeline::{bloom::Bloom, tonemapping::Tonemapping, Skybox},
     math::vec3,
     pbr::{FogVolumeBundle, VolumetricFog, VolumetricLight},
@@ -59,6 +60,44 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ambient_intensity: 0.0,
             ..default()
         });
+
+    // Add the point light
+    commands
+        .spawn(PointLightBundle {
+            point_light: PointLight {
+                shadows_enabled: true,
+                range: 50.0,
+                color: RED.into(),
+                intensity: 1000.0,
+                ..default()
+            },
+            transform: Transform::from_xyz(-0.3493744, 1.900556, 1.0452124),
+            ..default()
+        })
+        .insert(VolumetricLight);
+
+    // Add the spot light
+    let mut spotlight_transform = Transform::from_xyz(-1.7817883, 3.901562, -2.7141085);
+    spotlight_transform.rotate(Quat::from_xyzw(
+        -0.83497995,
+        0.1066196,
+        -0.17422977,
+        0.5109645,
+    ));
+    commands
+        .spawn(SpotLightBundle {
+            transform: spotlight_transform,
+            spot_light: SpotLight {
+                intensity: 5000.0, // lumens
+                color: Color::WHITE,
+                shadows_enabled: true,
+                inner_angle: 0.76,
+                outer_angle: 0.94,
+                ..default()
+            },
+            ..default()
+        })
+        .insert(VolumetricLight);
 
     // Add the fog volume.
     commands.spawn(FogVolumeBundle {


### PR DESCRIPTION
# Objective
- Fixes: https://github.com/bevyengine/bevy/issues/14451

## Solution
- Adding volumetric fog sampling code for both point lights and spotlights.

## Testing
- I have modified the example of volumetric_fog.rs by adding a volumetric point light and a volumetric spotlight.

https://github.com/user-attachments/assets/3eeb77a0-f22d-40a6-a48a-2dd75d55a877

