### PR TITLE
Fix gizmos

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -93,6 +93,7 @@ use crate::config::GizmoMeshConfig;
 use {
     bevy_ecs::{
         component::Component,
+        entity::Entity,
         query::ROQueryItem,
         system::{
             lifetimeless::{Read, SRes},
@@ -109,7 +110,7 @@ use {
             ShaderStages, ShaderType, VertexFormat,
         },
         renderer::RenderDevice,
-        sync_world::TemporaryRenderEntity,
+        sync_world::{MainEntity, TemporaryRenderEntity},
         Extract, ExtractSchedule, Render, RenderApp, RenderSet,
     },
     bytemuck::cast_slice,
@@ -467,6 +468,9 @@ fn extract_gizmo_data(
                 render_layers: config.render_layers.clone(),
                 handle: handle.clone(),
             },
+            // The immediate mode API does not have a main world entity to refer to,
+            // but we do need MainEntity on this render entity for the systems to find it.
+            MainEntity::from(Entity::PLACEHOLDER),
             TemporaryRenderEntity,
         ));
     }


### PR DESCRIPTION
# Objective

- Immediate mode gizmos don't have a main world entity but the phase items require `MainEntity` since #15756

## Solution

- Add a dummy `MainEntity` component.

## Testing

Both the `3d_gizmos` and `2d_gizmos` examples show gizmos again
