### PR TITLE
Fix `clippy::needless_lifetimes` for `bevy_ecs`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -601,7 +601,7 @@ impl<'w, T: Resource> From<Res<'w, T>> for Ref<'w, T> {
     }
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a Res<'w, T>
+impl<'a, T: Resource> IntoIterator for &'a Res<'_, T>
 where
     &'a T: IntoIterator,
 {
@@ -632,7 +632,7 @@ pub struct ResMut<'w, T: ?Sized + Resource> {
     pub(crate) changed_by: &'w mut &'static Location<'static>,
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a ResMut<'w, T>
+impl<'a, T: Resource> IntoIterator for &'a ResMut<'_, T>
 where
     &'a T: IntoIterator,
 {
@@ -644,7 +644,7 @@ where
     }
 }
 
-impl<'w, 'a, T: Resource> IntoIterator for &'a mut ResMut<'w, T>
+impl<'a, T: Resource> IntoIterator for &'a mut ResMut<'_, T>
 where
     &'a mut T: IntoIterator,
 {
@@ -794,7 +794,7 @@ impl<'w, T: ?Sized> Ref<'w, T> {
     }
 }
 
-impl<'w, 'a, T> IntoIterator for &'a Ref<'w, T>
+impl<'a, T> IntoIterator for &'a Ref<'_, T>
 where
     &'a T: IntoIterator,
 {
@@ -924,7 +924,7 @@ impl<'w, T: ?Sized> From<Mut<'w, T>> for Ref<'w, T> {
     }
 }
 
-impl<'w, 'a, T> IntoIterator for &'a Mut<'w, T>
+impl<'a, T> IntoIterator for &'a Mut<'_, T>
 where
     &'a T: IntoIterator,
 {
@@ -936,7 +936,7 @@ where
     }
 }
 
-impl<'w, 'a, T> IntoIterator for &'a mut Mut<'w, T>
+impl<'a, T> IntoIterator for &'a mut Mut<'_, T>
 where
     &'a mut T: IntoIterator,
 {
@@ -1064,7 +1064,7 @@ impl<'w> MutUntyped<'w> {
     }
 }
 
-impl<'w> DetectChanges for MutUntyped<'w> {
+impl DetectChanges for MutUntyped<'_> {
     #[inline]
     fn is_added(&self) -> bool {
         self.ticks

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1494,7 +1494,7 @@ pub struct TickCells<'a> {
     pub changed: &'a UnsafeCell<Tick>,
 }
 
-impl<'a> TickCells<'a> {
+impl TickCells<'_> {
     /// # Safety
     /// All cells contained within must uphold the safety invariants of [`UnsafeCellDeref::read`].
     #[inline]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -471,7 +471,7 @@ pub struct ReserveEntitiesIterator<'a> {
     new_indices: core::ops::Range<u32>,
 }
 
-impl<'a> Iterator for ReserveEntitiesIterator<'a> {
+impl Iterator for ReserveEntitiesIterator<'_> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -489,8 +489,8 @@ impl<'a> Iterator for ReserveEntitiesIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for ReserveEntitiesIterator<'a> {}
-impl<'a> core::iter::FusedIterator for ReserveEntitiesIterator<'a> {}
+impl ExactSizeIterator for ReserveEntitiesIterator<'_> {}
+impl core::iter::FusedIterator for ReserveEntitiesIterator<'_> {}
 
 /// A [`World`]'s internal metadata store on all of its entities.
 ///

--- a/crates/bevy_ecs/src/event/iterators.rs
+++ b/crates/bevy_ecs/src/event/iterators.rs
@@ -37,7 +37,7 @@ impl<'a, E: Event> Iterator for EventIterator<'a, E> {
     }
 }
 
-impl<'a, E: Event> ExactSizeIterator for EventIterator<'a, E> {
+impl<E: Event> ExactSizeIterator for EventIterator<'_, E> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -132,7 +132,7 @@ impl<'a, E: Event> Iterator for EventIteratorWithId<'a, E> {
     }
 }
 
-impl<'a, E: Event> ExactSizeIterator for EventIteratorWithId<'a, E> {
+impl<E: Event> ExactSizeIterator for EventIteratorWithId<'_, E> {
     fn len(&self) -> usize {
         self.unread
     }

--- a/crates/bevy_ecs/src/event/mut_iterators.rs
+++ b/crates/bevy_ecs/src/event/mut_iterators.rs
@@ -39,7 +39,7 @@ impl<'a, E: Event> Iterator for EventMutIterator<'a, E> {
     }
 }
 
-impl<'a, E: Event> ExactSizeIterator for EventMutIterator<'a, E> {
+impl<E: Event> ExactSizeIterator for EventMutIterator<'_, E> {
     fn len(&self) -> usize {
         self.iter.len()
     }
@@ -135,7 +135,7 @@ impl<'a, E: Event> Iterator for EventMutIteratorWithId<'a, E> {
     }
 }
 
-impl<'a, E: Event> ExactSizeIterator for EventMutIteratorWithId<'a, E> {
+impl<E: Event> ExactSizeIterator for EventMutIteratorWithId<'_, E> {
     fn len(&self) -> usize {
         self.unread
     }

--- a/crates/bevy_ecs/src/event/mutator.rs
+++ b/crates/bevy_ecs/src/event/mutator.rs
@@ -48,7 +48,7 @@ pub struct EventMutator<'w, 's, E: Event> {
     events: ResMut<'w, Events<E>>,
 }
 
-impl<'w, 's, E: Event> EventMutator<'w, 's, E> {
+impl<E: Event> EventMutator<'_, '_, E> {
     /// Iterates over the events this [`EventMutator`] has not seen yet. This updates the
     /// [`EventMutator`]'s event counter, which means subsequent event reads will not include events
     /// that happened before now.

--- a/crates/bevy_ecs/src/event/reader.rs
+++ b/crates/bevy_ecs/src/event/reader.rs
@@ -20,7 +20,7 @@ pub struct EventReader<'w, 's, E: Event> {
     events: Res<'w, Events<E>>,
 }
 
-impl<'w, 's, E: Event> EventReader<'w, 's, E> {
+impl<E: Event> EventReader<'_, '_, E> {
     /// Iterates over the events this [`EventReader`] has not seen yet. This updates the
     /// [`EventReader`]'s event counter, which means subsequent event reads will not include events
     /// that happened before now.

--- a/crates/bevy_ecs/src/event/writer.rs
+++ b/crates/bevy_ecs/src/event/writer.rs
@@ -64,7 +64,7 @@ pub struct EventWriter<'w, E: Event> {
     events: ResMut<'w, Events<E>>,
 }
 
-impl<'w, E: Event> EventWriter<'w, E> {
+impl<E: Event> EventWriter<'_, E> {
     /// Sends an `event`, which can later be read by [`EventReader`](super::EventReader)s.
     /// This method returns the [ID](`EventId`) of the sent `event`.
     ///

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -120,7 +120,7 @@ impl<'w, E, B: Bundle> Trigger<'w, E, B> {
     }
 }
 
-impl<'w, E: Debug, B: Bundle> Debug for Trigger<'w, E, B> {
+impl<E: Debug, B: Bundle> Debug for Trigger<'_, E, B> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Trigger")
             .field("event", &self.event)
@@ -131,7 +131,7 @@ impl<'w, E: Debug, B: Bundle> Debug for Trigger<'w, E, B> {
     }
 }
 
-impl<'w, E, B: Bundle> Deref for Trigger<'w, E, B> {
+impl<E, B: Bundle> Deref for Trigger<'_, E, B> {
     type Target = E;
 
     fn deref(&self) -> &Self::Target {
@@ -139,7 +139,7 @@ impl<'w, E, B: Bundle> Deref for Trigger<'w, E, B> {
     }
 }
 
-impl<'w, E, B: Bundle> DerefMut for Trigger<'w, E, B> {
+impl<E, B: Bundle> DerefMut for Trigger<'_, E, B> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.event
     }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -36,7 +36,7 @@ impl<'a, T: SparseSetIndex> FormattedBitSet<'a, T> {
     }
 }
 
-impl<'a, T: SparseSetIndex + Debug> Debug for FormattedBitSet<'a, T> {
+impl<T: SparseSetIndex + Debug> Debug for FormattedBitSet<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list()
             .entries(self.bit_set.ones().map(T::get_sparse_set_index))

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -18,9 +18,9 @@ pub enum QueryEntityError<'w> {
     AliasedMutability(Entity),
 }
 
-impl<'w> core::error::Error for QueryEntityError<'w> {}
+impl core::error::Error for QueryEntityError<'_> {}
 
-impl<'w> core::fmt::Display for QueryEntityError<'w> {
+impl core::fmt::Display for QueryEntityError<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Self::QueryDoesNotMatch(entity, world) => {
@@ -39,7 +39,7 @@ impl<'w> core::fmt::Display for QueryEntityError<'w> {
     }
 }
 
-impl<'w> core::fmt::Debug for QueryEntityError<'w> {
+impl core::fmt::Debug for QueryEntityError<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match *self {
             Self::QueryDoesNotMatch(entity, world) => {
@@ -75,7 +75,7 @@ fn format_archetype(
     Ok(())
 }
 
-impl<'w> PartialEq for QueryEntityError<'w> {
+impl PartialEq for QueryEntityError<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::QueryDoesNotMatch(e1, _), Self::QueryDoesNotMatch(e2, _)) if e1 == e2 => true,
@@ -86,7 +86,7 @@ impl<'w> PartialEq for QueryEntityError<'w> {
     }
 }
 
-impl<'w> Eq for QueryEntityError<'w> {}
+impl Eq for QueryEntityError<'_> {}
 
 /// An error that occurs when evaluating a [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState) as a single expected result via
 /// [`get_single`](crate::system::Query::get_single) or [`get_single_mut`](crate::system::Query::get_single_mut).

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -441,7 +441,7 @@ unsafe impl ReadOnlyQueryData for EntityLocation {}
 /// `fetch` accesses all components in a readonly way.
 /// This is sound because `update_component_access` and `update_archetype_component_access` set read access for all components and panic when appropriate.
 /// Filters are unchanged.
-unsafe impl<'a> WorldQuery for EntityRef<'a> {
+unsafe impl WorldQuery for EntityRef<'_> {
     type Item<'w> = EntityRef<'w>;
     type Fetch<'w> = UnsafeWorldCell<'w>;
     type State = ();
@@ -513,7 +513,7 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
 }
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
-unsafe impl<'a> QueryData for EntityRef<'a> {
+unsafe impl QueryData for EntityRef<'_> {
     type ReadOnly = Self;
 }
 
@@ -521,7 +521,7 @@ unsafe impl<'a> QueryData for EntityRef<'a> {
 unsafe impl ReadOnlyQueryData for EntityRef<'_> {}
 
 /// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
-unsafe impl<'a> WorldQuery for EntityMut<'a> {
+unsafe impl WorldQuery for EntityMut<'_> {
     type Item<'w> = EntityMut<'w>;
     type Fetch<'w> = UnsafeWorldCell<'w>;
     type State = ();
@@ -598,7 +598,7 @@ unsafe impl<'a> QueryData for EntityMut<'a> {
 }
 
 /// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
-unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
+unsafe impl WorldQuery for FilteredEntityRef<'_> {
     type Fetch<'w> = (UnsafeWorldCell<'w>, Access<ComponentId>);
     type Item<'w> = FilteredEntityRef<'w>;
     type State = FilteredAccess<ComponentId>;
@@ -685,7 +685,7 @@ unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
 }
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
-unsafe impl<'a> QueryData for FilteredEntityRef<'a> {
+unsafe impl QueryData for FilteredEntityRef<'_> {
     type ReadOnly = Self;
 }
 
@@ -693,7 +693,7 @@ unsafe impl<'a> QueryData for FilteredEntityRef<'a> {
 unsafe impl ReadOnlyQueryData for FilteredEntityRef<'_> {}
 
 /// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
-unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
+unsafe impl WorldQuery for FilteredEntityMut<'_> {
     type Fetch<'w> = (UnsafeWorldCell<'w>, Access<ComponentId>);
     type Item<'w> = FilteredEntityMut<'w>;
     type State = FilteredAccess<ComponentId>;
@@ -786,7 +786,7 @@ unsafe impl<'a> QueryData for FilteredEntityMut<'a> {
 /// SAFETY: `EntityRefExcept` guards access to all components in the bundle `B`
 /// and populates `Access` values so that queries that conflict with this access
 /// are rejected.
-unsafe impl<'a, B> WorldQuery for EntityRefExcept<'a, B>
+unsafe impl<B> WorldQuery for EntityRefExcept<'_, B>
 where
     B: Bundle,
 {
@@ -871,7 +871,7 @@ where
 }
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`.
-unsafe impl<'a, B> QueryData for EntityRefExcept<'a, B>
+unsafe impl<B> QueryData for EntityRefExcept<'_, B>
 where
     B: Bundle,
 {
@@ -880,12 +880,12 @@ where
 
 /// SAFETY: `EntityRefExcept` enforces read-only access to its contained
 /// components.
-unsafe impl<'a, B> ReadOnlyQueryData for EntityRefExcept<'a, B> where B: Bundle {}
+unsafe impl<B> ReadOnlyQueryData for EntityRefExcept<'_, B> where B: Bundle {}
 
 /// SAFETY: `EntityMutExcept` guards access to all components in the bundle `B`
 /// and populates `Access` values so that queries that conflict with this access
 /// are rejected.
-unsafe impl<'a, B> WorldQuery for EntityMutExcept<'a, B>
+unsafe impl<B> WorldQuery for EntityMutExcept<'_, B>
 where
     B: Bundle,
 {
@@ -1246,7 +1246,7 @@ impl<T: Component> Copy for RefFetch<'_, T> {}
 /// This is sound because `update_component_access` and `update_archetype_component_access` add read access for that component and panic when appropriate.
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
-unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
+unsafe impl<T: Component> WorldQuery for Ref<'_, T> {
     type Item<'w> = Ref<'w, T>;
     type Fetch<'w> = RefFetch<'w, T>;
     type State = ComponentId;
@@ -1408,12 +1408,12 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
 }
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
-unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {
+unsafe impl<T: Component> QueryData for Ref<'_, T> {
     type ReadOnly = Self;
 }
 
 /// SAFETY: access is read only
-unsafe impl<'__w, T: Component> ReadOnlyQueryData for Ref<'__w, T> {}
+unsafe impl<T: Component> ReadOnlyQueryData for Ref<'_, T> {}
 
 /// The [`WorldQuery::Fetch`] type for `&mut T`.
 pub struct WriteFetch<'w, T: Component> {
@@ -1445,7 +1445,7 @@ impl<T: Component> Copy for WriteFetch<'_, T> {}
 /// This is sound because `update_component_access` and `update_archetype_component_access` add write access for that component and panic when appropriate.
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
-unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
+unsafe impl<T: Component> WorldQuery for &mut T {
     type Item<'w> = Mut<'w, T>;
     type Fetch<'w> = WriteFetch<'w, T>;
     type State = ComponentId;
@@ -1620,7 +1620,7 @@ unsafe impl<'__w, T: Component> QueryData for &'__w mut T {
 /// This is sound because `update_component_access` and `update_archetype_component_access` add write access for that component and panic when appropriate.
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
-unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
+unsafe impl<T: Component> WorldQuery for Mut<'_, T> {
     type Item<'w> = Mut<'w, T>;
     type Fetch<'w> = WriteFetch<'w, T>;
     type State = ComponentId;

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1058,7 +1058,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for QueryIter<'w, 's, D, F> {
+impl<'w, D: QueryData, F: QueryFilter> Iterator for QueryIter<'w, '_, D, F> {
     type Item = D::Item<'w>;
 
     #[inline(always)]
@@ -1101,9 +1101,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for QueryIter<'w, 's, D, F> 
 }
 
 // This is correct as [`QueryIter`] always returns `None` once exhausted.
-impl<'w, 's, D: QueryData, F: QueryFilter> FusedIterator for QueryIter<'w, 's, D, F> {}
+impl<D: QueryData, F: QueryFilter> FusedIterator for QueryIter<'_, '_, D, F> {}
 
-impl<'w, 's, D: QueryData, F: QueryFilter> Debug for QueryIter<'w, 's, D, F> {
+impl<D: QueryData, F: QueryFilter> Debug for QueryIter<'_, '_, D, F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryIter").finish()
     }
@@ -1190,8 +1190,7 @@ where
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator> Iterator
-    for QuerySortedIter<'w, 's, D, F, I>
+impl<'w, D: QueryData, F: QueryFilter, I: Iterator> Iterator for QuerySortedIter<'w, '_, D, F, I>
 where
     I: Iterator<Item = Entity>,
 {
@@ -1209,8 +1208,8 @@ where
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator> DoubleEndedIterator
-    for QuerySortedIter<'w, 's, D, F, I>
+impl<D: QueryData, F: QueryFilter, I: Iterator> DoubleEndedIterator
+    for QuerySortedIter<'_, '_, D, F, I>
 where
     I: DoubleEndedIterator<Item = Entity>,
 {
@@ -1222,23 +1221,21 @@ where
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator> ExactSizeIterator
-    for QuerySortedIter<'w, 's, D, F, I>
+impl<D: QueryData, F: QueryFilter, I: Iterator> ExactSizeIterator
+    for QuerySortedIter<'_, '_, D, F, I>
 where
     I: ExactSizeIterator<Item = Entity>,
 {
 }
 
 // This is correct as [`QuerySortedIter`] returns `None` once exhausted if `entity_iter` does.
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator> FusedIterator
-    for QuerySortedIter<'w, 's, D, F, I>
-where
-    I: FusedIterator<Item = Entity>,
+impl<D: QueryData, F: QueryFilter, I: Iterator> FusedIterator for QuerySortedIter<'_, '_, D, F, I> where
+    I: FusedIterator<Item = Entity>
 {
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>> Debug
-    for QuerySortedIter<'w, 's, D, F, I>
+impl<D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>> Debug
+    for QuerySortedIter<'_, '_, D, F, I>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QuerySortedIter").finish()
@@ -1369,8 +1366,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>>
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: Borrow<Entity>>>
-    QueryManyIter<'w, 's, D, F, I>
+impl<D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: Borrow<Entity>>>
+    QueryManyIter<'_, '_, D, F, I>
 {
     /// Get next result from the back of the query
     #[inline(always)]
@@ -1395,8 +1392,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: Borrow<E
     }
 }
 
-impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>> Iterator
-    for QueryManyIter<'w, 's, D, F, I>
+impl<'w, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>> Iterator
+    for QueryManyIter<'w, '_, D, F, I>
 {
     type Item = D::Item<'w>;
 
@@ -1424,13 +1421,8 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: Borrow<Enti
     }
 }
 
-impl<
-        'w,
-        's,
-        D: ReadOnlyQueryData,
-        F: QueryFilter,
-        I: DoubleEndedIterator<Item: Borrow<Entity>>,
-    > DoubleEndedIterator for QueryManyIter<'w, 's, D, F, I>
+impl<D: ReadOnlyQueryData, F: QueryFilter, I: DoubleEndedIterator<Item: Borrow<Entity>>>
+    DoubleEndedIterator for QueryManyIter<'_, '_, D, F, I>
 {
     #[inline(always)]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -1452,13 +1444,13 @@ impl<
 }
 
 // This is correct as [`QueryManyIter`] always returns `None` once exhausted.
-impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>> FusedIterator
-    for QueryManyIter<'w, 's, D, F, I>
+impl<D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>> FusedIterator
+    for QueryManyIter<'_, '_, D, F, I>
 {
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>> Debug
-    for QueryManyIter<'w, 's, D, F, I>
+impl<D: QueryData, F: QueryFilter, I: Iterator<Item: Borrow<Entity>>> Debug
+    for QueryManyIter<'_, '_, D, F, I>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryManyIter").finish()
@@ -1636,8 +1628,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, const K: usize> QueryCombinationIter<
 // Iterator type is intentionally implemented only for read-only access.
 // Doing so for mutable references would be unsound, because calling `next`
 // multiple times would allow multiple owned references to the same data to exist.
-impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, const K: usize> Iterator
-    for QueryCombinationIter<'w, 's, D, F, K>
+impl<'w, D: ReadOnlyQueryData, F: QueryFilter, const K: usize> Iterator
+    for QueryCombinationIter<'w, '_, D, F, K>
 {
     type Item = [D::Item<'w>; K];
 
@@ -1679,7 +1671,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, const K: usize> Iterator
     }
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> ExactSizeIterator for QueryIter<'w, 's, D, F>
+impl<D: QueryData, F: QueryFilter> ExactSizeIterator for QueryIter<'_, '_, D, F>
 where
     F: ArchetypeFilter,
 {
@@ -1689,14 +1681,12 @@ where
 }
 
 // This is correct as [`QueryCombinationIter`] always returns `None` once exhausted.
-impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, const K: usize> FusedIterator
-    for QueryCombinationIter<'w, 's, D, F, K>
+impl<D: ReadOnlyQueryData, F: QueryFilter, const K: usize> FusedIterator
+    for QueryCombinationIter<'_, '_, D, F, K>
 {
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, const K: usize> Debug
-    for QueryCombinationIter<'w, 's, D, F, K>
-{
+impl<D: QueryData, F: QueryFilter, const K: usize> Debug for QueryCombinationIter<'_, '_, D, F, K> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryCombinationIter").finish()
     }

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -16,7 +16,7 @@ pub struct QueryParIter<'w, 's, D: QueryData, F: QueryFilter> {
     pub(crate) batching_strategy: BatchingStrategy,
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
+impl<'w, D: QueryData, F: QueryFilter> QueryParIter<'w, '_, D, F> {
     /// Changes the batching strategy used when iterating.
     ///
     /// For more information on how this affects the resultant iteration, see

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -167,7 +167,7 @@ fn map_id_events(
 
 // For all practical purposes, the api surface of `RemovedComponents<T>`
 // should be similar to `EventReader<T>` to reduce confusion.
-impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
+impl<T: Component> RemovedComponents<'_, '_, T> {
     /// Fetch underlying [`EventCursor`].
     pub fn reader(&self) -> &EventCursor<RemovedComponentEntity> {
         &self.reader
@@ -245,10 +245,10 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
 }
 
 // SAFETY: Only reads World removed component events
-unsafe impl<'a> ReadOnlySystemParam for &'a RemovedComponentEvents {}
+unsafe impl ReadOnlySystemParam for &RemovedComponentEvents {}
 
 // SAFETY: no component value access.
-unsafe impl<'a> SystemParam for &'a RemovedComponentEvents {
+unsafe impl SystemParam for &RemovedComponentEvents {
     type State = ();
     type Item<'w, 's> = &'w RemovedComponentEvents;
 

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -205,8 +205,8 @@ impl ParamBuilder {
 }
 
 // SAFETY: Calls `init_query_param`, just like `Query::init_state`.
-unsafe impl<'w, 's, D: QueryData + 'static, F: QueryFilter + 'static>
-    SystemParamBuilder<Query<'w, 's, D, F>> for QueryState<D, F>
+unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static>
+    SystemParamBuilder<Query<'_, '_, D, F>> for QueryState<D, F>
 {
     fn build(self, world: &mut World, system_meta: &mut SystemMeta) -> QueryState<D, F> {
         self.validate_world(world.id());
@@ -278,13 +278,8 @@ impl<'a, D: QueryData, F: QueryFilter>
 }
 
 // SAFETY: Calls `init_query_param`, just like `Query::init_state`.
-unsafe impl<
-        'w,
-        's,
-        D: QueryData + 'static,
-        F: QueryFilter + 'static,
-        T: FnOnce(&mut QueryBuilder<D, F>),
-    > SystemParamBuilder<Query<'w, 's, D, F>> for QueryParamBuilder<T>
+unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static, T: FnOnce(&mut QueryBuilder<D, F>)>
+    SystemParamBuilder<Query<'_, '_, D, F>> for QueryParamBuilder<T>
 {
     fn build(self, world: &mut World, system_meta: &mut SystemMeta) -> QueryState<D, F> {
         let mut builder = QueryBuilder::new(world);
@@ -440,8 +435,8 @@ all_tuples!(impl_param_set_builder_tuple, 1, 8, P, B, meta);
 
 // SAFETY: Relevant parameter ComponentId and ArchetypeComponentId access is applied to SystemMeta. If any ParamState conflicts
 // with any prior access, a panic will occur.
-unsafe impl<'w, 's, P: SystemParam, B: SystemParamBuilder<P>>
-    SystemParamBuilder<ParamSet<'w, 's, Vec<P>>> for ParamSetBuilder<Vec<B>>
+unsafe impl<P: SystemParam, B: SystemParamBuilder<P>> SystemParamBuilder<ParamSet<'_, '_, Vec<P>>>
+    for ParamSetBuilder<Vec<B>>
 {
     fn build(
         self,
@@ -489,7 +484,7 @@ impl<'a> DynParamBuilder<'a> {
 // SAFETY: `DynSystemParam::get_param` will call `get_param` on the boxed `DynSystemParamState`,
 // and the boxed builder was a valid implementation of `SystemParamBuilder` for that type.
 // The resulting `DynSystemParam` can only perform access by downcasting to that param type.
-unsafe impl<'a, 'w, 's> SystemParamBuilder<DynSystemParam<'w, 's>> for DynParamBuilder<'a> {
+unsafe impl<'w, 's> SystemParamBuilder<DynSystemParam<'w, 's>> for DynParamBuilder<'_> {
     fn build(
         self,
         world: &mut World,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1666,7 +1666,7 @@ pub struct EntityEntryCommands<'a, T> {
     marker: PhantomData<T>,
 }
 
-impl<'a, T: Component> EntityEntryCommands<'a, T> {
+impl<T: Component> EntityEntryCommands<'_, T> {
     /// Modify the component `T` if it exists, using the the function `modify`.
     pub fn and_modify(&mut self, modify: impl FnOnce(Mut<T>) + Send + Sync + 'static) -> &mut Self {
         self.entity_commands

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -62,7 +62,7 @@ impl SystemBuffer for ParallelCommandQueue {
     }
 }
 
-impl<'w, 's> ParallelCommands<'w, 's> {
+impl ParallelCommands<'_, '_> {
     /// Temporarily provides access to the [`Commands`] for the current thread.
     ///
     /// For an example, see the type-level documentation for [`ParallelCommands`].

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -33,8 +33,8 @@ pub trait ExclusiveSystemParam: Sized {
 /// for a given [`ExclusiveSystemParam`].
 pub type ExclusiveSystemParamItem<'s, P> = <P as ExclusiveSystemParam>::Item<'s>;
 
-impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> ExclusiveSystemParam
-    for &'a mut QueryState<D, F>
+impl<D: QueryData + 'static, F: QueryFilter + 'static> ExclusiveSystemParam
+    for &mut QueryState<D, F>
 {
     type State = QueryState<D, F>;
     type Item<'s> = &'s mut QueryState<D, F>;
@@ -48,7 +48,7 @@ impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> ExclusiveSystemParam
     }
 }
 
-impl<'a, P: SystemParam + 'static> ExclusiveSystemParam for &'a mut SystemState<P> {
+impl<P: SystemParam + 'static> ExclusiveSystemParam for &mut SystemState<P> {
     type State = SystemState<P>;
     type Item<'s> = &'s mut SystemState<P>;
 
@@ -61,7 +61,7 @@ impl<'a, P: SystemParam + 'static> ExclusiveSystemParam for &'a mut SystemState<
     }
 }
 
-impl<'_s, T: FromWorld + Send + 'static> ExclusiveSystemParam for Local<'_s, T> {
+impl<T: FromWorld + Send + 'static> ExclusiveSystemParam for Local<'_, T> {
     type State = SyncCell<T>;
     type Item<'s> = Local<'s, T>;
 

--- a/crates/bevy_ecs/src/system/input.rs
+++ b/crates/bevy_ecs/src/system/input.rs
@@ -136,7 +136,7 @@ impl<T: ?Sized + 'static> SystemInput for InRef<'_, T> {
     }
 }
 
-impl<'i, T: ?Sized> Deref for InRef<'i, T> {
+impl<T: ?Sized> Deref for InRef<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -183,7 +183,7 @@ impl<T: ?Sized + 'static> SystemInput for InMut<'_, T> {
     }
 }
 
-impl<'i, T: ?Sized> Deref for InMut<'i, T> {
+impl<T: ?Sized> Deref for InMut<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -191,7 +191,7 @@ impl<'i, T: ?Sized> Deref for InMut<'i, T> {
     }
 }
 
-impl<'i, T: ?Sized> DerefMut for InMut<'i, T> {
+impl<T: ?Sized> DerefMut for InMut<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0
     }
@@ -219,7 +219,7 @@ impl<E: 'static, B: Bundle> SystemInput for Trigger<'_, E, B> {
 /// function systems.
 pub struct StaticSystemInput<'a, I: SystemInput>(pub I::Inner<'a>);
 
-impl<'a, I: SystemInput> SystemInput for StaticSystemInput<'a, I> {
+impl<I: SystemInput> SystemInput for StaticSystemInput<'_, I> {
     type Param<'i> = StaticSystemInput<'i, I>;
     type Inner<'i> = I::Inner<'i>;
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1664,7 +1664,7 @@ impl<'w, D: QueryData, F: QueryFilter> Deref for Single<'w, D, F> {
     }
 }
 
-impl<'w, D: QueryData, F: QueryFilter> DerefMut for Single<'w, D, F> {
+impl<D: QueryData, F: QueryFilter> DerefMut for Single<'_, D, F> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.item
     }

--- a/crates/bevy_ecs/src/system/system_name.rs
+++ b/crates/bevy_ecs/src/system/system_name.rs
@@ -38,14 +38,14 @@ use derive_more::derive::{AsRef, Display, Into};
 #[as_ref(str)]
 pub struct SystemName<'s>(&'s str);
 
-impl<'s> SystemName<'s> {
+impl SystemName<'_> {
     /// Gets the name of the system.
     pub fn name(&self) -> &str {
         self.0
     }
 }
 
-impl<'s> Deref for SystemName<'s> {
+impl Deref for SystemName<'_> {
     type Target = str;
     fn deref(&self) -> &Self::Target {
         self.name()
@@ -73,7 +73,7 @@ unsafe impl SystemParam for SystemName<'_> {
 }
 
 // SAFETY: Only reads internal system state
-unsafe impl<'s> ReadOnlySystemParam for SystemName<'s> {}
+unsafe impl ReadOnlySystemParam for SystemName<'_> {}
 
 impl ExclusiveSystemParam for SystemName<'_> {
     type State = Cow<'static, str>;

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -23,7 +23,7 @@ pub struct DeferredWorld<'w> {
     world: UnsafeWorldCell<'w>,
 }
 
-impl<'w> Deref for DeferredWorld<'w> {
+impl Deref for DeferredWorld<'_> {
     type Target = World;
 
     fn deref(&self) -> &Self::Target {
@@ -52,7 +52,7 @@ impl<'w> From<&'w mut World> for DeferredWorld<'w> {
     }
 }
 
-impl<'w> DeferredWorld<'w> {
+impl DeferredWorld<'_> {
     /// Reborrow self as a new instance of [`DeferredWorld`]
     #[inline]
     pub fn reborrow(&mut self) -> DeferredWorld {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2010,7 +2010,7 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
     }
 }
 
-impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
+impl<'a, T: Component + Default> Entry<'_, 'a, T> {
     /// Ensures the entry has this component by inserting the default value if empty, and
     /// returns a mutable reference to this component in the entry.
     ///
@@ -2044,7 +2044,7 @@ pub struct OccupiedEntry<'w, 'a, T: Component> {
     _marker: PhantomData<T>,
 }
 
-impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
+impl<'a, T: Component> OccupiedEntry<'_, 'a, T> {
     /// Gets a reference to the component in the entry.
     ///
     /// # Examples

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2364,7 +2364,7 @@ impl World {
             Insert(BundleInserter<'w>, ArchetypeId),
         }
 
-        impl<'w> SpawnOrInsert<'w> {
+        impl SpawnOrInsert<'_> {
             fn entities(&mut self) -> &mut Entities {
                 match self {
                     SpawnOrInsert::Spawn(spawner) => spawner.entities(),


### PR DESCRIPTION
Part "4" for #15906. This fixes `clippy::needless_lifetimes` for `bevy_ecs`, to reduce the amount of code to review.

I say "4" in quotes because all the lint fixes can be merged separately, and don't depend on each other. Although all of them are required to truly make `ci lints` pass without errors.