### PR TITLE
Fix panic in `gamepad_viewer` example when gamepad is connected

### DIFF
--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -465,7 +465,7 @@ fn update_connected(
         .collect::<Vec<_>>()
         .join("\n");
 
-    *writer.text(query.single(), 2) = if !formatted.is_empty() {
+    *writer.text(query.single(), 1) = if !formatted.is_empty() {
         formatted
     } else {
         "None".to_string()


### PR DESCRIPTION
# Objective

Fixes #15832

## Solution

It seems that this was just a transliteration mistake during #15591.

Update the correct text span index.

## Testing

I tested on macos with:

`cargo run --example gamepad_viewer`
- without gamepad connected
- with gamepad connected
- disconnecting and reconnecting gamepad while running
