### PR TITLE
Move `ImageLoader` and `CompressedImageSaver` to `bevy_image`.

### DIFF
--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -1,5 +1,6 @@
+use crate::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
+
 use bevy_asset::saver::{AssetSaver, SavedAsset};
-use bevy_image::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
 use derive_more::derive::{Display, Error, From};
 use futures_lite::AsyncWriteExt;
 

--- a/crates/bevy_image/src/image_loader.rs
+++ b/crates/bevy_image/src/image_loader.rs
@@ -1,12 +1,6 @@
-use bevy_asset::{io::Reader, AssetLoader, LoadContext};
-use bevy_ecs::prelude::{FromWorld, World};
+use crate::image::{Image, ImageFormat, ImageType, TextureError};
+use bevy_asset::{io::Reader, AssetLoader, LoadContext, RenderAssetUsages};
 use derive_more::derive::{Display, Error, From};
-
-use crate::{
-    render_asset::RenderAssetUsages,
-    renderer::RenderDevice,
-    texture::{Image, ImageFormat, ImageType, TextureError},
-};
 
 use super::{CompressedImageFormats, ImageSampler};
 use serde::{Deserialize, Serialize};
@@ -15,6 +9,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone)]
 pub struct ImageLoader {
     supported_compressed_formats: CompressedImageFormats,
+}
+
+impl ImageLoader {
+    /// Creates a new image loader that supports the provided formats.
+    pub fn new(supported_compressed_formats: CompressedImageFormats) -> Self {
+        Self {
+            supported_compressed_formats,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -103,19 +106,6 @@ impl AssetLoader for ImageLoader {
 
     fn extensions(&self) -> &[&str] {
         ImageFormat::SUPPORTED_FILE_EXTENSIONS
-    }
-}
-
-impl FromWorld for ImageLoader {
-    fn from_world(world: &mut World) -> Self {
-        let supported_compressed_formats = match world.get_resource::<RenderDevice>() {
-            Some(render_device) => CompressedImageFormats::from_features(render_device.features()),
-
-            None => CompressedImageFormats::NONE,
-        };
-        Self {
-            supported_compressed_formats,
-        }
     }
 }
 

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -12,6 +12,7 @@ mod dds;
 mod exr_texture_loader;
 #[cfg(feature = "hdr")]
 mod hdr_texture_loader;
+mod image_loader;
 #[cfg(feature = "ktx2")]
 mod ktx2;
 
@@ -23,6 +24,7 @@ pub use dds::*;
 pub use exr_texture_loader::*;
 #[cfg(feature = "hdr")]
 pub use hdr_texture_loader::*;
+pub use image_loader::*;
 
 pub(crate) mod image_texture_conversion;
 pub use image_texture_conversion::IntoDynamicImageError;

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -6,6 +6,8 @@ mod image;
 pub use self::image::*;
 #[cfg(feature = "basis-universal")]
 mod basis;
+#[cfg(feature = "basis-universal")]
+mod compressed_image_saver;
 #[cfg(feature = "dds")]
 mod dds;
 #[cfg(feature = "exr")]
@@ -16,8 +18,8 @@ mod image_loader;
 #[cfg(feature = "ktx2")]
 mod ktx2;
 
-#[cfg(feature = "ktx2")]
-pub use self::ktx2::*;
+#[cfg(feature = "basis-universal")]
+pub use compressed_image_saver::*;
 #[cfg(feature = "dds")]
 pub use dds::*;
 #[cfg(feature = "exr")]
@@ -25,6 +27,8 @@ pub use exr_texture_loader::*;
 #[cfg(feature = "hdr")]
 pub use hdr_texture_loader::*;
 pub use image_loader::*;
+#[cfg(feature = "ktx2")]
+pub use ktx2::*;
 
 pub(crate) mod image_texture_conversion;
 pub use image_texture_conversion::IntoDynamicImageError;

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [features]
 # Texture formats (require more than just image support)
-basis-universal = ["dep:basis-universal", "bevy_image/basis-universal"]
+basis-universal = ["bevy_image/basis-universal"]
 dds = ["bevy_image/dds"]
 exr = ["bevy_image/exr"]
 hdr = ["bevy_image/hdr"]
@@ -85,8 +85,6 @@ derive_more = { version = "1", default-features = false, features = [
 ] }
 futures-lite = "2.0.1"
 ktx2 = { version = "0.3.0", optional = true }
-# For transcoding of UASTC/ETC1S universal formats, and for .basis file support
-basis-universal = { version = "0.3.0", optional = true }
 encase = { version = "0.10", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = [

--- a/crates/bevy_render/src/texture/compressed_image_saver.rs
+++ b/crates/bevy_render/src/texture/compressed_image_saver.rs
@@ -1,5 +1,5 @@
-use super::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
 use bevy_asset::saver::{AssetSaver, SavedAsset};
+use bevy_image::{Image, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderSettings};
 use derive_more::derive::{Display, Error, From};
 use futures_lite::AsyncWriteExt;
 

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -10,11 +10,11 @@ pub use crate::render_resource::DefaultImageSampler;
 pub use bevy_image::ExrTextureLoader;
 #[cfg(feature = "hdr")]
 pub use bevy_image::HdrTextureLoader;
-use bevy_image::ImageLoader;
 pub use bevy_image::{
-    BevyDefault, CompressedImageFormats, Image, ImageAddressMode, ImageFilterMode, ImageFormat,
-    ImageSampler, ImageSamplerDescriptor, ImageType, IntoDynamicImageError, TextureError,
-    TextureFormatPixelInfo,
+    BevyDefault, CompressedImageFormats, FileTextureError, Image, ImageAddressMode,
+    ImageFilterMode, ImageFormat, ImageFormatSetting, ImageLoader, ImageLoaderError,
+    ImageLoaderSettings, ImageSampler, ImageSamplerDescriptor, ImageType, IntoDynamicImageError,
+    TextureError, TextureFormatPixelInfo,
 };
 #[cfg(feature = "basis-universal")]
 pub use compressed_image_saver::*;

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "basis-universal")]
-mod compressed_image_saver;
 mod fallback_image;
 mod gpu_image;
 mod texture_attachment;
@@ -17,7 +15,7 @@ pub use bevy_image::{
     TextureError, TextureFormatPixelInfo,
 };
 #[cfg(feature = "basis-universal")]
-pub use compressed_image_saver::*;
+pub use bevy_image::{CompressedImageSaver, CompressedImageSaverError};
 pub use fallback_image::*;
 pub use gpu_image::*;
 pub use texture_attachment::*;


### PR DESCRIPTION
# Objective

This is a follow-up to #15650. While the core `Image` stuff moved from `bevy_render` to `bevy_image`, the `ImageLoader` and the `CompressedImageSaver` remained in `bevy_render`.

## Solution

I moved `ImageLoader` and `CompressedImageSaver` to `bevy_image` and re-exported everything out from `bevy_render`. The second step isn't strictly necessary, but `bevy_render` is already doing this for all the other `bevy_image` types, so I kept it the same for consistency.

Unfortunately I had to give `ImageLoader` a constructor so I can keep the `RenderDevice` stuff in `bevy_render`.

## Testing

It compiles!

## Migration Guide

- `ImageLoader` can no longer be initialized directly through `init_asset_loader`. Now you must use `app.register_asset_loader(ImageLoader::new(supported_compressed_formats))` (check out the implementation of `bevy_render::ImagePlugin`). This only affects you if you are initializing the loader manually and does not affect users of `bevy_render::ImagePlugin`.

## Followup work

- We should be able to move most of the `ImagePlugin` to `bevy_image`. This would likely require an `ImagePlugin` and a `RenderImagePlugin` or something though.