### PR TITLE
Time<Real> documentation improvement

### DIFF
--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -13,6 +13,12 @@ use crate::time::Time;
 /// [`TimePlugin`](crate::TimePlugin) and updated with time instants according
 /// to [`TimeUpdateStrategy`](crate::TimeUpdateStrategy).
 ///
+/// Note:
+/// Using [`TimeUpdateStrategy::ManualDuration`](crate::TimeUpdateStrategy::ManualDuration)
+/// allows for mocking the wall clock for testing purposes.
+/// Besides this use case, it is not recommended to do this, as it will no longer
+/// represent "wall clock" time as intended.
+///
 /// The [`delta()`](Time::delta) and [`elapsed()`](Time::elapsed) values of this
 /// clock should be used for anything which deals specifically with real time
 /// (wall clock time). It will not be affected by relative game speed

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -37,7 +37,7 @@ use crate::time::Time;
 /// [`last_update()`](Time::last_update) are recorded and accessible.
 ///
 /// [^disclaimer]: When using [`TimeUpdateStrategy::ManualDuration`](crate::TimeUpdateStrategy::ManualDuration),
-///     `Time<Real>` is only a *mock* of wall clock time.
+///     [`Time<Real>#impl-Time<Real>`] is only a *mock* of wall clock time.
 ///
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -11,7 +11,7 @@ use crate::time::Time;
 ///
 /// It is automatically inserted as a resource by
 /// [`TimePlugin`](crate::TimePlugin) and updated with time instants according
-/// to [`TimeUpdateStrategy`](crate::TimeUpdateStrategy).
+/// to [`TimeUpdateStrategy`](crate::TimeUpdateStrategy).[^disclaimer]
 ///
 /// Note:
 /// Using [`TimeUpdateStrategy::ManualDuration`](crate::TimeUpdateStrategy::ManualDuration)
@@ -22,7 +22,7 @@ use crate::time::Time;
 /// The [`delta()`](Time::delta) and [`elapsed()`](Time::elapsed) values of this
 /// clock should be used for anything which deals specifically with real time
 /// (wall clock time). It will not be affected by relative game speed
-/// adjustments, pausing or other adjustments.
+/// adjustments, pausing or other adjustments.[^disclaimer]
 ///
 /// The clock does not count time from [`startup()`](Time::startup) to
 /// [`first_update()`](Time::first_update()) into elapsed, but instead will
@@ -35,6 +35,10 @@ use crate::time::Time;
 /// [`Instant`]s for [`startup()`](Time::startup),
 /// [`first_update()`](Time::first_update) and
 /// [`last_update()`](Time::last_update) are recorded and accessible.
+///
+/// [^disclaimer]: When using [`TimeUpdateStrategy::ManualDuration`](crate::TimeUpdateStrategy::ManualDuration),
+///     `Time<Real>` is only a *mock* of wall clock time.
+///
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct Real {

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -32,7 +32,7 @@ use crate::time::Time;
 /// zero must be handled without errors in application logic, as it may
 /// theoretically also happen at other times.
 ///
-/// [`std::time::Instant`]s for [`startup()`](Time::startup),
+/// [`Instant`]s for [`startup()`](Time::startup),
 /// [`first_update()`](Time::first_update) and
 /// [`last_update()`](Time::last_update) are recorded and accessible.
 ///

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -32,7 +32,7 @@ use crate::time::Time;
 /// zero must be handled without errors in application logic, as it may
 /// theoretically also happen at other times.
 ///
-/// [`Instant`]s for [`startup()`](Time::startup),
+/// [`std::time::Instant`]s for [`startup()`](Time::startup),
 /// [`first_update()`](Time::first_update) and
 /// [`last_update()`](Time::last_update) are recorded and accessible.
 ///


### PR DESCRIPTION
# Objective

Fixes #15445

## Solution

Add a note to the doc comment for `Real`.

## Testing

Viewed the built documentation.


## Showcase

![image](https://github.com/user-attachments/assets/815b8655-c632-4c92-b64e-28c06959c38b)
[*possible bug in rustdoc rendering the footnote](https://github.com/rust-lang/rust/issues/131631)
