### PR TITLE
Basic integration of cubic spline curves with the Curve API

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -1070,13 +1070,7 @@ impl<P: VectorSpace> Curve<P> for CubicSegment<P> {
 
     #[inline]
     fn sample_unchecked(&self, t: f32) -> P {
-        self.sample_clamped(t)
-    }
-
-    #[inline]
-    fn sample_clamped(&self, t: f32) -> P {
-        let t_clamped = self.domain().clamp(t);
-        self.position(t_clamped)
+        self.position(t)
     }
 }
 
@@ -1215,13 +1209,7 @@ impl<P: VectorSpace> Curve<P> for CubicCurve<P> {
 
     #[inline]
     fn sample_unchecked(&self, t: f32) -> P {
-        self.sample_clamped(t)
-    }
-
-    #[inline]
-    fn sample_clamped(&self, t: f32) -> P {
-        let t_clamped = self.domain().clamp(t);
-        self.position(t_clamped)
+        self.position(t)
     }
 }
 
@@ -1270,7 +1258,7 @@ pub struct RationalSegment<P: VectorSpace> {
 }
 
 impl<P: VectorSpace> RationalSegment<P> {
-    /// Instantaneous position of a point at parametric value `t` in `[0, knot_span)`.
+    /// Instantaneous position of a point at parametric value `t` in `[0, 1]`.
     #[inline]
     pub fn position(&self, t: f32) -> P {
         let [a, b, c, d] = self.coeff;
@@ -1282,7 +1270,7 @@ impl<P: VectorSpace> RationalSegment<P> {
         numerator / denominator
     }
 
-    /// Instantaneous velocity of a point at parametric value `t` in `[0, knot_span)`.
+    /// Instantaneous velocity of a point at parametric value `t` in `[0, 1]`.
     #[inline]
     pub fn velocity(&self, t: f32) -> P {
         // A derivation for the following equations can be found in "Matrix representation for NURBS
@@ -1307,7 +1295,7 @@ impl<P: VectorSpace> RationalSegment<P> {
             - numerator * (denominator_derivative / denominator.squared())
     }
 
-    /// Instantaneous acceleration of a point at parametric value `t` in `[0, knot_span)`.
+    /// Instantaneous acceleration of a point at parametric value `t` in `[0, 1]`.
     #[inline]
     pub fn acceleration(&self, t: f32) -> P {
         // A derivation for the following equations can be found in "Matrix representation for NURBS
@@ -1385,21 +1373,12 @@ impl<P: VectorSpace> RationalSegment<P> {
 impl<P: VectorSpace> Curve<P> for RationalSegment<P> {
     #[inline]
     fn domain(&self) -> Interval {
-        // We don't presently enforce this invariant directly, but this is true.
-        // (Also, the knot span is not used by computations in `RationalSegment` internally.)
-        Interval::new(0.0, self.knot_span)
-            .expect("RationalSegment must have a positive knot span to be valid")
+        Interval::UNIT
     }
 
     #[inline]
     fn sample_unchecked(&self, t: f32) -> P {
-        self.sample_clamped(t)
-    }
-
-    #[inline]
-    fn sample_clamped(&self, t: f32) -> P {
-        let t_clamped = self.domain().clamp(t);
-        self.position(t_clamped)
+        self.position(t)
     }
 }
 
@@ -1557,13 +1536,7 @@ impl<P: VectorSpace> Curve<P> for RationalCurve<P> {
 
     #[inline]
     fn sample_unchecked(&self, t: f32) -> P {
-        self.sample_clamped(t)
-    }
-
-    #[inline]
-    fn sample_clamped(&self, t: f32) -> P {
-        let t_clamped = self.domain().clamp(t);
-        self.position(t_clamped)
+        self.position(t)
     }
 }
 


### PR DESCRIPTION
# Objective

We introduced the fancy Curve API earlier in this version. The goal of this PR is to provide a level of integration between that API and the existing spline constructions in `bevy_math`.

Note that this PR only covers the integration of position-sampling via the `Curve` API. Other (substantially more complex) planned work will introduce general facilities for handling derivatives.

## Solution

`CubicSegment`, `CubicCurve`, `RationalSegment`, and `RationalCurve` all now implement `Curve`, using their `position` function to sample the output.

Additionally, some documentation has been updated/corrected, and `Serialize`/`Deserialize` derives have been added for all the curve structs. (Note that there are some barriers to automatic registration of `ReflectSerialize`/`ReflectSerialize` involving generics that have not been resolved in this PR.)

---

## Migration Guide

The `RationalCurve::domain` method has been renamed to `RationalCurve::length`. Calling `.domain()` on a `RationalCurve` now returns its entire domain as an `Interval`.
