### PR TITLE
Improve `fps_overlay` example

### DIFF
--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -5,6 +5,13 @@ use bevy::{
     prelude::*,
 };
 
+struct OverlayColor;
+
+impl OverlayColor {
+    const RED: Color = Color::srgb(1.0, 0.0, 0.0);
+    const GREEN: Color = Color::srgb(0.0, 1.0, 0.0);
+}
+
 fn main() {
     App::new()
         .add_plugins((
@@ -15,7 +22,7 @@ fn main() {
                         // Here we define size of our overlay
                         font_size: 42.0,
                         // We can also change color of the overlay
-                        color: Color::srgb(0.0, 1.0, 0.0),
+                        color: OverlayColor::GREEN,
                         // If we want, we can use a custom font
                         font: default(),
                     },
@@ -47,9 +54,10 @@ fn setup(mut commands: Commands) {
         .with_children(|c| {
             c.spawn(TextBundle::from_section(
                 concat!(
-                    "Press 1 to change color of the overlay.\n",
-                    "Press 2 to change size of the overlay.\n",
-                    "Press 3 to toggle the overlay."
+                    "Press 1 to toggle the overlay color.\n",
+                    "Press 2 to decrease the overlay size.\n",
+                    "Press 3 to increase the overlay size.\n",
+                    "Press 4 to toggle the overlay visibility."
                 ),
                 TextStyle::default(),
             ));
@@ -59,12 +67,19 @@ fn setup(mut commands: Commands) {
 fn customize_config(input: Res<ButtonInput<KeyCode>>, mut overlay: ResMut<FpsOverlayConfig>) {
     if input.just_pressed(KeyCode::Digit1) {
         // Changing resource will affect overlay
-        overlay.text_config.color = Color::srgb(1.0, 0.0, 0.0);
+        if overlay.text_config.color == OverlayColor::GREEN {
+            overlay.text_config.color = OverlayColor::RED;
+        } else {
+            overlay.text_config.color = OverlayColor::GREEN;
+        }
     }
     if input.just_pressed(KeyCode::Digit2) {
         overlay.text_config.font_size -= 2.0;
     }
     if input.just_pressed(KeyCode::Digit3) {
+        overlay.text_config.font_size += 2.0;
+    }
+    if input.just_pressed(KeyCode::Digit4) {
         overlay.enabled = !overlay.enabled;
     }
 }


### PR DESCRIPTION
This PR improves the `fps_overlay` example by adding:

1. The ability to increase the overlay font size (previously, only decreasing the size was supported).
2. A toggle for overlay color between red and green (previously, it only changed from green to red without toggling back).