### PR TITLE
promote atlas sources texture_ids to pub visibility

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -15,7 +15,7 @@ use bevy_utils::HashMap;
 #[derive(Debug)]
 pub struct TextureAtlasSources {
     /// Maps from a specific image handle to the index in `textures` where they can be found.
-    pub(crate) texture_ids: HashMap<AssetId<Image>, usize>,
+    pub texture_ids: HashMap<AssetId<Image>, usize>,
 }
 impl TextureAtlasSources {
     /// Retrieves the texture *section* index of the given `texture` handle.


### PR DESCRIPTION
In order to create texture atlases from other systems (custom game solutions) that are compatible with the ones generated by the bevy builders, it would be nice to have the interface be fully public. This field is pub(crate). Unless there's a good reason, can we promote this to pub?

Alternatives:
- Don't do it.