### PR TITLE
Make `tracing` Optional for `bevy_utils`

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -9,15 +9,17 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["std", "serde"]
+default = ["std", "serde", "tracing"]
 std = [
   "alloc",
-  "tracing/std",
+  "log/std",
   "ahash/std",
   "dep:thread_local",
   "ahash/runtime-rng",
+  "tracing?/std",
 ]
 alloc = ["hashbrown/default"]
+tracing = ["dep:tracing"]
 detailed_trace = []
 serde = ["hashbrown/serde"]
 
@@ -25,7 +27,8 @@ serde = ["hashbrown/serde"]
 ahash = { version = "0.8.7", default-features = false, features = [
   "compile-time-rng",
 ] }
-tracing = { version = "0.1", default-features = false }
+log = { version = "0.4", default-features = false }
+tracing = { version = "0.1", default-features = false, optional = true }
 hashbrown = { version = "0.14.2", default-features = false }
 bevy_utils_proc_macros = { version = "0.15.0-dev", path = "macros" }
 thread_local = { version = "1.0", optional = true }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -39,13 +39,15 @@ pub use ahash::{AHasher, RandomState};
 pub use bevy_utils_proc_macros::*;
 pub use default::default;
 pub use hashbrown;
-pub use log;
 #[cfg(feature = "std")]
 pub use parallel_queue::*;
 pub use time::*;
 
 #[cfg(feature = "tracing")]
 pub use tracing;
+
+#[cfg(not(feature = "tracing"))]
+pub use log as tracing;
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
@@ -386,36 +388,36 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
     }
 }
 
-/// Calls the [`log::info!`] macro on a value.
+/// Calls the [`tracing::info!`] macro on a value.
 pub fn info<T: Debug>(data: T) {
-    log::info!("{:?}", data);
+    tracing::info!("{:?}", data);
 }
 
-/// Calls the [`log::debug!`] macro on a value.
+/// Calls the [`tracing::debug!`] macro on a value.
 pub fn dbg<T: Debug>(data: T) {
-    log::debug!("{:?}", data);
+    tracing::debug!("{:?}", data);
 }
 
-/// Processes a [`Result`] by calling the [`log::warn!`] macro in case of an [`Err`] value.
+/// Processes a [`Result`] by calling the [`tracing::warn!`] macro in case of an [`Err`] value.
 pub fn warn<E: Debug>(result: Result<(), E>) {
     if let Err(warn) = result {
-        log::warn!("{:?}", warn);
+        tracing::warn!("{:?}", warn);
     }
 }
 
-/// Processes a [`Result`] by calling the [`log::error!`] macro in case of an [`Err`] value.
+/// Processes a [`Result`] by calling the [`tracing::error!`] macro in case of an [`Err`] value.
 pub fn error<E: Debug>(result: Result<(), E>) {
     if let Err(error) = result {
-        log::error!("{:?}", error);
+        tracing::error!("{:?}", error);
     }
 }
 
-/// Like [`log::trace`], but conditional on cargo feature `detailed_trace`.
+/// Like [`tracing::trace`], but conditional on cargo feature `detailed_trace`.
 #[macro_export]
 macro_rules! detailed_trace {
     ($($tts:tt)*) => {
         if cfg!(detailed_trace) {
-            $crate::log::trace!($($tts)*);
+            $crate::tracing::trace!($($tts)*);
         }
     }
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -39,9 +39,12 @@ pub use ahash::{AHasher, RandomState};
 pub use bevy_utils_proc_macros::*;
 pub use default::default;
 pub use hashbrown;
+pub use log;
 #[cfg(feature = "std")]
 pub use parallel_queue::*;
 pub use time::*;
+
+#[cfg(feature = "tracing")]
 pub use tracing;
 
 #[cfg(feature = "alloc")]
@@ -383,36 +386,36 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
     }
 }
 
-/// Calls the [`tracing::info!`] macro on a value.
+/// Calls the [`log::info!`] macro on a value.
 pub fn info<T: Debug>(data: T) {
-    tracing::info!("{:?}", data);
+    log::info!("{:?}", data);
 }
 
-/// Calls the [`tracing::debug!`] macro on a value.
+/// Calls the [`log::debug!`] macro on a value.
 pub fn dbg<T: Debug>(data: T) {
-    tracing::debug!("{:?}", data);
+    log::debug!("{:?}", data);
 }
 
-/// Processes a [`Result`] by calling the [`tracing::warn!`] macro in case of an [`Err`] value.
+/// Processes a [`Result`] by calling the [`log::warn!`] macro in case of an [`Err`] value.
 pub fn warn<E: Debug>(result: Result<(), E>) {
     if let Err(warn) = result {
-        tracing::warn!("{:?}", warn);
+        log::warn!("{:?}", warn);
     }
 }
 
-/// Processes a [`Result`] by calling the [`tracing::error!`] macro in case of an [`Err`] value.
+/// Processes a [`Result`] by calling the [`log::error!`] macro in case of an [`Err`] value.
 pub fn error<E: Debug>(result: Result<(), E>) {
     if let Err(error) = result {
-        tracing::error!("{:?}", error);
+        log::error!("{:?}", error);
     }
 }
 
-/// Like [`tracing::trace`], but conditional on cargo feature `detailed_trace`.
+/// Like [`log::trace`], but conditional on cargo feature `detailed_trace`.
 #[macro_export]
 macro_rules! detailed_trace {
     ($($tts:tt)*) => {
         if cfg!(detailed_trace) {
-            $crate::tracing::trace!($($tts)*);
+            $crate::log::trace!($($tts)*);
         }
     }
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -47,6 +47,9 @@ pub use time::*;
 pub use tracing;
 
 #[cfg(not(feature = "tracing"))]
+// In cases where the tracing crate cannot be used, we can instead rely on log to
+// provide most of the required functionality.
+// Exporting log as tracing allows this decision to have minimal impact on consumers.
 pub use log as tracing;
 
 #[cfg(feature = "alloc")]

--- a/crates/bevy_utils/src/once.rs
+++ b/crates/bevy_utils/src/once.rs
@@ -11,52 +11,52 @@ macro_rules! once {
     }};
 }
 
-/// Call [`trace!`](crate::log::trace) once per call site.
+/// Call [`trace!`](crate::tracing::trace) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::log::trace!($($arg)+))
+        $crate::once!($crate::tracing::trace!($($arg)+))
     });
 }
 
-/// Call [`debug!`](crate::log::debug) once per call site.
+/// Call [`debug!`](crate::tracing::debug) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::log::debug!($($arg)+))
+        $crate::once!($crate::tracing::debug!($($arg)+))
     });
 }
 
-/// Call [`info!`](crate::log::info) once per call site.
+/// Call [`info!`](crate::tracing::info) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::log::info!($($arg)+))
+        $crate::once!($crate::tracing::info!($($arg)+))
     });
 }
 
-/// Call [`warn!`](crate::log::warn) once per call site.
+/// Call [`warn!`](crate::tracing::warn) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::log::warn!($($arg)+))
+        $crate::once!($crate::tracing::warn!($($arg)+))
     });
 }
 
-/// Call [`error!`](crate::log::error) once per call site.
+/// Call [`error!`](crate::tracing::error) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::log::error!($($arg)+))
+        $crate::once!($crate::tracing::error!($($arg)+))
     });
 }

--- a/crates/bevy_utils/src/once.rs
+++ b/crates/bevy_utils/src/once.rs
@@ -11,52 +11,52 @@ macro_rules! once {
     }};
 }
 
-/// Call [`trace!`](crate::tracing::trace) once per call site.
+/// Call [`trace!`](crate::log::trace) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::tracing::trace!($($arg)+))
+        $crate::once!($crate::log::trace!($($arg)+))
     });
 }
 
-/// Call [`debug!`](crate::tracing::debug) once per call site.
+/// Call [`debug!`](crate::log::debug) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::tracing::debug!($($arg)+))
+        $crate::once!($crate::log::debug!($($arg)+))
     });
 }
 
-/// Call [`info!`](crate::tracing::info) once per call site.
+/// Call [`info!`](crate::log::info) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::tracing::info!($($arg)+))
+        $crate::once!($crate::log::info!($($arg)+))
     });
 }
 
-/// Call [`warn!`](crate::tracing::warn) once per call site.
+/// Call [`warn!`](crate::log::warn) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::tracing::warn!($($arg)+))
+        $crate::once!($crate::log::warn!($($arg)+))
     });
 }
 
-/// Call [`error!`](crate::tracing::error) once per call site.
+/// Call [`error!`](crate::log::error) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::tracing::error!($($arg)+))
+        $crate::once!($crate::log::error!($($arg)+))
     });
 }


### PR DESCRIPTION
# Objective

- Allows `bevy_utils` to compile on platforms without atomic CAS operations (e.g., GameBoy Advance `thumbv4t-none-eabi`)
- Contributes to #15460 

## Solution

- Made `tracing` optional (behind the `tracing` feature, enabled by default).
- Switched to using `log` within `bevy_utils`, and exported it as `tracing`.

## Testing

- `cargo build --target thumbv4t-none-eabi`

## Migration Guide

If you were using `bevy_utils` with default features disabled, and you relied on the `tracing` re-export, and you relied on a `tracing` item that is _not_ available in `log`, enable the `tracing` feature.

## Notes

`tracing` has built-in support for capturing logs from `log` and this is enabled by default. The biggest loss going from `log` to `tracing` is the loss of `info_span`/etc. Otherwise, the crates are largely identical in behaviour, with `log` having no dependencies and more popularity on crates.io. 
