### PR TITLE
Enable `EntityRef::get_by_id` and friends to take multiple ids and get multiple pointers back

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -3181,7 +3181,7 @@ pub(crate) unsafe fn take_component<'a>(
 ///
 /// # Performance
 ///
-/// - The slice and array implementations peform an aliased mutability check in
+/// - The slice and array implementations perform an aliased mutability check in
 ///   [`DynamicComponentFetch::fetch_mut`] that is `O(N^2)`.
 /// - The [`HashSet`] implementation performs no such check as the type itself
 ///   guarantees unique IDs.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -3031,7 +3031,6 @@ pub(crate) unsafe fn take_component<'a>(
 #[cfg(test)]
 mod tests {
     use bevy_ptr::{OwningPtr, Ptr};
-    use bevy_utils::HashSet;
     use core::panic::AssertUnwindSafe;
 
     use crate::{

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -3205,7 +3205,7 @@ mod tests {
         let mut world = World::new();
         let entity = world.spawn_empty().id();
         let entity = world.entity(entity);
-        assert!(entity.get_by_id(invalid_component_id).is_ok());
+        assert!(entity.get_by_id(invalid_component_id).is_err());
     }
 
     #[test]
@@ -3214,8 +3214,8 @@ mod tests {
 
         let mut world = World::new();
         let mut entity = world.spawn_empty();
-        assert!(entity.get_by_id(invalid_component_id).is_ok());
-        assert!(entity.get_mut_by_id(invalid_component_id).is_ok());
+        assert!(entity.get_by_id(invalid_component_id).is_err());
+        assert!(entity.get_mut_by_id(invalid_component_id).is_err());
     }
 
     // regression test for https://github.com/bevyengine/bevy/pull/7387

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -16,7 +16,7 @@ pub struct TryRunScheduleError(pub InternedScheduleLabel);
 pub enum EntityComponentError {
     /// The component with the given [`ComponentId`] does not exist on the entity.
     #[error("The component with the ID {0:?} does not exist on the entity.")]
-    NoSuchComponent(ComponentId),
+    MissingComponent(ComponentId),
     /// The component with the given [`ComponentId`] was requested mutably more than once.
     #[error("The component with the ID {0:?} was requested mutably more than once.")]
     AliasedMutability(ComponentId),

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -12,7 +12,7 @@ use crate::{component::ComponentId, schedule::InternedScheduleLabel};
 pub struct TryRunScheduleError(pub InternedScheduleLabel);
 
 /// An error that occurs when dynamically retrieving components from an entity.
-#[derive(Error, Debug, Clone, Copy)]
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntityComponentError {
     /// The component with the given [`ComponentId`] does not exist on the entity.
     #[error("The component with the ID {0:?} does not exist on the entity.")]

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -15,9 +15,9 @@ pub struct TryRunScheduleError(pub InternedScheduleLabel);
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntityComponentError {
     /// The component with the given [`ComponentId`] does not exist on the entity.
-    #[error("The component with the ID {0:?} does not exist on the entity.")]
+    #[error("The component with ID {0:?} does not exist on the entity.")]
     MissingComponent(ComponentId),
     /// The component with the given [`ComponentId`] was requested mutably more than once.
-    #[error("The component with the ID {0:?} was requested mutably more than once.")]
+    #[error("The component with ID {0:?} was requested mutably more than once.")]
     AliasedMutability(ComponentId),
 }

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::schedule::InternedScheduleLabel;
+use crate::{component::ComponentId, schedule::InternedScheduleLabel};
 
 /// The error type returned by [`World::try_run_schedule`] if the provided schedule does not exist.
 ///
@@ -10,3 +10,14 @@ use crate::schedule::InternedScheduleLabel;
 #[derive(Error, Debug)]
 #[error("The schedule with the label {0:?} was not found.")]
 pub struct TryRunScheduleError(pub InternedScheduleLabel);
+
+/// An error that occurs when dynamically retrieving components from an entity.
+#[derive(Error, Debug, Clone, Copy)]
+pub enum EntityComponentError {
+    /// The component with the given [`ComponentId`] does not exist on the entity.
+    #[error("The component with the ID {0:?} does not exist on the entity.")]
+    NoSuchComponent(ComponentId),
+    /// The component with the given [`ComponentId`] was requested mutably more than once.
+    #[error("The component with the ID {0:?} was requested mutably more than once.")]
+    AliasedMutability(ComponentId),
+}

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -15,12 +15,12 @@ use crate::{
     removal_detection::RemovedComponentEvents,
     storage::{ComponentSparseSet, Storages, Table},
     system::Resource,
-    world::RawCommandQueue,
+    world::{error::EntityComponentError, RawCommandQueue},
 };
 use bevy_ptr::Ptr;
 #[cfg(feature = "track_change_detection")]
 use bevy_ptr::UnsafeCellDeref;
-use core::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, ptr};
+use core::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, mem::MaybeUninit, ptr};
 
 /// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
@@ -929,6 +929,64 @@ impl<'w> UnsafeEntityCell<'w> {
         } else {
             None
         }
+    }
+
+    /// Gets the components of the given [`ComponentId`]s from the entity.
+    ///
+    /// # Safety
+    ///
+    /// It is the callers responsibility to ensure that:
+    /// - the [`UnsafeEntityCell`] has permission to access the components mutably
+    /// - `component_ids` must contain no repeated [`ComponentId`]s.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EntityComponentError::NoSuchComponent`] if the entity does not have a component.
+    pub(crate) unsafe fn get_components_mut_by_id<const N: usize>(
+        &mut self,
+        component_ids: [ComponentId; N],
+    ) -> Result<[MutUntyped<'w>; N], EntityComponentError> {
+        let mut ptrs = [const { MaybeUninit::uninit() }; N];
+        for (ptr, id) in core::iter::zip(&mut ptrs, component_ids) {
+            *ptr = MaybeUninit::new(
+                // SAFETY: callers must ensure that `component_ids` contains no repeated `ComponentId`s.
+                unsafe { self.get_mut_by_id(id) }
+                    .ok_or(EntityComponentError::NoSuchComponent(id))?,
+            );
+        }
+
+        // SAFETY: Each ptr was initialized in the loop above.
+        let ptrs = ptrs.map(|ptr| unsafe { MaybeUninit::assume_init(ptr) });
+
+        Ok(ptrs)
+    }
+
+    /// Gets multiple mutable untyped components from the entity based on the
+    /// given iterator of [`ComponentId`]s.
+    ///
+    /// # Safety
+    ///
+    /// It is the callers responsibility to ensure that:
+    /// - the [`UnsafeEntityCell`] has permission to access the components mutably
+    /// - `component_ids` must contain no repeated [`ComponentId`]s.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EntityComponentError::NoSuchComponent`] if the entity does not have a component.
+    pub(crate) unsafe fn get_components_dynamic_mut_by_id(
+        &mut self,
+        component_ids: impl ExactSizeIterator<Item = ComponentId>,
+    ) -> Result<Vec<MutUntyped<'w>>, EntityComponentError> {
+        let mut ptrs = Vec::with_capacity(component_ids.len());
+        for id in component_ids {
+            ptrs.push(
+                // SAFETY: callers must ensure that `component_ids` contains no repeated `ComponentId`s.
+                unsafe { self.get_mut_by_id(id) }
+                    .ok_or(EntityComponentError::NoSuchComponent(id))?,
+            );
+        }
+
+        Ok(ptrs)
     }
 }
 


### PR DESCRIPTION
# Objective

- Closes #15577 

## Solution

The following functions can now also take multiple component IDs and return multiple pointers back:
- `EntityRef::get_by_id`
- `EntityMut::get_by_id`
- `EntityMut::into_borrow_by_id`
- `EntityMut::get_mut_by_id`
- `EntityMut::into_mut_by_id`
- `EntityWorldMut::get_by_id`
- `EntityWorldMut::into_borrow_by_id`
- `EntityWorldMut::get_mut_by_id`
- `EntityWorldMut::into_mut_by_id`

If you pass in X, you receive Y:
- give a single `ComponentId`, receive a single `Ptr`/`MutUntyped`
- give a `[ComponentId; N]` (array), receive a `[Ptr; N]`/`[MutUntyped; N]`
- give a `&[ComponentId; N]` (array), receive a `[Ptr; N]`/`[MutUntyped; N]`
- give a `&[ComponentId]` (slice), receive a `Vec<Ptr>`/`Vec<MutUntyped>`
- give a `&HashSet<ComponentId>`, receive a `HashMap<ComponentId, Ptr>`/`HashMap<ComponentId, MutUntyped>`

## Testing

- Added 4 new tests.

---

## Migration Guide

- The following functions now return an `Result<_, EntityComponentError>` instead of a `Option<_>`: `EntityRef::get_by_id`, `EntityMut::get_by_id`, `EntityMut::into_borrow_by_id`, `EntityMut::get_mut_by_id`, `EntityMut::into_mut_by_id`, `EntityWorldMut::get_by_id`, `EntityWorldMut::into_borrow_by_id`, `EntityWorldMut::get_mut_by_id`, `EntityWorldMut::into_mut_by_id`