### PR TITLE
Fix `clippy::needless_lifetimes` for `bevy_reflect`

### DIFF
--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -489,7 +489,7 @@ impl<'a> ReflectMeta<'a> {
     }
 }
 
-impl<'a> StructField<'a> {
+impl StructField<'_> {
     /// Generates a `TokenStream` for `NamedField` or `UnnamedField` construction.
     pub fn to_info_tokens(&self, bevy_reflect_path: &Path) -> proc_macro2::TokenStream {
         let name = match &self.data.ident {
@@ -1197,7 +1197,7 @@ impl<'a> ReflectTypePath<'a> {
     }
 }
 
-impl<'a> ToTokens for ReflectTypePath<'a> {
+impl ToTokens for ReflectTypePath<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         match self {
             Self::Internal { ident, .. } | Self::Primitive(ident) => ident.to_tokens(tokens),

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -199,7 +199,7 @@ impl<'a> FromReflectVariantBuilder<'a> {
     }
 }
 
-impl<'a> VariantBuilder for FromReflectVariantBuilder<'a> {
+impl VariantBuilder for FromReflectVariantBuilder<'_> {
     fn reflect_enum(&self) -> &ReflectEnum {
         self.reflect_enum
     }
@@ -231,7 +231,7 @@ impl<'a> TryApplyVariantBuilder<'a> {
     }
 }
 
-impl<'a> VariantBuilder for TryApplyVariantBuilder<'a> {
+impl VariantBuilder for TryApplyVariantBuilder<'_> {
     fn reflect_enum(&self) -> &ReflectEnum {
         self.reflect_enum
     }

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -389,7 +389,7 @@ impl<'a> Iterator for ArrayIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for ArrayIter<'a> {}
+impl ExactSizeIterator for ArrayIter<'_> {}
 
 /// Returns the `u64` hash of the given [array](Array).
 #[inline]

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -283,7 +283,7 @@ impl<'a> Iterator for VariantFieldIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for VariantFieldIter<'a> {}
+impl ExactSizeIterator for VariantFieldIter<'_> {}
 
 pub enum VariantField<'a> {
     Struct(&'a str, &'a dyn PartialReflect),

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -192,7 +192,7 @@ pub enum ArgValue<'a> {
     Mut(&'a mut dyn PartialReflect),
 }
 
-impl<'a> Deref for ArgValue<'a> {
+impl Deref for ArgValue<'_> {
     type Target = dyn PartialReflect;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -255,7 +255,7 @@ impl_type_path!((in bevy_reflect) DynamicFunction<'env>);
 /// This takes the format: `DynamicFunction(fn {name}({arg1}: {type1}, {arg2}: {type2}, ...) -> {return_type})`.
 ///
 /// Names for arguments and the function itself are optional and will default to `_` if not provided.
-impl<'env> Debug for DynamicFunction<'env> {
+impl Debug for DynamicFunction<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let name = self.info.name().unwrap_or(&Cow::Borrowed("_"));
         write!(f, "DynamicFunction(fn {name}(")?;
@@ -275,7 +275,7 @@ impl<'env> Debug for DynamicFunction<'env> {
     }
 }
 
-impl<'env> Clone for DynamicFunction<'env> {
+impl Clone for DynamicFunction<'_> {
     fn clone(&self) -> Self {
         Self {
             info: self.info.clone(),

--- a/crates/bevy_reflect/src/func/dynamic_function_mut.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_mut.rs
@@ -214,7 +214,7 @@ impl<'env> DynamicFunctionMut<'env> {
 /// This takes the format: `DynamicFunctionMut(fn {name}({arg1}: {type1}, {arg2}: {type2}, ...) -> {return_type})`.
 ///
 /// Names for arguments and the function itself are optional and will default to `_` if not provided.
-impl<'env> Debug for DynamicFunctionMut<'env> {
+impl Debug for DynamicFunctionMut<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let name = self.info.name().unwrap_or(&Cow::Borrowed("_"));
         write!(f, "DynamicFunctionMut(fn {name}(")?;

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -524,7 +524,7 @@ impl<'a> IntoIterator for &'a DynamicMap {
     }
 }
 
-impl<'a> ExactSizeIterator for MapIter<'a> {}
+impl ExactSizeIterator for MapIter<'_> {}
 
 /// Compares a [`Map`] with a [`PartialReflect`] value.
 ///

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -57,7 +57,7 @@ pub struct AccessError<'a> {
     pub(super) offset: Option<usize>,
 }
 
-impl<'a> AccessError<'a> {
+impl AccessError<'_> {
     /// Returns the kind of [`AccessError`].
     pub const fn kind(&self) -> &AccessErrorKind {
         &self.kind

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -37,7 +37,7 @@ pub enum ReflectPathError<'a> {
     },
 }
 
-impl<'a> core::error::Error for ReflectPathError<'a> {}
+impl core::error::Error for ReflectPathError<'_> {}
 
 /// Something that can be interpreted as a reflection path in [`GetPath`].
 pub trait ReflectPath<'a>: Sized {

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -162,7 +162,7 @@ impl fmt::Display for Token<'_> {
         }
     }
 }
-impl<'a> Token<'a> {
+impl Token<'_> {
     const SYMBOLS: &'static [u8] = b".#[]";
     fn symbol_from_byte(byte: u8) -> Option<Self> {
         match byte {

--- a/crates/bevy_reflect/src/serde/de/arrays.rs
+++ b/crates/bevy_reflect/src/serde/de/arrays.rs
@@ -22,7 +22,7 @@ impl<'a> ArrayVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for ArrayVisitor<'a> {
+impl<'de> Visitor<'de> for ArrayVisitor<'_> {
     type Value = DynamicArray;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/deserializer.rs
+++ b/crates/bevy_reflect/src/serde/de/deserializer.rs
@@ -104,7 +104,7 @@ impl<'a> ReflectDeserializer<'a> {
     }
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for ReflectDeserializer<'_> {
     type Value = Box<dyn PartialReflect>;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -115,7 +115,7 @@ impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
             registry: &'a TypeRegistry,
         }
 
-        impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
+        impl<'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'_> {
             type Value = Box<dyn PartialReflect>;
 
             fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -271,7 +271,7 @@ impl<'a> TypedReflectDeserializer<'a> {
     }
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
+impl<'de> DeserializeSeed<'de> for TypedReflectDeserializer<'_> {
     type Value = Box<dyn PartialReflect>;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>

--- a/crates/bevy_reflect/src/serde/de/enums.rs
+++ b/crates/bevy_reflect/src/serde/de/enums.rs
@@ -38,7 +38,7 @@ impl<'a> EnumVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
+impl<'de> Visitor<'de> for EnumVisitor<'_> {
     type Value = DynamicEnum;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -112,7 +112,7 @@ impl<'de> DeserializeSeed<'de> for VariantDeserializer {
     {
         struct VariantVisitor(&'static EnumInfo);
 
-        impl<'de> Visitor<'de> for VariantVisitor {
+        impl Visitor<'_> for VariantVisitor {
             type Value = &'static VariantInfo;
 
             fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -157,7 +157,7 @@ struct StructVariantVisitor<'a> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for StructVariantVisitor<'a> {
+impl<'de> Visitor<'de> for StructVariantVisitor<'_> {
     type Value = DynamicStruct;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -185,7 +185,7 @@ struct TupleVariantVisitor<'a> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a, 'de> Visitor<'de> for TupleVariantVisitor<'a> {
+impl<'de> Visitor<'de> for TupleVariantVisitor<'_> {
     type Value = DynamicTuple;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/helpers.rs
+++ b/crates/bevy_reflect/src/serde/de/helpers.rs
@@ -47,7 +47,7 @@ impl<'de> Deserialize<'de> for Ident {
     {
         struct IdentVisitor;
 
-        impl<'de> Visitor<'de> for IdentVisitor {
+        impl Visitor<'_> for IdentVisitor {
             type Value = Ident;
 
             fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/lists.rs
+++ b/crates/bevy_reflect/src/serde/de/lists.rs
@@ -22,7 +22,7 @@ impl<'a> ListVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for ListVisitor<'a> {
+impl<'de> Visitor<'de> for ListVisitor<'_> {
     type Value = DynamicList;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/maps.rs
+++ b/crates/bevy_reflect/src/serde/de/maps.rs
@@ -19,7 +19,7 @@ impl<'a> MapVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for MapVisitor<'a> {
+impl<'de> Visitor<'de> for MapVisitor<'_> {
     type Value = DynamicMap;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/options.rs
+++ b/crates/bevy_reflect/src/serde/de/options.rs
@@ -23,7 +23,7 @@ impl<'a> OptionVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for OptionVisitor<'a> {
+impl<'de> Visitor<'de> for OptionVisitor<'_> {
     type Value = DynamicEnum;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/registrations.rs
+++ b/crates/bevy_reflect/src/serde/de/registrations.rs
@@ -29,7 +29,7 @@ impl<'a, 'de> DeserializeSeed<'de> for TypeRegistrationDeserializer<'a> {
     {
         struct TypeRegistrationVisitor<'a>(&'a TypeRegistry);
 
-        impl<'de, 'a> Visitor<'de> for TypeRegistrationVisitor<'a> {
+        impl<'a> Visitor<'_> for TypeRegistrationVisitor<'a> {
             type Value = &'a TypeRegistration;
 
             fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/sets.rs
+++ b/crates/bevy_reflect/src/serde/de/sets.rs
@@ -19,7 +19,7 @@ impl<'a> SetVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for SetVisitor<'a> {
+impl<'de> Visitor<'de> for SetVisitor<'_> {
     type Value = DynamicSet;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/structs.rs
+++ b/crates/bevy_reflect/src/serde/de/structs.rs
@@ -28,7 +28,7 @@ impl<'a> StructVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for StructVisitor<'a> {
+impl<'de> Visitor<'de> for StructVisitor<'_> {
     type Value = DynamicStruct;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/tuple_structs.rs
+++ b/crates/bevy_reflect/src/serde/de/tuple_structs.rs
@@ -30,7 +30,7 @@ impl<'a> TupleStructVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for TupleStructVisitor<'a> {
+impl<'de> Visitor<'de> for TupleStructVisitor<'_> {
     type Value = DynamicTupleStruct;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/de/tuples.rs
+++ b/crates/bevy_reflect/src/serde/de/tuples.rs
@@ -27,7 +27,7 @@ impl<'a> TupleVisitor<'a> {
     }
 }
 
-impl<'a, 'de> Visitor<'de> for TupleVisitor<'a> {
+impl<'de> Visitor<'de> for TupleVisitor<'_> {
     type Value = DynamicTuple;
 
     fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -278,7 +278,7 @@ mod tests {
                     registry: &'a TypeRegistry,
                 }
 
-                impl<'a, 'de> Visitor<'de> for EnemyListVisitor<'a> {
+                impl<'de> Visitor<'de> for EnemyListVisitor<'_> {
                     type Value = Vec<Arc<dyn Enemy>>;
 
                     fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {

--- a/crates/bevy_reflect/src/serde/ser/arrays.rs
+++ b/crates/bevy_reflect/src/serde/ser/arrays.rs
@@ -13,7 +13,7 @@ impl<'a> ArraySerializer<'a> {
     }
 }
 
-impl<'a> Serialize for ArraySerializer<'a> {
+impl Serialize for ArraySerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/enums.rs
+++ b/crates/bevy_reflect/src/serde/ser/enums.rs
@@ -22,7 +22,7 @@ impl<'a> EnumSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for EnumSerializer<'a> {
+impl Serialize for EnumSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/lists.rs
+++ b/crates/bevy_reflect/src/serde/ser/lists.rs
@@ -13,7 +13,7 @@ impl<'a> ListSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for ListSerializer<'a> {
+impl Serialize for ListSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/maps.rs
+++ b/crates/bevy_reflect/src/serde/ser/maps.rs
@@ -13,7 +13,7 @@ impl<'a> MapSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for MapSerializer<'a> {
+impl Serialize for MapSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/serialize_with_registry.rs
+++ b/crates/bevy_reflect/src/serde/ser/serialize_with_registry.rs
@@ -90,7 +90,7 @@ struct SerializableWithRegistry<'a, T: SerializeWithRegistry> {
     registry: &'a TypeRegistry,
 }
 
-impl<'a, T: SerializeWithRegistry> Serialize for SerializableWithRegistry<'a, T> {
+impl<T: SerializeWithRegistry> Serialize for SerializableWithRegistry<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/crates/bevy_reflect/src/serde/ser/serializer.rs
+++ b/crates/bevy_reflect/src/serde/ser/serializer.rs
@@ -58,7 +58,7 @@ impl<'a> ReflectSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for ReflectSerializer<'a> {
+impl Serialize for ReflectSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -144,7 +144,7 @@ impl<'a> TypedReflectSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for TypedReflectSerializer<'a> {
+impl Serialize for TypedReflectSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/sets.rs
+++ b/crates/bevy_reflect/src/serde/ser/sets.rs
@@ -13,7 +13,7 @@ impl<'a> SetSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for SetSerializer<'a> {
+impl Serialize for SetSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/structs.rs
+++ b/crates/bevy_reflect/src/serde/ser/structs.rs
@@ -19,7 +19,7 @@ impl<'a> StructSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for StructSerializer<'a> {
+impl Serialize for StructSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/tuple_structs.rs
+++ b/crates/bevy_reflect/src/serde/ser/tuple_structs.rs
@@ -19,7 +19,7 @@ impl<'a> TupleStructSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for TupleStructSerializer<'a> {
+impl Serialize for TupleStructSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/serde/ser/tuples.rs
+++ b/crates/bevy_reflect/src/serde/ser/tuples.rs
@@ -13,7 +13,7 @@ impl<'a> TupleSerializer<'a> {
     }
 }
 
-impl<'a> Serialize for TupleSerializer<'a> {
+impl Serialize for TupleSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -205,7 +205,7 @@ impl<'a> Iterator for FieldIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for FieldIter<'a> {}
+impl ExactSizeIterator for FieldIter<'_> {}
 
 /// A convenience trait which combines fetching and downcasting of struct
 /// fields.

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -88,7 +88,7 @@ impl<'a> Iterator for TupleFieldIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for TupleFieldIter<'a> {}
+impl ExactSizeIterator for TupleFieldIter<'_> {}
 
 /// A convenience trait which combines fetching and downcasting of tuple
 /// fields.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -159,7 +159,7 @@ impl<'a> Iterator for TupleStructFieldIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for TupleStructFieldIter<'a> {}
+impl ExactSizeIterator for TupleStructFieldIter<'_> {}
 
 /// A convenience trait which combines fetching and downcasting of tuple
 /// struct fields.


### PR DESCRIPTION
Part "3" for #15906. This fixes `clippy::needless_lifetimes` for `bevy_reflect`, to reduce the amount of code to review.

I say "3" in quotes because all the lint fixes can be merged separately, and don't depend on each other. Although all of them are required to truly make `ci lints` pass without errors.