### PR TITLE
Add `no_std` support to `bevy_mikktspace`

### DIFF
--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -15,8 +15,15 @@ license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 rust-version = "1.76.0"
 
+[features]
+default = ["std"]
+
+std = ["glam/std"]
+libm = ["glam/libm", "dep:libm"]
+
 [dependencies]
-glam = "0.29"
+glam = { version = "0.29.0", default-features = false }
+libm = { version = "0.2", default-features = false, optional = true }
 
 [[example]]
 name = "generate"

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -45,6 +45,7 @@
     unsafe_code
 )]
 
+use alloc::{vec, vec::Vec};
 use core::ptr::{self, null_mut};
 
 use glam::Vec3;
@@ -211,7 +212,7 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
     let mut index = 0;
     let iNrFaces = geometry.num_faces();
     let mut bRes: bool = false;
-    let fThresCos = fAngularThreshold.to_radians().cos();
+    let fThresCos = cos(fAngularThreshold.to_radians());
     f = 0;
     while f < iNrFaces {
         let verts = geometry.num_vertices_of_face(f);
@@ -630,7 +631,7 @@ unsafe fn VNotZero(v: Vec3) -> bool {
 }
 
 unsafe fn NotZero(fX: f32) -> bool {
-    fX.abs() > 1.17549435e-38f32
+    abs(fX) > 1.17549435e-38f32
 }
 
 unsafe fn EvalTspace<I: Geometry>(
@@ -724,7 +725,7 @@ unsafe fn EvalTspace<I: Geometry>(
             } else {
                 fCos
             };
-            fAngle = (fCos as f64).acos() as f32;
+            fAngle = acosf64(fCos as f64) as f32;
             fMagS = (*pTriInfos.offset(f as isize)).fMagS;
             fMagT = (*pTriInfos.offset(f as isize)).fMagT;
             res.vOs = res.vOs + (fAngle * vOs);
@@ -1010,7 +1011,7 @@ unsafe fn InitTriInfo<I: Geometry>(
             0i32
         };
         if NotZero(fSignedAreaSTx2) {
-            let fAbsArea: f32 = fSignedAreaSTx2.abs();
+            let fAbsArea: f32 = abs(fSignedAreaSTx2);
             let fLenOs: f32 = vOs.length();
             let fLenOt: f32 = vOt.length();
             let fS: f32 = if (*pTriInfos.offset(f as isize)).iFlag & 8i32 == 0i32 {
@@ -1807,4 +1808,64 @@ unsafe fn GenerateInitialVerticesIndexList<I: Geometry>(
         t += 1
     }
     return iTSpacesOffs;
+}
+
+fn cos(value: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        value.cos()
+    }
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    {
+        libm::cosf(value)
+    }
+    #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+    {
+        compile_error!("Require either 'libm' or 'std' for `cos`")
+    }
+}
+
+fn acos(value: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        value.acos()
+    }
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    {
+        libm::acosf(value)
+    }
+    #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+    {
+        compile_error!("Require either 'libm' or 'std' for `acos`")
+    }
+}
+
+fn abs(value: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        value.abs()
+    }
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    {
+        libm::fabsf(value)
+    }
+    #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+    {
+        compile_error!("Require either 'libm' or 'std' for `abs`")
+    }
+}
+
+fn acosf64(value: f64) -> f64 {
+    #[cfg(feature = "std")]
+    {
+        value.acos()
+    }
+    #[cfg(all(not(feature = "std"), feature = "libm"))]
+    {
+        libm::acos(value)
+    }
+    #[cfg(all(not(feature = "std"), not(feature = "libm")))]
+    {
+        compile_error!("Require either 'libm' or 'std' for `acos`")
+    }
 }

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -11,6 +11,9 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 use glam::{Vec2, Vec3};
 


### PR DESCRIPTION
# Objective

- Contributes to #15460
- Allows `bevy_mikktspace` to be used in `no_std` contexts.

## Solution

- Added `std` (default) and `libm` features which control the inclusion of the standard library. To use `bevy_mikktspace` in `no_std` environments, enable the `libm` feature.

## Testing

- CI
- `cargo clippy -p bevy_mikktspace --target "x86_64-unknown-none" --no-default-features --features libm`
