### PR TITLE
Put curve-related stuff behind a feature

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -21,7 +21,6 @@ rand = { version = "0.8", features = [
 ], default-features = false, optional = true }
 rand_distr = { version = "0.4.3", optional = true }
 smallvec = { version = "1.11" }
-
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "glam",
 ], optional = true }
@@ -36,7 +35,7 @@ bevy_math = { path = ".", version = "0.15.0-dev", features = ["approx"] }
 glam = { version = "0.29", features = ["approx"] }
 
 [features]
-default = ["rand", "bevy_reflect"]
+default = ["rand", "bevy_reflect", "curve"]
 serialize = ["dep:serde", "glam/serde"]
 # Enable approx for glam types to approximate floating point equality comparisons and assertions
 approx = ["dep:approx", "glam/approx"]
@@ -51,8 +50,9 @@ glam_assert = ["glam/glam-assert"]
 debug_glam_assert = ["glam/debug-glam-assert"]
 # Enable the rand dependency for shape_sampling
 rand = ["dep:rand", "dep:rand_distr", "glam/rand"]
+curve = []
 
-[lints]
+[lints] # Include code related to the Curve trait
 workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -50,9 +50,10 @@ glam_assert = ["glam/glam-assert"]
 debug_glam_assert = ["glam/debug-glam-assert"]
 # Enable the rand dependency for shape_sampling
 rand = ["dep:rand", "dep:rand_distr", "glam/rand"]
+# Include code related to the Curve trait
 curve = []
 
-[lints] # Include code related to the Curve trait
+[lints]
 workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -2,14 +2,13 @@
 
 use core::{fmt::Debug, iter::once};
 
-use crate::{
-    curve::{Curve, Interval},
-    ops::FloatPow,
-    Vec2, VectorSpace,
-};
+use crate::{ops::FloatPow, Vec2, VectorSpace};
 
 use itertools::Itertools;
 use thiserror::Error;
+
+#[cfg(feature = "curve")]
+use crate::curve::{Curve, Interval};
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -1062,6 +1061,7 @@ impl CubicSegment<Vec2> {
     }
 }
 
+#[cfg(feature = "curve")]
 impl<P: VectorSpace> Curve<P> for CubicSegment<P> {
     #[inline]
     fn domain(&self) -> Interval {
@@ -1199,6 +1199,7 @@ impl<P: VectorSpace> CubicCurve<P> {
     }
 }
 
+#[cfg(feature = "curve")]
 impl<P: VectorSpace> Curve<P> for CubicCurve<P> {
     #[inline]
     fn domain(&self) -> Interval {
@@ -1370,6 +1371,7 @@ impl<P: VectorSpace> RationalSegment<P> {
     }
 }
 
+#[cfg(feature = "curve")]
 impl<P: VectorSpace> Curve<P> for RationalSegment<P> {
     #[inline]
     fn domain(&self) -> Interval {
@@ -1526,6 +1528,7 @@ impl<P: VectorSpace> RationalCurve<P> {
     }
 }
 
+#[cfg(feature = "curve")]
 impl<P: VectorSpace> Curve<P> for RationalCurve<P> {
     #[inline]
     fn domain(&self) -> Interval {

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -17,7 +17,6 @@ pub mod bounding;
 pub mod common_traits;
 mod compass;
 pub mod cubic_splines;
-pub mod curve;
 mod direction;
 mod float_ord;
 mod isometry;
@@ -26,13 +25,17 @@ pub mod primitives;
 mod ray;
 mod rects;
 mod rotation2d;
+
+#[cfg(feature = "curve")]
+pub mod curve;
+
 #[cfg(feature = "rand")]
 pub mod sampling;
-pub use compass::{CompassOctant, CompassQuadrant};
 
 pub use affine3::*;
 pub use aspect_ratio::AspectRatio;
 pub use common_traits::*;
+pub use compass::{CompassOctant, CompassQuadrant};
 pub use direction::*;
 pub use float_ord::*;
 pub use isometry::{Isometry2d, Isometry3d};
@@ -40,10 +43,9 @@ pub use ops::FloatPow;
 pub use ray::{Ray2d, Ray3d};
 pub use rects::*;
 pub use rotation2d::Rot2;
+
 #[cfg(feature = "rand")]
-pub use sampling::FromRng;
-#[cfg(feature = "rand")]
-pub use sampling::ShapeSample;
+pub use sampling::{FromRng, ShapeSample};
 
 /// The math prelude.
 ///
@@ -56,7 +58,6 @@ pub mod prelude {
             CubicHermite, CubicNurbs, CubicNurbsError, CubicSegment, CyclicCubicGenerator,
             RationalCurve, RationalGenerator, RationalSegment,
         },
-        curve::*,
         direction::{Dir2, Dir3, Dir3A},
         ops,
         primitives::*,
@@ -64,6 +65,10 @@ pub mod prelude {
         Isometry3d, Mat2, Mat3, Mat4, Quat, Ray2d, Ray3d, Rect, Rot2, StableInterpolate, URect,
         UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles,
     };
+
+    #[doc(hidden)]
+    #[cfg(feature = "curve")]
+    pub use crate::curve::*;
 
     #[doc(hidden)]
     #[cfg(feature = "rand")]

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -44,6 +44,9 @@ pub use ray::{Ray2d, Ray3d};
 pub use rects::*;
 pub use rotation2d::Rot2;
 
+#[cfg(feature = "curve")]
+pub use curve::Curve;
+
 #[cfg(feature = "rand")]
 pub use sampling::{FromRng, ShapeSample};
 


### PR DESCRIPTION
# Objective

A bunch of code is used only if you care about the `Curve` trait. Put it behind a feature so it can be ignored if wanted.

## Solution

Added a default feature `curve` to `bevy_math` which feature-gates the `curve` module and internal integrations.

## Testing

Tested compiling with the feature enabled and disabled.