### PR TITLE
Fix `loading_screen` example

### DIFF
--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -275,15 +275,15 @@ fn load_loading_screen(mut commands: Commands) {
 
 // Determines when to show the loading screen
 fn display_loading_screen(
-    mut loading_screen: Query<&mut Visibility, With<LoadingScreen>>,
+    mut loading_screen: Query<&mut Visibility, (With<LoadingScreen>, With<Node>)>,
     loading_state: Res<LoadingState>,
 ) {
-    match loading_state.as_ref() {
-        LoadingState::LevelLoading => {
-            *loading_screen.get_single_mut().unwrap() = Visibility::Visible;
-        }
-        LoadingState::LevelReady => *loading_screen.get_single_mut().unwrap() = Visibility::Hidden,
+    let visibility = match loading_state.as_ref() {
+        LoadingState::LevelLoading => Visibility::Visible,
+        LoadingState::LevelReady => Visibility::Hidden,
     };
+
+    *loading_screen.single_mut() = visibility;
 }
 
 mod pipelines_ready {


### PR DESCRIPTION
# Objective

Since #15641, `loading_screen` panics.

```
called `Result::unwrap()` on an `Err` value: MultipleEntities("bevy_ecs::query::state::QueryState<&mut bevy_render::view::visibility::Visibility, bevy_ecs::query::filter::With<loading_screen::LoadingScreen>>")
```

Before that PR, the camera did not have a `Visibility` component. But `Visibility` is now a required component of `Camera`. So the query matches multiple entities.

## Solution

Minimal change to make the example behave like it used to.

Plus a tiny drive-by cleanup to remove a redundant unwrap.

## Testing

`cargo run --example loading_screen`