### PR TITLE
Use global clear color for camera driver node.

### DIFF
--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -1,5 +1,5 @@
 use crate::{
-    camera::{ExtractedCamera, NormalizedRenderTarget, SortedCameras},
+    camera::{ClearColor, ExtractedCamera, NormalizedRenderTarget, SortedCameras},
     render_graph::{Node, NodeRunError, RenderGraphContext},
     renderer::RenderContext,
     view::ExtractedWindows,
@@ -53,6 +53,8 @@ impl Node for CameraDriverNode {
             }
         }
 
+        let clear_color_global = world.get_resource::<ClearColor>().unwrap();
+
         // wgpu (and some backends) require doing work for swap chains if you call `get_current_texture()` and `present()`
         // This ensures that Bevy doesn't crash, even when there are no cameras (and therefore no work submitted).
         for (id, window) in world.resource::<ExtractedWindows>().iter() {
@@ -72,7 +74,7 @@ impl Node for CameraDriverNode {
                     view: swap_chain_texture,
                     resolve_target: None,
                     ops: Operations {
-                        load: LoadOp::Clear(wgpu::Color::BLACK),
+                        load: LoadOp::Clear(clear_color_global.to_linear().into()),
                         store: StoreOp::Store,
                     },
                 })],

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -53,7 +53,7 @@ impl Node for CameraDriverNode {
             }
         }
 
-        let clear_color_global = world.get_resource::<ClearColor>().unwrap();
+        let clear_color_global = world.resource::<ClearColor>();
 
         // wgpu (and some backends) require doing work for swap chains if you call `get_current_texture()` and `present()`
         // This ensures that Bevy doesn't crash, even when there are no cameras (and therefore no work submitted).


### PR DESCRIPTION
When no cameras are configured, the `ClearColor` resource has no effect on the default window.

Fixes https://discord.com/channels/691052431525675048/866787577687310356/1292601838075379796

![image](https://github.com/user-attachments/assets/f42479c0-b239-4660-acd0-daa859b1f815)
![image](https://github.com/user-attachments/assets/4d625960-f105-4a29-91a3-44f4baadac30)
