### PR TITLE
bevy_reflect: Add casting traits to support `Box` and other wrapper types

### DIFF
--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -148,7 +148,7 @@ impl ReflectAsset {
     }
 }
 
-impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
+impl<A: Asset + FromReflect + Reflect> FromType<A> for ReflectAsset {
     fn from_type() -> Self {
         ReflectAsset {
             handle_type_id: TypeId::of::<Handle<A>>(),

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -57,7 +57,7 @@ impl ReflectBundleFns {
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
-    pub fn new<T: Bundle + FromReflect + TypePath + BundleFromComponents>() -> Self {
+    pub fn new<T: Bundle + FromReflect + Reflect + TypePath + BundleFromComponents>() -> Self {
         <ReflectBundle as FromType<T>>::from_type().0
     }
 }

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -140,7 +140,7 @@ impl ReflectComponentFns {
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
-    pub fn new<T: Component + FromReflect + TypePath>() -> Self {
+    pub fn new<T: Component + FromReflect + Reflect + TypePath>() -> Self {
         <ReflectComponent as FromType<T>>::from_type().0
     }
 }

--- a/crates/bevy_ecs/src/reflect/event.rs
+++ b/crates/bevy_ecs/src/reflect/event.rs
@@ -45,7 +45,7 @@ impl ReflectEventFns {
     ///
     /// This is useful if you want to start with the default implementation
     /// before overriding some of the functions to create a custom implementation.
-    pub fn new<'a, T: Event + FromReflect + TypePath>() -> Self
+    pub fn new<'a, T: Event + FromReflect + Reflect + TypePath>() -> Self
     where
         T::Trigger<'a>: Default,
     {

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -1,5 +1,5 @@
 use crate::entity::{EntityMapper, MapEntities};
-use bevy_reflect::{FromReflect, FromType, PartialReflect};
+use bevy_reflect::{FromReflect, FromType, PartialReflect, Reflect};
 
 /// For a specific type of value, this maps any fields with values of type [`Entity`] to a new world.
 ///
@@ -25,7 +25,7 @@ impl ReflectMapEntities {
     }
 }
 
-impl<C: FromReflect + MapEntities> FromType<C> for ReflectMapEntities {
+impl<C: FromReflect + Reflect + MapEntities> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
             map_entities: |reflected, mut mapper| {

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -78,7 +78,7 @@ impl ReflectResourceFns {
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
-    pub fn new<T: Resource + FromReflect + TypePath>() -> Self {
+    pub fn new<T: Resource + FromReflect + Reflect + TypePath>() -> Self {
         <ReflectResource as FromType<T>>::from_type().0
     }
 }
@@ -206,7 +206,7 @@ impl ReflectResource {
     }
 }
 
-impl<R: Resource + FromReflect + TypePath> FromType<R> for ReflectResource {
+impl<R: Resource + FromReflect + Reflect + TypePath> FromType<R> for ReflectResource {
     fn from_type() -> Self {
         ReflectResource(ReflectResourceFns {
             insert: |world, reflected_resource, registry| {

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.rs
@@ -17,6 +17,7 @@ fn main() {
     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
     //~^ ERROR: `NoReflect` does not implement `GetTypeRegistration` so cannot provide type registration information
     //~| ERROR: `NoReflect` does not implement `Typed` so cannot provide static type information
+    //~| ERROR: `NoReflect` does not implement `CastPartialReflect` so cannot be cast to `dyn PartialReflect`
 
     // foo doesn't implement Reflect because NoReflect doesn't implement Reflect
     foo.get_field::<NoReflect>("a").unwrap();

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.rs
@@ -19,16 +19,13 @@ mod missing_attribute {
 }
 
 mod incorrect_inner_type {
-    use bevy_reflect::{FromReflect, GetTypeRegistration, reflect_remote};
+    use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, reflect_remote};
 
     #[reflect_remote(super::external_crate::TheirOuter<T>)]
-    //~^ ERROR: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
-    //~| ERROR: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
-    //~| ERROR: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
-    //~| ERROR: `TheirInner<T>` does not implement `TypePath` so cannot provide dynamic type path information
+    //~^ ERROR: `TheirInner<T>` does not implement `CastPartialReflect` so cannot be cast to `dyn PartialReflect`
     //~| ERROR: `?` operator has incompatible types
     //~| ERROR: mismatched types
-    struct MyOuter<T: FromReflect + GetTypeRegistration> {
+    struct MyOuter<T: FromReflect + Reflect + GetTypeRegistration> {
         // Reason: Should not use `MyInner<T>` directly
         pub inner: MyInner<T>,
         //~^ ERROR: mismatched types

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_pass.rs
@@ -9,7 +9,7 @@ mod external_crate {
 }
 
 #[reflect_remote(external_crate::TheirOuter<T>)]
-struct MyOuter<T: FromReflect + Typed + GetTypeRegistration> {
+struct MyOuter<T: FromReflect + Reflect + Typed + GetTypeRegistration> {
     #[reflect(remote = MyInner<T>)]
     pub inner: external_crate::TheirInner<T>,
 }

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -711,7 +711,8 @@ impl<'a> ReflectStruct<'a> {
         for field in self.fields().iter() {
             let field_ty = field.reflected_type();
             let member = field.to_member();
-            let accessor = self.access_for_field(field, false);
+            let accessor = self.access_for_field(field, false, true);
+            let non_cast_accessor = self.access_for_field(field, false, false);
 
             match &field.attrs.clone {
                 CloneBehavior::Default => {
@@ -729,7 +730,17 @@ impl<'a> ReflectStruct<'a> {
                         }
                     } else {
                         quote! {
-                            <#field_ty as #bevy_reflect_path::PartialReflect>::reflect_clone_and_take(#accessor)?
+                            #FQResult::map_err(
+                                <dyn #bevy_reflect_path::Reflect>::take(
+                                    #bevy_reflect_path::PartialReflect::reflect_clone(#accessor)?
+                                ),
+                                |_| #bevy_reflect_path::ReflectCloneError::FailedDowncast {
+                                    expected: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Borrowed(<#field_ty as #bevy_reflect_path::TypePath>::type_path()),
+                                    received: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Owned(
+                                        #bevy_reflect_path::__macro_exports::alloc_utils::ToString::to_string(#bevy_reflect_path::DynamicTypePath::reflect_type_path(#accessor))
+                                    ),
+                                }
+                            )?
                         }
                     };
 
@@ -739,12 +750,28 @@ impl<'a> ReflectStruct<'a> {
                 }
                 CloneBehavior::Trait => {
                     tokens.extend(quote! {
-                        #member: #FQClone::clone(#accessor),
+                        #member: #FQClone::clone(#non_cast_accessor),
                     });
                 }
                 CloneBehavior::Func(clone_fn) => {
+                    let value = if field.attrs.ignore.is_ignored() {
+                        quote!(#clone_fn(#non_cast_accessor))
+                    } else {
+                        quote! {
+                            #clone_fn(#FQOption::ok_or_else(
+                                <dyn #bevy_reflect_path::PartialReflect>::try_downcast_ref(#accessor),
+                                || #bevy_reflect_path::ReflectCloneError::FailedDowncast {
+                                    expected: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Borrowed(<#field_ty as #bevy_reflect_path::TypePath>::type_path()),
+                                    received: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Owned(
+                                        #bevy_reflect_path::__macro_exports::alloc_utils::ToString::to_string(#bevy_reflect_path::DynamicTypePath::reflect_type_path(#accessor))
+                                    ),
+                                }
+                            )?)
+                        }
+                    };
+
                     tokens.extend(quote! {
-                        #member: #clone_fn(#accessor),
+                        #member: #value,
                     });
                 }
             }
@@ -779,21 +806,30 @@ impl<'a> ReflectStruct<'a> {
 
     /// Generates an accessor for the given field.
     ///
-    /// The mutability of the access can be controlled by the `is_mut` parameter.
+    /// The mutability of the access can be controlled by the `is_mutable` parameter.
     ///
     /// Generally, this just returns something like `&self.field`.
     /// However, if the struct is a remote wrapper, this then becomes `&self.0.field` in order to access the field on the inner type.
     ///
     /// If the field itself is a remote type, the above accessor is further wrapped in a call to `ReflectRemote::as_wrapper[_mut]`.
+    ///
+    /// If `is_castable` is true, the accessor is wrapped in a call to `CastPartialReflect::as_partial_reflect[_mut]` to handle reflection casting
+    /// when the field is not a remote type.
     pub fn access_for_field(
         &self,
         field: &StructField<'a>,
         is_mutable: bool,
+        is_castable: bool,
     ) -> proc_macro2::TokenStream {
         let bevy_reflect_path = self.meta().bevy_reflect_path();
         let member = field.to_member();
 
         let prefix_tokens = if is_mutable { quote!(&mut) } else { quote!(&) };
+        let cast_method = if is_mutable {
+            quote!(as_partial_reflect_mut)
+        } else {
+            quote!(as_partial_reflect)
+        };
 
         let accessor = if self.meta.is_remote_wrapper() {
             quote!(self.0.#member)
@@ -813,7 +849,13 @@ impl<'a> ReflectStruct<'a> {
                     <#wrapper_ty as #bevy_reflect_path::ReflectRemote>::#method(#prefix_tokens #accessor)
                 }
             }
-            None => quote!(#prefix_tokens #accessor),
+            None => {
+                if is_castable {
+                    quote!(#bevy_reflect_path::cast::CastPartialReflect::#cast_method(#prefix_tokens #accessor))
+                } else {
+                    quote!(#prefix_tokens #accessor)
+                }
+            }
         }
     }
 }

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -318,7 +318,7 @@ impl<'a> VariantBuilder for ReflectCloneVariantBuilder<'a> {
         let bevy_reflect_path = self.reflect_enum.meta().bevy_reflect_path();
         let field_ty = field.field.reflected_type();
         let alias = field.alias;
-        let alias = match &field.field.attrs.remote {
+        let non_cast_alias = match &field.field.attrs.remote {
             Some(wrapper_ty) => {
                 quote! {
                     <#wrapper_ty as #bevy_reflect_path::ReflectRemote>::as_wrapper(#alias)
@@ -326,21 +326,53 @@ impl<'a> VariantBuilder for ReflectCloneVariantBuilder<'a> {
             }
             None => alias.to_token_stream(),
         };
+        let alias = match &field.field.attrs.remote {
+            Some(wrapper_ty) => {
+                quote! {
+                    <#wrapper_ty as #bevy_reflect_path::ReflectRemote>::as_wrapper(#alias)
+                }
+            }
+            None => quote! {
+                #bevy_reflect_path::cast::CastPartialReflect::as_partial_reflect(#alias)
+            },
+        };
 
         match &field.field.attrs.clone {
             CloneBehavior::Default => {
                 quote! {
-                    <#field_ty as #bevy_reflect_path::PartialReflect>::reflect_clone_and_take(#alias)?
+                    #FQResult::map_err(
+                        <dyn #bevy_reflect_path::Reflect>::take(
+                            #bevy_reflect_path::PartialReflect::reflect_clone(#alias)?
+                        ),
+                        |_| #bevy_reflect_path::ReflectCloneError::FailedDowncast {
+                            expected: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Borrowed(<#field_ty as #bevy_reflect_path::TypePath>::type_path()),
+                            received: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Owned(
+                                #bevy_reflect_path::__macro_exports::alloc_utils::ToString::to_string(#bevy_reflect_path::DynamicTypePath::reflect_type_path(#alias))
+                            ),
+                        }
+                    )?
                 }
             }
             CloneBehavior::Trait => {
                 quote! {
-                    #FQClone::clone(#alias)
+                    #FQClone::clone(#non_cast_alias)
                 }
             }
             CloneBehavior::Func(clone_fn) => {
-                quote! {
-                    #clone_fn(#alias)
+                if field.field.attrs.ignore.is_ignored() {
+                    quote!(#clone_fn(#non_cast_alias))
+                } else {
+                    quote! {
+                        #clone_fn(#FQOption::ok_or_else(
+                            <dyn #bevy_reflect_path::PartialReflect>::try_downcast_ref(#alias),
+                            || #bevy_reflect_path::ReflectCloneError::FailedDowncast {
+                                expected: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Borrowed(<#field_ty as #bevy_reflect_path::TypePath>::type_path()),
+                                received: #bevy_reflect_path::__macro_exports::alloc_utils::Cow::Owned(
+                                    #bevy_reflect_path::__macro_exports::alloc_utils::ToString::to_string(#bevy_reflect_path::DynamicTypePath::reflect_type_path(#alias))
+                                ),
+                            }
+                        )?)
+                    }
                 }
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/casting.rs
+++ b/crates/bevy_reflect/derive/src/impls/casting.rs
@@ -15,28 +15,34 @@ pub(crate) fn impl_casting_traits(
 
     quote! {
         impl #impl_generics #bevy_reflect_path::cast::CastPartialReflect for #type_path #ty_generics #where_reflect_clause {
+            #[inline]
             fn as_partial_reflect(&self) -> &dyn #bevy_reflect_path::PartialReflect {
                 self
             }
 
+            #[inline]
             fn as_partial_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::PartialReflect {
                 self
             }
 
+            #[inline]
             fn into_partial_reflect(self: #bevy_reflect_path::__macro_exports::alloc_utils::Box<Self>) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::PartialReflect> {
                 self
             }
         }
 
         impl #impl_generics #bevy_reflect_path::cast::CastReflect for #type_path #ty_generics #where_reflect_clause {
+            #[inline]
             fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
                 self
             }
 
+            #[inline]
             fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
                 self
             }
 
+            #[inline]
             fn into_reflect(self: #bevy_reflect_path::__macro_exports::alloc_utils::Box<Self>) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::Reflect> {
                 self
             }

--- a/crates/bevy_reflect/derive/src/impls/casting.rs
+++ b/crates/bevy_reflect/derive/src/impls/casting.rs
@@ -1,0 +1,45 @@
+use crate::derive_data::ReflectMeta;
+use crate::where_clause_options::WhereClauseOptions;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Generates impls for the `CastPartialReflect` and `CastReflect` traits.
+pub(crate) fn impl_casting_traits(
+    meta: &ReflectMeta,
+    where_clause_options: &WhereClauseOptions,
+) -> TokenStream {
+    let bevy_reflect_path = meta.bevy_reflect_path();
+    let type_path = meta.type_path();
+    let (impl_generics, ty_generics, where_clause) = type_path.generics().split_for_impl();
+    let where_reflect_clause = where_clause_options.extend_where_clause(where_clause);
+
+    quote! {
+        impl #impl_generics #bevy_reflect_path::cast::CastPartialReflect for #type_path #ty_generics #where_reflect_clause {
+            fn as_partial_reflect(&self) -> &dyn #bevy_reflect_path::PartialReflect {
+                self
+            }
+
+            fn as_partial_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::PartialReflect {
+                self
+            }
+
+            fn into_partial_reflect(self: #bevy_reflect_path::__macro_exports::alloc_utils::Box<Self>) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::PartialReflect> {
+                self
+            }
+        }
+
+        impl #impl_generics #bevy_reflect_path::cast::CastReflect for #type_path #ty_generics #where_reflect_clause {
+            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
+                self
+            }
+
+            fn into_reflect(self: #bevy_reflect_path::__macro_exports::alloc_utils::Box<Self>) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::Reflect> {
+                self
+            }
+        }
+    }
+}

--- a/crates/bevy_reflect/derive/src/impls/common.rs
+++ b/crates/bevy_reflect/derive/src/impls/common.rs
@@ -56,21 +56,6 @@ pub fn impl_full_reflect(where_clause_options: &WhereClauseOptions) -> proc_macr
             #any_impls
 
             #[inline]
-            fn into_reflect(self: #bevy_reflect_path::__macro_exports::alloc_utils::Box<Self>) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::Reflect> {
-                self
-            }
-
-            #[inline]
-            fn as_reflect(&self) -> &dyn #bevy_reflect_path::Reflect {
-                self
-            }
-
-            #[inline]
-            fn as_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::Reflect {
-                self
-            }
-
-            #[inline]
             fn set(
                 &mut self,
                 value: #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::Reflect>
@@ -149,21 +134,6 @@ pub fn common_partial_reflect_methods(
         #[inline]
         fn try_as_reflect_mut(&mut self) -> #FQOption<&mut dyn #bevy_reflect_path::Reflect> {
             #FQOption::Some(self)
-        }
-
-        #[inline]
-        fn into_partial_reflect(self: #bevy_reflect_path::__macro_exports::alloc_utils::Box<Self>) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::PartialReflect> {
-            self
-        }
-
-        #[inline]
-        fn as_partial_reflect(&self) -> &dyn #bevy_reflect_path::PartialReflect {
-            self
-        }
-
-        #[inline]
-        fn as_partial_reflect_mut(&mut self) -> &mut dyn #bevy_reflect_path::PartialReflect {
-            self
         }
 
         #hash_fn

--- a/crates/bevy_reflect/derive/src/impls/common.rs
+++ b/crates/bevy_reflect/derive/src/impls/common.rs
@@ -2,6 +2,7 @@ use bevy_macro_utils::fq_std::{FQAny, FQOption, FQResult};
 
 use quote::quote;
 
+use crate::impls::casting::impl_casting_traits;
 use crate::{derive_data::ReflectMeta, where_clause_options::WhereClauseOptions};
 
 pub fn impl_full_reflect(where_clause_options: &WhereClauseOptions) -> proc_macro2::TokenStream {
@@ -48,6 +49,8 @@ pub fn impl_full_reflect(where_clause_options: &WhereClauseOptions) -> proc_macr
         }
     };
 
+    let casting_impls = impl_casting_traits(meta, where_clause_options);
+
     quote! {
         impl #impl_generics #bevy_reflect_path::Reflect for #type_path #ty_generics #where_reflect_clause {
             #any_impls
@@ -76,6 +79,8 @@ pub fn impl_full_reflect(where_clause_options: &WhereClauseOptions) -> proc_macr
                 #FQResult::Ok(())
             }
         }
+
+        #casting_impls
     }
 }
 

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -341,18 +341,25 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
             is_mutable: bool,
             bevy_reflect_path: &Path,
         ) -> proc_macro2::TokenStream {
-            let method = if is_mutable {
+            let remote_method = if is_mutable {
                 quote!(as_wrapper_mut)
             } else {
                 quote!(as_wrapper)
+            };
+            let cast_method = if is_mutable {
+                quote!(#bevy_reflect_path::cast::CastPartialReflect::as_partial_reflect_mut)
+            } else {
+                quote!(#bevy_reflect_path::cast::CastPartialReflect::as_partial_reflect)
             };
 
             field
                 .attrs
                 .remote
                 .as_ref()
-                .map(|ty| quote!(<#ty as #bevy_reflect_path::ReflectRemote>::#method(#ident)))
-                .unwrap_or_else(|| quote!(#ident))
+                .map(
+                    |ty| quote!(<#ty as #bevy_reflect_path::ReflectRemote>::#remote_method(#ident)),
+                )
+                .unwrap_or_else(|| quote!(#cast_method(#ident)))
         }
 
         match &variant.fields {

--- a/crates/bevy_reflect/derive/src/impls/mod.rs
+++ b/crates/bevy_reflect/derive/src/impls/mod.rs
@@ -1,4 +1,5 @@
 mod assertions;
+mod casting;
 mod common;
 mod enums;
 #[cfg(feature = "functions")]

--- a/crates/bevy_reflect/derive/src/struct_utility.rs
+++ b/crates/bevy_reflect/derive/src/struct_utility.rs
@@ -23,8 +23,8 @@ impl FieldAccessors {
             .active_fields()
             .map(|field| {
                 (
-                    reflect_struct.access_for_field(field, false),
-                    reflect_struct.access_for_field(field, true),
+                    reflect_struct.access_for_field(field, false, true),
+                    reflect_struct.access_for_field(field, true, true),
                 )
             })
             .unzip();

--- a/crates/bevy_reflect/derive/src/where_clause_options.rs
+++ b/crates/bevy_reflect/derive/src/where_clause_options.rs
@@ -231,14 +231,14 @@ impl<'a, 'b> WhereClauseOptions<'a, 'b> {
         }
     }
 
-    /// The `PartialReflect` or `FromReflect` bound to use based on `#[reflect(from_reflect = false)]`.
+    /// The `CastPartialReflect` or `FromReflect` bound to use based on `#[reflect(from_reflect = false)]`.
     fn reflect_bound(&self) -> TokenStream {
         let bevy_reflect_path = self.meta.bevy_reflect_path();
 
         if self.meta.from_reflect().should_auto_derive() {
             quote!(#bevy_reflect_path::FromReflect)
         } else {
-            quote!(#bevy_reflect_path::PartialReflect)
+            quote!(#bevy_reflect_path::cast::CastPartialReflect)
         }
     }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -204,21 +204,6 @@ impl PartialReflect for DynamicArray {
         self.represented_type
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }
@@ -537,7 +522,7 @@ mod tests {
             usize::MAX
         };
 
-        let b = Box::new([(); SIZE]).into_reflect();
+        let b = (Box::new([(); SIZE]) as Box<dyn Reflect>).into_reflect();
 
         let array = b.reflect_ref().as_array().unwrap();
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -3,9 +3,9 @@
 //! [array-like]: https://doc.rust-lang.org/book/ch03-02-data-types.html#the-array-type
 use crate::generics::impl_generic_info_methods;
 use crate::{
-    type_info::impl_type_methods, utility::reflect_hasher, ApplyError, Generics, MaybeTyped,
-    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
-    TypePath,
+    cast::impl_cast_partial_reflect, type_info::impl_type_methods, utility::reflect_hasher,
+    ApplyError, Generics, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
 };
 use alloc::{boxed::Box, vec::Vec};
 use bevy_reflect_derive::impl_type_path;
@@ -348,6 +348,7 @@ impl<'a> IntoIterator for &'a DynamicArray {
 }
 
 impl_type_path!((in bevy_reflect) DynamicArray);
+impl_cast_partial_reflect!(for DynamicArray);
 
 /// An iterator over an [`Array`].
 pub struct ArrayIter<'a> {

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -68,6 +68,10 @@ use bevy_reflect_derive::impl_type_path;
 ///
 /// [`dyn PartialReflect`]: PartialReflect
 /// [derives `Reflect`]: derive@crate::Reflect
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not implement `CastPartialReflect` so cannot be cast to `dyn PartialReflect`",
+    note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
+)]
 pub trait CastPartialReflect: Send + Sync + 'static {
     /// Casts this type to a [`dyn PartialReflect`] reference.
     ///
@@ -112,6 +116,10 @@ impl<T: ?Sized + CastPartialReflect> CastPartialReflect for Box<T> {
 ///
 /// [`dyn Reflect`]: Reflect
 /// [derives `Reflect`]: derive@crate::Reflect
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not implement `CastReflect` so cannot be cast to `dyn Reflect`",
+    note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
+)]
 pub trait CastReflect: CastPartialReflect {
     /// Casts this type to a [`dyn Reflect`] reference.
     ///

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -1,25 +1,30 @@
 use crate::__macro_exports::RegisterForReflection;
-use crate::{MaybeTyped, PartialReflect, Reflect};
+
+use crate::utility::GenericTypeInfoCell;
+use crate::{
+    GetTypeRegistration, MaybeTyped, OpaqueInfo, PartialReflect, Reflect, TypeInfo, TypePath,
+    TypeRegistration, Typed,
+};
 use alloc::boxed::Box;
 use bevy_reflect_derive::impl_type_path;
 
-pub trait CastPartialReflect {
+pub trait CastPartialReflect: Send + Sync + 'static {
     fn as_partial_reflect(&self) -> &dyn PartialReflect;
     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect;
     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect>;
 }
 
-impl<T: PartialReflect> CastPartialReflect for T {
+impl<T: CastPartialReflect> CastPartialReflect for Box<T> {
     fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
+        T::as_partial_reflect(self)
     }
 
     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
+        T::as_partial_reflect_mut(self)
     }
 
     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
+        T::into_partial_reflect(*self)
     }
 }
 
@@ -85,17 +90,17 @@ pub trait CastReflect: CastPartialReflect {
     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect>;
 }
 
-impl<T: Reflect> CastReflect for T {
+impl<T: CastReflect> CastReflect for Box<T> {
     fn as_reflect(&self) -> &dyn Reflect {
-        self
+        T::as_reflect(self)
     }
 
     fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
+        T::as_reflect_mut(self)
     }
 
     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
+        T::into_reflect(*self)
     }
 }
 
@@ -132,14 +137,70 @@ impl_type_path!(::alloc::boxed::Box<T: ?Sized>);
 impl MaybeTyped for Box<dyn Reflect> {}
 impl MaybeTyped for Box<dyn PartialReflect> {}
 
+impl<T: TypePath + Send + Sync> Typed for Box<T> {
+    fn type_info() -> &'static TypeInfo {
+        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+        CELL.get_or_insert::<Self, _>(|| TypeInfo::Opaque(OpaqueInfo::new::<Self>()))
+    }
+}
+
 impl RegisterForReflection for Box<dyn Reflect> {}
 impl RegisterForReflection for Box<dyn PartialReflect> {}
+
+impl<T: TypePath + Send + Sync> GetTypeRegistration for Box<T> {
+    fn get_type_registration() -> TypeRegistration {
+        TypeRegistration::of::<Self>()
+    }
+}
+
+macro_rules! impl_cast_partial_reflect {
+    ($(<$($id:ident),* $(,)?>)? for $ty:ty $(where $($tt:tt)*)?) => {
+        impl $(<$($id),*>)? $crate::cast::CastPartialReflect for $ty $(where $($tt)*)? {
+            fn as_partial_reflect(&self) -> &dyn $crate::PartialReflect {
+                self
+            }
+
+            fn as_partial_reflect_mut(&mut self) -> &mut dyn $crate::PartialReflect {
+                self
+            }
+
+            fn into_partial_reflect(self: ::alloc::boxed::Box<Self>) -> ::alloc::boxed::Box<dyn $crate::PartialReflect> {
+                self
+            }
+        }
+    };
+}
+
+pub(crate) use impl_cast_partial_reflect;
+
+macro_rules! impl_casting_traits {
+    ($(<$($id:ident),* $(,)?>)? for $ty:ty $(where $($tt:tt)*)?) => {
+
+        $crate::cast::impl_cast_partial_reflect!($(<$($id),*>)? for $ty $(where $($tt)*)?);
+
+        impl $(<$($id),*>)? $crate::cast::CastReflect for $ty $(where $($tt)*)? {
+            fn as_reflect(&self) -> &dyn $crate::Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn $crate::Reflect {
+                self
+            }
+
+            fn into_reflect(self: ::alloc::boxed::Box<Self>) -> ::alloc::boxed::Box<dyn $crate::Reflect> {
+                self
+            }
+        }
+    };
+}
+
+pub(crate) use impl_casting_traits;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate as bevy_reflect;
-    use crate::{structs::Struct, tuple_struct::TupleStruct};
+    use crate::{structs::Struct, tuple::Tuple, tuple_struct::TupleStruct};
     use static_assertions::assert_not_impl_all;
 
     #[test]
@@ -178,6 +239,17 @@ mod tests {
 
         let field = my_struct.field(0).unwrap();
         assert_eq!(field.try_downcast_ref::<i32>(), Some(&123));
+
+        let field_info = field.get_represented_type_info().unwrap();
+        assert!(field_info.ty().is::<i32>());
+    }
+
+    #[test]
+    fn should_reflect_boxed_tuple_field() {
+        let my_struct: Box<dyn Tuple> = Box::new((Box::new(10_i32),));
+
+        let field = my_struct.field(0).unwrap();
+        assert_eq!(field.try_downcast_ref::<i32>(), Some(&10));
 
         let field_info = field.get_represented_type_info().unwrap();
         assert!(field_info.ty().is::<i32>());

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -1,0 +1,186 @@
+use crate as bevy_reflect;
+use crate::__macro_exports::RegisterForReflection;
+use crate::{MaybeTyped, PartialReflect, Reflect};
+use alloc::boxed::Box;
+use bevy_reflect_derive::impl_type_path;
+
+pub trait CastPartialReflect {
+    fn as_partial_reflect(&self) -> &dyn PartialReflect;
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect;
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect>;
+}
+
+impl<T: PartialReflect> CastPartialReflect for T {
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+impl CastPartialReflect for dyn PartialReflect {
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+impl CastPartialReflect for dyn Reflect {
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self.as_partial_reflect()
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self.as_partial_reflect_mut()
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self.into_partial_reflect()
+    }
+}
+
+impl CastPartialReflect for Box<dyn PartialReflect> {
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self.as_ref()
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self.as_mut()
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        *self
+    }
+}
+
+impl CastPartialReflect for Box<dyn Reflect> {
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self.as_ref().as_partial_reflect()
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self.as_mut().as_partial_reflect_mut()
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self.into_reflect().into_partial_reflect()
+    }
+}
+
+pub trait CastReflect: CastPartialReflect {
+    fn as_reflect(&self) -> &dyn Reflect;
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect;
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect>;
+}
+
+impl<T: Reflect> CastReflect for T {
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+}
+
+impl CastReflect for dyn Reflect {
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+}
+
+impl CastReflect for Box<dyn Reflect> {
+    fn as_reflect(&self) -> &dyn Reflect {
+        self.as_ref()
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self.as_mut()
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        *self
+    }
+}
+
+impl_type_path!(::alloc::boxed::Box<T: ?Sized>);
+
+impl MaybeTyped for Box<dyn Reflect> {}
+impl MaybeTyped for Box<dyn PartialReflect> {}
+
+impl RegisterForReflection for Box<dyn Reflect> {}
+impl RegisterForReflection for Box<dyn PartialReflect> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as bevy_reflect;
+    use crate::{structs::Struct, tuple_struct::TupleStruct};
+    use static_assertions::assert_not_impl_all;
+
+    #[test]
+    fn should_not_reflect_box() {
+        assert_not_impl_all!(Box<i32>: Reflect, PartialReflect);
+        assert_not_impl_all!(Box<dyn PartialReflect>: Reflect, PartialReflect);
+        assert_not_impl_all!(Box<dyn Reflect>: Reflect, PartialReflect);
+    }
+
+    #[test]
+    fn should_reflect_boxed_struct_field() {
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct MyStruct {
+            value: Box<dyn Reflect>,
+        }
+
+        let my_struct: Box<dyn Struct> = Box::new(MyStruct {
+            value: Box::new(123_i32),
+        });
+
+        let field = my_struct.field("value").unwrap();
+        assert_eq!(field.try_downcast_ref::<i32>(), Some(&123));
+
+        let field_info = field.get_represented_type_info().unwrap();
+        assert!(field_info.ty().is::<i32>());
+    }
+
+    #[test]
+    fn should_reflect_boxed_tuple_struct_field() {
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct MyStruct(Box<dyn Reflect>);
+
+        let my_struct: Box<dyn TupleStruct> = Box::new(MyStruct(Box::new(123_i32)));
+
+        let field = my_struct.field(0).unwrap();
+        assert_eq!(field.try_downcast_ref::<i32>(), Some(&123));
+
+        let field_info = field.get_represented_type_info().unwrap();
+        assert!(field_info.ty().is::<i32>());
+    }
+}

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -28,34 +28,6 @@ impl<T: CastPartialReflect> CastPartialReflect for Box<T> {
     }
 }
 
-impl CastPartialReflect for dyn PartialReflect {
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-}
-
-impl CastPartialReflect for dyn Reflect {
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self.as_partial_reflect()
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self.as_partial_reflect_mut()
-    }
-
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self.into_partial_reflect()
-    }
-}
-
 impl CastPartialReflect for Box<dyn PartialReflect> {
     fn as_partial_reflect(&self) -> &dyn PartialReflect {
         self.as_ref()
@@ -101,20 +73,6 @@ impl<T: CastReflect> CastReflect for Box<T> {
 
     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
         T::into_reflect(*self)
-    }
-}
-
-impl CastReflect for dyn Reflect {
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
     }
 }
 

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -2,8 +2,8 @@ use crate::__macro_exports::RegisterForReflection;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    GetTypeRegistration, MaybeTyped, OpaqueInfo, PartialReflect, Reflect, TypeInfo, TypePath,
-    TypeRegistration, Typed,
+    GetTypeRegistration, OpaqueInfo, PartialReflect, Reflect, TypeInfo, TypePath, TypeRegistration,
+    Typed,
 };
 use alloc::boxed::Box;
 use bevy_reflect_derive::impl_type_path;
@@ -14,7 +14,7 @@ pub trait CastPartialReflect: Send + Sync + 'static {
     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect>;
 }
 
-impl<T: CastPartialReflect> CastPartialReflect for Box<T> {
+impl<T: ?Sized + CastPartialReflect> CastPartialReflect for Box<T> {
     fn as_partial_reflect(&self) -> &dyn PartialReflect {
         T::as_partial_reflect(self)
     }
@@ -28,41 +28,13 @@ impl<T: CastPartialReflect> CastPartialReflect for Box<T> {
     }
 }
 
-impl CastPartialReflect for Box<dyn PartialReflect> {
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self.as_ref()
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self.as_mut()
-    }
-
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        *self
-    }
-}
-
-impl CastPartialReflect for Box<dyn Reflect> {
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self.as_ref().as_partial_reflect()
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self.as_mut().as_partial_reflect_mut()
-    }
-
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self.into_reflect().into_partial_reflect()
-    }
-}
-
 pub trait CastReflect: CastPartialReflect {
     fn as_reflect(&self) -> &dyn Reflect;
     fn as_reflect_mut(&mut self) -> &mut dyn Reflect;
     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect>;
 }
 
-impl<T: CastReflect> CastReflect for Box<T> {
+impl<T: ?Sized + CastReflect> CastReflect for Box<T> {
     fn as_reflect(&self) -> &dyn Reflect {
         T::as_reflect(self)
     }
@@ -76,36 +48,16 @@ impl<T: CastReflect> CastReflect for Box<T> {
     }
 }
 
-impl CastReflect for Box<dyn Reflect> {
-    fn as_reflect(&self) -> &dyn Reflect {
-        self.as_ref()
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self.as_mut()
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        *self
-    }
-}
-
 impl_type_path!(::alloc::boxed::Box<T: ?Sized>);
 
-impl MaybeTyped for Box<dyn Reflect> {}
-impl MaybeTyped for Box<dyn PartialReflect> {}
-
-impl<T: TypePath + Send + Sync> Typed for Box<T> {
+impl<T: ?Sized + TypePath + Send + Sync> Typed for Box<T> {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
         CELL.get_or_insert::<Self, _>(|| TypeInfo::Opaque(OpaqueInfo::new::<Self>()))
     }
 }
 
-impl RegisterForReflection for Box<dyn Reflect> {}
-impl RegisterForReflection for Box<dyn PartialReflect> {}
-
-impl<T: TypePath + Send + Sync> GetTypeRegistration for Box<T> {
+impl<T: ?Sized + TypePath + Send + Sync> GetTypeRegistration for Box<T> {
     fn get_type_registration() -> TypeRegistration {
         TypeRegistration::of::<Self>()
     }
@@ -211,5 +163,38 @@ mod tests {
 
         let field_info = field.get_represented_type_info().unwrap();
         assert!(field_info.ty().is::<i32>());
+    }
+
+    #[test]
+    fn should_allow_custom_trait_objects() {
+        trait Equippable: Reflect {}
+
+        impl TypePath for dyn Equippable {
+            fn type_path() -> &'static str {
+                "dyn my_crate::Equippable"
+            }
+
+            fn short_type_path() -> &'static str {
+                "dyn Equippable"
+            }
+        }
+
+        #[derive(Reflect)]
+        struct Sword(u32);
+
+        impl Equippable for Sword {}
+
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct Player {
+            weapon: Box<dyn Equippable>,
+        }
+
+        let player: Box<dyn Struct> = Box::new(Player {
+            weapon: Box::new(Sword(123)),
+        });
+
+        let weapon = player.field("weapon").unwrap();
+        assert!(weapon.reflect_partial_eq(&Sword(123)).unwrap_or_default());
     }
 }

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -1,4 +1,57 @@
-use crate::__macro_exports::RegisterForReflection;
+//! Traits for casting types to [`dyn PartialReflect`] and [`dyn Reflect`] trait objects.
+//!
+//! These traits are used internally by the [derive macro] and other [`Reflect`] implementations,
+//! to allow for transparent wrapper types, such as [`Box`], to be used as fields.
+//!
+//! # Custom Trait Objects
+//!
+//! These traits also enable the usage of custom trait objects as reflected fields.
+//!
+//! The only requirements are:
+//! - The trait must have at least [`CastPartialReflect`] as a supertrait.
+//!   This includes using [`CastReflect`], [`PartialReflect`], or [`Reflect`] as supertraits,
+//!   since they are all subtraits of [`CastPartialReflect`].
+//! - The trait must implement [`TypePath`] for its trait object
+//!
+//! ```
+//! # use bevy_reflect::{PartialReflect, Reflect, Struct, TypePath};
+//! #
+//! trait Equippable: PartialReflect {}
+//!
+//! impl TypePath for dyn Equippable {
+//!     fn type_path() -> &'static str {
+//!         "dyn my_crate::Equippable"
+//!     }
+//!
+//!     fn short_type_path() -> &'static str {
+//!         "dyn Equippable"
+//!     }
+//! }
+//!
+//! #[derive(Reflect)]
+//! struct Sword(u32);
+//!
+//! impl Equippable for Sword {}
+//!
+//! #[derive(Reflect)]
+//! #[reflect(from_reflect = false)]
+//! struct Player {
+//!    weapon: Box<dyn Equippable>,
+//! }
+//!
+//! let player: Box<dyn Struct> = Box::new(Player {
+//!     weapon: Box::new(Sword(123)),
+//! });
+//!
+//! let weapon = player.field("weapon").unwrap();
+//! assert!(weapon.reflect_partial_eq(&Sword(123)).unwrap_or_default());
+//! ```
+//!
+//! [`dyn PartialReflect`]: PartialReflect
+//! [`dyn Reflect`]: crate::Reflect
+//! [derive macro]: derive@crate::Reflect
+//! [`Reflect`]: crate::Reflect
+//! [`TypePath`]: crate::TypePath
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
@@ -8,9 +61,33 @@ use crate::{
 use alloc::boxed::Box;
 use bevy_reflect_derive::impl_type_path;
 
+/// A trait used to cast `Self` to a [`dyn PartialReflect`] trait object.
+///
+/// This is automatically implemented for any type that [derives `Reflect`],
+/// as well as [`Box<T>`] where `T` also implements [`CastPartialReflect`].
+///
+/// [`dyn PartialReflect`]: PartialReflect
+/// [derives `Reflect`]: derive@crate::Reflect
 pub trait CastPartialReflect: Send + Sync + 'static {
+    /// Casts this type to a [`dyn PartialReflect`] reference.
+    ///
+    /// This is useful for coercing trait objects.
+    ///
+    /// [`dyn PartialReflect`]: PartialReflect
     fn as_partial_reflect(&self) -> &dyn PartialReflect;
+
+    /// Casts this type to a mutable [`dyn PartialReflect`] reference.
+    ///
+    /// This is useful for coercing trait objects.
+    ///
+    /// [`dyn PartialReflect`]: PartialReflect
     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect;
+
+    /// Casts this type into a boxed [`dyn PartialReflect`] instance.
+    ///
+    /// This is useful for coercing trait objects.
+    ///
+    /// [`dyn PartialReflect`]: PartialReflect
     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect>;
 }
 
@@ -28,9 +105,33 @@ impl<T: ?Sized + CastPartialReflect> CastPartialReflect for Box<T> {
     }
 }
 
+/// A trait used to cast `Self` to a [`dyn Reflect`] trait object.
+///
+/// This is automatically implemented for any type that [derives `Reflect`],
+/// as well as [`Box<T>`] where `T` also implements [`CastReflect`].
+///
+/// [`dyn Reflect`]: Reflect
+/// [derives `Reflect`]: derive@crate::Reflect
 pub trait CastReflect: CastPartialReflect {
+    /// Casts this type to a [`dyn Reflect`] reference.
+    ///
+    /// This is useful for coercing trait objects.
+    ///
+    /// [`dyn Reflect`]: Reflect
     fn as_reflect(&self) -> &dyn Reflect;
+
+    /// Casts this type to a mutable [`dyn Reflect`] reference.
+    ///
+    /// This is useful for coercing trait objects.
+    ///
+    /// [`dyn Reflect`]: Reflect
     fn as_reflect_mut(&mut self) -> &mut dyn Reflect;
+
+    /// Casts this type into a boxed [`dyn Reflect`] instance.
+    ///
+    /// This is useful for coercing trait objects.
+    ///
+    /// [`dyn Reflect`]: Reflect
     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect>;
 }
 
@@ -167,7 +268,7 @@ mod tests {
 
     #[test]
     fn should_allow_custom_trait_objects() {
-        trait Equippable: Reflect {}
+        trait Equippable: CastPartialReflect {}
 
         impl TypePath for dyn Equippable {
             fn type_path() -> &'static str {

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -167,14 +167,17 @@ impl<T: ?Sized + TypePath + Send + Sync> GetTypeRegistration for Box<T> {
 macro_rules! impl_cast_partial_reflect {
     ($(<$($id:ident),* $(,)?>)? for $ty:ty $(where $($tt:tt)*)?) => {
         impl $(<$($id),*>)? $crate::cast::CastPartialReflect for $ty $(where $($tt)*)? {
+            #[inline]
             fn as_partial_reflect(&self) -> &dyn $crate::PartialReflect {
                 self
             }
 
+            #[inline]
             fn as_partial_reflect_mut(&mut self) -> &mut dyn $crate::PartialReflect {
                 self
             }
 
+            #[inline]
             fn into_partial_reflect(self: ::alloc::boxed::Box<Self>) -> ::alloc::boxed::Box<dyn $crate::PartialReflect> {
                 self
             }
@@ -190,14 +193,17 @@ macro_rules! impl_casting_traits {
         $crate::cast::impl_cast_partial_reflect!($(<$($id),*>)? for $ty $(where $($tt)*)?);
 
         impl $(<$($id),*>)? $crate::cast::CastReflect for $ty $(where $($tt)*)? {
+            #[inline]
             fn as_reflect(&self) -> &dyn $crate::Reflect {
                 self
             }
 
+            #[inline]
             fn as_reflect_mut(&mut self) -> &mut dyn $crate::Reflect {
                 self
             }
 
+            #[inline]
             fn into_reflect(self: ::alloc::boxed::Box<Self>) -> ::alloc::boxed::Box<dyn $crate::Reflect> {
                 self
             }

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -1,4 +1,3 @@
-use crate as bevy_reflect;
 use crate::__macro_exports::RegisterForReflection;
 use crate::{MaybeTyped, PartialReflect, Reflect};
 use alloc::boxed::Box;

--- a/crates/bevy_reflect/src/cast.rs
+++ b/crates/bevy_reflect/src/cast.rs
@@ -273,6 +273,25 @@ mod tests {
     }
 
     #[test]
+    fn should_allow_boxed_type_parameter() {
+        #[derive(Reflect)]
+        #[reflect(from_reflect = false)]
+        struct MyStruct<T> {
+            value: T,
+        }
+
+        let my_struct: Box<dyn Struct> = Box::new(MyStruct {
+            value: Box::new(123_i32),
+        });
+
+        let field = my_struct.field("value").unwrap();
+        assert_eq!(field.try_downcast_ref::<i32>(), Some(&123));
+
+        let field_info = field.get_represented_type_info().unwrap();
+        assert!(field_info.ty().is::<i32>());
+    }
+
+    #[test]
     fn should_allow_custom_trait_objects() {
         trait Equippable: CastPartialReflect {}
 

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -51,7 +51,7 @@ impl From<()> for DynamicVariant {
 /// # Example
 ///
 /// ```
-/// # use bevy_reflect::{enums::{DynamicEnum, DynamicVariant}, Reflect, PartialReflect};
+/// # use bevy_reflect::{cast::CastPartialReflect, enums::{DynamicEnum, DynamicVariant}, Reflect, PartialReflect};
 ///
 /// // The original enum value
 /// let mut value: Option<usize> = Some(123);

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -1,6 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
+    cast::impl_cast_partial_reflect,
     enums::{
         enum_debug, enum_hash, enum_partial_cmp, enum_partial_eq, Enum, VariantFieldIter,
         VariantType,
@@ -420,3 +421,4 @@ impl PartialReflect for DynamicEnum {
 }
 
 impl_type_path!((in bevy_reflect) DynamicEnum);
+impl_cast_partial_reflect!(for DynamicEnum);

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -296,21 +296,6 @@ impl PartialReflect for DynamicEnum {
         self.represented_type
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,7 +1,7 @@
 use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     type_info::impl_type_methods,
-    MaybeTyped, PartialReflect, Type, TypeInfo, TypePath,
+    MaybeTyped, Type, TypeInfo, TypePath,
 };
 use alloc::borrow::Cow;
 use bevy_platform::sync::Arc;
@@ -20,7 +20,7 @@ pub struct NamedField {
 
 impl NamedField {
     /// Create a new [`NamedField`].
-    pub fn new<T: PartialReflect + MaybeTyped + TypePath>(name: &'static str) -> Self {
+    pub fn new<T: MaybeTyped + TypePath>(name: &'static str) -> Self {
         Self {
             name,
             type_info: T::maybe_type_info,
@@ -83,7 +83,7 @@ pub struct UnnamedField {
 
 impl UnnamedField {
     /// Create a new [`UnnamedField`].
-    pub fn new<T: PartialReflect + MaybeTyped + TypePath>(index: usize) -> Self {
+    pub fn new<T: MaybeTyped + TypePath>(index: usize) -> Self {
         Self {
             index,
             type_info: T::maybe_type_info,

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -1,5 +1,7 @@
+use crate::cast::CastPartialReflect;
 use crate::{FromType, PartialReflect, Reflect};
 use alloc::boxed::Box;
+use core::any::Any;
 
 /// A trait that enables types to be dynamically constructed from reflected data.
 ///
@@ -26,7 +28,7 @@ use alloc::boxed::Box;
     message = "`{Self}` does not implement `FromReflect` so cannot be created through reflection",
     note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
 )]
-pub trait FromReflect: Reflect + Sized {
+pub trait FromReflect: Any + CastPartialReflect + Sized {
     /// Constructs a concrete instance of `Self` from a reflected value.
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self>;
 
@@ -117,7 +119,7 @@ impl ReflectFromReflect {
     }
 }
 
-impl<T: FromReflect> FromType<T> for ReflectFromReflect {
+impl<T: FromReflect + Reflect> FromType<T> for ReflectFromReflect {
     fn from_type() -> Self {
         Self {
             from_reflect: |reflect_value| {

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -369,18 +369,6 @@ impl PartialReflect for DynamicFunction<'static> {
         None
     }
 
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -1,3 +1,4 @@
+use crate::cast::impl_cast_partial_reflect;
 use crate::{
     __macro_exports::RegisterForReflection,
     func::{
@@ -443,6 +444,7 @@ impl MaybeTyped for DynamicFunction<'static> {}
 impl RegisterForReflection for DynamicFunction<'static> {}
 
 impl_type_path!((in bevy_reflect) DynamicFunction<'env>);
+impl_cast_partial_reflect!(for DynamicFunction<'static>);
 
 /// Outputs the function's signature.
 ///

--- a/crates/bevy_reflect/src/impls/alloc/borrow.rs
+++ b/crates/bevy_reflect/src/impls/alloc/borrow.rs
@@ -26,19 +26,6 @@ impl PartialReflect for Cow<'static, str> {
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }
@@ -205,19 +192,6 @@ impl<T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistrat
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
-    }
-
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
     }
 
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {

--- a/crates/bevy_reflect/src/impls/alloc/borrow.rs
+++ b/crates/bevy_reflect/src/impls/alloc/borrow.rs
@@ -141,7 +141,7 @@ impl FromReflect for Cow<'static, str> {
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(Cow<'static, str>);
 
-impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> List
+impl<T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> List
     for Cow<'static, [T]>
 {
     fn get(&self, index: usize) -> Option<&dyn PartialReflect> {
@@ -200,7 +200,7 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> List
     }
 }
 
-impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> PartialReflect
+impl<T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> PartialReflect
     for Cow<'static, [T]>
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
@@ -276,10 +276,10 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> Parti
 impl_full_reflect!(
     <T> for Cow<'static, [T]>
     where
-        T: FromReflect + Clone + MaybeTyped + TypePath + GetTypeRegistration,
+        T: FromReflect + Reflect + Clone + MaybeTyped + TypePath + GetTypeRegistration,
 );
 
-impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> Typed
+impl<T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> Typed
     for Cow<'static, [T]>
 {
     fn type_info() -> &'static TypeInfo {
@@ -288,8 +288,8 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> Typed
     }
 }
 
-impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> GetTypeRegistration
-    for Cow<'static, [T]>
+impl<T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistration>
+    GetTypeRegistration for Cow<'static, [T]>
 {
     fn get_type_registration() -> TypeRegistration {
         TypeRegistration::of::<Cow<'static, [T]>>()
@@ -300,7 +300,7 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> GetTy
     }
 }
 
-impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> FromReflect
+impl<T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> FromReflect
     for Cow<'static, [T]>
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
@@ -317,4 +317,4 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> FromR
 }
 
 #[cfg(feature = "functions")]
-crate::func::macros::impl_function_traits!(Cow<'static, [T]>; <T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration>);
+crate::func::macros::impl_function_traits!(Cow<'static, [T]>; <T: FromReflect + Reflect + MaybeTyped + Clone + TypePath + GetTypeRegistration>);

--- a/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
+++ b/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
@@ -15,8 +15,8 @@ use bevy_reflect_derive::impl_type_path;
 
 impl<K, V> Map for ::alloc::collections::BTreeMap<K, V>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
 {
     fn get(&self, key: &dyn PartialReflect) -> Option<&dyn PartialReflect> {
         key.try_downcast_ref::<K>()
@@ -94,8 +94,8 @@ where
 
 impl<K, V> PartialReflect for ::alloc::collections::BTreeMap<K, V>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
@@ -171,14 +171,14 @@ where
 impl_full_reflect!(
     <K, V> for ::alloc::collections::BTreeMap<K, V>
     where
-        K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-        V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+        K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+        V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
 );
 
 impl<K, V> Typed for ::alloc::collections::BTreeMap<K, V>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
 {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
@@ -195,8 +195,8 @@ where
 
 impl<K, V> GetTypeRegistration for ::alloc::collections::BTreeMap<K, V>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
 {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<Self>();
@@ -208,8 +208,8 @@ where
 
 impl<K, V> FromReflect for ::alloc::collections::BTreeMap<K, V>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
         let ref_map = reflect.reflect_ref().as_map().ok()?;
@@ -230,7 +230,7 @@ impl_type_path!(::alloc::collections::BTreeMap<K, V>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::alloc::collections::BTreeMap<K, V>;
     <
-        K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
-        V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration
+        K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Ord,
+        V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration
     >
 );

--- a/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
+++ b/crates/bevy_reflect/src/impls/alloc/collections/btree/map.rs
@@ -100,18 +100,7 @@ where
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
     }
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
 
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
     #[inline]
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)

--- a/crates/bevy_reflect/src/impls/alloc/collections/vec_deque.rs
+++ b/crates/bevy_reflect/src/impls/alloc/collections/vec_deque.rs
@@ -3,7 +3,7 @@ use bevy_reflect_derive::impl_type_path;
 use crate::impls::macros::impl_reflect_for_veclike;
 #[cfg(feature = "functions")]
 use crate::{
-    from_reflect::FromReflect, type_info::MaybeTyped, type_path::TypePath,
+    from_reflect::FromReflect, reflect::Reflect, type_info::MaybeTyped, type_path::TypePath,
     type_registry::GetTypeRegistration,
 };
 
@@ -17,4 +17,4 @@ impl_reflect_for_veclike!(
 );
 impl_type_path!(::alloc::collections::VecDeque<T>);
 #[cfg(feature = "functions")]
-crate::func::macros::impl_function_traits!(::alloc::collections::VecDeque<T>; <T: FromReflect + MaybeTyped + TypePath + GetTypeRegistration>);
+crate::func::macros::impl_function_traits!(::alloc::collections::VecDeque<T>; <T: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration>);

--- a/crates/bevy_reflect/src/impls/alloc/vec.rs
+++ b/crates/bevy_reflect/src/impls/alloc/vec.rs
@@ -3,7 +3,7 @@ use bevy_reflect_derive::impl_type_path;
 use crate::impls::macros::impl_reflect_for_veclike;
 #[cfg(feature = "functions")]
 use crate::{
-    from_reflect::FromReflect, type_info::MaybeTyped, type_path::TypePath,
+    from_reflect::FromReflect, reflect::Reflect, type_info::MaybeTyped, type_path::TypePath,
     type_registry::GetTypeRegistration,
 };
 
@@ -17,7 +17,7 @@ impl_reflect_for_veclike!(
 );
 impl_type_path!(::alloc::vec::Vec<T>);
 #[cfg(feature = "functions")]
-crate::func::macros::impl_function_traits!(::alloc::vec::Vec<T>; <T: FromReflect + MaybeTyped + TypePath + GetTypeRegistration>);
+crate::func::macros::impl_function_traits!(::alloc::vec::Vec<T>; <T: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_reflect/src/impls/bevy_platform/collections/hash_map.rs
+++ b/crates/bevy_reflect/src/impls/bevy_platform/collections/hash_map.rs
@@ -1,6 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::impls::macros::impl_reflect_for_hashmap;
+use crate::Reflect;
 #[cfg(feature = "functions")]
 use crate::{
     from_reflect::FromReflect, type_info::MaybeTyped, type_path::TypePath,
@@ -14,8 +15,8 @@ impl_type_path!(::bevy_platform::collections::HashMap<K, V, S>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::bevy_platform::collections::HashMap<K, V, S>;
     <
-        K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-        V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+        K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+        V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
         S: TypePath + BuildHasher + Default + Send + Sync
     >
 );

--- a/crates/bevy_reflect/src/impls/bevy_platform/collections/hash_set.rs
+++ b/crates/bevy_reflect/src/impls/bevy_platform/collections/hash_set.rs
@@ -2,7 +2,10 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::impls::macros::impl_reflect_for_hashset;
 #[cfg(feature = "functions")]
-use crate::{from_reflect::FromReflect, type_path::TypePath, type_registry::GetTypeRegistration};
+use crate::{
+    from_reflect::FromReflect, reflect::Reflect, type_path::TypePath,
+    type_registry::GetTypeRegistration,
+};
 #[cfg(feature = "functions")]
 use core::hash::{BuildHasher, Hash};
 
@@ -11,7 +14,7 @@ impl_type_path!(::bevy_platform::collections::HashSet<V, S>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::bevy_platform::collections::HashSet<V, S>;
     <
-        V: Hash + Eq + FromReflect + TypePath + GetTypeRegistration,
+        V: Hash + Eq + FromReflect + Reflect + TypePath + GetTypeRegistration,
         S: TypePath + BuildHasher + Default + Send + Sync
     >
 );

--- a/crates/bevy_reflect/src/impls/core/panic.rs
+++ b/crates/bevy_reflect/src/impls/core/panic.rs
@@ -2,6 +2,7 @@ use crate::{
     error::ReflectCloneError,
     kind::{ReflectKind, ReflectMut, ReflectOwned, ReflectRef},
     prelude::*,
+    reflect::impl_full_reflect,
     reflect::ApplyError,
     type_info::{OpaqueInfo, TypeInfo, Typed},
     type_path::DynamicTypePath,
@@ -109,37 +110,6 @@ impl PartialReflect for &'static Location<'static> {
     }
 }
 
-impl Reflect for &'static Location<'static> {
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
-
 impl Typed for &'static Location<'static> {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
@@ -161,3 +131,5 @@ impl FromReflect for &'static Location<'static> {
         reflect.try_downcast_ref::<Self>().copied()
     }
 }
+
+impl_full_reflect!(for &'static Location<'static>);

--- a/crates/bevy_reflect/src/impls/core/panic.rs
+++ b/crates/bevy_reflect/src/impls/core/panic.rs
@@ -29,19 +29,6 @@ impl PartialReflect for &'static Location<'static> {
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }

--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -323,19 +323,6 @@ impl PartialReflect for &'static str {
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }
@@ -465,19 +452,6 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> P
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }
@@ -548,21 +522,6 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> R
 
     #[inline]
     fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    #[inline]
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    #[inline]
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
         self
     }
 

--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -1,9 +1,10 @@
 use crate::{
     array::{Array, ArrayInfo, ArrayIter},
+    cast::{CastPartialReflect, CastReflect},
     error::ReflectCloneError,
     kind::{ReflectKind, ReflectMut, ReflectOwned, ReflectRef},
     prelude::*,
-    reflect::ApplyError,
+    reflect::{impl_full_reflect, ApplyError},
     type_info::{MaybeTyped, OpaqueInfo, TypeInfo, Typed},
     type_registry::{
         FromType, GetTypeRegistration, ReflectDeserialize, ReflectFromPtr, ReflectSerialize,
@@ -403,37 +404,6 @@ impl PartialReflect for &'static str {
     }
 }
 
-impl Reflect for &'static str {
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
-
 impl Typed for &'static str {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
@@ -456,6 +426,8 @@ impl FromReflect for &'static str {
         reflect.try_downcast_ref::<Self>().copied()
     }
 }
+
+impl_full_reflect!(for &'static str);
 
 impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> Array for [T; N] {
     #[inline]
@@ -601,8 +573,8 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> R
     }
 }
 
-impl<T: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> FromReflect
-    for [T; N]
+impl<T: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize>
+    FromReflect for [T; N]
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
         let ref_array = reflect.reflect_ref().as_array().ok()?;
@@ -645,6 +617,38 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> G
 
     fn register_type_dependencies(registry: &mut TypeRegistry) {
         registry.register::<T>();
+    }
+}
+
+impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> CastPartialReflect
+    for [T; N]
+{
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+}
+
+impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> CastReflect
+    for [T; N]
+{
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
     }
 }
 

--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -601,7 +601,7 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> R
     }
 }
 
-impl<T: FromReflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> FromReflect
+impl<T: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> FromReflect
     for [T; N]
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {

--- a/crates/bevy_reflect/src/impls/core/sync.rs
+++ b/crates/bevy_reflect/src/impls/core/sync.rs
@@ -54,18 +54,6 @@ macro_rules! impl_reflect_for_atomic {
                     Some(<Self as Typed>::type_info())
                 }
                 #[inline]
-                fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-                    self
-                }
-                #[inline]
-                fn as_partial_reflect(&self) -> &dyn PartialReflect {
-                    self
-                }
-                #[inline]
-                fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-                    self
-                }
-                #[inline]
                 fn try_into_reflect(
                     self: Box<Self>,
                 ) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {

--- a/crates/bevy_reflect/src/impls/hashbrown.rs
+++ b/crates/bevy_reflect/src/impls/hashbrown.rs
@@ -1,7 +1,7 @@
 use crate::impls::macros::{impl_reflect_for_hashmap, impl_reflect_for_hashset};
 #[cfg(feature = "functions")]
 use crate::{
-    from_reflect::FromReflect, type_info::MaybeTyped, type_path::TypePath,
+    from_reflect::FromReflect, reflect::Reflect, type_info::MaybeTyped, type_path::TypePath,
     type_registry::GetTypeRegistration,
 };
 use bevy_reflect_derive::impl_type_path;
@@ -13,8 +13,8 @@ impl_type_path!(::hashbrown::hash_map::HashMap<K, V, S>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::hashbrown::hash_map::HashMap<K, V, S>;
     <
-        K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-        V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+        K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+        V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
         S: TypePath + BuildHasher + Default + Send + Sync
     >
 );
@@ -24,7 +24,7 @@ impl_type_path!(::hashbrown::hash_set::HashSet<V, S>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::hashbrown::hash_set::HashSet<V, S>;
     <
-        V: Hash + Eq + FromReflect + TypePath + GetTypeRegistration,
+        V: Hash + Eq + FromReflect + Reflect + TypePath + GetTypeRegistration,
         S: TypePath + BuildHasher + Default + Send + Sync
     >
 );

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -118,19 +118,6 @@ where
     }
 
     #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
-    #[inline]
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }
@@ -322,19 +309,6 @@ where
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
-    }
-
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -1,4 +1,5 @@
 use crate::{
+    reflect::impl_full_reflect,
     set::{Set, SetInfo},
     utility::GenericTypeInfoCell,
     FromReflect, FromType, Generics, GetTypeRegistration, PartialReflect, Reflect,
@@ -11,7 +12,7 @@ use bevy_reflect::{
     MaybeTyped, ReflectFromReflect, ReflectKind, TypeRegistry, Typed,
 };
 use bevy_reflect_derive::impl_type_path;
-use core::{any::Any, hash::BuildHasher, hash::Hash};
+use core::{hash::BuildHasher, hash::Hash};
 use indexmap::{IndexMap, IndexSet};
 
 impl<K, V, S> Map for IndexMap<K, V, S>
@@ -182,42 +183,6 @@ where
     }
 }
 
-impl<K, V, S> Reflect for IndexMap<K, V, S>
-where
-    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
-    S: TypePath + BuildHasher + Default + Send + Sync,
-{
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
-
 impl<K, V, S> Typed for IndexMap<K, V, S>
 where
     K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
@@ -277,6 +242,13 @@ where
     }
 }
 
+impl_full_reflect!(
+    <K, V, S> for IndexMap<K, V, S>
+    where
+        K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+        V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
+        S: TypePath + BuildHasher + Default + Send + Sync,
+);
 impl_type_path!(::indexmap::IndexMap<K, V, S>);
 
 impl<T, S> Set for IndexSet<T, S>
@@ -415,41 +387,6 @@ where
     }
 }
 
-impl<T, S> Reflect for IndexSet<T, S>
-where
-    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
-    S: TypePath + BuildHasher + Default + Send + Sync,
-{
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
-
 impl<T, S> Typed for IndexSet<T, S>
 where
     T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
@@ -496,4 +433,10 @@ where
     }
 }
 
+impl_full_reflect!(
+    <T, S> for IndexSet<T, S>
+    where
+        T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
+        S: TypePath + BuildHasher + Default + Send + Sync,
+);
 impl_type_path!(::indexmap::IndexSet<T, S>);

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -16,8 +16,8 @@ use indexmap::{IndexMap, IndexSet};
 
 impl<K, V, S> Map for IndexMap<K, V, S>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn get(&self, key: &dyn PartialReflect) -> Option<&dyn PartialReflect> {
@@ -108,8 +108,8 @@ where
 
 impl<K, V, S> PartialReflect for IndexMap<K, V, S>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
@@ -184,8 +184,8 @@ where
 
 impl<K, V, S> Reflect for IndexMap<K, V, S>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
@@ -220,8 +220,8 @@ where
 
 impl<K, V, S> Typed for IndexMap<K, V, S>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn type_info() -> &'static TypeInfo {
@@ -239,8 +239,8 @@ where
 
 impl<K, V, S> FromReflect for IndexMap<K, V, S>
 where
-    K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
@@ -260,8 +260,8 @@ where
 
 impl<K, V, S> GetTypeRegistration for IndexMap<K, V, S>
 where
-    K: Hash + Eq + FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
-    V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+    K: Hash + Eq + FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
+    V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
     S: TypePath + BuildHasher + Send + Sync + Default,
 {
     fn get_type_registration() -> TypeRegistration {
@@ -281,7 +281,7 @@ impl_type_path!(::indexmap::IndexMap<K, V, S>);
 
 impl<T, S> Set for IndexSet<T, S>
 where
-    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn get(&self, value: &dyn PartialReflect) -> Option<&dyn PartialReflect> {
@@ -345,7 +345,7 @@ where
 
 impl<T, S> PartialReflect for IndexSet<T, S>
 where
-    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
@@ -417,7 +417,7 @@ where
 
 impl<T, S> Reflect for IndexSet<T, S>
 where
-    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
@@ -452,7 +452,7 @@ where
 
 impl<T, S> Typed for IndexSet<T, S>
 where
-    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn type_info() -> &'static TypeInfo {
@@ -468,7 +468,7 @@ where
 
 impl<T, S> FromReflect for IndexSet<T, S>
 where
-    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
@@ -486,7 +486,7 @@ where
 
 impl<T, S> GetTypeRegistration for IndexSet<T, S>
 where
-    T: FromReflect + TypePath + GetTypeRegistration + Eq + Hash,
+    T: FromReflect + Reflect + TypePath + GetTypeRegistration + Eq + Hash,
     S: TypePath + BuildHasher + Default + Send + Sync,
 {
     fn get_type_registration() -> TypeRegistration {

--- a/crates/bevy_reflect/src/impls/macros/list.rs
+++ b/crates/bevy_reflect/src/impls/macros/list.rs
@@ -66,20 +66,6 @@ macro_rules! impl_reflect_for_veclike {
                     Some(<Self as $crate::type_info::Typed>::type_info())
                 }
 
-                fn into_partial_reflect(self: bevy_platform::prelude::Box<Self>) -> bevy_platform::prelude::Box<dyn $crate::reflect::PartialReflect> {
-                    self
-                }
-
-                #[inline]
-                fn as_partial_reflect(&self) -> &dyn $crate::reflect::PartialReflect {
-                    self
-                }
-
-                #[inline]
-                fn as_partial_reflect_mut(&mut self) -> &mut dyn $crate::reflect::PartialReflect {
-                    self
-                }
-
                 fn try_into_reflect(
                     self: bevy_platform::prelude::Box<Self>,
                 ) -> Result<bevy_platform::prelude::Box<dyn $crate::reflect::Reflect>, bevy_platform::prelude::Box<dyn $crate::reflect::PartialReflect>> {

--- a/crates/bevy_reflect/src/impls/macros/list.rs
+++ b/crates/bevy_reflect/src/impls/macros/list.rs
@@ -1,7 +1,7 @@
 macro_rules! impl_reflect_for_veclike {
     ($ty:ty, $insert:expr, $remove:expr, $push:expr, $pop:expr, $sub:ty) => {
         const _: () = {
-            impl<T: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::list::List for $ty {
+            impl<T: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::list::List for $ty {
                 #[inline]
                 fn get(&self, index: usize) -> Option<&dyn $crate::reflect::PartialReflect> {
                     <$sub>::get(self, index).map(|value| value as &dyn $crate::reflect::PartialReflect)
@@ -60,7 +60,7 @@ macro_rules! impl_reflect_for_veclike {
                 }
             }
 
-            impl<T: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::reflect::PartialReflect for $ty {
+            impl<T: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::reflect::PartialReflect for $ty {
                 #[inline]
                 fn get_represented_type_info(&self) -> Option<&'static $crate::type_info::TypeInfo> {
                     Some(<Self as $crate::type_info::Typed>::type_info())
@@ -139,9 +139,9 @@ macro_rules! impl_reflect_for_veclike {
                 }
             }
 
-            $crate::impl_full_reflect!(<T> for $ty where T: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration);
+            $crate::impl_full_reflect!(<T> for $ty where T: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration);
 
-            impl<T: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::type_info::Typed for $ty {
+            impl<T: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::type_info::Typed for $ty {
                 fn type_info() -> &'static $crate::type_info::TypeInfo {
                     static CELL: $crate::utility::GenericTypeInfoCell = $crate::utility::GenericTypeInfoCell::new();
                     CELL.get_or_insert::<Self, _>(|| {
@@ -154,7 +154,7 @@ macro_rules! impl_reflect_for_veclike {
                 }
             }
 
-            impl<T: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::type_registry::GetTypeRegistration
+            impl<T: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::type_registry::GetTypeRegistration
                 for $ty
             {
                 fn get_type_registration() -> $crate::type_registry::TypeRegistration {
@@ -169,7 +169,7 @@ macro_rules! impl_reflect_for_veclike {
                 }
             }
 
-            impl<T: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::from_reflect::FromReflect for $ty {
+            impl<T: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration> $crate::from_reflect::FromReflect for $ty {
                 fn from_reflect(reflect: &dyn $crate::reflect::PartialReflect) -> Option<Self> {
                     let ref_list = reflect.reflect_ref().as_list().ok()?;
 

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -100,19 +100,6 @@ macro_rules! impl_reflect_for_hashmap {
                     Some(<Self as $crate::type_info::Typed>::type_info())
                 }
 
-                #[inline]
-                fn into_partial_reflect(self: bevy_platform::prelude::Box<Self>) -> bevy_platform::prelude::Box<dyn $crate::reflect::PartialReflect> {
-                    self
-                }
-
-                fn as_partial_reflect(&self) -> &dyn $crate::reflect::PartialReflect {
-                    self
-                }
-
-                fn as_partial_reflect_mut(&mut self) -> &mut dyn $crate::reflect::PartialReflect {
-                    self
-                }
-
                 fn try_into_reflect(
                     self: bevy_platform::prelude::Box<Self>,
                 ) -> Result<bevy_platform::prelude::Box<dyn $crate::reflect::Reflect>, bevy_platform::prelude::Box<dyn $crate::reflect::PartialReflect>> {

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -3,8 +3,8 @@ macro_rules! impl_reflect_for_hashmap {
         const _: () = {
             impl<K, V, S> $crate::map::Map for $ty
             where
-                K: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
-                V: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
+                K: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn get(&self, key: &dyn $crate::reflect::PartialReflect) -> Option<&dyn $crate::reflect::PartialReflect> {
@@ -92,8 +92,8 @@ macro_rules! impl_reflect_for_hashmap {
 
             impl<K, V, S> $crate::reflect::PartialReflect for $ty
             where
-                K: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
-                V: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
+                K: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn get_represented_type_info(&self) -> Option<&'static $crate::type_info::TypeInfo> {
@@ -170,15 +170,15 @@ macro_rules! impl_reflect_for_hashmap {
             $crate::impl_full_reflect!(
                 <K, V, S> for $ty
                 where
-                    K: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
-                    V: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
+                    K: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                    V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
                     S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             );
 
             impl<K, V, S> $crate::type_info::Typed for $ty
             where
-                K: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
-                V: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
+                K: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn type_info() -> &'static $crate::type_info::TypeInfo {
@@ -196,8 +196,8 @@ macro_rules! impl_reflect_for_hashmap {
 
             impl<K, V, S> $crate::type_registry::GetTypeRegistration for $ty
             where
-                K: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
-                V: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
+                K: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync + Default,
             {
                 fn get_type_registration() -> $crate::type_registry::TypeRegistration {
@@ -215,8 +215,8 @@ macro_rules! impl_reflect_for_hashmap {
 
             impl<K, V, S> $crate::from_reflect::FromReflect for $ty
             where
-                K: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
-                V: $crate::from_reflect::FromReflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
+                K: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_info::MaybeTyped + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn from_reflect(reflect: &dyn $crate::reflect::PartialReflect) -> Option<Self> {

--- a/crates/bevy_reflect/src/impls/macros/set.rs
+++ b/crates/bevy_reflect/src/impls/macros/set.rs
@@ -75,19 +75,6 @@ macro_rules! impl_reflect_for_hashset {
                 }
 
                 #[inline]
-                fn into_partial_reflect(self: bevy_platform::prelude::Box<Self>) -> bevy_platform::prelude::Box<dyn $crate::reflect::PartialReflect> {
-                    self
-                }
-
-                fn as_partial_reflect(&self) -> &dyn $crate::reflect::PartialReflect {
-                    self
-                }
-
-                fn as_partial_reflect_mut(&mut self) -> &mut dyn $crate::reflect::PartialReflect {
-                    self
-                }
-
-                #[inline]
                 fn try_into_reflect(
                     self: bevy_platform::prelude::Box<Self>,
                 ) -> Result<bevy_platform::prelude::Box<dyn $crate::reflect::Reflect>, bevy_platform::prelude::Box<dyn $crate::reflect::PartialReflect>> {

--- a/crates/bevy_reflect/src/impls/macros/set.rs
+++ b/crates/bevy_reflect/src/impls/macros/set.rs
@@ -3,7 +3,7 @@ macro_rules! impl_reflect_for_hashset {
         const _: () = {
             impl<V, S> $crate::set::Set for $ty
             where
-                V: $crate::from_reflect::FromReflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn get(&self, value: &dyn $crate::reflect::PartialReflect) -> Option<&dyn $crate::reflect::PartialReflect> {
@@ -67,7 +67,7 @@ macro_rules! impl_reflect_for_hashset {
 
             impl<V, S> $crate::reflect::PartialReflect for $ty
             where
-                V: $crate::from_reflect::FromReflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn get_represented_type_info(&self) -> Option<&'static $crate::type_info::TypeInfo> {
@@ -143,7 +143,7 @@ macro_rules! impl_reflect_for_hashset {
 
             impl<V, S> $crate::type_info::Typed for $ty
             where
-                V: $crate::from_reflect::FromReflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn type_info() -> &'static $crate::type_info::TypeInfo {
@@ -160,7 +160,7 @@ macro_rules! impl_reflect_for_hashset {
 
             impl<V, S> $crate::type_registry::GetTypeRegistration for $ty
             where
-                V: $crate::from_reflect::FromReflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync + Default,
             {
                 fn get_type_registration() -> $crate::type_registry::TypeRegistration {
@@ -178,13 +178,13 @@ macro_rules! impl_reflect_for_hashset {
             $crate::impl_full_reflect!(
                 <V, S> for $ty
                 where
-                    V: $crate::from_reflect::FromReflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                    V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
                     S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             );
 
             impl<V, S> $crate::from_reflect::FromReflect for $ty
             where
-                V: $crate::from_reflect::FromReflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
+                V: $crate::from_reflect::FromReflect + $crate::reflect::Reflect + $crate::type_path::TypePath + $crate::type_registry::GetTypeRegistration + Eq + core::hash::Hash,
                 S: $crate::type_path::TypePath + core::hash::BuildHasher + Default + Send + Sync,
             {
                 fn from_reflect(reflect: &dyn $crate::reflect::PartialReflect) -> Option<Self> {

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,4 +1,5 @@
 use crate::{
+    impl_full_reflect,
     list::{List, ListInfo, ListIter},
     utility::GenericTypeInfoCell,
     ApplyError, FromReflect, FromType, Generics, GetTypeRegistration, MaybeTyped, PartialReflect,
@@ -8,7 +9,6 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 use bevy_reflect::ReflectCloneError;
 use bevy_reflect_derive::impl_type_path;
-use core::any::Any;
 use smallvec::{Array as SmallArray, SmallVec};
 
 impl<T: SmallArray + TypePath + Send + Sync> List for SmallVec<T>
@@ -156,39 +156,12 @@ where
     }
 }
 
-impl<T: SmallArray + TypePath + Send + Sync> Reflect for SmallVec<T>
-where
-    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
-{
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
+impl_full_reflect!(
+    <T> for SmallVec<T>
+    where
+        T: SmallArray + TypePath + Send + Sync,
+        T::Item: FromReflect + Reflect + MaybeTyped + TypePath
+);
 
 impl<T: SmallArray + TypePath + Send + Sync + 'static> Typed for SmallVec<T>
 where

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -87,19 +87,6 @@ where
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -13,7 +13,7 @@ use smallvec::{Array as SmallArray, SmallVec};
 
 impl<T: SmallArray + TypePath + Send + Sync> List for SmallVec<T>
 where
-    T::Item: FromReflect + MaybeTyped + TypePath,
+    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
 {
     fn get(&self, index: usize) -> Option<&dyn PartialReflect> {
         if index < SmallVec::len(self) {
@@ -81,7 +81,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync> PartialReflect for SmallVec<T>
 where
-    T::Item: FromReflect + MaybeTyped + TypePath,
+    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
 {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
@@ -158,7 +158,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync> Reflect for SmallVec<T>
 where
-    T::Item: FromReflect + MaybeTyped + TypePath,
+    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
 {
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
@@ -192,7 +192,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync + 'static> Typed for SmallVec<T>
 where
-    T::Item: FromReflect + MaybeTyped + TypePath,
+    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
 {
     fn type_info() -> &'static TypeInfo {
         static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
@@ -209,7 +209,7 @@ impl_type_path!(::smallvec::SmallVec<T: SmallArray>);
 
 impl<T: SmallArray + TypePath + Send + Sync> FromReflect for SmallVec<T>
 where
-    T::Item: FromReflect + MaybeTyped + TypePath,
+    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
 {
     fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
         let ref_list = reflect.reflect_ref().as_list().ok()?;
@@ -226,7 +226,7 @@ where
 
 impl<T: SmallArray + TypePath + Send + Sync> GetTypeRegistration for SmallVec<T>
 where
-    T::Item: FromReflect + MaybeTyped + TypePath,
+    T::Item: FromReflect + Reflect + MaybeTyped + TypePath,
 {
     fn get_type_registration() -> TypeRegistration {
         let mut registration = TypeRegistration::of::<SmallVec<T>>();
@@ -236,4 +236,4 @@ where
 }
 
 #[cfg(feature = "functions")]
-crate::func::macros::impl_function_traits!(SmallVec<T>; <T: SmallArray + TypePath + Send + Sync> where T::Item: FromReflect + MaybeTyped + TypePath);
+crate::func::macros::impl_function_traits!(SmallVec<T>; <T: SmallArray + TypePath + Send + Sync> where T::Item: FromReflect + Reflect + MaybeTyped + TypePath);

--- a/crates/bevy_reflect/src/impls/std/collections/hash_map.rs
+++ b/crates/bevy_reflect/src/impls/std/collections/hash_map.rs
@@ -3,7 +3,7 @@ use bevy_reflect_derive::impl_type_path;
 use crate::impls::macros::impl_reflect_for_hashmap;
 #[cfg(feature = "functions")]
 use crate::{
-    from_reflect::FromReflect, type_info::MaybeTyped, type_path::TypePath,
+    from_reflect::FromReflect, reflect::Reflect, type_info::MaybeTyped, type_path::TypePath,
     type_registry::GetTypeRegistration,
 };
 #[cfg(feature = "functions")]
@@ -16,8 +16,8 @@ impl_type_path!(::std::collections::HashMap<K, V, S>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::std::collections::HashMap<K, V, S>;
     <
-        K: FromReflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
-        V: FromReflect + MaybeTyped + TypePath + GetTypeRegistration,
+        K: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration + Eq + Hash,
+        V: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration,
         S: TypePath + BuildHasher + Default + Send + Sync
     >
 );

--- a/crates/bevy_reflect/src/impls/std/collections/hash_set.rs
+++ b/crates/bevy_reflect/src/impls/std/collections/hash_set.rs
@@ -2,7 +2,10 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::impls::macros::impl_reflect_for_hashset;
 #[cfg(feature = "functions")]
-use crate::{from_reflect::FromReflect, type_path::TypePath, type_registry::GetTypeRegistration};
+use crate::{
+    from_reflect::FromReflect, reflect::Reflect, type_path::TypePath,
+    type_registry::GetTypeRegistration,
+};
 #[cfg(feature = "functions")]
 use core::hash::{BuildHasher, Hash};
 
@@ -11,7 +14,7 @@ impl_type_path!(::std::collections::HashSet<V, S>);
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(::std::collections::HashSet<V, S>;
     <
-        V: Hash + Eq + FromReflect + TypePath + GetTypeRegistration,
+        V: Hash + Eq + FromReflect + Reflect + TypePath + GetTypeRegistration,
         S: TypePath + BuildHasher + Default + Send + Sync
     >
 );

--- a/crates/bevy_reflect/src/impls/std/path.rs
+++ b/crates/bevy_reflect/src/impls/std/path.rs
@@ -2,7 +2,7 @@ use crate::{
     error::ReflectCloneError,
     kind::{ReflectKind, ReflectMut, ReflectOwned, ReflectRef},
     prelude::*,
-    reflect::ApplyError,
+    reflect::{impl_full_reflect, ApplyError},
     type_info::{OpaqueInfo, TypeInfo, Typed},
     type_path::DynamicTypePath,
     type_registry::{
@@ -116,37 +116,6 @@ impl PartialReflect for &'static Path {
     }
 }
 
-impl Reflect for &'static Path {
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
-
 impl Typed for &'static Path {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
@@ -168,6 +137,8 @@ impl FromReflect for &'static Path {
         reflect.try_downcast_ref::<Self>().copied()
     }
 }
+
+impl_full_reflect!(for &'static Path);
 
 impl PartialReflect for Cow<'static, Path> {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
@@ -259,37 +230,6 @@ impl PartialReflect for Cow<'static, Path> {
     }
 }
 
-impl Reflect for Cow<'static, Path> {
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-}
-
 impl Typed for Cow<'static, Path> {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
@@ -315,6 +255,8 @@ impl GetTypeRegistration for Cow<'static, Path> {
         registration
     }
 }
+
+impl_full_reflect!(for Cow<'static, Path>);
 
 #[cfg(feature = "functions")]
 crate::func::macros::impl_function_traits!(Cow<'static, Path>);

--- a/crates/bevy_reflect/src/impls/std/path.rs
+++ b/crates/bevy_reflect/src/impls/std/path.rs
@@ -35,19 +35,6 @@ impl PartialReflect for &'static Path {
         Some(<Self as Typed>::type_info())
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Ok(self)
     }
@@ -143,19 +130,6 @@ impl_full_reflect!(for &'static Path);
 impl PartialReflect for Cow<'static, Path> {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(<Self as Typed>::type_info())
-    }
-
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
     }
 
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -69,9 +69,9 @@
 //! Since `T: Reflect` implies `T: PartialReflect`, conversion from a `dyn Reflect` to a `dyn PartialReflect`
 //! trait object (upcasting) is infallible and can be performed with one of the following methods.
 //! Note that these are temporary while [the language feature for dyn upcasting coercion] is experimental:
-//! * [`PartialReflect::as_partial_reflect`] for `&dyn PartialReflect`
-//! * [`PartialReflect::as_partial_reflect_mut`] for `&mut dyn PartialReflect`
-//! * [`PartialReflect::into_partial_reflect`] for `Box<dyn PartialReflect>`
+//! * [`CastPartialReflect::as_partial_reflect`] for `&dyn PartialReflect`
+//! * [`CastPartialReflect::as_partial_reflect_mut`] for `&mut dyn PartialReflect`
+//! * [`CastPartialReflect::into_partial_reflect`] for `Box<dyn PartialReflect>`
 //!
 //! For conversion in the other direction — downcasting `dyn PartialReflect` to `dyn Reflect` —
 //! there are fallible methods:
@@ -164,8 +164,8 @@
 //! ```
 //!
 //! And to go back to a general-purpose `dyn PartialReflect`,
-//! we can just use the matching [`PartialReflect::as_partial_reflect`], [`PartialReflect::as_partial_reflect_mut`],
-//! or [`PartialReflect::into_partial_reflect`] methods.
+//! we can just use the matching [`CastPartialReflect::as_partial_reflect`], [`CastPartialReflect::as_partial_reflect_mut`],
+//! or [`CastPartialReflect::into_partial_reflect`] methods.
 //!
 //! ## Opaque Types
 //!
@@ -412,6 +412,7 @@
 //! ```
 //! # use serde::de::DeserializeSeed;
 //! # use bevy_reflect::{
+//! #     cast::CastPartialReflect,
 //! #     serde::{ReflectSerializer, ReflectDeserializer},
 //! #     Reflect, PartialReflect, FromReflect, TypeRegistry
 //! # };
@@ -539,6 +540,9 @@
 //! [the type registry]: #type-registration
 //! [runtime cost]: https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch
 //! [the language feature for dyn upcasting coercion]: https://github.com/rust-lang/rust/issues/65991
+//! [`CastPartialReflect::as_partial_reflect`]: cast::CastPartialReflect::as_partial_reflect
+//! [`CastPartialReflect::as_partial_reflect_mut`]: cast::CastPartialReflect::as_partial_reflect_mut
+//! [`CastPartialReflect::into_partial_reflect`]: cast::CastPartialReflect::into_partial_reflect
 //! [derive macro]: derive@crate::Reflect
 //! [`'static` lifetime]: https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html#trait-bound
 //! [`Tuple`]: crate::tuple::Tuple

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -595,6 +595,7 @@ extern crate alloc;
 extern crate self as bevy_reflect;
 
 pub mod array;
+pub mod cast;
 mod error;
 mod fields;
 mod from_reflect;

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -12,11 +12,10 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::generics::impl_generic_info_methods;
 use crate::{
-    type_info::impl_type_methods, utility::reflect_hasher, ApplyError, FromReflect, Generics,
-    MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type,
-    TypeInfo, TypePath,
+    cast::impl_cast_partial_reflect, type_info::impl_type_methods, utility::reflect_hasher,
+    ApplyError, FromReflect, Generics, MaybeTyped, PartialReflect, Reflect, ReflectKind,
+    ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
 };
-use crate::cast::impl_cast_partial_reflect;
 
 /// A trait used to power [list-like] operations via [reflection].
 ///
@@ -256,21 +255,6 @@ impl PartialReflect for DynamicList {
     #[inline]
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         self.represented_type
-    }
-
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
     }
 
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
@@ -580,7 +564,7 @@ mod tests {
             // If compiled in release mode, verify we dont overflow
             usize::MAX
         };
-        let b = Box::new(vec![(); SIZE]).into_reflect();
+        let b = (Box::new(vec![(); SIZE]) as Box<dyn Reflect>).into_reflect();
 
         let list = b.reflect_ref().as_list().unwrap();
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -16,6 +16,7 @@ use crate::{
     MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type,
     TypeInfo, TypePath,
 };
+use crate::cast::impl_cast_partial_reflect;
 
 /// A trait used to power [list-like] operations via [reflection].
 ///
@@ -338,6 +339,7 @@ impl PartialReflect for DynamicList {
 }
 
 impl_type_path!((in bevy_reflect) DynamicList);
+impl_cast_partial_reflect!(for DynamicList);
 
 impl Debug for DynamicList {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -133,7 +133,8 @@ pub struct ListInfo {
 
 impl ListInfo {
     /// Create a new [`ListInfo`].
-    pub fn new<TList: List + TypePath, TItem: FromReflect + MaybeTyped + TypePath>() -> Self {
+    pub fn new<TList: List + TypePath, TItem: FromReflect + Reflect + MaybeTyped + TypePath>(
+    ) -> Self {
         Self {
             ty: Type::of::<TList>(),
             generics: Generics::new(),

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -7,9 +7,9 @@ use bevy_platform::collections::HashTable;
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    generics::impl_generic_info_methods, type_info::impl_type_methods, ApplyError, Generics,
-    MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type,
-    TypeInfo, TypePath,
+    cast::impl_cast_partial_reflect, generics::impl_generic_info_methods,
+    type_info::impl_type_methods, ApplyError, Generics, MaybeTyped, PartialReflect, Reflect,
+    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
 };
 use alloc::{boxed::Box, format, vec::Vec};
 
@@ -407,6 +407,7 @@ impl PartialReflect for DynamicMap {
 }
 
 impl_type_path!((in bevy_reflect) DynamicMap);
+impl_cast_partial_reflect!(for DynamicMap);
 
 impl Debug for DynamicMap {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -339,21 +339,6 @@ impl PartialReflect for DynamicMap {
         self.represented_type
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -98,7 +98,7 @@ impl From<ReflectKindMismatchError> for ApplyError {
     message = "`{Self}` does not implement `PartialReflect` so cannot be introspected",
     note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
 )]
-pub trait PartialReflect: DynamicTypePath + Send + Sync
+pub trait PartialReflect: CastPartialReflect + DynamicTypePath + Send + Sync
 where
     // NB: we don't use `Self: Any` since for downcasting, `Reflect` should be used.
     Self: 'static,
@@ -119,21 +119,6 @@ where
     /// [`DynamicList`]: crate::list::DynamicList
     /// [`TypeRegistry::get_type_info`]: crate::TypeRegistry::get_type_info
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo>;
-
-    /// Casts this type to a boxed, reflected value.
-    ///
-    /// This is useful for coercing trait objects.
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect>;
-
-    /// Casts this type to a reflected value.
-    ///
-    /// This is useful for coercing trait objects.
-    fn as_partial_reflect(&self) -> &dyn PartialReflect;
-
-    /// Casts this type to a mutable, reflected value.
-    ///
-    /// This is useful for coercing trait objects.
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect;
 
     /// Attempts to cast this type to a boxed, [fully-reflected] value.
     ///
@@ -421,7 +406,7 @@ where
     message = "`{Self}` does not implement `Reflect` so cannot be fully reflected",
     note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
 )]
-pub trait Reflect: PartialReflect + DynamicTyped + Any {
+pub trait Reflect: PartialReflect + CastReflect + DynamicTyped + Any {
     /// Returns the value as a [`Box<dyn Any>`][core::any::Any].
     ///
     /// For remote wrapper types, this will return the remote type instead.
@@ -436,15 +421,6 @@ pub trait Reflect: PartialReflect + DynamicTyped + Any {
     ///
     /// For remote wrapper types, this will return the remote type instead.
     fn as_any_mut(&mut self) -> &mut dyn Any;
-
-    /// Casts this type to a boxed, fully-reflected value.
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect>;
-
-    /// Casts this type to a fully-reflected value.
-    fn as_reflect(&self) -> &dyn Reflect;
-
-    /// Casts this type to a mutable, fully-reflected value.
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect;
 
     /// Performs a type-checked assignment of a reflected value to this value.
     ///
@@ -475,7 +451,7 @@ impl dyn PartialReflect {
     ) -> Result<Box<T>, Box<dyn PartialReflect>> {
         self.try_into_reflect()?
             .downcast()
-            .map_err(PartialReflect::into_partial_reflect)
+            .map_err(CastPartialReflect::into_partial_reflect)
     }
 
     /// Downcasts the value to type `T`, unboxing and consuming the trait object.
@@ -632,18 +608,6 @@ macro_rules! impl_full_reflect {
                 self
             }
 
-            fn into_reflect(self: bevy_platform::prelude::Box<Self>) -> bevy_platform::prelude::Box<dyn $crate::Reflect> {
-                self
-            }
-
-            fn as_reflect(&self) -> &dyn $crate::Reflect {
-                self
-            }
-
-            fn as_reflect_mut(&mut self) -> &mut dyn $crate::Reflect {
-                self
-            }
-
             fn set(
                 &mut self,
                 value: bevy_platform::prelude::Box<dyn $crate::Reflect>,
@@ -655,4 +619,5 @@ macro_rules! impl_full_reflect {
     };
 }
 
+use crate::cast::{CastPartialReflect, CastReflect};
 pub(crate) use impl_full_reflect;

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -616,6 +616,9 @@ impl TypePath for dyn Reflect {
 
 macro_rules! impl_full_reflect {
     ($(<$($id:ident),* $(,)?>)? for $ty:ty $(where $($tt:tt)*)?) => {
+
+        $crate::cast::impl_casting_traits!($(<$($id),*>)? for $ty $(where $($tt)*)?);
+
         impl $(<$($id),*>)? $crate::Reflect for $ty $(where $($tt)*)? {
             fn into_any(self: bevy_platform::prelude::Box<Self>) -> bevy_platform::prelude::Box<dyn ::core::any::Any> {
                 self

--- a/crates/bevy_reflect/src/serde/ser/mod.rs
+++ b/crates/bevy_reflect/src/serde/ser/mod.rs
@@ -21,6 +21,7 @@ mod tuples;
 #[cfg(test)]
 mod tests {
     use crate::{
+        cast::CastPartialReflect,
         serde::{ReflectSerializer, ReflectSerializerProcessor},
         structs::Struct,
         PartialReflect, Reflect, ReflectSerialize, TypeRegistry,

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -264,21 +264,6 @@ impl PartialReflect for DynamicSet {
     }
 
     #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
-    #[inline]
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -7,6 +7,7 @@ use core::fmt::{Debug, Formatter};
 use bevy_platform::collections::{hash_table::OccupiedEntry as HashTableOccupiedEntry, HashTable};
 use bevy_reflect_derive::impl_type_path;
 
+use crate::cast::impl_cast_partial_reflect;
 use crate::{
     generics::impl_generic_info_methods, hash_error, type_info::impl_type_methods, ApplyError,
     Generics, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type,
@@ -333,6 +334,7 @@ impl PartialReflect for DynamicSet {
 }
 
 impl_type_path!((in bevy_reflect) DynamicSet);
+impl_cast_partial_reflect!(for DynamicSet);
 
 impl Debug for DynamicSet {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/crates/bevy_reflect/src/structs.rs
+++ b/crates/bevy_reflect/src/structs.rs
@@ -449,21 +449,6 @@ impl PartialReflect for DynamicStruct {
         self.represented_type
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }

--- a/crates/bevy_reflect/src/structs.rs
+++ b/crates/bevy_reflect/src/structs.rs
@@ -4,6 +4,7 @@
 use crate::generics::impl_generic_info_methods;
 use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
+    cast::impl_cast_partial_reflect,
     type_info::impl_type_methods,
     ApplyError, Generics, NamedField, PartialReflect, Reflect, ReflectKind, ReflectMut,
     ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
@@ -527,6 +528,7 @@ impl PartialReflect for DynamicStruct {
 }
 
 impl_type_path!((in bevy_reflect) DynamicStruct);
+impl_cast_partial_reflect!(for DynamicStruct);
 
 impl Debug for DynamicStruct {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -668,7 +668,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: FromReflect + MaybeTyped + TypePath + GetTypeRegistration),*> FromReflect for ($($name,)*)
+        impl<$($name: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> FromReflect for ($($name,)*)
         {
             fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
                 let _ref_tuple = reflect.reflect_ref().as_tuple().ok()?;
@@ -796,7 +796,7 @@ const _: () = {
     macro_rules! impl_from_arg_tuple {
     ($(#[$meta:meta])* $($name: ident),*) => {
         $(#[$meta])*
-        $crate::func::args::impl_from_arg!(($($name,)*); <$($name: FromReflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
+        $crate::func::args::impl_from_arg!(($($name,)*); <$($name: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
     };
 }
 
@@ -811,7 +811,7 @@ const _: () = {
     macro_rules! impl_into_return_tuple {
     ($(#[$meta:meta])* $($name: ident),+) => {
         $(#[$meta])*
-        $crate::func::impl_into_return!(($($name,)*); <$($name: FromReflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
+        $crate::func::impl_into_return!(($($name,)*); <$($name: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
     };
 }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -6,10 +6,13 @@ use variadics_please::all_tuples;
 
 use crate::generics::impl_generic_info_methods;
 use crate::{
-    type_info::impl_type_methods, utility::GenericTypePathCell, ApplyError, FromReflect, Generics,
-    GetTypeRegistration, MaybeTyped, PartialReflect, Reflect, ReflectCloneError, ReflectKind,
-    ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath, TypeRegistration, TypeRegistry,
-    Typed, UnnamedField,
+    cast::{impl_cast_partial_reflect, CastPartialReflect, CastReflect},
+    type_info::impl_type_methods,
+    utility::GenericTypePathCell,
+    ApplyError, FromReflect, Generics, GetTypeRegistration, MaybeTyped, PartialReflect, Reflect,
+    ReflectCloneError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
+    TypeRegistration, TypeRegistry, Typed, UnnamedField,
+    __macro_exports::RegisterForReflection,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{
@@ -360,6 +363,7 @@ impl PartialReflect for DynamicTuple {
 }
 
 impl_type_path!((in bevy_reflect) DynamicTuple);
+impl_cast_partial_reflect!(for DynamicTuple);
 
 impl FromIterator<Box<dyn PartialReflect>> for DynamicTuple {
     fn from_iter<I: IntoIterator<Item = Box<dyn PartialReflect>>>(fields: I) -> Self {
@@ -503,11 +507,11 @@ pub fn tuple_debug(dyn_tuple: &dyn Tuple, f: &mut Formatter<'_>) -> core::fmt::R
 
 macro_rules! impl_reflect_tuple {
     {$($index:tt : $name:tt),*} => {
-        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> Tuple for ($($name,)*) {
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> Tuple for ($($name,)*) {
             #[inline]
             fn field(&self, index: usize) -> Option<&dyn PartialReflect> {
                 match index {
-                    $($index => Some(&self.$index as &dyn PartialReflect),)*
+                    $($index => Some(CastPartialReflect::as_partial_reflect(&self.$index)),)*
                     _ => None,
                 }
             }
@@ -515,7 +519,7 @@ macro_rules! impl_reflect_tuple {
             #[inline]
             fn field_mut(&mut self, index: usize) -> Option<&mut dyn PartialReflect> {
                 match index {
-                    $($index => Some(&mut self.$index as &mut dyn PartialReflect),)*
+                    $($index => Some(CastPartialReflect::as_partial_reflect_mut(&mut self.$index)),)*
                     _ => None,
                 }
             }
@@ -537,12 +541,12 @@ macro_rules! impl_reflect_tuple {
             #[inline]
             fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>> {
                 vec![
-                    $(Box::new(self.$index),)*
+                    $(CastPartialReflect::into_partial_reflect(Box::new(self.$index)),)*
                 ]
             }
         }
 
-        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> PartialReflect for ($($name,)*) {
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> PartialReflect for ($($name,)*) {
             fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
                 Some(<Self as Typed>::type_info())
             }
@@ -606,7 +610,9 @@ macro_rules! impl_reflect_tuple {
             fn reflect_clone(&self) -> Result<Box<dyn Reflect>, ReflectCloneError> {
                 Ok(Box::new((
                     $(
-                        self.$index.reflect_clone()?
+                        self.$index
+                            .as_partial_reflect()
+                            .reflect_clone()?
                             .take::<$name>()
                             .expect("`Reflect::reflect_clone` should return the same type"),
                     )*
@@ -614,7 +620,7 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> Reflect for ($($name,)*) {
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> Reflect for ($($name,)*) {
             fn into_any(self: Box<Self>) -> Box<dyn Any> {
                 self
             }
@@ -645,7 +651,35 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl <$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> Typed for ($($name,)*) {
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> CastPartialReflect for ($($name,)*) {
+            fn as_partial_reflect(&self) -> &dyn PartialReflect {
+                self
+            }
+
+            fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+                self
+            }
+
+            fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+                self
+            }
+        }
+
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> CastReflect for ($($name,)*) {
+            fn as_reflect(&self) -> &dyn Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+                self
+            }
+
+            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+                self
+            }
+        }
+
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> Typed for ($($name,)*) {
             fn type_info() -> &'static TypeInfo {
                 static CELL: $crate::utility::GenericTypeInfoCell = $crate::utility::GenericTypeInfoCell::new();
                 CELL.get_or_insert::<Self, _>(|| {
@@ -658,17 +692,17 @@ macro_rules! impl_reflect_tuple {
             }
         }
 
-        impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> GetTypeRegistration for ($($name,)*) {
+        impl<$($name: CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> GetTypeRegistration for ($($name,)*) {
             fn get_type_registration() -> TypeRegistration {
                 TypeRegistration::of::<($($name,)*)>()
             }
 
             fn register_type_dependencies(_registry: &mut TypeRegistry) {
-                $(_registry.register::<$name>();)*
+                $(<$name as RegisterForReflection>::__register(_registry);)*
             }
         }
 
-        impl<$($name: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> FromReflect for ($($name,)*)
+        impl<$($name: FromReflect + CastPartialReflect + MaybeTyped + TypePath + RegisterForReflection),*> FromReflect for ($($name,)*)
         {
             fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
                 let _ref_tuple = reflect.reflect_ref().as_tuple().ok()?;
@@ -796,7 +830,7 @@ const _: () = {
     macro_rules! impl_from_arg_tuple {
     ($(#[$meta:meta])* $($name: ident),*) => {
         $(#[$meta])*
-        $crate::func::args::impl_from_arg!(($($name,)*); <$($name: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
+        $crate::func::args::impl_from_arg!(($($name,)*); <$($name: FromReflect + Reflect + MaybeTyped + TypePath + RegisterForReflection),*>);
     };
 }
 
@@ -811,7 +845,7 @@ const _: () = {
     macro_rules! impl_into_return_tuple {
     ($(#[$meta:meta])* $($name: ident),+) => {
         $(#[$meta])*
-        $crate::func::impl_into_return!(($($name,)*); <$($name: FromReflect + Reflect + MaybeTyped + TypePath + GetTypeRegistration),*>);
+        $crate::func::impl_into_return!(($($name,)*); <$($name: FromReflect + Reflect + MaybeTyped + TypePath + RegisterForReflection),*>);
     };
 }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -289,19 +289,6 @@ impl PartialReflect for DynamicTuple {
         self.represented_type
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }
@@ -551,19 +538,6 @@ macro_rules! impl_reflect_tuple {
                 Some(<Self as Typed>::type_info())
             }
 
-            #[inline]
-            fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-                self
-            }
-
-            fn as_partial_reflect(&self) -> &dyn PartialReflect {
-                self
-            }
-
-            fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-                self
-            }
-
             fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
                 Ok(self)
             }
@@ -630,18 +604,6 @@ macro_rules! impl_reflect_tuple {
             }
 
             fn as_any_mut(&mut self) -> &mut dyn Any {
-                self
-            }
-
-            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-                self
-            }
-
-            fn as_reflect(&self) -> &dyn Reflect {
-                self
-            }
-
-            fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
                 self
             }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -297,21 +297,6 @@ impl PartialReflect for DynamicTupleStruct {
         self.represented_type
     }
 
-    #[inline]
-    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect(&self) -> &dyn PartialReflect {
-        self
-    }
-
-    #[inline]
-    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
-        self
-    }
-
     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
         Err(self)
     }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -6,6 +6,7 @@ use bevy_reflect_derive::impl_type_path;
 use crate::generics::impl_generic_info_methods;
 use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
+    cast::impl_cast_partial_reflect,
     tuple::{DynamicTuple, Tuple},
     type_info::impl_type_methods,
     ApplyError, Generics, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
@@ -377,6 +378,7 @@ impl PartialReflect for DynamicTupleStruct {
 }
 
 impl_type_path!((in bevy_reflect) DynamicTupleStruct);
+impl_cast_partial_reflect!(for DynamicTupleStruct);
 
 impl Debug for DynamicTupleStruct {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -7,7 +7,7 @@ use crate::{
     structs::{DynamicStruct, StructInfo},
     tuple::{DynamicTuple, TupleInfo},
     tuple_struct::{DynamicTupleStruct, TupleStructInfo},
-    Generics, PartialReflect, Reflect, ReflectKind, TypePath, TypePathTable,
+    Generics, Reflect, ReflectKind, TypePath, TypePathTable,
 };
 use core::{
     any::{Any, TypeId},
@@ -117,7 +117,7 @@ pub trait Typed: Reflect + TypePath {
     message = "`{Self}` does not implement `Typed` so cannot provide static type information",
     note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
 )]
-pub trait MaybeTyped: PartialReflect {
+pub trait MaybeTyped {
     /// Returns the compile-time [info] for the underlying type, if it exists.
     ///
     /// [info]: TypeInfo

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -7,7 +7,7 @@ use crate::{
     structs::{DynamicStruct, StructInfo},
     tuple::{DynamicTuple, TupleInfo},
     tuple_struct::{DynamicTupleStruct, TupleStructInfo},
-    Generics, Reflect, ReflectKind, TypePath, TypePathTable,
+    Generics, ReflectKind, TypePath, TypePathTable,
 };
 use core::{
     any::{Any, TypeId},
@@ -592,7 +592,7 @@ pub struct OpaqueInfo {
 
 impl OpaqueInfo {
     /// Creates a new [`OpaqueInfo`].
-    pub fn new<T: Reflect + TypePath + ?Sized>() -> Self {
+    pub fn new<T: TypePath + ?Sized>() -> Self {
         Self {
             ty: Type::of::<T>(),
             generics: Generics::new(),

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -96,7 +96,7 @@ use thiserror::Error;
     message = "`{Self}` does not implement `Typed` so cannot provide static type information",
     note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
 )]
-pub trait Typed: Reflect + TypePath {
+pub trait Typed: TypePath {
     /// Returns the compile-time [info] for the underlying type.
     ///
     /// [info]: TypeInfo

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -39,7 +39,7 @@ use thiserror::Error;
 ///
 /// ```
 /// # use core::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, NamedField, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, structs::StructInfo, TypeInfo, TypePath, OpaqueInfo, ApplyError};
+/// # use bevy_reflect::{cast::{CastPartialReflect, CastReflect}, DynamicTypePath, NamedField, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, structs::StructInfo, TypeInfo, TypePath, OpaqueInfo, ApplyError};
 /// # use bevy_reflect::utility::NonGenericTypeInfoCell;
 /// use bevy_reflect::Typed;
 ///
@@ -68,9 +68,6 @@ use thiserror::Error;
 /// # }
 /// # impl PartialReflect for MyStruct {
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
-/// #     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> { todo!() }
-/// #     fn as_partial_reflect(&self) -> &dyn PartialReflect { todo!() }
-/// #     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect { todo!() }
 /// #     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> { todo!() }
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
@@ -83,10 +80,17 @@ use thiserror::Error;
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }
 /// #     fn as_any_mut(&mut self) -> &mut dyn Any { todo!() }
-/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { todo!() }
-/// #     fn as_reflect(&self) -> &dyn Reflect { todo!() }
-/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
+/// # }
+/// # impl CastPartialReflect for MyStruct {
+/// #     fn as_partial_reflect(&self) -> &dyn PartialReflect { self }
+/// #     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect { self }
+/// #     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> { self }
+/// # }
+/// # impl CastReflect for MyStruct {
+/// #     fn as_reflect(&self) -> &dyn Reflect { self }
+/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { self }
+/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { self }
 /// # }
 /// ```
 ///

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -561,7 +561,7 @@ impl Debug for TypeRegistration {
 
 impl TypeRegistration {
     /// Creates type registration information for `T`.
-    pub fn of<T: Reflect + Typed + TypePath>() -> Self {
+    pub fn of<T: Typed + TypePath>() -> Self {
         Self {
             data: Default::default(),
             type_info: T::type_info(),

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -56,7 +56,7 @@ mod sealed {
 ///
 /// ```
 /// # use core::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, NamedField, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, structs::StructInfo, Typed, TypeInfo, TypePath, ApplyError};
+/// # use bevy_reflect::{cast::{CastPartialReflect, CastReflect}, DynamicTypePath, NamedField, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, structs::StructInfo, Typed, TypeInfo, TypePath, ApplyError};
 /// use bevy_reflect::utility::NonGenericTypeInfoCell;
 ///
 /// struct Foo {
@@ -79,9 +79,6 @@ mod sealed {
 /// # }
 /// # impl PartialReflect for Foo {
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
-/// #     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> { todo!() }
-/// #     fn as_partial_reflect(&self) -> &dyn PartialReflect { todo!() }
-/// #     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect { todo!() }
 /// #     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> { todo!() }
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
@@ -94,10 +91,17 @@ mod sealed {
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }
 /// #     fn as_any_mut(&mut self) -> &mut dyn Any { todo!() }
-/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { todo!() }
-/// #     fn as_reflect(&self) -> &dyn Reflect { todo!() }
-/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
+/// # }
+/// # impl CastPartialReflect for Foo {
+/// #     fn as_partial_reflect(&self) -> &dyn PartialReflect { self }
+/// #     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect { self }
+/// #     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> { self }
+/// # }
+/// # impl CastReflect for Foo {
+/// #     fn as_reflect(&self) -> &dyn Reflect { self }
+/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { self }
+/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { self }
 /// # }
 /// ```
 ///
@@ -144,7 +148,7 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 ///
 /// ```
 /// # use core::any::Any;
-/// # use bevy_reflect::{DynamicTypePath, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, tuple_struct::TupleStructInfo, Typed, TypeInfo, TypePath, UnnamedField, ApplyError, Generics, TypeParamInfo};
+/// # use bevy_reflect::{cast::{CastPartialReflect, CastReflect}, DynamicTypePath, PartialReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, tuple_struct::TupleStructInfo, Typed, TypeInfo, TypePath, UnnamedField, ApplyError, Generics, TypeParamInfo};
 /// use bevy_reflect::utility::GenericTypeInfoCell;
 ///
 /// struct Foo<T>(T);
@@ -166,9 +170,6 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 /// # }
 /// # impl<T: PartialReflect + TypePath> PartialReflect for Foo<T> {
 /// #     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> { todo!() }
-/// #     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> { todo!() }
-/// #     fn as_partial_reflect(&self) -> &dyn PartialReflect { todo!() }
-/// #     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect { todo!() }
 /// #     fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> { todo!() }
 /// #     fn try_as_reflect(&self) -> Option<&dyn Reflect> { todo!() }
 /// #     fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> { todo!() }
@@ -181,10 +182,17 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 /// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
 /// #     fn as_any(&self) -> &dyn Any { todo!() }
 /// #     fn as_any_mut(&mut self) -> &mut dyn Any { todo!() }
-/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { todo!() }
-/// #     fn as_reflect(&self) -> &dyn Reflect { todo!() }
-/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
+/// # }
+/// # impl<T: PartialReflect + TypePath> CastPartialReflect for Foo<T> {
+/// #     fn as_partial_reflect(&self) -> &dyn PartialReflect { self }
+/// #     fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect { self }
+/// #     fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> { self }
+/// # }
+/// # impl<T: Reflect + Typed + TypePath> CastReflect for Foo<T> {
+/// #     fn as_reflect(&self) -> &dyn Reflect { self }
+/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { self }
+/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { self }
 /// # }
 /// ```
 ///

--- a/crates/bevy_scene/src/reflect_utils.rs
+++ b/crates/bevy_scene/src/reflect_utils.rs
@@ -1,4 +1,6 @@
-use bevy_reflect::{PartialReflect, ReflectFromReflect, TypeRegistration};
+use bevy_reflect::{
+    cast::CastPartialReflect, PartialReflect, ReflectFromReflect, TypeRegistration,
+};
 
 /// Attempts to clone a [`PartialReflect`] value using various methods.
 ///
@@ -14,12 +16,12 @@ pub(super) fn clone_reflect_value(
 ) -> Box<dyn PartialReflect> {
     value
         .reflect_clone()
-        .map(PartialReflect::into_partial_reflect)
+        .map(CastPartialReflect::into_partial_reflect)
         .unwrap_or_else(|_| {
             type_registration
                 .data::<ReflectFromReflect>()
                 .and_then(|fr| fr.from_reflect(value.as_partial_reflect()))
-                .map(PartialReflect::into_partial_reflect)
+                .map(CastPartialReflect::into_partial_reflect)
                 .unwrap_or_else(|| value.to_dynamic())
         })
 }

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -4,6 +4,7 @@ use crate::{DynamicEntity, DynamicScene};
 use bevy_ecs::entity::Entity;
 use bevy_platform::collections::HashSet;
 use bevy_reflect::{
+    cast::CastPartialReflect,
     serde::{
         ReflectDeserializer, TypeRegistrationDeserializer, TypedReflectDeserializer,
         TypedReflectSerializer,
@@ -497,7 +498,7 @@ impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
                 .get(registration.type_id())
                 .and_then(|tr| tr.data::<ReflectFromReflect>())
                 .and_then(|fr| fr.from_reflect(value.as_partial_reflect()))
-                .map(PartialReflect::into_partial_reflect)
+                .map(CastPartialReflect::into_partial_reflect)
                 .unwrap_or(value);
 
             entries.push(value);

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[cfg(feature = "bevy_reflect")]
-use bevy_reflect::{FromReflect, GetTypeRegistration, Typed};
+use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, Typed};
 
 /// State installation methods for [`App`] and [`SubApp`].
 pub trait AppExtStates {
@@ -65,7 +65,7 @@ pub trait AppExtStates {
     /// This enables reflection code to access the state. For detailed information, see the docs on [`crate::reflect::ReflectState`] .
     fn register_type_state<S>(&mut self) -> &mut Self
     where
-        S: States + FromReflect + GetTypeRegistration + Typed;
+        S: States + FromReflect + Reflect + GetTypeRegistration + Typed;
 
     #[cfg(feature = "bevy_reflect")]
     /// Registers the state type `T` using [`App::register_type`],
@@ -75,7 +75,7 @@ pub trait AppExtStates {
     /// For detailed information, see the docs on [`crate::reflect::ReflectState`] and [`crate::reflect::ReflectFreelyMutableState`].
     fn register_type_mutable_state<S>(&mut self) -> &mut Self
     where
-        S: FreelyMutableState + FromReflect + GetTypeRegistration + Typed;
+        S: FreelyMutableState + FromReflect + Reflect + GetTypeRegistration + Typed;
 }
 
 /// Separate function to only warn once for all state installation methods.
@@ -212,7 +212,7 @@ impl AppExtStates for SubApp {
     #[cfg(feature = "bevy_reflect")]
     fn register_type_state<S>(&mut self) -> &mut Self
     where
-        S: States + FromReflect + GetTypeRegistration + Typed,
+        S: States + FromReflect + Reflect + GetTypeRegistration + Typed,
     {
         self.register_type::<S>();
         self.register_type::<State<S>>();
@@ -224,7 +224,7 @@ impl AppExtStates for SubApp {
     #[cfg(feature = "bevy_reflect")]
     fn register_type_mutable_state<S>(&mut self) -> &mut Self
     where
-        S: FreelyMutableState + FromReflect + GetTypeRegistration + Typed,
+        S: FreelyMutableState + FromReflect + Reflect + GetTypeRegistration + Typed,
     {
         self.register_type::<S>();
         self.register_type::<State<S>>();
@@ -285,7 +285,7 @@ impl AppExtStates for App {
     #[cfg(feature = "bevy_reflect")]
     fn register_type_state<S>(&mut self) -> &mut Self
     where
-        S: States + FromReflect + GetTypeRegistration + Typed,
+        S: States + FromReflect + Reflect + GetTypeRegistration + Typed,
     {
         self.main_mut().register_type_state::<S>();
         self
@@ -294,7 +294,7 @@ impl AppExtStates for App {
     #[cfg(feature = "bevy_reflect")]
     fn register_type_mutable_state<S>(&mut self) -> &mut Self
     where
-        S: FreelyMutableState + FromReflect + GetTypeRegistration + Typed,
+        S: FreelyMutableState + FromReflect + Reflect + GetTypeRegistration + Typed,
     {
         self.main_mut().register_type_mutable_state::<S>();
         self

--- a/examples/reflection/dynamic_types.rs
+++ b/examples/reflection/dynamic_types.rs
@@ -2,6 +2,7 @@
 
 use bevy::reflect::{
     array::DynamicArray,
+    cast::CastPartialReflect,
     enums::{DynamicEnum, DynamicVariant},
     list::DynamicList,
     map::DynamicMap,


### PR DESCRIPTION
# Objective

Closes #3392
Closes #3400
Closes #6098
Closes #9929
Closes #14776

Here we go again...

I won't go into detail about the problem space as it has been covered in all those issues/PRs above (see #14776 for a high-level overview).

Essentially, we want to enable this:

```rust
#[derive(Reflect)]
struct Player {
    weapon: Box<dyn Reflect>
}
```

without directly implementing `Reflect` for `Box<dyn Reflect>`, as this makes it very easy to accidentally "double-box" your trait object. And though those double-boxed values would still behave as though it were just the inner type, it would really be potentially dozens of unnecessary pointer dereferences and heap allocations depending on how deep the double-boxing goes.

So what's the solution?

#14776 attempted to solve the problem by using remote reflection and introducing a `RemoteBox<T>` type, as suggested by @soqb.

While that approach works and saves us from the double-boxing problem, it still has some limitations.

The biggest limitation is the inability to use it as a type parameter to another type (e.g. the `T` in `Foo<T>`), since remote reflection doesn't support remotely reflecting a type parameter.

This is a real pain point as it significantly blocks us from supporting things like `Vec<Box<dyn Reflect>>` and `HashMap<String, Box<dyn Reflect>>`—arguably some of the most common cases for this feature.

So this PR attempts to support `Box<dyn Reflect>` without implementing `Reflect` on it and without using remote reflection.

How? By taking [another idea](https://github.com/bevyengine/bevy/pull/14776#issuecomment-2293705905) from @soqb!

## Solution

This PR introduces two new traits: `CastPartialReflect` and `CastReflect`. These are used to cast to `dyn PartialReflect` and `dyn Reflect`, respectively. In fact, they're supertraits of those traits!

By introducing these traits, we can alter the behavior of the logic used in the derive macro and custom implementations to rely on them. In other words, rather than requiring a type that _is_ `PartialReflect`, we require one that _casts_ to `PartialReflect`.

This means we can support any wrapper type around a reflected type and almost act as if it doesn't exist!

Obviously, this is meant to work with `Box<dyn Reflect>` and `Box<dyn PartialReflect>`, but it also supports `Box<T: PartialReflect>` (if you need that for some reason) as well as `Box<dyn CustomTrait>`, where `CustomTrait: CastPartialReflect`.

### Future Work

To keep these PRs smaller and tighter in scope, I decided to split this feature across multiple PRs.

This is the primary one, that lays down the groundwork for those to come.

The following PRs may potentially be somewhat controversial, and they may modify the API proposed here in less ergonomic ways in order to achieve their goals.

#### `FromReflect`

One thing we may want to do is support `FromReflect` for these types so their container types can also be `FromReflect`.

Now we could just implement it and return `None` or attempt to clone and cast the data (which is also likely to return `None`), but this almost makes the problem worse: types containing these ones will almost always fail.

Instead, we should look into making `ReflectFromReflect` available to these types. One way will be through a global `TypeRegistry`. However, since that may be a ways out, another way is through storing it on `TypeInfo`, which is the solution I'm planning to look into.

#### Serialization

With `FromReflect` solved, we're going to want a way to easily serialize and deserialize these types.

Luckily, #15131 sorta already solved this problem. I'll work on rebasing that PR so it can be reviewed and merged, making support for `Box<dyn Reflect>` serialization almost trivial.

However, it still needs review. If we don't like the approach or can't agree on the format for the dynamic types, then that affects `Box<dyn Reflect>` as well (seeing as it is partially a dynamic type).

#### Modification

Currently, the wrapper type is completely hidden away (apart from `TypeInfo` and `TypeRegistration`) once thrown behind a `dyn PartialReflect` or `dyn Reflect`. This works fine, but it does mean that there is no way to modify the wrapper itself.

As [suggested](https://github.com/bevyengine/bevy/pull/14776#issuecomment-2294341351) by @SkiFire13, it would be nice if there was a way to `Reflect::set` or `PartialReflect::apply` the `Box<dyn Reflect>` itself so it's stored value could be changed at runtime.

This is a trickier problem to solve and may require a larger change. I think it might be possible by moving the `apply` and `set` methods to these new traits (or rather, introduce new traits for modifying `PartialReflect` and `Reflect` types). That should allow wrapper types like `Box` to control how they are modified.

On top of another big change, this will potentially also affect the ergonomics of supporting custom trait objects. If so, it's not the end of the world, but all of these nuances are better off being explored in a separate PR.

## Testing

You can test locally by running:

```
cargo test --package bevy_reflect --all-features
```

---

## Showcase

A common occurrence when reflecting a type is wanting to store reflected data within a reflected type. This wasn't possible before, but now it is!

```rust
#[derive(Reflect)]
struct Sword {
    damage: u32
}

#[derive(Reflect)]
// Keep in mind that `Box<dyn Reflect>` does not implement `FromReflect`.
// Because of this, we will need to opt-out of the automatic `FromReflect` impl:
#[reflect(from_reflect = false)]
struct Player {
    weapon: Box<dyn Reflect>
}

let player = Player {
    // We can create our `Box<dyn Reflect>` as normal:
    weapon: Box::new(Sword { damage: 100 })
};

// Now we can reflect `weapon`!
let weapon: &dyn Reflect = player.weapon.as_reflect();
assert!(weapon.reflect_partial_eq(&Sword { damage: 100 }).unwrap_or_default());
```

This works thanks to changes in `bevy_reflect` that makes the reflection logic now use the new `CastPartialReflect` and `CastReflect` traits. This means our fields no longer need to implement `Reflect` themselves, but can instead delegate their reflection behavior to another type at runtime!

## Migration Guide

The `Reflect` bound has been removed from `FromReflect`. If you were relying on that bound existing, you will now need to add it yourself:

```rust
// BEFORE
impl<T: FromReflect> MyType<T> {/* ... */}

// AFTER
impl<T: FromReflect + Reflect> MyType<T> {/* ... */}
```

The `Reflect` bound has been removed from `Typed`. If you were relying on that bound existing, you will now need to add it yourself:

```rust
// BEFORE
impl<T: Typed> MyType<T> {/* ... */}

// AFTER
impl<T: Typed + Reflect> MyType<T> {/* ... */}
```

The following trait methods have been moved:

- `Reflect::as_reflect` → `CastReflect::as_reflect`
- `Reflect::as_reflect_mut` → `CastReflect::as_reflect_mut`
- `Reflect::into_reflect` → `CastReflect::into_reflect`

`Reflect` now also requires `CastReflect`.