### PR TITLE
`Populated` (query) system param

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -58,8 +58,8 @@ pub mod prelude {
         },
         system::{
             Commands, Deferred, EntityCommand, EntityCommands, In, InMut, InRef, IntoSystem, Local,
-            NonSend, NonSendMut, ParallelCommands, ParamSet, Query, ReadOnlySystem, Res, ResMut,
-            Resource, Single, System, SystemIn, SystemInput, SystemParamBuilder,
+            NonSend, NonSendMut, ParallelCommands, ParamSet, Populated, Query, ReadOnlySystem, Res,
+            ResMut, Resource, Single, System, SystemIn, SystemInput, SystemParamBuilder,
             SystemParamFunction,
         },
         world::{

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -35,8 +35,8 @@ use core::{
 ///
 /// # Similar parameters
 ///
-/// [`Query`] has few sibling [`SystemParam`], which perform additional validation:
-/// - [`Single`] - Exactly one matching query item.
+/// [`Query`] has few sibling [`SystemParam`](crate::system::system_param::SystemParam)s, which perform additional validation:
+/// - [`Single`](Single) - Exactly one matching query item.
 /// - [`Option<Single>`] - Zero or one matching query item.
 /// - [`Populated`] - At least one matching query item.
 ///

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -33,6 +33,15 @@ use core::{
 ///
 /// [`World`]: crate::world::World
 ///
+/// # Similar parameters
+///
+/// [`Query`] has few sibling parameters, which perform additional validation:
+/// - [`Single`] - Exactly one matching query item.
+/// - [`Option<Single>`] - Zero or one matching query item.
+/// - [`Populated`] - At least one matching query item.
+/// 
+/// Those parameters will prevent systems from running if their requirements aren't met.
+///
 /// # System parameter declaration
 ///
 /// A query should always be declared as a system parameter.
@@ -1672,6 +1681,10 @@ impl<'w, D: QueryData, F: QueryFilter> Single<'w, D, F> {
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if no matching entities exist.
 /// This will cause systems that use this parameter to be skipped.
+///
+/// Much like [`Query::is_empty`] the worst case runtime will be `O(n)` where `n` is the number of *potential* matches.
+/// This can be notably expensive for queries that rely on non-archetypal filters such as [`Added`] or [`Changed`]
+/// which must individually check each query result for a match.
 ///
 /// See [`Query`] for more details.
 pub struct Populated<'w, 's, D: QueryData, F: QueryFilter = ()>(pub(crate) Query<'w, 's, D, F>);

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -36,7 +36,7 @@ use core::{
 /// # Similar parameters
 ///
 /// [`Query`] has few sibling [`SystemParam`](crate::system::system_param::SystemParam)s, which perform additional validation:
-/// - [`Single`](Single) - Exactly one matching query item.
+/// - [`Single`] - Exactly one matching query item.
 /// - [`Option<Single>`] - Zero or one matching query item.
 /// - [`Populated`] - At least one matching query item.
 ///

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1683,7 +1683,7 @@ impl<'w, D: QueryData, F: QueryFilter> Single<'w, D, F> {
 /// This will cause systems that use this parameter to be skipped.
 ///
 /// Much like [`Query::is_empty`] the worst case runtime will be `O(n)` where `n` is the number of *potential* matches.
-/// This can be notably expensive for queries that rely on non-archetypal filters such as [`Added`] or [`Changed`]
+/// This can be notably expensive for queries that rely on non-archetypal filters such as [`Added`](crate::query::Added) or [`Changed`](crate::query::Changed)
 /// which must individually check each query result for a match.
 ///
 /// See [`Query`] for more details.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1667,3 +1667,32 @@ impl<'w, D: QueryData, F: QueryFilter> QuerySingle<'w, D, F> {
         self.item
     }
 }
+
+/// [System parameter] that works very much like [`Query`] except it always contains at least one matching entity.
+///
+/// This [`SystemParam`](crate::system::SystemParam) fails validation if no matching entities exist.
+/// This will cause systems that use this parameter to be skipped.
+///
+/// See [`Query`] for more details.
+pub struct QueryNonEmpty<'w, 's, D: QueryData, F: QueryFilter = ()>(pub(crate) Query<'w, 's, D, F>);
+
+impl<'w, 's, D: QueryData, F: QueryFilter> Deref for QueryNonEmpty<'w, 's, D, F> {
+    type Target = Query<'w, 's, D, F>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<D: QueryData, F: QueryFilter> DerefMut for QueryNonEmpty<'_, '_, D, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter> QueryNonEmpty<'w, 's, D, F> {
+    /// Returns the inner item with ownership.
+    pub fn into_inner(self) -> Query<'w, 's, D, F> {
+        self.0
+    }
+}

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -39,7 +39,7 @@ use core::{
 /// - [`Single`] - Exactly one matching query item.
 /// - [`Option<Single>`] - Zero or one matching query item.
 /// - [`Populated`] - At least one matching query item.
-/// 
+///
 /// Those parameters will prevent systems from running if their requirements aren't met.
 ///
 /// # System parameter declaration

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1674,9 +1674,9 @@ impl<'w, D: QueryData, F: QueryFilter> Single<'w, D, F> {
 /// This will cause systems that use this parameter to be skipped.
 ///
 /// See [`Query`] for more details.
-pub struct QueryNonEmpty<'w, 's, D: QueryData, F: QueryFilter = ()>(pub(crate) Query<'w, 's, D, F>);
+pub struct Populated<'w, 's, D: QueryData, F: QueryFilter = ()>(pub(crate) Query<'w, 's, D, F>);
 
-impl<'w, 's, D: QueryData, F: QueryFilter> Deref for QueryNonEmpty<'w, 's, D, F> {
+impl<'w, 's, D: QueryData, F: QueryFilter> Deref for Populated<'w, 's, D, F> {
     type Target = Query<'w, 's, D, F>;
 
     fn deref(&self) -> &Self::Target {
@@ -1684,13 +1684,13 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Deref for QueryNonEmpty<'w, 's, D, F>
     }
 }
 
-impl<D: QueryData, F: QueryFilter> DerefMut for QueryNonEmpty<'_, '_, D, F> {
+impl<D: QueryData, F: QueryFilter> DerefMut for Populated<'_, '_, D, F> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> QueryNonEmpty<'w, 's, D, F> {
+impl<'w, 's, D: QueryData, F: QueryFilter> Populated<'w, 's, D, F> {
     /// Returns the inner item with ownership.
     pub fn into_inner(self) -> Query<'w, 's, D, F> {
         self.0

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -35,7 +35,7 @@ use core::{
 ///
 /// # Similar parameters
 ///
-/// [`Query`] has few sibling parameters, which perform additional validation:
+/// [`Query`] has few sibling [`SystemParam`], which perform additional validation:
 /// - [`Single`] - Exactly one matching query item.
 /// - [`Option<Single>`] - Zero or one matching query item.
 /// - [`Populated`] - At least one matching query item.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -26,7 +26,7 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use super::QueryNonEmpty;
+use super::Populated;
 
 /// A parameter that can be used in a [`System`](super::System).
 ///
@@ -502,10 +502,10 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOn
 // SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
 // this Query conflicts with any prior access, a panic will occur.
 unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
-    for QueryNonEmpty<'world, 'state, D, F>
+    for Populated<'world, 'state, D, F>
 {
     type State = QueryState<D, F>;
-    type Item<'w, 's> = QueryNonEmpty<'w, 's, D, F>;
+    type Item<'w, 's> = Populated<'w, 's, D, F>;
 
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
         Query::<'world, 'state, D, F>::init_state(world, system_meta)
@@ -531,7 +531,7 @@ unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> Sy
         let query = unsafe {
             Query::<'world, 'state, D, F>::get_param(state, system_meta, world, change_tick)
         };
-        QueryNonEmpty(query)
+        Populated(query)
     }
 
     #[inline]
@@ -552,7 +552,7 @@ unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> Sy
 
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
 unsafe impl<'w, 's, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOnlySystemParam
-    for QueryNonEmpty<'w, 's, D, F>
+    for Populated<'w, 's, D, F>
 {
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -501,14 +501,14 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOn
 
 // SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
 // this Query conflicts with any prior access, a panic will occur.
-unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
-    for Populated<'world, 'state, D, F>
+unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
+    for Populated<'_, '_, D, F>
 {
     type State = QueryState<D, F>;
     type Item<'w, 's> = Populated<'w, 's, D, F>;
 
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
-        Query::<'world, 'state, D, F>::init_state(world, system_meta)
+        Query::init_state(world, system_meta)
     }
 
     unsafe fn new_archetype(
@@ -517,7 +517,7 @@ unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> Sy
         system_meta: &mut SystemMeta,
     ) {
         // SAFETY: Delegate to existing `SystemParam` implementations.
-        unsafe { Query::<'world, 'state, D, F>::new_archetype(state, archetype, system_meta) };
+        unsafe { Query::new_archetype(state, archetype, system_meta) };
     }
 
     #[inline]
@@ -528,9 +528,7 @@ unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> Sy
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
         // SAFETY: Delegate to existing `SystemParam` implementations.
-        let query = unsafe {
-            Query::<'world, 'state, D, F>::get_param(state, system_meta, world, change_tick)
-        };
+        let query = unsafe { Query::get_param(state, system_meta, world, change_tick) };
         Populated(query)
     }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -26,6 +26,8 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
+use super::QueryNonEmpty;
+
 /// A parameter that can be used in a [`System`](super::System).
 ///
 /// # Derive
@@ -496,6 +498,63 @@ unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOn
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
 unsafe impl<'a, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOnlySystemParam
     for Option<QuerySingle<'a, D, F>>
+{
+}
+
+// SAFETY: Relevant query ComponentId and ArchetypeComponentId access is applied to SystemMeta. If
+// this Query conflicts with any prior access, a panic will occur.
+unsafe impl<'world, 'state, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
+    for QueryNonEmpty<'world, 'state, D, F>
+{
+    type State = QueryState<D, F>;
+    type Item<'w, 's> = QueryNonEmpty<'w, 's, D, F>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        Query::<'world, 'state, D, F>::init_state(world, system_meta)
+    }
+
+    unsafe fn new_archetype(
+        state: &mut Self::State,
+        archetype: &Archetype,
+        system_meta: &mut SystemMeta,
+    ) {
+        // SAFETY: Delegate to existing `SystemParam` implementations.
+        unsafe { Query::<'world, 'state, D, F>::new_archetype(state, archetype, system_meta) };
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        state: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        // SAFETY: Delegate to existing `SystemParam` implementations.
+        let query = unsafe {
+            Query::<'world, 'state, D, F>::get_param(state, system_meta, world, change_tick)
+        };
+        QueryNonEmpty(query)
+    }
+
+    #[inline]
+    unsafe fn validate_param(
+        state: &Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell,
+    ) -> bool {
+        state.validate_world(world.id());
+        // SAFETY:
+        // - We have read-only access to the components accessed by query.
+        // - The world has been validated.
+        !unsafe {
+            state.is_empty_unsafe_world_cell(world, system_meta.last_run, world.change_tick())
+        }
+    }
+}
+
+// SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
+unsafe impl<'w, 's, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOnlySystemParam
+    for QueryNonEmpty<'w, 's, D, F>
 {
 }
 

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -5,8 +5,9 @@
 //! - [`Res<R>`], [`ResMut<R>`] - If resource doesn't exist.
 //! - [`QuerySingle<D, F>`] - If there is no or more than one entities matching.
 //! - [`Option<QuerySingle<D, F>>`] - If there are more than one entities matching.
+//! - [`QueryNonEmpty<D, F>`] - If there are no matching entities matching.
 
-use bevy::prelude::*;
+use bevy::{ecs::system::QueryNonEmpty, prelude::*};
 use rand::Rng;
 
 fn main() {
@@ -105,9 +106,9 @@ fn user_input(
 }
 
 // System that moves the enemies in a circle.
-// TODO: Use [`NonEmptyQuery`] when it exists.
-fn move_targets(mut enemies: Query<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
-    for (mut transform, mut target) in &mut enemies {
+// Only runs if there are enemies.
+fn move_targets(mut enemies: QueryNonEmpty<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
+    for (mut transform, mut target) in &mut *enemies {
         target.rotation += target.rotation_speed * time.delta_seconds();
         transform.rotation = Quat::from_rotation_z(target.rotation);
         let offset = transform.right() * target.radius;

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -2,12 +2,12 @@
 //! from running if their acquiry conditions aren't met.
 //!
 //! Fallible parameters include:
-//! - [`Res<R>`], [`ResMut<R>`] - If resource doesn't exist.
-//! - [`Single<D, F>`] - If there is no or more than one entities matching.
-//! - [`Option<Single<D, F>>`] - If there are more than one entities matching.
-//! - [`QueryNonEmpty<D, F>`] - If there are no matching entities matching.
+//! - [`Res<R>`], [`ResMut<R>`] - Resource has to exist.
+//! - [`Single<D, F>`] - There must be exactly one matching entity.
+//! - [`Option<Single<D, F>>`] - There must be zero or one matching entity.
+//! - [`Populated<D, F>`] - There must be at least one matching entity.
 
-use bevy::{ecs::system::QueryNonEmpty, prelude::*};
+use bevy::prelude::*;
 use rand::Rng;
 
 fn main() {
@@ -107,7 +107,7 @@ fn user_input(
 
 // System that moves the enemies in a circle.
 // Only runs if there are enemies.
-fn move_targets(mut enemies: QueryNonEmpty<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
+fn move_targets(mut enemies: Populated<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
     for (mut transform, mut target) in &mut *enemies {
         target.rotation += target.rotation_speed * time.delta_seconds();
         transform.rotation = Quat::from_rotation_z(target.rotation);


### PR DESCRIPTION
# Objective

Add a `Populated` system parameter that acts like `Query`, but prevents system from running if there are no matching entities.

Fixes: #15302

## Solution

Implement the system param which newtypes the `Query`.
The only change is new validation, which fails if query is empty.

The new system param is used in `fallible_params` example.

## Testing

Ran `fallible_params` example.
