### PR TITLE
Fix `query_gltf_primitives` example

### DIFF
--- a/examples/3d/query_gltf_primitives.rs
+++ b/examples/3d/query_gltf_primitives.rs
@@ -23,7 +23,11 @@ fn find_top_material_and_mesh(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
     time: Res<Time>,
-    mat_query: Query<(&Handle<StandardMaterial>, &Handle<Mesh>, &GltfMaterialName)>,
+    mat_query: Query<(
+        &MeshMaterial3d<StandardMaterial>,
+        &Mesh3d,
+        &GltfMaterialName,
+    )>,
 ) {
     for (mat_handle, mesh_handle, name) in mat_query.iter() {
         // locate a material by material name


### PR DESCRIPTION
This example was missed during the port to required components for meshes and materials.
Easy fix, I checked that it works as it did in the PR that added the example (#13912).