### PR TITLE
Fix invalid scene file for `scene` example

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -1,36 +1,28 @@
 (
   resources: {
     "scene::ResourceA": (
-      score: 2,
+      score: 1,
     ),
   },
   entities: {
     4294967296: (
       components: {
-        "bevy_transform::components::transform::Transform": (
-          translation: (
-            x: 0.0,
-            y: 0.0,
-            z: 0.0
-          ),
-          rotation: (
-            x: 0.0,
-            y: 0.0,
-            z: 0.0,
-            w: 1.0,
-          ),
-          scale: (
-            x: 1.0,
-            y: 1.0,
-            z: 1.0
-          ),
+        "bevy_core::name::Name": (
+          hash: 17588334858059901562,
+          name: "joe",
         ),
-        "scene::ComponentB": (
-          value: "hello",
+        "bevy_transform::components::global_transform::GlobalTransform": ((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)),
+        "bevy_transform::components::transform::Transform": (
+          translation: (0.0, 0.0, 0.0),
+          rotation: (0.0, 0.0, 0.0, 1.0),
+          scale: (1.0, 1.0, 1.0),
         ),
         "scene::ComponentA": (
           x: 1.0,
           y: 2.0,
+        ),
+        "scene::ComponentB": (
+          value: "hello",
         ),
       },
     ),
@@ -42,5 +34,5 @@
         ),
       },
     ),
-  }
+  },
 )


### PR DESCRIPTION
# Objective

Fixes #15828

## Solution

Ran the example to generate `load_scene_example-new.scn.ron` and replaced `load_scene_example.scn.ron` with the contents. 

## Testing

`cargo run --example scene`