### PR TITLE
Fix potential deadlock in `AssetServer` on single-threaded modes.

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -36,7 +36,7 @@ use either::Either;
 use futures_lite::{FutureExt, StreamExt};
 use info::*;
 use loaders::*;
-use parking_lot::RwLock;
+use parking_lot::{RwLock, RwLockWriteGuard};
 use std::path::{Path, PathBuf};
 
 /// Loads and tracks the state of [`Asset`] values from a configured [`AssetReader`](crate::io::AssetReader). This can be used to kick off new asset loads and
@@ -383,7 +383,7 @@ impl AssetServer {
         );
 
         if should_load {
-            self.spawn_load_task(handle.clone().untyped(), path, &mut infos, guard);
+            self.spawn_load_task(handle.clone().untyped(), path, infos, guard);
         }
 
         handle
@@ -407,7 +407,7 @@ impl AssetServer {
         );
 
         if should_load {
-            self.spawn_load_task(handle.clone(), path, &mut infos, guard);
+            self.spawn_load_task(handle.clone(), path, infos, guard);
         }
 
         handle
@@ -417,7 +417,7 @@ impl AssetServer {
         &self,
         handle: UntypedHandle,
         path: AssetPath<'static>,
-        infos: &mut AssetInfos,
+        mut infos: RwLockWriteGuard<AssetInfos>,
         guard: G,
     ) {
         // drop the lock on `AssetInfos` before spawning a task that may block on it in single-threaded


### PR DESCRIPTION
# Objective

Fixes #15807 

## Solution

We move the guard into this function.

## Testing

N/A, This is just reverting to the old behavior before #15509.