### PR TITLE
Allow access a method handler

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -399,6 +399,11 @@ impl RemoteMethods {
     ) -> Option<RemoteMethod> {
         self.0.insert(method_name.into(), handler)
     }
+
+    /// Retrieves a handler by method name.
+    pub fn get(&self, method_name: &str) -> Option<&RemoteMethod> {
+        self.0.get(method_name)
+    }
 }
 
 /// A single request from a Bevy Remote Protocol client to the server,


### PR DESCRIPTION
# Objective

- I'm building a streaming plugin for `bevy_remote` and accessing to builtin method will be very valuable

## Solution

- Add a method to allow access a handler by method name.

## Testing

- CI should pass