### PR TITLE
UI materials: don't reserve in loop when enough capacity

### DIFF
--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -643,9 +643,9 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
             },
         );
         if transparent_phase.items.capacity() < extracted_uinodes.uinodes.len() {
-            transparent_phase
-                .items
-                .reserve(extracted_uinodes.uinodes.len());
+            transparent_phase.items.reserve_exact(
+                transparent_phase.items.capacity() - extracted_uinodes.uinodes.len(),
+            );
         }
         transparent_phase.add(TransparentUi {
             draw_function,

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -642,9 +642,11 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
                 bind_group_data: material.key.clone(),
             },
         );
-        transparent_phase
-            .items
-            .reserve(extracted_uinodes.uinodes.len());
+        if transparent_phase.items.capacity() < extracted_uinodes.uinodes.len() {
+            transparent_phase
+                .items
+                .reserve(extracted_uinodes.uinodes.len());
+        }
         transparent_phase.add(TransparentUi {
             draw_function,
             pipeline,

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -644,7 +644,7 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
         );
         if transparent_phase.items.capacity() < extracted_uinodes.uinodes.len() {
             transparent_phase.items.reserve_exact(
-                transparent_phase.items.capacity() - extracted_uinodes.uinodes.len(),
+                extracted_uinodes.uinodes.len() - transparent_phase.items.capacity(),
             );
         }
         transparent_phase.add(TransparentUi {


### PR DESCRIPTION
# Objective

- UI materials reserve too much capacity in a vec: for every node in the transparent phase, it reserves enough memory to store all the nodes
- Update #10437 

## Solution

- Only reserve extra memory if there's not enough
- Only reserve the needed memory, not more
