### PR TITLE
fix spatial audio examples

### DIFF
--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -3,6 +3,7 @@ use bevy::{
     audio::{AudioPlugin, SpatialScale},
     color::palettes::css::*,
     prelude::*,
+    time::Stopwatch,
 };
 
 /// Spatial audio uses the distance to attenuate the sound volume. In 2D with the default camera,
@@ -75,7 +76,7 @@ fn setup(
 
 #[derive(Component, Default)]
 struct Emitter {
-    stopped: bool,
+    stopwatch: Stopwatch,
 }
 
 fn update_emitters(
@@ -85,11 +86,17 @@ fn update_emitters(
 ) {
     for (mut emitter_transform, mut emitter) in emitters.iter_mut() {
         if keyboard.just_pressed(KeyCode::Space) {
-            emitter.stopped = !emitter.stopped;
+            if emitter.stopwatch.paused() {
+                emitter.stopwatch.unpause();
+            } else {
+                emitter.stopwatch.pause();
+            }
         }
 
-        if !emitter.stopped {
-            emitter_transform.translation.x = ops::sin(time.elapsed_seconds()) * 500.0;
+        emitter.stopwatch.tick(time.delta());
+
+        if !emitter.stopwatch.paused() {
+            emitter_transform.translation.x = ops::sin(emitter.stopwatch.elapsed_secs()) * 500.0;
         }
     }
 }

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -2,6 +2,7 @@
 use bevy::{
     color::palettes::basic::{BLUE, LIME, RED},
     prelude::*,
+    time::Stopwatch,
 };
 
 fn main() {
@@ -77,7 +78,7 @@ fn setup(
 
 #[derive(Component, Default)]
 struct Emitter {
-    stopped: bool,
+    stopwatch: Stopwatch,
 }
 
 fn update_positions(
@@ -87,12 +88,18 @@ fn update_positions(
 ) {
     for (mut emitter_transform, mut emitter) in emitters.iter_mut() {
         if keyboard.just_pressed(KeyCode::Space) {
-            emitter.stopped = !emitter.stopped;
+            if emitter.stopwatch.paused() {
+                emitter.stopwatch.unpause();
+            } else {
+                emitter.stopwatch.pause();
+            }
         }
 
-        if !emitter.stopped {
-            emitter_transform.translation.x = ops::sin(time.elapsed_seconds()) * 3.0;
-            emitter_transform.translation.z = ops::cos(time.elapsed_seconds()) * 3.0;
+        emitter.stopwatch.tick(time.delta());
+
+        if !emitter.stopwatch.paused() {
+            emitter_transform.translation.x = ops::sin(emitter.stopwatch.elapsed_secs()) * 3.0;
+            emitter_transform.translation.z = ops::cos(emitter.stopwatch.elapsed_secs()) * 3.0;
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #15837 

## Solution

- Change `Emitter` components to use `Stopwatch` to allow the time to be tracked independently.

## Testing

- Changes were tested. 
- Run either the `spatial_audio_2d` or `spatial_audio_3d` example to test
