### PR TITLE
Ensure Bevy's rendering byte usage is little-endian

### DIFF
--- a/crates/bevy_image/src/hdr_texture_loader.rs
+++ b/crates/bevy_image/src/hdr_texture_loader.rs
@@ -54,10 +54,10 @@ impl AssetLoader for HdrTextureLoader {
         for rgb in image_buffer.pixels() {
             let alpha = 1.0f32;
 
-            rgba_data.extend_from_slice(&rgb.0[0].to_ne_bytes());
-            rgba_data.extend_from_slice(&rgb.0[1].to_ne_bytes());
-            rgba_data.extend_from_slice(&rgb.0[2].to_ne_bytes());
-            rgba_data.extend_from_slice(&alpha.to_ne_bytes());
+            rgba_data.extend_from_slice(&rgb.0[0].to_le_bytes());
+            rgba_data.extend_from_slice(&rgb.0[1].to_le_bytes());
+            rgba_data.extend_from_slice(&rgb.0[2].to_le_bytes());
+            rgba_data.extend_from_slice(&alpha.to_le_bytes());
         }
 
         Ok(Image::new(

--- a/crates/bevy_image/src/image_texture_conversion.rs
+++ b/crates/bevy_image/src/image_texture_conversion.rs
@@ -119,10 +119,10 @@ impl Image {
                     let b = pixel[2];
                     let a = 1f32;
 
-                    local_data.extend_from_slice(&r.to_ne_bytes());
-                    local_data.extend_from_slice(&g.to_ne_bytes());
-                    local_data.extend_from_slice(&b.to_ne_bytes());
-                    local_data.extend_from_slice(&a.to_ne_bytes());
+                    local_data.extend_from_slice(&r.to_le_bytes());
+                    local_data.extend_from_slice(&g.to_le_bytes());
+                    local_data.extend_from_slice(&b.to_le_bytes());
+                    local_data.extend_from_slice(&a.to_le_bytes());
                 }
 
                 data = local_data;

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -474,14 +474,14 @@ impl FrameData {
 
         let timestamps = data[..(self.num_timestamps * 8) as usize]
             .chunks(8)
-            .map(|v| u64::from_ne_bytes(v.try_into().unwrap()))
+            .map(|v| u64::from_le_bytes(v.try_into().unwrap()))
             .collect::<Vec<u64>>();
 
         let start = self.pipeline_statistics_buffer_offset as usize;
         let len = (self.num_pipeline_statistics as usize) * 40;
         let pipeline_statistics = data[start..start + len]
             .chunks(8)
-            .map(|v| u64::from_ne_bytes(v.try_into().unwrap()))
+            .map(|v| u64::from_le_bytes(v.try_into().unwrap()))
             .collect::<Vec<u64>>();
 
         let mut diagnostics = Vec::new();


### PR DESCRIPTION
# Objective

- Fixes (partially) #15701.

## Solution

- Use little-endian bytes over native-endian bytes where applicable.

## Testing

- Ran CI.

## Open Questions

- Should we config-gate these for big-endian targets? It looks like there are [very few targets](https://doc.rust-lang.org/nightly/rustc/platform-support.html) that use big-endian.