### PR TITLE
`spirv_shader_passthrough` must enable `wgpu/spirv`

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -22,7 +22,7 @@ shader_format_glsl = ["naga/glsl-in", "naga/wgsl-out", "naga_oil/glsl"]
 shader_format_spirv = ["wgpu/spirv", "naga/spv-in", "naga/spv-out"]
 
 # Enable SPIR-V shader passthrough
-spirv_shader_passthrough = ["shader_format_spirv"]
+spirv_shader_passthrough = ["wgpu/spirv"]
 
 trace = ["profiling"]
 tracing-tracy = []

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -22,7 +22,7 @@ shader_format_glsl = ["naga/glsl-in", "naga/wgsl-out", "naga_oil/glsl"]
 shader_format_spirv = ["wgpu/spirv", "naga/spv-in", "naga/spv-out"]
 
 # Enable SPIR-V shader passthrough
-spirv_shader_passthrough = []
+spirv_shader_passthrough = ["shader_format_spirv"]
 
 trace = ["profiling"]
 tracing-tracy = []


### PR DESCRIPTION
# Objective

Fixes #15515

## Solution

I went for the simplest solution because "format" in `shader_format_spirv` didn't sound directly related.

## Testing

The command `cargo b -p bevy --no-default-features -F spirv_shader_passthrough,x11` failed before, but works now.