### PR TITLE
Fix overflow panic on Stopwatch at Duration::MAX

### DIFF
--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -129,7 +129,7 @@ impl Stopwatch {
     /// ```
     pub fn tick(&mut self, delta: Duration) -> &Self {
         if !self.paused() {
-            self.elapsed += delta;
+            self.elapsed = self.elapsed.saturating_add(delta);
         }
         self
     }


### PR DESCRIPTION
See #15924 for more details
close #15924

from the issue, this code panic:
```rust
use bevy::time::Stopwatch;
use std::time::Duration;

fn main() {
    let second = Duration::from_secs(1);

    let mut stopwatch = Stopwatch::new();
    // lot of time has passed... or a timer with Duration::MAX that was artificially set has "finished":
    // timer.set_elapsed(timer.remaining());
    stopwatch.set_elapsed(Duration::MAX);
    // panic
    stopwatch.tick(second);

    let mut stopwatch = Stopwatch::new();
    stopwatch.set_elapsed(Duration::MAX - second);
    // this doesnt panic as its still one off the max
    stopwatch.tick(second);
    // this panic
    stopwatch.tick(second);
}
```

with this PR changes, the code now doesn't panic.

have a good day !
