### PR TITLE
Fix `minimising` example minimizing every frame

### DIFF
--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -30,7 +30,7 @@ fn minimise_automatically(
     let mut window = windows.single_mut();
     window.set_minimized(true);
 
-    *done = true
+    *done = true;
 }
 
 /// A simple 3d scene, taken from the `3d_scene` example

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -21,16 +21,14 @@ fn main() {
 fn minimise_automatically(
     mut windows: Query<&mut Window>,
     frames: Res<FrameCount>,
-    mut done: Local<bool>,
 ) {
-    if *done || frames.0 < 60 {
+    if frames.0 != 60 {
         return;
     }
 
     let mut window = windows.single_mut();
     window.set_minimized(true);
 
-    *done = true;
 }
 
 /// A simple 3d scene, taken from the `3d_scene` example

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -18,17 +18,13 @@ fn main() {
         .run();
 }
 
-fn minimise_automatically(
-    mut windows: Query<&mut Window>,
-    frames: Res<FrameCount>,
-) {
+fn minimise_automatically(mut windows: Query<&mut Window>, frames: Res<FrameCount>) {
     if frames.0 != 60 {
         return;
     }
 
     let mut window = windows.single_mut();
     window.set_minimized(true);
-
 }
 
 /// A simple 3d scene, taken from the `3d_scene` example

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -1,6 +1,6 @@
 //! A test to confirm that `bevy` allows minimising the window
 //! This is run in CI to ensure that this doesn't regress again.
-use bevy::prelude::*;
+use bevy::{core::FrameCount, prelude::*};
 
 fn main() {
     // TODO: Combine this with `resizing` once multiple_windows is simpler than
@@ -18,13 +18,19 @@ fn main() {
         .run();
 }
 
-fn minimise_automatically(mut windows: Query<&mut Window>, mut frames: Local<u32>) {
-    if *frames == 60 {
-        let mut window = windows.single_mut();
-        window.set_minimized(true);
-    } else {
-        *frames += 1;
+fn minimise_automatically(
+    mut windows: Query<&mut Window>,
+    frames: Res<FrameCount>,
+    mut done: Local<bool>,
+) {
+    if *done || frames.0 < 60 {
+        return;
     }
+
+    let mut window = windows.single_mut();
+    window.set_minimized(true);
+
+    *done = true
 }
 
 /// A simple 3d scene, taken from the `3d_scene` example


### PR DESCRIPTION
# Objective

The `minimising` example is a bit annoying to run locally, because it attempts to minimize the window every frame, so un-minimizing it is difficult.

## Solution

Only minimize once.

The contents of the example can now be inspected, and the window easily closed after the minimization happens.

## Testing

`cargo run --example minimising`

I tested on macos only.
