### PR TITLE
Change RawHandleWrapper so that we can create it

### DIFF
--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -50,7 +50,6 @@ impl<W: 'static> Deref for WindowWrapper<W> {
 /// thread-safe.
 #[derive(Debug, Clone, Component)]
 pub struct RawHandleWrapper {
-    _window: Arc<dyn Any + Send + Sync>,
     /// Raw handle to a window.
     pub window_handle: RawWindowHandle,
     /// Raw handle to the display server.
@@ -63,7 +62,6 @@ impl RawHandleWrapper {
         window: &WindowWrapper<W>,
     ) -> Result<RawHandleWrapper, HandleError> {
         Ok(RawHandleWrapper {
-            _window: window.reference.clone(),
             window_handle: window.window_handle()?.as_raw(),
             display_handle: window.display_handle()?.as_raw(),
         })


### PR DESCRIPTION
# Objective

The winit windowing backend does not require a mutable reference to the window to be able to change it. For example you can set the window fullscreen or change the title without needing a mutable reference. The same cannot be said for other windowing backends like glfw. This becomes a problem when, to create a WindowWrapper, you need to give it ownership of the window. And you need a WindowWrapper to create a RawHandleWrapper which you need to render things to the window. There doesn't seem to be any reason to give ownership of the window to the WindowWrapper, but in doing so, there is no easy way of getting a mutable reference to the window anymore.

## Solution

The solution that I came to was to remove _window field from the RawHandleWrapper so that I could construct a RawHandleWrapper without needing to give ownership of the window itself. I don't know what the _window field did, but removing it didn't seem to do anything.

## Testing

I ran a window_resizing example and 2d_shapes example and they both ran well enough. I didn't really change much and I think that any errors should have been caught when building the engine.