### PR TITLE
Impose a more sensible ordering for animation graph evaluation.

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -41,6 +41,7 @@ blake3 = { version = "1.0" }
 thiserror = "1"
 thread_local = "1"
 uuid = { version = "1.7", features = ["v4"] }
+smallvec = "1"
 
 [lints]
 workspace = true

--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -206,14 +206,12 @@ pub(crate) trait GetKeyframe {
 /// This is factored out so that it can be shared between implementations of
 /// [`crate::keyframes::Keyframes`].
 pub(crate) fn interpolate_keyframes<T>(
-    dest: &mut T,
     keyframes: &(impl GetKeyframe<Output = T> + ?Sized),
     interpolation: Interpolation,
     step_start: usize,
     time: f32,
-    weight: f32,
     duration: f32,
-) -> Result<(), AnimationEvaluationError>
+) -> Result<T, AnimationEvaluationError>
 where
     T: Animatable + Clone,
 {
@@ -265,9 +263,7 @@ where
         }
     };
 
-    *dest = T::interpolate(dest, &value, weight);
-
-    Ok(())
+    Ok(value)
 }
 
 /// Evaluates a cubic Bézier curve at a value `t`, given two endpoints and the

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -1,14 +1,25 @@
 //! The animation graph, which allows animations to be blended together.
 
-use core::ops::{Index, IndexMut};
+use core::iter;
+use core::ops::{Index, IndexMut, Range};
 use std::io::{self, Write};
 
-use bevy_asset::{io::Reader, Asset, AssetId, AssetLoader, AssetPath, Handle, LoadContext};
+use bevy_asset::{
+    io::Reader, Asset, AssetEvent, AssetId, AssetLoader, AssetPath, Assets, Handle, LoadContext,
+};
+use bevy_ecs::{
+    event::EventReader,
+    system::{Res, ResMut, Resource},
+};
 use bevy_reflect::{Reflect, ReflectSerialize};
 use bevy_utils::HashMap;
-use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::{
+    graph::{DiGraph, NodeIndex},
+    Direction,
+};
 use ron::de::SpannedError;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use thiserror::Error;
 
 use crate::{AnimationClip, AnimationTargetId};
@@ -170,6 +181,96 @@ pub enum AnimationGraphLoadError {
     /// is supplied.
     #[error("RON serialization")]
     SpannedRon(#[from] SpannedError),
+}
+
+/// Acceleration structures for animation graphs that allows Bevy to evaluate
+/// them quickly.
+///
+/// These are kept up to date as [`AnimationGraph`] instances are added,
+/// modified, and removed.
+#[derive(Default, Reflect, Resource)]
+pub struct ThreadedAnimationGraphs(
+    pub(crate) HashMap<AssetId<AnimationGraph>, ThreadedAnimationGraph>,
+);
+
+/// An acceleration structure for an animation graph that allows Bevy to
+/// evaluate it quickly.
+///
+/// This is kept up to date as the associated [`AnimationGraph`] instance is
+/// added, modified, or removed.
+#[derive(Default, Reflect)]
+pub(crate) struct ThreadedAnimationGraph {
+    /// A cached postorder traversal of the graph.
+    ///
+    /// The node indices here are stored in postorder. Siblings are stored in
+    /// descending order. This is because the [`KeyframeEvaluator`] uses a stack
+    /// for evaluation. Consider this graph:
+    ///
+    ///                 ┌─────┐
+    ///                 │     │
+    ///                 │  1  │
+    ///                 │     │
+    ///                 └──┬──┘
+    ///                    │
+    ///            ┌───────┼───────┐
+    ///            │       │       │
+    ///            ▼       ▼       ▼
+    ///         ┌─────┐ ┌─────┐ ┌─────┐
+    ///         │     │ │     │ │     │
+    ///         │  2  │ │  3  │ │  4  │
+    ///         │     │ │     │ │     │
+    ///         └──┬──┘ └─────┘ └─────┘
+    ///            │
+    ///        ┌───┴───┐
+    ///        │       │
+    ///        ▼       ▼
+    ///     ┌─────┐ ┌─────┐
+    ///     │     │ │     │
+    ///     │  5  │ │  6  │
+    ///     │     │ │     │
+    ///     └─────┘ └─────┘
+    ///
+    /// The postorder traversal in this case will be (4, 3, 6, 5, 2, 1).
+    ///
+    /// The fact that the children of each node are sorted in reverse ensures
+    /// that, at each level, the order of blending proceeds in ascending order
+    /// by node index, as we guarantee. To illustrate this, consider the way
+    /// the graph above is evaluated. (Interpolation is represented with the ⊕
+    /// symbol.)
+    ///
+    /// | Step | Node | Operation  | Stack (after operation) | Blend Register |
+    /// | ---- | -----| ---------- | ----------------------- | -------------- |
+    /// | 1    | 4    | Push       | 4                       |                |
+    /// | 2    | 3    | Push       | 4 3                     |                |
+    /// | 3    | 6    | Push       | 4 3 6                   |                |
+    /// | 4    | 5    | Push       | 4 3 6 5                 |                |
+    /// | 5    | 2    | Blend 5    | 4 3 6                   | 5              |
+    /// | 6    | 2    | Blend 6    | 4 3                     | 5 ⊕ 6          |
+    /// | 7    | 2    | Push Blend | 4 3 2                   |                |
+    /// | 8    | 1    | Blend 2    | 4 3                     | 2              |
+    /// | 9    | 1    | Blend 3    | 4                       | 2 ⊕ 3          |
+    /// | 10   | 1    | Blend 4    |                         | 2 ⊕ 3 ⊕ 4      |
+    /// | 11   | 1    | Push Blend | 1                       |                |
+    /// | 12   |      | Commit     |                         |                |
+    pub(crate) threaded_graph: Vec<AnimationNodeIndex>,
+
+    /// A mapping from each parent node index to the range within
+    /// [`Self::sorted_edges`].
+    ///
+    /// This allows for quick lookup of the children of each node, sorted in
+    /// ascending order of node index, without having to sort the result of the
+    /// `petgraph` traversal functions every frame.
+    pub(crate) sorted_edge_ranges: Vec<Range<u32>>,
+
+    /// A list of the children of each node, sorted in ascending order.
+    pub(crate) sorted_edges: Vec<AnimationNodeIndex>,
+
+    /// A mapping from node index to a bitfield specifying the mask groups that
+    /// this node masks *out* (i.e. doesn't animate).
+    ///
+    /// A 1 in bit position N indicates that this node doesn't animate any
+    /// targets of mask group N.
+    pub(crate) computed_masks: Vec<u64>,
 }
 
 /// A version of [`AnimationGraph`] suitable for serializing as an asset.
@@ -569,5 +670,114 @@ impl From<AnimationGraph> for SerializedAnimationGraph {
             root: animation_graph.root,
             mask_groups: animation_graph.mask_groups,
         }
+    }
+}
+
+/// A system that creates, updates, and removes [`ThreadedAnimationGraph`]
+/// structures for every changed [`AnimationGraph`].
+///
+/// The [`ThreadedAnimationGraph`] contains acceleration structures that allow
+/// for quick evaluation of that graph's animations.
+pub(crate) fn thread_animation_graphs(
+    mut threaded_animation_graphs: ResMut<ThreadedAnimationGraphs>,
+    animation_graphs: Res<Assets<AnimationGraph>>,
+    mut animation_graph_asset_events: EventReader<AssetEvent<AnimationGraph>>,
+) {
+    for animation_graph_asset_event in animation_graph_asset_events.read() {
+        match *animation_graph_asset_event {
+            AssetEvent::Added { id }
+            | AssetEvent::Modified { id }
+            | AssetEvent::LoadedWithDependencies { id } => {
+                // Fetch the animation graph.
+                let Some(animation_graph) = animation_graphs.get(id) else {
+                    continue;
+                };
+
+                // Reuse the allocation if possible.
+                let mut threaded_animation_graph =
+                    threaded_animation_graphs.0.remove(&id).unwrap_or_default();
+                threaded_animation_graph.clear();
+
+                // Recursively thread the graph in postorder.
+                threaded_animation_graph.init(animation_graph);
+                threaded_animation_graph.build_from(
+                    &animation_graph.graph,
+                    animation_graph.root,
+                    0,
+                );
+
+                // Write in the threaded graph.
+                threaded_animation_graphs
+                    .0
+                    .insert(id, threaded_animation_graph);
+            }
+
+            AssetEvent::Removed { id } => {
+                threaded_animation_graphs.0.remove(&id);
+            }
+            AssetEvent::Unused { .. } => {}
+        }
+    }
+}
+
+impl ThreadedAnimationGraph {
+    /// Removes all the data in this [`ThreadedAnimationGraph`], keeping the
+    /// memory around for later reuse.
+    fn clear(&mut self) {
+        self.threaded_graph.clear();
+        self.sorted_edge_ranges.clear();
+        self.sorted_edges.clear();
+    }
+
+    /// Prepares the [`ThreadedAnimationGraph`] for recursion.
+    fn init(&mut self, animation_graph: &AnimationGraph) {
+        let node_count = animation_graph.graph.node_count();
+        let edge_count = animation_graph.graph.edge_count();
+
+        self.threaded_graph.reserve(node_count);
+        self.sorted_edges.reserve(edge_count);
+
+        self.sorted_edge_ranges.clear();
+        self.sorted_edge_ranges
+            .extend(iter::repeat(0..0).take(node_count));
+
+        self.computed_masks.clear();
+        self.computed_masks.extend(iter::repeat(0).take(node_count));
+    }
+
+    /// Recursively constructs the [`ThreadedAnimationGraph`] for the subtree
+    /// rooted at the given node.
+    ///
+    /// `mask` specifies the computed mask of the parent node. (It could be
+    /// fetched from the [`Self::computed_masks`] field, but we pass it
+    /// explicitly as a micro-optimization.)
+    fn build_from(
+        &mut self,
+        graph: &AnimationDiGraph,
+        node_index: AnimationNodeIndex,
+        mut mask: u64,
+    ) {
+        // Accumulate the mask.
+        mask |= graph.node_weight(node_index).unwrap().mask;
+        self.computed_masks.insert(node_index.index(), mask);
+
+        // Gather up the indices of our children, and sort them.
+        let mut kids: SmallVec<[AnimationNodeIndex; 8]> = graph
+            .neighbors_directed(node_index, Direction::Outgoing)
+            .collect();
+        kids.sort_unstable();
+
+        // Write in the list of kids.
+        self.sorted_edge_ranges[node_index.index()] =
+            (self.sorted_edges.len() as u32)..((self.sorted_edges.len() + kids.len()) as u32);
+        self.sorted_edges.extend_from_slice(&kids);
+
+        // Recurse. (This is a postorder traversal.)
+        for kid in kids.into_iter().rev() {
+            self.build_from(graph, kid, mask);
+        }
+
+        // Finally, push our index.
+        self.threaded_graph.push(node_index);
     }
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -313,7 +313,8 @@ async fn load_gltf<'a, 'b, 'c>(
                         ReadOutputs::MorphTargetWeights(weights) => {
                             let weights: Vec<_> = weights.into_f32().collect();
                             Box::new(MorphWeightsKeyframes {
-                                morph_target_count: weights.len() / keyframe_timestamps.len(),
+                                morph_target_count: (weights.len() / keyframe_timestamps.len())
+                                    as u32,
                                 weights,
                             }) as Box<dyn Keyframes>
                         }

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -47,24 +47,24 @@ static NODE_RECTS: [NodeRect; 5] = [
     NodeRect::new(10.00, 10.00, 97.64, 48.41),
     NodeRect::new(10.00, 78.41, 97.64, 48.41),
     NodeRect::new(286.08, 78.41, 97.64, 48.41),
-    NodeRect::new(148.04, 44.20, 97.64, 48.41),
+    NodeRect::new(148.04, 112.61, 97.64, 48.41), // was 44.20
     NodeRect::new(10.00, 146.82, 97.64, 48.41),
 ];
 
 /// The positions of the horizontal lines in the UI.
 static HORIZONTAL_LINES: [Line; 6] = [
-    Line::new(107.64, 34.21, 20.20),
+    Line::new(107.64, 34.21, 158.24),
     Line::new(107.64, 102.61, 20.20),
-    Line::new(107.64, 171.02, 158.24),
-    Line::new(127.84, 68.41, 20.20),
-    Line::new(245.68, 68.41, 20.20),
+    Line::new(107.64, 171.02, 20.20),
+    Line::new(127.84, 136.82, 20.20),
+    Line::new(245.68, 136.82, 20.20),
     Line::new(265.88, 102.61, 20.20),
 ];
 
 /// The positions of the vertical lines in the UI.
 static VERTICAL_LINES: [Line; 2] = [
-    Line::new(127.83, 34.21, 68.40),
-    Line::new(265.88, 68.41, 102.61),
+    Line::new(127.83, 102.61, 68.40),
+    Line::new(265.88, 34.21, 102.61),
 ];
 
 /// Initializes the app.


### PR DESCRIPTION
This commit changes the animation graph evaluation to be operate in a more sensible order and updates the semantics of blend nodes to conform to [the animation composition RFC]. Prior to this patch, a node graph like this:

                ┌─────┐
                │     │
                │  1  │
                │     │
                └──┬──┘
                   │
           ┌───────┴───────┐
           │               │
           ▼               ▼
        ┌─────┐         ┌─────┐
        │     │         │     │
        │  2  │         │  3  │
        │     │         │     │
        └──┬──┘         └──┬──┘
           │               │
       ┌───┴───┐       ┌───┴───┐
       │       │       │       │
       ▼       ▼       ▼       ▼
    ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐
    │     │ │     │ │     │ │     │
    │  4  │ │  6  │ │  5  │ │  7  │
    │     │ │     │ │     │ │     │
    └─────┘ └─────┘ └─────┘ └─────┘

Would be evaluated as (((4 ⊕ 5) ⊕ 6) ⊕ 7), with the blend (lerp/slerp) operation notated as ⊕. As quaternion multiplication isn't commutative, this is very counterintuitive and will especially lead to trouble with the forthcoming additive blending feature (#15198).

This patch fixes the issue by changing the evaluation order to postorder, with children of a node evaluated in ascending order by node index. It also makes blend nodes normalize the weights of their children, as suggested by [the animation composition RFC].

To do so, this patch revamps `Keyframes` to be based on an *evaluation stack* and a *blend register*. During target evaluation, the graph evaluator traverses the graph in postorder. When encountering a clip node, the evaluator pushes the possibly-interpolated value onto the evaluation stack. When encountering a blend node, the evaluator pops values off the stack into the blend register, accumulating weights as appropriate. When the graph is completely evaluated, the top element on the stack is *committed* to the property of the component.

A new system, the *graph threading* system, is added in order to cache the sorted postorder traversal to avoid the overhead of sorting children at animation evaluation time. Mask evaluation has been moved to this system so that the graph only has to be traversed at most once per frame. Unlike the `ActiveAnimation` list, the *threaded graph* is cached from frame to frame and only has to be regenerated when the animation graph asset changes.

This patch currently regresses the `animate_target` performance in `many_foxes` by around 35%, resulting in an FPS loss of about 2-3 FPS. I'd argue that this is an acceptable price to pay for a much more intuitive system. In the future, we can mitigate the regression with a fast path that avoids consulting the graph if only one animation is playing. However, in the interest of keeping this patch simple, I didn't do so here.

Note that this PR should land on top of #15434, which has been waiting for a while and would heavily conflict with this patch. Consequently I'm marking it as a draft.

## Migration guide

* Animation graph blend nodes now implicitly normalize their children's weights to sum to 1. You may need to change your graphs appropriately.
* Animation graph nodes are now evaluated in postorder, with children evaluated in ascending order of node index. You may need to change your graphs appropriately.

[the animation composition RFC]: https://github.com/bevyengine/rfcs/blob/main/rfcs/51-animation-composition.md