### PR TITLE
move ANDROID_APP to bevy_window

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -47,7 +47,7 @@ thiserror = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-bevy_winit = { path = "../bevy_winit", version = "0.15.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -17,7 +17,7 @@ pub struct AndroidAssetReader;
 
 impl AssetReader for AndroidAssetReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let asset_manager = bevy_winit::ANDROID_APP
+        let asset_manager = bevy_window::ANDROID_APP
             .get()
             .expect("Bevy must be setup with the #[bevy_main] macro on Android")
             .asset_manager();
@@ -31,7 +31,7 @@ impl AssetReader for AndroidAssetReader {
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let meta_path = get_meta_path(path);
-        let asset_manager = bevy_winit::ANDROID_APP
+        let asset_manager = bevy_window::ANDROID_APP
             .get()
             .expect("Bevy must be setup with the #[bevy_main] macro on Android")
             .asset_manager();
@@ -47,7 +47,7 @@ impl AssetReader for AndroidAssetReader {
         &'a self,
         path: &'a Path,
     ) -> Result<Box<PathStream>, AssetReaderError> {
-        let asset_manager = bevy_winit::ANDROID_APP
+        let asset_manager = bevy_window::ANDROID_APP
             .get()
             .expect("Bevy must be setup with the #[bevy_main] macro on Android")
             .asset_manager();
@@ -76,7 +76,7 @@ impl AssetReader for AndroidAssetReader {
         &'a self,
         path: &'a Path,
     ) -> std::result::Result<bool, AssetReaderError> {
-        let asset_manager = bevy_winit::ANDROID_APP
+        let asset_manager = bevy_window::ANDROID_APP
             .get()
             .expect("Bevy must be setup with the #[bevy_main] macro on Android")
             .asset_manager();

--- a/crates/bevy_derive/src/bevy_main.rs
+++ b/crates/bevy_derive/src/bevy_main.rs
@@ -12,8 +12,8 @@ pub fn bevy_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         #[no_mangle]
         #[cfg(target_os = "android")]
-        fn android_main(android_app: bevy::winit::android_activity::AndroidApp) {
-            let _ = bevy::winit::ANDROID_APP.set(android_app);
+        fn android_main(android_app: bevy::window::android_activity::AndroidApp) {
+            let _ = bevy::window::ANDROID_APP.set(android_app);
             main();
         }
 

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -29,6 +29,9 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 raw-window-handle = "0.6"
 smol_str = "0.2"
 
+[target.'cfg(target_os = "android")'.dependencies]
+android-activity = "0.6"
+
 [lints]
 workspace = true
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -27,6 +27,9 @@ mod window;
 
 pub use crate::raw_handle::*;
 
+#[cfg(target_os = "android")]
+pub use android_activity;
+
 pub use event::*;
 pub use monitor::*;
 pub use system::*;
@@ -188,3 +191,9 @@ pub enum ExitCondition {
     /// surprise your users.
     DontExit,
 }
+
+/// [`AndroidApp`] provides an interface to query the application state as well as monitor events
+/// (for example lifecycle and input events).
+#[cfg(target_os = "android")]
+pub static ANDROID_APP: std::sync::OnceLock<android_activity::AndroidApp> =
+    std::sync::OnceLock::new();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -18,8 +18,6 @@ use bevy_derive::Deref;
 use bevy_window::{RawHandleWrapperHolder, WindowEvent};
 use core::marker::PhantomData;
 use winit::event_loop::EventLoop;
-#[cfg(target_os = "android")]
-pub use winit::platform::android::activity as android_activity;
 
 use bevy_a11y::AccessibilityRequested;
 use bevy_app::{App, Last, Plugin};
@@ -51,12 +49,6 @@ mod system;
 mod winit_config;
 mod winit_monitors;
 mod winit_windows;
-
-/// [`AndroidApp`] provides an interface to query the application state as well as monitor events
-/// (for example lifecycle and input events).
-#[cfg(target_os = "android")]
-pub static ANDROID_APP: std::sync::OnceLock<android_activity::AndroidApp> =
-    std::sync::OnceLock::new();
 
 /// A [`Plugin`] that uses `winit` to create and manage windows, and receive window and input
 /// events.
@@ -119,7 +111,7 @@ impl<T: Event> Plugin for WinitPlugin<T> {
         {
             use winit::platform::android::EventLoopBuilderExtAndroid;
             let msg = "Bevy must be setup with the #[bevy_main] macro on Android";
-            event_loop_builder.with_android_app(ANDROID_APP.get().expect(msg).clone());
+            event_loop_builder.with_android_app(bevy_window::ANDROID_APP.get().expect(msg).clone());
         }
 
         app.init_non_send_resource::<WinitWindows>()


### PR DESCRIPTION
# Objective

- Remove dependency in bevy_asset to bevy_winit
- First step for #15565 

## Solution

- the static `ANDROID_APP` and the `android_activity` reexport are now in `bevy_window`

## Migration Guide

If you use the `android_activity` reexport from `bevy::winit::android_activity`, it is now in `bevy::window::android_activity`. Same for the `ANDROID_APP` static