### PR TITLE
screenshot comparison: prepare macos folder in the expected format by upload-artifact action

### DIFF
--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -225,8 +225,8 @@ jobs:
     needs: [make-macos-screenshots-available]
     uses: ./.github/workflows/send-screenshots-to-pixeleagle.yml
     with:
-      commit: ${{ github.event.workflow_run.event.sha }}
-      branch: ${{ github.event.workflow_run.event.ref_name }}
+      commit: ${{ github.event.workflow_run.head_commit }}
+      branch: ${{ github.event.workflow_run.head_branch }}
       artifact: screenshots-macos
       os: macos
     secrets: inherit

--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -208,12 +208,16 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/screenshots-macos.zip', Buffer.from(download.data));
             return "true"
-      - run: unzip screenshots-macos.zip
+      - name: prepare artifact folder
+        run: |
+          unzip screenshots-macos.zip
+          mkdir screenshots
+          mv screenshots-* screenshots/
       - name: save screenshots
         uses: actions/upload-artifact@v4
         with:
           name: screenshots-macos
-          path: screenshots-macos
+          path: screenshots
 
 
   compare-macos-screenshots:


### PR DESCRIPTION
# Objective

- After #15894, creenshot upload now works on linux but still fails on macOS 
- Artifact with screenshot is not prepared correctly:
![Screenshot 2024-10-14 at 21 58 49](https://github.com/user-attachments/assets/8a50613d-aba6-49ee-b9c3-614d77f34ed0)

## Solution

- Try to prepare it like the `upload-artifact` action expects it
