### PR TITLE
examples(shaders/glsl): Update GLSL Shader Example Camera View uniform

### DIFF
--- a/assets/shaders/custom_material.vert
+++ b/assets/shaders/custom_material.vert
@@ -7,14 +7,19 @@ layout(location = 2) in vec2 Vertex_Uv;
 layout(location = 0) out vec2 v_Uv;
 
 layout(set = 0, binding = 0) uniform CameraViewProj {
-    mat4 ViewProj;
-    mat4 View;
-    mat4 InverseView;
-    mat4 Projection;
-    vec3 WorldPosition;
-    float width;
-    float height;
-};
+    mat4 clip_from_world;
+    mat4 unjittered_clip_from_world;
+    mat4 world_from_clip;
+    mat4 world_from_view;
+    mat4 view_from_world;
+    mat4 clip_from_view;
+    mat4 view_from_clip;
+    vec3 world_position; // Camera's world position
+    float exposure;
+    vec4 viewport; // viewport(x_origin, y_origin, width, height)
+    vec4 frustum[6];
+    // See full definition in: crates/bevy_render/src/view/view.wgsl
+} camera_view;
 
 struct Mesh {
     mat3x4 Model;
@@ -41,7 +46,7 @@ mat4 affine_to_square(mat3x4 affine) {
 
 void main() {
     v_Uv = Vertex_Uv;
-    gl_Position = ViewProj
+    gl_Position = camera_view.clip_from_world
         * affine_to_square(Meshes[gl_InstanceIndex].Model)
         * vec4(Vertex_Position, 1.0);
 }

--- a/assets/shaders/custom_material.vert
+++ b/assets/shaders/custom_material.vert
@@ -8,17 +8,14 @@ layout(location = 0) out vec2 v_Uv;
 
 layout(set = 0, binding = 0) uniform CameraViewProj {
     mat4 clip_from_world;
-    mat4 unjittered_clip_from_world;
-    mat4 world_from_clip;
-    mat4 world_from_view;
-    mat4 view_from_world;
-    mat4 clip_from_view;
-    mat4 view_from_clip;
-    vec3 world_position; // Camera's world position
-    float exposure;
-    vec4 viewport; // viewport(x_origin, y_origin, width, height)
-    vec4 frustum[6];
+    // Other attributes exist that can be described here.
     // See full definition in: crates/bevy_render/src/view/view.wgsl
+    // Attributes added here must be in the same order as they are defined
+    // in view.wgsl, and they must be contiguous starting from the top to
+    // ensure they have the same layout.
+    //
+    // Needing to maintain this mapping yourself is one of the harder parts of using
+    // GLSL with Bevy. WGSL provides a much better user experience! 
 } camera_view;
 
 struct Mesh {


### PR DESCRIPTION
# Objective
The Custom Material GLSL shader example has an old version of the camera view uniform structure. 
This PR updates the example GLSL custom material shader to have the latest structure. 


## Solution

I was running into issues using the camera world position (it wasn't changing) and someone in discord pointed me to the source of truth.
  `crates/bevy_render/src/view/view.wgsl`

After using this latest uniform structure in my project I'm now able to work with the camera position in my shader.

## Testing
I tested this change by running the example with:
```bash
cargo run --features shader_format_glsl --example shader_material_glsl
```
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/39fc82ec-ff3b-4864-ad73-05f3a25db483">
