### PR TITLE
Skip bloom rendering if HDR is disabled

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -127,6 +127,9 @@ impl ViewNode for BloomNode {
         ): QueryItem<Self::ViewQuery>,
         world: &World,
     ) -> Result<(), NodeRunError> {
+        if !camera.hdr {
+            return Ok(());
+        }
         if bloom_settings.intensity == 0.0 {
             return Ok(());
         }


### PR DESCRIPTION
# Objective

- Fix crash when toggling `camera.hdr` while having `Bloom` component, which can be reproduced with `transmission` example where you can toggle it with `H` key. https://github.com/bevyengine/bevy/issues/15570#issuecomment-2401696969
- `Bloom` component is conditionally extracted [here](https://github.com/bevyengine/bevy/blob/aa5e93d0bf67b4d979421ae548524736e9448383/crates/bevy_core_pipeline/src/bloom/settings.rs#L222-L230), so before retained rendering world the component existed in rendering world only when HDR is enabled.

## Solution

- Skip bloom rendering if `!camera.hdr`.

It seems that conditional extraction is no longer a valid pattern, because [`extract_component`](https://dev-docs.bevyengine.org/bevy/render/extract_component/trait.ExtractComponent.html#tymethod.extract_component) returning `None` will keep the previous value if it existed.

## Testing

- `transmission` example no longer crashes when toggling HDR