### PR TITLE
Fix panic due to malformed mesh in `specialized_mesh_pipeline`

### DIFF
--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
         PrimitiveTopology::TriangleList,
         RenderAssetUsages::default(),
     )
-    .with_inserted_indices(Indices::U32(vec![0, 1, 2, 0, 2, 3]))
+    .with_inserted_indices(Indices::U32(vec![0, 1, 2]))
     .with_inserted_attribute(
         Mesh::ATTRIBUTE_POSITION,
         vec![


### PR DESCRIPTION
# Objective

Fixes #15891

## Solution

Just remove the invalid triangle. I'm assuming that line of code was originally copied from one that was drawing a quad.

## Testing

- `cargo run --example specialized_mesh_pipeline`
- hover over over the triangles

Tested on macos
