### PR TITLE
Fix missing Msaa::Off in scrolling_fog example

### DIFF
--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -55,6 +55,7 @@ fn setup(
             hdr: true,
             ..default()
         },
+        Msaa::Off,
         TemporalAntiAliasing::default(),
         Bloom::default(),
         VolumetricFog {


### PR DESCRIPTION
# Objective

- The `scrolling_fog` example has a camera with the `TemporalAntiAliasing` component, but it's missing the `Msaa::Off` component, which leads to this warning being printed on current `main`:

```
WARN bevy_core_pipeline::taa: Temporal anti-aliasing requires MSAA to be disabled
```

## Solution

- This PR adds the `Msaa::Off` component to the example to explicitly disable MSAA in favor of TAA.
