### PR TITLE
Fix sprite and picking examples

### DIFF
--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -129,6 +129,7 @@ fn setup(
             }),
             ..Default::default()
         },
+        Transform::from_scale(Vec3::splat(6.0)).with_translation(Vec3::new(50.0, 0.0, 0.0)),
         RightSprite,
         animation_config_2,
     ));

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -1,6 +1,6 @@
 //! A simple scene to demonstrate picking events
 
-use bevy::{color::palettes::css::*, prelude::*};
+use bevy::{color::palettes::tailwind::CYAN_400, prelude::*};
 
 fn main() {
     let mut app = App::new();
@@ -44,13 +44,13 @@ fn setup(
         .observe(
             |evt: Trigger<Pointer<Out>>, mut texts: Query<&mut TextStyle>| {
                 let mut style = texts.get_mut(evt.entity()).unwrap();
-                style.color = WHITE.into();
+                style.color = Color::WHITE;
             },
         )
         .observe(
             |evt: Trigger<Pointer<Over>>, mut texts: Query<&mut TextStyle>| {
                 let mut style = texts.get_mut(evt.entity()).unwrap();
-                style.color = BLUE.into();
+                style.color = CYAN_400.into();
             },
         );
     // circular base

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_systems(Startup, (setup, setup_atlas))
         .add_systems(Update, (move_sprite, animate_sprite))
         .run();
@@ -99,15 +99,20 @@ struct AnimationTimer(Timer);
 
 fn animate_sprite(
     time: Res<Time>,
-    mut query: Query<(&AnimationIndices, &mut AnimationTimer, &mut TextureAtlas)>,
+    mut query: Query<(&AnimationIndices, &mut AnimationTimer, &mut Sprite)>,
 ) {
     for (indices, mut timer, mut sprite) in &mut query {
+        let Some(texture_atlas) = &mut sprite.texture_atlas else {
+            continue;
+        };
+
         timer.tick(time.delta());
+
         if timer.just_finished() {
-            sprite.index = if sprite.index == indices.last {
+            texture_atlas.index = if texture_atlas.index == indices.last {
                 indices.first
             } else {
-                sprite.index + 1
+                texture_atlas.index + 1
             };
         }
     }


### PR DESCRIPTION
# Objective

Looks like #15489 broke some examples :) And there are some other issues as well.

Gabe's brother Gabe is tiny in the `sprite_animation` example:

![kuva](https://github.com/user-attachments/assets/810ce110-ecd8-4ca5-94c8-a5655f381131)

Gabe is not running in the `sprite_picking` example, and (unrelated) is also very blurry: (note that the screenshot is a bit zoomed in)

![kuva](https://github.com/user-attachments/assets/cb115a71-e3fe-41ed-817c-d5215c44adb5)

Unrelated to sprites, the text in the `simple_picking` example is way too dark when hovered:

![kuva](https://github.com/user-attachments/assets/f0f9e331-8d03-44ea-becd-bf22ad68ea71)

## Solution

Both Gabes are now the correct size:

![kuva](https://github.com/user-attachments/assets/08eb936a-0341-471e-90f6-2e7067871e5b)

Gabe is crisp and running:

![kuva](https://github.com/user-attachments/assets/8fa158e8-2caa-4339-bbcd-2c14b7cfc04f)

The text has better contrast:

![kuva](https://github.com/user-attachments/assets/2af09523-0bdc-45a7-9149-50aa9c754957)