### PR TITLE
Meshlet builder improvements redux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1209,7 +1209,7 @@ setup = [
     "curl",
     "-o",
     "assets/models/bunny.meshlet_mesh",
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/8443bbdee0bf517e6c297dede7f6a46ab712ee4c/bunny.meshlet_mesh",
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/167cdaf0b08f89fb747b83b94c27755f116cd408/bunny.meshlet_mesh",
   ],
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1209,7 +1209,7 @@ setup = [
     "curl",
     "-o",
     "assets/models/bunny.meshlet_mesh",
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/167cdaf0b08f89fb747b83b94c27755f116cd408/bunny.meshlet_mesh",
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/8483db58832542383820c3f44e4730e566910be7/bunny.meshlet_mesh",
   ],
 ]
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -18,7 +18,7 @@ shader_format_glsl = ["bevy_render/shader_format_glsl"]
 trace = ["bevy_render/trace"]
 ios_simulator = ["bevy_render/ios_simulator"]
 # Enables the meshlet renderer for dense high-poly scenes (experimental)
-meshlet = ["dep:lz4_flex", "dep:range-alloc", "dep:bevy_tasks"]
+meshlet = ["dep:lz4_flex", "dep:range-alloc", "dep:half", "dep:bevy_tasks"]
 # Enables processing meshes into meshlet meshes
 meshlet_processor = [
   "meshlet",
@@ -50,16 +50,17 @@ bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 # other
 bitflags = "2.3"
 fixedbitset = "0.5"
-# meshlet
-lz4_flex = { version = "0.11", default-features = false, features = [
-  "frame",
-], optional = true }
 derive_more = { version = "1", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
+# meshlet
+lz4_flex = { version = "0.11", default-features = false, features = [
+  "frame",
+], optional = true }
 range-alloc = { version = "0.1.3", optional = true }
+half = { version = "2", features = ["bytemuck"], optional = true }
 meshopt = { version = "0.3.0", optional = true }
 metis = { version = "0.2", optional = true }
 itertools = { version = "0.13", optional = true }

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -95,9 +95,9 @@ pub struct MeshletBoundingSpheres {
     /// Bounding sphere used for frustum and occlusion culling for this meshlet.
     pub culling_sphere: MeshletBoundingSphere,
     /// Bounding sphere used for determining if this meshlet's group is at the correct level of detail for a given view.
-    pub group_lod_sphere: MeshletBoundingSphere,
+    pub lod_group_sphere: MeshletBoundingSphere,
     /// Bounding sphere used for determining if this meshlet's parent group is at the correct level of detail for a given view.
-    pub parent_group_lod_sphere: MeshletBoundingSphere,
+    pub lod_parent_group_sphere: MeshletBoundingSphere,
 }
 
 /// A spherical bounding volume used for a [`Meshlet`].

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -9,6 +9,7 @@ use bevy_reflect::TypePath;
 use bevy_tasks::block_on;
 use bytemuck::{Pod, Zeroable};
 use derive_more::derive::{Display, Error, From};
+use half::f16;
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use std::io::{Read, Write};
 
@@ -51,7 +52,7 @@ pub struct MeshletMesh {
     pub(crate) meshlets: Arc<[Meshlet]>,
     /// Spherical bounding volumes.
     pub(crate) meshlet_bounding_spheres: Arc<[MeshletBoundingSpheres]>,
-    /// Meshlet simplification errors.
+    /// Meshlet group and parent group simplification errors.
     pub(crate) meshlet_simplification_errors: Arc<[MeshletSimplificationError]>,
 }
 
@@ -109,14 +110,13 @@ pub struct MeshletBoundingSphere {
 }
 
 /// Simplification error used for choosing level of detail for a [`Meshlet`].
-// TODO: pack2x16float
 #[derive(Copy, Clone, Pod, Zeroable)]
 #[repr(C)]
 pub struct MeshletSimplificationError {
     /// Simplification error used for determining if this meshlet's group is at the correct level of detail for a given view.
-    pub group_error: f32,
+    pub group_error: f16,
     /// Simplification error used for determining if this meshlet's parent group is at the correct level of detail for a given view.
-    pub parent_group_error: f32,
+    pub parent_group_error: f16,
 }
 
 /// An [`AssetSaver`] for `.meshlet_mesh` [`MeshletMesh`] assets.

--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
@@ -64,8 +64,9 @@ fn cull_clusters(
 
     // Check LOD cut (cluster group error imperceptible, and parent group error not imperceptible)
     let simplification_errors = unpack2x16float(meshlet_simplification_errors[meshlet_id]);
-    if !lod_error_is_imperceptible(bounding_spheres.lod_group_sphere, simplification_errors.x, world_from_local, world_scale) { return; }
-    if lod_error_is_imperceptible(bounding_spheres.lod_parent_group_sphere, simplification_errors.y, world_from_local, world_scale) { return; }
+    let lod_is_ok = lod_error_is_imperceptible(bounding_spheres.lod_group_sphere, simplification_errors.x, world_from_local, world_scale);
+    let parent_lod_is_ok = lod_error_is_imperceptible(bounding_spheres.lod_parent_group_sphere, simplification_errors.y, world_from_local, world_scale);
+    if !lod_is_ok || parent_lod_is_ok { return; }
 #endif
 
     // Project the culling bounding sphere to view-space for occlusion culling

--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
@@ -141,7 +141,6 @@ fn cull_clusters(
     meshlet_raster_clusters[buffer_slot] = cluster_id;
 }
 
-// TODO: This doesn't account for perspective and other edge cases as well as Nanite does
 // https://github.com/zeux/meshoptimizer/blob/1e48e96c7e8059321de492865165e9ef071bffba/demo/nanite.cpp#L115
 fn lod_error_is_imperceptible(lod_sphere: MeshletBoundingSphere, simplification_error: f32, world_from_local: mat4x4<f32>, world_scale: f32) -> bool {
     let sphere_world_space = (world_from_local * vec4(lod_sphere.center, 1.0)).xyz;

--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
@@ -152,14 +152,12 @@ fn lod_error_is_imperceptible(lod_sphere: MeshletBoundingSphere, simplification_
         // Perspective
         let distance_to_closest_point_on_sphere = distance(sphere_world_space, view.world_position) - radius_world_space;
         let distance_to_closest_point_on_sphere_clamped_to_znear = max(distance_to_closest_point_on_sphere, view.clip_from_view[3][2]);
-        projected_error *= view.clip_from_view[1][1] / distance_to_closest_point_on_sphere_clamped_to_znear;
-    } else {
-        // Orthographic
-        projected_error *= view.clip_from_view[1][1] * 0.5;
+        projected_error /= distance_to_closest_point_on_sphere_clamped_to_znear;
     }
+    projected_error *= view.clip_from_view[1][1] * 0.5;
     projected_error *= view.viewport.w;
 
-    return projected_error < 0.5;
+    return projected_error < 1.0;
 }
 
 // https://zeux.io/2023/01/12/approximate-projected-bounds

--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
@@ -63,9 +63,9 @@ fn cull_clusters(
     }
 
     // Check LOD cut (cluster group error imperceptible, and parent group error not imperceptible)
-    let simplification_errors = meshlet_simplification_errors[meshlet_id];
-    if !lod_error_is_imperceptible(bounding_spheres.lod_group_sphere, simplification_errors.group_error, world_from_local, world_scale) { return; }
-    if lod_error_is_imperceptible(bounding_spheres.lod_parent_group_sphere, simplification_errors.parent_group_error, world_from_local, world_scale) { return; }
+    let simplification_errors = unpack2x16float(meshlet_simplification_errors[meshlet_id]);
+    if !lod_error_is_imperceptible(bounding_spheres.lod_group_sphere, simplification_errors.x, world_from_local, world_scale) { return; }
+    if lod_error_is_imperceptible(bounding_spheres.lod_parent_group_sphere, simplification_errors.y, world_from_local, world_scale) { return; }
 #endif
 
     // Project the culling bounding sphere to view-space for occlusion culling

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -9,7 +9,7 @@ use bevy_render::{
 };
 use bevy_utils::HashMap;
 use bitvec::{order::Lsb0, vec::BitVec, view::BitView};
-use core::ops::Range;
+use core::{iter, ops::Range};
 use derive_more::derive::{Display, Error};
 use half::f16;
 use itertools::Itertools;
@@ -18,7 +18,6 @@ use meshopt::{
 };
 use metis::Graph;
 use smallvec::SmallVec;
-use std::iter;
 
 /// Default vertex position quantization factor for use with [`MeshletMesh::from_mesh`].
 ///

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -24,9 +24,12 @@ use smallvec::SmallVec;
 /// Snaps vertices to the nearest 1/16th of a centimeter (1/2^4).
 pub const DEFAULT_VERTEX_POSITION_QUANTIZATION_FACTOR: u8 = 4;
 
-const TARGET_MESHLETS_PER_GROUP: usize = 8;
 const MESHLET_VERTEX_SIZE_IN_BYTES: usize = 32;
 const CENTIMETERS_PER_METER: f32 = 100.0;
+
+const TARGET_MESHLETS_PER_GROUP: usize = 8;
+// Reject groups that keep at least 95% of their original triangles
+const SIMPLIFICATION_FAILURE_PERCENTAGE: f32 = 0.95;
 
 impl MeshletMesh {
     /// Process a [`Mesh`] to generate a [`MeshletMesh`].
@@ -325,8 +328,10 @@ fn simplify_meshlet_group(
         Some(&mut error),
     );
 
-    // Check if we were able to simplify at least a little (95% of the original triangle count)
-    if simplified_group_indices.len() as f32 / group_indices.len() as f32 > 0.95 {
+    // Check if we were able to simplify at least a little
+    if simplified_group_indices.len() as f32 / group_indices.len() as f32
+        > SIMPLIFICATION_FAILURE_PERCENTAGE
+    {
         return None;
     }
 

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -111,8 +111,8 @@ impl MeshletMesh {
                 &position_only_vertex_remap,
             );
 
-            // Group meshlets into roughly groups of 4, grouping meshlets with a high number of shared vertices
-            // http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf
+            // Group meshlets into roughly groups of size TARGET_MESHLETS_PER_GROUP,
+            // grouping meshlets with a high number of shared vertices
             let groups = group_meshlets(
                 simplification_queue.clone(),
                 &connected_meshlets_per_meshlet,
@@ -272,6 +272,7 @@ fn find_connected_meshlets(
     connected_meshlets
 }
 
+// METIS manual: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf
 fn group_meshlets(
     simplification_queue: Range<usize>,
     connected_meshlets_per_meshlet: &[Vec<(usize, usize)>],

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -9,7 +9,7 @@ use bevy_render::{
 };
 use bevy_utils::HashMap;
 use bitvec::{order::Lsb0, vec::BitVec, view::BitView};
-use core::{iter, ops::Range};
+use core::iter;
 use derive_more::derive::{Display, Error};
 use half::f16;
 use itertools::Itertools;
@@ -105,11 +105,12 @@ impl MeshletMesh {
         let mut vertex_locks = vec![0; vertices.vertex_count];
 
         // Build further LODs
-        let mut simplification_queue = 0..meshlets.len();
+        let mut simplification_queue = Vec::from_iter(0..meshlets.len());
+        let mut retry_queue = Vec::new();
         while simplification_queue.len() > 1 {
             // For each meshlet build a list of connected meshlets (meshlets that share a vertex)
             let connected_meshlets_per_meshlet = find_connected_meshlets(
-                simplification_queue.clone(),
+                &simplification_queue,
                 &meshlets,
                 &position_only_vertex_remap,
                 position_only_vertex_count as usize,
@@ -117,10 +118,7 @@ impl MeshletMesh {
 
             // Group meshlets into roughly groups of size TARGET_MESHLETS_PER_GROUP,
             // grouping meshlets with a high number of shared vertices
-            let groups = group_meshlets(
-                simplification_queue.clone(),
-                &connected_meshlets_per_meshlet,
-            );
+            let groups = group_meshlets(&connected_meshlets_per_meshlet, &simplification_queue);
 
             // Lock borders between groups to prevent cracks when simplifying
             lock_group_borders(
@@ -132,12 +130,19 @@ impl MeshletMesh {
             );
 
             let next_lod_start = meshlets.len();
+            for group_meshlets in groups.into_iter() {
+                // If the group only has a single meshlet, we can't simplify it well, so retry later
+                if group_meshlets.len() == 1 {
+                    retry_queue.push(group_meshlets[0]);
+                    continue;
+                }
 
-            for group_meshlets in groups.into_iter().filter(|group| group.len() > 1) {
                 // Simplify the group to ~50% triangle count
                 let Some((simplified_group_indices, mut group_error)) =
                     simplify_meshlet_group(&group_meshlets, &meshlets, &vertices, &vertex_locks)
                 else {
+                    // Couldn't simplify the group enough, retry its meshlets later
+                    retry_queue.extend_from_slice(&group_meshlets);
                     continue;
                 };
 
@@ -177,7 +182,12 @@ impl MeshletMesh {
                 );
             }
 
-            simplification_queue = next_lod_start..meshlets.len();
+            // Set simplification queue to the list of newly created (and retrying) meshlets
+            simplification_queue.clear();
+            simplification_queue.extend(next_lod_start..meshlets.len());
+            if !simplification_queue.is_empty() {
+                simplification_queue.extend(retry_queue.drain(..));
+            }
         }
 
         // Copy vertex attributes per meshlet and compress
@@ -237,22 +247,22 @@ fn compute_meshlets(indices: &[u32], vertices: &VertexDataAdapter) -> Meshlets {
 }
 
 fn find_connected_meshlets(
-    simplification_queue: Range<usize>,
+    simplification_queue: &[usize],
     meshlets: &Meshlets,
     position_only_vertex_remap: &[u32],
     position_only_vertex_count: usize,
 ) -> Vec<Vec<(usize, usize)>> {
     // For each vertex, build a list of all meshlets that use it
     let mut vertices_to_meshlets = vec![Vec::new(); position_only_vertex_count];
-    for meshlet_id in simplification_queue.clone() {
-        let meshlet = meshlets.get(meshlet_id);
+    for (meshlet_queue_id, meshlet_id) in simplification_queue.iter().enumerate() {
+        let meshlet = meshlets.get(*meshlet_id);
         for index in meshlet.triangles {
             let vertex_id = position_only_vertex_remap[meshlet.vertices[*index as usize] as usize];
             let vertex_to_meshlets = &mut vertices_to_meshlets[vertex_id as usize];
             // Meshlets are added in order, so we can just check the last element to deduplicate,
             // in the case of two triangles sharing the same vertex within a single meshlet
-            if vertex_to_meshlets.last() != Some(&meshlet_id) {
-                vertex_to_meshlets.push(meshlet_id);
+            if vertex_to_meshlets.last() != Some(&meshlet_queue_id) {
+                vertex_to_meshlets.push(meshlet_queue_id);
             }
         }
     }
@@ -260,9 +270,14 @@ fn find_connected_meshlets(
     // For each meshlet pair, count how many vertices they share
     let mut meshlet_pair_to_shared_vertex_count = HashMap::new();
     for vertex_meshlet_ids in vertices_to_meshlets {
-        for (meshlet_id1, meshlet_id2) in vertex_meshlet_ids.into_iter().tuple_combinations() {
+        for (meshlet_queue_id1, meshlet_queue_id2) in
+            vertex_meshlet_ids.into_iter().tuple_combinations()
+        {
             let count = meshlet_pair_to_shared_vertex_count
-                .entry((meshlet_id1.min(meshlet_id2), meshlet_id1.max(meshlet_id2)))
+                .entry((
+                    meshlet_queue_id1.min(meshlet_queue_id2),
+                    meshlet_queue_id1.max(meshlet_queue_id2),
+                ))
                 .or_insert(0);
             *count += 1;
         }
@@ -270,12 +285,12 @@ fn find_connected_meshlets(
 
     // For each meshlet, gather all other meshlets that share at least one vertex along with their shared vertex count
     let mut connected_meshlets = vec![Vec::new(); simplification_queue.len()];
-    for ((meshlet_id1, meshlet_id2), shared_count) in meshlet_pair_to_shared_vertex_count {
+    for ((meshlet_queue_id1, meshlet_queue_id2), shared_count) in
+        meshlet_pair_to_shared_vertex_count
+    {
         // We record both id1->id2 and id2->id1 as adjacency is symmetrical
-        connected_meshlets[meshlet_id1 - simplification_queue.start]
-            .push((meshlet_id2, shared_count));
-        connected_meshlets[meshlet_id2 - simplification_queue.start]
-            .push((meshlet_id1, shared_count));
+        connected_meshlets[meshlet_queue_id1].push((meshlet_queue_id2, shared_count));
+        connected_meshlets[meshlet_queue_id2].push((meshlet_queue_id1, shared_count));
     }
 
     // The order of meshlets depends on hash traversal order; to produce deterministic results, sort them
@@ -288,18 +303,18 @@ fn find_connected_meshlets(
 
 // METIS manual: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf
 fn group_meshlets(
-    simplification_queue: Range<usize>,
     connected_meshlets_per_meshlet: &[Vec<(usize, usize)>],
+    simplification_queue: &[usize],
 ) -> Vec<SmallVec<[usize; TARGET_MESHLETS_PER_GROUP]>> {
     let mut xadj = Vec::with_capacity(simplification_queue.len() + 1);
     let mut adjncy = Vec::new();
     let mut adjwgt = Vec::new();
-    for meshlet_id in simplification_queue.clone() {
+    for meshlet_queue_id in 0..simplification_queue.len() {
         xadj.push(adjncy.len() as i32);
-        for (connected_meshlet_id, shared_vertex_count) in
-            connected_meshlets_per_meshlet[meshlet_id - simplification_queue.start].iter()
+        for (connected_meshlet_queue_id, shared_vertex_count) in
+            connected_meshlets_per_meshlet[meshlet_queue_id].iter()
         {
-            adjncy.push((connected_meshlet_id - simplification_queue.start) as i32);
+            adjncy.push(*connected_meshlet_queue_id as i32);
             adjwgt.push(*shared_vertex_count as i32);
             // TODO: Additional weight based on meshlet spatial proximity
         }
@@ -318,8 +333,8 @@ fn group_meshlets(
         .unwrap();
 
     let mut groups = vec![SmallVec::new(); partition_count];
-    for (i, meshlet_group) in group_per_meshlet.into_iter().enumerate() {
-        groups[meshlet_group as usize].push(i + simplification_queue.start);
+    for (meshlet_queue_id, meshlet_group) in group_per_meshlet.into_iter().enumerate() {
+        groups[meshlet_group as usize].push(simplification_queue[meshlet_queue_id]);
     }
     groups
 }

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -23,7 +23,7 @@ use smallvec::SmallVec;
 
 // Aim to have 8 meshlets per group
 const TARGET_MESHLETS_PER_GROUP: usize = 8;
-// Reject groups that keep at least 95% of their original triangles
+// Reject groups that keep over 95% of their original triangles
 const SIMPLIFICATION_FAILURE_PERCENTAGE: f32 = 0.95;
 
 /// Default vertex position quantization factor for use with [`MeshletMesh::from_mesh`].

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -159,7 +159,7 @@ impl MeshletMesh {
         let mut vertex_uvs = Vec::new();
         let mut bevy_meshlets = Vec::with_capacity(meshlets.len());
         for (i, meshlet) in meshlets.meshlets.iter().enumerate() {
-            build_and_compress_meshlet_vertex_data(
+            build_and_compress_per_meshlet_vertex_data(
                 meshlet,
                 meshlets.get(i).vertices,
                 &vertex_buffer,
@@ -415,7 +415,7 @@ fn split_simplified_group_into_new_meshlets(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn build_and_compress_meshlet_vertex_data(
+fn build_and_compress_per_meshlet_vertex_data(
     meshlet: &meshopt_Meshlet,
     meshlet_vertex_ids: &[u32],
     vertex_buffer: &[u8],

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -95,7 +95,7 @@ impl MeshletMesh {
         let (position_only_vertex_count, position_only_vertex_remap) = generate_vertex_remap_multi(
             vertices.vertex_count,
             &[VertexStream::new_with_stride::<Vec3, _>(
-                &vertex_buffer,
+                vertex_buffer.as_ptr(),
                 vertex_stride,
             )],
             Some(&indices),

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -341,7 +341,7 @@ fn lock_group_borders(
                 let vertex_id =
                     position_only_vertex_remap[meshlet.vertices[*index as usize] as usize] as usize;
 
-                // If the vertex not yet claimed by any group, or was already claimed by this group
+                // If the vertex is not yet claimed by any group, or was already claimed by this group
                 if position_only_locks[vertex_id] == -1
                     || position_only_locks[vertex_id] == group_id as i32
                 {

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -92,7 +92,7 @@ impl MeshletMesh {
         .collect::<Vec<_>>();
 
         // Generate a position-only vertex buffer for determining what meshlets are connected for use in grouping
-        let (_, position_only_vertex_remap) = generate_vertex_remap_multi(
+        let (position_only_vertex_count, position_only_vertex_remap) = generate_vertex_remap_multi(
             vertices.vertex_count,
             &[VertexStream::new_with_stride::<Vec3, _>(
                 &vertex_buffer,
@@ -109,6 +109,7 @@ impl MeshletMesh {
                 simplification_queue.clone(),
                 &meshlets,
                 &position_only_vertex_remap,
+                position_only_vertex_count as usize,
             );
 
             // Group meshlets into roughly groups of size TARGET_MESHLETS_PER_GROUP,
@@ -227,9 +228,10 @@ fn find_connected_meshlets(
     simplification_queue: Range<usize>,
     meshlets: &Meshlets,
     position_only_vertex_remap: &[u32],
+    position_only_vertex_count: usize,
 ) -> Vec<Vec<(usize, usize)>> {
     // For each vertex, build a list of all meshlets that use it
-    let mut vertices_to_meshlets = vec![Vec::new(); position_only_vertex_remap.len()];
+    let mut vertices_to_meshlets = vec![Vec::new(); position_only_vertex_count];
     for meshlet_id in simplification_queue.clone() {
         let meshlet = meshlets.get(meshlet_id);
         for index in meshlet.triangles {

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -349,10 +349,7 @@ fn compute_lod_group_data(
             meshlet_lod_bounding_sphere.center * meshlet_lod_bounding_sphere.radius;
         weight += meshlet_lod_bounding_sphere.radius;
     }
-    // TODO: Check needed?
-    // if weight > 0.0 {
     group_bounding_sphere.center /= weight;
-    // }
 
     // Force parent group sphere to contain all child group spheres (we're currently building the parent from its children)
     // TODO: This does not produce the absolute minimal bounding sphere. Doing so is non-trivial.

--- a/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
@@ -26,8 +26,8 @@ fn get_meshlet_triangle_count(meshlet: ptr<function, Meshlet>) -> u32 {
 
 struct MeshletBoundingSpheres {
     culling_sphere: MeshletBoundingSphere,
-    group_lod_sphere: MeshletBoundingSphere,
-    parent_group_lod_sphere: MeshletBoundingSphere,
+    lod_group_sphere: MeshletBoundingSphere,
+    lod_parent_group_sphere: MeshletBoundingSphere,
 }
 
 struct MeshletBoundingSphere {

--- a/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
@@ -25,14 +25,19 @@ fn get_meshlet_triangle_count(meshlet: ptr<function, Meshlet>) -> u32 {
 }
 
 struct MeshletBoundingSpheres {
-    self_culling: MeshletBoundingSphere,
-    self_lod: MeshletBoundingSphere,
-    parent_lod: MeshletBoundingSphere,
+    culling_sphere: MeshletBoundingSphere,
+    group_lod_sphere: MeshletBoundingSphere,
+    parent_group_lod_sphere: MeshletBoundingSphere,
 }
 
 struct MeshletBoundingSphere {
     center: vec3<f32>,
     radius: f32,
+}
+
+struct MeshletSimplificationError {
+    group_error: f32,
+    parent_group_error: f32,
 }
 
 struct DispatchIndirectArgs {
@@ -62,16 +67,17 @@ var<push_constant> cluster_count: u32;
 var<push_constant> meshlet_raster_cluster_rightmost_slot: u32;
 @group(0) @binding(0) var<storage, read> meshlet_cluster_meshlet_ids: array<u32>; // Per cluster
 @group(0) @binding(1) var<storage, read> meshlet_bounding_spheres: array<MeshletBoundingSpheres>; // Per meshlet
-@group(0) @binding(2) var<storage, read> meshlet_cluster_instance_ids: array<u32>; // Per cluster
-@group(0) @binding(3) var<storage, read> meshlet_instance_uniforms: array<Mesh>; // Per entity instance
-@group(0) @binding(4) var<storage, read> meshlet_view_instance_visibility: array<u32>; // 1 bit per entity instance, packed as a bitmask
-@group(0) @binding(5) var<storage, read_write> meshlet_second_pass_candidates: array<atomic<u32>>; // 1 bit per cluster , packed as a bitmask
-@group(0) @binding(6) var<storage, read_write> meshlet_software_raster_indirect_args: DispatchIndirectArgs; // Single object shared between all workgroups/clusters/triangles
-@group(0) @binding(7) var<storage, read_write> meshlet_hardware_raster_indirect_args: DrawIndirectArgs; // Single object shared between all workgroups/clusters/triangles
-@group(0) @binding(8) var<storage, read_write> meshlet_raster_clusters: array<u32>; // Single object shared between all workgroups/clusters/triangles
-@group(0) @binding(9) var depth_pyramid: texture_2d<f32>; // From the end of the last frame for the first culling pass, and from the first raster pass for the second culling pass
-@group(0) @binding(10) var<uniform> view: View;
-@group(0) @binding(11) var<uniform> previous_view: PreviousViewUniforms;
+@group(0) @binding(2) var<storage, read> meshlet_simplification_errors: array<MeshletSimplificationError>; // Per meshlet
+@group(0) @binding(3) var<storage, read> meshlet_cluster_instance_ids: array<u32>; // Per cluster
+@group(0) @binding(4) var<storage, read> meshlet_instance_uniforms: array<Mesh>; // Per entity instance
+@group(0) @binding(5) var<storage, read> meshlet_view_instance_visibility: array<u32>; // 1 bit per entity instance, packed as a bitmask
+@group(0) @binding(6) var<storage, read_write> meshlet_second_pass_candidates: array<atomic<u32>>; // 1 bit per cluster , packed as a bitmask
+@group(0) @binding(7) var<storage, read_write> meshlet_software_raster_indirect_args: DispatchIndirectArgs; // Single object shared between all workgroups/clusters/triangles
+@group(0) @binding(8) var<storage, read_write> meshlet_hardware_raster_indirect_args: DrawIndirectArgs; // Single object shared between all workgroups/clusters/triangles
+@group(0) @binding(9) var<storage, read_write> meshlet_raster_clusters: array<u32>; // Single object shared between all workgroups/clusters/triangles
+@group(0) @binding(10) var depth_pyramid: texture_2d<f32>; // From the end of the last frame for the first culling pass, and from the first raster pass for the second culling pass
+@group(0) @binding(11) var<uniform> view: View;
+@group(0) @binding(12) var<uniform> previous_view: PreviousViewUniforms;
 
 fn should_cull_instance(instance_id: u32) -> bool {
     let bit_offset = instance_id % 32u;

--- a/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
@@ -35,11 +35,6 @@ struct MeshletBoundingSphere {
     radius: f32,
 }
 
-struct MeshletSimplificationError {
-    group_error: f32,
-    parent_group_error: f32,
-}
-
 struct DispatchIndirectArgs {
     x: atomic<u32>,
     y: u32,
@@ -67,7 +62,7 @@ var<push_constant> cluster_count: u32;
 var<push_constant> meshlet_raster_cluster_rightmost_slot: u32;
 @group(0) @binding(0) var<storage, read> meshlet_cluster_meshlet_ids: array<u32>; // Per cluster
 @group(0) @binding(1) var<storage, read> meshlet_bounding_spheres: array<MeshletBoundingSpheres>; // Per meshlet
-@group(0) @binding(2) var<storage, read> meshlet_simplification_errors: array<MeshletSimplificationError>; // Per meshlet
+@group(0) @binding(2) var<storage, read> meshlet_simplification_errors: array<u32>; // Per meshlet
 @group(0) @binding(3) var<storage, read> meshlet_cluster_instance_ids: array<u32>; // Per cluster
 @group(0) @binding(4) var<storage, read> meshlet_instance_uniforms: array<Mesh>; // Per entity instance
 @group(0) @binding(5) var<storage, read> meshlet_view_instance_visibility: array<u32>; // 1 bit per entity instance, packed as a bitmask

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -290,6 +290,7 @@ impl Plugin for MeshletPlugin {
     }
 }
 
+/// The meshlet mesh equivalent of [`bevy_render::mesh::Mesh3d`].
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
 #[reflect(Component, Default)]
 #[require(Transform, Visibility)]

--- a/crates/bevy_pbr/src/meshlet/persistent_buffer_impls.rs
+++ b/crates/bevy_pbr/src/meshlet/persistent_buffer_impls.rs
@@ -1,9 +1,41 @@
 use super::{
-    asset::{Meshlet, MeshletBoundingSpheres},
+    asset::{Meshlet, MeshletBoundingSpheres, MeshletSimplificationError},
     persistent_buffer::PersistentGpuBufferable,
 };
 use alloc::sync::Arc;
 use bevy_math::Vec2;
+
+impl PersistentGpuBufferable for Arc<[Meshlet]> {
+    type Metadata = (u64, u64, u64);
+
+    fn size_in_bytes(&self) -> usize {
+        self.len() * size_of::<Meshlet>()
+    }
+
+    fn write_bytes_le(
+        &self,
+        (vertex_position_offset, vertex_attribute_offset, index_offset): Self::Metadata,
+        buffer_slice: &mut [u8],
+    ) {
+        let vertex_position_offset = (vertex_position_offset * 8) as u32;
+        let vertex_attribute_offset = (vertex_attribute_offset as usize / size_of::<u32>()) as u32;
+        let index_offset = index_offset as u32;
+
+        for (i, meshlet) in self.iter().enumerate() {
+            let size = size_of::<Meshlet>();
+            let i = i * size;
+            let bytes = bytemuck::cast::<_, [u8; size_of::<Meshlet>()]>(Meshlet {
+                start_vertex_position_bit: meshlet.start_vertex_position_bit
+                    + vertex_position_offset,
+                start_vertex_attribute_id: meshlet.start_vertex_attribute_id
+                    + vertex_attribute_offset,
+                start_index_id: meshlet.start_index_id + index_offset,
+                ..*meshlet
+            });
+            buffer_slice[i..(i + size)].clone_from_slice(&bytes);
+        }
+    }
+}
 
 impl PersistentGpuBufferable for Arc<[u8]> {
     type Metadata = ();
@@ -41,43 +73,23 @@ impl PersistentGpuBufferable for Arc<[Vec2]> {
     }
 }
 
-impl PersistentGpuBufferable for Arc<[Meshlet]> {
-    type Metadata = (u64, u64, u64);
-
-    fn size_in_bytes(&self) -> usize {
-        self.len() * size_of::<Meshlet>()
-    }
-
-    fn write_bytes_le(
-        &self,
-        (vertex_position_offset, vertex_attribute_offset, index_offset): Self::Metadata,
-        buffer_slice: &mut [u8],
-    ) {
-        let vertex_position_offset = (vertex_position_offset * 8) as u32;
-        let vertex_attribute_offset = (vertex_attribute_offset as usize / size_of::<u32>()) as u32;
-        let index_offset = index_offset as u32;
-
-        for (i, meshlet) in self.iter().enumerate() {
-            let size = size_of::<Meshlet>();
-            let i = i * size;
-            let bytes = bytemuck::cast::<_, [u8; size_of::<Meshlet>()]>(Meshlet {
-                start_vertex_position_bit: meshlet.start_vertex_position_bit
-                    + vertex_position_offset,
-                start_vertex_attribute_id: meshlet.start_vertex_attribute_id
-                    + vertex_attribute_offset,
-                start_index_id: meshlet.start_index_id + index_offset,
-                ..*meshlet
-            });
-            buffer_slice[i..(i + size)].clone_from_slice(&bytes);
-        }
-    }
-}
-
 impl PersistentGpuBufferable for Arc<[MeshletBoundingSpheres]> {
     type Metadata = ();
 
     fn size_in_bytes(&self) -> usize {
         self.len() * size_of::<MeshletBoundingSpheres>()
+    }
+
+    fn write_bytes_le(&self, _: Self::Metadata, buffer_slice: &mut [u8]) {
+        buffer_slice.clone_from_slice(bytemuck::cast_slice(self));
+    }
+}
+
+impl PersistentGpuBufferable for Arc<[MeshletSimplificationError]> {
+    type Metadata = ();
+
+    fn size_in_bytes(&self) -> usize {
+        self.len() * size_of::<MeshletSimplificationError>()
     }
 
     fn write_bytes_le(&self, _: Self::Metadata, buffer_slice: &mut [u8]) {

--- a/crates/bevy_pbr/src/meshlet/resource_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/resource_manager.rs
@@ -135,6 +135,7 @@ impl ResourceManager {
                         storage_buffer_read_only_sized(false, None),
                         storage_buffer_read_only_sized(false, None),
                         storage_buffer_read_only_sized(false, None),
+                        storage_buffer_read_only_sized(false, None),
                         storage_buffer_sized(false, None),
                         storage_buffer_sized(false, None),
                         storage_buffer_sized(false, None),
@@ -624,6 +625,7 @@ pub fn prepare_meshlet_view_bind_groups(
         let entries = BindGroupEntries::sequential((
             cluster_meshlet_ids.as_entire_binding(),
             meshlet_mesh_manager.meshlet_bounding_spheres.binding(),
+            meshlet_mesh_manager.meshlet_simplification_errors.binding(),
             cluster_instance_ids.as_entire_binding(),
             instance_manager.instance_uniforms.binding().unwrap(),
             view_resources.instance_visibility.as_entire_binding(),
@@ -652,6 +654,7 @@ pub fn prepare_meshlet_view_bind_groups(
         let entries = BindGroupEntries::sequential((
             cluster_meshlet_ids.as_entire_binding(),
             meshlet_mesh_manager.meshlet_bounding_spheres.binding(),
+            meshlet_mesh_manager.meshlet_simplification_errors.binding(),
             cluster_instance_ids.as_entire_binding(),
             instance_manager.instance_uniforms.binding().unwrap(),
             view_resources.instance_visibility.as_entire_binding(),

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -17,7 +17,7 @@ use camera_controller::{CameraController, CameraControllerPlugin};
 use std::{f32::consts::PI, path::Path, process::ExitCode};
 
 const ASSET_URL: &str =
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/167cdaf0b08f89fb747b83b94c27755f116cd408/bunny.meshlet_mesh";
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/8483db58832542383820c3f44e4730e566910be7/bunny.meshlet_mesh";
 
 fn main() -> ExitCode {
     if !Path::new("./assets/models/bunny.meshlet_mesh").exists() {

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -17,7 +17,7 @@ use camera_controller::{CameraController, CameraControllerPlugin};
 use std::{f32::consts::PI, path::Path, process::ExitCode};
 
 const ASSET_URL: &str =
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/8443bbdee0bf517e6c297dede7f6a46ab712ee4c/bunny.meshlet_mesh";
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/167cdaf0b08f89fb747b83b94c27755f116cd408/bunny.meshlet_mesh";
 
 fn main() -> ExitCode {
     if !Path::new("./assets/models/bunny.meshlet_mesh").exists() {


### PR DESCRIPTION
Take a bunch more improvements from @zeux's nanite.cpp code

* Use position-only vertices (discard other attributes) to determine meshlet connectivity for grouping
* Rather than using the lock borders flag when simplifying meshlet groups, provide the locked vertices ourselves. The lock borders flag locks the entire border of the meshlet group, but really we only want to lock the edges between meshlet groups - outwards facing edges are fine to unlock. This gives a really significant increase to the DAG quality.
* Add back stuck meshlets (group has only a single meshlet, simplification failed) to the simplification queue to allow them to get used later on and have another attempt at simplifying
* Target 8 meshlets per group instead of 4 (second biggest improvement after manual locks)
* Provide a seed to metis for deterministic meshlet building
* Misc other improvements

Need to merge https://github.com/bevyengine/bevy/pull/15846 first