### PR TITLE
Remove a `dbg!` statement left over from debugging

### DIFF
--- a/crates/bevy_remote/src/http.rs
+++ b/crates/bevy_remote/src/http.rs
@@ -430,7 +430,7 @@ impl Body for BrpStream {
     }
 
     fn is_end_stream(&self) -> bool {
-        dbg!(self.rx.is_closed())
+        self.rx.is_closed()
     }
 }
 


### PR DESCRIPTION
I wonder who left that there...