### PR TITLE
Fix *most* clippy lints

### DIFF
--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -587,7 +587,7 @@ impl AssetSources {
             AssetSourceId::Name(name) => self
                 .sources
                 .get(&name)
-                .ok_or_else(|| MissingAssetSourceError(AssetSourceId::Name(name))),
+                .ok_or(MissingAssetSourceError(AssetSourceId::Name(name))),
         }
     }
 

--- a/crates/bevy_ecs/src/batching.rs
+++ b/crates/bevy_ecs/src/batching.rs
@@ -101,7 +101,7 @@ impl BatchingStrategy {
         );
         let batches = thread_count * self.batches_per_thread;
         // Round up to the nearest batch size.
-        let batch_size = (max_items() + batches - 1) / batches;
+        let batch_size = max_items().div_ceil(batches);
         batch_size.clamp(self.batch_size_limits.start, self.batch_size_limits.end)
     }
 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -461,7 +461,6 @@ impl BundleInfo {
     }
 
     /// Returns an iterator over the [ID](ComponentId) of each component explicitly defined in this bundle (ex: this excludes Required Components).
-
     /// To iterate all components contributed by this bundle (including Required Components), see [`BundleInfo::iter_contributed_components`]
     #[inline]
     pub fn iter_explicit_components(&self) -> impl Iterator<Item = ComponentId> + '_ {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -463,7 +463,6 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// #[derive(Component)]
     /// struct Label(&'static str);
-
     /// fn example_system(mut commands: Commands) {
     ///     // Create a new, empty entity
     ///     let entity = commands.spawn_empty().id();
@@ -565,7 +564,6 @@ impl<'w, 's> Commands<'w, 's> {
     ///         counter.0 += 25;
     ///     });
     /// }
-
     /// # bevy_ecs::system::assert_is_system(add_three_to_counter_system);
     /// # bevy_ecs::system::assert_is_system(add_twenty_five_to_counter_system);
     /// ```

--- a/crates/bevy_ecs/src/world/component_constants.rs
+++ b/crates/bevy_ecs/src/world/component_constants.rs
@@ -1,9 +1,9 @@
+//! Internal components used by bevy with a fixed component id.
+//! Constants are used to skip [`TypeId`] lookups in hot paths.
 use super::*;
 use crate::{self as bevy_ecs};
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
-/// Internal components used by bevy with a fixed component id.
-/// Constants are used to skip [`TypeId`] lookups in hot paths.
 
 /// [`ComponentId`] for [`OnAdd`]
 pub const ON_ADD: ComponentId = ComponentId::new(0);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1175,7 +1175,7 @@ impl World {
     pub fn get_many_entities_mut<const N: usize>(
         &mut self,
         entities: [Entity; N],
-    ) -> Result<[EntityMut<'_>; N], QueryEntityError> {
+    ) -> Result<[EntityMut<'_>; N], QueryEntityError<'_>> {
         self.get_entity_mut(entities).map_err(|e| match e {
             EntityFetchError::NoSuchEntity(entity) => QueryEntityError::NoSuchEntity(entity),
             EntityFetchError::AliasedMutability(entity) => {
@@ -1212,7 +1212,7 @@ impl World {
     pub fn get_many_entities_dynamic_mut<'w>(
         &'w mut self,
         entities: &[Entity],
-    ) -> Result<Vec<EntityMut<'w>>, QueryEntityError> {
+    ) -> Result<Vec<EntityMut<'w>>, QueryEntityError<'w>> {
         self.get_entity_mut(entities).map_err(|e| match e {
             EntityFetchError::NoSuchEntity(entity) => QueryEntityError::NoSuchEntity(entity),
             EntityFetchError::AliasedMutability(entity) => {
@@ -1255,7 +1255,7 @@ impl World {
     pub fn get_many_entities_from_set_mut<'w>(
         &'w mut self,
         entities: &EntityHashSet,
-    ) -> Result<Vec<EntityMut<'w>>, QueryEntityError> {
+    ) -> Result<Vec<EntityMut<'w>>, QueryEntityError<'w>> {
         self.get_entity_mut(entities)
             .map(|fetched| fetched.into_values().collect())
             .map_err(|e| match e {
@@ -1331,13 +1331,13 @@ impl World {
     ///
     /// // `spawn` can accept a single component:
     /// world.spawn(Position { x: 0.0, y: 0.0 });
-
+    ///
     /// // It can also accept a tuple of components:
     /// world.spawn((
     ///     Position { x: 0.0, y: 0.0 },
     ///     Velocity { x: 1.0, y: 1.0 },
     /// ));
-
+    ///
     /// // Or it can accept a pre-defined Bundle of components:
     /// world.spawn(PhysicsBundle {
     ///     position: Position { x: 2.0, y: 2.0 },

--- a/crates/bevy_image/src/ktx2.rs
+++ b/crates/bevy_image/src/ktx2.rs
@@ -166,8 +166,8 @@ pub fn ktx2_buffer_to_image(
                             (height >> level as u32).max(1),
                         );
                         let (num_blocks_x, num_blocks_y) = (
-                            ((level_width + block_width_pixels - 1) / block_width_pixels) .max(1),
-                            ((level_height + block_height_pixels - 1) / block_height_pixels) .max(1),
+                            level_width.div_ceil(block_width_pixels) .max(1),
+                            level_height.div_ceil(block_height_pixels) .max(1),
                         );
                         let level_bytes = (num_blocks_x * num_blocks_y * block_bytes) as usize;
 
@@ -247,8 +247,8 @@ pub fn ktx2_buffer_to_image(
             (depth as usize >> level).max(1),
         );
         let (num_blocks_x, num_blocks_y) = (
-            ((level_width + block_width_pixels - 1) / block_width_pixels).max(1),
-            ((level_height + block_height_pixels - 1) / block_height_pixels).max(1),
+            level_width.div_ceil(block_width_pixels).max(1),
+            level_height.div_ceil(block_height_pixels).max(1),
         );
         let level_bytes = num_blocks_x * num_blocks_y * level_depth * block_bytes;
 

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -223,10 +223,6 @@ impl MorphAttributes {
     }
 }
 
-/// Integer division rounded up.
-const fn div_ceil(lhf: u32, rhs: u32) -> u32 {
-    (lhf + rhs - 1) / rhs
-}
 struct Rect(u32, u32);
 
 /// Find the smallest rectangle of maximum edge size `max_edge` that contains
@@ -249,7 +245,7 @@ struct Rect(u32, u32);
 fn lowest_2d(min_includes: u32, max_edge: u32) -> Option<(Rect, u32)> {
     (1..=max_edge)
         .filter_map(|a| {
-            let b = div_ceil(min_includes, a);
+            let b = min_includes.div_ceil(a);
             let diff = (a * b).checked_sub(min_includes)?;
             Some((Rect(a, b), diff))
         })

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -268,8 +268,8 @@ impl ViewNode for SsaoNode {
                 &[view_uniform_offset.offset],
             );
             preprocess_depth_pass.dispatch_workgroups(
-                div_ceil(camera_size.x, 16),
-                div_ceil(camera_size.y, 16),
+                camera_size.x.div_ceil(16),
+                camera_size.y.div_ceil(16),
                 1,
             );
         }
@@ -289,11 +289,7 @@ impl ViewNode for SsaoNode {
                 &bind_groups.common_bind_group,
                 &[view_uniform_offset.offset],
             );
-            ssao_pass.dispatch_workgroups(
-                div_ceil(camera_size.x, 8),
-                div_ceil(camera_size.y, 8),
-                1,
-            );
+            ssao_pass.dispatch_workgroups(camera_size.x.div_ceil(8), camera_size.y.div_ceil(8), 1);
         }
 
         {
@@ -312,8 +308,8 @@ impl ViewNode for SsaoNode {
                 &[view_uniform_offset.offset],
             );
             spatial_denoise_pass.dispatch_workgroups(
-                div_ceil(camera_size.x, 8),
-                div_ceil(camera_size.y, 8),
+                camera_size.x.div_ceil(8),
+                camera_size.y.div_ceil(8),
                 1,
             );
         }
@@ -804,9 +800,4 @@ fn hilbert_index(mut x: u16, mut y: u16) -> u16 {
     }
 
     index
-}
-
-/// Divide `numerator` by `denominator`, rounded up to the nearest multiple of `denominator`.
-fn div_ceil(numerator: u32, denominator: u32) -> u32 {
-    (numerator + denominator - 1) / denominator
 }

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -277,7 +277,7 @@ impl<'a> ReflectDerive<'a> {
             return Ok(Self::Opaque(meta));
         }
 
-        return match &input.data {
+        match &input.data {
             Data::Struct(data) => {
                 let fields = Self::collect_struct_fields(&data.fields)?;
                 let reflect_struct = ReflectStruct {
@@ -302,7 +302,7 @@ impl<'a> ReflectDerive<'a> {
                 input.span(),
                 "reflection not supported for unions",
             )),
-        };
+        }
     }
 
     /// Set the remote type for this derived type.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -44,7 +44,6 @@ use core::{
 ///
 /// [struct-like]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html
 /// [reflection]: crate
-
 /// [unit structs]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#unit-like-structs-without-any-fields
 pub trait Struct: PartialReflect {
     /// Returns a reference to the value of the field named `name` as a `&dyn

--- a/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
@@ -121,7 +121,7 @@ impl<T: GpuArrayBufferable> BatchedUniformBuffer<T> {
 
 #[inline]
 fn align_to_next(value: u64, alignment: u64) -> u64 {
-    debug_assert!(alignment & (alignment - 1) == 0);
+    debug_assert!(alignment.is_power_of_two());
     ((value - 1) | (alignment - 1)) + 1
 }
 

--- a/crates/bevy_render/src/render_resource/bind_group_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_entries.rs
@@ -92,7 +92,6 @@ use super::{Sampler, TextureView};
 ///     ],
 /// );
 /// ```
-
 pub struct BindGroupEntries<'b, const N: usize = 1> {
     entries: [BindGroupEntry<'b>; N],
 }

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -10,7 +10,6 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// This enum allows specifying values for various [`Style`](crate::Style) properties in different units,
 /// such as logical pixels, percentages, or automatically determined values.
-
 #[derive(Copy, Clone, Debug, Reflect)]
 #[reflect(Default, PartialEq, Debug)]
 #[cfg_attr(
@@ -204,7 +203,7 @@ impl Val {
 /// A type which is commonly used to define margins, paddings and borders.
 ///
 /// # Examples
-
+///
 /// ## Margin
 ///
 /// A margin is used to create space around UI elements, outside of any defined borders.
@@ -244,7 +243,6 @@ impl Val {
 ///     bottom: Val::Px(40.0),
 /// };
 /// ```
-
 #[derive(Copy, Clone, PartialEq, Debug, Reflect)]
 #[reflect(Default, PartialEq, Debug)]
 #[cfg_attr(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2046,7 +2046,6 @@ pub struct CalculatedClip {
 /// appear in the UI hierarchy. In such a case, the last node to be added to its parent
 /// will appear in front of its siblings.
 ///
-
 /// Nodes without this component will be treated as if they had a value of [`ZIndex(0)`].
 #[derive(Component, Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq)]

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -85,7 +85,6 @@ fn toggle_vsync(input: Res<ButtonInput<KeyCode>>, mut window: Single<&mut Window
 /// This feature only works on some platforms. Please check the
 /// [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.window_level)
 /// for more details.
-
 fn switch_level(input: Res<ButtonInput<KeyCode>>, mut window: Single<&mut Window>) {
     if input.just_pressed(KeyCode::KeyT) {
         window.window_level = match window.window_level {


### PR DESCRIPTION
# Objective

Another clippy-lint fix: the goal is so that `ci lints` actually displays the problems that a contributor caused, and not a bunch of existing stuff in the repo.

## Solution

This fixes all but the `clippy::needless_lifetimes` lint, which will result in substantially more fixes and be in other PR(s). I also explicitly allow `non_local_definitions` since it is [not working correctly, but will be fixed](https://github.com/rust-lang/rust/issues/131643).

A few things were manually fixed: for example, some places had an explicitly defined `div_ceil` function that was used, which is no longer needed since this function is stable on unsigned integers. Also, empty lines in doc comments were handled individually.

## Testing

I ran `cargo clippy --workspace --all-targets --all-features --fix --allow-staged` with the `clippy::needless_lifetimes` lint marked as `allow` in `Cargo.toml` to avoid fixing that too. It now passes with all but the listed lint.