### PR TITLE
Don't trigger animation events when paused 2

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -951,6 +951,10 @@ fn trigger_untargeted_animation_events(
         };
 
         for (index, active_animation) in player.active_animations.iter() {
+            if active_animation.paused {
+                continue;
+            }
+
             let Some(clip) = graph
                 .get(*index)
                 .and_then(|node| match &node.node_type {


### PR DESCRIPTION
# Objective

I completely forgot that animation events are triggered in two separate systems (sorry). The issue ~~fixed~~ by #15677, can still happen if the animation event is not targeting a specific bone.

## Solution

_Realy_ don't trigger animation events for paused animations.
