### PR TITLE
Make `entity` mutable to fix compilation error

### DIFF
--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -743,7 +743,7 @@ mod menu {
                                     button_text_style.clone(),
                                 ));
                                 for volume_setting in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] {
-                                    let entity = parent.spawn((
+                                    let mut entity = parent.spawn((
                                         ButtonBundle {
                                             style: Style {
                                                 width: Val::Px(30.0),


### PR DESCRIPTION
# Objective
- Fixes compilation error `E0596` that occurs because the entity is not mutable in the settings menu system.

## Solution
- Make `entity` mutable

## Testing
- Verified that the menu system example compiles and runs successfully.