### PR TITLE
bevy_reflect: Generic parameter info

### DIFF
--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -15,6 +15,7 @@ use crate::{
 use quote::{quote, ToTokens};
 use syn::token::Comma;
 
+use crate::generics::generate_generics;
 use syn::{
     parse_str, punctuated::Punctuated, spanned::Spanned, Data, DeriveInput, Field, Fields,
     GenericParam, Generics, Ident, LitStr, Meta, Path, PathSegment, Type, TypeParam, Variant,
@@ -627,19 +628,18 @@ impl<'a> ReflectStruct<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[cfg_attr(
-            not(feature = "documentation"),
-            expect(
-                unused_mut,
-                reason = "Needs to be mutable if `documentation` feature is enabled.",
-            )
-        )]
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new::<Self>(&[
                 #(#field_infos),*
             ])
             .with_custom_attributes(#custom_attributes)
         };
+
+        if let Some(generics) = generate_generics(self.meta()) {
+            info.extend(quote! {
+                .with_generics(#generics)
+            });
+        }
 
         #[cfg(feature = "documentation")]
         {
@@ -730,19 +730,18 @@ impl<'a> ReflectEnum<'a> {
             .custom_attributes()
             .to_tokens(bevy_reflect_path);
 
-        #[cfg_attr(
-            not(feature = "documentation"),
-            expect(
-                unused_mut,
-                reason = "Needs to be mutable if `documentation` feature is enabled.",
-            )
-        )]
         let mut info = quote! {
             #bevy_reflect_path::EnumInfo::new::<Self>(&[
                 #(#variants),*
             ])
             .with_custom_attributes(#custom_attributes)
         };
+
+        if let Some(generics) = generate_generics(self.meta()) {
+            info.extend(quote! {
+                .with_generics(#generics)
+            });
+        }
 
         #[cfg(feature = "documentation")]
         {

--- a/crates/bevy_reflect/derive/src/generics.rs
+++ b/crates/bevy_reflect/derive/src/generics.rs
@@ -32,7 +32,7 @@ pub(crate) fn generate_generics(meta: &ReflectMeta) -> Option<TokenStream> {
                 Some(quote! {
                     #bevy_reflect_path::GenericInfo::Type(
                         #bevy_reflect_path::TypeParamInfo::new::<#ident>(
-                            ::alloc::borrow::Cow::Borrowed(#name),
+                            ::std::borrow::Cow::Borrowed(#name),
                         )
                         #with_default
                     )
@@ -53,7 +53,7 @@ pub(crate) fn generate_generics(meta: &ReflectMeta) -> Option<TokenStream> {
                     )]
                     #bevy_reflect_path::GenericInfo::Const(
                         #bevy_reflect_path::ConstParamInfo::new::<#ty>(
-                            ::alloc::borrow::Cow::Borrowed(#name),
+                            ::std::borrow::Cow::Borrowed(#name),
                         )
                         #with_default
                     )

--- a/crates/bevy_reflect/derive/src/generics.rs
+++ b/crates/bevy_reflect/derive/src/generics.rs
@@ -1,0 +1,62 @@
+use crate::derive_data::ReflectMeta;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::punctuated::Punctuated;
+use syn::{GenericParam, Path, Token};
+
+/// Creates a `TokenStream` for generating an expression that creates a `Generics` instance.
+///
+/// Returns `None` if `Generics` cannot or should not be generated.
+pub(crate) fn generate_generics(meta: &ReflectMeta) -> Option<TokenStream> {
+    if !meta.attrs().type_path_attrs().should_auto_derive() {
+        // Cannot verify that all generic parameters implement `TypePath`
+        return None;
+    }
+
+    let bevy_reflect_path = meta.bevy_reflect_path();
+
+    let generics = meta
+        .type_path()
+        .generics()
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            GenericParam::Type(ty_param) => {
+                let ident = &ty_param.ident;
+                Some(generate_generic_info(
+                    ident,
+                    ident.to_string(),
+                    false,
+                    bevy_reflect_path,
+                ))
+            }
+            GenericParam::Const(const_param) => {
+                let ty = &const_param.ty;
+                let name = const_param.ident.to_string();
+                Some(generate_generic_info(ty, name, true, bevy_reflect_path))
+            }
+            GenericParam::Lifetime(_) => None,
+        })
+        .collect::<Punctuated<_, Token![,]>>();
+
+    if generics.is_empty() {
+        // No generics to generate
+        return None;
+    }
+
+    Some(quote!(#bevy_reflect_path::Generics::from_iter([ #generics ])))
+}
+
+fn generate_generic_info(
+    ty: impl ToTokens,
+    name: String,
+    is_const: bool,
+    bevy_reflect_path: &Path,
+) -> TokenStream {
+    quote! {
+        #bevy_reflect_path::GenericInfo::new::<#ty>(
+            ::alloc::borrow::Cow::Borrowed(#name),
+            #is_const
+        )
+    }
+}

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -25,6 +25,7 @@ mod documentation;
 mod enum_utility;
 mod field_attributes;
 mod from_reflect;
+mod generics;
 mod ident;
 mod impls;
 mod meta;

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,7 +1,8 @@
+use crate::generics::impl_generic_info_methods;
 use crate::{
     self as bevy_reflect, type_info::impl_type_methods, utility::reflect_hasher, ApplyError,
-    MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type,
-    TypeInfo, TypePath,
+    Generics, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, Type, TypeInfo, TypePath,
 };
 use bevy_reflect_derive::impl_type_path;
 use core::{
@@ -79,6 +80,7 @@ pub trait Array: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct ArrayInfo {
     ty: Type,
+    generics: Generics,
     item_info: fn() -> Option<&'static TypeInfo>,
     item_ty: Type,
     capacity: usize,
@@ -97,6 +99,7 @@ impl ArrayInfo {
     ) -> Self {
         Self {
             ty: Type::of::<TArray>(),
+            generics: Generics::new(),
             item_info: TItem::maybe_type_info,
             item_ty: Type::of::<TItem>(),
             capacity,
@@ -138,6 +141,8 @@ impl ArrayInfo {
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_generic_info_methods!(generics);
 }
 
 /// A fixed-size list of reflected values.

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,7 +1,8 @@
+use crate::generics::impl_generic_info_methods;
 use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     type_info::impl_type_methods,
-    DynamicEnum, PartialReflect, Type, TypePath, VariantInfo, VariantType,
+    DynamicEnum, Generics, PartialReflect, Type, TypePath, VariantInfo, VariantType,
 };
 use alloc::sync::Arc;
 use bevy_utils::HashMap;
@@ -138,6 +139,7 @@ pub trait Enum: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct EnumInfo {
     ty: Type,
+    generics: Generics,
     variants: Box<[VariantInfo]>,
     variant_names: Box<[&'static str]>,
     variant_indices: HashMap<&'static str, usize>,
@@ -163,6 +165,7 @@ impl EnumInfo {
 
         Self {
             ty: Type::of::<TEnum>(),
+            generics: Generics::new(),
             variants: variants.to_vec().into_boxed_slice(),
             variant_names,
             variant_indices,
@@ -239,6 +242,8 @@ impl EnumInfo {
     }
 
     impl_custom_attribute_methods!(self.custom_attributes, "enum");
+
+    impl_generic_info_methods!(generics);
 }
 
 /// An iterator over the fields in the current enum variant.

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -17,6 +17,13 @@ impl Generics {
         // a linear search is often faster using a `HashMap`.
         self.0.iter().find(|info| info.name() == name)
     }
+
+    pub fn with(mut self, info: impl Into<GenericInfo>) -> Self {
+        self.0 = IntoIterator::into_iter(self.0)
+            .chain(core::iter::once(info.into()))
+            .collect();
+        self
+    }
 }
 
 impl FromIterator<GenericInfo> for Generics {
@@ -60,6 +67,18 @@ impl GenericInfo {
             Self::Const(info) => info.ty(),
         }
     });
+}
+
+impl From<TypeParamInfo> for GenericInfo {
+    fn from(info: TypeParamInfo) -> Self {
+        Self::Type(info)
+    }
+}
+
+impl From<ConstParamInfo> for GenericInfo {
+    fn from(info: ConstParamInfo) -> Self {
+        Self::Const(info)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -1,0 +1,85 @@
+use crate::type_info::impl_type_methods;
+use crate::{Type, TypePath};
+use alloc::borrow::Cow;
+use bevy_utils::HashMap;
+use core::fmt::{Debug, Formatter};
+
+#[derive(Clone, Default)]
+pub struct Generics {
+    infos: Box<[GenericInfo]>,
+    index_map: HashMap<Cow<'static, str>, usize>,
+}
+
+impl Debug for Generics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut list = f.debug_list();
+        list.entries(self.infos.iter());
+        list.finish()
+    }
+}
+
+impl Generics {
+    pub fn new() -> Self {
+        Self {
+            infos: Box::new([]),
+            index_map: HashMap::new(),
+        }
+    }
+
+    pub fn with<T: TypePath + ?Sized>(
+        mut self,
+        name: impl Into<Cow<'static, str>>,
+        is_const: bool,
+    ) -> Self {
+        let name = name.into();
+        self.index_map.insert(name.clone(), self.infos.len());
+        self.infos = IntoIterator::into_iter(self.infos)
+            .chain(core::iter::once(GenericInfo::new::<T>(name, is_const)))
+            .collect();
+        self
+    }
+}
+
+impl FromIterator<GenericInfo> for Generics {
+    fn from_iter<T: IntoIterator<Item = GenericInfo>>(iter: T) -> Self {
+        let mut index_map = HashMap::new();
+        let infos = iter
+            .into_iter()
+            .enumerate()
+            .map(|(index, info)| {
+                index_map.insert(info.name().clone(), index);
+                info
+            })
+            .collect::<Vec<_>>()
+            .into();
+
+        Self { infos, index_map }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GenericInfo {
+    name: Cow<'static, str>,
+    ty: Type,
+    is_const: bool,
+}
+
+impl GenericInfo {
+    pub fn new<T: TypePath + ?Sized>(name: impl Into<Cow<'static, str>>, is_const: bool) -> Self {
+        Self {
+            name: name.into(),
+            ty: Type::of::<T>(),
+            is_const,
+        }
+    }
+
+    pub fn name(&self) -> &Cow<'static, str> {
+        &self.name
+    }
+
+    pub fn is_const(&self) -> bool {
+        self.is_const
+    }
+
+    impl_type_methods!(ty);
+}

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -2,52 +2,37 @@ use crate::type_info::impl_type_methods;
 use crate::{Reflect, Type, TypePath};
 use alloc::borrow::Cow;
 use alloc::sync::Arc;
-use core::fmt::{Debug, Formatter};
 
-#[derive(Clone, Default)]
-pub struct Generics {
-    infos: Box<[GenericInfo]>,
-}
-
-impl Debug for Generics {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        let mut list = f.debug_list();
-        list.entries(self.infos.iter());
-        list.finish()
-    }
-}
+#[derive(Clone, Default, Debug)]
+pub struct Generics(Box<[GenericInfo]>);
 
 impl Generics {
     pub fn new() -> Self {
-        Self {
-            infos: Box::new([]),
-        }
+        Self(Box::new([]))
     }
 
     pub fn get(&self, name: &str) -> Option<&GenericInfo> {
         // For small sets of generics (the most common case),
         // a linear search is often faster using a `HashMap`.
-        self.infos.iter().find(|info| info.name() == name)
+        self.0.iter().find(|info| info.name() == name)
     }
 
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &GenericInfo> {
-        self.infos.iter()
+        self.0.iter()
     }
 
     pub fn len(&self) -> usize {
-        self.infos.len()
+        self.0.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.infos.is_empty()
+        self.0.is_empty()
     }
 }
 
 impl FromIterator<GenericInfo> for Generics {
     fn from_iter<T: IntoIterator<Item = GenericInfo>>(iter: T) -> Self {
-        Self {
-            infos: iter.into_iter().collect(),
-        }
+        Self(iter.into_iter().collect())
     }
 }
 
@@ -166,6 +151,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::{Reflect, Typed};
+    use core::fmt::Debug;
 
     #[test]
     fn should_maintain_order() {

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -83,3 +83,18 @@ impl GenericInfo {
 
     impl_type_methods!(ty);
 }
+
+macro_rules! impl_generic_info_methods {
+    ($field:ident) => {
+        pub fn with_generics(mut self, generics: crate::generics::Generics) -> Self {
+            self.$field = generics;
+            self
+        }
+
+        pub fn generics(&self) -> &crate::generics::Generics {
+            &self.$field
+        }
+    };
+}
+
+pub(crate) use impl_generic_info_methods;

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -48,9 +48,9 @@ impl Generics {
     }
 }
 
-impl FromIterator<GenericInfo> for Generics {
-    fn from_iter<T: IntoIterator<Item = GenericInfo>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
+impl<T: Into<GenericInfo>> FromIterator<T> for Generics {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().map(Into::into).collect())
     }
 }
 

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -148,14 +148,19 @@ impl ConstParamInfo {
 }
 
 macro_rules! impl_generic_info_methods {
+    // Implements both getter and setter methods for the given field.
     ($field:ident) => {
+        $crate::generics::impl_generic_info_methods!(self => &self.$field);
+
         pub fn with_generics(mut self, generics: crate::generics::Generics) -> Self {
             self.$field = generics;
             self
         }
-
-        pub fn generics(&self) -> &crate::generics::Generics {
-            &self.$field
+    };
+    // Implements only a getter method for the given expression.
+    ($self:ident => $expr:expr) => {
+        pub fn generics(&$self) -> &crate::generics::Generics {
+            $expr
         }
     };
 }

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -5,9 +5,9 @@ use core::any::Any;
 
 use crate::{
     self as bevy_reflect, utility::GenericTypeInfoCell, ApplyError, FromReflect, FromType,
-    GetTypeRegistration, List, ListInfo, ListIter, MaybeTyped, PartialReflect, Reflect,
-    ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypeRegistration, Typed,
+    Generics, GetTypeRegistration, List, ListInfo, ListIter, MaybeTyped, PartialReflect, Reflect,
+    ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeParamInfo,
+    TypePath, TypeRegistration, Typed,
 };
 
 impl<T: SmallArray + TypePath + Send + Sync> List for SmallVec<T>
@@ -183,7 +183,12 @@ where
 {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| TypeInfo::List(ListInfo::new::<Self, T::Item>()))
+        CELL.get_or_insert::<Self, _>(|| {
+            TypeInfo::List(
+                ListInfo::new::<Self, T::Item>()
+                    .with_generics(Generics::from_iter([TypeParamInfo::new::<T>("T")])),
+            )
+        })
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -7,12 +7,11 @@ use crate::{
     reflect::impl_full_reflect,
     set_apply, set_partial_eq, set_try_apply,
     utility::{reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell},
-    ApplyError, Array, ArrayInfo, ArrayIter, ConstParamInfo, DynamicMap, DynamicSet,
-    DynamicTypePath, FromReflect, FromType, GenericInfo, Generics, GetTypeRegistration, List,
-    ListInfo, ListIter, Map, MapInfo, MapIter, MaybeTyped, OpaqueInfo, PartialReflect, Reflect,
-    ReflectDeserialize, ReflectFromPtr, ReflectFromReflect, ReflectKind, ReflectMut, ReflectOwned,
-    ReflectRef, ReflectSerialize, Set, SetInfo, TypeInfo, TypeParamInfo, TypePath,
-    TypeRegistration, TypeRegistry, Typed,
+    ApplyError, Array, ArrayInfo, ArrayIter, DynamicMap, DynamicSet, DynamicTypePath, FromReflect,
+    FromType, Generics, GetTypeRegistration, List, ListInfo, ListIter, Map, MapInfo, MapIter,
+    MaybeTyped, OpaqueInfo, PartialReflect, Reflect, ReflectDeserialize, ReflectFromPtr,
+    ReflectFromReflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize, Set,
+    SetInfo, TypeInfo, TypeParamInfo, TypePath, TypeRegistration, TypeRegistry, Typed,
 };
 use alloc::{borrow::Cow, collections::VecDeque};
 use bevy_reflect_derive::{impl_reflect, impl_reflect_opaque};
@@ -1465,14 +1464,7 @@ impl<T: FromReflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usiz
 impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> Typed for [T; N] {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| {
-            TypeInfo::Array(
-                ArrayInfo::new::<Self, T>(N).with_generics(Generics::from_iter([
-                    GenericInfo::Type(TypeParamInfo::new::<T>("T")),
-                    GenericInfo::Const(ConstParamInfo::new::<usize>("N")),
-                ])),
-            )
-        })
+        CELL.get_or_insert::<Self, _>(|| TypeInfo::Array(ArrayInfo::new::<Self, T>(N)))
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -7,11 +7,12 @@ use crate::{
     reflect::impl_full_reflect,
     set_apply, set_partial_eq, set_try_apply,
     utility::{reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell},
-    ApplyError, Array, ArrayInfo, ArrayIter, DynamicMap, DynamicSet, DynamicTypePath, FromReflect,
-    FromType, GetTypeRegistration, List, ListInfo, ListIter, Map, MapInfo, MapIter, MaybeTyped,
-    OpaqueInfo, PartialReflect, Reflect, ReflectDeserialize, ReflectFromPtr, ReflectFromReflect,
-    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize, Set, SetInfo, TypeInfo,
-    TypePath, TypeRegistration, TypeRegistry, Typed,
+    ApplyError, Array, ArrayInfo, ArrayIter, ConstParamInfo, DynamicMap, DynamicSet,
+    DynamicTypePath, FromReflect, FromType, GenericInfo, Generics, GetTypeRegistration, List,
+    ListInfo, ListIter, Map, MapInfo, MapIter, MaybeTyped, OpaqueInfo, PartialReflect, Reflect,
+    ReflectDeserialize, ReflectFromPtr, ReflectFromReflect, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, ReflectSerialize, Set, SetInfo, TypeInfo, TypeParamInfo, TypePath,
+    TypeRegistration, TypeRegistry, Typed,
 };
 use alloc::{borrow::Cow, collections::VecDeque};
 use bevy_reflect_derive::{impl_reflect, impl_reflect_opaque};
@@ -525,7 +526,13 @@ macro_rules! impl_reflect_for_veclike {
         impl<T: FromReflect + MaybeTyped + TypePath + GetTypeRegistration> Typed for $ty {
             fn type_info() -> &'static TypeInfo {
                 static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-                CELL.get_or_insert::<Self, _>(|| TypeInfo::List(ListInfo::new::<Self, T>()))
+                CELL.get_or_insert::<Self, _>(|| {
+                    TypeInfo::List(
+                        ListInfo::new::<Self, T>().with_generics(Generics::from_iter([
+                            TypeParamInfo::new::<T>("T")
+                        ]))
+                    )
+                })
             }
         }
 
@@ -764,7 +771,14 @@ macro_rules! impl_reflect_for_hashmap {
         {
             fn type_info() -> &'static TypeInfo {
                 static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-                CELL.get_or_insert::<Self, _>(|| TypeInfo::Map(MapInfo::new::<Self, K, V>()))
+                CELL.get_or_insert::<Self, _>(|| {
+                    TypeInfo::Map(
+                        MapInfo::new::<Self, K, V>().with_generics(Generics::from_iter([
+                            TypeParamInfo::new::<K>("K"),
+                            TypeParamInfo::new::<V>("V"),
+                        ])),
+                    )
+                })
             }
         }
 
@@ -981,7 +995,13 @@ macro_rules! impl_reflect_for_hashset {
         {
             fn type_info() -> &'static TypeInfo {
                 static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-                CELL.get_or_insert::<Self, _>(|| TypeInfo::Set(SetInfo::new::<Self, V>()))
+                CELL.get_or_insert::<Self, _>(|| {
+                    TypeInfo::Set(
+                        SetInfo::new::<Self, V>().with_generics(Generics::from_iter([
+                            TypeParamInfo::new::<V>("V")
+                        ]))
+                    )
+                })
             }
         }
 
@@ -1230,7 +1250,14 @@ where
 {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| TypeInfo::Map(MapInfo::new::<Self, K, V>()))
+        CELL.get_or_insert::<Self, _>(|| {
+            TypeInfo::Map(
+                MapInfo::new::<Self, K, V>().with_generics(Generics::from_iter([
+                    TypeParamInfo::new::<K>("K"),
+                    TypeParamInfo::new::<V>("V"),
+                ])),
+            )
+        })
     }
 }
 
@@ -1438,7 +1465,14 @@ impl<T: FromReflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usiz
 impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> Typed for [T; N] {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| TypeInfo::Array(ArrayInfo::new::<Self, T>(N)))
+        CELL.get_or_insert::<Self, _>(|| {
+            TypeInfo::Array(
+                ArrayInfo::new::<Self, T>(N).with_generics(Generics::from_iter([
+                    GenericInfo::Type(TypeParamInfo::new::<T>("T")),
+                    GenericInfo::Const(ConstParamInfo::new::<usize>("N")),
+                ])),
+            )
+        })
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -583,6 +583,7 @@ mod impls {
 
 pub mod attributes;
 mod enums;
+mod generics;
 pub mod serde;
 pub mod std_traits;
 #[cfg(feature = "debug_stack")]
@@ -610,6 +611,7 @@ pub use array::*;
 pub use enums::*;
 pub use fields::*;
 pub use from_reflect::*;
+pub use generics::*;
 pub use kind::*;
 pub use list::*;
 pub use map::*;

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -6,10 +6,11 @@ use core::{
 
 use bevy_reflect_derive::impl_type_path;
 
+use crate::generics::impl_generic_info_methods;
 use crate::{
     self as bevy_reflect, type_info::impl_type_methods, utility::reflect_hasher, ApplyError,
-    FromReflect, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
-    ReflectRef, Type, TypeInfo, TypePath,
+    FromReflect, Generics, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
 };
 
 /// A trait used to power [list-like] operations via [reflection].
@@ -111,6 +112,7 @@ pub trait List: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct ListInfo {
     ty: Type,
+    generics: Generics,
     item_info: fn() -> Option<&'static TypeInfo>,
     item_ty: Type,
     #[cfg(feature = "documentation")]
@@ -122,6 +124,7 @@ impl ListInfo {
     pub fn new<TList: List + TypePath, TItem: FromReflect + MaybeTyped + TypePath>() -> Self {
         Self {
             ty: Type::of::<TList>(),
+            generics: Generics::new(),
             item_info: TItem::maybe_type_info,
             item_ty: Type::of::<TItem>(),
             #[cfg(feature = "documentation")]
@@ -157,6 +160,8 @@ impl ListInfo {
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_generic_info_methods!(generics);
 }
 
 /// A list of reflected values.

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -3,9 +3,11 @@ use core::fmt::{Debug, Formatter};
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
+use crate::generics::impl_generic_info_methods;
 use crate::{
-    self as bevy_reflect, type_info::impl_type_methods, ApplyError, MaybeTyped, PartialReflect,
-    Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
+    self as bevy_reflect, type_info::impl_type_methods, ApplyError, Generics, MaybeTyped,
+    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
+    TypePath,
 };
 
 /// A trait used to power [map-like] operations via [reflection].
@@ -97,6 +99,7 @@ pub trait Map: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct MapInfo {
     ty: Type,
+    generics: Generics,
     key_info: fn() -> Option<&'static TypeInfo>,
     key_ty: Type,
     value_info: fn() -> Option<&'static TypeInfo>,
@@ -114,6 +117,7 @@ impl MapInfo {
     >() -> Self {
         Self {
             ty: Type::of::<TMap>(),
+            generics: Generics::new(),
             key_info: TKey::maybe_type_info,
             key_ty: Type::of::<TKey>(),
             value_info: TValue::maybe_type_info,
@@ -166,6 +170,8 @@ impl MapInfo {
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_generic_info_methods!(generics);
 }
 
 #[macro_export]

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -3,9 +3,11 @@ use core::fmt::{Debug, Formatter};
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::hashbrown::{hash_table::OccupiedEntry as HashTableOccupiedEntry, HashTable};
 
+use crate::generics::impl_generic_info_methods;
 use crate::{
-    self as bevy_reflect, hash_error, type_info::impl_type_methods, ApplyError, PartialReflect,
-    Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
+    self as bevy_reflect, hash_error, type_info::impl_type_methods, ApplyError, Generics,
+    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
+    TypePath,
 };
 
 /// A trait used to power [set-like] operations via [reflection].
@@ -81,6 +83,7 @@ pub trait Set: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct SetInfo {
     ty: Type,
+    generics: Generics,
     value_ty: Type,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -91,6 +94,7 @@ impl SetInfo {
     pub fn new<TSet: Set + TypePath, TValue: Reflect + TypePath>() -> Self {
         Self {
             ty: Type::of::<TSet>(),
+            generics: Generics::new(),
             value_ty: Type::of::<TValue>(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -117,6 +121,8 @@ impl SetInfo {
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_generic_info_methods!(generics);
 }
 
 /// An ordered set of reflected values.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,9 +1,10 @@
+use crate::generics::impl_generic_info_methods;
 use crate::{
     self as bevy_reflect,
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     type_info::impl_type_methods,
-    ApplyError, NamedField, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
-    ReflectRef, Type, TypeInfo, TypePath,
+    ApplyError, Generics, NamedField, PartialReflect, Reflect, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
 };
 use alloc::{borrow::Cow, sync::Arc};
 use bevy_reflect_derive::impl_type_path;
@@ -79,6 +80,7 @@ pub trait Struct: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct StructInfo {
     ty: Type,
+    generics: Generics,
     fields: Box<[NamedField]>,
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
@@ -104,6 +106,7 @@ impl StructInfo {
 
         Self {
             ty: Type::of::<T>(),
+            generics: Generics::new(),
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
             field_indices,
@@ -168,6 +171,8 @@ impl StructInfo {
     }
 
     impl_custom_attribute_methods!(self.custom_attributes, "struct");
+
+    impl_generic_info_methods!(generics);
 }
 
 /// An iterator over the field values of a struct.

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,11 +1,12 @@
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::all_tuples;
 
+use crate::generics::impl_generic_info_methods;
 use crate::{
     self as bevy_reflect, type_info::impl_type_methods, utility::GenericTypePathCell, ApplyError,
-    FromReflect, GetTypeRegistration, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut,
-    ReflectOwned, ReflectRef, Type, TypeInfo, TypePath, TypeRegistration, TypeRegistry, Typed,
-    UnnamedField,
+    FromReflect, Generics, GetTypeRegistration, MaybeTyped, PartialReflect, Reflect, ReflectKind,
+    ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath, TypeRegistration, TypeRegistry,
+    Typed, UnnamedField,
 };
 use core::{
     any::Any,
@@ -142,6 +143,7 @@ impl GetTupleField for dyn Tuple {
 #[derive(Clone, Debug)]
 pub struct TupleInfo {
     ty: Type,
+    generics: Generics,
     fields: Box<[UnnamedField]>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -156,6 +158,7 @@ impl TupleInfo {
     pub fn new<T: Reflect + TypePath>(fields: &[UnnamedField]) -> Self {
         Self {
             ty: Type::of::<T>(),
+            generics: Generics::new(),
             fields: fields.to_vec().into_boxed_slice(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -190,6 +193,8 @@ impl TupleInfo {
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_generic_info_methods!(generics);
 }
 
 /// A tuple which allows fields to be added at runtime.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,11 +1,12 @@
 use bevy_reflect_derive::impl_type_path;
 
+use crate::generics::impl_generic_info_methods;
 use crate::{
     self as bevy_reflect,
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     type_info::impl_type_methods,
-    ApplyError, DynamicTuple, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
-    ReflectRef, Tuple, Type, TypeInfo, TypePath, UnnamedField,
+    ApplyError, DynamicTuple, Generics, PartialReflect, Reflect, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, Tuple, Type, TypeInfo, TypePath, UnnamedField,
 };
 use alloc::sync::Arc;
 use core::{
@@ -62,6 +63,7 @@ pub trait TupleStruct: PartialReflect {
 #[derive(Clone, Debug)]
 pub struct TupleStructInfo {
     ty: Type,
+    generics: Generics,
     fields: Box<[UnnamedField]>,
     custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
@@ -77,6 +79,7 @@ impl TupleStructInfo {
     pub fn new<T: Reflect + TypePath>(fields: &[UnnamedField]) -> Self {
         Self {
             ty: Type::of::<T>(),
+            generics: Generics::new(),
             fields: fields.to_vec().into_boxed_slice(),
             custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
@@ -122,6 +125,8 @@ impl TupleStructInfo {
     }
 
     impl_custom_attribute_methods!(self.custom_attributes, "struct");
+
+    impl_generic_info_methods!(generics);
 }
 
 /// An iterator over the field values of a tuple struct.

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -501,7 +501,6 @@ macro_rules! impl_type_methods {
         /// [`TypeId`]: std::any::TypeId
         pub fn type_id(&self) -> ::core::any::TypeId {
             self.ty().id()
-
         }
 
         /// The [stable, full type path] of this type.

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -467,19 +467,27 @@ impl Hash for Type {
 }
 
 macro_rules! impl_type_methods {
+    // Generates the type methods based off a single field.
     ($field:ident) => {
+        $crate::type_info::impl_type_methods!(self => {
+            &self.$field
+        });
+    };
+    // Generates the type methods based off a custom expression.
+    ($self:ident => $expr:expr) => {
         /// The underlying Rust [type].
         ///
         /// [type]: crate::type_info::Type
-        pub fn ty(&self) -> &$crate::type_info::Type {
-            &self.$field
+        pub fn ty(&$self) -> &$crate::type_info::Type {
+            $expr
         }
 
         /// The [`TypeId`] of this type.
         ///
         /// [`TypeId`]: std::any::TypeId
         pub fn type_id(&self) -> ::core::any::TypeId {
-            self.$field.id()
+            self.ty().id()
+
         }
 
         /// The [stable, full type path] of this type.
@@ -489,7 +497,7 @@ macro_rules! impl_type_methods {
         /// [stable, full type path]: TypePath
         /// [`type_path_table`]: Self::type_path_table
         pub fn type_path(&self) -> &'static str {
-            self.$field.path()
+            self.ty().path()
         }
 
         /// A representation of the type path of this type.
@@ -498,7 +506,7 @@ macro_rules! impl_type_methods {
         ///
         /// [`TypePath`]: crate::type_path::TypePath
         pub fn type_path_table(&self) -> &$crate::type_path::TypePathTable {
-            &self.$field.type_path_table()
+            &self.ty().type_path_table()
         }
 
         /// Check if the given type matches this one.
@@ -510,7 +518,7 @@ macro_rules! impl_type_methods {
         /// [`TypeId`]: std::any::TypeId
         /// [`TypePath`]: crate::type_path::TypePath
         pub fn is<T: ::core::any::Any>(&self) -> bool {
-            self.$field.is::<T>()
+            self.ty().is::<T>()
         }
     };
 }

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -1,7 +1,7 @@
 use crate::{
     ArrayInfo, DynamicArray, DynamicEnum, DynamicList, DynamicMap, DynamicStruct, DynamicTuple,
-    DynamicTupleStruct, EnumInfo, ListInfo, MapInfo, PartialReflect, Reflect, ReflectKind, SetInfo,
-    StructInfo, TupleInfo, TupleStructInfo, TypePath, TypePathTable,
+    DynamicTupleStruct, EnumInfo, Generics, ListInfo, MapInfo, PartialReflect, Reflect,
+    ReflectKind, SetInfo, StructInfo, TupleInfo, TupleStructInfo, TypePath, TypePathTable,
 };
 use core::{
     any::{Any, TypeId},
@@ -515,6 +515,7 @@ macro_rules! impl_type_methods {
     };
 }
 
+use crate::generics::impl_generic_info_methods;
 pub(crate) use impl_type_methods;
 
 /// A container for compile-time info related to reflection-opaque types, including primitives.
@@ -528,6 +529,7 @@ pub(crate) use impl_type_methods;
 #[derive(Debug, Clone)]
 pub struct OpaqueInfo {
     ty: Type,
+    generics: Generics,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -536,6 +538,7 @@ impl OpaqueInfo {
     pub fn new<T: Reflect + TypePath + ?Sized>() -> Self {
         Self {
             ty: Type::of::<T>(),
+            generics: Generics::new(),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -554,6 +557,8 @@ impl OpaqueInfo {
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_generic_info_methods!(generics);
 }
 
 #[cfg(test)]

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -293,6 +293,20 @@ impl TypeInfo {
             Self::Opaque(_) => ReflectKind::Opaque,
         }
     }
+
+    impl_generic_info_methods!(self => {
+        match self {
+            Self::Struct(info) => info.generics(),
+            Self::TupleStruct(info) => info.generics(),
+            Self::Tuple(info) => info.generics(),
+            Self::List(info) => info.generics(),
+            Self::Array(info) => info.generics(),
+            Self::Map(info) => info.generics(),
+            Self::Set(info) => info.generics(),
+            Self::Enum(info) => info.generics(),
+            Self::Opaque(info) => info.generics(),
+        }
+    });
 }
 
 macro_rules! impl_cast_method {

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -138,7 +138,7 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, TypePath, UnnamedField, ApplyError};
+/// # use bevy_reflect::{DynamicTypePath, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, TypePath, UnnamedField, ApplyError, Generics, TypeParamInfo};
 /// use bevy_reflect::utility::GenericTypeInfoCell;
 ///
 /// struct Foo<T>(T);
@@ -148,7 +148,8 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 ///         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
 ///         CELL.get_or_insert::<Self, _>(|| {
 ///             let fields = [UnnamedField::new::<T>(0)];
-///             let info = TupleStructInfo::new::<Self>(&fields);
+///             let info = TupleStructInfo::new::<Self>(&fields)
+///                 .with_generics(Generics::from_iter([TypeParamInfo::new::<T>("T")]));
 ///             TypeInfo::TupleStruct(info)
 ///         })
 ///     }


### PR DESCRIPTION
# Objective

Currently, reflecting a generic type provides no information about the generic parameters. This means that you can't get access to the type of `T` in `Foo<T>` without creating custom type data (we do this for [`ReflectHandle`](https://docs.rs/bevy/0.14.2/bevy/asset/struct.ReflectHandle.html#method.asset_type_id)).

## Solution

This PR makes it so that generic type parameters and generic const parameters are tracked in a `Generics` struct stored on the `TypeInfo` for a type.

For example, `struct Foo<T, const N: usize>` will store `T` and `N` as a `TypeParamInfo` and `ConstParamInfo`, respectively.

The stored information includes:

- The name of the generic parameter (i.e. `T`, `N`, etc.)
- The type of the generic parameter (remember that we're dealing with monomorphized types, so this will actually be a concrete type)
- The default type/value, if any (e.g. `f32` in `T = f32` or `10` in `const N: usize = 10`)

### Caveats

The only requirement for this to work is that the user does not opt-out of the automatic `TypePath` derive with `#[reflect(type_path = false)]`.

Doing so prevents the macro code from 100% knowing that the generic type implements `TypePath`. This in turn means the generated `Typed` impl can't add generics to the type.

There are two solutions for this—both of which I think we should explore in a future PR:

1. We could just not use `TypePath`. This would mean that we can't store the `Type` of the generic, but we can at least store the `TypeId`.
2. We could provide a way to opt out of the automatic `Typed` derive with a `#[reflect(typed = false)]` attribute. This would allow users to manually implement `Typed` to add whatever generic information they need (e.g. skipping a parameter that can't implement `TypePath` while the rest can).

I originally thought about making `Generics` an enum with `Generic`, `NonGeneric`, and `Unavailable` variants to signify whether there are generics, no generics, or generics that cannot be added due to opting out of `TypePath`. I ultimately decided against this as I think it adds a bit too much complexity for such an uncommon problem. 

Additionally, users don't necessarily _have_ to know the generics of a type, so just skipping them should generally be fine for now.

## Testing

You can test locally by running:

```
cargo test --package bevy_reflect
```

---

## Showcase

You can now access generic parameters via `TypeInfo`!

```rust
#[derive(Reflect)]
struct MyStruct<T, const N: usize>([T; N]);

let generics = MyStruct::<f32, 10>::type_info().generics();

// Get by index:
let t = generics.get(0).unwrap();
assert_eq!(t.name(), "T");
assert!(t.ty().is::<f32>());
assert!(!t.is_const());

// Or by name:
let n = generics.get_named("N").unwrap();
assert_eq!(n.name(), "N");
assert!(n.ty().is::<usize>());
assert!(n.is_const());
```

You can even access parameter defaults:

```rust
#[derive(Reflect)]
struct MyStruct<T = String, const N: usize = 10>([T; N]);

let generics = MyStruct::<f32, 5>::type_info().generics();

let GenericInfo::Type(info) = generics.get_named("T").unwrap() else {
    panic!("expected a type parameter");
};

let default = info.default().unwrap();

assert!(default.is::<String>());

let GenericInfo::Const(info) = generics.get_named("N").unwrap() else {
    panic!("expected a const parameter");
};

let default = info.default().unwrap();

assert_eq!(default.downcast_ref::<usize>().unwrap(), &10);
```