### PR TITLE
Don't trigger animation events when paused

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1144,7 +1144,9 @@ pub fn animate_targets(
                         };
 
                         // Trigger all animation events that occurred this tick, if any.
-                        if let Some(triggered_events) = TriggeredEvents::from_animation(
+                        if active_animation.paused {
+                            // Don't trigger events when paused.
+                        } else if let Some(triggered_events) = TriggeredEvents::from_animation(
                             AnimationEventTarget::Node(target_id),
                             clip,
                             active_animation,

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1143,27 +1143,27 @@ pub fn animate_targets(
                             continue;
                         };
 
-                        // Trigger all animation events that occurred this tick, if any.
-                        if active_animation.paused {
-                            // Don't trigger events when paused.
-                        } else if let Some(triggered_events) = TriggeredEvents::from_animation(
-                            AnimationEventTarget::Node(target_id),
-                            clip,
-                            active_animation,
-                        ) {
-                            if !triggered_events.is_empty() {
-                                par_commands.command_scope(move |mut commands| {
-                                    for TimedAnimationEvent { time, event } in
-                                        triggered_events.iter()
-                                    {
-                                        commands.queue(trigger_animation_event(
-                                            entity,
-                                            *time,
-                                            active_animation.weight,
-                                            event.clone().0,
-                                        ));
-                                    }
-                                });
+                        if !active_animation.paused {
+                            // Trigger all animation events that occurred this tick, if any.
+                            if let Some(triggered_events) = TriggeredEvents::from_animation(
+                                AnimationEventTarget::Node(target_id),
+                                clip,
+                                active_animation,
+                            ) {
+                                if !triggered_events.is_empty() {
+                                    par_commands.command_scope(move |mut commands| {
+                                        for TimedAnimationEvent { time, event } in
+                                            triggered_events.iter()
+                                        {
+                                            commands.queue(trigger_animation_event(
+                                                entity,
+                                                *time,
+                                                active_animation.weight,
+                                                event.clone().0,
+                                            ));
+                                        }
+                                    });
+                                }
                             }
                         }
 


### PR DESCRIPTION
# Objective

Pausing the `animated_fox` example perfectly as one of the feet hits the ground causes the event to be triggered every frame. 

Context: #15538

## Solution

Don't trigger animation events if the animation is paused.

## Testing

Ran the example, I no longer see the issue.

