### PR TITLE
Fix horizontal scrolling in scroll example for macOS

### DIFF
--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -56,7 +56,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     // header
                     parent.spawn((
                         TextBundle::from_section(
-                            "Horizontally Scrolling list (Shift + Mousewheel)",
+                            "Horizontally Scrolling list (Ctrl + Mousewheel)",
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                 font_size: FONT_SIZE,
@@ -391,7 +391,8 @@ pub fn update_scroll_position(
             MouseScrollUnit::Pixel => (mouse_wheel_event.x, mouse_wheel_event.y),
         };
 
-        if keyboard_input.pressed(KeyCode::ShiftLeft) || keyboard_input.pressed(KeyCode::ShiftRight)
+        if keyboard_input.pressed(KeyCode::ControlLeft)
+            || keyboard_input.pressed(KeyCode::ControlLeft)
         {
             std::mem::swap(&mut dx, &mut dy);
         }

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -392,7 +392,7 @@ pub fn update_scroll_position(
         };
 
         if keyboard_input.pressed(KeyCode::ControlLeft)
-            || keyboard_input.pressed(KeyCode::ControlLeft)
+            || keyboard_input.pressed(KeyCode::ControlRight)
         {
             std::mem::swap(&mut dx, &mut dy);
         }


### PR DESCRIPTION
# Objective
Fixes #15401

## Solution
Changes the scroll inversion hotkey in the example from Shift to Control.

Shift is idiomatic for this. Since we cannot use Shift per #15401, I picked another modifier arbitrarily. A production app would handle this in a platform specific way until the platform behaviors are unified upstream, but no point here.

## Testing
I don't have a mac readily available for testing, if someone wouldn't mind testing. I would also appreciate confirmation that trackpad is working nicely.