### PR TITLE
Add `Trigger::components`, which lists the component targets that were triggered

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -41,7 +41,7 @@ derive_more = { version = "1", default-features = false, features = [
 ] }
 nonmax = "0.5"
 arrayvec = { version = "0.7.4", optional = true }
-smallvec = "1"
+smallvec = { version = "1", features = ["union"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -135,15 +135,15 @@ pub(crate) struct AddBundle {
 }
 
 impl AddBundle {
-    pub(crate) fn iter_inserted(&self) -> impl Iterator<Item = ComponentId> + '_ {
+    pub(crate) fn iter_inserted(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         self.added.iter().chain(self.existing.iter()).copied()
     }
 
-    pub(crate) fn iter_added(&self) -> impl Iterator<Item = ComponentId> + '_ {
+    pub(crate) fn iter_added(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         self.added.iter().copied()
     }
 
-    pub(crate) fn iter_existing(&self) -> impl Iterator<Item = ComponentId> + '_ {
+    pub(crate) fn iter_existing(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         self.existing.iter().copied()
     }
 }
@@ -489,7 +489,7 @@ impl Archetype {
     ///
     /// All of the IDs are unique.
     #[inline]
-    pub fn components(&self) -> impl Iterator<Item = ComponentId> + '_ {
+    pub fn components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         self.components.indices()
     }
 

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -464,7 +464,7 @@ impl BundleInfo {
 
     /// To iterate all components contributed by this bundle (including Required Components), see [`BundleInfo::iter_contributed_components`]
     #[inline]
-    pub fn iter_explicit_components(&self) -> impl Iterator<Item = ComponentId> + '_ {
+    pub fn iter_explicit_components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         self.explicit_components().iter().copied()
     }
 
@@ -472,7 +472,7 @@ impl BundleInfo {
     ///
     /// To iterate only components explicitly defined in this bundle, see [`BundleInfo::iter_explicit_components`]
     #[inline]
-    pub fn iter_contributed_components(&self) -> impl Iterator<Item = ComponentId> + '_ {
+    pub fn iter_contributed_components(&self) -> impl Iterator<Item = ComponentId> + Clone + '_ {
         self.component_ids.iter().copied()
     }
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -200,13 +200,20 @@ impl ObserverDescriptor {
 #[derive(Debug)]
 pub struct ObserverTrigger {
     /// The [`Entity`] of the observer handling the trigger.
-    observer: Entity,
+    pub observer: Entity,
     /// The [`Event`] the trigger targeted.
-    event_type: ComponentId,
+    pub event_type: ComponentId,
     /// The [`ComponentId`]s the trigger targeted.
     components: SmallVec<[ComponentId; 2]>,
     /// The entity the trigger targeted.
-    entity: Entity,
+    pub entity: Entity,
+}
+
+impl ObserverTrigger {
+    /// Returns the components that the trigger targeted.
+    pub fn components(&self) -> &[ComponentId] {
+        &self.components
+    }
 }
 
 // Map between an observer entity and its runner

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -204,7 +204,7 @@ pub struct ObserverTrigger {
     /// The [`Event`] the trigger targeted.
     event_type: ComponentId,
     /// The [`ComponentId`]s the trigger targeted.
-    components: SmallVec<[ComponentId; 1]>,
+    components: SmallVec<[ComponentId; 2]>,
     /// The entity the trigger targeted.
     entity: Entity,
 }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -423,7 +423,7 @@ macro_rules! impl_sparse_set {
             }
 
             /// Returns an iterator visiting all keys (indices) in arbitrary order.
-            pub fn indices(&self) -> impl Iterator<Item = I> + '_ {
+            pub fn indices(&self) -> impl Iterator<Item = I> + Clone + '_ {
                 self.indices.iter().cloned()
             }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -501,7 +501,7 @@ impl<'w> DeferredWorld<'w> {
         &mut self,
         event: ComponentId,
         entity: Entity,
-        components: impl Iterator<Item = ComponentId>,
+        components: impl Iterator<Item = ComponentId> + Clone,
     ) {
         Observers::invoke::<_>(
             self.reborrow(),


### PR DESCRIPTION
# Objective

- Closes #14774 

## Solution

Added:

```rust
impl<'w, E, B: Bundle> Trigger<'w, E, B> {
    pub fn components(&self) -> &[ComponentId];
}
```

I went with storing it in the trigger as a `SmallVec<[Component; 1]>` because a singular target component will be the most common case, and it remains the same size as `Vec<ComponentId>`.

## Testing

Added a test.