### PR TITLE
Make `AnimatableCurve::curve` public

### DIFF
--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -187,7 +187,10 @@ impl<T, C> AnimationCompatibleCurve<T> for C where C: Curve<T> + Debug + Clone +
 #[derive(Reflect, FromReflect)]
 #[reflect(from_reflect = false)]
 pub struct AnimatableCurve<P, C> {
-    curve: C,
+    /// The inner [curve] whose values are used to animate the property.
+    ///
+    /// [curve]: Curve
+    pub curve: C,
     #[reflect(ignore)]
     _phantom: PhantomData<P>,
 }


### PR DESCRIPTION
# Objective

The other `Curve -> AnimationCurve` wrappers allow public access to the inner curve, so this one should as well.

## Solution

Made the field public. Instances will still need to be constructed using the (more ergonomic) `from_curve` method, which infers the phantom type for the user.