### PR TITLE
`QuerySingle` family of system params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1893,6 +1893,17 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "falliable_params"
+path = "examples/ecs/falliable_params.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.falliable_params]
+name = "Falliable System Parameters"
+description = "Systems are skipped if their parameters cannot be acquired"
+category = "ECS (Entity Component System)"
+wasm = false
+
+[[example]]
 name = "startup_system"
 path = "examples/ecs/startup_system.rs"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1893,12 +1893,12 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
-name = "falliable_params"
-path = "examples/ecs/falliable_params.rs"
+name = "fallible_params"
+path = "examples/ecs/fallible_params.rs"
 doc-scrape-examples = true
 
-[package.metadata.example.falliable_params]
-name = "Falliable System Parameters"
+[package.metadata.example.fallible_params]
+name = "Fallible System Parameters"
 description = "Systems are skipped if their parameters cannot be acquired"
 category = "ECS (Entity Component System)"
 wasm = false

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -542,12 +542,11 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 /// See the [`Resource`] documentation for usage.
 ///
 /// If you need a unique mutable borrow, use [`ResMut`] instead.
+/// 
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
+/// This will cause systems that use it to be skipped.
 ///
-/// # Panics
-///
-/// Panics when used as a [`SystemParameter`](crate::system::SystemParam) if the resource does not exist.
-///
-/// Use `Option<Res<T>>` instead if the resource might not always exist.
+/// Use [`Option<Res<T>>`] instead if the resource might not always exist.
 pub struct Res<'w, T: ?Sized + Resource> {
     pub(crate) value: &'w T,
     pub(crate) ticks: Ticks<'w>,
@@ -621,12 +620,11 @@ impl_debug!(Res<'w, T>, Resource);
 /// See the [`Resource`] documentation for usage.
 ///
 /// If you need a shared borrow, use [`Res`] instead.
+/// 
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
+/// This will cause systems that use it to be skipped.
 ///
-/// # Panics
-///
-/// Panics when used as a [`SystemParam`](crate::system::SystemParam) if the resource does not exist.
-///
-/// Use `Option<ResMut<T>>` instead if the resource might not always exist.
+/// Use [`Option<ResMut<T>>`] instead if the resource might not always exist.
 pub struct ResMut<'w, T: ?Sized + Resource> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: TicksMut<'w>,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -542,7 +542,7 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 /// See the [`Resource`] documentation for usage.
 ///
 /// If you need a unique mutable borrow, use [`ResMut`] instead.
-/// 
+///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
 /// This will cause systems that use it to be skipped.
 ///
@@ -620,7 +620,7 @@ impl_debug!(Res<'w, T>, Resource);
 /// See the [`Resource`] documentation for usage.
 ///
 /// If you need a shared borrow, use [`Res`] instead.
-/// 
+///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
 /// This will cause systems that use it to be skipped.
 ///
@@ -682,11 +682,10 @@ impl<'w, T: Resource> From<ResMut<'w, T>> for Mut<'w, T> {
 /// the scheduler to instead run the system on the main thread so that it doesn't send the resource
 /// over to another thread.
 ///
-/// # Panics
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if non-send resource doesn't exist.
+/// This will cause systems that use it to be skipped.
 ///
-/// Panics when used as a `SystemParameter` if the resource does not exist.
-///
-/// Use `Option<NonSendMut<T>>` instead if the resource might not always exist.
+/// Use [`Option<NonSendMut<T>>`] instead if the resource might not always exist.
 pub struct NonSendMut<'w, T: ?Sized + 'static> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: TicksMut<'w>,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -544,7 +544,7 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 /// If you need a unique mutable borrow, use [`ResMut`] instead.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
-/// This will cause systems that use it to be skipped.
+/// This will cause systems that use this parameter to be skipped.
 ///
 /// Use [`Option<Res<T>>`] instead if the resource might not always exist.
 pub struct Res<'w, T: ?Sized + Resource> {
@@ -622,7 +622,7 @@ impl_debug!(Res<'w, T>, Resource);
 /// If you need a shared borrow, use [`Res`] instead.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
-/// This will cause systems that use it to be skipped.
+/// This will cause systems that use this parameter to be skipped.
 ///
 /// Use [`Option<ResMut<T>>`] instead if the resource might not always exist.
 pub struct ResMut<'w, T: ?Sized + Resource> {
@@ -683,7 +683,7 @@ impl<'w, T: Resource> From<ResMut<'w, T>> for Mut<'w, T> {
 /// over to another thread.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if non-send resource doesn't exist.
-/// This will cause systems that use it to be skipped.
+/// This will cause systems that use this parameter to be skipped.
 ///
 /// Use [`Option<NonSendMut<T>>`] instead if the resource might not always exist.
 pub struct NonSendMut<'w, T: ?Sized + 'static> {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -58,8 +58,9 @@ pub mod prelude {
         },
         system::{
             Commands, Deferred, EntityCommand, EntityCommands, In, InMut, InRef, IntoSystem, Local,
-            NonSend, NonSendMut, ParallelCommands, ParamSet, Query, ReadOnlySystem, Res, ResMut,
-            Resource, System, SystemIn, SystemInput, SystemParamBuilder, SystemParamFunction,
+            NonSend, NonSendMut, ParallelCommands, ParamSet, Query, QuerySingle, ReadOnlySystem,
+            Res, ResMut, Resource, System, SystemIn, SystemInput, SystemParamBuilder,
+            SystemParamFunction,
         },
         world::{
             Command, EntityMut, EntityRef, EntityWorldMut, FromWorld, OnAdd, OnInsert, OnRemove,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -8,8 +8,8 @@ use crate::{
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
-use core::borrow::Borrow;
-use std::{
+use core::{
+    borrow::Borrow,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1636,11 +1636,12 @@ impl<'w, 'q, Q: QueryData, F: QueryFilter> From<&'q mut Query<'w, '_, Q, F>>
 
 /// [System parameter] that provides readonly access to single entity's components, much like [`Query::single`].
 ///
-/// For meaning behind the generic arguments refer to [`Query`].
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if zero or more than one matching entity exists.
+/// This will cause systems that use it to be skipped.
 ///
-/// When used as a parameter in a system, multiple matching will prevent the system from running.
-/// System skipping will also happen when no matching entity exists, but the behavior can be
-/// handled by using [`Option<QuerySingle>`] instead, which allows zero or one matching entity.
+/// Use [`Option<QuerySingle<D, F>>`] instead if zero or one matching entities can exist.
+///
+/// See [`Query`] for meaning behind the generic arguments.
 pub struct QuerySingle<'w, D: ReadOnlyQueryData, F: QueryFilter = ()> {
     pub(crate) single: <D::ReadOnly as WorldQuery>::Item<'w>,
     pub(crate) _filter: PhantomData<F>,
@@ -1656,11 +1657,12 @@ impl<'w, D: ReadOnlyQueryData, F: QueryFilter> Deref for QuerySingle<'w, D, F> {
 
 /// [System parameter] that provides mutable access to single entity's components, much like [`Query::single_mut`].
 ///
-/// For meaning behind the generic arguments refer to [`Query`].
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if zero or more than one matching entity exists.
+/// This will cause systems that use it to be skipped.
 ///
-/// When used as a parameter in a system, multiple matching will prevent the system from running.
-/// System skipping will also happen when no matching entity exists, but the behavior can be
-/// handled by using [`Option<QuerySingleMut>`] instead, which allows zero or one matching entity.
+/// Use [`Option<QuerySingleMut<D, F>>`] instead if zero or one matching entities can exist.
+///
+/// See [`Query`] for meaning behind the generic arguments.
 pub struct QuerySingleMut<'w, D: QueryData, F: QueryFilter = ()> {
     pub(crate) single: D::Item<'w>,
     pub(crate) _filter: PhantomData<F>,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1641,7 +1641,7 @@ impl<'w, 'q, Q: QueryData, F: QueryFilter> From<&'q mut Query<'w, '_, Q, F>>
 ///
 /// Use [`Option<QuerySingle<D, F>>`] instead if zero or one matching entities can exist.
 ///
-/// See [`Query`] for meaning behind the generic arguments.
+/// See [`Query`] for more details.
 pub struct QuerySingle<'w, D: QueryData, F: QueryFilter = ()> {
     pub(crate) item: D::Item<'w>,
     pub(crate) _filter: PhantomData<F>,

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -112,10 +112,14 @@ pub trait System: Send + Sync + 'static {
     /// - The method [`System::update_archetype_component_access`] must be called at some
     ///   point before this one, with the same exact [`World`]. If [`System::update_archetype_component_access`]
     ///   panics (or otherwise does not return for any reason), this method must not be called.
+    /// - This is called directly before [`System::run_unsafe`] with no other world mutations inbetween.
     unsafe fn validate_param_unsafe(&self, world: UnsafeWorldCell) -> bool;
 
     /// Safe version of [`System::validate_param_unsafe`].
     /// that runs on exclusive, single-threaded `world` pointer.
+    ///
+    /// This method still has to be called directly before [`System::run_unsafe`]/[`System::run`]
+    /// to return the correct result.
     fn validate_param(&mut self, world: &World) -> bool {
         let world_cell = world.as_unsafe_world_cell_readonly();
         self.update_archetype_component_access(world_cell);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1410,11 +1410,10 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
 /// the scheduler to instead run the system on the main thread so that it doesn't send the resource
 /// over to another thread.
 ///
-/// # Panics
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if non-send resource doesn't exist.
+/// This will cause systems that use it to be skipped.
 ///
-/// Panics when used as a `SystemParameter` if the resource does not exist.
-///
-/// Use `Option<NonSend<T>>` instead if the resource might not always exist.
+/// Use [`Option<NonSend<T>>`] instead if the resource might not always exist.
 pub struct NonSend<'w, T: 'static> {
     pub(crate) value: &'w T,
     ticks: ComponentTicks,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -356,6 +356,8 @@ fn assert_component_access_compatibility(
     panic!("error[B0001]: Query<{query_type}, {filter_type}> in system {system_name} accesses component(s){accesses} in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevyengine.org/learn/errors/b0001");
 }
 
+// SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
+// this Query conflicts with any prior access, a panic will occur.
 unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> SystemParam
     for QuerySingle<'a, D, F>
 {
@@ -371,7 +373,7 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
         archetype: &Archetype,
         system_meta: &mut SystemMeta,
     ) {
-        Query::new_archetype(state, archetype, system_meta)
+        Query::new_archetype(state, archetype, system_meta);
     }
 
     #[inline]
@@ -420,6 +422,8 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
     }
 }
 
+// SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
+// this Query conflicts with any prior access, a panic will occur.
 unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> SystemParam
     for Option<QuerySingle<'a, D, F>>
 {
@@ -435,7 +439,7 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
         archetype: &Archetype,
         system_meta: &mut SystemMeta,
     ) {
-        QuerySingle::new_archetype(state, archetype, system_meta)
+        QuerySingle::new_archetype(state, archetype, system_meta);
     }
 
     #[inline]
@@ -483,14 +487,12 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
                 world.change_tick(),
             )
         };
-        match result {
-            Ok(_) => true,
-            Err(QuerySingleError::NoEntities(_)) => true,
-            Err(QuerySingleError::MultipleEntities(_)) => false,
-        }
+        !matches!(result, Err(QuerySingleError::MultipleEntities(_)))
     }
 }
 
+// SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
+// this Query conflicts with any prior access, a panic will occur.
 unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     for QuerySingleMut<'a, D, F>
 {
@@ -506,7 +508,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         archetype: &Archetype,
         system_meta: &mut SystemMeta,
     ) {
-        Query::new_archetype(state, archetype, system_meta)
+        Query::new_archetype(state, archetype, system_meta);
     }
 
     #[inline]
@@ -537,6 +539,8 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     }
 }
 
+// SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
+// this Query conflicts with any prior access, a panic will occur.
 unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     for Option<QuerySingleMut<'a, D, F>>
 {
@@ -552,7 +556,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         archetype: &Archetype,
         system_meta: &mut SystemMeta,
     ) {
-        QuerySingleMut::new_archetype(state, archetype, system_meta)
+        QuerySingleMut::new_archetype(state, archetype, system_meta);
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -230,7 +230,7 @@ pub unsafe trait SystemParam: Sized {
     /// When using system parameters that require `change_tick` you can use
     /// [`UnsafeWorldCell::change_tick()`]. Even if this isn't the exact
     /// same tick used for [`SystemParam::get_param`], the world access
-    /// ensures that thre queried data will be the same in both calls.
+    /// ensures that the queried data will be the same in both calls.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1410,7 +1410,7 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
 /// the scheduler to instead run the system on the main thread so that it doesn't send the resource
 /// over to another thread.
 ///
-/// This [`SystemParam`](crate::system::SystemParam) fails validation if non-send resource doesn't exist.
+/// This [`SystemParam`] fails validation if non-send resource doesn't exist.
 /// This will cause systems that use it to be skipped.
 ///
 /// Use [`Option<NonSend<T>>`] instead if the resource might not always exist.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -384,8 +384,7 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         state.validate_world(world.id());
-        // SAFETY:
-        // the query ensures that the components it accesses are not mutably accessible somewhere else
+        // SAFETY: State ensures that the components it accesses are not mutably accessible elsewhere
         // and the query is read only.
         let result = unsafe {
             state.as_readonly().get_single_unchecked_manual(
@@ -408,8 +407,7 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
         world: UnsafeWorldCell,
     ) -> bool {
         state.validate_world(world.id());
-        // SAFETY:
-        // the query ensures that the components it accesses are not mutably accessible somewhere else
+        // SAFETY: State ensures that the components it accesses are not mutably accessible elsewhere
         // and the query is read only.
         let result = unsafe {
             state.as_readonly().get_single_unchecked_manual(
@@ -450,8 +448,7 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         state.validate_world(world.id());
-        // SAFETY:
-        // the query ensures that the components it accesses are not mutably accessible somewhere else
+        // SAFETY: State ensures that the components it accesses are not mutably accessible elsewhere
         // and the query is read only.
         let result = unsafe {
             state.as_readonly().get_single_unchecked_manual(
@@ -477,8 +474,7 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> System
         world: UnsafeWorldCell,
     ) -> bool {
         state.validate_world(world.id());
-        // SAFETY:
-        // the query ensures that the components it accesses are not mutably accessible somewhere else
+        // SAFETY: State ensures that the components it accesses are not mutably accessible elsewhere
         // and the query is read only.
         let result = unsafe {
             state.as_readonly().get_single_unchecked_manual(
@@ -519,7 +515,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         state.validate_world(world.id());
-        // SAFETY: query has unique world access
+        // SAFETY: State ensures that the components it accesses are not accessible somewhere elsewhere.
         let result =
             unsafe { state.get_single_unchecked_manual(world, system_meta.last_run, change_tick) };
         let single = result.unwrap();
@@ -535,7 +531,8 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> bool {
-        QuerySingle::validate_param(state.as_readonly(), system_meta, world)
+        // SAFETY: Delegate to another `SystemParam` implementation.
+        unsafe { QuerySingle::validate_param(state.as_readonly(), system_meta, world) }
     }
 }
 
@@ -567,7 +564,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         state.validate_world(world.id());
-        // SAFETY: query has unique world access
+        // SAFETY: State ensures that the components it accesses are not accessible elsewhere.
         let result =
             unsafe { state.get_single_unchecked_manual(world, system_meta.last_run, change_tick) };
         match result {
@@ -586,11 +583,14 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> bool {
-        Option::<QuerySingle<'a, D::ReadOnly, F>>::validate_param(
-            state.as_readonly(),
-            system_meta,
-            world,
-        )
+        // SAFETY: Delegate to another `SystemParam` implementation.
+        unsafe {
+            Option::<QuerySingle<'a, D::ReadOnly, F>>::validate_param(
+                state.as_readonly(),
+                system_meta,
+                world,
+            )
+        }
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -232,13 +232,16 @@ pub unsafe trait SystemParam: Sized {
     /// same tick used for [`SystemParam::get_param`], the world access
     /// ensures that the queried data will be the same in both calls.
     ///
+    /// This method has to be called directly before [`SystemParam::get_param`] with no other (relevant)
+    /// world mutations inbetween. Otherwise, while it won't lead to any undefined behavior,
+    /// the validity of the param may change.
+    ///
     /// # Safety
     ///
     /// - The passed [`UnsafeWorldCell`] must have read-only access to world data
     ///   registered in [`init_state`](SystemParam::init_state).
     /// - `world` must be the same [`World`] that was used to initialize [`state`](SystemParam::init_state).
     /// - All `world`'s archetypes have been processed by [`new_archetype`](SystemParam::new_archetype).
-    /// - This is called directly before [`SystemParam::get_param`] with no other world mutations inbetween.
     unsafe fn validate_param(
         _state: &Self::State,
         _system_meta: &SystemMeta,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -10,7 +10,7 @@ use crate::{
         QuerySingleError, QueryState, ReadOnlyQueryData,
     },
     storage::{ResourceData, SparseSetIndex},
-    system::{Query, SystemMeta, QuerySingle, QuerySingleMut},
+    system::{Query, QuerySingle, QuerySingleMut, SystemMeta},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FromWorld, World},
 };
 use bevy_ecs_macros::impl_param_set;

--- a/examples/README.md
+++ b/examples/README.md
@@ -288,6 +288,7 @@ Example | Description
 [Dynamic ECS](../examples/ecs/dynamic.rs) | Dynamically create components, spawn entities with those components and query those components
 [ECS Guide](../examples/ecs/ecs_guide.rs) | Full guide to Bevy's ECS
 [Event](../examples/ecs/event.rs) | Illustrates event creation, activation, and reception
+[Fallible System Parameters](../examples/ecs/fallible_params.rs) | Systems are skipped if their parameters cannot be acquired
 [Fixed Timestep](../examples/ecs/fixed_timestep.rs) | Shows how to create systems that run every fixed timestep, rather than every tick
 [Generic System](../examples/ecs/generic_system.rs) | Shows how to create systems that can be reused with different types
 [Hierarchy](../examples/ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities

--- a/examples/ecs/falliable_params.rs
+++ b/examples/ecs/falliable_params.rs
@@ -1,0 +1,130 @@
+//! This example demonstrates how falliable parameters can prevent systems from running
+//! if their acquiry conditions aren't met.
+//!
+//! Falliable parameters include:
+//! - [`Res<R>`], [`ResMut<R>`] - If resource doesn't exist.
+//! - [`QuerySingle<D, F>`], [`QuerySingleMut<D, F>`] - If there is no or more than one entities matching.
+//! - [`Option<QuerySingle<D, F>>`], [`Option<QuerySingleMut<D, F>>`] - If there are more than one entities matching.
+
+use std::ops::DerefMut;
+
+use bevy::{
+    ecs::system::{QuerySingle, QuerySingleMut},
+    prelude::*,
+};
+use rand::Rng;
+
+fn main() {
+    println!();
+
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (user_input, move_targets, move_pointer).chain())
+        .run();
+}
+
+#[derive(Component, Default)]
+struct Enemy {
+    origin: Vec2,
+    radius: f32,
+    rotation: f32,
+    rotation_speed: f32,
+}
+
+#[derive(Component, Default)]
+struct Player {
+    speed: f32,
+    rotation_speed: f32,
+    stay_away: f32,
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let texture = asset_server.load("textures/simplespace/ship_C.png");
+    commands.spawn((
+        Player {
+            speed: 100.0,
+            rotation_speed: 2.0,
+            stay_away: 50.0,
+        },
+        SpriteBundle {
+            transform: Transform::from_translation(Vec3::ZERO),
+            texture,
+            ..default()
+        },
+    ));
+}
+
+fn user_input(
+    mut commands: Commands,
+    enemies: Query<Entity, With<Enemy>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    asset_server: Res<AssetServer>,
+) {
+    let mut rng = rand::thread_rng();
+    if keyboard_input.just_pressed(KeyCode::KeyA) {
+        let texture = asset_server.load("textures/simplespace/enemy_A.png");
+        commands.spawn((
+            Enemy {
+                origin: Vec2::new(rng.gen_range(-200.0..200.0), rng.gen_range(-200.0..200.0)),
+                radius: rng.gen_range(50.0..150.0),
+                rotation: rng.gen_range(0.0..std::f32::consts::TAU),
+                rotation_speed: rng.gen_range(0.5..1.5),
+            },
+            SpriteBundle {
+                sprite: Sprite {
+                    color: bevy::color::palettes::basic::RED.into(),
+                    ..default()
+                },
+                transform: Transform::from_translation(Vec3::ZERO),
+                texture,
+                ..default()
+            },
+        ));
+    }
+
+    if keyboard_input.just_pressed(KeyCode::KeyR) {
+        if let Some(entity) = enemies.iter().next() {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+// TODO: Use [`NonEmptyQuery`]
+fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
+    for (mut transform, mut target) in &mut enemies {
+        target.rotation += target.rotation_speed * time.delta_seconds();
+        transform.rotation = Quat::from_rotation_z(target.rotation);
+        let offset = transform.right() * target.radius;
+        transform.translation = target.origin.extend(0.0) + offset;
+    }
+}
+
+/// Constantly rotates the pointer if there are no targets.
+/// Points towards target if exactly one exists.
+/// Does nothing (system doesn't run) when there are more than one entity.
+fn move_pointer(
+    mut player: QuerySingleMut<(&mut Transform, &Player)>,
+    enemy: Option<QuerySingle<&Transform, (With<Enemy>, Without<Player>)>>,
+    time: Res<Time>,
+) {
+    let (ref mut player_transform, ref player) = player.deref_mut();
+    if let Some(enemy_transform) = enemy {
+        let delta = enemy_transform.translation - player_transform.translation;
+        let distance = delta.length();
+        let front = delta / distance;
+        let up = Vec3::Z;
+        let side = front.cross(up);
+        player_transform.rotation = Quat::from_mat3(&Mat3::from_cols(side, front, up));
+
+        let come_closer = distance - player.stay_away;
+        if 0.0 < come_closer {
+            let velocity = (player.speed * time.delta_seconds()).min(come_closer);
+            player_transform.translation += front * velocity;
+        }
+    } else {
+        player_transform.rotate_axis(Dir3::Z, player.rotation_speed * time.delta_seconds());
+    }
+}

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -1,12 +1,10 @@
-//! This example demonstrates how falliable parameters can prevent systems from running
+//! This example demonstrates how fallible parameters can prevent systems from running
 //! if their acquiry conditions aren't met.
 //!
-//! Falliable parameters include:
+//! Fallible parameters include:
 //! - [`Res<R>`], [`ResMut<R>`] - If resource doesn't exist.
 //! - [`QuerySingle<D, F>`], [`QuerySingleMut<D, F>`] - If there is no or more than one entities matching.
 //! - [`Option<QuerySingle<D, F>>`], [`Option<QuerySingleMut<D, F>>`] - If there are more than one entities matching.
-
-use std::ops::DerefMut;
 
 use bevy::{
     ecs::system::{QuerySingle, QuerySingleMut},
@@ -15,6 +13,10 @@ use bevy::{
 use rand::Rng;
 
 fn main() {
+    println!();
+    println!("Press 'A' to add enemy ships and 'R' to remove them.");
+    println!("Player ship will wait for enemy ships and track one if it exists,");
+    println!("but will stop tracking if there are more than one.");
     println!();
 
     App::new()
@@ -110,7 +112,7 @@ fn move_pointer(
     enemy: Option<QuerySingle<&Transform, (With<Enemy>, Without<Player>)>>,
     time: Res<Time>,
 ) {
-    let (ref mut player_transform, ref player) = player.deref_mut();
+    let (ref mut player_transform, ref player) = &mut *player;
     if let Some(enemy_transform) = enemy {
         let delta = enemy_transform.translation - player_transform.translation;
         let distance = delta.length();

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -3,8 +3,8 @@
 //!
 //! Fallible parameters include:
 //! - [`Res<R>`], [`ResMut<R>`] - If resource doesn't exist.
-//! - [`QuerySingle<D, F>`], [`QuerySingleMut<D, F>`] - If there is no or more than one entities matching.
-//! - [`Option<QuerySingle<D, F>>`], [`Option<QuerySingleMut<D, F>>`] - If there are more than one entities matching.
+//! - [`QuerySingle<D, F>`] - If there is no or more than one entities matching.
+//! - [`Option<QuerySingle<D, F>>`] - If there are more than one entities matching.
 
 use bevy::prelude::*;
 use rand::Rng;
@@ -120,11 +120,9 @@ fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time
 /// If there is one, player will track it.
 /// If there are too many enemies, the player will cease all action (the system will not run).
 fn move_pointer(
-    // `QuerySingleMut` ensures the system runs ONLY when exactly one entity exists.
-    // It gives us mutable access to the query content.
+    // `QuerySingle` ensures the system runs ONLY when exactly one entity exists.
     mut player: QuerySingle<(&mut Transform, &Player)>,
     // `Option<QuerySingle>` ensures that the system runs ONLY when zero or one entity exists.
-    // It gives us readonly access to the query content.
     enemy: Option<QuerySingle<&Transform, (With<Enemy>, Without<Player>)>>,
     time: Res<Time>,
 ) {

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -120,9 +120,9 @@ fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time
 /// If there is one, player will track it.
 /// If there are too many enemies, the player will cease all action (the system will not run).
 fn move_pointer(
-    // `QuerySingle` ensures the system runs ONLY when exactly one entity exists.
+    // `QuerySingle` ensures the system runs ONLY when exactly one matching entity exists.
     mut player: QuerySingle<(&mut Transform, &Player)>,
-    // `Option<QuerySingle>` ensures that the system runs ONLY when zero or one entity exists.
+    // `Option<QuerySingle>` ensures that the system runs ONLY when zero or one matching entity exists.
     enemy: Option<QuerySingle<&Transform, (With<Enemy>, Without<Player>)>>,
     time: Res<Time>,
 ) {

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -6,10 +6,7 @@
 //! - [`QuerySingle<D, F>`], [`QuerySingleMut<D, F>`] - If there is no or more than one entities matching.
 //! - [`Option<QuerySingle<D, F>>`], [`Option<QuerySingleMut<D, F>>`] - If there are more than one entities matching.
 
-use bevy::{
-    ecs::system::{QuerySingle, QuerySingleMut},
-    prelude::*,
-};
+use bevy::prelude::*;
 use rand::Rng;
 
 fn main() {
@@ -125,7 +122,7 @@ fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time
 fn move_pointer(
     // `QuerySingleMut` ensures the system runs ONLY when exactly one entity exists.
     // It gives us mutable access to the query content.
-    mut player: QuerySingleMut<(&mut Transform, &Player)>,
+    mut player: QuerySingle<(&mut Transform, &Player)>,
     // `Option<QuerySingle>` ensures that the system runs ONLY when zero or one entity exists.
     // It gives us readonly access to the query content.
     enemy: Option<QuerySingle<&Transform, (With<Enemy>, Without<Player>)>>,

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -1,5 +1,5 @@
-//! This example demonstrates how fallible parameters can prevent systems from running
-//! if their acquiry conditions aren't met.
+//! This example demonstrates how fallible parameters can prevent their systems
+//! from running if their acquiry conditions aren't met.
 //!
 //! Fallible parameters include:
 //! - [`Res<R>`], [`ResMut<R>`] - If resource doesn't exist.
@@ -22,10 +22,13 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
+        // We add all the systems one after another.
+        // We don't need to use run conditions here.
         .add_systems(Update, (user_input, move_targets, move_pointer).chain())
         .run();
 }
 
+/// Enemy component stores data for movement in a circle.
 #[derive(Component, Default)]
 struct Enemy {
     origin: Vec2,
@@ -34,24 +37,31 @@ struct Enemy {
     rotation_speed: f32,
 }
 
+/// Player component stores data for going after enemies.
 #[derive(Component, Default)]
 struct Player {
     speed: f32,
     rotation_speed: f32,
-    stay_away: f32,
+    min_follow_radius: f32,
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Spawn 2D camera.
     commands.spawn(Camera2dBundle::default());
 
+    // Spawn player.
     let texture = asset_server.load("textures/simplespace/ship_C.png");
     commands.spawn((
         Player {
             speed: 100.0,
             rotation_speed: 2.0,
-            stay_away: 50.0,
+            min_follow_radius: 50.0,
         },
         SpriteBundle {
+            sprite: Sprite {
+                color: bevy::color::palettes::tailwind::BLUE_800.into(),
+                ..default()
+            },
             transform: Transform::from_translation(Vec3::ZERO),
             texture,
             ..default()
@@ -59,6 +69,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 }
 
+// System that reads user input.
+// If user presses 'A' we spawn a new random enemy.
+// If user presses 'R' we remove a random enemy (if any exist).
 fn user_input(
     mut commands: Commands,
     enemies: Query<Entity, With<Enemy>>,
@@ -77,7 +90,7 @@ fn user_input(
             },
             SpriteBundle {
                 sprite: Sprite {
-                    color: bevy::color::palettes::basic::RED.into(),
+                    color: bevy::color::palettes::tailwind::RED_800.into(),
                     ..default()
                 },
                 transform: Transform::from_translation(Vec3::ZERO),
@@ -94,7 +107,8 @@ fn user_input(
     }
 }
 
-// TODO: Use [`NonEmptyQuery`]
+// System that moves the enemies in a circle.
+// TODO: Use [`NonEmptyQuery`] when it exists.
 fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
     for (mut transform, mut target) in &mut enemies {
         target.rotation += target.rotation_speed * time.delta_seconds();
@@ -104,29 +118,35 @@ fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time
     }
 }
 
-/// Constantly rotates the pointer if there are no targets.
-/// Points towards target if exactly one exists.
-/// Does nothing (system doesn't run) when there are more than one entity.
+/// System that moves the player.
+/// The player will search for enemies if there are none.
+/// If there is one, player will track it.
+/// If there are too many enemies, the player will cease all action (the system will not run).
 fn move_pointer(
+    // `QuerySingleMut` ensures the system runs ONLY when exactly one entity exists.
+    // It gives us mutable access to the query content.
     mut player: QuerySingleMut<(&mut Transform, &Player)>,
+    // `Option<QuerySingle>` ensures that the system runs ONLY when zero or one entity exists.
+    // It gives us readonly access to the query content.
     enemy: Option<QuerySingle<&Transform, (With<Enemy>, Without<Player>)>>,
     time: Res<Time>,
 ) {
-    let (ref mut player_transform, ref player) = &mut *player;
+    let (player_transform, player) = &mut *player;
     if let Some(enemy_transform) = enemy {
+        // Enemy found, rotate and move towards it.
         let delta = enemy_transform.translation - player_transform.translation;
         let distance = delta.length();
         let front = delta / distance;
         let up = Vec3::Z;
         let side = front.cross(up);
         player_transform.rotation = Quat::from_mat3(&Mat3::from_cols(side, front, up));
-
-        let come_closer = distance - player.stay_away;
-        if 0.0 < come_closer {
-            let velocity = (player.speed * time.delta_seconds()).min(come_closer);
+        let max_step = distance - player.min_follow_radius;
+        if 0.0 < max_step {
+            let velocity = (player.speed * time.delta_seconds()).min(max_step);
             player_transform.translation += front * velocity;
         }
     } else {
+        // No enemy found, keep searching.
         player_transform.rotate_axis(Dir3::Z, player.rotation_speed * time.delta_seconds());
     }
 }


### PR DESCRIPTION
# Objective

Add the following system params:
- `QuerySingle<D, F>` - Valid if only one matching entity exists,
- `Option<QuerySingle<D, F>>` - Valid if zero or one matching entity exists.

As @chescock pointed out, we don't need `Mut` variants.

Fixes: #15264

## Solution

Implement the type and both variants of system params.
Also implement `ReadOnlySystemParam` for readonly queries.

Added a new ECS example `fallible_params` which showcases `SingleQuery` usage.
In the future we might want to add `NonEmptyQuery`, `NonEmptyEventReader` and `Res` to it (or maybe just stop at mentioning it).

## Testing

Tested with the example.
There is a lot of warning spam so we might want to implement #15391.
