### PR TITLE
Despawn and despawn_recursive benchmarks

### DIFF
--- a/benches/benches/bevy_ecs/world/despawn.rs
+++ b/benches/benches/bevy_ecs/world/despawn.rs
@@ -1,0 +1,32 @@
+use bevy_ecs::prelude::*;
+use criterion::Criterion;
+use glam::*;
+
+#[derive(Component)]
+struct A(Mat4);
+#[derive(Component)]
+struct B(Vec4);
+
+pub fn world_despawn(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("despawn_world");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+
+    for entity_count in (0..5).map(|i| 10_u32.pow(i)) {
+        let mut world = World::default();
+        for _ in 0..entity_count {
+            world.spawn((A(Mat4::default()), B(Vec4::default())));
+        }
+
+        let ents = world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+        group.bench_function(format!("{}_entities", entity_count), |bencher| {
+            bencher.iter(|| {
+                ents.iter().for_each(|e| {
+                    world.despawn(*e);
+                });
+            });
+        });
+    }
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/world/despawn_recursive.rs
+++ b/benches/benches/bevy_ecs/world/despawn_recursive.rs
@@ -1,5 +1,7 @@
 use bevy_ecs::prelude::*;
 use bevy_hierarchy::despawn_with_children_recursive;
+use bevy_hierarchy::BuildChildren;
+use bevy_hierarchy::ChildBuild;
 use criterion::Criterion;
 use glam::*;
 
@@ -16,7 +18,11 @@ pub fn world_despawn_recursive(criterion: &mut Criterion) {
     for entity_count in (0..5).map(|i| 10_u32.pow(i)) {
         let mut world = World::default();
         for _ in 0..entity_count {
-            world.spawn((A(Mat4::default()), B(Vec4::default())));
+            world
+                .spawn((A(Mat4::default()), B(Vec4::default())))
+                .with_children(|parent| {
+                    parent.spawn((A(Mat4::default()), B(Vec4::default())));
+                });
         }
 
         let ents = world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();

--- a/benches/benches/bevy_ecs/world/despawn_recursive.rs
+++ b/benches/benches/bevy_ecs/world/despawn_recursive.rs
@@ -1,0 +1,33 @@
+use bevy_ecs::prelude::*;
+use bevy_hierarchy::despawn_with_children_recursive;
+use criterion::Criterion;
+use glam::*;
+
+#[derive(Component)]
+struct A(Mat4);
+#[derive(Component)]
+struct B(Vec4);
+
+pub fn world_despawn_recursive(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("despawn_world_recursive");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+
+    for entity_count in (0..5).map(|i| 10_u32.pow(i)) {
+        let mut world = World::default();
+        for _ in 0..entity_count {
+            world.spawn((A(Mat4::default()), B(Vec4::default())));
+        }
+
+        let ents = world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+        group.bench_function(format!("{}_entities", entity_count), |bencher| {
+            bencher.iter(|| {
+                ents.iter().for_each(|e| {
+                    despawn_with_children_recursive(&mut world, *e);
+                });
+            });
+        });
+    }
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/world/mod.rs
+++ b/benches/benches/bevy_ecs/world/mod.rs
@@ -3,6 +3,12 @@ use criterion::criterion_group;
 mod commands;
 use commands::*;
 
+mod despawn;
+use despawn::*;
+
+mod despawn_recursive;
+use despawn_recursive::*;
+
 mod spawn;
 use spawn::*;
 
@@ -28,6 +34,8 @@ criterion_group!(
     world_query_iter,
     world_query_for_each,
     world_spawn,
+    world_despawn,
+    world_despawn_recursive,
     query_get,
     query_get_many::<2>,
     query_get_many::<5>,


### PR DESCRIPTION
# Objective

Add despawn and despawn_recursive benchmarks in a similar vein to the spawn benchmark.

## Testing

Ran `cargo bench` from `benches` and it compiled fine.

On my machine:
```
despawn_world/1_entities
                        time:   [3.1495 ns 3.1574 ns 3.1652 ns]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
despawn_world/10_entities
                        time:   [28.629 ns 28.674 ns 28.720 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
despawn_world/100_entities
                        time:   [286.95 ns 287.41 ns 287.90 ns]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
despawn_world/1000_entities
                        time:   [2.8739 µs 2.9001 µs 2.9355 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
despawn_world/10000_entities
                        time:   [28.535 µs 28.617 µs 28.698 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

despawn_world_recursive/1_entities
                        time:   [5.2270 ns 5.2507 ns 5.2907 ns]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe
despawn_world_recursive/10_entities
                        time:   [57.495 ns 57.590 ns 57.691 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
despawn_world_recursive/100_entities
                        time:   [514.43 ns 518.91 ns 526.88 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
despawn_world_recursive/1000_entities
                        time:   [5.0362 µs 5.0463 µs 5.0578 µs]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
despawn_world_recursive/10000_entities
                        time:   [51.159 µs 51.603 µs 52.215 µs]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
```