### PR TITLE
Remove `thiserror` from `bevy_time`

### DIFF
--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -26,7 +26,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 # other
 crossbeam-channel = "0.5.0"
 serde = { version = "1", features = ["derive"], optional = true }
-thiserror = "1.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- Contributes to #15460

## Solution

- Removed `thiserror` from `bevy_time`

## Notes

`thiserror` actually wasn't even used in this crate.
