### PR TITLE
15540 Make World::flush_commands private

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2492,7 +2492,9 @@ impl World {
         }
     }
 
-    /// Flushes queued entities and calls [`World::flush_commands`].
+    /// Flushes queued entities and commands.
+    ///
+    /// Queued entities will be spawned, and then commands will be applied.
     #[inline]
     pub fn flush(&mut self) {
         self.flush_entities();

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2486,7 +2486,7 @@ impl World {
     ///
     /// This will panic if any of the queued commands are [`spawn`](Commands::spawn).
     /// If this is possible, you should instead use [`flush`](Self::flush).
-    pub fn flush_commands(&mut self) {
+    pub(crate) fn flush_commands(&mut self) {
         // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`
         if !unsafe { self.command_queue.is_empty() } {
             // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2474,13 +2474,6 @@ impl World {
         }
     }
 
-    /// Flushes queued entities and calls [`World::flush_commands`].
-    #[inline]
-    pub fn flush(&mut self) {
-        self.flush_entities();
-        self.flush_commands();
-    }
-
     /// Applies any commands in the world's internal [`CommandQueue`].
     /// This does not apply commands from any systems, only those stored in the world.
     ///
@@ -2496,6 +2489,13 @@ impl World {
                     .apply_or_drop_queued(Some(self.into()));
             };
         }
+    }
+
+    /// Flushes queued entities and calls [`World::flush_commands`].
+    #[inline]
+    pub fn flush(&mut self) {
+        self.flush_entities();
+        self.flush_commands();
     }
 
     /// Increments the world's current change tick and returns the old value.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2477,6 +2477,7 @@ impl World {
     /// Applies any commands in the world's internal [`CommandQueue`].
     /// This does not apply commands from any systems, only those stored in the world.
     ///
+    /// # Panics
     /// This will panic if any of the queued commands are [`spawn`](Commands::spawn).
     /// If this is possible, you should instead use [`flush`](Self::flush).
     pub(crate) fn flush_commands(&mut self) {


### PR DESCRIPTION
# Objective

Fixes #15540 

End-users risk using `World::flush_commands` instead of `World::flush`, which panics if any queued commands are `spawn`. Hiding `World::flush_commands` would help avoid calling a potentially panicky function, and helps alleviate end-user API confusion.

## Solution

This PR updates the function visibility to crate-level, like `World::flush_entities`, hiding it from the end-user while still making it accessible for the tests that are currently set up.

## Testing

The change was tested by executing the available tests for `bevy_ecs`. From what I've gathered, `World::flush_commands` is not used in any other bevy crate. If further testing is recommended, please inform me!