### PR TITLE
Remove `Handle<T>` trait implementations that are dependent on `Component`

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -18,6 +18,7 @@ use bevy_core_pipeline::{
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
+    entity::EntityHashMap,
     prelude::*,
     system::{lifetimeless::SRes, SystemParamItem},
 };
@@ -25,7 +26,6 @@ use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_render::{
     camera::TemporalJitter,
-    extract_instances::ExtractedInstances,
     extract_resource::ExtractResource,
     mesh::{Mesh3d, MeshVertexBufferLayoutRef, RenderMesh},
     render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
@@ -276,7 +276,7 @@ where
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<DrawFunctions<Shadow>>()
-                .init_resource::<ExtractedInstances<AssetId<M>>>()
+                .init_resource::<RenderMaterialInstances<M>>()
                 .add_render_command::<Shadow, DrawPrepass<M>>()
                 .add_render_command::<Transmissive3d, DrawMaterial<M>>()
                 .add_render_command::<Transparent3d, DrawMaterial<M>>()
@@ -490,7 +490,15 @@ impl<P: PhaseItem, M: Material, const I: usize> RenderCommand<P> for SetMaterial
     }
 }
 
-pub type RenderMaterialInstances<M> = ExtractedInstances<AssetId<M>>;
+/// Stores all extracted instances of a [`Material`] in the render world.
+#[derive(Resource, Deref, DerefMut)]
+pub struct RenderMaterialInstances<M: Material>(pub EntityHashMap<AssetId<M>>);
+
+impl<M: Material> Default for RenderMaterialInstances<M> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
 
 pub const fn alpha_mode_pipeline_key(alpha_mode: AlphaMode, msaa: &Msaa) -> MeshPipelineKey {
     match alpha_mode {

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -195,7 +195,7 @@ impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
     }
 }
 
-/// This system extracts all components of the corresponding [`ExtractComponent`], for entities that are synced via [`SyncToRenderWorld`].
+/// This system extracts all components of the corresponding [`ExtractComponent`], for entities that are synced via [`crate::sync_world::SyncToRenderWorld`].
 fn extract_components<C: ExtractComponent>(
     mut commands: Commands,
     mut previous_len: Local<usize>,

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -6,12 +6,10 @@ use crate::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{Asset, Handle};
 use bevy_ecs::{
     component::Component,
     prelude::*,
     query::{QueryFilter, QueryItem, ReadOnlyQueryData},
-    system::lifetimeless::Read,
     world::OnAdd,
 };
 use core::{marker::PhantomData, ops::Deref};
@@ -205,17 +203,6 @@ impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
                 render_app.add_systems(ExtractSchedule, extract_components::<C>);
             }
         }
-    }
-}
-
-impl<T: Asset> ExtractComponent for Handle<T> {
-    type QueryData = Read<Handle<T>>;
-    type QueryFilter = ();
-    type Out = Handle<T>;
-
-    #[inline]
-    fn extract_component(handle: QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
-        Some(handle.clone_weak())
     }
 }
 

--- a/crates/bevy_render/src/extract_instances.rs
+++ b/crates/bevy_render/src/extract_instances.rs
@@ -7,13 +7,12 @@
 use core::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{Asset, AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     entity::EntityHashMap,
     prelude::Entity,
     query::{QueryFilter, QueryItem, ReadOnlyQueryData},
-    system::{lifetimeless::Read, Query, ResMut, Resource},
+    system::{Query, ResMut, Resource},
 };
 
 use crate::{prelude::ViewVisibility, Extract, ExtractSchedule, RenderApp};
@@ -132,17 +131,5 @@ fn extract_visible<EI>(
                 extracted_instances.insert(entity, extract_instance);
             }
         }
-    }
-}
-
-impl<A> ExtractInstance for AssetId<A>
-where
-    A: Asset,
-{
-    type QueryData = Read<Handle<A>>;
-    type QueryFilter = ();
-
-    fn extract(item: QueryItem<'_, Self::QueryData>) -> Option<Self> {
-        Some(item.id())
     }
 }


### PR DESCRIPTION
# Objective

- Another step towards #15716
- Remove trait implementations that are dependent on `Handle<T>` being a `Component`

## Solution

- Remove unused `ExtractComponent` trait implementation for `Handle<T>`
- Remove unused `ExtractInstance` trait implementation for `AssetId`
  - Although the `ExtractInstance` trait wasn't used, the `AssetId`s were being stored inside of `ExtractedInstances` which has an `ExtractInstance` trait bound on its contents.
  I've upgraded the `RenderMaterialInstances` type alias to be its own resource, identical to `ExtractedInstances<AssetId<M>>` to get around that with minimal breakage.
## Testing

Tested `many_cubes`, rendering did not explode
