### PR TITLE
Fix `ReflectKind` description wording

### DIFF
--- a/crates/bevy_reflect/src/kind.rs
+++ b/crates/bevy_reflect/src/kind.rs
@@ -1,7 +1,8 @@
+use thiserror::Error;
+
 #[cfg(feature = "functions")]
 use crate::func::Function;
 use crate::{Array, Enum, List, Map, PartialReflect, Set, Struct, Tuple, TupleStruct};
-use thiserror::Error;
 
 /// A zero-sized enumeration of the "kinds" of a reflected type.
 ///
@@ -272,8 +273,9 @@ impl ReflectOwned {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashSet;
+
+    use super::*;
 
     #[test]
     fn should_cast_ref() {

--- a/crates/bevy_reflect/src/kind.rs
+++ b/crates/bevy_reflect/src/kind.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use crate::func::Function;
 use crate::{Array, Enum, List, Map, PartialReflect, Set, Struct, Tuple, TupleStruct};
 
-/// A zero-sized enumeration of the "kinds" of a reflected type.
+/// An enumeration of the "kinds" of a reflected type.
 ///
 /// Each kind corresponds to a specific reflection trait,
 /// such as [`Struct`] or [`List`],


### PR DESCRIPTION
# Objective

The "zero-sized" description was outdated and misleading.

## Solution

Changed the description to just say that it's an enumeration (an enum)