### PR TITLE
fix: removed WinitPlugin from headless_renderer example

### DIFF
--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -24,6 +24,7 @@ use bevy::{
         texture::{BevyDefault, TextureFormatPixelInfo},
         Extract, Render, RenderApp, RenderSet,
     },
+    winit::WinitPlugin,
 };
 use crossbeam_channel::{Receiver, Sender};
 use std::{
@@ -86,7 +87,9 @@ fn main() {
                     primary_window: None,
                     exit_condition: bevy::window::ExitCondition::DontExit,
                     close_when_requested: false,
-                }),
+                })
+                // WinitPlugin will panic in environments without a display server.
+                .disable::<WinitPlugin>(),
         )
         .add_plugins(ImageCopyPlugin)
         // headless frame capture

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -82,11 +82,11 @@ fn main() {
         .add_plugins(
             DefaultPlugins
                 .set(ImagePlugin::default_nearest())
-                // Do not create a window on startup.
+                // Not strictly necessary, as the inclusion of ScheduleRunnerPlugin below
+                // replaces the bevy_winit app runner and so a window is never created.
                 .set(WindowPlugin {
                     primary_window: None,
-                    exit_condition: bevy::window::ExitCondition::DontExit,
-                    close_when_requested: false,
+                    ..default()
                 })
                 // WinitPlugin will panic in environments without a display server.
                 .disable::<WinitPlugin>(),
@@ -94,6 +94,8 @@ fn main() {
         .add_plugins(ImageCopyPlugin)
         // headless frame capture
         .add_plugins(CaptureFramePlugin)
+        // ScheduleRunnerPlugin provides an alternative to the default bevy_winit app runner, which
+        // manages the loop without creating a window.
         .add_plugins(ScheduleRunnerPlugin::run_loop(
             // Run 60 times per second.
             Duration::from_secs_f64(1.0 / 60.0),


### PR DESCRIPTION
# Objective

The `headless_renderer` example is meant to showcase running bevy as a headless renderer, but if run without a display server (for example, over an SSH connection), a panic occurs in `bevy_winit` despite never creating a window:

```rust
bevy_winit-0.14.1/src/lib.rs:132:14:
winit-0.30.5/src/platform_impl/linux/mod.rs:
neither WAYLAND_DISPLAY nor WAYLAND_SOCKET nor DISPLAY is set.
```

This example should run successfully in situations without an available display server, as although the GPU is used for rendering, no window is ever created.

## Solution

Disabling WinitPlugin, where the above panic occurs, allows the example to run in a fully headless environment.

## Testing

- I tested this change in normal circumstances with a display server (on macOS Sequoia and Asahi Linux) and behavior was normal.
- I tested with no display server by connecting via SSH, and running the example (on Asahi Linux). Previously this panics, but with this change it runs normally.

## Considerations

- One could argue that ultimately the user should not need to remove `WinitPlugin`, and instead bevy should only throw the above panic when the application first attempts to create a window.