### PR TITLE
bevy_winit(emit raw winit events)

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -19,7 +19,7 @@ use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_window::{RawHandleWrapperHolder, WindowEvent};
 use core::marker::PhantomData;
-use winit::event_loop::EventLoop;
+use winit::{event_loop::EventLoop, window::WindowId};
 
 use bevy_a11y::AccessibilityRequested;
 use bevy_app::{App, Last, Plugin};
@@ -122,6 +122,7 @@ impl<T: Event> Plugin for WinitPlugin<T> {
         app.init_non_send_resource::<WinitWindows>()
             .init_resource::<WinitMonitors>()
             .init_resource::<WinitSettings>()
+            .add_event::<RawWinitWindowEvent>()
             .set_runner(winit_runner::<T>)
             .add_systems(
                 Last,
@@ -154,6 +155,21 @@ impl<T: Event> Plugin for WinitPlugin<T> {
 #[derive(Debug, Default, Clone, Copy, Event, Reflect)]
 #[reflect(Debug, Default)]
 pub struct WakeUp;
+
+/// The original window event as produced by winit. This is meant as an escape
+/// hatch for power users that wish add custom winit integrations.
+/// If you want to process events for your app or game, you should instead use
+/// `bevy::window::WindowEvent`, or one of its sub-events.
+///
+/// When you receive this event it has already been handled by Bevy's main loop.
+/// Sending these events will NOT cause them to be processed by Bevy.
+#[derive(Debug, Clone, Event)]
+pub struct RawWinitWindowEvent {
+    /// The window for which the event was fired.
+    pub window_id: WindowId,
+    /// The raw winit window event.
+    pub event: winit::event::WindowEvent,
+}
 
 /// A wrapper type around [`winit::event_loop::EventLoopProxy`] with the specific
 /// [`winit::event::Event::UserEvent`] used in the [`WinitPlugin`].

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -156,8 +156,8 @@ impl<T: Event> Plugin for WinitPlugin<T> {
 #[reflect(Debug, Default)]
 pub struct WakeUp;
 
-/// The original window event as produced by winit. This is meant as an escape
-/// hatch for power users that wish add custom winit integrations.
+/// The original window event as produced by Winit. This is meant as an escape
+/// hatch for power users that wish add custom Winit integrations.
 /// If you want to process events for your app or game, you should instead use
 /// `bevy::window::WindowEvent`, or one of its sub-events.
 ///

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -157,7 +157,7 @@ impl<T: Event> Plugin for WinitPlugin<T> {
 pub struct WakeUp;
 
 /// The original window event as produced by Winit. This is meant as an escape
-/// hatch for power users that wish add custom Winit integrations.
+/// hatch for power users that wish to add custom Winit integrations.
 /// If you want to process events for your app or game, you should instead use
 /// `bevy::window::WindowEvent`, or one of its sub-events.
 ///


### PR DESCRIPTION
# Objective

- Exposes raw winit events making Bevy even more modular and powerful for custom plugin developers (e.g. a custom render plugin).

XRef: https://github.com/bevyengine/bevy/issues/5977
It doesn't quite close the issue as sending events is not supported (or not very useful to be precise). I would think that supporting that requires some extra considerations by someone a bit more familiar with the `bevy_winit` crate. That said, this PR could be a nice step forward.

## Solution

Emit `RawWinitWindowEvent` objects for each received event.

## Testing

I verified that the events are emitted using a basic test app. I don't think it makes sense to solidify this behavior in one of the examples.

---

## Showcase

My example usage for a custom `egui_winit` integration:

```rust
for ev in winit_events.read() {
    if ev.window_id == window.id {
        let _ = egui_winit.on_window_event(&window, &ev.event);
    }
}
```