### PR TITLE
easing_functions example: draw point closer to its curve

### DIFF
--- a/examples/animation/easing_functions.rs
+++ b/examples/animation/easing_functions.rs
@@ -88,7 +88,7 @@ fn setup(mut commands: Commands) {
                             color,
                             ..default()
                         },
-                        transform: Transform::from_xyz(110.0, 15.0, 0.0),
+                        transform: Transform::from_xyz(SIZE_PER_FUNCTION + 5.0, 15.0, 0.0),
                         ..default()
                     });
                     p.spawn(SpriteBundle {
@@ -113,6 +113,8 @@ fn setup(mut commands: Commands) {
     );
 }
 
+const SIZE_PER_FUNCTION: f32 = 95.0;
+
 fn display_curves(
     mut gizmos: Gizmos,
     ease_functions: Query<(&SelectedEaseFunction, &Transform, &Children)>,
@@ -121,7 +123,6 @@ fn display_curves(
     time: Res<Time>,
 ) {
     let samples = 100;
-    let size = 95.0;
     let duration = 2.5;
     let time_margin = 0.5;
 
@@ -136,16 +137,16 @@ fn display_curves(
             [
                 Vec2::new(transform.translation.x, transform.translation.y + 15.0),
                 Vec2::new(
-                    transform.translation.x + size,
+                    transform.translation.x + SIZE_PER_FUNCTION,
                     transform.translation.y + 15.0,
                 ),
                 Vec2::new(
-                    transform.translation.x + size,
-                    transform.translation.y + 15.0 + size,
+                    transform.translation.x + SIZE_PER_FUNCTION,
+                    transform.translation.y + 15.0 + SIZE_PER_FUNCTION,
                 ),
                 Vec2::new(
                     transform.translation.x,
-                    transform.translation.y + 15.0 + size,
+                    transform.translation.y + 15.0 + SIZE_PER_FUNCTION,
                 ),
                 Vec2::new(transform.translation.x, transform.translation.y + 15.0),
             ],
@@ -156,8 +157,8 @@ fn display_curves(
         let f = easing_curve(0.0, 1.0, *function);
         let drawn_curve = f.by_ref().graph().map(|(x, y)| {
             Vec2::new(
-                x * size + transform.translation.x,
-                y * size + transform.translation.y + 15.0,
+                x * SIZE_PER_FUNCTION + transform.translation.x,
+                y * SIZE_PER_FUNCTION + transform.translation.y + 15.0,
             )
         });
         gizmos.curve_2d(
@@ -167,13 +168,17 @@ fn display_curves(
         );
 
         // Show progress along the curve for the current time
-        let y = f.sample(now).unwrap() * size + 15.0;
+        let y = f.sample(now).unwrap() * SIZE_PER_FUNCTION + 15.0;
         transforms.get_mut(children[0]).unwrap().translation.y = y;
-        transforms.get_mut(children[1]).unwrap().translation = Vec3::new(now * size, y, 0.0);
+        transforms.get_mut(children[1]).unwrap().translation =
+            Vec3::new(now * SIZE_PER_FUNCTION, y, 0.0);
         gizmos.linestrip_2d(
             [
                 Vec2::new(transform.translation.x, transform.translation.y + y),
-                Vec2::new(transform.translation.x + size, transform.translation.y + y),
+                Vec2::new(
+                    transform.translation.x + SIZE_PER_FUNCTION,
+                    transform.translation.y + y,
+                ),
             ],
             color.darker(0.2),
         );


### PR DESCRIPTION
# Objective

- After #15711 which added a column to the example, the point of a curve was too close to the next curve

## Solution

- Make it closer to its own
