### PR TITLE
bevy_ecs: flush entities after running observers and hooks in despawn

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1297,7 +1297,6 @@ impl<'w> EntityWorldMut<'w> {
     /// See [`World::despawn`] for more details.
     pub fn despawn(self) {
         let world = self.world;
-        world.flush_entities();
         let archetype = &world.archetypes[self.location.archetype_id];
 
         // SAFETY: Archetype cannot be mutably aliased by DeferredWorld

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1323,6 +1323,10 @@ impl<'w> EntityWorldMut<'w> {
             world.removed_components.send(component_id, self.entity);
         }
 
+        // Observers and on_remove hooks may reserve new entities, which
+        // requires a flush before Entities::free may be called.
+        world.flush_entities();
+
         let location = world
             .entities
             .free(self.entity)


### PR DESCRIPTION
# Objective

Fixes #14467

Observers and component lifecycle hooks are allowed to perform operations that subsequently require `Entities` to be flushed, such as reserving a new entity. If this occurs during an `on_remove` hook or an `OnRemove` event trigger during an `EntityWorldMut::despawn`, a panic will occur.

## Solution

Call `world.flush_entities()` after running `on_remove` hooks/observers during `despawn`

## Testing

Added a new test that fails before the fix and succeeds afterward.
