### PR TITLE
Fix `motion_blur` example instructions

### DIFF
--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -246,7 +246,7 @@ fn setup_ui(mut commands: Commands) {
             p.spawn(TextSpan::default());
             p.spawn(TextSpan::new("1/2: -/+ shutter angle (blur amount)\n"));
             p.spawn(TextSpan::new("3/4: -/+ sample count (blur quality)\n"));
-            p.spawn(TextSpan::new("3/4: -/+ sample count (blur quality)\n"));
+            p.spawn(TextSpan::new("Spacebar: cycle camera\n"));
         });
 }
 


### PR DESCRIPTION
# Objective

Fixes a mistake in the migration done in #15591.

## Solution

Restore a line of instructions that was accidentally dropped.

## Testing

`cargo run --example motion_blur`

Tested that instructions make sense and text updates correctly when keys are pressed.

