### PR TITLE
Fix formatting of `irradiance_volumes` example instructions

### DIFF
--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -341,11 +341,11 @@ impl AppStatus {
         };
 
         format!(
-            "{CLICK_TO_MOVE_HELP_TEXT}
-        {voxels_help_text}
-        {irradiance_volume_help_text}
-        {rotation_help_text}
-        {switch_mesh_help_text}"
+            "{CLICK_TO_MOVE_HELP_TEXT}\n\
+            {voxels_help_text}\n\
+            {irradiance_volume_help_text}\n\
+            {rotation_help_text}\n\
+            {switch_mesh_help_text}"
         )
         .into()
     }


### PR DESCRIPTION
# Objective

Fix minor text formatting issue introduced in #15033

Before:

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/cec4302b-a7cf-4afb-82f8-7354fa5fea00">

After:

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/ab62e58b-e563-4250-842f-90bed3a153a1">

## Solution

Add explicit linebreaks and `\` to ignore indentation on following lines. 

## Testing

`cargo run --example irradiance_volumes`