### PR TITLE
Fix meshlet materials

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -550,7 +550,7 @@ pub(super) fn clear_material_instances<M: Material>(
 
 fn extract_mesh_materials<M: Material>(
     mut material_instances: ResMut<RenderMaterialInstances<M>>,
-    query: Extract<Query<(Entity, &ViewVisibility, &MeshMaterial3d<M>), With<Mesh3d>>>,
+    query: Extract<Query<(Entity, &ViewVisibility, &MeshMaterial3d<M>)>>,
 ) {
     for (entity, view_visibility, material) in &query {
         if view_visibility.get() {

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -55,7 +55,7 @@ use self::{
     },
     visibility_buffer_raster_node::MeshletVisibilityBufferRasterPassNode,
 };
-use crate::{graph::NodePbr, Material};
+use crate::{graph::NodePbr, Material, MeshMaterial3d};
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_asset::{load_internal_asset, AssetApp, Handle};
 use bevy_core_pipeline::{
@@ -288,7 +288,7 @@ impl Plugin for MeshletPlugin {
 #[derive(Bundle, Clone)]
 pub struct MaterialMeshletMeshBundle<M: Material> {
     pub meshlet_mesh: Handle<MeshletMesh>,
-    pub material: Handle<M>,
+    pub material: MeshMaterial3d<M>,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -86,18 +86,20 @@ fn setup(
     for x in -2..=2 {
         commands.spawn(MaterialMeshletMeshBundle {
             meshlet_mesh: meshlet_mesh_handle.clone(),
-            material: standard_materials.add(StandardMaterial {
-                base_color: match x {
-                    -2 => Srgba::hex("#dc2626").unwrap().into(),
-                    -1 => Srgba::hex("#ea580c").unwrap().into(),
-                    0 => Srgba::hex("#facc15").unwrap().into(),
-                    1 => Srgba::hex("#16a34a").unwrap().into(),
-                    2 => Srgba::hex("#0284c7").unwrap().into(),
-                    _ => unreachable!(),
-                },
-                perceptual_roughness: (x + 2) as f32 / 4.0,
-                ..default()
-            }),
+            material: standard_materials
+                .add(StandardMaterial {
+                    base_color: match x {
+                        -2 => Srgba::hex("#dc2626").unwrap().into(),
+                        -1 => Srgba::hex("#ea580c").unwrap().into(),
+                        0 => Srgba::hex("#facc15").unwrap().into(),
+                        1 => Srgba::hex("#16a34a").unwrap().into(),
+                        2 => Srgba::hex("#0284c7").unwrap().into(),
+                        _ => unreachable!(),
+                    },
+                    perceptual_roughness: (x + 2) as f32 / 4.0,
+                    ..default()
+                })
+                .into(),
             transform: Transform::default()
                 .with_scale(Vec3::splat(0.2))
                 .with_translation(Vec3::new(x as f32 / 2.0, 0.0, -0.3)),
@@ -107,7 +109,7 @@ fn setup(
     for x in -2..=2 {
         commands.spawn(MaterialMeshletMeshBundle {
             meshlet_mesh: meshlet_mesh_handle.clone(),
-            material: debug_material.clone(),
+            material: debug_material.clone().into(),
             transform: Transform::default()
                 .with_scale(Vec3::splat(0.2))
                 .with_rotation(Quat::from_rotation_y(PI))


### PR DESCRIPTION
# Objective

After #15524, there are these bunny-shaped holes in rendering in the meshlet example!

![broken](https://github.com/user-attachments/assets/9e9f20ec-b820-44df-b961-68a1dee44002)

This is because (1) they're using a raw asset handle instead of `MeshMaterial3d`, and (2) the system that extracts mesh materials into the render world has an unnecessary `With<Mesh3d>` filter, which makes it not account for meshlets.

## Solution

Remove the redundant filter and use `MeshMaterial3d`. The bunnies got some paint!

![fixed](https://github.com/user-attachments/assets/adb42556-fd4b-4000-8ca8-1356250dd532)