### PR TITLE
Add "bevy_input_focus" crate.

### DIFF
--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bevy_input_focus"
+version = "0.15.0-dev"
+edition = "2021"
+description = "Keyboard focus management"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy", "color"]
+rust-version = "1.76.0"
+
+[dependencies]
+bevy_app = { path = "../bevy_app", version = "0.15.0-dev", default-features = false }
+bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev", default-features = false }
+bevy_input = { path = "../bevy_input", version = "0.15.0-dev", default-features = false }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev", default-features = false }
+bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev", default-features = false }
+bevy_window = { path = "../bevy_window", version = "0.15.0-dev", default-features = false }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = ["-Zunstable-options", "--generate-link-to-definition"]
+all-features = true

--- a/crates/bevy_input_focus/README.md
+++ b/crates/bevy_input_focus/README.md
@@ -1,0 +1,7 @@
+# Bevy Input Focus
+
+[![License](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/bevyengine/bevy#license)
+[![Crates.io](https://img.shields.io/crates/v/bevy_input_focus.svg)](https://crates.io/crates/bevy_input_focus)
+[![Downloads](https://img.shields.io/crates/d/bevy_input_focus.svg)](https://crates.io/crates/bevy_input_focus)
+[![Docs](https://docs.rs/bevy_input_focus/badge.svg)](https://docs.rs/bevy_input_focus/latest/bevy_input_focus/)
+[![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -1,0 +1,131 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![forbid(unsafe_code)]
+#![doc(
+    html_logo_url = "https://bevyengine.org/assets/icon.png",
+    html_favicon_url = "https://bevyengine.org/assets/icon.png"
+)]
+
+//! Keyboard focus system for Bevy.
+//!
+//! This crate provides a system for managing keyboard focus in Bevy applications, including:
+//! * A resource for tracking which entity has keyboard focus.
+//! * Methods for getting and setting keyboard focus.
+//! * Event definitions for triggering bubble-able keyboard input events to the focused entity.
+//! * A system for dispatching keyboard input events to the focused entity.
+//!
+//! This crate does *not* provide any integration with UI widgets, or provide functions for
+//! tab navigation or gamepad-based focus navigation, as those are typically application-specific.
+
+use bevy_app::{App, Plugin, Update};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    event::{Event, EventReader},
+    query::With,
+    system::{Commands, Query, Res, Resource},
+    world::{Command, DeferredWorld, World},
+};
+use bevy_hierarchy::Parent;
+use bevy_input::keyboard::KeyboardInput;
+use bevy_window::Window;
+
+/// Resource representing which entity has keyboard focus, if any.
+#[derive(Clone, Debug, Resource)]
+pub struct KeyboardFocus(pub Option<Entity>);
+
+/// Marker component for which entity should receive keyboard input if nothing is focused.
+#[derive(Clone, Debug, Component)]
+pub struct DefaultKeyHandler;
+
+/// Helper functions for [`World`] and [`DeferredWorld`] to set and clear keyboard focus.
+pub trait SetKeyboardFocus {
+    /// Set keyboard focus to the given entity.
+    fn set_keyboard_focus(&mut self, entity: Entity);
+    /// Clear keyboard focus.
+    fn clear_keyboard_focus(&mut self);
+}
+
+impl SetKeyboardFocus for World {
+    fn set_keyboard_focus(&mut self, entity: Entity) {
+        if let Some(mut focus) = self.get_resource_mut::<KeyboardFocus>() {
+            focus.0 = Some(entity);
+        }
+    }
+
+    fn clear_keyboard_focus(&mut self) {
+        if let Some(mut focus) = self.get_resource_mut::<KeyboardFocus>() {
+            focus.0 = None;
+        }
+    }
+}
+
+impl<'w> SetKeyboardFocus for DeferredWorld<'w> {
+    fn set_keyboard_focus(&mut self, entity: Entity) {
+        if let Some(mut focus) = self.get_resource_mut::<KeyboardFocus>() {
+            focus.0 = Some(entity);
+        }
+    }
+
+    fn clear_keyboard_focus(&mut self) {
+        if let Some(mut focus) = self.get_resource_mut::<KeyboardFocus>() {
+            focus.0 = None;
+        }
+    }
+}
+
+/// Command to set keyboard focus to the given entity.
+pub struct SetFocusCommand(Option<Entity>);
+
+impl Command for SetFocusCommand {
+    fn apply(self, world: &mut World) {
+        if let Some(mut focus) = world.get_resource_mut::<KeyboardFocus>() {
+            focus.0 = self.0;
+        }
+    }
+}
+
+/// A bubble-able event for keyboard input. This event is normally dispatched to the current
+/// keyboard focus entity, if any. If no entity has keyboard focus, then the event is dispatched to
+/// the main window.
+#[derive(Clone, Debug, Component)]
+pub struct FocusKeyboardInput(pub KeyboardInput);
+
+impl Event for FocusKeyboardInput {
+    type Traversal = &'static Parent;
+
+    const AUTO_PROPAGATE: bool = true;
+}
+
+/// Plugin which registers the system for dispatching keyboard events based on focus and
+/// hover state.
+pub struct InputDispatchPlugin;
+
+impl Plugin for InputDispatchPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(KeyboardFocus(None))
+            .add_systems(Update, dispatch_keyboard_input);
+    }
+}
+
+fn dispatch_keyboard_input(
+    mut key_events: EventReader<KeyboardInput>,
+    focus: Res<KeyboardFocus>,
+    windows: Query<Entity, With<Window>>,
+    mut commands: Commands,
+) {
+    // If an element has keyboard focus, then dispatch the key event to that element.
+    if let Some(focus_elt) = focus.0 {
+        for ev in key_events.read() {
+            commands.trigger_targets(FocusKeyboardInput(ev.clone()), focus_elt);
+        }
+    } else {
+        // If no element has keyboard focus, then dispatch the key event to the main window.
+        // TODO: How to determine which window is the main window?
+        // For now, just dispatch to all windows.
+        for ev in key_events.read() {
+            for window in windows.iter() {
+                commands.trigger_targets(FocusKeyboardInput(ev.clone()), window);
+            }
+        }
+    }
+}

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -47,6 +47,7 @@ crates=(
     bevy_dylib
     bevy_color
     bevy_picking
+    bevy_input_focus
 )
 
 if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
# Objective

Define a framework for handling keyboard focus and bubbled keyboard events, as discussed in #15374.

## Solution

Introduces a new crate, `bevy_input_focus`. This crate provides:

* A resource for tracking which entity has keyboard focus.
* Methods for getting and setting keyboard focus.
* Event definitions for triggering bubble-able keyboard input events to the focused entity.
* A system for dispatching keyboard input events to the focused entity.

This crate does *not* provide any integration with UI widgets, or provide functions for
tab navigation or gamepad-based focus navigation, as those are typically application-specific.

## Testing

Most of the code has been copied from a different project, one that has been well tested. However, most of what's in this module consists of type definitions, with relatively small amounts of executable code. That being said, I expect that there will be substantial bikeshedding on the design, and I would prefer to hold off writing tests until after things have settled.

I think that an example would be appropriate, however I'm waiting on a few other pending changes to Bevy before doing so. In particular, I can see a simple example with four buttons, with focus navigation between them, and which can be triggered by the keyboard.

@alice-i-cecile 