### PR TITLE
feature gate `use bevy_animation` in `bevy_gltf`

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -3,11 +3,13 @@ use crate::{
     GltfMeshExtras, GltfNode, GltfSceneExtras, GltfSkin,
 };
 
-use bevy_animation::prelude::{
-    Keyframes, MorphWeightsKeyframes, RotationKeyframes, ScaleKeyframes, TranslationKeyframes,
-};
 #[cfg(feature = "bevy_animation")]
-use bevy_animation::{AnimationTarget, AnimationTargetId};
+use bevy_animation::{
+    keyframes::{
+        Keyframes, MorphWeightsKeyframes, RotationKeyframes, ScaleKeyframes, TranslationKeyframes,
+    },
+    AnimationTarget, AnimationTargetId,
+};
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, Handle, LoadContext, ReadAssetBytesError,
 };


### PR DESCRIPTION
# Objective

`bevy_gltf` have an instance where `use bevy_animation` is not behind `#[cfg(feature = "bevy_animation")]`.

This resulted in a compile error when the feature is not enabled: `failed to resolve: use of undeclared crate or module 'bevy_animation'`. 

## Solution

move this instance of `use bevy_animation` behind the `cfg` attribute.

## Testing

I no longer get the error when compiling without the feature.

