### PR TITLE
Rename init_component & friends

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1318,9 +1318,9 @@ impl Bundles {
         self.bundle_ids.get(&type_id).cloned()
     }
 
-    /// Initializes a new [`BundleInfo`] for a statically known type.
+    /// Registers a new [`BundleInfo`] for a statically known type.
     ///
-    /// Also initializes all the components in the bundle.
+    /// Also registers all the components in the bundle.
     pub(crate) fn register_info<T: Bundle>(
         &mut self,
         components: &mut Components,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -786,7 +786,7 @@ impl<'w> BundleInserter<'w> {
     ) -> Self {
         let bundle_id = world
             .bundles
-            .init_info::<T>(&mut world.components, &mut world.storages);
+            .register_info::<T>(&mut world.components, &mut world.storages);
         // SAFETY: We just ensured this bundle exists
         unsafe { Self::new_with_id(world, archetype_id, bundle_id, change_tick) }
     }
@@ -1135,7 +1135,7 @@ impl<'w> BundleSpawner<'w> {
     pub fn new<T: Bundle>(world: &'w mut World, change_tick: Tick) -> Self {
         let bundle_id = world
             .bundles
-            .init_info::<T>(&mut world.components, &mut world.storages);
+            .register_info::<T>(&mut world.components, &mut world.storages);
         // SAFETY: we initialized this bundle_id in `init_info`
         unsafe { Self::new_with_id(world, bundle_id, change_tick) }
     }
@@ -1321,7 +1321,7 @@ impl Bundles {
     /// Initializes a new [`BundleInfo`] for a statically known type.
     ///
     /// Also initializes all the components in the bundle.
-    pub(crate) fn init_info<T: Bundle>(
+    pub(crate) fn register_info<T: Bundle>(
         &mut self,
         components: &mut Components,
         storages: &mut Storages,

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -205,7 +205,7 @@ unsafe impl<C: Component> Bundle for C {
         storages: &mut Storages,
         ids: &mut impl FnMut(ComponentId),
     ) {
-        ids(components.init_component::<C>(storages));
+        ids(components.register_component::<C>(storages));
     }
 
     unsafe fn from_components<T, F>(ctx: &mut T, func: &mut F) -> Self

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -856,7 +856,7 @@ impl Components {
             } = self;
             let type_id = TypeId::of::<T>();
             *indices.entry(type_id).or_insert_with(|| {
-                let id = Components::init_component_inner(
+                let id = Components::register_component_inner(
                     components,
                     storages,
                     ComponentDescriptor::new::<T>(),
@@ -891,11 +891,11 @@ impl Components {
         storages: &mut Storages,
         descriptor: ComponentDescriptor,
     ) -> ComponentId {
-        Components::init_component_inner(&mut self.components, storages, descriptor)
+        Components::register_component_inner(&mut self.components, storages, descriptor)
     }
 
     #[inline]
-    fn init_component_inner(
+    fn register_component_inner(
         components: &mut Vec<ComponentInfo>,
         storages: &mut Storages,
         descriptor: ComponentDescriptor,
@@ -1004,7 +1004,7 @@ impl Components {
     /// instance.
     ///
     /// Returns [`None`] if the `Resource` type has not
-    /// yet been initialized using [`Components::init_resource()`].
+    /// yet been initialized using [`Components::register_resource()`].
     ///
     /// ```
     /// use bevy_ecs::prelude::*;
@@ -1036,7 +1036,7 @@ impl Components {
     ///
     /// * [`Components::resource_id()`]
     #[inline]
-    pub fn init_resource<T: Resource>(&mut self) -> ComponentId {
+    pub fn register_resource<T: Resource>(&mut self) -> ComponentId {
         // SAFETY: The [`ComponentDescriptor`] matches the [`TypeId`]
         unsafe {
             self.get_or_insert_resource_with(TypeId::of::<T>(), || {
@@ -1049,7 +1049,7 @@ impl Components {
     /// If a resource of this type has already been initialized, this will return
     /// the ID of the pre-existing resource.
     #[inline]
-    pub fn init_non_send<T: Any>(&mut self) -> ComponentId {
+    pub fn register_non_send<T: Any>(&mut self) -> ComponentId {
         // SAFETY: The [`ComponentDescriptor`] matches the [`TypeId`]
         unsafe {
             self.get_or_insert_resource_with(TypeId::of::<T>(), || {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1039,7 +1039,7 @@ impl Components {
     pub fn register_resource<T: Resource>(&mut self) -> ComponentId {
         // SAFETY: The [`ComponentDescriptor`] matches the [`TypeId`]
         unsafe {
-            self.get_or_insert_resource_with(TypeId::of::<T>(), || {
+            self.get_or_register_resource_with(TypeId::of::<T>(), || {
                 ComponentDescriptor::new_resource::<T>()
             })
         }
@@ -1052,7 +1052,7 @@ impl Components {
     pub fn register_non_send<T: Any>(&mut self) -> ComponentId {
         // SAFETY: The [`ComponentDescriptor`] matches the [`TypeId`]
         unsafe {
-            self.get_or_insert_resource_with(TypeId::of::<T>(), || {
+            self.get_or_register_resource_with(TypeId::of::<T>(), || {
                 ComponentDescriptor::new_non_send::<T>(StorageType::default())
             })
         }
@@ -1062,7 +1062,7 @@ impl Components {
     ///
     /// The [`ComponentDescriptor`] must match the [`TypeId`]
     #[inline]
-    unsafe fn get_or_insert_resource_with(
+    unsafe fn get_or_register_resource_with(
         &mut self,
         type_id: TypeId,
         func: impl FnOnce() -> ComponentDescriptor,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -837,8 +837,8 @@ pub struct Components {
 }
 
 impl Components {
-    /// Initializes a component of type `T` with this instance.
-    /// If a component of this type has already been initialized, this will return
+    /// Registers a component of type `T` with this instance.
+    /// If a component of this type has already been registered, this will return
     /// the ID of the pre-existing component.
     ///
     /// # See also
@@ -875,7 +875,7 @@ impl Components {
         id
     }
 
-    /// Initializes a component described by `descriptor`.
+    /// Registers a component described by `descriptor`.
     ///
     /// ## Note
     ///
@@ -1028,8 +1028,8 @@ impl Components {
         self.get_resource_id(TypeId::of::<T>())
     }
 
-    /// Initializes a [`Resource`] of type `T` with this instance.
-    /// If a resource of this type has already been initialized, this will return
+    /// Registers a [`Resource`] of type `T` with this instance.
+    /// If a resource of this type has already been registered, this will return
     /// the ID of the pre-existing resource.
     ///
     /// # See also
@@ -1045,8 +1045,8 @@ impl Components {
         }
     }
 
-    /// Initializes a [non-send resource](crate::system::NonSend) of type `T` with this instance.
-    /// If a resource of this type has already been initialized, this will return
+    /// Registers a [non-send resource](crate::system::NonSend) of type `T` with this instance.
+    /// If a resource of this type has already been registered, this will return
     /// the ID of the pre-existing resource.
     #[inline]
     pub fn register_non_send<T: Any>(&mut self) -> ComponentId {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -652,7 +652,7 @@ impl ComponentInfo {
 /// [`World`].
 ///
 /// Each time a new `Component` type is registered within a `World` using
-/// e.g. [`World::init_component`] or [`World::init_component_with_descriptor`]
+/// e.g. [`World::register_component`] or [`World::register_component_with_descriptor`]
 /// or a Resource with e.g. [`World::init_resource`],
 /// a corresponding `ComponentId` is created to track it.
 ///
@@ -844,9 +844,9 @@ impl Components {
     /// # See also
     ///
     /// * [`Components::component_id()`]
-    /// * [`Components::init_component_with_descriptor()`]
+    /// * [`Components::register_component_with_descriptor()`]
     #[inline]
-    pub fn init_component<T: Component>(&mut self, storages: &mut Storages) -> ComponentId {
+    pub fn register_component<T: Component>(&mut self, storages: &mut Storages) -> ComponentId {
         let mut registered = false;
         let id = {
             let Components {
@@ -885,8 +885,8 @@ impl Components {
     /// # See also
     ///
     /// * [`Components::component_id()`]
-    /// * [`Components::init_component()`]
-    pub fn init_component_with_descriptor(
+    /// * [`Components::register_component()`]
+    pub fn register_component_with_descriptor(
         &mut self,
         storages: &mut Storages,
         descriptor: ComponentDescriptor,
@@ -966,7 +966,7 @@ impl Components {
     /// instance.
     ///
     /// Returns [`None`] if the `Component` type has not
-    /// yet been initialized using [`Components::init_component()`].
+    /// yet been initialized using [`Components::register_component()`].
     ///
     /// ```
     /// use bevy_ecs::prelude::*;
@@ -976,7 +976,7 @@ impl Components {
     /// #[derive(Component)]
     /// struct ComponentA;
     ///
-    /// let component_a_id = world.init_component::<ComponentA>();
+    /// let component_a_id = world.register_component::<ComponentA>();
     ///
     /// assert_eq!(component_a_id, world.components().component_id::<ComponentA>().unwrap())
     /// ```
@@ -1293,7 +1293,7 @@ struct InitComponentId<T: Component> {
 impl<T: Component> FromWorld for InitComponentId<T> {
     fn from_world(world: &mut World) -> Self {
         Self {
-            component_id: world.init_component::<T>(),
+            component_id: world.register_component::<T>(),
             marker: PhantomData,
         }
     }
@@ -1384,7 +1384,7 @@ impl RequiredComponents {
         storages: &mut Storages,
         constructor: fn() -> C,
     ) {
-        let component_id = components.init_component::<C>(storages);
+        let component_id = components.register_component::<C>(storages);
         let erased: RequiredComponentConstructor = RequiredComponentConstructor(Arc::new(
             move |table,
                   sparse_sets,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -181,8 +181,8 @@ mod tests {
         assert_eq!(
             ids,
             &[
-                world.init_component::<TableStored>(),
-                world.init_component::<SparseStored>(),
+                world.register_component::<TableStored>(),
+                world.register_component::<SparseStored>(),
             ]
         );
 
@@ -235,10 +235,10 @@ mod tests {
         assert_eq!(
             ids,
             &[
-                world.init_component::<A>(),
-                world.init_component::<TableStored>(),
-                world.init_component::<SparseStored>(),
-                world.init_component::<B>(),
+                world.register_component::<A>(),
+                world.register_component::<TableStored>(),
+                world.register_component::<SparseStored>(),
+                world.register_component::<B>(),
             ]
         );
 
@@ -288,7 +288,7 @@ mod tests {
             },
         );
 
-        assert_eq!(ids, &[world.init_component::<C>(),]);
+        assert_eq!(ids, &[world.register_component::<C>(),]);
 
         let e4 = world
             .spawn(BundleWithIgnored {
@@ -2011,7 +2011,7 @@ mod tests {
         struct Y;
 
         let mut world = World::new();
-        let x_id = world.init_component::<X>();
+        let x_id = world.register_component::<X>();
 
         let mut e = world.spawn_empty();
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -733,7 +733,7 @@ mod tests {
         world.flush();
 
         let mut event = EventWithData { counter: 0 };
-        let component_a = world.init_component::<A>();
+        let component_a = world.register_component::<A>();
         world.trigger_targets_ref(&mut event, component_a);
         assert_eq!(5, event.counter);
     }
@@ -756,7 +756,7 @@ mod tests {
     fn observer_multiple_events() {
         let mut world = World::new();
         world.init_resource::<Order>();
-        let on_remove = world.init_component::<OnRemove>();
+        let on_remove = world.register_component::<OnRemove>();
         world.spawn(
             // SAFETY: OnAdd and OnRemove are both unit types, so this is safe
             unsafe {
@@ -779,8 +779,8 @@ mod tests {
     fn observer_multiple_components() {
         let mut world = World::new();
         world.init_resource::<Order>();
-        world.init_component::<A>();
-        world.init_component::<B>();
+        world.register_component::<A>();
+        world.register_component::<B>();
 
         world.observe(|_: Trigger<OnAdd, (A, B)>, mut res: ResMut<Order>| res.observed("add_ab"));
 
@@ -883,7 +883,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Order>();
 
-        let component_id = world.init_component::<A>();
+        let component_id = world.register_component::<A>();
         world.spawn(
             Observer::new(|_: Trigger<OnAdd>, mut res: ResMut<Order>| res.observed("event_a"))
                 .with_component(component_id),
@@ -905,7 +905,7 @@ mod tests {
     fn observer_dynamic_trigger() {
         let mut world = World::new();
         world.init_resource::<Order>();
-        let event_a = world.init_component::<EventA>();
+        let event_a = world.register_component::<EventA>();
 
         world.spawn(ObserverState {
             // SAFETY: we registered `event_a` above and it matches the type of TriggerA

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -393,7 +393,7 @@ fn hook_on_add<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     _: ComponentId,
 ) {
     world.commands().queue(move |world: &mut World| {
-        let event_type = world.init_component::<E>();
+        let event_type = world.register_component::<E>();
         let mut components = Vec::new();
         B::component_ids(&mut world.components, &mut world.storages, &mut |id| {
             components.push(id);

--- a/crates/bevy_ecs/src/observer/trigger_event.rs
+++ b/crates/bevy_ecs/src/observer/trigger_event.rs
@@ -16,14 +16,14 @@ pub struct TriggerEvent<E, Targets: TriggerTargets = ()> {
 
 impl<E: Event, Targets: TriggerTargets> TriggerEvent<E, Targets> {
     pub(super) fn trigger(mut self, world: &mut World) {
-        let event_type = world.init_component::<E>();
+        let event_type = world.register_component::<E>();
         trigger_event(world, event_type, &mut self.event, self.targets);
     }
 }
 
 impl<E: Event, Targets: TriggerTargets> TriggerEvent<&mut E, Targets> {
     pub(super) fn trigger_ref(self, world: &mut World) {
-        let event_type = world.init_component::<E>();
+        let event_type = world.register_component::<E>();
         trigger_event(world, event_type, self.event, self.targets);
     }
 }

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -312,9 +312,9 @@ mod tests {
         let mut world = World::new();
         let entity_a = world.spawn((A(0), B(0))).id();
         let entity_b = world.spawn((A(0), C(0))).id();
-        let component_id_a = world.init_component::<A>();
-        let component_id_b = world.init_component::<B>();
-        let component_id_c = world.init_component::<C>();
+        let component_id_a = world.register_component::<A>();
+        let component_id_b = world.register_component::<B>();
+        let component_id_c = world.register_component::<C>();
 
         let mut query_a = QueryBuilder::<Entity>::new(&mut world)
             .with_id(component_id_a)
@@ -401,8 +401,8 @@ mod tests {
     fn builder_dynamic_components() {
         let mut world = World::new();
         let entity = world.spawn((A(0), B(1))).id();
-        let component_id_a = world.init_component::<A>();
-        let component_id_b = world.init_component::<B>();
+        let component_id_a = world.register_component::<A>();
+        let component_id_b = world.register_component::<B>();
 
         let mut query = QueryBuilder::<FilteredEntityRef>::new(&mut world)
             .ref_id(component_id_a)

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1188,7 +1188,7 @@ unsafe impl<T: Component> WorldQuery for &T {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -1387,7 +1387,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -1586,7 +1586,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -1976,7 +1976,7 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -191,7 +191,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -302,7 +302,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -730,7 +730,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<ComponentId> {
@@ -948,7 +948,7 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
-        world.init_component::<T>()
+        world.register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<ComponentId> {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1866,7 +1866,7 @@ mod tests {
     #[test]
     fn can_transmute_empty_tuple() {
         let mut world = World::new();
-        world.init_component::<A>();
+        world.register_component::<A>();
         let entity = world.spawn(A(10)).id();
 
         let q = world.query::<()>();
@@ -1922,8 +1922,8 @@ mod tests {
     )]
     fn cannot_transmute_to_include_data_not_in_original_query() {
         let mut world = World::new();
-        world.init_component::<A>();
-        world.init_component::<B>();
+        world.register_component::<A>();
+        world.register_component::<B>();
         world.spawn(A(0));
 
         let query_state = world.query::<&A>();
@@ -1962,7 +1962,7 @@ mod tests {
     )]
     fn cannot_transmute_entity_ref() {
         let mut world = World::new();
-        world.init_component::<A>();
+        world.register_component::<A>();
 
         let q = world.query::<EntityRef>();
         let _ = q.transmute::<&A>(&world);
@@ -2030,8 +2030,8 @@ mod tests {
     )]
     fn cannot_transmute_changed_without_access() {
         let mut world = World::new();
-        world.init_component::<A>();
-        world.init_component::<B>();
+        world.register_component::<A>();
+        world.register_component::<B>();
         let query = QueryState::<&A>::new(&mut world);
         let _new_query = query.transmute_filtered::<Entity, Changed<B>>(&world);
     }
@@ -2044,7 +2044,7 @@ mod tests {
         world.spawn((A(1), B(2)));
 
         let mut world2 = World::new();
-        world2.init_component::<B>();
+        world2.register_component::<B>();
 
         world.query::<(&A, &B)>().transmute::<&B>(&world2);
     }
@@ -2134,7 +2134,7 @@ mod tests {
             (&bevy_ecs::query::state::tests::A, ()) joined with (&bevy_ecs::query::state::tests::B, ()).")]
     fn cannot_join_wrong_fetch() {
         let mut world = World::new();
-        world.init_component::<C>();
+        world.register_component::<C>();
         let query_1 = QueryState::<&A>::new(&mut world);
         let query_2 = QueryState::<&B>::new(&mut world);
         let _query: QueryState<&C> = query_1.join(&world, &query_2);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -133,7 +133,7 @@ impl Schedules {
     /// Ignore system order ambiguities caused by conflicts on [`Resource`]s of type `T`.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self, world: &mut World) {
         self.ignored_scheduling_ambiguities
-            .insert(world.components.init_resource::<T>());
+            .insert(world.components.register_resource::<T>());
     }
 
     /// Iterate through the [`ComponentId`]'s that will be ignored.

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -127,7 +127,7 @@ impl Schedules {
     /// Ignore system order ambiguities caused by conflicts on [`Component`]s of type `T`.
     pub fn allow_ambiguous_component<T: Component>(&mut self, world: &mut World) {
         self.ignored_scheduling_ambiguities
-            .insert(world.init_component::<T>());
+            .insert(world.register_component::<T>());
     }
 
     /// Ignore system order ambiguities caused by conflicts on [`Resource`]s of type `T`.

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -831,7 +831,7 @@ mod tests {
     fn table() {
         let mut components = Components::default();
         let mut storages = Storages::default();
-        let component_id = components.init_component::<W<TableRow>>(&mut storages);
+        let component_id = components.register_component::<W<TableRow>>(&mut storages);
         let columns = &[component_id];
         let mut table = TableBuilder::with_capacity(0, columns.len())
             .add_column(components.get_info(component_id).unwrap())

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1445,7 +1445,7 @@ mod tests {
         let mut world = World::default();
         let mut system = IntoSystem::into_system(a_not_b_system);
         let mut expected_ids = HashSet::<ArchetypeComponentId>::new();
-        let a_id = world.init_component::<A>();
+        let a_id = world.register_component::<A>();
 
         // set up system and verify its access is empty
         system.initialize(&mut world);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -591,7 +591,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
     type Item<'w, 's> = Res<'w, T>;
 
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
-        let component_id = world.components.init_resource::<T>();
+        let component_id = world.components.register_resource::<T>();
         let archetype_component_id = world.initialize_resource_internal(component_id).id();
 
         let combined_access = system_meta.component_access_set.combined_access();
@@ -698,7 +698,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
     type Item<'w, 's> = ResMut<'w, T>;
 
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
-        let component_id = world.components.init_resource::<T>();
+        let component_id = world.components.register_resource::<T>();
         let archetype_component_id = world.initialize_resource_internal(component_id).id();
 
         let combined_access = system_meta.component_access_set.combined_access();
@@ -1248,7 +1248,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
         system_meta.set_non_send();
 
-        let component_id = world.components.init_non_send::<T>();
+        let component_id = world.components.register_non_send::<T>();
         let archetype_component_id = world.initialize_non_send_internal(component_id).id();
 
         let combined_access = system_meta.component_access_set.combined_access();
@@ -1352,7 +1352,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
         system_meta.set_non_send();
 
-        let component_id = world.components.init_non_send::<T>();
+        let component_id = world.components.register_non_send::<T>();
         let archetype_component_id = world.initialize_non_send_internal(component_id).id();
 
         let combined_access = system_meta.component_access_set.combined_access();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -955,7 +955,7 @@ impl<'w> EntityWorldMut<'w> {
         let world = &mut self.world;
         let storages = &mut world.storages;
         let components = &mut world.components;
-        let bundle_id = world.bundles.init_info::<T>(components, storages);
+        let bundle_id = world.bundles.register_info::<T>(components, storages);
         // SAFETY: We just ensured this bundle exists
         let bundle_info = unsafe { world.bundles.get_unchecked(bundle_id) };
         let old_location = self.location;
@@ -1221,7 +1221,7 @@ impl<'w> EntityWorldMut<'w> {
     pub fn remove<T: Bundle>(&mut self) -> &mut Self {
         let storages = &mut self.world.storages;
         let components = &mut self.world.components;
-        let bundle_info = self.world.bundles.init_info::<T>(components, storages);
+        let bundle_info = self.world.bundles.register_info::<T>(components, storages);
 
         // SAFETY: the `BundleInfo` is initialized above
         self.location = unsafe { self.remove_bundle(bundle_info) };
@@ -1237,7 +1237,7 @@ impl<'w> EntityWorldMut<'w> {
         let storages = &mut self.world.storages;
         let components = &mut self.world.components;
 
-        let retained_bundle = self.world.bundles.init_info::<T>(components, storages);
+        let retained_bundle = self.world.bundles.register_info::<T>(components, storages);
         // SAFETY: `retained_bundle` exists as we just initialized it.
         let retained_bundle_info = unsafe { self.world.bundles.get_unchecked(retained_bundle) };
         let old_location = self.location;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -3107,7 +3107,7 @@ mod tests {
     #[test]
     fn entity_mut_insert_by_id() {
         let mut world = World::new();
-        let test_component_id = world.init_component::<TestComponent>();
+        let test_component_id = world.register_component::<TestComponent>();
 
         let mut entity = world.spawn_empty();
         OwningPtr::make(TestComponent(42), |ptr| {
@@ -3135,8 +3135,8 @@ mod tests {
     #[test]
     fn entity_mut_insert_bundle_by_id() {
         let mut world = World::new();
-        let test_component_id = world.init_component::<TestComponent>();
-        let test_component_2_id = world.init_component::<TestComponent2>();
+        let test_component_id = world.register_component::<TestComponent>();
+        let test_component_2_id = world.register_component::<TestComponent2>();
 
         let component_ids = [test_component_id, test_component_2_id];
         let test_component_value = TestComponent(42);
@@ -3175,7 +3175,7 @@ mod tests {
     #[test]
     fn entity_mut_remove_by_id() {
         let mut world = World::new();
-        let test_component_id = world.init_component::<TestComponent>();
+        let test_component_id = world.register_component::<TestComponent>();
 
         let mut entity = world.spawn(TestComponent(42));
         entity.remove_by_id(test_component_id);
@@ -3192,8 +3192,8 @@ mod tests {
     #[test]
     fn entity_ref_except() {
         let mut world = World::new();
-        world.init_component::<TestComponent>();
-        world.init_component::<TestComponent2>();
+        world.register_component::<TestComponent>();
+        world.register_component::<TestComponent2>();
 
         world.spawn(TestComponent(0)).insert(TestComponent2(0));
 
@@ -3458,7 +3458,7 @@ mod tests {
     #[test]
     fn filtered_entity_ref_normal() {
         let mut world = World::new();
-        let a_id = world.init_component::<A>();
+        let a_id = world.register_component::<A>();
 
         let e: FilteredEntityRef = world.spawn(A).into();
 
@@ -3472,7 +3472,7 @@ mod tests {
     #[test]
     fn filtered_entity_ref_missing() {
         let mut world = World::new();
-        let a_id = world.init_component::<A>();
+        let a_id = world.register_component::<A>();
 
         let e: FilteredEntityRef = world.spawn(()).into();
 
@@ -3486,7 +3486,7 @@ mod tests {
     #[test]
     fn filtered_entity_mut_normal() {
         let mut world = World::new();
-        let a_id = world.init_component::<A>();
+        let a_id = world.register_component::<A>();
 
         let mut e: FilteredEntityMut = world.spawn(A).into();
 
@@ -3502,7 +3502,7 @@ mod tests {
     #[test]
     fn filtered_entity_mut_missing() {
         let mut world = World::new();
-        let a_id = world.init_component::<A>();
+        let a_id = world.register_component::<A>();
 
         let mut e: FilteredEntityMut = world.spawn(()).into();
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -271,7 +271,7 @@ impl World {
     /// Will panic if `T` exists in any archetypes.
     pub fn register_component_hooks<T: Component>(&mut self) -> &mut ComponentHooks {
         let index = self.register_component::<T>();
-        assert!(!self.archetypes.archetypes.iter().any(|a| a.contains(index)), "Components hooks cannot be modified if the component already exists in an archetype, use init_component if {} may already be in use", std::any::type_name::<T>());
+        assert!(!self.archetypes.archetypes.iter().any(|a| a.contains(index)), "Components hooks cannot be modified if the component already exists in an archetype, use register_component if {} may already be in use", std::any::type_name::<T>());
         // SAFETY: We just created this component
         unsafe { self.components.get_hooks_mut(index).debug_checked_unwrap() }
     }
@@ -283,7 +283,7 @@ impl World {
         &mut self,
         id: ComponentId,
     ) -> Option<&mut ComponentHooks> {
-        assert!(!self.archetypes.archetypes.iter().any(|a| a.contains(id)), "Components hooks cannot be modified if the component already exists in an archetype, use init_component if the component with id {:?} may already be in use", id);
+        assert!(!self.archetypes.archetypes.iter().any(|a| a.contains(id)), "Components hooks cannot be modified if the component already exists in an archetype, use register_component if the component with id {:?} may already be in use", id);
         self.components.get_hooks_mut(id)
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1312,7 +1312,7 @@ impl World {
     pub fn init_resource<R: Resource + FromWorld>(&mut self) -> ComponentId {
         #[cfg(feature = "track_change_detection")]
         let caller = Location::caller();
-        let component_id = self.components.init_resource::<R>();
+        let component_id = self.components.register_resource::<R>();
         if self
             .storages
             .resources
@@ -1358,7 +1358,7 @@ impl World {
         value: R,
         #[cfg(feature = "track_change_detection")] caller: &'static Location,
     ) {
-        let component_id = self.components.init_resource::<R>();
+        let component_id = self.components.register_resource::<R>();
         OwningPtr::make(value, |ptr| {
             // SAFETY: component_id was just initialized and corresponds to resource of type R.
             unsafe {
@@ -1388,7 +1388,7 @@ impl World {
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) -> ComponentId {
         #[cfg(feature = "track_change_detection")]
         let caller = Location::caller();
-        let component_id = self.components.init_non_send::<R>();
+        let component_id = self.components.register_non_send::<R>();
         if self
             .storages
             .non_send_resources
@@ -1425,7 +1425,7 @@ impl World {
     pub fn insert_non_send_resource<R: 'static>(&mut self, value: R) {
         #[cfg(feature = "track_change_detection")]
         let caller = Location::caller();
-        let component_id = self.components.init_non_send::<R>();
+        let component_id = self.components.register_non_send::<R>();
         OwningPtr::make(value, |ptr| {
             // SAFETY: component_id was just initialized and corresponds to resource of type R.
             unsafe {
@@ -1704,7 +1704,7 @@ impl World {
         let change_tick = self.change_tick();
         let last_change_tick = self.last_change_tick();
 
-        let component_id = self.components.init_resource::<R>();
+        let component_id = self.components.register_resource::<R>();
         let data = self.initialize_resource_internal(component_id);
         if !data.is_present() {
             OwningPtr::make(func(), |ptr| {
@@ -1861,7 +1861,7 @@ impl World {
 
         let bundle_id = self
             .bundles
-            .init_info::<B>(&mut self.components, &mut self.storages);
+            .register_info::<B>(&mut self.components, &mut self.storages);
         enum SpawnOrInsert<'w> {
             Spawn(BundleSpawner<'w>),
             Insert(BundleInserter<'w>, ArchetypeId),
@@ -2447,10 +2447,10 @@ impl World {
     /// This is largely equivalent to calling [`register_component`](Self::register_component) on each
     /// component in the bundle.
     #[inline]
-    pub fn init_bundle<B: Bundle>(&mut self) -> &BundleInfo {
+    pub fn register_bundle<B: Bundle>(&mut self) -> &BundleInfo {
         let id = self
             .bundles
-            .init_info::<B>(&mut self.components, &mut self.storages);
+            .register_info::<B>(&mut self.components, &mut self.storages);
         // SAFETY: We just initialised the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -294,7 +294,7 @@ impl World {
     /// enables the dynamic initialization of new component definitions at runtime for advanced use cases.
     ///
     /// While the option to initialize a component from a descriptor is useful in type-erased
-    /// contexts, the standard `World::init_component` function should always be used instead
+    /// contexts, the standard [`World::register_component`] function should always be used instead
     /// when type information is available at compile time.
     pub fn register_component_with_descriptor(
         &mut self,
@@ -2444,7 +2444,7 @@ impl World {
     /// Initializes all of the components in the given [`Bundle`] and returns both the component
     /// ids and the bundle id.
     ///
-    /// This is largely equivalent to calling [`init_component`](Self::register_component) on each
+    /// This is largely equivalent to calling [`register_component`](Self::register_component) on each
     /// component in the bundle.
     #[inline]
     pub fn init_bundle<B: Bundle>(&mut self) -> &BundleInfo {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -261,7 +261,7 @@ impl World {
         unsafe { Commands::new_raw_from_entities(self.command_queue.clone(), &self.entities) }
     }
 
-    /// Initializes a new [`Component`] type and returns the [`ComponentId`] created for it.
+    /// Registers a new [`Component`] type and returns the [`ComponentId`] created for it.
     pub fn register_component<T: Component>(&mut self) -> ComponentId {
         self.components.register_component::<T>(&mut self.storages)
     }
@@ -287,13 +287,13 @@ impl World {
         self.components.get_hooks_mut(id)
     }
 
-    /// Initializes a new [`Component`] type and returns the [`ComponentId`] created for it.
+    /// Registers a new [`Component`] type and returns the [`ComponentId`] created for it.
     ///
     /// This method differs from [`World::register_component`] in that it uses a [`ComponentDescriptor`]
-    /// to initialize the new component type instead of statically available type information. This
-    /// enables the dynamic initialization of new component definitions at runtime for advanced use cases.
+    /// to register the new component type instead of statically available type information. This
+    /// enables the dynamic registration of new component definitions at runtime for advanced use cases.
     ///
-    /// While the option to initialize a component from a descriptor is useful in type-erased
+    /// While the option to register a component from a descriptor is useful in type-erased
     /// contexts, the standard [`World::register_component`] function should always be used instead
     /// when type information is available at compile time.
     pub fn register_component_with_descriptor(
@@ -2441,7 +2441,7 @@ impl World {
         self.storages.non_send_resources.clear();
     }
 
-    /// Initializes all of the components in the given [`Bundle`] and returns both the component
+    /// Registers all of the components in the given [`Bundle`] and returns both the component
     /// ids and the bundle id.
     ///
     /// This is largely equivalent to calling [`register_component`](Self::register_component) on each

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -85,7 +85,7 @@ fn main() {
                     };
                     // Register our new component to the world with a layout specified by it's size
                     // SAFETY: [u64] is Send + Sync
-                    let id = world.init_component_with_descriptor(unsafe {
+                    let id = world.register_component_with_descriptor(unsafe {
                         ComponentDescriptor::new_with_layout(
                             name.to_string(),
                             StorageType::Table,


### PR DESCRIPTION
# Objective

- Fixes #15451 

## Migration Guide

- `World::init_component` has been renamed to `register_component`.
- `World::init_component_with_descriptor` has been renamed to `register_component_with_descriptor`.
- `World::init_bundle` has been renamed to `register_bundle`.
- `Components::init_component` has been renamed to `register_component`.
- `Components::init_component_with_descriptor` has been renamed to `register_component_with_descriptor`.
- `Components::init_resource` has been renamed to `register_resource`.
- `Components::init_non_send` had been renamed to `register_non_send`.