### PR TITLE
Fix a system ordering issue with motion blur for skinned meshes.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -163,7 +163,7 @@ impl Plugin for MeshRenderPlugin {
                 .add_systems(
                     Render,
                     (
-                        set_mesh_motion_vector_flags.before(RenderSet::Queue),
+                        set_mesh_motion_vector_flags.in_set(RenderSet::PrepareAssets),
                         prepare_skins.in_set(RenderSet::PrepareResources),
                         prepare_morphs.in_set(RenderSet::PrepareResources),
                         prepare_mesh_bind_group.in_set(RenderSet::PrepareBindGroups),
@@ -208,7 +208,11 @@ impl Plugin for MeshRenderPlugin {
                                 .after(prepare_view_targets),
                             collect_meshes_for_gpu_building
                                 .in_set(RenderSet::PrepareAssets)
-                                .after(allocator::allocate_and_free_meshes),
+                                .after(allocator::allocate_and_free_meshes)
+                                // This must be before
+                                // `set_mesh_motion_vector_flags` so it doesn't
+                                // overwrite those flags.
+                                .before(set_mesh_motion_vector_flags),
                         ),
                     );
             } else {


### PR DESCRIPTION
Currently, it's possible for the `collect_meshes_for_gpu_building` system to run after `set_mesh_motion_vector_flags`. This will cause those motion vector flags to be overwritten, which will cause the shader to ignore the motion vectors for skinned meshes, which will cause graphical artifacts.

This patch corrects the issue by forcing `set_mesh_motion_vector_flags` to run after `collect_meshes_for_gpu_building`.