### PR TITLE
Add a dynamic alternative to `get_components`

### DIFF
--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -12,7 +12,7 @@ use crate::{component::ComponentId, schedule::InternedScheduleLabel};
 pub struct TryRunScheduleError(pub InternedScheduleLabel);
 
 /// An error that occurs when dynamically retrieving components from an entity.
-#[derive(Error, Debug, Clone, Copy)]
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntityComponentError {
     /// The component with the given [`ComponentId`] does not exist on the entity.
     #[error("The component with the ID {0:?} does not exist on the entity.")]

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::schedule::InternedScheduleLabel;
+use crate::{component::ComponentId, schedule::InternedScheduleLabel};
 
 /// The error type returned by [`World::try_run_schedule`] if the provided schedule does not exist.
 ///
@@ -10,3 +10,14 @@ use crate::schedule::InternedScheduleLabel;
 #[derive(Error, Debug)]
 #[error("The schedule with the label {0:?} was not found.")]
 pub struct TryRunScheduleError(pub InternedScheduleLabel);
+
+/// An error that occurs when dynamically retrieving components from an entity.
+#[derive(Error, Debug, Clone, Copy)]
+pub enum EntityComponentError {
+    /// The component with the given [`ComponentId`] does not exist on the entity.
+    #[error("The component with the ID {0:?} does not exist on the entity.")]
+    NoSuchComponent(ComponentId),
+    /// The component with the given [`ComponentId`] was requested mutably more than once.
+    #[error("The component with the ID {0:?} was requested mutably more than once.")]
+    AliasedMutability(ComponentId),
+}

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -15,12 +15,12 @@ use crate::{
     removal_detection::RemovedComponentEvents,
     storage::{ComponentSparseSet, Storages, Table},
     system::Resource,
-    world::RawCommandQueue,
+    world::{error::EntityComponentError, RawCommandQueue},
 };
 use bevy_ptr::Ptr;
 #[cfg(feature = "track_change_detection")]
 use bevy_ptr::UnsafeCellDeref;
-use core::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, ptr};
+use core::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, mem::MaybeUninit, ptr};
 
 /// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
@@ -929,6 +929,64 @@ impl<'w> UnsafeEntityCell<'w> {
         } else {
             None
         }
+    }
+
+    /// Gets the components of the given [`ComponentId`]s from the entity.
+    ///
+    /// # Safety
+    ///
+    /// It is the callers responsibility to ensure that:
+    /// - the [`UnsafeEntityCell`] has permission to access the components mutably
+    /// - `component_ids` must contain no repeated [`ComponentId`]s.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EntityComponentError::NoSuchComponent`] if the entity does not have a component.
+    pub(crate) unsafe fn get_components_mut_by_id<const N: usize>(
+        &mut self,
+        component_ids: [ComponentId; N],
+    ) -> Result<[MutUntyped<'w>; N], EntityComponentError> {
+        let mut ptrs = [const { MaybeUninit::uninit() }; N];
+        for (ptr, id) in core::iter::zip(&mut ptrs, component_ids) {
+            *ptr = MaybeUninit::new(
+                // SAFETY: callers must ensure that `component_ids` contains no repeated `ComponentId`s.
+                unsafe { self.get_mut_by_id(id) }
+                    .ok_or(EntityComponentError::NoSuchComponent(id))?,
+            );
+        }
+
+        // SAFETY: Each ptr was initialized in the loop above.
+        let ptrs = ptrs.map(|ptr| unsafe { MaybeUninit::assume_init(ptr) });
+
+        Ok(ptrs)
+    }
+
+    /// Gets multiple mutable untyped components from the entity based on the
+    /// given iterator of [`ComponentId`]s.
+    ///
+    /// # Safety
+    ///
+    /// It is the callers responsibility to ensure that:
+    /// - the [`UnsafeEntityCell`] has permission to access the components mutably
+    /// - `component_ids` must contain no repeated [`ComponentId`]s.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EntityComponentError::NoSuchComponent`] if the entity does not have a component.
+    pub(crate) unsafe fn get_components_dynamic_mut_by_id(
+        &mut self,
+        component_ids: impl ExactSizeIterator<Item = ComponentId>,
+    ) -> Result<Vec<MutUntyped<'w>>, EntityComponentError> {
+        let mut ptrs = Vec::with_capacity(component_ids.len());
+        for id in component_ids {
+            ptrs.push(
+                // SAFETY: callers must ensure that `component_ids` contains no repeated `ComponentId`s.
+                unsafe { self.get_mut_by_id(id) }
+                    .ok_or(EntityComponentError::NoSuchComponent(id))?,
+            );
+        }
+
+        Ok(ptrs)
     }
 }
 


### PR DESCRIPTION
# Objective

- Closes #15577

Unlike `get_components`, we're able to add a mutable variant here since checking for aliasing is as simple as ensuring uniqueness in a slice.

## Solution

Added:
```rust
impl<'w> EntityRef<'w> {
    pub fn get_components_by_id<const N: usize>(&self, component_ids: [ComponentId; N]) -> Result<[Ptr<'w>; N], EntityComponentError>;
    pub fn get_components_dynamic_by_id(&self, component_ids: &[ComponentId]) -> Result<Vec<Ptr<'w>>, EntityComponentError>;
}

impl<'w> EntityMut<'w> {
    pub fn get_components_by_id<const N: usize>(&self, component_ids: [ComponentId; N]) -> Result<[Ptr<'_>; N], EntityComponentError>;
    pub fn get_components_dynamic_by_id(&self, component_ids: &[ComponentId]) -> Result<Vec<Ptr<'_>>, EntityComponentError>;

    pub fn get_components_mut_by_id<const N: usize>(&mut self, component_ids: [ComponentId; N]) -> Result<[MutUntyped<'_>; N], EntityComponentError>;
    pub fn get_components_dynamic_mut_by_id(&mut self, component_ids: &[ComponentId]) -> Result<Vec<MutUntyped<'_>>, EntityComponentError>;
}

impl<'w> EntityWorldMut<'w> {
    pub fn get_components_by_id<const N: usize>(&self, component_ids: [ComponentId; N]) -> Result<[Ptr<'_>; N], EntityComponentError>;
    pub fn get_components_dynamic_by_id(&self, component_ids: &[ComponentId]) -> Result<Vec<Ptr<'_>>, EntityComponentError>;

    pub fn get_components_mut_by_id<const N: usize>(&mut self, component_ids: [ComponentId; N]) -> Result<[MutUntyped<'_>; N], EntityComponentError>;
    pub fn get_components_dynamic_mut_by_id(&mut self, component_ids: &[ComponentId]) -> Result<Vec<MutUntyped<'_>>, EntityComponentError>;
}
```

I originally added a `get_components_from_set_mut_by_id` function that takes a `HashSet` and returns a `Vec`, but ideally that should return a `HashMap` as the order isn't guaranteed with a `Vec`. I'll leave that to a follow up PR (and hopefully one that abstracts over the container).

I'm open to bikeshedding the names, but I think these draw a nice parallel with `get_components`.

## Testing

Added 4 new tests.