### PR TITLE
Read back full screen state from window on macOS

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -9,10 +9,12 @@ use bevy_ecs::{
 use bevy_input::keyboard::KeyboardFocusLost;
 use bevy_utils::tracing::{error, info, warn};
 use bevy_window::{
-    ClosingWindow, Monitor, MonitorSelection, PrimaryMonitor, RawHandleWrapper, VideoMode, Window,
-    WindowClosed, WindowClosing, WindowCreated, WindowFocused, WindowMode, WindowResized,
-    WindowWrapper,
+    ClosingWindow, Monitor, PrimaryMonitor, RawHandleWrapper, VideoMode, Window, WindowClosed,
+    WindowClosing, WindowCreated, WindowFocused, WindowMode, WindowResized, WindowWrapper,
 };
+
+#[cfg(target_os = "macos")]
+use bevy_window::MonitorSelection;
 
 use winit::{
     dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize},

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -9,8 +9,9 @@ use bevy_ecs::{
 use bevy_input::keyboard::KeyboardFocusLost;
 use bevy_utils::tracing::{error, info, warn};
 use bevy_window::{
-    ClosingWindow, Monitor, PrimaryMonitor, RawHandleWrapper, VideoMode, Window, WindowClosed,
-    WindowClosing, WindowCreated, WindowFocused, WindowMode, WindowResized, WindowWrapper,
+    ClosingWindow, Monitor, MonitorSelection, PrimaryMonitor, RawHandleWrapper, VideoMode, Window,
+    WindowClosed, WindowClosing, WindowCreated, WindowFocused, WindowMode, WindowResized,
+    WindowWrapper,
 };
 
 use winit::{
@@ -326,6 +327,17 @@ pub(crate) fn changed_windows(
                 if winit_window.fullscreen() != new_mode {
                     winit_window.set_fullscreen(new_mode);
                 }
+            }
+        } else {
+            #[cfg(target_os = "macos")]
+            match (winit_window.fullscreen(), window.mode) {
+                (Some(winit::window::Fullscreen::Borderless(_)), WindowMode::Windowed) => {
+                    window.mode = WindowMode::BorderlessFullscreen(MonitorSelection::Current);
+                }
+                (None, WindowMode::BorderlessFullscreen(_)) => {
+                    window.mode = WindowMode::Windowed;
+                }
+                _ => {}
             }
         }
 


### PR DESCRIPTION
# Objective

I'm trying to display on a menu screen of my game the Windowed/Full screen state. However, on macOS it's possible for the user to trigger borderless fullscreen directly from the window controls, which results in a stale/wrong state displayed.

## Solution

- Add logic to read back full screen state and apply it to the window when the user directly makes it full screen via the window controls on macOS

## Testing

- Did you test these changes? If so, how? Yes, mostly on my game
- Are there any parts that need more testing? I'm not sure if this has performance implications, as the call might be blocking on the UI thread. However, unscientifically I didn't notice any degradation.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Adding log statements to the match branches should suffice.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? Just macOS
