### PR TITLE
Use `try_insert` in `on_remove_cursor_icon`

### DIFF
--- a/crates/bevy_render/src/view/window/cursor.rs
+++ b/crates/bevy_render/src/view/window/cursor.rs
@@ -166,9 +166,10 @@ pub fn update_cursors(
 
 /// Resets the cursor to the default icon when `CursorIcon` is removed.
 pub fn on_remove_cursor_icon(trigger: Trigger<OnRemove, CursorIcon>, mut commands: Commands) {
+    // Use `try_insert` to avoid panic if the window is being destroyed.
     commands
         .entity(trigger.entity())
-        .insert(PendingCursor(Some(CursorSource::System(
+        .try_insert(PendingCursor(Some(CursorSource::System(
             convert_system_cursor_icon(SystemCursorIcon::Default),
         ))));
 }


### PR DESCRIPTION
# Objective

- Fixes #15490 introduced in #15094.

## Solution

- Use non-panicking `try_insert`

## Testing

- Closing window with `CursorIcon` no longer crashes after this change (confirmed with `window_settings` example)
