### PR TITLE
Remove warning for children in UI hierarchies without Style

### DIFF
--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -121,12 +121,6 @@ impl UiSurface {
         for child in children {
             if let Some(taffy_node) = self.entity_to_taffy.get(&child) {
                 self.taffy_children_scratch.push(*taffy_node);
-            } else {
-                warn!(
-                    "Unstyled child `{child}` in a UI entity hierarchy. You are using an entity \
-without UI components as a child of an entity with UI components, results may be unexpected. \
-If this is intentional, consider adding a GhostNode component to this entity."
-                );
             }
         }
 

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -290,8 +290,8 @@ impl UiSurface {
                 .map_err(LayoutError::TaffyError)
         } else {
             warn!(
-                "Styled child in a non-UI entity hierarchy. You are using an entity \
-with UI components as a child of an entity without UI components, results may be unexpected."
+                "Styled child ({entity}) in a non-UI entity hierarchy. You are using an entity \
+with UI components as a child of an entity without UI components, your UI layout may be broken."
             );
             Err(LayoutError::InvalidHierarchy)
         }


### PR DESCRIPTION
# Objective

As discussed in #15591, this warning prevents us from storing leaf nodes without a `Style` component. Because text sections (as distinct entities) should not be laid out using `taffy`, this warning is incorrect.

Users may also have other uses for doing this, and this should generally increase flexibility without posing particularly serious correctness concerns.

## Solution

- removed warning about non-UI children with UI parents
- improved the warning about UI parents with non-UI parents
   - this warning should stay, for now, as it results in a genuine failure to perform `taffy` layout
   - that said, we should be clearer about the cause and potentially harmful results of this!
   
## Testing

I inserted an empty entity into the hierarchy in the `button` example as a leaf node, and it ran with no warnings.
