### PR TITLE
send_events is ambiguous_with_all

### DIFF
--- a/crates/bevy_dev_tools/src/ci_testing/mod.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/mod.rs
@@ -56,7 +56,8 @@ impl Plugin for CiTestingPlugin {
                 systems::send_events
                     .before(trigger_screenshots)
                     .before(bevy_window::close_when_requested)
-                    .in_set(SendEvents),
+                    .in_set(SendEvents)
+                    .ambiguous_with_all(),
             );
 
         // The offending system does not exist in the wasm32 target.


### PR DESCRIPTION
# Objective

> Alice 🌹 — Today at 3:43 PM
bevy_dev_tools::ci_testing::systems::send_events
This system should be marked as ambiguous with everything I think

## Solution

- Mark it as `ambiguous_with_all`