### PR TITLE
Remove `ExtractComponent::Out`

### DIFF
--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -207,7 +207,7 @@ fn extract_components<C: ExtractComponent>(
         if let Some(component) = C::extract_component(query_item) {
             values.push((entity, component));
         } else {
-            commands.entity(entity).remove::<C>();
+            commands.entity(entity).remove::<C::Out>();
         }
     }
     *previous_len = values.len();
@@ -226,7 +226,7 @@ fn extract_visible_components<C: ExtractComponent>(
             if let Some(component) = C::extract_component(query_item) {
                 values.push((entity, component));
             } else {
-                commands.entity(entity).remove::<C>();
+                commands.entity(entity).remove::<C::Out>();
             }
         }
     }


### PR DESCRIPTION
# Objective

- `C: ExtractComponent` inserts `C::Out` instead of `C`, so we need to remove `C::Out`. cc #15904.

## Solution

- `C` -> `C::Out`

## Testing

- CAS has `<ContrastAdaptiveSharpening as ExtractComponent>::Out = (DenoiseCas, CasUniform)`. Setting its strength to zero correctly removes the effect after this change.