### PR TITLE
Fix auto_exposure example

### DIFF
--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -96,7 +96,7 @@ fn setup(
                     ),
                     ..default()
                 })),
-                Transform::from_translation(side * 2.0 + height),
+                Transform::from_translation(side * 2.0 + height).looking_at(height, Vec3::Y),
             ));
         }
     }


### PR DESCRIPTION
# Objective

Fixes #15824

## Solution

Looks like this was just a goof in migrating the example itself.

Added back in the rotation component of the transform that got dropped.

## Testing

`cargo run --example auto_exposure`