### PR TITLE
Fixes to animation graph evaluation

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1098,7 +1098,7 @@ pub fn animate_targets(
                 };
 
                 match animation_graph_node.node_type {
-                    AnimationNodeType::Blend | AnimationNodeType::Add => {
+                    AnimationNodeType::Blend => {
                         // This is a blend node.
                         for edge_index in threaded_animation_graph.sorted_edge_ranges
                             [animation_graph_node_index.index()]
@@ -1107,6 +1107,27 @@ pub fn animate_targets(
                             if let Err(err) = evaluation_state.blend_all(
                                 threaded_animation_graph.sorted_edges[edge_index as usize],
                             ) {
+                                warn!("Failed to blend animation: {:?}", err);
+                            }
+                        }
+
+                        if let Err(err) = evaluation_state.push_blend_register_all(
+                            animation_graph_node.weight,
+                            animation_graph_node_index,
+                        ) {
+                            warn!("Animation blending failed: {:?}", err);
+                        }
+                    }
+
+                    AnimationNodeType::Add => {
+                        // This is an additive blend node.
+                        for edge_index in threaded_animation_graph.sorted_edge_ranges
+                            [animation_graph_node_index.index()]
+                        .clone()
+                        {
+                            if let Err(err) = evaluation_state
+                                .add_all(threaded_animation_graph.sorted_edges[edge_index as usize])
+                            {
                                 warn!("Failed to blend animation: {:?}", err);
                             }
                         }
@@ -1169,7 +1190,7 @@ pub fn animate_targets(
                             continue;
                         };
 
-                        let weight = active_animation.weight;
+                        let weight = active_animation.weight * animation_graph_node.weight;
                         let seek_time = active_animation.seek_time;
 
                         for curve in curves {
@@ -1313,6 +1334,20 @@ impl AnimationEvaluationState {
                 .get_mut(curve_evaluator_type)
                 .unwrap()
                 .blend(node_index)?;
+        }
+        Ok(())
+    }
+
+    /// Calls [`AnimationCurveEvaluator::add`] on all curve evaluator types
+    /// that we've been building up for a single target.
+    ///
+    /// The given `node_index` is the node that we're evaluating.
+    fn add_all(&mut self, node_index: AnimationNodeIndex) -> Result<(), AnimationEvaluationError> {
+        for curve_evaluator_type in self.current_curve_evaluator_types.keys() {
+            self.curve_evaluators
+                .get_mut(curve_evaluator_type)
+                .unwrap()
+                .add(node_index)?;
         }
         Ok(())
     }


### PR DESCRIPTION
# Objective

Fix a couple of substantial errors found during the development of #15665:
- `AnimationCurveEvaluator::add` was secretly unreachable. In other words, additive blending never actually occurred.
- Weights from the animation graph nodes were ignored, and only `ActiveAnimation`'s weights were used.

## Solution

Made additive blending reachable and included the graph node weight in the weight of the stack elements appended in the curve application loop of `animate_targets`.

## Testing

Tested on existing examples and on the new example added in #15665. 
