### PR TITLE
Add the ability to control font smoothing

### DIFF
--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -3,12 +3,12 @@ use bevy_math::{IVec2, UVec2};
 use bevy_render::{
     render_asset::RenderAssetUsages,
     render_resource::{Extent3d, TextureDimension, TextureFormat},
-    texture::Image,
+    texture::{Image, ImageSampler},
 };
 use bevy_sprite::{DynamicTextureAtlasBuilder, TextureAtlasLayout};
 use bevy_utils::HashMap;
 
-use crate::{GlyphAtlasLocation, TextError};
+use crate::{FontSmoothing, GlyphAtlasLocation, TextError};
 
 /// Rasterized glyphs are cached, stored in, and retrieved from, a `FontAtlas`.
 ///
@@ -39,8 +39,9 @@ impl FontAtlas {
         textures: &mut Assets<Image>,
         texture_atlases_layout: &mut Assets<TextureAtlasLayout>,
         size: UVec2,
+        font_smoothing: FontSmoothing,
     ) -> FontAtlas {
-        let texture = textures.add(Image::new_fill(
+        let mut image = Image::new_fill(
             Extent3d {
                 width: size.x,
                 height: size.y,
@@ -51,7 +52,11 @@ impl FontAtlas {
             TextureFormat::Rgba8UnormSrgb,
             // Need to keep this image CPU persistent in order to add additional glyphs later on
             RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD,
-        ));
+        );
+        if font_smoothing == FontSmoothing::None {
+            image.sampler = ImageSampler::nearest();
+        }
+        let texture = textures.add(image);
         let texture_atlas = texture_atlases_layout.add(TextureAtlasLayout::new_empty(size));
         Self {
             texture_atlas,

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -244,7 +244,7 @@ impl TextPipeline {
                             textures,
                             font_system,
                             swash_cache,
-                            &layout_glyph,
+                            layout_glyph,
                             font_smoothing,
                         )
                     })?;

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -218,8 +218,8 @@ impl TextPipeline {
                     layout_glyph.x = layout_glyph.x.round();
                     layout_glyph.y = layout_glyph.y.round();
                     layout_glyph.w = layout_glyph.w.round();
-                    layout_glyph.y_offset = layout_glyph.y_offset.round();
                     layout_glyph.x_offset = layout_glyph.x_offset.round();
+                    layout_glyph.y_offset = layout_glyph.y_offset.round();
                     layout_glyph.line_height_opt = layout_glyph.line_height_opt.map(f32::round);
                 }
                 let section_index = layout_glyph.metadata;

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -220,8 +220,7 @@ impl TextPipeline {
                     layout_glyph.w = layout_glyph.w.round();
                     layout_glyph.y_offset = layout_glyph.y_offset.round();
                     layout_glyph.x_offset = layout_glyph.x_offset.round();
-                    layout_glyph.line_height_opt =
-                        layout_glyph.line_height_opt.map(|lh| lh.round());
+                    layout_glyph.line_height_opt = layout_glyph.line_height_opt.map(f32::round);
                 }
                 let section_index = layout_glyph.metadata;
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -210,18 +210,24 @@ impl TextPipeline {
                     .map(move |layout_glyph| (layout_glyph, run.line_y))
             })
             .try_for_each(|(layout_glyph, line_y)| {
-                let mut layout_glyph = layout_glyph.clone();
+                let mut temp_glyph;
 
-                if font_smoothing == FontSmoothing::None {
+                let layout_glyph = if font_smoothing == FontSmoothing::None {
                     // If font smoothing is disabled, round the glyph positions and sizes,
                     // effectively discarding all subpixel layout.
-                    layout_glyph.x = layout_glyph.x.round();
-                    layout_glyph.y = layout_glyph.y.round();
-                    layout_glyph.w = layout_glyph.w.round();
-                    layout_glyph.x_offset = layout_glyph.x_offset.round();
-                    layout_glyph.y_offset = layout_glyph.y_offset.round();
-                    layout_glyph.line_height_opt = layout_glyph.line_height_opt.map(f32::round);
-                }
+                    temp_glyph = layout_glyph.clone();
+                    temp_glyph.x = temp_glyph.x.round();
+                    temp_glyph.y = temp_glyph.y.round();
+                    temp_glyph.w = temp_glyph.w.round();
+                    temp_glyph.x_offset = temp_glyph.x_offset.round();
+                    temp_glyph.y_offset = temp_glyph.y_offset.round();
+                    temp_glyph.line_height_opt = temp_glyph.line_height_opt.map(f32::round);
+
+                    &temp_glyph
+                } else {
+                    layout_glyph
+                };
+
                 let section_index = layout_glyph.metadata;
 
                 let font_handle = sections[section_index].style.font.clone_weak();

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -280,6 +280,8 @@ pub enum BreakLineOn {
 pub enum FontSmoothing {
     /// No antialiasing. Useful for when you want to render text with a pixel art aesthetic.
     ///
+    /// Combine this with `UiAntiAlias::Off` and `Msaa::Off` on your 2D camera for a fully pixelated look.
+    ///
     /// **Note:** Due to limitations of the underlying text rendering library,
     /// this may require specially-crafted pixel fonts to look good, especially at small sizes.
     None,

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -7,7 +7,7 @@ use bevy_utils::default;
 use cosmic_text::{Buffer, Metrics};
 use serde::{Deserialize, Serialize};
 
-use crate::Font;
+use crate::{font, Font};
 pub use cosmic_text::{
     self, FamilyOwned as FontFamily, Stretch as FontStretch, Style as FontStyle,
     Weight as FontWeight,
@@ -124,6 +124,12 @@ impl Text {
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, will still occur.
     pub const fn with_no_wrap(mut self) -> Self {
         self.linebreak_behavior = BreakLineOn::NoWrap;
+        self
+    }
+
+    /// Returns this [`Text`] with the specified [`FontSmoothing`].
+    pub const fn with_font_smoothing(mut self, font_smoothing: FontSmoothing) -> Self {
+        self.font_smoothing = font_smoothing;
         self
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -36,6 +36,8 @@ pub struct Text {
     pub justify: JustifyText,
     /// How the text should linebreak when running out of the bounds determined by `max_size`
     pub linebreak_behavior: BreakLineOn,
+    /// The antialiasing method to use when rendering text.
+    pub font_smoothing: FontSmoothing,
 }
 
 impl Text {
@@ -259,4 +261,26 @@ pub enum BreakLineOn {
     /// No soft wrapping, where text is automatically broken up into separate lines when it overflows a boundary, will ever occur.
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, is still enabled.
     NoWrap,
+}
+
+/// Determines which antialiasing method to use when rendering text. By default, text is
+/// rendered with grayscale antialiasing, but this can be changed to achieve a pixelated look.
+///
+/// **Note:** Subpixel antialiasing (a.k.a. “ClearType” on Windows) is not currently supported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
+#[doc(alias = "antialiasing")]
+#[doc(alias = "pixelated")]
+pub enum FontSmoothing {
+    /// No antialiasing. Useful for when you want to render text with a pixel art aesthetic.
+    ///
+    /// **Note:** Due to limitations of the underlying text rendering library,
+    /// this may require specially-crafted pixel fonts to look good, especially at small sizes.
+    None,
+    /// The default grayscale antialising. Produces text that looks smooth,
+    /// even at small font sizes and low resolutions with modern vector fonts.
+    #[default]
+    Antialiased,
+    // TODO: Add subpixel antialias support
+    // SubpixelAntialiased,
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -286,7 +286,7 @@ pub enum FontSmoothing {
     /// The default grayscale antialiasing. Produces text that looks smooth,
     /// even at small font sizes and low resolutions with modern vector fonts.
     #[default]
-    Antialiased,
+    AntiAliased,
     // TODO: Add subpixel antialias support
-    // SubpixelAntialiased,
+    // SubpixelAntiAliased,
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -283,7 +283,7 @@ pub enum FontSmoothing {
     /// **Note:** Due to limitations of the underlying text rendering library,
     /// this may require specially-crafted pixel fonts to look good, especially at small sizes.
     None,
-    /// The default grayscale antialising. Produces text that looks smooth,
+    /// The default grayscale antialiasing. Produces text that looks smooth,
     /// even at small font sizes and low resolutions with modern vector fonts.
     #[default]
     Antialiased,

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -272,7 +272,7 @@ pub enum BreakLineOn {
 /// Determines which antialiasing method to use when rendering text. By default, text is
 /// rendered with grayscale antialiasing, but this can be changed to achieve a pixelated look.
 ///
-/// **Note:** Subpixel antialiasing (a.k.a. “ClearType” on Windows) is not currently supported.
+/// **Note:** Subpixel antialiasing is not currently supported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
 #[doc(alias = "antialiasing")]

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -7,7 +7,7 @@ use bevy_utils::default;
 use cosmic_text::{Buffer, Metrics};
 use serde::{Deserialize, Serialize};
 
-use crate::{font, Font};
+use crate::Font;
 pub use cosmic_text::{
     self, FamilyOwned as FontFamily, Stretch as FontStretch, Style as FontStyle,
     Weight as FontWeight,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -191,6 +191,7 @@ pub fn update_text2d_layout(
                 scale_factor.into(),
                 text.justify,
                 text.linebreak_behavior,
+                text.font_smoothing,
                 text_bounds,
                 &mut font_atlas_sets,
                 &mut texture_atlases,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2385,6 +2385,8 @@ impl<'w, 's> DefaultUiCamera<'w, 's> {
 /// Marker for controlling whether Ui is rendered with or without anti-aliasing
 /// in a camera. By default, Ui is always anti-aliased.
 ///
+/// **Note:** This does not affect text anti-aliasing. For that, use the `font_smoothing` property of the [`bevy_text::Text`] component.
+///
 /// ```
 /// use bevy_core_pipeline::prelude::*;
 /// use bevy_ecs::prelude::*;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -250,6 +250,7 @@ fn queue_text(
             scale_factor.into(),
             text.justify,
             text.linebreak_behavior,
+            text.font_smoothing,
             physical_node_size,
             font_atlas_sets,
             texture_atlases,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -140,14 +140,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Demonstrate font smoothing off
     commands.spawn(Text2dBundle {
-        text: Text {
-            sections: vec![TextSection::new(
-                "FontSmoothing::None",
-                slightly_smaller_text_style.clone(),
-            )],
-            font_smoothing: FontSmoothing::None,
-            ..default()
-        },
+        text: Text::from_section("FontSmoothing::None", slightly_smaller_text_style.clone())
+            .with_font_smoothing(FontSmoothing::None),
         transform: Transform::from_translation(Vec3::new(-400.0, -250.0, 0.0)),
         ..default()
     });

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -10,7 +10,7 @@ use bevy::{
     math::ops,
     prelude::*,
     sprite::Anchor,
-    text::{BreakLineOn, TextBounds},
+    text::{BreakLineOn, FontSmoothing, TextBounds},
 };
 
 fn main() {
@@ -97,6 +97,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     )],
                     justify: JustifyText::Left,
                     linebreak_behavior: BreakLineOn::WordBoundary,
+                    ..default()
                 },
                 // Wrap text in the rectangle
                 text_2d_bounds: TextBounds::from(box_size),
@@ -127,6 +128,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     )],
                     justify: JustifyText::Left,
                     linebreak_behavior: BreakLineOn::AnyCharacter,
+                    ..default()
                 },
                 // Wrap text in the rectangle
                 text_2d_bounds: TextBounds::from(other_box_size),
@@ -135,6 +137,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             });
         });
+
+    // Demonstrate font smoothing off
+    commands.spawn(Text2dBundle {
+        text: Text {
+            sections: vec![TextSection::new(
+                "FontSmoothing::None",
+                slightly_smaller_text_style.clone(),
+            )],
+            font_smoothing: FontSmoothing::None,
+            ..default()
+        },
+        transform: Transform::from_translation(Vec3::new(-400.0, -250.0, 0.0)),
+        ..default()
+    });
 
     for (text_anchor, color) in [
         (Anchor::TopLeft, Color::Srgba(RED)),

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -55,6 +55,7 @@ fn setup(mut commands: Commands) {
         }],
         justify: JustifyText::Left,
         linebreak_behavior: BreakLineOn::AnyCharacter,
+        ..default()
     };
 
     commands

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -66,6 +66,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
             sections,
             justify: JustifyText::Center,
             linebreak_behavior: BreakLineOn::AnyCharacter,
+            ..default()
         },
         ..Default::default()
     });

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -129,6 +129,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                     }],
                     justify: JustifyText::Left,
                     linebreak_behavior,
+                    ..default()
                 };
                 let text_id = commands
                     .spawn(TextBundle {


### PR DESCRIPTION
# Objective

- Fixes #10720
- Adds the ability to control font smoothing of rendered text

## Solution

- Introduce the `FontSmoothing` enum, with two possible variants (`FontSmoothing::None` and `FontSmoothing::AntiAliased`):
  - This is based on `-webkit-font-smoothing`, in line with our practice of adopting CSS-like properties/names for UI;
  - I could have gone instead for the [`font-smooth` property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth) that's also supported by browsers, but didn't since it's also non-standard, has an uglier name, and doesn't allow controlling the type of antialias applied.
  - Having an enum instead of e.g. a boolean, leaves the path open for adding `FontSmoothing::SubpixelAntiAliased` in the future, without a breaking change;
- Add all the necessary plumbing to get the `FontSmoothing` information to where we rasterize the glyphs and store them in the atlas;
- Change the font atlas key to also take into account the smoothing setting, not only font and font size;
- Since COSMIC Text [doesn't support controlling font smoothing](https://github.com/pop-os/cosmic-text/issues/279), we roll out our own threshold-based “implementation”:
  - This has the downside of **looking ugly for “regular” vector fonts** ⚠️, since it doesn't properly take the hinting information into account like a proper implementation on the rasterizer side would.
  - However, **for fonts that have been specifically authored to be pixel fonts, (a common use case in games!) this is not as big of a problem**, since all lines are vertical/horizontal, and close to the final pixel boundaries (as long as the font is used at a multiple of the size originally intended by the author)
  - Once COSMIC exposes this functionality, we can switch to using it directly, and get better results;
- Use a nearest neighbor sampler for atlases with font smoothing disabled, so that you can scale the text via transform and still get the pixelated look;
- Add a convenience method to `Text` for setting the font smoothing;
- Add a demonstration of using the `FontSmoothing` property to the `text2d` example.

## Testing

- Did you test these changes? If so, how?
  - Yes. Via the `text2d`example, and also in my game.
- Are there any parts that need more testing?
  - I'd like help from someone for testing this on devices/OSs with fractional scaling (Android/Windows)
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Both via the `text2d` example and also by using it directly on your projects.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - macOS

---

## Showcase

```rust
commands.spawn(Text2dBundle {
    text: Text::from_section("Hello, World!", default())
        .with_font_smoothing(FontSmoothing::None),
    ..default()
});
```
![Screenshot 2024-09-22 at 12 33 39](https://github.com/user-attachments/assets/93e19672-b8c0-4cba-a8a3-4525fe2ae1cb)

<img width="740" alt="image" src="https://github.com/user-attachments/assets/b881b02c-4e43-410b-902f-6985c25140fc">

## Migration Guide

- `Text` now contains a `font_smoothing: FontSmoothing` property, make sure to include it or add `..default()` when using the struct directly;
- `FontSizeKey` has been renamed to `FontAtlasKey`, and now also contains the `FontSmoothing` setting;
- The following methods now take an extra `font_smoothing: FontSmoothing` argument:
  - `FontAtlas::new()`
  - `FontAtlasSet::add_glyph_to_atlas()`
  - `FontAtlasSet::get_glyph_atlas_info()`
  - `FontAtlasSet::get_outlined_glyph_texture()`