### PR TITLE
Cleanup unneeded lifetimes in bevy_asset

### DIFF
--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -508,11 +508,11 @@ impl AssetLoader for AnimationGraphAssetLoader {
 
     type Error = AnimationGraphLoadError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -676,11 +676,11 @@ mod tests {
 
         type Error = CoolTextLoaderError;
 
-        async fn load<'a>(
-            &'a self,
-            reader: &'a mut dyn Reader,
-            _settings: &'a Self::Settings,
-            load_context: &'a mut LoadContext<'_>,
+        async fn load(
+            &self,
+            reader: &mut dyn Reader,
+            _settings: &Self::Settings,
+            load_context: &mut LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -30,11 +30,11 @@ pub trait AssetLoader: Send + Sync + 'static {
     /// The type of [error](`std::error::Error`) which could be encountered by this loader.
     type Error: Into<Box<dyn core::error::Error + Send + Sync + 'static>>;
     /// Asynchronously loads [`AssetLoader::Asset`] (and any other labeled assets) from the bytes provided by [`Reader`].
-    fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext,
+    fn load(
+        &self,
+        reader: &mut dyn Reader,
+        settings: &Self::Settings,
+        load_context: &mut LoadContext,
     ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>>;
 
     /// Returns a list of extensions supported by this [`AssetLoader`], without the preceding dot.

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -173,11 +173,11 @@ impl Process for () {
     type Settings = ();
     type OutputLoader = ();
 
-    async fn process<'a>(
-        &'a self,
-        _context: &'a mut bevy_asset::processor::ProcessContext<'_>,
+    async fn process(
+        &self,
+        _context: &mut bevy_asset::processor::ProcessContext<'_>,
         _meta: AssetMeta<(), Self>,
-        _writer: &'a mut bevy_asset::io::Writer,
+        _writer: &mut bevy_asset::io::Writer,
     ) -> Result<(), bevy_asset::processor::ProcessError> {
         unreachable!()
     }
@@ -196,11 +196,11 @@ impl AssetLoader for () {
     type Asset = ();
     type Settings = ();
     type Error = std::io::Error;
-    async fn load<'a>(
-        &'a self,
-        _reader: &'a mut dyn crate::io::Reader,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut crate::LoadContext<'_>,
+    async fn load(
+        &self,
+        _reader: &mut dyn crate::io::Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut crate::LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         unreachable!();
     }

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -83,7 +83,7 @@ use thiserror::Error;
 /// [`AssetProcessor`] can be run in the background while a Bevy App is running. Changes to assets will be automatically detected and hot-reloaded.
 ///
 /// Assets will only be re-processed if they have been changed. A hash of each asset source is stored in the metadata of the processed version of the
-/// asset, which is used to determine if the asset source has actually changed.  
+/// asset, which is used to determine if the asset source has actually changed.
 ///
 /// A [`ProcessorTransactionLog`] is produced, which uses "write-ahead logging" to make the [`AssetProcessor`] crash and failure resistant. If a failed/unfinished
 /// transaction from a previous run is detected, the affected asset(s) will be re-processed.
@@ -155,10 +155,10 @@ impl AssetProcessor {
 
     /// Retrieves the [`AssetSource`] for this processor
     #[inline]
-    pub fn get_source<'a, 'b>(
-        &'a self,
-        id: impl Into<AssetSourceId<'b>>,
-    ) -> Result<&'a AssetSource, MissingAssetSourceError> {
+    pub fn get_source<'a>(
+        &self,
+        id: impl Into<AssetSourceId<'a>>,
+    ) -> Result<&AssetSource, MissingAssetSourceError> {
         self.data.sources.get(id.into())
     }
 
@@ -565,11 +565,11 @@ impl AssetProcessor {
 
         /// Retrieves asset paths recursively. If `clean_empty_folders_writer` is Some, it will be used to clean up empty
         /// folders when they are discovered.
-        async fn get_asset_paths<'a>(
-            reader: &'a dyn ErasedAssetReader,
-            clean_empty_folders_writer: Option<&'a dyn ErasedAssetWriter>,
+        async fn get_asset_paths(
+            reader: &dyn ErasedAssetReader,
+            clean_empty_folders_writer: Option<&dyn ErasedAssetWriter>,
             path: PathBuf,
-            paths: &'a mut Vec<PathBuf>,
+            paths: &mut Vec<PathBuf>,
         ) -> Result<bool, AssetReaderError> {
             if reader.is_directory(&path).await? {
                 let mut path_stream = reader.read_directory(&path).await?;
@@ -1093,11 +1093,11 @@ impl<T: Process> Process for InstrumentedAssetProcessor<T> {
     type Settings = T::Settings;
     type OutputLoader = T::OutputLoader;
 
-    fn process<'a>(
-        &'a self,
-        context: &'a mut ProcessContext,
+    fn process(
+        &self,
+        context: &mut ProcessContext,
         meta: AssetMeta<(), Self>,
-        writer: &'a mut crate::io::Writer,
+        writer: &mut crate::io::Writer,
     ) -> impl ConditionalSendFuture<
         Output = Result<<Self::OutputLoader as crate::AssetLoader>::Settings, ProcessError>,
     > {

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -27,11 +27,11 @@ pub trait Process: Send + Sync + Sized + 'static {
     type OutputLoader: AssetLoader;
     /// Processes the asset stored on `context` in some way using the settings stored on `meta`. The results are written to `writer`. The
     /// final written processed asset is loadable using [`Process::OutputLoader`]. This load will use the returned [`AssetLoader::Settings`].
-    fn process<'a>(
-        &'a self,
-        context: &'a mut ProcessContext,
+    fn process(
+        &self,
+        context: &mut ProcessContext,
         meta: AssetMeta<(), Self>,
-        writer: &'a mut Writer,
+        writer: &mut Writer,
     ) -> impl ConditionalSendFuture<
         Output = Result<<Self::OutputLoader as AssetLoader>::Settings, ProcessError>,
     >;
@@ -179,11 +179,11 @@ where
         LoadTransformAndSaveSettings<Loader::Settings, Transformer::Settings, Saver::Settings>;
     type OutputLoader = Saver::OutputLoader;
 
-    async fn process<'a>(
-        &'a self,
-        context: &'a mut ProcessContext<'_>,
+    async fn process(
+        &self,
+        context: &mut ProcessContext<'_>,
         meta: AssetMeta<(), Self>,
-        writer: &'a mut Writer,
+        writer: &mut Writer,
     ) -> Result<<Self::OutputLoader as AssetLoader>::Settings, ProcessError> {
         let AssetAction::Process { settings, .. } = meta.asset else {
             return Err(ProcessError::WrongMetaType);

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -24,12 +24,12 @@ pub trait AssetSaver: Send + Sync + 'static {
     type Error: Into<Box<dyn core::error::Error + Send + Sync + 'static>>;
 
     /// Saves the given runtime [`Asset`] by writing it to a byte format using `writer`. The passed in `settings` can influence how the
-    /// `asset` is saved.  
-    fn save<'a>(
-        &'a self,
-        writer: &'a mut Writer,
-        asset: SavedAsset<'a, Self::Asset>,
-        settings: &'a Self::Settings,
+    /// `asset` is saved.
+    fn save(
+        &self,
+        writer: &mut Writer,
+        asset: SavedAsset<'_, Self::Asset>,
+        settings: &Self::Settings,
     ) -> impl ConditionalSendFuture<
         Output = Result<<Self::OutputLoader as AssetLoader>::Settings, Self::Error>,
     >;
@@ -38,7 +38,7 @@ pub trait AssetSaver: Send + Sync + 'static {
 /// A type-erased dynamic variant of [`AssetSaver`] that allows callers to save assets without knowing the actual type of the [`AssetSaver`].
 pub trait ErasedAssetSaver: Send + Sync + 'static {
     /// Saves the given runtime [`ErasedLoadedAsset`] by writing it to a byte format using `writer`. The passed in `settings` can influence how the
-    /// `asset` is saved.  
+    /// `asset` is saved.
     fn save<'a>(
         &'a self,
         writer: &'a mut Writer,

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -282,7 +282,7 @@ impl AssetInfos {
 
     pub(crate) fn get_path_and_type_id_handle(
         &self,
-        path: &AssetPath,
+        path: &AssetPath<'_>,
         type_id: TypeId,
     ) -> Option<UntypedHandle> {
         let id = self.path_to_id.get(path)?.get(&type_id)?;
@@ -291,7 +291,7 @@ impl AssetInfos {
 
     pub(crate) fn get_path_ids<'a>(
         &'a self,
-        path: &'a AssetPath<'a>,
+        path: &'a AssetPath<'_>,
     ) -> impl Iterator<Item = UntypedAssetId> + 'a {
         /// Concrete type to allow returning an `impl Iterator` even if `self.path_to_id.get(&path)` is `None`
         enum HandlesByPathIterator<T> {
@@ -322,7 +322,7 @@ impl AssetInfos {
 
     pub(crate) fn get_path_handles<'a>(
         &'a self,
-        path: &'a AssetPath<'a>,
+        path: &'a AssetPath<'_>,
     ) -> impl Iterator<Item = UntypedHandle> + 'a {
         self.get_path_ids(path)
             .filter_map(|id| self.get_id_handle(id))

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -311,11 +311,11 @@ impl<T: AssetLoader> AssetLoader for InstrumentedAssetLoader<T> {
     type Settings = T::Settings;
     type Error = T::Error;
 
-    fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn crate::io::Reader,
-        settings: &'a Self::Settings,
-        load_context: &'a mut crate::LoadContext,
+    fn load(
+        &self,
+        reader: &mut dyn crate::io::Reader,
+        settings: &Self::Settings,
+        load_context: &mut crate::LoadContext,
     ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         let span = info_span!(
             "asset loading",
@@ -383,11 +383,11 @@ mod tests {
 
         type Error = String;
 
-        async fn load<'a>(
-            &'a self,
-            _: &'a mut dyn crate::io::Reader,
-            _: &'a Self::Settings,
-            _: &'a mut crate::LoadContext<'_>,
+        async fn load(
+            &self,
+            _: &mut dyn crate::io::Reader,
+            _: &Self::Settings,
+            _: &mut crate::LoadContext<'_>,
         ) -> Result<Self::Asset, Self::Error> {
             self.sender.send(()).unwrap();
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -131,10 +131,10 @@ impl AssetServer {
     }
 
     /// Retrieves the [`AssetSource`] for the given `source`.
-    pub fn get_source<'a, 'b>(
-        &'a self,
-        source: impl Into<AssetSourceId<'b>>,
-    ) -> Result<&'a AssetSource, MissingAssetSourceError> {
+    pub fn get_source<'a>(
+        &self,
+        source: impl Into<AssetSourceId<'a>>,
+    ) -> Result<&AssetSource, MissingAssetSourceError> {
         self.data.sources.get(source.into())
     }
 
@@ -218,9 +218,9 @@ impl AssetServer {
     }
 
     /// Retrieves the default [`AssetLoader`] for the given path, if one can be found.
-    pub async fn get_path_asset_loader<'a, 'b>(
+    pub async fn get_path_asset_loader<'a>(
         &self,
-        path: impl Into<AssetPath<'b>>,
+        path: impl Into<AssetPath<'a>>,
     ) -> Result<Arc<dyn ErasedAssetLoader>, MissingAssetLoaderForExtensionError> {
         let path = path.into();
 
@@ -245,7 +245,7 @@ impl AssetServer {
     }
 
     /// Retrieves the default [`AssetLoader`] for the given [`Asset`] [`TypeId`], if one can be found.
-    pub async fn get_asset_loader_with_asset_type_id<'a>(
+    pub async fn get_asset_loader_with_asset_type_id(
         &self,
         type_id: TypeId,
     ) -> Result<Arc<dyn ErasedAssetLoader>, MissingAssetLoaderForTypeIdError> {
@@ -257,7 +257,7 @@ impl AssetServer {
     }
 
     /// Retrieves the default [`AssetLoader`] for the given [`Asset`] type, if one can be found.
-    pub async fn get_asset_loader_with_asset_type<'a, A: Asset>(
+    pub async fn get_asset_loader_with_asset_type<A: Asset>(
         &self,
     ) -> Result<Arc<dyn ErasedAssetLoader>, MissingAssetLoaderForTypeIdError> {
         self.get_asset_loader_with_asset_type_id(TypeId::of::<A>())

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -42,11 +42,11 @@ impl AssetLoader for AudioLoader {
     type Settings = ();
     type Error = std::io::Error;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<AudioSource, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -111,7 +111,7 @@ pub trait AddAudioSource {
     /// so that it can be converted to a [`rodio::Source`] type,
     /// and [`Asset`], so that it can be registered as an asset.
     /// To use this method on [`App`][bevy_app::App],
-    /// the [audio][super::AudioPlugin] and [asset][bevy_asset::AssetPlugin] plugins must be added first.    
+    /// the [audio][super::AudioPlugin] and [asset][bevy_asset::AssetPlugin] plugins must be added first.
     fn add_audio_source<T>(&mut self) -> &mut Self
     where
         T: Decodable + Asset,

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -179,11 +179,11 @@ impl AssetLoader for GltfLoader {
     type Asset = Gltf;
     type Settings = GltfLoaderSettings;
     type Error = GltfError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        settings: &'a GltfLoaderSettings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        settings: &GltfLoaderSettings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Gltf, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -93,11 +93,11 @@ impl AssetSaver for MeshletMeshSaverLoader {
     type OutputLoader = Self;
     type Error = MeshletMeshSaveOrLoadError;
 
-    async fn save<'a>(
-        &'a self,
-        writer: &'a mut Writer,
-        asset: SavedAsset<'a, MeshletMesh>,
-        _settings: &'a (),
+    async fn save(
+        &self,
+        writer: &mut Writer,
+        asset: SavedAsset<'_, MeshletMesh>,
+        _settings: &(),
     ) -> Result<(), MeshletMeshSaveOrLoadError> {
         // Write asset magic number
         writer
@@ -127,11 +127,11 @@ impl AssetLoader for MeshletMeshSaverLoader {
     type Settings = ();
     type Error = MeshletMeshSaveOrLoadError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a (),
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<MeshletMesh, MeshletMeshSaveOrLoadError> {
         // Load and check magic number
         let magic = async_read_u64(reader).await?;

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -259,11 +259,11 @@ impl AssetLoader for ShaderLoader {
     type Asset = Shader;
     type Settings = ();
     type Error = ShaderLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Shader, Self::Error> {
         let ext = load_context.path().extension().unwrap().to_str().unwrap();
         let path = load_context.asset_path().to_string();

--- a/crates/bevy_render/src/texture/compressed_image_saver.rs
+++ b/crates/bevy_render/src/texture/compressed_image_saver.rs
@@ -19,11 +19,11 @@ impl AssetSaver for CompressedImageSaver {
     type OutputLoader = ImageLoader;
     type Error = CompressedImageSaverError;
 
-    async fn save<'a>(
-        &'a self,
-        writer: &'a mut bevy_asset::io::Writer,
-        image: SavedAsset<'a, Self::Asset>,
-        _settings: &'a Self::Settings,
+    async fn save(
+        &self,
+        writer: &mut bevy_asset::io::Writer,
+        image: SavedAsset<'_, Self::Asset>,
+        _settings: &Self::Settings,
     ) -> Result<ImageLoaderSettings, Self::Error> {
         let is_srgb = image.texture_descriptor.format.is_srgb();
 

--- a/crates/bevy_render/src/texture/exr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/exr_texture_loader.rs
@@ -35,11 +35,11 @@ impl AssetLoader for ExrTextureLoader {
     type Settings = ExrTextureLoaderSettings;
     type Error = ExrTextureLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {
         let format = TextureFormat::Rgba32Float;
         debug_assert_eq!(

--- a/crates/bevy_render/src/texture/hdr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/hdr_texture_loader.rs
@@ -30,11 +30,11 @@ impl AssetLoader for HdrTextureLoader {
     type Asset = Image;
     type Settings = HdrTextureLoaderSettings;
     type Error = HdrTextureLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        settings: &'a Self::Settings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        settings: &Self::Settings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {
         let format = TextureFormat::Rgba32Float;
         debug_assert_eq!(

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -86,11 +86,11 @@ impl AssetLoader for ImageLoader {
     type Asset = Image;
     type Settings = ImageLoaderSettings;
     type Error = ImageLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        settings: &'a ImageLoaderSettings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        settings: &ImageLoaderSettings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -46,11 +46,11 @@ impl AssetLoader for SceneLoader {
     type Settings = ();
     type Error = SceneLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a (),
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -22,11 +22,11 @@ impl AssetLoader for FontLoader {
     type Asset = Font;
     type Settings = ();
     type Error = FontLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a (),
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Font, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;

--- a/examples/asset/asset_decompression.rs
+++ b/examples/asset/asset_decompression.rs
@@ -39,11 +39,12 @@ impl AssetLoader for GzAssetLoader {
     type Asset = GzAsset;
     type Settings = ();
     type Error = GzAssetLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a (),
-        load_context: &'a mut LoadContext<'_>,
+
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let compressed_path = load_context.path();
         let file_name = compressed_path

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -33,11 +33,11 @@ impl AssetLoader for CustomAssetLoader {
     type Asset = CustomAsset;
     type Settings = ();
     type Error = CustomAssetLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a (),
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -72,11 +72,11 @@ impl AssetLoader for BlobAssetLoader {
     type Settings = ();
     type Error = BlobAssetLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a (),
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         info!("Loading Blob...");
         let mut bytes = Vec::new();

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -81,11 +81,11 @@ impl AssetLoader for TextLoader {
     type Asset = Text;
     type Settings = TextSettings;
     type Error = std::io::Error;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        settings: &'a TextSettings,
-        _load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        settings: &TextSettings,
+        _load_context: &mut LoadContext<'_>,
     ) -> Result<Text, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -135,11 +135,11 @@ impl AssetLoader for CoolTextLoader {
     type Settings = ();
     type Error = CoolTextLoaderError;
 
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut dyn Reader,
-        _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<CoolText, Self::Error> {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
@@ -211,11 +211,11 @@ impl AssetSaver for CoolTextSaver {
     type OutputLoader = TextLoader;
     type Error = std::io::Error;
 
-    async fn save<'a>(
-        &'a self,
-        writer: &'a mut Writer,
-        asset: SavedAsset<'a, Self::Asset>,
-        _settings: &'a Self::Settings,
+    async fn save(
+        &self,
+        writer: &mut Writer,
+        asset: SavedAsset<'_, Self::Asset>,
+        _settings: &Self::Settings,
     ) -> Result<TextSettings, Self::Error> {
         writer.write_all(asset.text.as_bytes()).await?;
         Ok(TextSettings::default())


### PR DESCRIPTION
# Objective

Fixes #15541

A bunch of lifetimes were added during the Assets V2 rework, but after moving to async traits in #12550 they can be elided. That PR mentions that this might be the case, but apparently it wasn't followed up on at the time.

~~I ended up grepping for `<'a` and finding a similar case in `bevy_reflect` which I also fixed.~~ (edit: that one was needed apparently)

Note that elided lifetimes are unstable in `impl Trait`. If that gets stabilized then we can elide even more.

## Solution

Remove the extra lifetimes.

## Testing

Everything still compiles. If I have messed something up there is a small risk that some user code stops compiling, but all the examples still work at least.

---

## Migration Guide

The traits `AssetLoader`, `AssetSaver` and `Process` traits from `bevy_asset` now use elided lifetimes. If you implement these then remove the named lifetime.
