### PR TITLE
Add NoDefaultMaterial3d

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -559,10 +559,22 @@ fn extract_mesh_materials<M: Material>(
     }
 }
 
+#[derive(Component)]
+pub struct NoDefaultMaterial3d;
+
 /// Extracts default materials for 3D meshes with no [`MeshMaterial3d`].
 pub(super) fn extract_default_materials(
     mut material_instances: ResMut<RenderMaterialInstances<StandardMaterial>>,
-    query: Extract<Query<(Entity, &ViewVisibility), (With<Mesh3d>, Without<HasMaterial3d>)>>,
+    query: Extract<
+        Query<
+            (Entity, &ViewVisibility),
+            (
+                With<Mesh3d>,
+                Without<HasMaterial3d>,
+                Without<NoDefaultMaterial3d>,
+            ),
+        >,
+    >,
 ) {
     for (entity, view_visibility) in &query {
         if view_visibility.get() {


### PR DESCRIPTION
# Objective

- Spawning a Mesh3d without a material will automatically add a default material. This isn't always a wanted behaviour.

## Solution

- Add a marker component to not automatically add a default material. I'd prefer if the default material feature just wasn't a thing
- We can't just manually add the `HasMaterial3d` component because the engine uses that to fined entities with a material and the point is that these meshes don't have materials.

## Testing

- Did you test these changes? 
	- I modified the 3d_scene example to use the new component and the cube disappeared as expected.
