### PR TITLE
Add `AssetPath::exists`

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -474,7 +474,10 @@ impl<'a> AssetPath<'a> {
             return None;
         }
         let path = self.path();
-        let path = path.is_absolute().then(|| path.strip_prefix("/").ok()).flatten()?;
+        let path = path
+            .is_absolute()
+            .then(|| path.strip_prefix("/").ok())
+            .flatten()?;
         Some(Path::new(crate::AssetPlugin::DEFAULT_UNPROCESSED_FILE_PATH).join(path))
     }
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -465,27 +465,36 @@ impl<'a> AssetPath<'a> {
         Some(extension)
     }
 
-    /// Returns whether the asset file exists using the std [`Path::exists`] method.
+    /// Returns the path of the [`AssetPath`] relative to the app root.
+    /// Returns None if the [`AssetPath`] uses a non-default Asset Source.
     ///
-    /// Returns false when the asset does not exist or if the [`AssetPath`] uses a custom [`AssetSourceId`].
-    pub fn exists(&self) -> bool {
+    /// Ex: an [`AssetPath`] referencing "/models/apple.gltf" would return a [`PathBuf`] for "assets/models/apple.gltf"
+    pub fn get_root_relative_path(&self) -> Option<PathBuf> {
         if let AssetSourceId::Name(_) = self.source {
-            return false;
+            return None;
         }
         let path = self.path();
         let path = if path.is_absolute() {
             match path.strip_prefix("/") {
                 Ok(path) => path,
                 Err(_) => {
-                    return false;
+                    return None;
                 }
             }
         } else {
             path
         };
-        Path::new(crate::AssetPlugin::DEFAULT_UNPROCESSED_FILE_PATH)
-            .join(path)
-            .exists()
+        Some(Path::new(crate::AssetPlugin::DEFAULT_UNPROCESSED_FILE_PATH).join(path))
+    }
+
+    /// Returns whether the asset file exists using the std [`Path::exists`] method.
+    ///
+    /// Returns false when the asset does not exist or if the [`AssetPath`] uses a custom [`AssetSourceId`].
+    pub fn exists(&self) -> bool {
+        match self.get_root_relative_path() {
+            Some(path) => path.exists(),
+            None => false,
+        }
     }
 
     pub(crate) fn iter_secondary_extensions(full_extension: &str) -> impl Iterator<Item = &str> {

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -474,16 +474,7 @@ impl<'a> AssetPath<'a> {
             return None;
         }
         let path = self.path();
-        let path = if path.is_absolute() {
-            match path.strip_prefix("/") {
-                Ok(path) => path,
-                Err(_) => {
-                    return None;
-                }
-            }
-        } else {
-            path
-        };
+        let path = path.is_absolute().then(|| path.strip_prefix("/").ok()).flatten()?;
         Some(Path::new(crate::AssetPlugin::DEFAULT_UNPROCESSED_FILE_PATH).join(path))
     }
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -465,6 +465,29 @@ impl<'a> AssetPath<'a> {
         Some(extension)
     }
 
+    /// Returns whether the asset file exists using the std [`Path::exists`] method.
+    ///
+    /// Returns false when the asset does not exist or if the [`AssetPath`] uses a custom [`AssetSourceId`].
+    pub fn exists(&self) -> bool {
+        if let AssetSourceId::Name(_) = self.source {
+            return false;
+        }
+        let path = self.path();
+        let path = if path.is_absolute() {
+            match path.strip_prefix("/") {
+                Ok(path) => path,
+                Err(_) => {
+                    return false;
+                }
+            }
+        } else {
+            path
+        };
+        Path::new(crate::AssetPlugin::DEFAULT_UNPROCESSED_FILE_PATH)
+            .join(path)
+            .exists()
+    }
+
     pub(crate) fn iter_secondary_extensions(full_extension: &str) -> impl Iterator<Item = &str> {
         full_extension.chars().enumerate().filter_map(|(i, c)| {
             if c == '.' {


### PR DESCRIPTION
# Objective

- Add functionality to determine if an `AssetPath` references an actual file/directory or not.
- Fixes #14427

## Solution

- Added a `AssetPath::exists` method which returns whether the path references an existing file or directory.
- The method pre-parses the path to be relative to the default "assets" folder, returning false if the `AssetPath` uses a custom source.
- The existence check uses the std `Path::exists` method.

## Testing

- Tested using a small test app. `Assetpath`s that referenced real asset files returned true, and the rest returned false.
- I tested on linux, but since the method uses the standard library's `Path` struct, it should work on any system.