### PR TITLE
use previous ubuntu version for example validation

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -181,7 +181,7 @@ jobs:
 
   run-examples-on-wasm:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -79,7 +79,7 @@ jobs:
 
   run-examples-linux-vulkan:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Objective

- Example validation job fails in CI
- This happened after GitHub updated the latest version of ubuntu from the 22.04 to the 24.04
- The package libegl1-mesa is not available on ubuntu 24.04

## Solution

- Keep using ubuntu 22.04
- This is a temp fix and we should fix the update

## Testing

- if it can get merged then it works 🤷 