### PR TITLE
Alternative fix for `mesh2d_manual` example

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -11,7 +11,7 @@ use bevy::{
     math::{ops, FloatOrd},
     prelude::*,
     render::{
-        mesh::{Indices, RenderMesh},
+        mesh::{Indices, MeshVertexAttribute, RenderMesh},
         render_asset::{RenderAssetUsages, RenderAssets},
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline,
@@ -84,10 +84,14 @@ fn star(
     }
     // Set the position attribute
     star.insert_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);
-    // And a RGB color attribute as well
-    let mut v_color: Vec<[f32; 4]> = vec![LinearRgba::BLACK.to_f32_array()];
-    v_color.extend_from_slice(&[LinearRgba::from(YELLOW).to_f32_array(); 10]);
-    star.insert_attribute(Mesh::ATTRIBUTE_COLOR, v_color);
+    // And a RGB color attribute as well. A built-in `Mesh::ATTRIBUTE_COLOR` exists, but we
+    // use a custom vertex attribute here for demonstration purposes.
+    let mut v_color: Vec<u32> = vec![LinearRgba::BLACK.as_u32()];
+    v_color.extend_from_slice(&[LinearRgba::from(YELLOW).as_u32(); 10]);
+    star.insert_attribute(
+        MeshVertexAttribute::new("Vertex_Color", 1, VertexFormat::Uint32),
+        v_color,
+    );
 
     // Now, we specify the indices of the vertex that are going to compose the
     // triangles in our star. Vertices in triangles have to be specified in CCW


### PR DESCRIPTION
# Objective

Fixes #15847

Alternative to #15862. Would appreciate a rendering person signaling preference for one or the other.

## Solution

Partially revert the changes made to this example in #15524.

Add comment explaining that the non-usage of the built-in color vertex attribute is intentional.

## Testing

`cargo run --example mesh2d_manual`

