### PR TITLE
Store `QueryState` in `Query` as a `Cow` and remove distinct `QueryLens` type

### DIFF
--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -71,7 +71,7 @@ fn setup<T: Component + Default>(entity_count: u32) -> World {
 
 // create a cached query in setup to avoid extra costs in each iter
 fn generic_filter_query<F: QueryFilter>(world: &mut World) -> QueryState<Entity, F> {
-    world.query_filtered::<Entity, F>()
+    world.query_state_filtered::<Entity, F>()
 }
 
 fn generic_bench<P: Copy>(
@@ -135,7 +135,7 @@ fn all_changed_detection_generic<T: Component + Default + BenchModify>(
                 || {
                     let mut world = setup::<T>(entity_count);
                     world.clear_trackers();
-                    let mut query = world.query::<&mut T>();
+                    let mut query = world.query_state::<&mut T>();
                     for mut component in query.iter_mut(&mut world) {
                         black_box(component.bench_modify());
                     }
@@ -185,7 +185,7 @@ fn few_changed_detection_generic<T: Component + Default + BenchModify>(
                 || {
                     let mut world = setup::<T>(entity_count);
                     world.clear_trackers();
-                    let mut query = world.query::<&mut T>();
+                    let mut query = world.query_state::<&mut T>();
                     let mut to_modify: Vec<bevy_ecs::prelude::Mut<T>> =
                         query.iter_mut(&mut world).collect();
                     to_modify.shuffle(&mut deterministic_rand());
@@ -316,7 +316,7 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
                     let mut world = World::new();
                     add_archetypes_entities::<T>(&mut world, archetype_count, entity_count);
                     world.clear_trackers();
-                    let mut query = world.query::<(
+                    let mut query = world.query_state::<(
                         Option<&mut Data<0>>,
                         Option<&mut Data<1>>,
                         Option<&mut Data<2>>,

--- a/benches/benches/bevy_ecs/iteration/iter_frag.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag.rs
@@ -23,7 +23,7 @@ impl<'w> Benchmark<'w> {
 
         create_entities!(world; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
-        let query = world.query::<&mut Data>();
+        let query = world.query_state::<&mut Data>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach.rs
@@ -23,7 +23,7 @@ impl<'w> Benchmark<'w> {
 
         create_entities!(world; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
-        let query = world.query::<&mut Data>();
+        let query = world.query_state::<&mut Data>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach_sparse.rs
@@ -34,7 +34,7 @@ impl<'w> Benchmark<'w> {
         create_entities!(world; C70, C71, C72, C73, C74, C75, C76, C77, C78, C79);
         create_entities!(world; C80, C81, C82, C83, C84, C85, C86, C87, C88, C89);
         create_entities!(world; C90, C91, C92, C93, C94, C95, C96, C97, C98, C99);
-        let query = world.query::<&mut Data>();
+        let query = world.query_state::<&mut Data>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide.rs
@@ -51,7 +51,7 @@ impl<'w> Benchmark<'w> {
 
         create_entities!(world; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide_sparse.rs
@@ -61,7 +61,7 @@ impl<'w> Benchmark<'w> {
         create_entities!(world; C70, C71, C72, C73, C74, C75, C76, C77, C78, C79);
         create_entities!(world; C80, C81, C82, C83, C84, C85, C86, C87, C88, C89);
         create_entities!(world; C90, C91, C92, C93, C94, C95, C96, C97, C98, C99);
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_sparse.rs
@@ -34,7 +34,7 @@ impl<'w> Benchmark<'w> {
         create_entities!(world; C70, C71, C72, C73, C74, C75, C76, C77, C78, C79);
         create_entities!(world; C80, C81, C82, C83, C84, C85, C86, C87, C88, C89);
         create_entities!(world; C90, C91, C92, C93, C94, C95, C96, C97, C98, C99);
-        let query = world.query::<&mut Data>();
+        let query = world.query_state::<&mut Data>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_wide.rs
@@ -51,7 +51,7 @@ impl<'w> Benchmark<'w> {
 
         create_entities!(world; A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_frag_wide_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_wide_sparse.rs
@@ -61,7 +61,7 @@ impl<'w> Benchmark<'w> {
         create_entities!(world; C70, C71, C72, C73, C74, C75, C76, C77, C78, C79);
         create_entities!(world; C80, C81, C82, C83, C84, C85, C86, C87, C88, C89);
         create_entities!(world; C90, C91, C92, C93, C94, C95, C96, C97, C98, C99);
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple.rs
@@ -29,7 +29,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query::<(&Velocity, &mut Position)>();
+        let query = world.query_state::<(&Velocity, &mut Position)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach.rs
@@ -29,7 +29,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query::<(&Velocity, &mut Position)>();
+        let query = world.query_state::<(&Velocity, &mut Position)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_hybrid.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_hybrid.rs
@@ -30,7 +30,7 @@ impl<'w> Benchmark<'w> {
             world.entity_mut(e).despawn();
         }
 
-        let query = world.query::<(&mut TableData, &SparseData)>();
+        let query = world.query_state::<(&mut TableData, &SparseData)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_sparse_set.rs
@@ -31,7 +31,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query::<(&Velocity, &mut Position)>();
+        let query = world.query_state::<(&Velocity, &mut Position)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide.rs
@@ -51,7 +51,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide_sparse_set.rs
@@ -53,7 +53,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_sparse_set.rs
@@ -31,7 +31,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query::<(&Velocity, &mut Position)>();
+        let query = world.query_state::<(&Velocity, &mut Position)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_wide.rs
@@ -51,7 +51,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/iter_simple_wide_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_wide_sparse_set.rs
@@ -53,7 +53,7 @@ impl<'w> Benchmark<'w> {
             .take(10_000),
         );
 
-        let query = world.query();
+        let query = world.query_state();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/par_iter_simple.rs
+++ b/benches/benches/bevy_ecs/iteration/par_iter_simple.rs
@@ -60,7 +60,7 @@ impl<'w> Benchmark<'w> {
             insert_if_bit_enabled::<15>(&mut e, i);
         }
 
-        let query = world.query::<(&Velocity, &mut Position)>();
+        let query = world.query_state::<(&Velocity, &mut Position)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/iteration/par_iter_simple_foreach_hybrid.rs
+++ b/benches/benches/bevy_ecs/iteration/par_iter_simple_foreach_hybrid.rs
@@ -32,7 +32,7 @@ impl<'w> Benchmark<'w> {
             world.entity_mut(e).despawn();
         }
 
-        let query = world.query::<(&mut TableData, &SparseData)>();
+        let query = world.query_state::<(&mut TableData, &SparseData)>();
         Self(world, query)
     }
 

--- a/benches/benches/bevy_ecs/world/world_get.rs
+++ b/benches/benches/bevy_ecs/world/world_get.rs
@@ -100,7 +100,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
             let mut world = setup::<Table>(entity_count);
-            let mut query = world.query::<&Table>();
+            let mut query = world.query_state::<&Table>();
 
             bencher.iter(|| {
                 for i in 0..entity_count {
@@ -118,7 +118,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
                 WideTable<4>,
                 WideTable<5>,
             )>(entity_count);
-            let mut query = world.query::<(
+            let mut query = world.query_state::<(
                 &WideTable<0>,
                 &WideTable<1>,
                 &WideTable<2>,
@@ -136,7 +136,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
         });
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
             let mut world = setup::<Sparse>(entity_count);
-            let mut query = world.query::<&Sparse>();
+            let mut query = world.query_state::<&Sparse>();
 
             bencher.iter(|| {
                 for i in 0..entity_count {
@@ -156,7 +156,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
                     WideSparse<4>,
                     WideSparse<5>,
                 )>(entity_count);
-                let mut query = world.query::<(
+                let mut query = world.query_state::<(
                     &WideSparse<0>,
                     &WideSparse<1>,
                     &WideSparse<2>,
@@ -186,7 +186,7 @@ pub fn world_query_iter(criterion: &mut Criterion) {
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
             let mut world = setup::<Table>(entity_count);
-            let mut query = world.query::<&Table>();
+            let mut query = world.query_state::<&Table>();
 
             bencher.iter(|| {
                 let mut count = 0;
@@ -200,7 +200,7 @@ pub fn world_query_iter(criterion: &mut Criterion) {
         });
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
             let mut world = setup::<Sparse>(entity_count);
-            let mut query = world.query::<&Sparse>();
+            let mut query = world.query_state::<&Sparse>();
 
             bencher.iter(|| {
                 let mut count = 0;
@@ -225,7 +225,7 @@ pub fn world_query_for_each(criterion: &mut Criterion) {
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
             let mut world = setup::<Table>(entity_count);
-            let mut query = world.query::<&Table>();
+            let mut query = world.query_state::<&Table>();
 
             bencher.iter(|| {
                 let mut count = 0;
@@ -239,7 +239,7 @@ pub fn world_query_for_each(criterion: &mut Criterion) {
         });
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
             let mut world = setup::<Sparse>(entity_count);
-            let mut query = world.query::<&Sparse>();
+            let mut query = world.query_state::<&Sparse>();
 
             bencher.iter(|| {
                 let mut count = 0;

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -226,7 +226,7 @@ mod tests {
         let e1 = world.spawn_empty().id();
         let name = Name::new("MyName");
         let e2 = world.spawn(name.clone()).id();
-        let mut query = world.query::<NameOrEntity>();
+        let mut query = world.query_state::<NameOrEntity>();
         let d1 = query.get(&world, e1).unwrap();
         let d2 = query.get(&world, e2).unwrap();
         // NameOrEntity Display for entities without a Name should be {index}v{generation}

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -357,7 +357,7 @@ impl SpecializedRenderPipeline for TaaPipeline {
 }
 
 fn extract_taa_settings(mut commands: Commands, mut main_world: ResMut<MainWorld>) {
-    let mut cameras_3d = main_world.query_filtered::<(
+    let mut cameras_3d = main_world.query_state_filtered::<(
         &RenderEntity,
         &Camera,
         &Projection,

--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -325,6 +325,14 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
                 #(#named_field_idents: <#field_types as #path::query::WorldQuery>::State,)*
             }
 
+            impl #user_impl_generics ::core::clone::Clone for #state_struct_name #user_ty_generics #user_where_clauses {
+                fn clone(&self) -> Self {
+                    Self {
+                        #(#named_field_idents: ::core::clone::Clone::clone(&self.#named_field_idents),)*
+                    }
+                }
+            }
+
             #mutable_world_query_impl
 
             #read_only_impl

--- a/crates/bevy_ecs/macros/src/query_filter.rs
+++ b/crates/bevy_ecs/macros/src/query_filter.rs
@@ -158,6 +158,14 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
                 #(#named_field_idents: <#field_types as #path::query::WorldQuery>::State,)*
             }
 
+            impl #user_impl_generics ::core::clone::Clone for #state_struct_name #user_ty_generics #user_where_clauses {
+                fn clone(&self) -> Self {
+                    Self {
+                        #(#named_field_idents: ::core::clone::Clone::clone(&self.#named_field_idents),)*
+                    }
+                }
+            }
+
             #world_query_impl
 
             #filter_impl

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1282,7 +1282,7 @@ mod tests {
 
         // Since the world is always ahead, as long as changes can't get older than `u32::MAX` (which we ensure),
         // the wrapping difference will always be positive, so wraparound doesn't matter.
-        let mut query = world.query::<Ref<C>>();
+        let mut query = world.query_state::<Ref<C>>();
         assert!(query.single(&world).is_changed());
     }
 
@@ -1297,7 +1297,7 @@ mod tests {
         *world.change_tick.get_mut() += MAX_CHANGE_AGE + CHECK_TICK_THRESHOLD;
         let change_tick = world.change_tick();
 
-        let mut query = world.query::<Ref<C>>();
+        let mut query = world.query_state::<Ref<C>>();
         for tracker in query.iter(&world) {
             let ticks_since_insert = change_tick.relative_to(*tracker.ticks.added).get();
             let ticks_since_change = change_tick.relative_to(*tracker.ticks.changed).get();

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -448,7 +448,7 @@ pub type ComponentHook = for<'w> fn(DeferredWorld<'w>, Entity, ComponentId);
 /// world.init_resource::<TrackedEntities>();
 ///
 /// // No entities with `MyTrackedComponent` have been added yet, so we can safely add component hooks
-/// let mut tracked_component_query = world.query::<&MyTrackedComponent>();
+/// let mut tracked_component_query = world.query_state::<&MyTrackedComponent>();
 /// assert!(tracked_component_query.iter(&world).next().is_none());
 ///
 /// world.register_component_hooks::<MyTrackedComponent>().on_add(|mut world, entity, _component_id| {

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -122,7 +122,7 @@ mod test {
         let entity = world.spawn((Present1, Present2)).id();
 
         let err = world
-            .query::<&NotPresent>()
+            .query_state::<&NotPresent>()
             .get(&world, entity)
             .unwrap_err();
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2001,7 +2001,7 @@ mod tests {
     fn query_sorts() {
         let mut world = World::new();
 
-        let mut query = world.query::<Entity>();
+        let mut query = world.query_state::<Entity>();
 
         let sort = query.iter(&world).sort::<Entity>().collect::<Vec<_>>();
 
@@ -2074,7 +2074,7 @@ mod tests {
         world.spawn((A(2.22),));
 
         {
-            let mut query = world.query::<&A>();
+            let mut query = world.query_state::<&A>();
             let mut iter = query.iter(&world);
             println!(
                 "archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
@@ -2104,7 +2104,7 @@ mod tests {
         world.spawn((Sparse(33),));
 
         {
-            let mut query = world.query::<&Sparse>();
+            let mut query = world.query_state::<&Sparse>();
             let mut iter = query.iter(&world);
             println!(
                 "before_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
@@ -2129,7 +2129,7 @@ mod tests {
     fn empty_query_sort_after_next_does_not_panic() {
         let mut world = World::new();
         {
-            let mut query = world.query::<(&A, &Sparse)>();
+            let mut query = world.query_state::<(&A, &Sparse)>();
             let mut iter = query.iter(&world);
             println!(
                 "before_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",
@@ -2157,7 +2157,7 @@ mod tests {
         world.spawn((A(1.1), Sparse(22)));
         world.spawn((A(2.22), Sparse(33)));
         {
-            let mut query = world.query::<(&A, &Sparse)>();
+            let mut query = world.query_state::<(&A, &Sparse)>();
             let mut iter = query.iter(&world);
             println!(
                 "before_next_call: archetype_entities: {} table_entities: {} current_len: {} current_row: {}",

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -378,7 +378,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes].
     /// However, the lens uses the filter of the original query when present.
     ///
@@ -540,7 +540,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort_unstable`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes]..
     /// However, the lens uses the filter of the original query when present.
     ///
@@ -632,7 +632,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort_by`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes].
     /// However, the lens uses the filter of the original query when present.
     ///
@@ -730,7 +730,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort_unstable_by`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes].
     /// However, the lens uses the filter of the original query when present.
     ///
@@ -796,7 +796,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort_by_key`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes].
     /// However, the lens uses the filter of the original query when present.
     ///
@@ -925,7 +925,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort_unstable_by_key`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes].
     /// However, the lens uses the filter of the original query when present.
     ///
@@ -994,7 +994,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///
     /// This uses [`slice::sort_by_cached_key`] internally.
     ///
-    /// Defining the lens works like [`transmute_lens`](crate::system::Query::transmute_lens).
+    /// Defining the lens works like [`transmute`](crate::system::Query::transmute).
     /// This includes the allowed parameter type changes listed under [allowed transmutes].
     /// However, the lens uses the filter of the original query when present.
     ///

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -80,6 +80,24 @@ pub struct QueryState<D: QueryData, F: QueryFilter = ()> {
     par_iter_span: Span,
 }
 
+impl<D: QueryData, F: QueryFilter> Clone for QueryState<D, F> {
+    fn clone(&self) -> Self {
+        Self {
+            world_id: self.world_id,
+            archetype_generation: self.archetype_generation,
+            matched_tables: self.matched_tables.clone(),
+            matched_archetypes: self.matched_archetypes.clone(),
+            component_access: self.component_access.clone(),
+            matched_storage_ids: self.matched_storage_ids.clone(),
+            is_dense: self.is_dense,
+            fetch_state: self.fetch_state.clone(),
+            filter_state: self.filter_state.clone(),
+            #[cfg(feature = "trace")]
+            par_iter_span: self.par_iter_span.clone(),
+        }
+    }
+}
+
 impl<D: QueryData, F: QueryFilter> fmt::Debug for QueryState<D, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryState")

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -188,6 +188,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             is_dense: self.is_dense,
             fetch_state: self.fetch_state,
             filter_state: self.filter_state,
+            #[cfg(feature = "trace")]
+            par_iter_span: self.par_iter_span,
         }
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -95,7 +95,7 @@ impl<D: QueryData, F: QueryFilter> fmt::Debug for QueryState<D, F> {
 
 impl<D: QueryData, F: QueryFilter> FromWorld for QueryState<D, F> {
     fn from_world(world: &mut World) -> Self {
-        world.query_filtered()
+        world.query_state_filtered()
     }
 }
 
@@ -779,7 +779,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     ///
     /// world.spawn(A(73));
     ///
-    /// let mut query_state = world.query::<&A>();
+    /// let mut query_state = world.query_state::<&A>();
     ///
     /// let component_values = query_state.get_many(&world, entities).unwrap();
     ///
@@ -852,7 +852,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     ///
     /// world.spawn(A(73));
     ///
-    /// let mut query_state = world.query::<&mut A>();
+    /// let mut query_state = world.query_state::<&mut A>();
     ///
     /// let mut mutable_component_values = query_state.get_many_mut(&mut world, entities).unwrap();
     ///
@@ -1428,7 +1428,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// # let entities: Vec<Entity> = (0..3).map(|i| world.spawn(A(i)).id()).collect();
     /// # let entities: [Entity; 3] = entities.try_into().unwrap();
     ///
-    /// let mut query_state = world.query::<&mut A>();
+    /// let mut query_state = world.query_state::<&mut A>();
     ///
     /// query_state.par_iter_mut(&mut world).for_each(|mut a| {
     ///     a.0 += 5;
@@ -1729,7 +1729,7 @@ mod tests {
 
         let entities: Vec<Entity> = (0..10).map(|_| world.spawn_empty().id()).collect();
 
-        let query_state = world.query::<Entity>();
+        let query_state = world.query_state::<Entity>();
 
         // These don't matter for the test
         let last_change_tick = world.last_change_tick();
@@ -1803,7 +1803,7 @@ mod tests {
         let mut world_1 = World::new();
         let world_2 = World::new();
 
-        let mut query_state = world_1.query::<Entity>();
+        let mut query_state = world_1.query_state::<Entity>();
         let _panics = query_state.get(&world_2, Entity::from_raw(0));
     }
 
@@ -1813,7 +1813,7 @@ mod tests {
         let mut world_1 = World::new();
         let world_2 = World::new();
 
-        let mut query_state = world_1.query::<Entity>();
+        let mut query_state = world_1.query_state::<Entity>();
         let _panics = query_state.get_many(&world_2, []);
     }
 
@@ -1823,7 +1823,7 @@ mod tests {
         let mut world_1 = World::new();
         let mut world_2 = World::new();
 
-        let mut query_state = world_1.query::<Entity>();
+        let mut query_state = world_1.query_state::<Entity>();
         let _panics = query_state.get_many_mut(&mut world_2, []);
     }
 
@@ -1841,7 +1841,7 @@ mod tests {
         let mut world = World::new();
         world.spawn((A(1), B(0)));
 
-        let query_state = world.query::<(&A, &B)>();
+        let query_state = world.query_state::<(&A, &B)>();
         let mut new_query_state = query_state.transmute::<&A>(&world);
         assert_eq!(new_query_state.iter(&world).len(), 1);
         let a = new_query_state.single(&world);
@@ -1855,7 +1855,7 @@ mod tests {
         world.spawn((A(0), B(0)));
         world.spawn((A(1), B(0), C(0)));
 
-        let query_state = world.query_filtered::<(&A, &B), Without<C>>();
+        let query_state = world.query_state_filtered::<(&A, &B), Without<C>>();
         let mut new_query_state = query_state.transmute::<&A>(&world);
         // even though we change the query to not have Without<C>, we do not get the component with C.
         let a = new_query_state.single(&world);
@@ -1869,7 +1869,7 @@ mod tests {
         world.register_component::<A>();
         let entity = world.spawn(A(10)).id();
 
-        let q = world.query::<()>();
+        let q = world.query_state::<()>();
         let mut q = q.transmute::<Entity>(&world);
         assert_eq!(q.single(&world), entity);
     }
@@ -1879,11 +1879,11 @@ mod tests {
         let mut world = World::new();
         world.spawn(A(10));
 
-        let q = world.query::<&A>();
+        let q = world.query_state::<&A>();
         let mut new_q = q.transmute::<Ref<A>>(&world);
         assert!(new_q.single(&world).is_added());
 
-        let q = world.query::<Ref<A>>();
+        let q = world.query_state::<Ref<A>>();
         let _ = q.transmute::<&A>(&world);
     }
 
@@ -1892,7 +1892,7 @@ mod tests {
         let mut world = World::new();
         world.spawn(A(0));
 
-        let q = world.query::<&mut A>();
+        let q = world.query_state::<&mut A>();
         let _ = q.transmute::<Ref<A>>(&world);
         let _ = q.transmute::<&A>(&world);
     }
@@ -1902,7 +1902,7 @@ mod tests {
         let mut world = World::new();
         world.spawn(A(0));
 
-        let q: QueryState<EntityMut<'_>> = world.query::<EntityMut>();
+        let q: QueryState<EntityMut<'_>> = world.query_state::<EntityMut>();
         let _ = q.transmute::<EntityRef>(&world);
     }
 
@@ -1911,7 +1911,7 @@ mod tests {
         let mut world = World::new();
         world.spawn((A(0), B(0)));
 
-        let query_state = world.query::<(Option<&A>, &B)>();
+        let query_state = world.query_state::<(Option<&A>, &B)>();
         let _ = query_state.transmute::<Option<&A>>(&world);
         let _ = query_state.transmute::<&B>(&world);
     }
@@ -1926,7 +1926,7 @@ mod tests {
         world.register_component::<B>();
         world.spawn(A(0));
 
-        let query_state = world.query::<&A>();
+        let query_state = world.query_state::<&A>();
         let mut _new_query_state = query_state.transmute::<(&A, &B)>(&world);
     }
 
@@ -1938,7 +1938,7 @@ mod tests {
         let mut world = World::new();
         world.spawn(A(0));
 
-        let query_state = world.query::<&A>();
+        let query_state = world.query_state::<&A>();
         let mut _new_query_state = query_state.transmute::<&mut A>(&world);
     }
 
@@ -1950,7 +1950,7 @@ mod tests {
         let mut world = World::new();
         world.spawn(C(0));
 
-        let query_state = world.query::<Option<&A>>();
+        let query_state = world.query_state::<Option<&A>>();
         let mut new_query_state = query_state.transmute::<&A>(&world);
         let x = new_query_state.single(&world);
         assert_eq!(x.0, 1234);
@@ -1964,7 +1964,7 @@ mod tests {
         let mut world = World::new();
         world.register_component::<A>();
 
-        let q = world.query::<EntityRef>();
+        let q = world.query_state::<EntityRef>();
         let _ = q.transmute::<&A>(&world);
     }
 
@@ -2046,7 +2046,7 @@ mod tests {
         let mut world2 = World::new();
         world2.register_component::<B>();
 
-        world.query::<(&A, &B)>().transmute::<&B>(&world2);
+        world.query_state::<(&A, &B)>().transmute::<&B>(&world2);
     }
 
     /// Regression test for issue #14528
@@ -2065,7 +2065,7 @@ mod tests {
         world.spawn((Dense, Sparse));
 
         let mut query = world
-            .query_filtered::<&Dense, With<Sparse>>()
+            .query_state_filtered::<&Dense, With<Sparse>>()
             .transmute::<&Dense>(&world);
 
         let matched = query.iter(&world).count();
@@ -2086,7 +2086,7 @@ mod tests {
         world.spawn((Dense, Sparse));
 
         let mut query = world
-            .query::<&Dense>()
+            .query_state::<&Dense>()
             .transmute_filtered::<&Dense, With<Sparse>>(&world);
 
         // Note: `transmute_filtered` is supposed to keep the same matched tables/archetypes,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -663,7 +663,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
 
     /// Use this to transform a [`QueryState`] into a more generic [`QueryState`].
     /// This can be useful for passing to another function that might take the more general form.
-    /// See [`Query::transmute_lens`](crate::system::Query::transmute_lens) for more details.
+    /// See [`Query::transmute`](crate::system::Query::transmute) for more details.
     ///
     /// You should not call [`update_archetypes`](Self::update_archetypes) on the returned [`QueryState`] as the result will be unpredictable.
     /// You might end up with a mix of archetypes that only matched the original query + archetypes that only match

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -48,7 +48,7 @@ pub unsafe trait WorldQuery {
     /// State used to construct a [`Self::Fetch`](WorldQuery::Fetch). This will be cached inside [`QueryState`](crate::query::QueryState),
     /// so it is best to move as much data / computation here as possible to reduce the cost of
     /// constructing [`Self::Fetch`](WorldQuery::Fetch).
-    type State: Send + Sync + Sized;
+    type State: Clone + Send + Sync + Sized;
 
     /// This function manually implements subtyping for the query items.
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort>;

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -104,7 +104,10 @@ pub unsafe trait WorldQuery {
     /// Sets available accesses for implementors with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
     /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).
     ///
-    /// Called when constructing a [`QueryLens`](crate::system::QueryLens) or calling [`QueryState::from_builder`](super::QueryState::from_builder)
+    /// Called inside [`Query::transmute`], [`Query::join`], and [`QueryState::from_builder`](super::QueryState::from_builder)
+    ///
+    /// [`Query::transmute`]: crate::system::Query::transmute
+    /// [`Query::join`]: crate::system::Query::join
     fn set_access(_state: &mut Self::State, _access: &FilteredAccess<ComponentId>) {}
 
     /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -701,7 +701,7 @@ mod tests {
 
         let mut count = 0;
 
-        let mut q = world.query::<&Zst>();
+        let mut q = world.query_state::<&Zst>();
         for zst in q.iter(&world) {
             // Ensure that the references returned are properly aligned.
             assert_eq!(

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2034,7 +2034,7 @@ mod tests {
         command_queue.apply(&mut world);
         assert_eq!(world.entities().len(), 1);
         let results = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
@@ -2047,7 +2047,7 @@ mod tests {
         }
         command_queue.apply(&mut world);
         let results2 = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
@@ -2067,7 +2067,7 @@ mod tests {
         }
         command_queue.apply(&mut world);
         let results3 = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
@@ -2094,7 +2094,7 @@ mod tests {
         command_queue1.apply(&mut world);
 
         let results = world
-            .query::<(&W<u8>, &W<u16>, &W<u32>)>()
+            .query_state::<(&W<u8>, &W<u16>, &W<u32>)>()
             .iter(&world)
             .map(|(a, b, c)| (a.0, b.0, c.0))
             .collect::<Vec<_>>();
@@ -2128,7 +2128,7 @@ mod tests {
             .id();
         command_queue.apply(&mut world);
         let results_before = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
@@ -2147,13 +2147,13 @@ mod tests {
         assert_eq!(sparse_is_dropped.load(Ordering::Relaxed), 1);
 
         let results_after = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
         assert_eq!(results_after, vec![]);
         let results_after_u64 = world
-            .query::<&W<u64>>()
+            .query_state::<&W<u64>>()
             .iter(&world)
             .map(|v| v.0)
             .collect::<Vec<_>>();
@@ -2174,7 +2174,7 @@ mod tests {
             .id();
         command_queue.apply(&mut world);
         let results_before = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
@@ -2200,13 +2200,13 @@ mod tests {
         assert_eq!(sparse_is_dropped.load(Ordering::Relaxed), 1);
 
         let results_after = world
-            .query::<(&W<u32>, &W<u64>)>()
+            .query_state::<(&W<u32>, &W<u64>)>()
             .iter(&world)
             .map(|(a, b)| (a.0, b.0))
             .collect::<Vec<_>>();
         assert_eq!(results_after, vec![]);
         let results_after_u64 = world
-            .query::<&W<u64>>()
+            .query_state::<&W<u64>>()
             .iter(&world)
             .map(|v| v.0)
             .collect::<Vec<_>>();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1547,7 +1547,7 @@ mod tests {
     fn query_validates_world_id() {
         let mut world1 = World::new();
         let world2 = World::new();
-        let qstate = world1.query::<()>();
+        let qstate = world1.query_state::<()>();
         // SAFETY: doesnt access anything
         let query = unsafe {
             Query::new(

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1549,10 +1549,10 @@ mod tests {
         let world2 = World::new();
         let qstate = world1.query_state::<()>();
         // SAFETY: doesnt access anything
-        let query = unsafe {
+        let query: Query<'_, '_, _, _> = unsafe {
             Query::new(
                 world2.as_unsafe_world_cell_readonly(),
-                &qstate,
+                alloc::borrow::Cow::Borrowed(&qstate),
                 Tick::new(0),
                 Tick::new(0),
             )

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -463,6 +463,13 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         }
     }
 
+    /// Returns the backing [`QueryState`] of this query.
+    /// If the state was borrowed when this query was created,
+    /// a clone of the state will be returned.
+    pub fn into_state(self) -> QueryState<D, F> {
+        self.state.into_owned()
+    }
+
     /// Returns an [`Iterator`] over the read-only query items.
     ///
     /// This iterator is always guaranteed to return results from each matching entity once and only once.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -16,6 +16,7 @@ use crate::{
         FromWorld, World,
     },
 };
+use alloc::borrow::Cow;
 use bevy_ecs_macros::impl_param_set;
 pub use bevy_ecs_macros::{Resource, SystemParam};
 use bevy_ptr::UnsafeCellDeref;
@@ -318,7 +319,14 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         // SAFETY: We have registered all of the query's world accesses,
         // so the caller ensures that `world` has permission to access any
         // world data that the query needs.
-        unsafe { Query::new(world, state, system_meta.last_run, change_tick) }
+        unsafe {
+            Query::new(
+                world,
+                Cow::Borrowed(state),
+                system_meta.last_run,
+                change_tick,
+            )
+        }
     }
 }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use core::ops::Deref;
 
 use crate::{
@@ -260,7 +261,7 @@ impl<'w> DeferredWorld<'w> {
             let world_cell = self.world;
             Query::new(
                 world_cell,
-                state,
+                Cow::Borrowed(state),
                 world_cell.last_change_tick(),
                 world_cell.change_tick(),
             )

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1826,11 +1826,11 @@ impl<'w> EntityWorldMut<'w> {
     /// let mut entity = world.spawn_empty();
     /// entity.entry().or_insert_with(|| Comp(4));
     /// # let entity_id = entity.id();
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 4);
     ///
     /// # let mut entity = world.get_entity_mut(entity_id).unwrap();
     /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 5);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 5);
     /// ```
     pub fn entry<'a, T: Component>(&'a mut self) -> Entry<'w, 'a, T> {
         if self.contains::<T>() {
@@ -1914,7 +1914,7 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
     /// let mut entity = world.spawn(Comp(0));
     ///
     /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 1);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 1);
     /// ```
     #[inline]
     pub fn and_modify<F: FnOnce(Mut<'_, T>)>(self, f: F) -> Self {
@@ -1971,11 +1971,11 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
     ///
     /// entity.entry().or_insert(Comp(4));
     /// # let entity_id = entity.id();
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 4);
     ///
     /// # let mut entity = world.get_entity_mut(entity_id).unwrap();
     /// entity.entry().or_insert(Comp(15)).0 *= 2;
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 8);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 8);
     /// ```
     #[inline]
     pub fn or_insert(self, default: T) -> Mut<'a, T> {
@@ -1999,7 +1999,7 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
     /// let mut entity = world.spawn_empty();
     ///
     /// entity.entry().or_insert_with(|| Comp(4));
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 4);
     /// ```
     #[inline]
     pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> Mut<'a, T> {
@@ -2025,7 +2025,7 @@ impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
     /// let mut entity = world.spawn_empty();
     ///
     /// entity.entry::<Comp>().or_default();
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 0);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 0);
     /// ```
     #[inline]
     pub fn or_default(self) -> Mut<'a, T> {
@@ -2092,7 +2092,7 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     ///     o.get_mut().0 += 2
     /// }
     ///
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 17);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 17);
     /// ```
     #[inline]
     pub fn get_mut(&mut self) -> Mut<'_, T> {
@@ -2121,7 +2121,7 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     ///     o.into_mut().0 += 10;
     /// }
     ///
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 15);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 15);
     /// ```
     #[inline]
     pub fn into_mut(self) -> Mut<'a, T> {
@@ -2145,7 +2145,7 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     ///     o.insert(Comp(10));
     /// }
     ///
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 10);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 10);
     /// ```
     #[inline]
     pub fn insert(&mut self, component: T) {
@@ -2168,7 +2168,7 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     ///     assert_eq!(o.take(), Comp(5));
     /// }
     ///
-    /// assert_eq!(world.query::<&Comp>().iter(&world).len(), 0);
+    /// assert_eq!(world.query_state::<&Comp>().iter(&world).len(), 0);
     /// ```
     #[inline]
     pub fn take(self) -> T {
@@ -2200,7 +2200,7 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
     ///     v.insert(Comp(10));
     /// }
     ///
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 10);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 10);
     /// ```
     #[inline]
     pub fn insert(self, component: T) -> Mut<'a, T> {
@@ -2225,7 +2225,7 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
     ///     v.insert_entry(Comp(10));
     /// }
     ///
-    /// assert_eq!(world.query::<&Comp>().single(&world).0, 10);
+    /// assert_eq!(world.query_state::<&Comp>().single(&world).0, 10);
     /// ```
     #[inline]
     pub fn insert_entry(self, component: T) -> OccupiedEntry<'w, 'a, T> {
@@ -3774,7 +3774,7 @@ mod tests {
             unsafe { entity.insert_by_id(test_component_id, ptr) };
         });
 
-        let components: Vec<_> = world.query::<&TestComponent>().iter(&world).collect();
+        let components: Vec<_> = world.query_state::<&TestComponent>().iter(&world).collect();
 
         assert_eq!(components, vec![&TestComponent(42)]);
 
@@ -3786,7 +3786,7 @@ mod tests {
             unsafe { entity.insert_by_ids(&[test_component_id], vec![ptr].into_iter()) };
         });
 
-        let components: Vec<_> = world.query::<&TestComponent>().iter(&world).collect();
+        let components: Vec<_> = world.query_state::<&TestComponent>().iter(&world).collect();
 
         assert_eq!(components, vec![&TestComponent(42), &TestComponent(84)]);
     }
@@ -3810,7 +3810,7 @@ mod tests {
         });
 
         let dynamic_components: Vec<_> = world
-            .query::<(&TestComponent, &TestComponent2)>()
+            .query_state::<(&TestComponent, &TestComponent2)>()
             .iter(&world)
             .collect();
 
@@ -3824,7 +3824,7 @@ mod tests {
 
         static_world.spawn((test_component_value, test_component_2_value));
         let static_components: Vec<_> = static_world
-            .query::<(&TestComponent, &TestComponent2)>()
+            .query_state::<(&TestComponent, &TestComponent2)>()
             .iter(&static_world)
             .collect();
 
@@ -3839,7 +3839,7 @@ mod tests {
         let mut entity = world.spawn(TestComponent(42));
         entity.remove_by_id(test_component_id);
 
-        let components: Vec<_> = world.query::<&TestComponent>().iter(&world).collect();
+        let components: Vec<_> = world.query_state::<&TestComponent>().iter(&world).collect();
 
         assert_eq!(components, vec![] as Vec<&TestComponent>);
 
@@ -3856,7 +3856,7 @@ mod tests {
 
         world.spawn(TestComponent(0)).insert(TestComponent2(0));
 
-        let mut query = world.query::<EntityRefExcept<TestComponent>>();
+        let mut query = world.query_state::<EntityRefExcept<TestComponent>>();
 
         let mut found = false;
         for entity_ref in query.iter_mut(&mut world) {
@@ -3931,7 +3931,7 @@ mod tests {
         let mut world = World::new();
         world.spawn(TestComponent(0)).insert(TestComponent2(0));
 
-        let mut query = world.query::<EntityMutExcept<TestComponent>>();
+        let mut query = world.query_state::<EntityMutExcept<TestComponent>>();
 
         let mut found = false;
         for mut entity_mut in query.iter_mut(&mut world) {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -44,7 +44,7 @@ use crate::{
     removal_detection::RemovedComponentEvents,
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
-    system::{Commands, Resource},
+    system::{Commands, Query, Resource},
     world::{
         command_queue::RawCommandQueue,
         error::{EntityFetchError, TryRunScheduleError},
@@ -1579,8 +1579,21 @@ impl World {
         self.last_change_tick = self.increment_change_tick();
     }
 
+    /// Returns a [`Query`] for the given [`QueryData`].
+    pub fn query<D: QueryData>(&mut self) -> Query<'_, 'static, D, ()> {
+        self.query_state_filtered::<D, ()>().into_query(self)
+    }
+
+    /// Returns a [`Query`] for the given filtered [`QueryData`].
+    pub fn query_filtered<D: QueryData, F: QueryFilter>(&mut self) -> Query<'_, 'static, D, F> {
+        self.query_state_filtered::<D, F>().into_query(self)
+    }
+
     /// Returns [`QueryState`] for the given [`QueryData`], which is used to efficiently
     /// run queries on the [`World`] by storing and reusing the [`QueryState`].
+    ///
+    /// # Examples
+    ///
     /// ```
     /// use bevy_ecs::{component::Component, entity::Entity, world::World};
     ///
@@ -1648,6 +1661,9 @@ impl World {
 
     /// Returns [`QueryState`] for the given filtered [`QueryData`], which is used to efficiently
     /// run queries on the [`World`] by storing and reusing the [`QueryState`].
+    ///
+    /// # Examples
+    ///
     /// ```
     /// use bevy_ecs::{component::Component, entity::Entity, world::World, query::With};
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1602,7 +1602,7 @@ impl World {
     ///     (Position { x: 0.0, y: 0.0}, Velocity { x: 0.0, y: 1.0 }),
     /// ]).collect::<Vec<Entity>>();
     ///
-    /// let mut query = world.query::<(&mut Position, &Velocity)>();
+    /// let mut query = world.query_state::<(&mut Position, &Velocity)>();
     /// for (mut position, velocity) in query.iter_mut(&mut world) {
     ///    position.x += velocity.x;
     ///    position.y += velocity.y;
@@ -1629,7 +1629,7 @@ impl World {
     /// let a = world.spawn((Order(2), Label("second"))).id();
     /// let b = world.spawn((Order(3), Label("third"))).id();
     /// let c = world.spawn((Order(1), Label("first"))).id();
-    /// let mut entities = world.query::<(Entity, &Order, &Label)>()
+    /// let mut entities = world.query_state::<(Entity, &Order, &Label)>()
     ///     .iter(&world)
     ///     .collect::<Vec<_>>();
     /// // Sort the query results by their `Order` component before comparing
@@ -1642,8 +1642,8 @@ impl World {
     /// ]);
     /// ```
     #[inline]
-    pub fn query<D: QueryData>(&mut self) -> QueryState<D, ()> {
-        self.query_filtered::<D, ()>()
+    pub fn query_state<D: QueryData>(&mut self) -> QueryState<D, ()> {
+        self.query_state_filtered::<D, ()>()
     }
 
     /// Returns [`QueryState`] for the given filtered [`QueryData`], which is used to efficiently
@@ -1660,13 +1660,13 @@ impl World {
     /// let e1 = world.spawn(A).id();
     /// let e2 = world.spawn((A, B)).id();
     ///
-    /// let mut query = world.query_filtered::<Entity, With<B>>();
+    /// let mut query = world.query_state_filtered::<Entity, With<B>>();
     /// let matching_entities = query.iter(&world).collect::<Vec<Entity>>();
     ///
     /// assert_eq!(matching_entities, vec![e2]);
     /// ```
     #[inline]
-    pub fn query_filtered<D: QueryData, F: QueryFilter>(&mut self) -> QueryState<D, F> {
+    pub fn query_state_filtered<D: QueryData, F: QueryFilter>(&mut self) -> QueryState<D, F> {
         QueryState::new(self)
     }
 

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -1271,7 +1271,7 @@ mod tests {
             .add_children(&[child])
             .id();
 
-        let mut query = world.query::<&Children>();
+        let mut query = world.query_state::<&Children>();
         let children = query.get(&world, parent).unwrap();
         assert_eq!(**children, [child]);
     }
@@ -1281,7 +1281,7 @@ mod tests {
         let mut world = World::new();
         let parent = world.spawn_empty().add_children(&[]).id();
 
-        let mut query = world.query::<&Children>();
+        let mut query = world.query_state::<&Children>();
         let children = query.get(&world, parent);
         assert!(children.is_err());
     }

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -268,7 +268,7 @@ mod tests {
         queue.apply(&mut world);
 
         let mut results = world
-            .query::<(&N, &Idx)>()
+            .query_state::<(&N, &Idx)>()
             .iter(&world)
             .map(|(a, b)| (a.clone(), *b))
             .collect::<Vec<_>>();

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -2038,7 +2038,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2048,7 +2048,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<(&Gamepad, &GamepadSettings)>()
+                .query_state::<(&Gamepad, &GamepadSettings)>()
                 .iter(ctx.app.world())
                 .len(),
             1
@@ -2061,7 +2061,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2071,7 +2071,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<(&Gamepad, &GamepadSettings)>()
+                .query_state::<(&Gamepad, &GamepadSettings)>()
                 .iter(ctx.app.world())
                 .len(),
             1
@@ -2082,14 +2082,14 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .is_err());
         // Settings should be kept
         assert!(ctx
             .app
             .world_mut()
-            .query::<&GamepadSettings>()
+            .query_state::<&GamepadSettings>()
             .get(ctx.app.world(), entity)
             .is_ok());
 
@@ -2099,13 +2099,13 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .is_err());
         assert!(ctx
             .app
             .world_mut()
-            .query::<&GamepadSettings>()
+            .query_state::<&GamepadSettings>()
             .get(ctx.app.world(), entity)
             .is_ok());
     }
@@ -2116,7 +2116,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2128,14 +2128,14 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .is_err());
         // Settings should be kept
         assert!(ctx
             .app
             .world_mut()
-            .query::<&GamepadSettings>()
+            .query_state::<&GamepadSettings>()
             .get(ctx.app.world(), entity)
             .is_ok());
     }
@@ -2147,7 +2147,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2157,7 +2157,7 @@ mod tests {
         let mut settings = ctx
             .app
             .world_mut()
-            .query::<&mut GamepadSettings>()
+            .query_state::<&mut GamepadSettings>()
             .get_mut(ctx.app.world_mut(), entity)
             .expect("be alive");
         assert_ne!(settings.default_button_settings, button_settings);
@@ -2167,7 +2167,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2177,7 +2177,7 @@ mod tests {
         let settings = ctx
             .app
             .world_mut()
-            .query::<&GamepadSettings>()
+            .query_state::<&GamepadSettings>()
             .get(ctx.app.world(), entity)
             .expect("be alive");
         assert_eq!(settings.default_button_settings, button_settings);
@@ -2189,7 +2189,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2200,7 +2200,7 @@ mod tests {
         assert_eq!(
             ctx.app
                 .world_mut()
-                .query::<&Gamepad>()
+                .query_state::<&Gamepad>()
                 .iter(ctx.app.world())
                 .len(),
             0
@@ -2208,7 +2208,7 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<(Entity, &GamepadSettings)>()
+            .query_state::<(Entity, &GamepadSettings)>()
             .get(ctx.app.world(), entity)
             .is_ok());
     }
@@ -2523,7 +2523,7 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .pressed(GamepadButton::DPadDown));
@@ -2544,7 +2544,7 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .pressed(GamepadButton::DPadDown));
@@ -2569,7 +2569,7 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .just_pressed(GamepadButton::DPadDown));
@@ -2579,7 +2579,7 @@ mod tests {
         assert!(!ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .just_pressed(GamepadButton::DPadDown));
@@ -2628,7 +2628,7 @@ mod tests {
         assert!(!ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .pressed(GamepadButton::DPadDown));
@@ -2673,7 +2673,7 @@ mod tests {
         assert!(ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .just_released(GamepadButton::DPadDown));
@@ -2683,7 +2683,7 @@ mod tests {
         assert!(!ctx
             .app
             .world_mut()
-            .query::<&Gamepad>()
+            .query_state::<&Gamepad>()
             .get(ctx.app.world(), entity)
             .unwrap()
             .just_released(GamepadButton::DPadDown));

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -826,7 +826,7 @@ pub fn check_dir_light_mesh_visibility(
     // TODO: use resource to avoid unnecessary memory alloc
     let mut defer_queue = core::mem::take(defer_visible_entities_queue.deref_mut());
     commands.queue(move |world: &mut World| {
-        let mut query = world.query::<&mut ViewVisibility>();
+        let mut query = world.query_state::<&mut ViewVisibility>();
         for entities in defer_queue.iter_mut() {
             let mut iter = query.iter_many_mut(world, entities.iter());
             while let Some(mut view_visibility) = iter.fetch_next() {

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -15,7 +15,7 @@ pub struct CameraDriverNode {
 impl CameraDriverNode {
     pub fn new(world: &mut World) -> Self {
         Self {
-            cameras: world.query(),
+            cameras: world.query_state(),
         }
     }
 }

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -372,7 +372,7 @@ pub struct ViewNodeRunner<N: ViewNode> {
 impl<N: ViewNode> ViewNodeRunner<N> {
     pub fn new(node: N, world: &mut World) -> Self {
         Self {
-            view_query: world.query_filtered(),
+            view_query: world.query_state_filtered(),
             node,
         }
     }

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -291,8 +291,8 @@ impl<P: PhaseItem, C: RenderCommand<P>> RenderCommandState<P, C> {
     pub fn new(world: &mut World) -> Self {
         Self {
             state: SystemState::new(world),
-            view: world.query(),
-            entity: world.query(),
+            view: world.query_state(),
+            entity: world.query_state(),
         }
     }
 }

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -277,7 +277,7 @@ mod tests {
 
         entity_sync_system(&mut main_world, &mut render_world);
 
-        let mut q = render_world.query_filtered::<Entity, With<MainEntity>>();
+        let mut q = render_world.query_state_filtered::<Entity, With<MainEntity>>();
 
         // Only one synchronized entity
         assert!(q.iter(&render_world).count() == 1);

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -715,7 +715,7 @@ mod test {
         schedule.run(&mut world);
         world.clear_trackers();
 
-        let mut q = world.query::<Ref<InheritedVisibility>>();
+        let mut q = world.query_state::<Ref<InheritedVisibility>>();
 
         assert!(!q.get(&world, id1).unwrap().is_changed());
         assert!(!q.get(&world, id2).unwrap().is_changed());

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -163,7 +163,7 @@ mod tests {
         // make sure that the scene was added as a child of the root entity
         let (scene_entity, scene_component_a) = app
             .world_mut()
-            .query::<(Entity, &ComponentA)>()
+            .query_state::<(Entity, &ComponentA)>()
             .single(app.world());
         assert_eq!(scene_component_a.x, 3.0);
         assert_eq!(scene_component_a.y, 4.0);

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -253,7 +253,7 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// # let mut world = World::default();
     /// # world.init_resource::<AppTypeRegistry>();
     /// # let _entity = world.spawn(MyComponent).id();
-    /// let mut query = world.query_filtered::<Entity, With<MyComponent>>();
+    /// let mut query = world.query_state_filtered::<Entity, With<MyComponent>>();
     ///
     /// let scene = DynamicSceneBuilder::from_world(&world)
     ///     .extract_entities(query.iter(&world))
@@ -526,7 +526,7 @@ mod tests {
         let entity_a = world.spawn(ComponentA).id();
         let _entity_b = world.spawn(ComponentB).id();
 
-        let mut query = world.query_filtered::<Entity, With<ComponentA>>();
+        let mut query = world.query_state_filtered::<Entity, With<ComponentA>>();
         let scene = DynamicSceneBuilder::from_world(&world)
             .extract_entities(query.iter(&world))
             .build();

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -507,7 +507,9 @@ mod tests {
 
         // clone only existing entity
         let mut scene_spawner = SceneSpawner::default();
-        let entity = world.query_state_filtered::<Entity, With<A>>().single(&world);
+        let entity = world
+            .query_state_filtered::<Entity, With<A>>()
+            .single(&world);
         let scene = DynamicSceneBuilder::from_world(&world)
             .extract_entity(entity)
             .build();

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -503,11 +503,11 @@ mod tests {
         // start test
         world.spawn(A(42));
 
-        assert_eq!(world.query::<&A>().iter(&world).len(), 1);
+        assert_eq!(world.query_state::<&A>().iter(&world).len(), 1);
 
         // clone only existing entity
         let mut scene_spawner = SceneSpawner::default();
-        let entity = world.query_filtered::<Entity, With<A>>().single(&world);
+        let entity = world.query_state_filtered::<Entity, With<A>>().single(&world);
         let scene = DynamicSceneBuilder::from_world(&world)
             .extract_entity(entity)
             .build();
@@ -518,7 +518,7 @@ mod tests {
             .unwrap();
 
         // verify we spawned exactly one new entity with our expected component
-        assert_eq!(world.query::<&A>().iter(&world).len(), 2);
+        assert_eq!(world.query_state::<&A>().iter(&world).len(), 2);
 
         // verify that we can get this newly-spawned entity by the instance ID
         let new_entity = scene_spawner
@@ -531,7 +531,7 @@ mod tests {
 
         // verify this new entity contains the same data as the original entity
         let [old_a, new_a] = world
-            .query::<&A>()
+            .query_state::<&A>()
             .get_many(&world, [entity, new_entity])
             .unwrap();
         assert_eq!(old_a, new_a);

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -722,9 +722,9 @@ mod tests {
         let my_resource = my_resource.unwrap();
         assert_eq!(my_resource.foo, 123);
 
-        assert_eq!(3, dst_world.query::<&Foo>().iter(&dst_world).count());
-        assert_eq!(2, dst_world.query::<&Bar>().iter(&dst_world).count());
-        assert_eq!(1, dst_world.query::<&Baz>().iter(&dst_world).count());
+        assert_eq!(3, dst_world.query_state::<&Foo>().iter(&dst_world).count());
+        assert_eq!(2, dst_world.query_state::<&Bar>().iter(&dst_world).count());
+        assert_eq!(1, dst_world.query_state::<&Baz>().iter(&dst_world).count());
     }
 
     fn roundtrip_ron(world: &World) -> (DynamicScene, DynamicScene) {
@@ -762,18 +762,18 @@ mod tests {
         assert_scene_eq(&scene, &deserialized_scene);
 
         let bar_to_foo = dst_world
-            .query_filtered::<&MyEntityRef, Without<Foo>>()
+            .query_state_filtered::<&MyEntityRef, Without<Foo>>()
             .get_single(&dst_world)
             .cloned()
             .unwrap();
         let foo = dst_world
-            .query_filtered::<Entity, With<Foo>>()
+            .query_state_filtered::<Entity, With<Foo>>()
             .get_single(&dst_world)
             .unwrap();
 
         assert_eq!(foo, bar_to_foo.0);
         assert!(dst_world
-            .query_filtered::<&MyEntityRef, With<Foo>>()
+            .query_state_filtered::<&MyEntityRef, With<Foo>>()
             .iter(&dst_world)
             .all(|r| world.get_entity(r.0).is_err()));
     }
@@ -793,7 +793,7 @@ mod tests {
         deserialized_scene
             .write_to_world(&mut world, &mut EntityHashMap::default())
             .unwrap();
-        assert_eq!(&qux, world.query::<&Qux>().single(&world));
+        assert_eq!(&qux, world.query_state::<&Qux>().single(&world));
     }
 
     #[test]

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -422,7 +422,7 @@ mod test {
         // Note that at this point, the `GlobalTransform`s will not have updated yet, due to `Commands` delay
         app.update();
 
-        let mut state = app.world_mut().query::<&GlobalTransform>();
+        let mut state = app.world_mut().query_state::<&GlobalTransform>();
         for global in state.iter(app.world()) {
             assert_eq!(global, &GlobalTransform::from_translation(translation));
         }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -632,7 +632,7 @@ mod tests {
 
         // despawn all cameras so we can reset ui_surface back to a fresh state
         let camera_entities = world
-            .query_filtered::<Entity, With<Camera>>()
+            .query_state_filtered::<Entity, With<Camera>>()
             .iter(&world)
             .collect::<Vec<_>>();
         for camera_entity in camera_entities {
@@ -849,7 +849,7 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let overlap_check = world
-            .query_filtered::<(Entity, &Node, &GlobalTransform), Without<Parent>>()
+            .query_state_filtered::<(Entity, &Node, &GlobalTransform), Without<Parent>>()
             .iter(&world)
             .fold(
                 Option::<(Rect, bool)>::None,
@@ -950,7 +950,7 @@ mod tests {
             world.run_system_once_with(new_pos, move_ui_node).unwrap();
             ui_schedule.run(world);
             let (ui_node_entity, TargetCamera(target_camera_entity)) = world
-                .query_filtered::<(Entity, &TargetCamera), With<MovingUiNode>>()
+                .query_state_filtered::<(Entity, &TargetCamera), With<MovingUiNode>>()
                 .get_single(world)
                 .expect("missing MovingUiNode");
             assert_eq!(expected_camera_entity, target_camera_entity);
@@ -994,7 +994,7 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let pos_inc = Vec2::splat(1.);
-        let total_cameras = world.query::<&Camera>().iter(&world).len();
+        let total_cameras = world.query_state::<&Camera>().iter(&world).len();
         // add total cameras - 1 (the assumed default) to get an idea for how many nodes we should expect
         let expected_max_taffy_node_count = get_taffy_node_count(&world) + total_cameras - 1;
 
@@ -1003,7 +1003,7 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let viewport_rects = world
-            .query::<(Entity, &Camera)>()
+            .query_state::<(Entity, &Camera)>()
             .iter(&world)
             .map(|(e, c)| (e, c.logical_viewport_rect().expect("missing viewport")))
             .collect::<Vec<_>>();

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -25,8 +25,8 @@ pub struct UiPassNode {
 impl UiPassNode {
     pub fn new(world: &mut World) -> Self {
         Self {
-            ui_view_query: world.query_filtered(),
-            default_camera_view_query: world.query(),
+            ui_view_query: world.query_state_filtered(),
+            default_camera_view_query: world.query_state(),
         }
     }
 }

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -227,7 +227,7 @@ mod tests {
         schedule.add_systems(ui_stack_system);
         schedule.run(&mut world);
 
-        let mut query = world.query::<&Label>();
+        let mut query = world.query_state::<&Label>();
         let ui_stack = world.resource::<UiStack>();
         let actual_result = ui_stack
             .uinodes
@@ -283,7 +283,7 @@ mod tests {
         schedule.add_systems(ui_stack_system);
         schedule.run(&mut world);
 
-        let mut query = world.query::<&Label>();
+        let mut query = world.query_state::<&Label>();
         let ui_stack = world.resource::<UiStack>();
         let actual_result = ui_stack
             .uinodes

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -415,7 +415,9 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
             _ => {}
         }
 
-        let mut windows = self.world_mut().query::<(&mut Window, &mut CachedWindow)>();
+        let mut windows = self
+            .world_mut()
+            .query_state::<(&mut Window, &mut CachedWindow)>();
         if let Ok((window_component, mut cache)) = windows.get_mut(self.world_mut(), window) {
             if window_component.is_changed() {
                 cache.window = window_component.clone();
@@ -482,7 +484,7 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 // This will trigger the surface destruction.
                 let mut query = self
                     .world_mut()
-                    .query_filtered::<Entity, With<PrimaryWindow>>();
+                    .query_state_filtered::<Entity, With<PrimaryWindow>>();
                 let entity = query.single(&self.world());
                 self.world_mut()
                     .entity_mut(entity)
@@ -502,7 +504,7 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 // Get windows that are cached but without raw handles. Those window were already created, but got their
                 // handle wrapper removed when the app was suspended.
                 let mut query = self.world_mut()
-                    .query_filtered::<(Entity, &Window), (With<CachedWindow>, Without<bevy_window::RawHandleWrapper>)>();
+                    .query_state_filtered::<(Entity, &Window), (With<CachedWindow>, Without<bevy_window::RawHandleWrapper>)>();
                 if let Ok((entity, window)) = query.get_single(&self.world()) {
                     let window = window.clone();
 

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -115,7 +115,7 @@ fn scene_load_check(
 
                 let mut query = scene
                     .world
-                    .query::<(Option<&DirectionalLight>, Option<&PointLight>)>();
+                    .query_state::<(Option<&DirectionalLight>, Option<&PointLight>)>();
                 scene_handle.has_light =
                     query
                         .iter(&scene.world)

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -133,7 +133,13 @@ fn spawn_enemy_using_input_resource() {
     app.update();
 
     // Check resulting changes, one entity has been spawned with `Enemy` component
-    assert_eq!(app.world_mut().query_state::<&Enemy>().iter(app.world()).len(), 1);
+    assert_eq!(
+        app.world_mut()
+            .query_state::<&Enemy>()
+            .iter(app.world())
+            .len(),
+        1
+    );
 
     // Clear the `just_pressed` status for all `KeyCode`s
     app.world_mut()
@@ -144,7 +150,13 @@ fn spawn_enemy_using_input_resource() {
     app.update();
 
     // Check resulting changes, no new entity has been spawned
-    assert_eq!(app.world_mut().query_state::<&Enemy>().iter(app.world()).len(), 1);
+    assert_eq!(
+        app.world_mut()
+            .query_state::<&Enemy>()
+            .iter(app.world())
+            .len(),
+        1
+    );
 }
 
 #[test]

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -133,7 +133,7 @@ fn spawn_enemy_using_input_resource() {
     app.update();
 
     // Check resulting changes, one entity has been spawned with `Enemy` component
-    assert_eq!(app.world_mut().query::<&Enemy>().iter(app.world()).len(), 1);
+    assert_eq!(app.world_mut().query_state::<&Enemy>().iter(app.world()).len(), 1);
 
     // Clear the `just_pressed` status for all `KeyCode`s
     app.world_mut()
@@ -144,7 +144,7 @@ fn spawn_enemy_using_input_resource() {
     app.update();
 
     // Check resulting changes, no new entity has been spawned
-    assert_eq!(app.world_mut().query::<&Enemy>().iter(app.world()).len(), 1);
+    assert_eq!(app.world_mut().query_state::<&Enemy>().iter(app.world()).len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
# Objective

The `QueryLens` type is *basically* a `Query`, except it stores the `QueryState` itself rather than a reference to it. We can unify `Query` and `QueryLens` by allowing `Query` to hold either a reference or a value, which `Cow` provides. As a byproduct, we can also now also return `Query`s from `World::query`, rather than `QueryState`s.

## Solution

The following changes have been made:
- `QueryState` can now be `Clone`d (required by `Cow`)
    - All `WorldQuery::State` types are now required to be `Clone`.
- Functions on `Query` returning `'s` have been replaced with `'_`.
- The current `World::query`/`World::query_filtered` functions have been renamed to `World::query_state`/`World::query_state_filtered`.
- New `World::query`/`World::query_filtered` functions have been added that return `Query` instead of `QueryState`.
- New type conversions have been added:
    - `Query<D, F>::into_state(self) -> QueryState<D, F>` (clones the state if it was borrowed)
    - `QueryState<D, F>::as_query(&mut self, &mut World) -> Query<D, F>`
    - `QueryState<D, F>::as_readonly_query(&self, &World) -> Query<D::ReadOnly, F>`
    - `QueryState<D, F>::into_query(self, &mut World) -> Query<D, F>`
    - `QueryState<D, F>::into_readonly_query(self, &World) -> Query<D::ReadOnly, F>`
    - `QueryState<D, F>::into_readonly(self) -> QueryState<D::ReadOnly, F>`
        - Similar to `QueryState::as_readonly`, but by value instead of by reference.
- The `QueryLens` type has been removed. `Query` can function exactly like it.
    - `Query::transmute_lens_filtered(&mut self) -> QueryLens` changed to `Query::transmute_filtered(&mut self) -> Query`
    - `Query::transmute_lens(&mut self) -> QueryLens` changed to `Query::transmute(&mut self) -> Query`
    - `Query::join(&mut self, other: &mut Query) -> QueryLens` changed to `Query::join(&mut self, other: &mut Query) -> Query`
    - `Query::join_filtered(&mut self, other: &mut Query) -> QueryLens` changed to `Query::join_filtered(&mut self, other: &mut Query) -> Query`
- The state structs for `QueryData`/`QueryFilter` derives now `impl Clone`.

## Testing

- Current tests pass.
- TODO: change compile fail test for query lens.

---

## Showcase

TODO?

## Migration Guide

- `QueryLens` usages should be replaced with `Query`.
    - `Query::transmute_lens_filtered(&mut self) -> QueryLens` changed to `Query::transmute_filtered(&mut self) -> Query`
    - `Query::transmute_lens(&mut self) -> QueryLens` changed to `Query::transmute(&mut self) -> Query`
    - `Query::join(&mut self, other: &mut Query) -> QueryLens` changed to `Query::join(&mut self, other: &mut Query) -> Query`
    - `Query::join_filtered(&mut self, other: &mut Query) -> QueryLens` changed to `Query::join_filtered(&mut self, other: &mut Query) -> Query`
- All `WorldQuery::State` types are now required to implement `Clone`.
- The old `World::query` and `World::query_filtered` functions were renamed to `World::query_state` and `World::query_state_filtered`, respectively.
- `Query` functions returning data with a `'s` now return `'_`, i.e. the query state lifetime is now bound by the `Query` instance rather than the contained `QueryState`.