### PR TITLE
Small addition to `World::flush_commands` explaining how `spawn` will cause it to panic.

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2207,8 +2207,8 @@ impl World {
     /// Applies any commands in the world's internal [`CommandQueue`].
     /// This does not apply commands from any systems, only those stored in the world.
     ///
-    /// This will panic if any of the queued commands are [`spawn`](Commands::spawn),
-    /// instead use [`flush`](Self::flush) if there is a chance of this.
+    /// This will panic if any of the queued commands are [`spawn`](Commands::spawn).
+    /// If this is possible, you should instead use [`flush`](Self::flush).
     pub fn flush_commands(&mut self) {
         // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`
         if !unsafe { self.command_queue.is_empty() } {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2206,6 +2206,9 @@ impl World {
 
     /// Applies any commands in the world's internal [`CommandQueue`].
     /// This does not apply commands from any systems, only those stored in the world.
+    ///
+    /// This will panic if any of the queued commands are [`spawn`](Commands::spawn),
+    /// instead use [`flush`](Self::flush) if there is a chance of this.
     pub fn flush_commands(&mut self) {
         // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`
         if !unsafe { self.command_queue.is_empty() } {


### PR DESCRIPTION
# Objective
`World::flush_commands` will cause a panic with `error[B0003]: Could not insert a bundle [...] for entity [...] because it doesn't exist in this World` if there was a `spawn` command in the queue and you should instead use `flush` for this but this isn't mentioned in the docs

## Solution
Add a note to the docs suggesting to use `World::flush` in this context. This error doesn't appear to happen with `spawn_batch` so I didn't add that to the note although you can cause it with `commands.spawn_empty().insert(...)` but I wasn't sure that was worth the documentation complexity as it is pretty unlikely (and equivalent to `commands.spawn(...)`.