### PR TITLE
Bubbling observers traversal should use query data

### DIFF
--- a/benches/benches/bevy_ecs/events/iter.rs
+++ b/benches/benches/bevy_ecs/events/iter.rs
@@ -17,7 +17,7 @@ impl<const SIZE: usize> Benchmark<SIZE> {
     }
 
     pub fn run(&mut self) {
-        let mut reader = self.0.get_reader();
+        let mut reader = self.0.get_cursor();
         for evt in reader.read(&self.0) {
             std::hint::black_box(evt);
         }

--- a/benches/benches/bevy_ecs/observers/propagation.rs
+++ b/benches/benches/bevy_ecs/observers/propagation.rs
@@ -1,14 +1,14 @@
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    event::{Event, EventWriter},
+    event::Event,
     observer::Trigger,
     world::World,
 };
-use bevy_hierarchy::{BuildChildren, Children, Parent};
+use bevy_hierarchy::{BuildChildren, Parent};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use rand::{prelude::SliceRandom, SeedableRng};
+use criterion::{black_box, Criterion};
+use rand::SeedableRng;
 use rand::{seq::IteratorRandom, Rng};
 use rand_chacha::ChaCha8Rng;
 
@@ -71,7 +71,7 @@ pub fn event_propagation(criterion: &mut Criterion) {
 struct TestEvent<const N: usize> {}
 
 impl<const N: usize> Event for TestEvent<N> {
-    type Traversal = Parent;
+    type Traversal = &'static Parent;
     const AUTO_PROPAGATE: bool = true;
 }
 

--- a/benches/benches/bevy_ecs/observers/simple.rs
+++ b/benches/benches/bevy_ecs/observers/simple.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{entity::Entity, event::Event, observer::Trigger, world::World};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, Criterion};
 use rand::{prelude::SliceRandom, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 fn deterministic_rand() -> ChaCha8Rng {

--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -43,7 +43,7 @@ pub fn spawn_commands(criterion: &mut Criterion) {
             bencher.iter(|| {
                 let mut commands = Commands::new(&mut command_queue, &world);
                 for i in 0..entity_count {
-                    let mut entity = commands
+                    let entity = commands
                         .spawn_empty()
                         .insert_if(A, || black_box(i % 2 == 0))
                         .insert_if(B, || black_box(i % 3 == 0))

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -1,5 +1,4 @@
 use bevy_reflect::func::{ArgList, IntoFunction, IntoFunctionMut, TypedFunction};
-use bevy_reflect::prelude::*;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 criterion_group!(benches, typed, into, call, clone);

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -26,7 +26,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
-            type Traversal = #bevy_ecs_path::traversal::TraverseNone;
+            type Traversal = ();
             const AUTO_PROPAGATE: bool = false;
         }
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -90,7 +90,7 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
     /// Enables or disables event propagation, allowing the same event to trigger observers on a chain of different entities.
     ///
     /// The path an event will propagate along is specified by its associated [`Traversal`] component. By default, events
-    /// use `TraverseNone` which ends the path immediately and prevents propagation.
+    /// use `()` which ends the path immediately and prevents propagation.
     ///
     /// To enable propagation, you must:
     /// + Set [`Event::Traversal`] to the component you want to propagate along.
@@ -521,7 +521,7 @@ mod tests {
     struct Parent(Entity);
 
     impl Traversal for Parent {
-        fn traverse(&self) -> Option<Entity> {
+        fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity> {
             Some(self.0)
         }
     }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -520,8 +520,8 @@ mod tests {
     #[derive(Component)]
     struct Parent(Entity);
 
-    impl<'a> Traversal for &'a Parent {
-        fn traverse<'b>(item: Self::Item<'b>) -> Option<Entity> {
+    impl Traversal for &'_ Parent {
+        fn traverse(item: Self::Item<'_>) -> Option<Entity> {
             Some(item.0)
         }
     }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -529,8 +529,8 @@ mod tests {
     #[derive(Component)]
     struct EventPropagating;
 
-    impl<'a> Event for EventPropagating {
-        type Traversal = &'a Parent;
+    impl Event for EventPropagating {
+        type Traversal = &'static Parent;
 
         const AUTO_PROPAGATE: bool = true;
     }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -520,8 +520,8 @@ mod tests {
     #[derive(Component)]
     struct Parent(Entity);
 
-    impl<'a> Traversal<'a> for &'a Parent {
-        fn traverse(item: Self::Item<'a>) -> Option<Entity> {
+    impl<'a> Traversal for &'a Parent {
+        fn traverse<'b>(item: Self::Item<'b>) -> Option<Entity> {
             Some(item.0)
         }
     }
@@ -529,8 +529,8 @@ mod tests {
     #[derive(Component)]
     struct EventPropagating;
 
-    impl Event for EventPropagating {
-        type Traversal<'a> = &'a Parent;
+    impl<'a> Event for EventPropagating {
+        type Traversal = &'a Parent;
 
         const AUTO_PROPAGATE: bool = true;
     }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -520,9 +520,9 @@ mod tests {
     #[derive(Component)]
     struct Parent(Entity);
 
-    impl Traversal for Parent {
-        fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity> {
-            Some(self.0)
+    impl<'a> Traversal<'a> for &'a Parent {
+        fn traverse(item: Self::Item<'a>) -> Option<Entity> {
+            Some(item.0)
         }
     }
 
@@ -530,7 +530,7 @@ mod tests {
     struct EventPropagating;
 
     impl Event for EventPropagating {
-        type Traversal = Parent;
+        type Traversal<'a> = &'a Parent;
 
         const AUTO_PROPAGATE: bool = true;
     }

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -21,8 +21,8 @@ pub trait Traversal: QueryData {
     fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity>;
 }
 
-impl Traversal for () {
-    fn traverse<'a>(_: Self::Item<'a>) -> Option<Entity> {
+impl<'a> Traversal for () {
+    fn traverse(_: Self::Item<'a>) -> Option<Entity> {
         None
     }
 }

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -18,11 +18,11 @@ use crate::{entity::Entity, query::ReadOnlyQueryData};
 /// [observers]: crate::observer::Observer
 pub trait Traversal: ReadOnlyQueryData {
     /// Returns the next entity to visit.
-    fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity>;
+    fn traverse(item: Self::Item<'_>) -> Option<Entity>;
 }
 
-impl<'a> Traversal for () {
-    fn traverse(_: Self::Item<'a>) -> Option<Entity> {
+impl Traversal for () {
+    fn traverse(_: Self::Item<'_>) -> Option<Entity> {
         None
     }
 }

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -1,6 +1,6 @@
 //! A trait for components that let you traverse the ECS.
 
-use crate::{entity::Entity, query::QueryData};
+use crate::{entity::Entity, query::ReadOnlyQueryData};
 
 /// A component that can point to another entity, and which can be used to define a path through the ECS.
 ///
@@ -16,7 +16,7 @@ use crate::{entity::Entity, query::QueryData};
 /// [specify the direction]: crate::event::Event::Traversal
 /// [event propagation]: crate::observer::Trigger::propagate
 /// [observers]: crate::observer::Observer
-pub trait Traversal: QueryData {
+pub trait Traversal: ReadOnlyQueryData {
     /// Returns the next entity to visit.
     fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity>;
 }

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -1,15 +1,11 @@
 //! A trait for components that let you traverse the ECS.
 
-use crate::{
-    component::{Component, StorageType},
-    entity::Entity,
-};
+use crate::{entity::Entity, query::QueryData};
 
 /// A component that can point to another entity, and which can be used to define a path through the ECS.
 ///
-/// Traversals are used to [specify the direction] of [event propagation] in [observers]. By default,
-/// events use the [`TraverseNone`] placeholder component, which cannot actually be created or added to
-/// an entity and so never causes traversal.
+/// Traversals are used to [specify the direction] of [event propagation] in [observers].
+/// The default query is `()`.
 ///
 /// Infinite loops are possible, and are not checked for. While looping can be desirable in some contexts
 /// (for example, an observer that triggers itself multiple times before stopping), following an infinite
@@ -20,24 +16,13 @@ use crate::{
 /// [specify the direction]: crate::event::Event::Traversal
 /// [event propagation]: crate::observer::Trigger::propagate
 /// [observers]: crate::observer::Observer
-pub trait Traversal: Component {
+pub trait Traversal: QueryData {
     /// Returns the next entity to visit.
-    fn traverse(&self) -> Option<Entity>;
+    fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity>;
 }
 
-/// A traversal component that doesn't traverse anything. Used to provide a default traversal
-/// implementation for events.
-///
-/// It is not possible to actually construct an instance of this component.
-pub enum TraverseNone {}
-
-impl Traversal for TraverseNone {
-    #[inline(always)]
-    fn traverse(&self) -> Option<Entity> {
+impl Traversal for () {
+    fn traverse<'a>(_: Self::Item<'a>) -> Option<Entity> {
         None
     }
-}
-
-impl Component for TraverseNone {
-    const STORAGE_TYPE: StorageType = StorageType::Table;
 }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -387,7 +387,7 @@ impl<'w> DeferredWorld<'w> {
     /// # Safety
     /// Caller must ensure `E` is accessible as the type represented by `event`
     #[inline]
-    pub(crate) unsafe fn trigger_observers_with_data<'a, E, C>(
+    pub(crate) unsafe fn trigger_observers_with_data<'a, E, T>(
         &mut self,
         event: ComponentId,
         mut entity: Entity,
@@ -395,7 +395,7 @@ impl<'w> DeferredWorld<'w> {
         data: &mut E,
         mut propagate: bool,
     ) where
-        C: Component,
+        T: Traversal,
     {
         loop {
             Observers::invoke::<_>(
@@ -409,7 +409,7 @@ impl<'w> DeferredWorld<'w> {
             if !propagate {
                 break;
             }
-            if let Some(traverse_to) = self.get::<C>(entity).and_then(|arg0: &C| C::traverse(arg0)) {
+            if let Some(traverse_to) = self.get::<T>(entity).and_then(|t: &T| T::traverse(t.???)) {
                 entity = traverse_to;
             } else {
                 break;

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -8,7 +8,7 @@ use crate::{
     event::{Event, EventId, Events, SendBatchIds},
     observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
-    query::{QueryData, QueryFilter, WorldQuery},
+    query::{QueryData, QueryFilter},
     system::{Commands, Query, Resource},
     traversal::Traversal,
 };
@@ -395,8 +395,7 @@ impl<'w> DeferredWorld<'w> {
         data: &mut E,
         mut propagate: bool,
     ) where
-        T: Traversal + Component,
-        T: WorldQuery<Item<'a> = T>
+        T: Traversal,
     {
         loop {
             Observers::invoke::<_>(
@@ -410,7 +409,11 @@ impl<'w> DeferredWorld<'w> {
             if !propagate {
                 break;
             }
-            if let Some(traverse_to) = self.get_entity(entity).and_then(|e| e.get_components::<&T>().and_then(|t| T::traverse(t))) {
+            if let Some(traverse_to) = self
+                .get_entity(entity)
+                .and_then(|entity| entity.get_components::<T>())
+                .and_then(T::traverse)
+            {
                 entity = traverse_to;
             } else {
                 break;

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -8,7 +8,7 @@ use crate::{
     event::{Event, EventId, Events, SendBatchIds},
     observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
-    query::{QueryData, QueryFilter},
+    query::{QueryData, QueryFilter, WorldQuery},
     system::{Commands, Query, Resource},
     traversal::Traversal,
 };
@@ -395,7 +395,8 @@ impl<'w> DeferredWorld<'w> {
         data: &mut E,
         mut propagate: bool,
     ) where
-        T: Traversal,
+        T: Traversal + Component,
+        T: WorldQuery<Item<'a> = T>
     {
         loop {
             Observers::invoke::<_>(
@@ -409,7 +410,7 @@ impl<'w> DeferredWorld<'w> {
             if !propagate {
                 break;
             }
-            if let Some(traverse_to) = self.get::<T>(entity).and_then(|t: &T| T::traverse(t.???)) {
+            if let Some(traverse_to) = self.get_entity(entity).and_then(|e| e.get_components::<&T>().and_then(|t| T::traverse(t))) {
                 entity = traverse_to;
             } else {
                 break;

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -387,7 +387,7 @@ impl<'w> DeferredWorld<'w> {
     /// # Safety
     /// Caller must ensure `E` is accessible as the type represented by `event`
     #[inline]
-    pub(crate) unsafe fn trigger_observers_with_data<'a, E, T>(
+    pub(crate) unsafe fn trigger_observers_with_data<E, T>(
         &mut self,
         event: ComponentId,
         mut entity: Entity,

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -148,8 +148,8 @@ impl<'w> DeferredWorld<'w> {
         match self.get_resource_mut() {
             Some(x) => x,
             None => panic!(
-                "Requested resource {} does not exist in the `World`. 
-                Did you forget to add it using `app.insert_resource` / `app.init_resource`? 
+                "Requested resource {} does not exist in the `World`.
+                Did you forget to add it using `app.insert_resource` / `app.init_resource`?
                 Resources are also implicitly added via `app.add_event`,
                 and can be added by plugins.",
                 std::any::type_name::<R>()
@@ -178,8 +178,8 @@ impl<'w> DeferredWorld<'w> {
         match self.get_non_send_resource_mut() {
             Some(x) => x,
             None => panic!(
-                "Requested non-send resource {} does not exist in the `World`. 
-                Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`? 
+                "Requested non-send resource {} does not exist in the `World`.
+                Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`?
                 Non-send resources can also be added by plugins.",
                 std::any::type_name::<R>()
             ),
@@ -387,7 +387,7 @@ impl<'w> DeferredWorld<'w> {
     /// # Safety
     /// Caller must ensure `E` is accessible as the type represented by `event`
     #[inline]
-    pub(crate) unsafe fn trigger_observers_with_data<E, C>(
+    pub(crate) unsafe fn trigger_observers_with_data<'a, E, C>(
         &mut self,
         event: ComponentId,
         mut entity: Entity,
@@ -395,7 +395,7 @@ impl<'w> DeferredWorld<'w> {
         data: &mut E,
         mut propagate: bool,
     ) where
-        C: Traversal,
+        C: Component,
     {
         loop {
             Observers::invoke::<_>(
@@ -409,7 +409,7 @@ impl<'w> DeferredWorld<'w> {
             if !propagate {
                 break;
             }
-            if let Some(traverse_to) = self.get::<C>(entity).and_then(C::traverse) {
+            if let Some(traverse_to) = self.get::<C>(entity).and_then(|arg0: &C| C::traverse(arg0)) {
                 entity = traverse_to;
             } else {
                 break;

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -80,7 +80,7 @@ impl Deref for Parent {
 ///
 /// [event propagation]: bevy_ecs::observer::Trigger::propagate
 impl Traversal for &Parent {
-    fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity> {
+    fn traverse(item: Self::Item<'_>) -> Option<Entity> {
         Some(item.0)
     }
 }

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -79,8 +79,8 @@ impl Deref for Parent {
 /// `Parent::traverse` will never form loops in properly-constructed hierarchies.
 ///
 /// [event propagation]: bevy_ecs::observer::Trigger::propagate
-impl Traversal for Parent {
-    fn traverse(&self) -> Option<Entity> {
-        Some(self.0)
+impl Traversal for &Parent {
+    fn traverse<'a>(item: Self::Item<'a>) -> Option<Entity> {
+        Some(item.0)
     }
 }

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -73,7 +73,7 @@ impl<E> Event for Pointer<E>
 where
     E: Debug + Clone + Reflect,
 {
-    type Traversal = Parent;
+    type Traversal = &'static Parent;
 
     const AUTO_PROPAGATE: bool = true;
 }

--- a/examples/ecs/observer_propagation.rs
+++ b/examples/ecs/observer_propagation.rs
@@ -53,7 +53,7 @@ impl Event for Attack {
     // 1. Which component we want to propagate along. In this case, we want to "bubble" (meaning propagate
     //    from child to parent) so we use the `Parent` component for propagation. The component supplied
     //    must implement the `Traversal` trait.
-    type Traversal = Parent;
+    type Traversal = &'static Parent;
     // 2. We can also choose whether or not this event will propagate by default when triggered. If this is
     //    false, it will only propagate following a call to `Trigger::propagate(true)`.
     const AUTO_PROPAGATE: bool = true;


### PR DESCRIPTION
# Objective

Fixes #14331

## Solution

- Make `Traversal` a subtrait of `ReadOnlyQueryData`
- Update implementations and usages

## Testing

- Updated unit tests

## Migration Guide

Update implementations of `Traversal`.
