### PR TITLE
Add `sub_camera_view`, enabling sheared projection 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3431,6 +3431,17 @@ category = "3D Rendering"
 wasm = false
 
 [[example]]
+name = "camera_sub_view"
+path = "examples/3d/camera_sub_view.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.camera_sub_view]
+name = "Camera sub view"
+description = "Demonstrates using different sub view effects on a camera"
+category = "3D Rendering"
+wasm = true
+
+[[example]]
 name = "color_grading"
 path = "examples/3d/color_grading.rs"
 doc-scrape-examples = true

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -72,6 +72,29 @@ impl Default for Viewport {
 /// When [`Camera::sub_camera_view`] is `Some`, only the sub-section of the
 /// image defined by `size` and `offset` (relative to the `full_size` of the
 /// whole image) is projected to the cameras viewport.
+///
+/// Take the example of the following multi-monitor setup:
+/// ```css
+/// ┌───┬───┐
+/// │ A │ B │
+/// ├───┼───┤
+/// │ C │ D │
+/// └───┴───┘
+/// ```
+/// If each monitor is 1920x1080, the whole image will have a resolution of
+/// 3840x2160. For each monitor we can use a single camera with a viewport of
+/// the same size as the monitor it corresponds to. To ensure that the image is
+/// cohesive, we can use a different sub view on each camera:
+/// - Camera A: `full_size` = 3840x2160, `size` = 1920x1080, `offset` = 0,0
+/// - Camera B: `full_size` = 3840x2160, `size` = 1920x1080, `offset` = 1920,0
+/// - Camera C: `full_size` = 3840x2160, `size` = 1920x1080, `offset` = 0,1080
+/// - Camera D: `full_size` = 3840x2160, `size` = 1920x1080, `offset` =
+///   1920,1080
+///
+/// However since only the ratio between the values is important, they could all
+/// be divided by 120 and still produce the same image. Camera D would for
+/// example have the following values:
+/// `full_size` = 32x18, `size` = 16x9, `offset` = 16,9
 #[derive(Debug, Clone, Copy, Reflect, PartialEq)]
 pub struct SubCameraView {
     /// Size of the entire camera view

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -25,7 +25,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res, ResMut, Resource},
 };
-use bevy_math::{ops, vec2, Dir3, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
+use bevy_math::{ops, vec2, Dir3, IVec2, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render_macros::ExtractComponent;
 use bevy_transform::components::GlobalTransform;
@@ -72,7 +72,7 @@ pub struct SubCameraView {
     /// Size of the entire camera view
     pub full_size: UVec2,
     /// Offset of the sub camera
-    pub offset: UVec2,
+    pub offset: IVec2,
     /// Size of the sub camera
     pub size: UVec2,
 }
@@ -81,7 +81,7 @@ impl Default for SubCameraView {
     fn default() -> Self {
         Self {
             full_size: UVec2::new(100, 100),
-            offset: UVec2::new(0, 0),
+            offset: IVec2::new(0, 0),
             size: UVec2::new(100, 100),
         }
     }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -25,7 +25,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res, ResMut, Resource},
 };
-use bevy_math::{ops, vec2, Dir3, IVec2, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
+use bevy_math::{ops, vec2, Dir3, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render_macros::ExtractComponent;
 use bevy_transform::components::GlobalTransform;
@@ -72,12 +72,12 @@ impl Default for Viewport {
 /// When [`Camera::sub_camera_view`] is `Some`, only the sub-section of the
 /// image defined by `size` and `offset` (relative to the `full_size` of the
 /// whole image) is projected to the cameras viewport.
-#[derive(Debug, Clone, Copy, Reflect, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Reflect, PartialEq)]
 pub struct SubCameraView {
     /// Size of the entire camera view
     pub full_size: UVec2,
     /// Offset of the sub camera
-    pub offset: IVec2,
+    pub offset: Vec2,
     /// Size of the sub camera
     pub size: UVec2,
 }
@@ -85,9 +85,9 @@ pub struct SubCameraView {
 impl Default for SubCameraView {
     fn default() -> Self {
         Self {
-            full_size: UVec2::new(100, 100),
-            offset: IVec2::new(0, 0),
-            size: UVec2::new(100, 100),
+            full_size: UVec2::new(1, 1),
+            offset: Vec2::new(0., 0.),
+            size: UVec2::new(1, 1),
         }
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -106,6 +106,7 @@ pub struct ComputedCameraValues {
     target_info: Option<RenderTargetInfo>,
     // size of the `Viewport`
     old_viewport_size: Option<UVec2>,
+    old_sub_camera_view: Option<SubCameraView>,
 }
 
 /// How much energy a `Camera3d` absorbs from incoming light.
@@ -866,6 +867,7 @@ pub fn camera_system<T: CameraProjection + Component>(
                 || camera.is_added()
                 || camera_projection.is_changed()
                 || camera.computed.old_viewport_size != viewport_size
+                || camera.computed.old_sub_camera_view != camera.sub_camera_view
             {
                 let new_computed_target_info = normalized_target.get_render_target_info(
                     &windows,
@@ -923,6 +925,10 @@ pub fn camera_system<T: CameraProjection + Component>(
 
         if camera.computed.old_viewport_size != viewport_size {
             camera.computed.old_viewport_size = viewport_size;
+        }
+
+        if camera.computed.old_sub_camera_view != camera.sub_camera_view {
+            camera.computed.old_sub_camera_view = camera.sub_camera_view;
         }
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -67,6 +67,11 @@ impl Default for Viewport {
     }
 }
 
+/// Settings to define a camera sub view.
+///
+/// When added to a camera, only the sub-section of the image defined by `size`
+/// and `offset` (relative to the `full_size` of the whole image) is projected
+/// to the cameras viewport.
 #[derive(Debug, Clone, Copy, Reflect, PartialEq, Eq)]
 pub struct SubCameraView {
     /// Size of the entire camera view

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -69,9 +69,9 @@ impl Default for Viewport {
 
 /// Settings to define a camera sub view.
 ///
-/// When added to a camera, only the sub-section of the image defined by `size`
-/// and `offset` (relative to the `full_size` of the whole image) is projected
-/// to the cameras viewport.
+/// When [`Camera::sub_camera_view`] is `Some`, only the sub-section of the
+/// image defined by `size` and `offset` (relative to the `full_size` of the
+/// whole image) is projected to the cameras viewport.
 #[derive(Debug, Clone, Copy, Reflect, PartialEq, Eq)]
 pub struct SubCameraView {
     /// Size of the entire camera view

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -200,13 +200,11 @@ impl CameraProjection for PerspectiveProjection {
     fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4 {
         let full_width = sub_view.full_size.x as f32;
         let full_height = sub_view.full_size.y as f32;
-        let offset_x = sub_view.offset.x as f32;
-        let offset_y = sub_view.offset.y as f32;
         let sub_width = sub_view.size.x as f32;
         let sub_height = sub_view.size.y as f32;
-
+        let offset_x = sub_view.offset.x as f32;
         // Y-axis increases from top to bottom
-        let offset_y = full_height - (offset_y + sub_height);
+        let offset_y = full_height - ((sub_view.offset.y as f32) + sub_height);
 
         // Original frustum parameters
         let top = self.near * f32::tan(0.5 * self.fov);

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -76,6 +76,7 @@ pub struct CameraUpdateSystem;
 /// [`Camera`]: crate::camera::Camera
 pub trait CameraProjection {
     fn get_clip_from_view(&self) -> Mat4;
+    fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4;
     fn update(&mut self, width: f32, height: f32);
     fn far(&self) -> f32;
     fn get_frustum_corners(&self, z_near: f32, z_far: f32) -> [Vec3A; 8];
@@ -121,6 +122,13 @@ impl CameraProjection for Projection {
         match self {
             Projection::Perspective(projection) => projection.get_clip_from_view(),
             Projection::Orthographic(projection) => projection.get_clip_from_view(),
+        }
+    }
+
+    fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4 {
+        match self {
+            Projection::Perspective(projection) => projection.get_clip_from_view_for_sub(sub_view),
+            Projection::Orthographic(projection) => projection.get_clip_from_view_for_sub(sub_view),
         }
     }
 
@@ -187,6 +195,10 @@ pub struct PerspectiveProjection {
 impl CameraProjection for PerspectiveProjection {
     fn get_clip_from_view(&self) -> Mat4 {
         Mat4::perspective_infinite_reverse_rh(self.fov, self.aspect_ratio, self.near)
+    }
+
+    fn get_clip_from_view_for_sub(&self, _sub_view: &super::SubCameraView) -> Mat4 {
+        self.get_clip_from_view()
     }
 
     fn update(&mut self, width: f32, height: f32) {
@@ -393,6 +405,10 @@ impl CameraProjection for OrthographicProjection {
             self.far,
             self.near,
         )
+    }
+
+    fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4 {
+        self.get_clip_from_view()
     }
 
     fn update(&mut self, width: f32, height: f32) {

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -207,7 +207,7 @@ impl CameraProjection for PerspectiveProjection {
         let offset_y = full_height - ((sub_view.offset.y as f32) + sub_height);
 
         // Original frustum parameters
-        let top = self.near * f32::tan(0.5 * self.fov);
+        let top = self.near * ops::tan(0.5 * self.fov);
         let bottom = -top;
         let right = top * self.aspect_ratio;
         let left = -right;

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -202,9 +202,9 @@ impl CameraProjection for PerspectiveProjection {
         let full_height = sub_view.full_size.y as f32;
         let sub_width = sub_view.size.x as f32;
         let sub_height = sub_view.size.y as f32;
-        let offset_x = sub_view.offset.x as f32;
+        let offset_x = sub_view.offset.x;
         // Y-axis increases from top to bottom
-        let offset_y = full_height - ((sub_view.offset.y as f32) + sub_height);
+        let offset_y = full_height - (sub_view.offset.y + sub_height);
 
         // Original frustum parameters
         let top = self.near * ops::tan(0.5 * self.fov);
@@ -445,8 +445,8 @@ impl CameraProjection for OrthographicProjection {
     fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4 {
         let full_width = sub_view.full_size.x as f32;
         let full_height = sub_view.full_size.y as f32;
-        let offset_x = sub_view.offset.x as f32;
-        let offset_y = sub_view.offset.y as f32;
+        let offset_x = sub_view.offset.x;
+        let offset_y = sub_view.offset.y;
         let sub_width = sub_view.size.x as f32;
         let sub_height = sub_view.size.y as f32;
 

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -149,7 +149,7 @@ fn setup(
 
     // Orthographic camera right
     commands.spawn(Camera3dBundle {
-        projection: Projection::Orthographic(OrthographicProjection::default),
+        projection: OrthographicProjection::default().into(),
         camera: Camera {
             viewport: Option::from(Viewport {
                 physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -103,7 +103,7 @@ fn setup(
         ..default()
     });
 
-    // Perpective camera moving
+    // Perspective camera moving
     commands.spawn((
         Camera3dBundle {
             camera: Camera {

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -1,0 +1,183 @@
+//! Renders multiple cameras with different sub view efffects.
+use bevy::{
+    math::uvec2,
+    prelude::*,
+    render::camera::{SubCameraView, Viewport},
+};
+
+const PADDING: u32 = 10;
+const SMALL_SIZE: u32 = 100;
+const LARGE_SIZE: u32 = 450;
+
+const WINDOW_HEIGHT: f32 = (LARGE_SIZE + PADDING * 3 + SMALL_SIZE) as f32;
+const WINDOW_WIDTH: f32 = (LARGE_SIZE + PADDING * 2) as f32;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resize_constraints: WindowResizeConstraints {
+                    min_width: WINDOW_WIDTH,
+                    min_height: WINDOW_HEIGHT,
+                    max_width: WINDOW_WIDTH,
+                    max_height: WINDOW_HEIGHT,
+                },
+                ..default()
+            }),
+            ..default()
+        }))
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_camera_view)
+        .run();
+}
+
+#[derive(Debug, Component)]
+struct MovingCameraMarker;
+
+/// Set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let transform = Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y);
+
+    // Plane
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
+        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
+        ..default()
+    });
+
+    // Cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Cuboid::default()),
+        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+
+    // Main perspective Camera
+    commands.spawn(Camera3dBundle {
+        camera: Camera {
+            viewport: Option::from(Viewport {
+                physical_size: UVec2::new(LARGE_SIZE, LARGE_SIZE),
+                physical_position: UVec2::new(PADDING, PADDING * 2 + SMALL_SIZE),
+                ..default()
+            }),
+            ..default()
+        },
+        transform,
+        ..default()
+    });
+
+    // Perspective camera left half
+    commands.spawn(Camera3dBundle {
+        camera: Camera {
+            viewport: Option::from(Viewport {
+                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
+                physical_position: uvec2(PADDING, PADDING),
+                ..default()
+            }),
+            sub_camera_view: Some(SubCameraView {
+                full_size: uvec2(500, 500),
+                offset: uvec2(0, 0),
+                size: uvec2(250, 500),
+            }),
+            order: 1,
+            clear_color: ClearColorConfig::None,
+            ..default()
+        },
+        transform,
+        ..default()
+    });
+
+    // Perpective camera moving
+    commands.spawn((
+        Camera3dBundle {
+            camera: Camera {
+                viewport: Option::from(Viewport {
+                    physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
+                    physical_position: uvec2(PADDING * 2 + SMALL_SIZE, PADDING),
+                    ..default()
+                }),
+                sub_camera_view: Some(SubCameraView {
+                    full_size: uvec2(500, 500),
+                    offset: uvec2(0, 0),
+                    size: uvec2(100, 100),
+                }),
+                order: 2,
+                clear_color: ClearColorConfig::None,
+                ..default()
+            },
+            transform,
+            ..default()
+        },
+        MovingCameraMarker,
+    ));
+
+    // Perspective camera control
+    commands.spawn(Camera3dBundle {
+        camera: Camera {
+            viewport: Option::from(Viewport {
+                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
+                physical_position: uvec2(PADDING * 3 + SMALL_SIZE * 2, PADDING),
+                ..default()
+            }),
+            sub_camera_view: Some(SubCameraView {
+                full_size: uvec2(450, 450),
+                offset: uvec2(0, 0),
+                size: uvec2(450, 450),
+            }),
+            order: 3,
+            clear_color: ClearColorConfig::None,
+            ..default()
+        },
+        transform,
+        ..default()
+    });
+
+    // Orthographic camera right
+    commands.spawn(Camera3dBundle {
+        projection: Projection::Orthographic(OrthographicProjection::default),
+        camera: Camera {
+            viewport: Option::from(Viewport {
+                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
+                physical_position: uvec2(PADDING * 4 + SMALL_SIZE * 3, PADDING),
+                ..default()
+            }),
+            sub_camera_view: Some(SubCameraView {
+                full_size: uvec2(500, 500),
+                offset: uvec2(250, 0),
+                size: uvec2(250, 500),
+            }),
+            order: 4,
+            clear_color: ClearColorConfig::None,
+            ..default()
+        },
+        transform,
+        ..default()
+    });
+}
+
+fn move_camera_view(
+    mut movable_camera_query: Query<&mut Camera, With<MovingCameraMarker>>,
+    time: Res<Time>,
+) {
+    if let Ok(mut camera) = movable_camera_query.get_single_mut() {
+        if let Some(sub_view) = &mut camera.sub_camera_view {
+            sub_view.offset.x = (time.elapsed_seconds() * 100.) as u32 % 400;
+            sub_view.offset.y = sub_view.offset.x;
+        }
+    }
+}

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -7,7 +7,6 @@
 //!   camera
 //! - Rapidly change the sub view offset to get a screen shake effect
 use bevy::{
-    math::{ivec2, uvec2},
     prelude::*,
     render::camera::{ScalingMode, SubCameraView, Viewport},
 };
@@ -93,15 +92,15 @@ fn setup(
     commands.spawn(Camera3dBundle {
         camera: Camera {
             viewport: Option::from(Viewport {
-                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
-                physical_position: uvec2(PADDING, PADDING),
+                physical_size: UVec2::new(SMALL_SIZE, SMALL_SIZE),
+                physical_position: UVec2::new(PADDING, PADDING),
                 ..default()
             }),
             sub_camera_view: Some(SubCameraView {
                 // Set the sub view camera to the left half of the full image
-                full_size: uvec2(500, 500),
-                offset: ivec2(0, 0),
-                size: uvec2(250, 500),
+                full_size: UVec2::new(500, 500),
+                offset: IVec2::new(0, 0),
+                size: UVec2::new(250, 500),
             }),
             order: 1,
             ..default()
@@ -115,16 +114,16 @@ fn setup(
         Camera3dBundle {
             camera: Camera {
                 viewport: Option::from(Viewport {
-                    physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
-                    physical_position: uvec2(PADDING * 2 + SMALL_SIZE, PADDING),
+                    physical_size: UVec2::new(SMALL_SIZE, SMALL_SIZE),
+                    physical_position: UVec2::new(PADDING * 2 + SMALL_SIZE, PADDING),
                     ..default()
                 }),
                 sub_camera_view: Some(SubCameraView {
                     // Set the sub view camera to a fifth of the full view and
                     // move it in another system
-                    full_size: uvec2(500, 500),
-                    offset: ivec2(0, 0),
-                    size: uvec2(100, 100),
+                    full_size: UVec2::new(500, 500),
+                    offset: IVec2::new(0, 0),
+                    size: UVec2::new(100, 100),
                 }),
                 order: 2,
                 ..default()
@@ -139,16 +138,16 @@ fn setup(
     commands.spawn(Camera3dBundle {
         camera: Camera {
             viewport: Option::from(Viewport {
-                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
-                physical_position: uvec2(PADDING * 3 + SMALL_SIZE * 2, PADDING),
+                physical_size: UVec2::new(SMALL_SIZE, SMALL_SIZE),
+                physical_position: UVec2::new(PADDING * 3 + SMALL_SIZE * 2, PADDING),
                 ..default()
             }),
             sub_camera_view: Some(SubCameraView {
                 // Set the sub view to the full image, to ensure that it matches
                 // the projection without sub view
-                full_size: uvec2(450, 450),
-                offset: ivec2(0, 0),
-                size: uvec2(450, 450),
+                full_size: UVec2::new(450, 450),
+                offset: IVec2::new(0, 0),
+                size: UVec2::new(450, 450),
             }),
             order: 3,
             ..default()
@@ -186,15 +185,15 @@ fn setup(
         .into(),
         camera: Camera {
             viewport: Option::from(Viewport {
-                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
-                physical_position: uvec2(PADDING * 5 + SMALL_SIZE * 4, PADDING),
+                physical_size: UVec2::new(SMALL_SIZE, SMALL_SIZE),
+                physical_position: UVec2::new(PADDING * 5 + SMALL_SIZE * 4, PADDING),
                 ..default()
             }),
             sub_camera_view: Some(SubCameraView {
                 // Set the sub view camera to the left half of the full image
-                full_size: uvec2(500, 500),
-                offset: ivec2(0, 0),
-                size: uvec2(250, 500),
+                full_size: UVec2::new(500, 500),
+                offset: IVec2::new(0, 0),
+                size: UVec2::new(250, 500),
             }),
             order: 5,
             ..default()
@@ -213,16 +212,16 @@ fn setup(
             .into(),
             camera: Camera {
                 viewport: Option::from(Viewport {
-                    physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
-                    physical_position: uvec2(PADDING * 6 + SMALL_SIZE * 5, PADDING),
+                    physical_size: UVec2::new(SMALL_SIZE, SMALL_SIZE),
+                    physical_position: UVec2::new(PADDING * 6 + SMALL_SIZE * 5, PADDING),
                     ..default()
                 }),
                 sub_camera_view: Some(SubCameraView {
                     // Set the sub view camera to a fifth of the full view and
                     // move it in another system
-                    full_size: uvec2(500, 500),
-                    offset: ivec2(0, 0),
-                    size: uvec2(100, 100),
+                    full_size: UVec2::new(500, 500),
+                    offset: IVec2::new(0, 0),
+                    size: UVec2::new(100, 100),
                 }),
                 order: 6,
                 ..default()
@@ -242,16 +241,16 @@ fn setup(
         .into(),
         camera: Camera {
             viewport: Option::from(Viewport {
-                physical_size: uvec2(SMALL_SIZE, SMALL_SIZE),
-                physical_position: uvec2(PADDING * 7 + SMALL_SIZE * 6, PADDING),
+                physical_size: UVec2::new(SMALL_SIZE, SMALL_SIZE),
+                physical_position: UVec2::new(PADDING * 7 + SMALL_SIZE * 6, PADDING),
                 ..default()
             }),
             sub_camera_view: Some(SubCameraView {
                 // Set the sub view to the full image, to ensure that it matches
                 // the projection without sub view
-                full_size: uvec2(450, 450),
-                offset: ivec2(0, 0),
-                size: uvec2(450, 450),
+                full_size: UVec2::new(450, 450),
+                offset: IVec2::new(0, 0),
+                size: UVec2::new(450, 450),
             }),
             order: 7,
             ..default()

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -97,10 +97,16 @@ fn setup(
                 ..default()
             }),
             sub_camera_view: Some(SubCameraView {
-                // Set the sub view camera to the left half of the full image
-                full_size: UVec2::new(500, 500),
-                offset: IVec2::new(0, 0),
-                size: UVec2::new(250, 500),
+                // Set the sub view camera to the right half of the full image
+                //
+                // The values of `full_size` and `size` do not have to be the
+                // exact values of your physical viewport. The important part is
+                // the ratio between them.
+                full_size: UVec2::new(10, 10),
+                // The `offset` is also relative to the values in `full_size`
+                // and `size`
+                offset: IVec2::new(5, 0),
+                size: UVec2::new(5, 10),
             }),
             order: 1,
             ..default()
@@ -190,10 +196,14 @@ fn setup(
                 ..default()
             }),
             sub_camera_view: Some(SubCameraView {
-                // Set the sub view camera to the left half of the full image
-                full_size: UVec2::new(500, 500),
+                // Set the sub view camera to the left half of the full image.
+                //
+                // The values of `full_size` and `size` do not have to be the
+                // exact values of your physical viewport. The important part is
+                // the ratio between them.
+                full_size: UVec2::new(2, 2),
                 offset: IVec2::new(0, 0),
-                size: UVec2::new(250, 500),
+                size: UVec2::new(1, 2),
             }),
             order: 5,
             ..default()

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -105,7 +105,7 @@ fn setup(
                 full_size: UVec2::new(10, 10),
                 // The `offset` is also relative to the values in `full_size`
                 // and `size`
-                offset: IVec2::new(5, 0),
+                offset: Vec2::new(5.0, 0.0),
                 size: UVec2::new(5, 10),
             }),
             order: 1,
@@ -128,7 +128,7 @@ fn setup(
                     // Set the sub view camera to a fifth of the full view and
                     // move it in another system
                     full_size: UVec2::new(500, 500),
-                    offset: IVec2::new(0, 0),
+                    offset: Vec2::ZERO,
                     size: UVec2::new(100, 100),
                 }),
                 order: 2,
@@ -152,7 +152,7 @@ fn setup(
                 // Set the sub view to the full image, to ensure that it matches
                 // the projection without sub view
                 full_size: UVec2::new(450, 450),
-                offset: IVec2::new(0, 0),
+                offset: Vec2::ZERO,
                 size: UVec2::new(450, 450),
             }),
             order: 3,
@@ -202,7 +202,7 @@ fn setup(
                 // exact values of your physical viewport. The important part is
                 // the ratio between them.
                 full_size: UVec2::new(2, 2),
-                offset: IVec2::new(0, 0),
+                offset: Vec2::ZERO,
                 size: UVec2::new(1, 2),
             }),
             order: 5,
@@ -230,7 +230,7 @@ fn setup(
                     // Set the sub view camera to a fifth of the full view and
                     // move it in another system
                     full_size: UVec2::new(500, 500),
-                    offset: IVec2::new(0, 0),
+                    offset: Vec2::ZERO,
                     size: UVec2::new(100, 100),
                 }),
                 order: 6,
@@ -259,7 +259,7 @@ fn setup(
                 // Set the sub view to the full image, to ensure that it matches
                 // the projection without sub view
                 full_size: UVec2::new(450, 450),
-                offset: IVec2::new(0, 0),
+                offset: Vec2::ZERO,
                 size: UVec2::new(450, 450),
             }),
             order: 7,
@@ -276,7 +276,7 @@ fn move_camera_view(
 ) {
     for mut camera in movable_camera_query.iter_mut() {
         if let Some(sub_view) = &mut camera.sub_camera_view {
-            sub_view.offset.x = (time.elapsed_seconds() * 150.) as i32 % 450 - 50;
+            sub_view.offset.x = (time.elapsed_seconds() * 150.) % 450.0 - 50.0;
             sub_view.offset.y = sub_view.offset.x;
         }
     }

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -65,14 +65,13 @@ fn setup(
     });
 
     // Light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
 
     // Main perspective Camera
     commands.spawn(Camera3dBundle {

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -154,7 +154,7 @@ fn setup(
     commands.spawn(Camera3dBundle {
         projection: OrthographicProjection {
             scaling_mode: ScalingMode::FixedVertical(6.0),
-            ..default()
+            ..OrthographicProjection::default_3d()
         }
         .into(),
         camera: Camera {
@@ -174,7 +174,7 @@ fn setup(
     commands.spawn(Camera3dBundle {
         projection: OrthographicProjection {
             scaling_mode: ScalingMode::FixedVertical(6.0),
-            ..default()
+            ..OrthographicProjection::default_3d()
         }
         .into(),
         camera: Camera {
@@ -201,7 +201,7 @@ fn setup(
         Camera3dBundle {
             projection: OrthographicProjection {
                 scaling_mode: ScalingMode::FixedVertical(6.0),
-                ..default()
+                ..OrthographicProjection::default_3d()
             }
             .into(),
             camera: Camera {
@@ -230,7 +230,7 @@ fn setup(
     commands.spawn(Camera3dBundle {
         projection: OrthographicProjection {
             scaling_mode: ScalingMode::FixedVertical(6.0),
-            ..default()
+            ..OrthographicProjection::default_3d()
         }
         .into(),
         camera: Camera {

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -1,4 +1,11 @@
-//! Renders multiple cameras with different sub view efffects.
+//! Demonstrates different sub view effects.
+//!
+//! A sub view is essentially a smaller section of a larger viewport. Some use
+//! cases include:
+//! - Split one image across multiple cameras, for use in a multimonitor setups
+//! - Magnify a section of the image, by rendering a small sub view in another
+//!   camera
+//! - Rapidly change the sub view offset to get a screen shake effect
 use bevy::{
     math::{ivec2, uvec2},
     prelude::*,

--- a/examples/README.md
+++ b/examples/README.md
@@ -140,6 +140,7 @@ Example | Description
 [Blend Modes](../examples/3d/blend_modes.rs) | Showcases different blend modes
 [Built-in postprocessing](../examples/3d/post_processing.rs) | Demonstrates the built-in postprocessing features
 [Clearcoat](../examples/3d/clearcoat.rs) | Demonstrates the clearcoat PBR feature
+[Camera sub view](../examples/3d/camera_sub_view.rs) | Demonstrates using different sub view effects on a camera
 [Color grading](../examples/3d/color_grading.rs) | Demonstrates color grading
 [Deferred Rendering](../examples/3d/deferred_rendering.rs) | Renders meshes with both forward and deferred pipelines
 [Depth of field](../examples/3d/depth_of_field.rs) | Demonstrates depth of field

--- a/examples/README.md
+++ b/examples/README.md
@@ -139,8 +139,8 @@ Example | Description
 [Auto Exposure](../examples/3d/auto_exposure.rs) | A scene showcasing auto exposure
 [Blend Modes](../examples/3d/blend_modes.rs) | Showcases different blend modes
 [Built-in postprocessing](../examples/3d/post_processing.rs) | Demonstrates the built-in postprocessing features
-[Clearcoat](../examples/3d/clearcoat.rs) | Demonstrates the clearcoat PBR feature
 [Camera sub view](../examples/3d/camera_sub_view.rs) | Demonstrates using different sub view effects on a camera
+[Clearcoat](../examples/3d/clearcoat.rs) | Demonstrates the clearcoat PBR feature
 [Color grading](../examples/3d/color_grading.rs) | Demonstrates color grading
 [Deferred Rendering](../examples/3d/deferred_rendering.rs) | Renders meshes with both forward and deferred pipelines
 [Depth of field](../examples/3d/depth_of_field.rs) | Demonstrates depth of field


### PR DESCRIPTION
# Objective

- This PR fixes #12488

## Solution

- This PR adds a new property to `Camera` that emulates the functionality of the [setViewOffset()](https://threejs.org/docs/#api/en/cameras/PerspectiveCamera.setViewOffset) API in three.js.
- When set, the perspective and orthographic projections will restrict the visible area of the camera to a part of the view frustum defined by `offset` and `size`.

## Testing

- In the new `camera_sub_view` example, a fixed, moving and control sub view is created for both perspective and orthographic projection
- Run the example with `cargo run --example camera_sub_view`
- The code can be tested by adding a `SubCameraView` to a camera

---

## Showcase

![image](https://github.com/user-attachments/assets/75ac45fc-d75d-4664-8ef6-ff7865297c25)

- Left Half: Perspective Projection
- Right Half: Orthographic Projection
- Small boxes in order:
  - Sub view of the left half of the full image
  - Sub view moving from the top left to the bottom right of the full image
  - Sub view of the full image (acting as a control)
- Large box: No sub view

<details>
  <summary>Shortened camera setup of `camera_sub_view` example</summary>

```rust
    // Main perspective Camera
    commands.spawn(Camera3dBundle {
        transform,
        ..default()
    });

    // Perspective camera left half
    commands.spawn(Camera3dBundle {
        camera: Camera {
            sub_camera_view: Some(SubCameraView {
                // Set the sub view camera to the left half of the full image
                full_size: uvec2(500, 500),
                offset: ivec2(0, 0),
                size: uvec2(250, 500),
            }),
            order: 1,
            ..default()
        },
        transform,
        ..default()
    });

    // Perspective camera moving
    commands.spawn((
        Camera3dBundle {
            camera: Camera {
                sub_camera_view: Some(SubCameraView {
                    // Set the sub view camera to a fifth of the full view and
                    // move it in another system
                    full_size: uvec2(500, 500),
                    offset: ivec2(0, 0),
                    size: uvec2(100, 100),
                }),
                order: 2,
                ..default()
            },
            transform,
            ..default()
        },
        MovingCameraMarker,
    ));

    // Perspective camera control
    commands.spawn(Camera3dBundle {
        camera: Camera {
            sub_camera_view: Some(SubCameraView {
                // Set the sub view to the full image, to ensure that it matches
                // the projection without sub view
                full_size: uvec2(450, 450),
                offset: ivec2(0, 0),
                size: uvec2(450, 450),
            }),
            order: 3,
            ..default()
        },
        transform,
        ..default()
    });

    // Main orthographic camera
    commands.spawn(Camera3dBundle {
        projection: OrthographicProjection {
          ...
        }
        .into(),
        camera: Camera {
            order: 4,
            ..default()
        },
        transform,
        ..default()
    });

    // Orthographic camera left half
    commands.spawn(Camera3dBundle {
        projection: OrthographicProjection {
          ...
        }
        .into(),
        camera: Camera {
            sub_camera_view: Some(SubCameraView {
                // Set the sub view camera to the left half of the full image
                full_size: uvec2(500, 500),
                offset: ivec2(0, 0),
                size: uvec2(250, 500),
            }),
            order: 5,
            ..default()
        },
        transform,
        ..default()
    });

    // Orthographic camera moving
    commands.spawn((
        Camera3dBundle {
            projection: OrthographicProjection {
              ...
            }
            .into(),
            camera: Camera {
                sub_camera_view: Some(SubCameraView {
                    // Set the sub view camera to a fifth of the full view and
                    // move it in another system
                    full_size: uvec2(500, 500),
                    offset: ivec2(0, 0),
                    size: uvec2(100, 100),
                }),
                order: 6,
                ..default()
            },
            transform,
            ..default()
        },
        MovingCameraMarker,
    ));

    // Orthographic camera control
    commands.spawn(Camera3dBundle {
        projection: OrthographicProjection {
          ...
        }
        .into(),
        camera: Camera {
            sub_camera_view: Some(SubCameraView {
                // Set the sub view to the full image, to ensure that it matches
                // the projection without sub view
                full_size: uvec2(450, 450),
                offset: ivec2(0, 0),
                size: uvec2(450, 450),
            }),
            order: 7,
            ..default()
        },
        transform,
        ..default()
    });
```

</details>
