### PR TITLE
Minor fixes for `bevy_utils` in `no_std`

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -9,26 +9,33 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["std"]
-std = ["alloc", "tracing/std", "ahash/std"]
-alloc = []
+default = ["std", "serde"]
+std = [
+  "alloc",
+  "tracing/std",
+  "ahash/std",
+  "dep:thread_local",
+  "ahash/runtime-rng",
+]
+alloc = ["hashbrown/default"]
 detailed_trace = []
+serde = ["hashbrown/serde"]
 
 [dependencies]
 ahash = { version = "0.8.7", default-features = false, features = [
-  "runtime-rng",
+  "compile-time-rng",
 ] }
 tracing = { version = "0.1", default-features = false }
-web-time = { version = "1.1" }
-hashbrown = { version = "0.14.2", features = ["serde"] }
+hashbrown = { version = "0.14.2", default-features = false }
 bevy_utils_proc_macros = { version = "0.15.0-dev", path = "macros" }
-thread_local = "1.0"
+thread_local = { version = "1.0", optional = true }
 
 [dev-dependencies]
 static_assertions = "1.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
+web-time = { version = "1.1" }
 
 [lints]
 workspace = true

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -31,15 +31,18 @@ mod default;
 mod object_safe;
 pub use object_safe::assert_object_safe;
 mod once;
+#[cfg(feature = "std")]
 mod parallel_queue;
+mod time;
 
 pub use ahash::{AHasher, RandomState};
 pub use bevy_utils_proc_macros::*;
 pub use default::default;
 pub use hashbrown;
+#[cfg(feature = "std")]
 pub use parallel_queue::*;
+pub use time::*;
 pub use tracing;
-pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;

--- a/crates/bevy_utils/src/time.rs
+++ b/crates/bevy_utils/src/time.rs
@@ -1,0 +1,11 @@
+#[cfg(target_arch = "wasm32")]
+pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+pub use {
+    core::time::{Duration, TryFromFloatSecsError},
+    std::time::{Instant, SystemTime, SystemTimeError},
+};
+
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "std")))]
+pub use core::time::{Duration, TryFromFloatSecsError};


### PR DESCRIPTION
# Objective

- Contributes to #15460

## Solution

- Made `web-time` a `wasm32`-only dependency.
- Moved time-related exports to its own module for clarity.
- Feature-gated allocator requirements for `hashbrown` behind `alloc`.
- Enabled compile-time RNG for `ahash` (runtime RNG will preferentially used in `std` environments)
- Made `thread_local` optional by feature-gating the `Parallel` type.

## Testing

- Ran CI locally.
- `cargo build -p bevy_utils --target "x86_64-unknown-none" --no-default-features`
