### PR TITLE
introduction of `ConvexPolygon` and `ConvexPolygonMeshBuilder`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1640,7 +1640,7 @@ impl<const N: usize> ConvexPolygon<N> {
         Triangle2d::new(a, b, c).winding_order()
     }
 
-    /// Create a [`ConvexPolygon`] from its `vertices``.
+    /// Create a [`ConvexPolygon`] from its `vertices`.
     ///
     /// # Errors
     ///
@@ -1657,7 +1657,7 @@ impl<const N: usize> ConvexPolygon<N> {
         Ok(polygon)
     }
 
-    /// Create a [`ConvexPolygon`] from its `vertices``, without checks.
+    /// Create a [`ConvexPolygon`] from its `vertices`, without checks.
     /// Use this version only if you know that the `vertices` make up a convex polygon.
     #[inline(always)]
     pub fn new_unchecked(vertices: [Vec2; N]) -> Self {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1628,8 +1628,12 @@ pub enum ConvexPolygonError {
 }
 
 impl<const N: usize> ConvexPolygon<N> {
-
-    fn triangle_winding_order(&self, a_index: usize, b_index: usize, c_index: usize) -> WindingOrder {
+    fn triangle_winding_order(
+        &self,
+        a_index: usize,
+        b_index: usize,
+        c_index: usize,
+    ) -> WindingOrder {
         let a = self.vertices[a_index];
         let b = self.vertices[b_index];
         let c = self.vertices[c_index];
@@ -1654,7 +1658,7 @@ impl<const N: usize> ConvexPolygon<N> {
     }
 
     /// Create a [`ConvexPolygon`] from its `vertices``, without checks.
-    /// Use this version only if you know that the `vertices` make up a convex polygon. 
+    /// Use this version only if you know that the `vertices` make up a convex polygon.
     #[inline(always)]
     pub fn new_unchecked(vertices: [Vec2; N]) -> Self {
         Self { vertices }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1613,13 +1613,13 @@ impl<const N: usize> Polygon<N> {
     reflect(Serialize, Deserialize)
 )]
 pub struct ConvexPolygon<const N: usize> {
-    /// The vertices of the `ConvexPolygon`.
+    /// The vertices of the [`ConvexPolygon`].
     #[cfg_attr(feature = "serialize", serde(with = "super::serde::array"))]
     pub vertices: [Vec2; N],
 }
 impl<const N: usize> Primitive2d for ConvexPolygon<N> {}
 
-/// An error that happens when creating a `ConvexPolygon`.
+/// An error that happens when creating a [`ConvexPolygon`].
 #[derive(Error, Debug, Clone)]
 pub enum ConvexPolygonError {
     /// The created polygon is not convex.
@@ -1637,8 +1637,11 @@ impl<const N: usize> ConvexPolygon<N> {
         (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
     }
 
-    /// Create a `ConvexPolygon` from its vertices.
-    /// The convexity of the polygon is checked.
+    /// Create a [`ConvexPolygon`] from its `vertices``.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConvexPolygonError::NotConvex`] if the `vertices` do not form a convex polygon.
     pub fn new(vertices: [Vec2; N]) -> Result<Self, ConvexPolygonError> {
         let polygon = Self::new_unchecked(vertices);
         let ref_cross_product_sign = polygon.compute_cross_product_for(N - 1, 0, 1).signum();
@@ -1651,8 +1654,8 @@ impl<const N: usize> ConvexPolygon<N> {
         Ok(polygon)
     }
 
-    /// Create a `ConvexPolygon` from its vertices, without checks.
-    /// Only use this version if you know that the `vertices` make up a convex polygon. 
+    /// Create a [`ConvexPolygon`] from its `vertices``, without checks.
+    /// Use this version only if you know that the `vertices` make up a convex polygon. 
     #[inline(always)]
     pub fn new_unchecked(vertices: [Vec2; N]) -> Self {
         Self { vertices }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1644,7 +1644,7 @@ impl<const N: usize> ConvexPolygon<N> {
     ///
     /// # Errors
     ///
-    /// Returns a [`ConvexPolygonError::NotConvex`] if the `vertices` do not form a convex polygon.
+    /// Returns [`ConvexPolygonError::Concave`] if the `vertices` do not form a convex polygon.
     pub fn new(vertices: [Vec2; N]) -> Result<Self, ConvexPolygonError> {
         let polygon = Self::new_unchecked(vertices);
         let ref_winding_order = polygon.triangle_winding_order(N - 1, 0, 1);

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -7,8 +7,8 @@ use super::{Extrudable, MeshBuilder, Meshable};
 use bevy_math::{
     ops,
     primitives::{
-        Annulus, Capsule2d, Circle, CircularSector, CircularSegment, ConvexPolygon,
-        Ellipse, Rectangle, RegularPolygon, Rhombus, Triangle2d, Triangle3d, WindingOrder,
+        Annulus, Capsule2d, Circle, CircularSector, CircularSegment, ConvexPolygon, Ellipse,
+        Rectangle, RegularPolygon, Rhombus, Triangle2d, Triangle3d, WindingOrder,
     },
     FloatExt, Vec2,
 };
@@ -400,7 +400,7 @@ impl From<CircularSegment> for Mesh {
 
 /// A builder used for creating a [`Mesh`] with a [`ConvexPolygon`] shape.
 pub struct ConvexPolygonMeshBuilder<const N: usize> {
-    pub vertices: [Vec2; N]
+    pub vertices: [Vec2; N],
 }
 
 impl<const N: usize> Meshable for ConvexPolygon<N> {

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -415,8 +415,8 @@ impl<const N: usize> Meshable for ConvexPolygon<N> {
 
 impl<const N: usize> MeshBuilder for ConvexPolygonMeshBuilder<N> {
     fn build(&self) -> Mesh {
-        let mut indices = Vec::with_capacity(self.vertices.len() - 2);
-        let mut positions = Vec::with_capacity(self.vertices.len());
+        let mut indices = Vec::with_capacity((N - 2) * 3);
+        let mut positions = Vec::with_capacity(N);
 
         for vertex in self.vertices {
             positions.push([vertex.x, vertex.y, 0.0]);

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -67,7 +67,7 @@ impl PerimeterSegment {
     }
 }
 
-/// A trait for required for implementing `Meshable` for `Extrusion<T>`.
+/// A trait required for implementing `Meshable` for `Extrusion<T>`.
 ///
 /// ## Warning
 ///


### PR DESCRIPTION
# Objective

- As discussed on [Discord](https://discord.com/channels/691052431525675048/1203087353850364004/1285300659746246849), implement a `ConvexPolygon` 2D math primitive and associated mesh builder.
- The original goal was to have a mesh builder for the simplest (i.e. convex) polygons.

## Solution

- The `ConvexPolygon` is created from its vertices.
- The convexity of the polygon is checked when created via `new()` by verifying that the winding order of all the triangles formed with adjacent vertices is the same.
- The `ConvexPolygonMeshBuilder` uses an anchor vertex and goes through every adjacent pair of vertices in the polygon to form triangles that fill up the polygon.

## Testing

- Tested locally with my own simple `ConvexPolygonMeshBuilder` usage.