### PR TITLE
Remove `Return::Unit` variant

### DIFF
--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -15,8 +15,10 @@ pub enum Return<'a> {
 }
 
 impl<'a> Return<'a> {
-    /// An [`Owned`](Self::Owned) unit (`()`) type.
-    pub const UNIT: Return<'a> = Return::Owned(Box::new(()));
+    /// Creates an [`Owned`](Self::Owned) unit (`()`) type.
+    pub fn unit() -> Self {
+        Self::Owned(Box::new(()))
+    }
 
     /// Returns `true` if the return value is an [`Owned`](Self::Owned) unit (`()`) type.
     pub fn is_unit(&self) -> bool {
@@ -85,7 +87,7 @@ pub trait IntoReturn {
 
 impl IntoReturn for () {
     fn into_return<'a>(self) -> Return<'a> {
-        Return::UNIT
+        Return::unit()
     }
 }
 

--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -6,8 +6,6 @@ use crate::PartialReflect;
 /// [`DynamicFunctionMut`]: crate::func::DynamicFunctionMut
 #[derive(Debug)]
 pub enum Return<'a> {
-    /// The function returns nothing (i.e. it returns `()`).
-    Unit,
     /// The function returns an owned value.
     Owned(Box<dyn PartialReflect>),
     /// The function returns a reference to a value.
@@ -17,9 +15,15 @@ pub enum Return<'a> {
 }
 
 impl<'a> Return<'a> {
-    /// Returns `true` if the return value is [`Self::Unit`].
+    /// An [`Owned`](Self::Owned) unit (`()`) type.
+    pub const UNIT: Return<'a> = Return::Owned(Box::new(()));
+
+    /// Returns `true` if the return value is an [`Owned`](Self::Owned) unit (`()`) type.
     pub fn is_unit(&self) -> bool {
-        matches!(self, Return::Unit)
+        match self {
+            Return::Owned(val) => val.represents::<()>(),
+            _ => false
+        }
     }
 
     /// Unwraps the return value as an owned value.
@@ -81,7 +85,7 @@ pub trait IntoReturn {
 
 impl IntoReturn for () {
     fn into_return<'a>(self) -> Return<'a> {
-        Return::Unit
+        Return::UNIT
     }
 }
 

--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -7,6 +7,8 @@ use crate::PartialReflect;
 #[derive(Debug)]
 pub enum Return<'a> {
     /// The function returns an owned value.
+    ///
+    /// Owned values can be unit (`()`).
     Owned(Box<dyn PartialReflect>),
     /// The function returns a reference to a value.
     Ref(&'a dyn PartialReflect),

--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -8,7 +8,7 @@ use crate::PartialReflect;
 pub enum Return<'a> {
     /// The function returns an owned value.
     ///
-    /// Owned values can be unit (`()`).
+    /// This includes functions that return nothing (i.e. they return `()`).
     Owned(Box<dyn PartialReflect>),
     /// The function returns a reference to a value.
     Ref(&'a dyn PartialReflect),

--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -22,7 +22,7 @@ impl<'a> Return<'a> {
     pub fn is_unit(&self) -> bool {
         match self {
             Return::Owned(val) => val.represents::<()>(),
-            _ => false
+            _ => false,
         }
     }
 


### PR DESCRIPTION
# Objective

- Fixes #15447 

## Solution

- Remove the `Return::Unit` variant and use a `Return::Owned` variant holding a unit `()` type.

## Migration Guide

- Removed the `Return::Unit` variant; use `Return::unit()` instead.
