### PR TITLE
Fix untyped asset loads after #14808.

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -429,12 +429,11 @@ impl AssetServer {
             return handle;
         }
         let id = handle.id().untyped();
-        let owned_handle = Some(handle.clone().untyped());
 
         let server = self.clone();
         let task = IoTaskPool::get().spawn(async move {
             let path_clone = path.clone();
-            match server.load_internal(owned_handle, path, false, None).await {
+            match server.load_untyped_async(path).await {
                 Ok(handle) => server.send_asset_event(InternalAssetEvent::Loaded {
                     id,
                     loaded_asset: LoadedAsset::new_with_dependencies(


### PR DESCRIPTION
The logic in PR #14808 broke `bevy_asset_loader`, because calling `AssetServer::load_untyped()` initiates a load of an asset of type `LoadedUntypedAsset`, which doesn't match any asset loaders and therefore fails. I reverted the lines that were causing the problem. The resulting code seems to work, but I'm not sure if this was the correct fix.
