### PR TITLE
Fix `bevy_window` and `bevy_winit` readme badges

### DIFF
--- a/crates/bevy_window/README.md
+++ b/crates/bevy_window/README.md
@@ -1,7 +1,7 @@
 # Bevy Window
 
 [![License](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/bevyengine/bevy#license)
-[![Crates.io](https://img.shields.io/crates/v/bevy_name.svg)](https://crates.io/crates/bevy_name)
-[![Downloads](https://img.shields.io/crates/d/bevy_name.svg)](https://crates.io/crates/bevy_name)
-[![Docs](https://docs.rs/bevy_name/badge.svg)](https://docs.rs/bevy_name/latest/bevy_name/)
+[![Crates.io](https://img.shields.io/crates/v/bevy_window.svg)](https://crates.io/crates/bevy_window)
+[![Downloads](https://img.shields.io/crates/d/bevy_window.svg)](https://crates.io/crates/bevy_window)
+[![Docs](https://docs.rs/bevy_window/badge.svg)](https://docs.rs/bevy_window/latest/bevy_window/)
 [![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)

--- a/crates/bevy_winit/README.md
+++ b/crates/bevy_winit/README.md
@@ -1,7 +1,7 @@
 # Bevy Winit
 
 [![License](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](https://github.com/bevyengine/bevy#license)
-[![Crates.io](https://img.shields.io/crates/v/bevy_name.svg)](https://crates.io/crates/bevy_name)
-[![Downloads](https://img.shields.io/crates/d/bevy_name.svg)](https://crates.io/crates/bevy_name)
-[![Docs](https://docs.rs/bevy_name/badge.svg)](https://docs.rs/bevy_name/latest/bevy_name/)
+[![Crates.io](https://img.shields.io/crates/v/bevy_winit.svg)](https://crates.io/crates/bevy_winit)
+[![Downloads](https://img.shields.io/crates/d/bevy_winit.svg)](https://crates.io/crates/bevy_winit)
+[![Docs](https://docs.rs/bevy_winit/badge.svg)](https://docs.rs/bevy_winit/latest/bevy_winit/)
 [![Discord](https://img.shields.io/discord/691052431525675048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/bevy)


### PR DESCRIPTION
## Objective

Fix the badges for `bevy_window` and `bevy_winit`.

## Solution

Replace the placeholder `bevy_name` wit the correct crate name.
