### PR TITLE
Rename BreakLineOn to LineBreak

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -16,7 +16,7 @@ use bevy_utils::HashMap;
 use cosmic_text::{Attrs, Buffer, Family, Metrics, Shaping, Wrap};
 
 use crate::{
-    error::TextError, BreakLineOn, CosmicBuffer, Font, FontAtlasSets, FontSmoothing, JustifyText,
+    error::TextError, CosmicBuffer, Font, FontAtlasSets, FontSmoothing, JustifyText, LineBreak,
     PositionedGlyph, TextBounds, TextSection, YAxisOrientation,
 };
 
@@ -73,7 +73,7 @@ impl TextPipeline {
         &mut self,
         fonts: &Assets<Font>,
         sections: &[TextSection],
-        linebreak_behavior: BreakLineOn,
+        linebreak: LineBreak,
         bounds: TextBounds,
         scale_factor: f64,
         buffer: &mut CosmicBuffer,
@@ -144,11 +144,11 @@ impl TextPipeline {
 
         buffer.set_wrap(
             font_system,
-            match linebreak_behavior {
-                BreakLineOn::WordBoundary => Wrap::Word,
-                BreakLineOn::AnyCharacter => Wrap::Glyph,
-                BreakLineOn::WordOrCharacter => Wrap::WordOrGlyph,
-                BreakLineOn::NoWrap => Wrap::None,
+            match linebreak {
+                LineBreak::WordBoundary => Wrap::Word,
+                LineBreak::AnyCharacter => Wrap::Glyph,
+                LineBreak::WordOrCharacter => Wrap::WordOrGlyph,
+                LineBreak::NoWrap => Wrap::None,
             },
         );
 
@@ -183,7 +183,7 @@ impl TextPipeline {
         sections: &[TextSection],
         scale_factor: f64,
         text_alignment: JustifyText,
-        linebreak_behavior: BreakLineOn,
+        linebreak: LineBreak,
         font_smoothing: FontSmoothing,
         bounds: TextBounds,
         font_atlas_sets: &mut FontAtlasSets,
@@ -204,7 +204,7 @@ impl TextPipeline {
         self.update_buffer(
             fonts,
             sections,
-            linebreak_behavior,
+            linebreak,
             bounds,
             scale_factor,
             buffer,
@@ -301,7 +301,7 @@ impl TextPipeline {
         fonts: &Assets<Font>,
         sections: &[TextSection],
         scale_factor: f64,
-        linebreak_behavior: BreakLineOn,
+        linebreak: LineBreak,
         buffer: &mut CosmicBuffer,
         text_alignment: JustifyText,
         font_system: &mut CosmicFontSystem,
@@ -311,7 +311,7 @@ impl TextPipeline {
         self.update_buffer(
             fonts,
             sections,
-            linebreak_behavior,
+            linebreak,
             MIN_WIDTH_CONTENT_BOUNDS,
             scale_factor,
             buffer,

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -35,7 +35,7 @@ pub struct Text {
     /// Should not affect its position within a container.
     pub justify: JustifyText,
     /// How the text should linebreak when running out of the bounds determined by `max_size`
-    pub linebreak_behavior: BreakLineOn,
+    pub linebreak: LineBreak,
     /// The antialiasing method to use when rendering text.
     pub font_smoothing: FontSmoothing,
 }
@@ -123,7 +123,7 @@ impl Text {
     /// Returns this [`Text`] with soft wrapping disabled.
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, will still occur.
     pub const fn with_no_wrap(mut self) -> Self {
-        self.linebreak_behavior = BreakLineOn::NoWrap;
+        self.linebreak = LineBreak::NoWrap;
         self
     }
 
@@ -253,7 +253,7 @@ impl Default for TextStyle {
 /// Determines how lines will be broken when preventing text from running out of bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
-pub enum BreakLineOn {
+pub enum LineBreak {
     /// Uses the [Unicode Line Breaking Algorithm](https://www.unicode.org/reports/tr14/).
     /// Lines will be broken up at the nearest suitable word boundary, usually a space.
     /// This behavior suits most cases, as it keeps words intact across linebreaks.

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -1,6 +1,6 @@
 use crate::pipeline::CosmicFontSystem;
 use crate::{
-    BreakLineOn, CosmicBuffer, Font, FontAtlasSets, PositionedGlyph, SwashCache, Text, TextBounds,
+    CosmicBuffer, Font, FontAtlasSets, LineBreak, PositionedGlyph, SwashCache, Text, TextBounds,
     TextError, TextLayoutInfo, TextPipeline, YAxisOrientation,
 };
 use bevy_asset::Assets;
@@ -176,7 +176,7 @@ pub fn update_text2d_layout(
     for (entity, text, bounds, text_layout_info, mut buffer) in &mut text_query {
         if factor_changed || text.is_changed() || bounds.is_changed() || queue.remove(&entity) {
             let text_bounds = TextBounds {
-                width: if text.linebreak_behavior == BreakLineOn::NoWrap {
+                width: if text.linebreak == LineBreak::NoWrap {
                     None
                 } else {
                     bounds.width.map(|width| scale_value(width, scale_factor))
@@ -193,7 +193,7 @@ pub fn update_text2d_layout(
                 &text.sections,
                 scale_factor.into(),
                 text.justify,
-                text.linebreak_behavior,
+                text.linebreak,
                 text.font_smoothing,
                 text_bounds,
                 &mut font_atlas_sets,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -15,7 +15,7 @@ use {
     crate::widget::TextFlags,
     bevy_color::Color,
     bevy_text::{
-        BreakLineOn, CosmicBuffer, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle,
+        CosmicBuffer, JustifyText, LineBreak, Text, TextLayoutInfo, TextSection, TextStyle,
     },
 };
 
@@ -198,7 +198,7 @@ impl TextBundle {
     /// Returns this [`TextBundle`] with soft wrapping disabled.
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, will still occur.
     pub const fn with_no_wrap(mut self) -> Self {
-        self.text.linebreak_behavior = BreakLineOn::NoWrap;
+        self.text.linebreak = LineBreak::NoWrap;
         self
     }
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -16,7 +16,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{camera::Camera, texture::Image};
 use bevy_sprite::TextureAtlasLayout;
 use bevy_text::{
-    scale_value, BreakLineOn, CosmicBuffer, CosmicFontSystem, Font, FontAtlasSets, JustifyText,
+    scale_value, CosmicBuffer, CosmicFontSystem, Font, FontAtlasSets, JustifyText, LineBreak,
     SwashCache, Text, TextBounds, TextError, TextLayoutInfo, TextMeasureInfo, TextPipeline,
     YAxisOrientation,
 };
@@ -120,13 +120,13 @@ fn create_text_measure(
         fonts,
         &text.sections,
         scale_factor,
-        text.linebreak_behavior,
+        text.linebreak,
         buffer,
         text_alignment,
         font_system,
     ) {
         Ok(measure) => {
-            if text.linebreak_behavior == BreakLineOn::NoWrap {
+            if text.linebreak == LineBreak::NoWrap {
                 content_size.set(NodeMeasure::Fixed(FixedMeasure { size: measure.max }));
             } else {
                 content_size.set(NodeMeasure::Text(TextMeasure { info: measure }));
@@ -239,7 +239,7 @@ fn queue_text(
 ) {
     // Skip the text node if it is waiting for a new measure func
     if !text_flags.needs_new_measure_func {
-        let physical_node_size = if text.linebreak_behavior == BreakLineOn::NoWrap {
+        let physical_node_size = if text.linebreak == LineBreak::NoWrap {
             // With `NoWrap` set, no constraints are placed on the width of the text.
             TextBounds::UNBOUNDED
         } else {
@@ -257,7 +257,7 @@ fn queue_text(
             &text.sections,
             scale_factor.into(),
             text.justify,
-            text.linebreak_behavior,
+            text.linebreak,
             text.font_smoothing,
             physical_node_size,
             font_atlas_sets,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -10,7 +10,7 @@ use bevy::{
     math::ops,
     prelude::*,
     sprite::Anchor,
-    text::{BreakLineOn, FontSmoothing, TextBounds},
+    text::{FontSmoothing, LineBreak, TextBounds},
 };
 
 fn main() {
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         slightly_smaller_text_style.clone(),
                     )],
                     justify: JustifyText::Left,
-                    linebreak_behavior: BreakLineOn::WordBoundary,
+                    linebreak: LineBreak::WordBoundary,
                     ..default()
                 },
                 // Wrap text in the rectangle
@@ -127,7 +127,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         slightly_smaller_text_style.clone(),
                     )],
                     justify: JustifyText::Left,
-                    linebreak_behavior: BreakLineOn::AnyCharacter,
+                    linebreak: LineBreak::AnyCharacter,
                     ..default()
                 },
                 // Wrap text in the rectangle

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -9,7 +9,7 @@ use bevy::{
     color::palettes::basic::RED,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    text::{BreakLineOn, TextBounds},
+    text::{LineBreak, TextBounds},
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
@@ -54,7 +54,7 @@ fn setup(mut commands: Commands) {
             },
         }],
         justify: JustifyText::Left,
-        linebreak_behavior: BreakLineOn::AnyCharacter,
+        linebreak: LineBreak::AnyCharacter,
         ..default()
     };
 

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -6,7 +6,7 @@ use bevy::{
     color::palettes::basic::{BLUE, YELLOW},
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    text::{BreakLineOn, TextBounds},
+    text::{LineBreak, TextBounds},
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
@@ -65,7 +65,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
         text: Text {
             sections,
             justify: JustifyText::Center,
-            linebreak_behavior: BreakLineOn::AnyCharacter,
+            linebreak: LineBreak::AnyCharacter,
             ..default()
         },
         ..Default::default()

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates text wrapping and use of the `LineBreakOn` property.
 
 use argh::FromArgs;
-use bevy::{prelude::*, text::BreakLineOn, window::WindowResolution, winit::WinitSettings};
+use bevy::{prelude::*, text::LineBreak, window::WindowResolution, winit::WinitSettings};
 
 #[derive(FromArgs, Resource)]
 /// `text_wrap_debug` demonstrates text wrapping and use of the `LineBreakOn` property
@@ -64,11 +64,11 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .id();
 
-    for linebreak_behavior in [
-        BreakLineOn::AnyCharacter,
-        BreakLineOn::WordBoundary,
-        BreakLineOn::WordOrCharacter,
-        BreakLineOn::NoWrap,
+    for linebreak in [
+        LineBreak::AnyCharacter,
+        LineBreak::WordBoundary,
+        LineBreak::WordOrCharacter,
+        LineBreak::NoWrap,
     ] {
         let row_id = commands
             .spawn(NodeBundle {
@@ -112,7 +112,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
 
             let messages = [
                 format!("JustifyContent::{justification:?}"),
-                format!("LineBreakOn::{linebreak_behavior:?}"),
+                format!("LineBreakOn::{linebreak:?}"),
                 "Line 1\nLine 2".to_string(),
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas auctor, nunc ac faucibus fringilla.".to_string(),
                 "pneumonoultramicroscopicsilicovolcanoconiosis".to_string()
@@ -125,7 +125,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                         style: text_style.clone(),
                     }],
                     justify: JustifyText::Left,
-                    linebreak_behavior,
+                    linebreak,
                     ..default()
                 };
                 let text_id = commands


### PR DESCRIPTION
# Objective

- Improve code quality in preparation for https://github.com/bevyengine/bevy/discussions/15014

## Solution

- Rename BreakLineOn to LineBreak.

## Migration Guide

`BreakLineOn` was renamed to `LineBreak`, and paramters named `linebreak_behavior` were renamed to `linebreak`.
