### PR TITLE
Use shader_def for oit resolve layer count

### DIFF
--- a/crates/bevy_core_pipeline/src/oit/resolve/oit_resolve.wgsl
+++ b/crates/bevy_core_pipeline/src/oit/resolve/oit_resolve.wgsl
@@ -12,8 +12,7 @@ struct OitFragment {
     depth: f32,
 }
 // Contains all the colors and depth for this specific fragment
-// TODO don't hardcode size
-var<private> fragment_list: array<OitFragment, 32>;
+var<private> fragment_list: array<OitFragment, #{LAYER_COUNT}>;
 
 struct FullscreenVertexOutput {
     @builtin(position) position: vec4<f32>,


### PR DESCRIPTION
# Objective

- Size is currently hardcoded in the shader which means it will break if a user uses anything higher than that.

## Solution

- Use a shader_def to define the size

## Testing

Tested with the OIT example
