### PR TITLE
Fix `println` in `morph_targets` example

### DIFF
--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -103,8 +103,10 @@ fn name_morphs(
     let Some(names) = mesh.morph_target_names() else {
         return;
     };
+
+    info!("Target names:");
     for name in names {
-        println!("  {name}");
+        info!("  {name}");
     }
     *has_printed = true;
 }


### PR DESCRIPTION
# Objective

This example uses `println` from a system, which we don't advise people do. It also gives no context for the debug prints, which I assumed to be stray debug code at first.

## Solution

Use `info!`, and add a small amount of context so the console output looks deliberate.

## Testing

`cargo run --example morph_targets`

