### PR TITLE
bump async-channel to 2.3.0

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -100,7 +100,7 @@ encase = { version = "0.10", features = ["glam"] }
 profiling = { version = "1", features = [
   "profile-with-tracing",
 ], optional = true }
-async-channel = "2.2.0"
+async-channel = "2.3.0"
 nonmax = "0.5"
 smallvec = { version = "1.11", features = ["const_new"] }
 offset-allocator = "0.2"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -14,7 +14,7 @@ multi_threaded = ["dep:async-channel", "dep:concurrent-queue"]
 [dependencies]
 futures-lite = "2.0.1"
 async-executor = "1.11"
-async-channel = { version = "2.2.0", optional = true }
+async-channel = { version = "2.3.0", optional = true }
 async-io = { version = "2.0.0", optional = true }
 concurrent-queue = { version = "2.0.0", optional = true }
 


### PR DESCRIPTION
# Objective

- We use a feature introduced in async-channel 2.3.0, `force_send`
- Existing project fail to compile as they have a lock file on the 2.2.X

## Solution

- Bump async-channel
