### PR TITLE
Deprecate `Events::oldest_id`

### DIFF
--- a/crates/bevy_ecs/src/event/collections.rs
+++ b/crates/bevy_ecs/src/event/collections.rs
@@ -114,9 +114,7 @@ impl<E: Event> Default for Events<E> {
 impl<E: Event> Events<E> {
     /// Returns the index of the oldest event stored in the event buffer.
     pub fn oldest_event_count(&self) -> usize {
-        self.events_a
-            .start_event_count
-            .min(self.events_b.start_event_count)
+        self.events_a.start_event_count
     }
 
     /// "Sends" an `event` by writing it to the current event buffer.
@@ -279,7 +277,7 @@ impl<E: Event> Events<E> {
 
     /// Get a specific event by id if it still exists in the events buffer.
     pub fn get_event(&self, id: usize) -> Option<(&E, EventId<E>)> {
-        if id < self.oldest_id() {
+        if id < self.oldest_event_count() {
             return None;
         }
 
@@ -289,11 +287,6 @@ impl<E: Event> Events<E> {
         sequence
             .get(index)
             .map(|instance| (&instance.event, instance.event_id))
-    }
-
-    /// Oldest id still in the events buffer.
-    pub fn oldest_id(&self) -> usize {
-        self.events_a.start_event_count
     }
 
     /// Which event buffer is this event id a part of.


### PR DESCRIPTION
# Objective

Fixes #15617 

## Solution

The original author confirmed it was not intentional that both these methods exist.

They do the same, one has the better implementation and the other the better name.

## Testing

I just ran the unit tests of the module.

---

## Migration Guide

- Change usages of `Events::oldest_id` to `Events::oldest_event_count`
- If `Events::oldest_id` was used to get the actual oldest `EventId::id`, note that the deprecated method never reliably did that in the first place as the buffers may contain no id currently.