### PR TITLE
Fix app exit delay

### DIFF
--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -54,6 +54,5 @@ pub fn close_when_requested(
         // we may receive a `WindowCloseRequested` for a window we've just despawned in the above
         // loop.
         commands.entity(event.window).try_insert(ClosingWindow);
-        bevy_utils::tracing::info!("Marked window for closing!");
     }
 }

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -2,6 +2,7 @@ use crate::{ClosingWindow, PrimaryWindow, Window, WindowCloseRequested};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
+use bevy_utils::tracing::info;
 
 /// Exit the application when there are no open windows.
 ///
@@ -12,7 +13,7 @@ use bevy_ecs::prelude::*;
 /// [`WindowPlugin`]: crate::WindowPlugin
 pub fn exit_on_all_closed(mut app_exit_events: EventWriter<AppExit>, windows: Query<&Window>) {
     if windows.is_empty() {
-        bevy_utils::tracing::info!("No windows are open, exiting");
+        info!("No windows are open, exiting");
         app_exit_events.send(AppExit::Success);
     }
 }
@@ -54,5 +55,6 @@ pub fn close_when_requested(
         // we may receive a `WindowCloseRequested` for a window we've just despawned in the above
         // loop.
         commands.entity(event.window).try_insert(ClosingWindow);
+        info!("Marked window for closing!");
     }
 }

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -2,7 +2,6 @@ use crate::{ClosingWindow, PrimaryWindow, Window, WindowCloseRequested};
 
 use bevy_app::AppExit;
 use bevy_ecs::prelude::*;
-use bevy_utils::tracing::info;
 
 /// Exit the application when there are no open windows.
 ///
@@ -13,7 +12,7 @@ use bevy_utils::tracing::info;
 /// [`WindowPlugin`]: crate::WindowPlugin
 pub fn exit_on_all_closed(mut app_exit_events: EventWriter<AppExit>, windows: Query<&Window>) {
     if windows.is_empty() {
-        info!("No windows are open, exiting");
+        bevy_utils::tracing::info!("No windows are open, exiting");
         app_exit_events.send(AppExit::Success);
     }
 }
@@ -55,6 +54,6 @@ pub fn close_when_requested(
         // we may receive a `WindowCloseRequested` for a window we've just despawned in the above
         // loop.
         commands.entity(event.window).try_insert(ClosingWindow);
-        info!("Marked window for closing!");
+        bevy_utils::tracing::info!("Marked window for closing!");
     }
 }

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -556,14 +556,16 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 self.redraw_requested = true;
             }
 
+            let is_closing = {
+                let mut closing = self.world_mut().query_filtered::<(), With<ClosingWindow>>();
+                !closing.iter(self.world()).collect::<Vec<_>>().is_empty()
+            };
+
             // Running the app may have changed the WinitSettings resource, so we have to re-extract it.
             let (config, windows) = focused_windows_state.get(self.world());
             let focused = windows.iter().any(|(_, window)| window.focused);
 
-            let mut closing: SystemState<Query<(), With<ClosingWindow>>> =
-                SystemState::new(self.world_mut());
-
-            if !closing.get(self.world()).is_empty() {
+            if is_closing {
                 update_mode = UpdateMode::Continuous;
             } else {
                 update_mode = config.update_mode(focused);

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -632,6 +632,7 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
         if let Some(app_exit) = self.app.should_exit() {
             self.app_exit = Some(app_exit);
 
+            bevy_utils::tracing::info!("Exit event loop");
             event_loop.exit();
         }
     }

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -561,15 +561,14 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 self.redraw_requested = true;
             }
 
-            // Look for closing windows.
-            let is_closing = {
+            // Looks for closing windows.
+            let is_window_closing = {
                 let mut closing = self.world_mut().query_filtered::<(), With<ClosingWindow>>();
-                !closing.iter(self.world()).collect::<Vec<_>>().is_empty()
+                closing.iter(self.world()).next().is_some()
             };
 
-            // If there are closing windows, we force the app to update immediately so the app does
-            // not take too long to close.
-            if is_closing {
+            // If there are closing windows, ignore `UpdateMode::Reactive` to make the window close immediately.
+            if is_window_closing {
                 update_mode = UpdateMode::Continuous;
             } else {
                 // Running the app may have changed the WinitSettings resource, so we have to re-extract it.


### PR DESCRIPTION
# Objective

- Fixes #15513

## Solution

-  Look for windows marked with `ClosingWindow` after running app systems, and force update mode to be `UpdateMode::Continuous` if there are closing windows.