### PR TITLE
Make `contributors` example deterministic in CI

### DIFF
--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -1,7 +1,7 @@
 //! This example displays each contributor to the bevy source code as a bouncing bevy-ball.
 
 use bevy::{math::bounding::Aabb2d, prelude::*, utils::HashMap};
-use rand::{prelude::SliceRandom, Rng, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::{
     env::VarError,


### PR DESCRIPTION
# Objective

- Make the example deterministic when run with CI, so that the [screenshot comparison](https://thebevyflock.github.io/bevy-example-runner/) is stable
- Preserve the "truly random on each run" behavior so that every page load in the example showcase shows a different contributor first

## Solution

- Fall back to the static default contributor list in CI
- Store contributors in a `Vec` so that we can show repeats of the fallback contributor list, giving the appearance of lots of overlapping contributors in CI
- Use a shared seeded RNG throughout the app
- Give contributor birds a `z` value so that their depth is stable
- Remove the shuffle, which was redundant because contributors are first collected into a hashmap
- `chain` the systems so that the physics is deterministic from run to run

## Testing

```bash
echo '(setup: (fixed_frame_time: Some(0.05)), events: [(100, Screenshot), (500, AppExit)])' > config.ron
CI_TESTING_CONFIG=config.ron cargo run --example contributors --features=bevy_ci_testing
mv screenshot-100.png screenshot-100-a.png
CI_TESTING_CONFIG=config.ron cargo run --example contributors --features=bevy_ci_testing
diff screenshot-100.png screenshot-100-a.png
```

## Alternatives

I'd also be fine with removing this example from the list of examples that gets screenshot-tested in CI. Coverage from other 2d examples is probably adequate.
