### PR TITLE
Despawn unused light-view entity

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1260,6 +1260,11 @@ pub fn prepare_lights(
                     .map(|_| commands.spawn_empty().id())
                     .collect()
             });
+            if light_view_entities.len() != iter.len() {
+                let entities = core::mem::take(light_view_entities);
+                despawn_entities(&mut commands, entities);
+                light_view_entities.extend((0..iter.len()).map(|_| commands.spawn_empty().id()));
+            }
 
             for (cascade_index, (((cascade, frustum), bound), view_light_entity)) in
                 iter.zip(light_view_entities.iter().copied()).enumerate()

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -459,6 +459,8 @@ fn create_render_visible_mesh_entities(
 }
 
 #[derive(Component, Default, Deref, DerefMut)]
+/// Component automatically attached to a light entity to track light-view entities
+/// for each view.
 pub struct LightViewEntities(EntityHashMap<Vec<Entity>>);
 
 // TODO: using required component
@@ -1386,6 +1388,7 @@ pub fn prepare_lights(
         ));
     }
 
+    // Despawn light-view entities for views that no longer exist
     for mut entities in &mut light_view_entities {
         for (_, light_view_entities) in
             entities.extract_if(|entity, _| !live_views.contains(entity))

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -735,7 +735,8 @@ pub fn prepare_lights(
     let point_light_count = point_lights
         .iter()
         .filter(|light| light.1.spot_light_angles.is_none())
-        .count();
+        .count()
+        .min(max_texture_cubes);
 
     let point_light_volumetric_enabled_count = point_lights
         .iter()

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1047,12 +1047,12 @@ pub fn prepare_lights(
             // Lights are sorted, shadow enabled lights are first
             .take(point_light_count)
         {
-            let Ok(mut light_entities) = light_view_entities.get_mut(light_entity) else {
+            let Ok(mut light_view_entities) = light_view_entities.get_mut(light_entity) else {
                 continue;
             };
 
             if !light.shadows_enabled {
-                if let Some(entities) = light_entities.remove(&entity) {
+                if let Some(entities) = light_view_entities.remove(&entity) {
                     despawn_entities(&mut commands, entities);
                 }
                 continue;
@@ -1068,7 +1068,7 @@ pub fn prepare_lights(
             let view_translation = GlobalTransform::from_translation(light.transform.translation());
 
             // for each face of a cube and each view we spawn a light entity
-            let entities = light_entities
+            let light_view_entities = light_view_entities
                 .entry(entity)
                 .or_insert_with(|| (0..6).map(|_| commands.spawn_empty().id()).collect());
 
@@ -1081,7 +1081,7 @@ pub fn prepare_lights(
             for (face_index, ((view_rotation, frustum), view_light_entity)) in cube_face_rotations
                 .iter()
                 .zip(&point_light_frusta.unwrap().frusta)
-                .zip(entities.iter().copied())
+                .zip(light_view_entities.iter().copied())
                 .enumerate()
             {
                 let depth_texture_view =
@@ -1173,11 +1173,11 @@ pub fn prepare_lights(
                         array_layer_count: Some(1u32),
                     });
 
-            let entities = light_view_entities
+            let light_view_entities = light_view_entities
                 .entry(entity)
                 .or_insert_with(|| vec![commands.spawn_empty().id()]);
 
-            let view_light_entity = entities[0];
+            let view_light_entity = light_view_entities[0];
 
             commands.entity(view_light_entity).insert((
                 ShadowView {
@@ -1255,14 +1255,14 @@ pub fn prepare_lights(
                 .zip(frusta)
                 .zip(&light.cascade_shadow_config.bounds);
 
-            let entities = light_view_entities.entry(entity).or_insert_with(|| {
+            let light_view_entities = light_view_entities.entry(entity).or_insert_with(|| {
                 (0..iter.len())
                     .map(|_| commands.spawn_empty().id())
                     .collect()
             });
 
             for (cascade_index, (((cascade, frustum), bound), view_light_entity)) in
-                iter.zip(entities.iter().copied()).enumerate()
+                iter.zip(light_view_entities.iter().copied()).enumerate()
             {
                 gpu_lights.directional_lights[light_index].cascades[cascade_index] =
                     GpuDirectionalCascade {


### PR DESCRIPTION
# Objective

- Fixes #15897

## Solution

- Despawn light view entities when they go unused or when the corresponding view is not alive.

## Testing

- `scene_viewer` example no longer prints "The preprocessing index buffer wasn't present" warning
- modified an example to try toggling shadows for all kinds of light: https://gist.github.com/akimakinai/ddb0357191f5052b654370699d2314cf
