### PR TITLE
Use circle gizmos for capsule

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -563,11 +563,20 @@ where
                 .short_arc_3d_between(lower_center, start, lower_apex, self.color);
         });
 
-        let upper_lines = upper_points.windows(2).map(|win| (win[0], win[1]));
-        let lower_lines = lower_points.windows(2).map(|win| (win[0], win[1]));
-        upper_lines.chain(lower_lines).for_each(|(start, end)| {
-            self.gizmos.line(start, end, self.color);
-        });
+        let circle_rotation = self
+            .isometry
+            .rotation
+            .mul_quat(Quat::from_rotation_x(core::f32::consts::FRAC_PI_2));
+        self.gizmos.circle(
+            Isometry3d::new(upper_center, circle_rotation),
+            self.radius,
+            self.color,
+        );
+        self.gizmos.circle(
+            Isometry3d::new(lower_center, circle_rotation),
+            self.radius,
+            self.color,
+        );
 
         let connection_lines = upper_points.into_iter().zip(lower_points).skip(1);
         connection_lines.for_each(|(start, end)| {


### PR DESCRIPTION
# Objective

- The capsule gizmo uses straight lines for the upper and lower circle which looks pretty ugly.

## Solution

- Use the circle gizmo instead

---

## Showcase

**BEFORE**
![3d_gizmos_sy3CmKUvKO](https://github.com/user-attachments/assets/be014de4-751e-4b40-b814-b5b97bb72031)

**AFTER**
![3d_gizmos_nyADBAUJHg](https://github.com/user-attachments/assets/539ff765-f9d8-4afe-9ac6-41fe83e94e94)

(the circles are red for demonstration purposes only)

# Notes

I also tried using 3d arcs instead of circles but it looks like arcs need a lot more computation for an almost identical end result. Circles seem much simpler. The only thing I'm unsure about is if the rotation stuff is correct. It worked in my testing though.
