### PR TITLE
Fix `clippy::needless_lifetimes` for most crates

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -653,7 +653,7 @@ impl<'a> SliceReader<'a> {
     }
 }
 
-impl<'a> AsyncRead for SliceReader<'a> {
+impl AsyncRead for SliceReader<'_> {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -669,7 +669,7 @@ impl<'a> AsyncRead for SliceReader<'a> {
     }
 }
 
-impl<'a> AsyncSeekForward for SliceReader<'a> {
+impl AsyncSeekForward for SliceReader<'_> {
     fn poll_seek_forward(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -27,7 +27,7 @@ pub enum AssetSourceId<'a> {
     Name(CowArc<'a, str>),
 }
 
-impl<'a> Display for AssetSourceId<'a> {
+impl Display for AssetSourceId<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.as_str() {
             None => write!(f, "AssetSourceId::Default"),
@@ -114,13 +114,13 @@ impl From<String> for AssetSourceId<'static> {
     }
 }
 
-impl<'a> Hash for AssetSourceId<'a> {
+impl Hash for AssetSourceId<'_> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
     }
 }
 
-impl<'a> PartialEq for AssetSourceId<'a> {
+impl PartialEq for AssetSourceId<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.as_str().eq(&other.as_str())
     }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -56,13 +56,13 @@ pub struct AssetPath<'a> {
     label: Option<CowArc<'a, str>>,
 }
 
-impl<'a> Debug for AssetPath<'a> {
+impl Debug for AssetPath<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Display::fmt(self, f)
     }
 }
 
-impl<'a> Display for AssetPath<'a> {
+impl Display for AssetPath<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if let AssetSourceId::Name(name) = self.source() {
             write!(f, "{name}://")?;
@@ -565,7 +565,7 @@ impl<'a> From<AssetPath<'a>> for PathBuf {
     }
 }
 
-impl<'a> Serialize for AssetPath<'a> {
+impl Serialize for AssetPath<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -585,7 +585,7 @@ impl<'de> Deserialize<'de> for AssetPath<'static> {
 
 struct AssetPathVisitor;
 
-impl<'de> Visitor<'de> for AssetPathVisitor {
+impl Visitor<'_> for AssetPathVisitor {
     type Value = AssetPath<'static>;
 
     fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -79,7 +79,7 @@ pub struct SavedAsset<'a, A: Asset> {
     labeled_assets: &'a HashMap<CowArc<'static, str>, LabeledAsset>,
 }
 
-impl<'a, A: Asset> Deref for SavedAsset<'a, A> {
+impl<A: Asset> Deref for SavedAsset<'_, A> {
     type Target = A;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -152,14 +152,14 @@ pub struct TransformedSubAsset<'a, A: Asset> {
     labeled_assets: &'a mut HashMap<CowArc<'static, str>, LabeledAsset>,
 }
 
-impl<'a, A: Asset> Deref for TransformedSubAsset<'a, A> {
+impl<A: Asset> Deref for TransformedSubAsset<'_, A> {
     type Target = A;
     fn deref(&self) -> &Self::Target {
         self.value
     }
 }
 
-impl<'a, A: Asset> DerefMut for TransformedSubAsset<'a, A> {
+impl<A: Asset> DerefMut for TransformedSubAsset<'_, A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.value
     }

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -58,7 +58,7 @@ pub struct PlaybackRemoveMarker;
 pub(crate) struct EarPositions<'w, 's> {
     pub(crate) query: Query<'w, 's, (Entity, &'static GlobalTransform, &'static SpatialListener)>,
 }
-impl<'w, 's> EarPositions<'w, 's> {
+impl EarPositions<'_, '_> {
     /// Gets a set of transformed ear positions.
     ///
     /// If there are no listeners, use the default values. If a user has added multiple

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -130,7 +130,7 @@ pub struct NameOrEntity {
     pub entity: Entity,
 }
 
-impl<'a> core::fmt::Display for NameOrEntityItem<'a> {
+impl core::fmt::Display for NameOrEntityItem<'_> {
     #[inline(always)]
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self.name {

--- a/crates/bevy_core/src/serde.rs
+++ b/crates/bevy_core/src/serde.rs
@@ -24,7 +24,7 @@ impl<'de> Deserialize<'de> for Name {
 
 struct EntityVisitor;
 
-impl<'de> Visitor<'de> for EntityVisitor {
+impl Visitor<'_> for EntityVisitor {
     type Value = Name;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for FrameCount {
 
 struct FrameVisitor;
 
-impl<'de> Visitor<'de> for FrameVisitor {
+impl Visitor<'_> for FrameVisitor {
     type Value = FrameCount;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -340,7 +340,7 @@ pub struct Diagnostics<'w, 's> {
     queue: Deferred<'s, DiagnosticsBuffer>,
 }
 
-impl<'w, 's> Diagnostics<'w, 's> {
+impl Diagnostics<'_, '_> {
     /// Add a measurement to an enabled [`Diagnostic`]. The measurement is passed as a function so that
     /// it will be evaluated only if the [`Diagnostic`] is enabled. This can be useful if the value is
     /// costly to calculate.

--- a/crates/bevy_gizmos/src/arrows.rs
+++ b/crates/bevy_gizmos/src/arrows.rs
@@ -161,7 +161,7 @@ where
     }
 }
 
-impl<'w, 's, Config, Clear> Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,

--- a/crates/bevy_gizmos/src/curves.rs
+++ b/crates/bevy_gizmos/src/curves.rs
@@ -8,7 +8,7 @@ use bevy_math::{curve::Curve, Vec2, Vec3};
 
 use crate::prelude::{GizmoConfigGroup, Gizmos};
 
-impl<'w, 's, Config, Clear> Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -278,7 +278,7 @@ where
     }
 }
 
-impl<'w, 's, Config, Clear> Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -40,7 +40,7 @@ pub trait GizmoPrimitive2d<P: Primitive2d> {
 
 // direction 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Dir2> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Dir2> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -68,7 +68,7 @@ where
 
 // arc 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Arc2d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Arc2d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -124,7 +124,7 @@ where
 
 // circular sector 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<CircularSector> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<CircularSector> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -167,7 +167,7 @@ where
 
 // circular segment 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<CircularSegment> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<CircularSegment> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -331,7 +331,7 @@ where
 
 // rhombus 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Rhombus> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Rhombus> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -365,7 +365,7 @@ where
 
 // capsule 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Capsule2d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Capsule2d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -516,7 +516,7 @@ where
 
 // plane 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Plane2d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Plane2d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -651,8 +651,8 @@ where
 
 // polyline 2d
 
-impl<'w, 's, const N: usize, Config, Clear> GizmoPrimitive2d<Polyline2d<N>>
-    for Gizmos<'w, 's, Config, Clear>
+impl<const N: usize, Config, Clear> GizmoPrimitive2d<Polyline2d<N>>
+    for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -687,7 +687,7 @@ where
 
 // boxed polyline 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<BoxedPolyline2d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<BoxedPolyline2d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -722,7 +722,7 @@ where
 
 // triangle 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Triangle2d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Triangle2d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -752,7 +752,7 @@ where
 
 // rectangle 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<Rectangle> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<Rectangle> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -788,8 +788,7 @@ where
 
 // polygon 2d
 
-impl<'w, 's, const N: usize, Config, Clear> GizmoPrimitive2d<Polygon<N>>
-    for Gizmos<'w, 's, Config, Clear>
+impl<const N: usize, Config, Clear> GizmoPrimitive2d<Polygon<N>> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -834,7 +833,7 @@ where
 
 // boxed polygon 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<BoxedPolygon> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<BoxedPolygon> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -877,7 +876,7 @@ where
 
 // regular polygon 2d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive2d<RegularPolygon> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive2d<RegularPolygon> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -38,7 +38,7 @@ pub trait GizmoPrimitive3d<P: Primitive3d> {
 
 // direction 3d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive3d<Dir3> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive3d<Dir3> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -176,7 +176,7 @@ where
 
 // line 3d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive3d<Line3d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive3d<Line3d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -211,7 +211,7 @@ where
 
 // segment 3d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive3d<Segment3d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive3d<Segment3d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -239,8 +239,8 @@ where
 
 // polyline 3d
 
-impl<'w, 's, const N: usize, Config, Clear> GizmoPrimitive3d<Polyline3d<N>>
-    for Gizmos<'w, 's, Config, Clear>
+impl<const N: usize, Config, Clear> GizmoPrimitive3d<Polyline3d<N>>
+    for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -267,7 +267,7 @@ where
 
 // boxed polyline 3d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive3d<BoxedPolyline3d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive3d<BoxedPolyline3d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -301,7 +301,7 @@ where
 
 // triangle 3d
 
-impl<'w, 's, Config, Clear> GizmoPrimitive3d<Triangle3d> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive3d<Triangle3d> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -329,7 +329,7 @@ where
 
 // cuboid
 
-impl<'w, 's, Config, Clear> GizmoPrimitive3d<Cuboid> for Gizmos<'w, 's, Config, Clear>
+impl<Config, Clear> GizmoPrimitive3d<Cuboid> for Gizmos<'_, '_, Config, Clear>
 where
     Config: GizmoConfigGroup,
     Clear: 'static + Send + Sync,
@@ -936,7 +936,7 @@ where
 
 // tetrahedron
 
-impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Tetrahedron> for Gizmos<'w, 's, T> {
+impl<T: GizmoConfigGroup> GizmoPrimitive3d<Tetrahedron> for Gizmos<'_, '_, T> {
     type Output<'a>
         = ()
     where

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1930,7 +1930,7 @@ impl<'a> Iterator for GltfTreeIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for GltfTreeIterator<'a> {
+impl ExactSizeIterator for GltfTreeIterator<'_> {
     fn len(&self) -> usize {
         self.nodes.len()
     }
@@ -1992,7 +1992,7 @@ pub(super) struct PrimitiveMorphAttributesIter<'s>(
         Option<Iter<'s, [f32; 3]>>,
     ),
 );
-impl<'s> Iterator for PrimitiveMorphAttributesIter<'s> {
+impl Iterator for PrimitiveMorphAttributesIter<'_> {
     type Item = MorphAttributes;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -176,7 +176,7 @@ fn despawn_descendants_inner<'v, 'w>(
     world
 }
 
-impl<'w> DespawnRecursiveExt for EntityWorldMut<'w> {
+impl DespawnRecursiveExt for EntityWorldMut<'_> {
     /// Despawns the provided entity and its children.
     /// This will emit warnings for any entity that does not exist.
     fn despawn_recursive(self) {

--- a/crates/bevy_hierarchy/src/query_extension.rs
+++ b/crates/bevy_hierarchy/src/query_extension.rs
@@ -214,7 +214,7 @@ where
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for DescendantIter<'w, 's, D, F>
+impl<'w, D: QueryData, F: QueryFilter> Iterator for DescendantIter<'w, '_, D, F>
 where
     D::ReadOnly: WorldQuery<Item<'w> = &'w Children>,
 {
@@ -259,7 +259,7 @@ where
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for DescendantDepthFirstIter<'w, 's, D, F>
+impl<'w, D: QueryData, F: QueryFilter> Iterator for DescendantDepthFirstIter<'w, '_, D, F>
 where
     D::ReadOnly: WorldQuery<Item<'w> = &'w Children>,
 {
@@ -298,7 +298,7 @@ where
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for AncestorIter<'w, 's, D, F>
+impl<'w, D: QueryData, F: QueryFilter> Iterator for AncestorIter<'w, '_, D, F>
 where
     D::ReadOnly: WorldQuery<Item<'w> = &'w Parent>,
 {

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -760,7 +760,7 @@ impl From<wgpu::SamplerBorderColor> for ImageSamplerBorderColor {
     }
 }
 
-impl<'a> From<wgpu::SamplerDescriptor<'a>> for ImageSamplerDescriptor {
+impl From<wgpu::SamplerDescriptor<'_>> for ImageSamplerDescriptor {
     fn from(value: wgpu::SamplerDescriptor) -> Self {
         ImageSamplerDescriptor {
             label: value.label.map(ToString::to_string),
@@ -1591,7 +1591,7 @@ pub enum ImageType<'a> {
     Format(ImageFormat),
 }
 
-impl<'a> ImageType<'a> {
+impl ImageType<'_> {
     pub fn to_image_format(&self) -> Result<ImageFormat, TextureError> {
         match self {
             ImageType::MimeType(mime_type) => ImageFormat::from_mime_type(mime_type)

--- a/crates/bevy_macro_utils/src/symbol.rs
+++ b/crates/bevy_macro_utils/src/symbol.rs
@@ -11,7 +11,7 @@ impl PartialEq<Symbol> for Ident {
     }
 }
 
-impl<'a> PartialEq<Symbol> for &'a Ident {
+impl PartialEq<Symbol> for &Ident {
     fn eq(&self, word: &Symbol) -> bool {
         *self == word.0
     }
@@ -23,7 +23,7 @@ impl PartialEq<Symbol> for Path {
     }
 }
 
-impl<'a> PartialEq<Symbol> for &'a Path {
+impl PartialEq<Symbol> for &Path {
     fn eq(&self, word: &Symbol) -> bool {
         self.is_ident(word.0)
     }

--- a/crates/bevy_mesh/src/index.rs
+++ b/crates/bevy_mesh/src/index.rs
@@ -124,8 +124,8 @@ impl Iterator for IndicesIter<'_> {
     }
 }
 
-impl<'a> ExactSizeIterator for IndicesIter<'a> {}
-impl<'a> FusedIterator for IndicesIter<'a> {}
+impl ExactSizeIterator for IndicesIter<'_> {}
+impl FusedIterator for IndicesIter<'_> {}
 
 impl From<&Indices> for IndexFormat {
     fn from(indices: &Indices) -> Self {

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -75,7 +75,7 @@ impl<'a> RayCastSettings<'a> {
     }
 }
 
-impl<'a> Default for RayCastSettings<'a> {
+impl Default for RayCastSettings<'_> {
     fn default() -> Self {
         Self {
             visibility: RayCastVisibility::VisibleInView,
@@ -203,7 +203,7 @@ pub struct MeshRayCast<'w, 's> {
     >,
 }
 
-impl<'w, 's> MeshRayCast<'w, 's> {
+impl MeshRayCast<'_, '_> {
     /// Casts the `ray` into the world and returns a sorted list of intersections, nearest first.
     pub fn cast_ray(&mut self, ray: Ray3d, settings: &RayCastSettings) -> &[(Entity, RayMeshHit)] {
         let ray_cull = info_span!("ray culling");

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -396,7 +396,7 @@ impl<'a, T: ?Sized> From<&'a mut T> for PtrMut<'a> {
     }
 }
 
-impl<'a> OwningPtr<'a> {
+impl OwningPtr<'_> {
     /// Consumes a value and creates an [`OwningPtr`] to it while ensuring a double drop does not happen.
     #[inline]
     pub fn make<T, F: FnOnce(OwningPtr<'_>) -> R, R>(val: T, f: F) -> R {
@@ -407,7 +407,7 @@ impl<'a> OwningPtr<'a> {
     }
 }
 
-impl<'a, A: IsAligned> OwningPtr<'a, A> {
+impl<A: IsAligned> OwningPtr<'_, A> {
     /// Creates a new instance from a raw pointer.
     ///
     /// # Safety
@@ -473,7 +473,7 @@ impl<'a, A: IsAligned> OwningPtr<'a, A> {
     }
 }
 
-impl<'a> OwningPtr<'a, Unaligned> {
+impl OwningPtr<'_, Unaligned> {
     /// Consumes the [`OwningPtr`] to obtain ownership of the underlying data of type `T`.
     ///
     /// # Safety
@@ -509,13 +509,13 @@ impl<'a, T> ThinSlicePtr<'a, T> {
     }
 }
 
-impl<'a, T> Clone for ThinSlicePtr<'a, T> {
+impl<T> Clone for ThinSlicePtr<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, T> Copy for ThinSlicePtr<'a, T> {}
+impl<T> Copy for ThinSlicePtr<'_, T> {}
 
 impl<'a, T> From<&'a [T]> for ThinSlicePtr<'a, T> {
     #[inline]
@@ -545,7 +545,7 @@ mod private {
     use core::cell::UnsafeCell;
 
     pub trait SealedUnsafeCell {}
-    impl<'a, T> SealedUnsafeCell for &'a UnsafeCell<T> {}
+    impl<T> SealedUnsafeCell for &UnsafeCell<T> {}
 }
 
 /// Extension trait for helper methods on [`UnsafeCell`]

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -134,7 +134,7 @@ where
     }
 }
 
-impl<'w, 's, P> DerefMut for Extract<'w, 's, P>
+impl<P> DerefMut for Extract<'_, '_, P>
 where
     P: ReadOnlySystemParam,
 {

--- a/crates/bevy_render/src/render_resource/buffer.rs
+++ b/crates/bevy_render/src/render_resource/buffer.rs
@@ -71,7 +71,7 @@ pub struct BufferSlice<'a> {
     size: wgpu::BufferAddress,
 }
 
-impl<'a> BufferSlice<'a> {
+impl BufferSlice<'_> {
     #[inline]
     pub fn id(&self) -> BufferId {
         self.id

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -363,7 +363,7 @@ pub struct DynamicUniformBufferWriter<'a, T> {
     _marker: PhantomData<fn() -> T>,
 }
 
-impl<'a, T: ShaderType + WriteInto> DynamicUniformBufferWriter<'a, T> {
+impl<T: ShaderType + WriteInto> DynamicUniformBufferWriter<'_, T> {
     pub fn write(&mut self, value: &T) -> u32 {
         self.buffer.write(value).unwrap() as u32
     }
@@ -378,7 +378,7 @@ struct QueueWriteBufferViewWrapper<'a> {
     capacity: usize,
 }
 
-impl<'a> BufferMut for QueueWriteBufferViewWrapper<'a> {
+impl BufferMut for QueueWriteBufferViewWrapper<'_> {
     #[inline]
     fn capacity(&self) -> usize {
         self.capacity

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -240,7 +240,7 @@ pub struct FallbackImageMsaa<'w> {
     default_sampler: Res<'w, DefaultImageSampler>,
 }
 
-impl<'w> FallbackImageMsaa<'w> {
+impl FallbackImageMsaa<'_> {
     pub fn image_for_samplecount(&mut self, sample_count: u32, format: TextureFormat) -> &GpuImage {
         self.cache.entry((sample_count, format)).or_insert_with(|| {
             fallback_image_new(

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -73,7 +73,7 @@ impl<'a> SceneSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for SceneSerializer<'a> {
+impl Serialize for SceneSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -105,7 +105,7 @@ pub struct EntitiesSerializer<'a> {
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a> Serialize for EntitiesSerializer<'a> {
+impl Serialize for EntitiesSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -132,7 +132,7 @@ pub struct EntitySerializer<'a> {
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a> Serialize for EntitySerializer<'a> {
+impl Serialize for EntitySerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -163,7 +163,7 @@ pub struct SceneMapSerializer<'a> {
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a> Serialize for SceneMapSerializer<'a> {
+impl Serialize for SceneMapSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -213,7 +213,7 @@ pub struct SceneDeserializer<'a> {
     pub type_registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for SceneDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for SceneDeserializer<'_> {
     type Value = DynamicScene;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -234,7 +234,7 @@ struct SceneVisitor<'a> {
     pub type_registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for SceneVisitor<'a> {
+impl<'de> Visitor<'de> for SceneVisitor<'_> {
     type Value = DynamicScene;
 
     fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
@@ -306,7 +306,7 @@ pub struct SceneEntitiesDeserializer<'a> {
     pub type_registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for SceneEntitiesDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for SceneEntitiesDeserializer<'_> {
     type Value = Vec<DynamicEntity>;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -323,7 +323,7 @@ struct SceneEntitiesVisitor<'a> {
     pub type_registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for SceneEntitiesVisitor<'a> {
+impl<'de> Visitor<'de> for SceneEntitiesVisitor<'_> {
     type Value = Vec<DynamicEntity>;
 
     fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
@@ -355,7 +355,7 @@ pub struct SceneEntityDeserializer<'a> {
     pub type_registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for SceneEntityDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for SceneEntityDeserializer<'_> {
     type Value = DynamicEntity;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -378,7 +378,7 @@ struct SceneEntityVisitor<'a> {
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for SceneEntityVisitor<'a> {
+impl<'de> Visitor<'de> for SceneEntityVisitor<'_> {
     type Value = DynamicEntity;
 
     fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
@@ -436,7 +436,7 @@ pub struct SceneMapDeserializer<'a> {
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for SceneMapDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for SceneMapDeserializer<'_> {
     type Value = Vec<Box<dyn PartialReflect>>;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -453,7 +453,7 @@ struct SceneMapVisitor<'a> {
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
+impl<'de> Visitor<'de> for SceneMapVisitor<'_> {
     type Value = Vec<Box<dyn PartialReflect>>;
 
     fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -602,7 +602,7 @@ pub struct Scope<'scope, 'env: 'scope, T> {
     env: PhantomData<&'env mut &'env ()>,
 }
 
-impl<'scope, 'env, T: Send + 'scope> Scope<'scope, 'env, T> {
+impl<'scope, T: Send + 'scope> Scope<'scope, '_, T> {
     /// Spawns a scoped future onto the thread pool. The scope *must* outlive
     /// the provided future. The results of the future will be returned as a part of
     /// [`TaskPool::scope`]'s return value.
@@ -655,7 +655,7 @@ impl<'scope, 'env, T: Send + 'scope> Scope<'scope, 'env, T> {
     }
 }
 
-impl<'scope, 'env, T> Drop for Scope<'scope, 'env, T>
+impl<'scope, T> Drop for Scope<'scope, '_, T>
 where
     T: 'scope,
 {

--- a/crates/bevy_tasks/src/thread_executor.rs
+++ b/crates/bevy_tasks/src/thread_executor.rs
@@ -45,7 +45,7 @@ pub struct ThreadExecutor<'task> {
     thread_id: ThreadId,
 }
 
-impl<'task> Default for ThreadExecutor<'task> {
+impl Default for ThreadExecutor<'_> {
     fn default() -> Self {
         Self {
             executor: Executor::new(),

--- a/crates/bevy_text/src/text_access.rs
+++ b/crates/bevy_text/src/text_access.rs
@@ -72,7 +72,7 @@ pub struct TextReader<'w, 's, R: TextRoot> {
     >,
 }
 
-impl<'w, 's, R: TextRoot> TextReader<'w, 's, R> {
+impl<R: TextRoot> TextReader<'_, '_, R> {
     /// Returns an iterator over text spans in a text block, starting with the root entity.
     pub fn iter(&mut self, root_entity: Entity) -> TextSpanIter<R> {
         let stack = self.scratch.take();
@@ -210,7 +210,7 @@ impl<'a, R: TextRoot> Iterator for TextSpanIter<'a, R> {
     }
 }
 
-impl<'a, R: TextRoot> Drop for TextSpanIter<'a, R> {
+impl<R: TextRoot> Drop for TextSpanIter<'_, R> {
     fn drop(&mut self) {
         // Return the internal stack.
         let stack = core::mem::take(&mut self.stack);
@@ -248,7 +248,7 @@ pub struct TextWriter<'w, 's, R: TextRoot> {
     children: Query<'w, 's, &'static Children>,
 }
 
-impl<'w, 's, R: TextRoot> TextWriter<'w, 's, R> {
+impl<R: TextRoot> TextWriter<'_, '_, R> {
     /// Gets a mutable reference to a text span within a text block at a specific index in the flattened span list.
     pub fn get(
         &mut self,

--- a/crates/bevy_transform/src/helper.rs
+++ b/crates/bevy_transform/src/helper.rs
@@ -22,7 +22,7 @@ pub struct TransformHelper<'w, 's> {
     transform_query: Query<'w, 's, &'static Transform>,
 }
 
-impl<'w, 's> TransformHelper<'w, 's> {
+impl TransformHelper<'_, '_> {
     /// Computes the [`GlobalTransform`] of the given entity from the [`Transform`] component on it and its ancestors.
     pub fn compute_global_transform(
         &self,

--- a/crates/bevy_ui/src/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/ghost_hierarchy.rs
@@ -30,7 +30,7 @@ pub struct UiRootNodes<'w, 's> {
     ui_children: UiChildren<'w, 's>,
 }
 
-impl<'w, 's> UiRootNodes<'w, 's> {
+impl<'s> UiRootNodes<'_, 's> {
     pub fn iter(&'s self) -> impl Iterator<Item = Entity> + 's {
         self.root_node_query
             .iter()
@@ -123,7 +123,7 @@ pub struct UiChildrenIter<'w, 's> {
     >,
 }
 
-impl<'w, 's> Iterator for UiChildrenIter<'w, 's> {
+impl Iterator for UiChildrenIter<'_, '_> {
     type Item = Entity;
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2495,7 +2495,7 @@ pub struct DefaultUiCamera<'w, 's> {
     primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
 }
 
-impl<'w, 's> DefaultUiCamera<'w, 's> {
+impl DefaultUiCamera<'_, '_> {
     pub fn get(&self) -> Option<Entity> {
         self.default_cameras.get_single().ok().or_else(|| {
             // If there isn't a single camera and the query isn't empty, there is two or more cameras queried.

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -26,7 +26,7 @@ struct PlayerCounter<'w, 's> {
     count: ResMut<'w, PlayerCount>,
 }
 
-impl<'w, 's> PlayerCounter<'w, 's> {
+impl PlayerCounter<'_, '_> {
     fn count(&mut self) {
         self.count.0 = self.players.iter().len();
     }


### PR DESCRIPTION
Part "2" for #15906. This fixes `clippy::needless_lifetimes` for all crates except `bevy_reflect` and `bevy_ecs`, to reduce the amount of code to review.

I say "2" in quotes because all the lint fixes can be merged separately, and don't depend on each other. Although all of them are required to truly make `ci lints` pass without errors.