### PR TITLE
Use `#[doc(fake_variadic)]` on `StableInterpolate`

### DIFF
--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -310,8 +310,31 @@ impl StableInterpolate for Dir3A {
     }
 }
 
+// If you're confused about how #[doc(fake_variadic)] works,
+// then the `all_tuples` macro is nicely documented (it can be found in the `bevy_utils` crate).
+// tl;dr: `#[doc(fake_variadic)]` goes on the impl of tuple length one.
+// the others have to be hidden using `#[doc(hidden)]`.
 macro_rules! impl_stable_interpolate_tuple {
+    (($T:ident, $n:tt)) => {
+        impl_stable_interpolate_tuple! {
+            @impl
+            #[cfg_attr(any(docsrs, docsrs_dep), doc(fake_variadic))]
+            #[cfg_attr(
+                any(docsrs, docsrs_dep),
+                doc = "This trait is implemented for tuples up to 10 items long."
+            )]
+            ($T, $n)
+        }
+    };
     ($(($T:ident, $n:tt)),*) => {
+        impl_stable_interpolate_tuple! {
+            @impl
+            #[cfg_attr(any(docsrs, docsrs_dep), doc(hidden))]
+            $(($T, $n)),*
+        }
+    };
+    (@impl $(#[$($meta:meta)*])* $(($T:ident, $n:tt)),*) => {
+        $(#[$($meta)*])*
         impl<$($T: StableInterpolate),*> StableInterpolate for ($($T,)*) {
             fn interpolate_stable(&self, other: &Self, t: f32) -> Self {
                 (

--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -321,7 +321,7 @@ macro_rules! impl_stable_interpolate_tuple {
             #[cfg_attr(any(docsrs, docsrs_dep), doc(fake_variadic))]
             #[cfg_attr(
                 any(docsrs, docsrs_dep),
-                doc = "This trait is implemented for tuples up to 10 items long."
+                doc = "This trait is implemented for tuples up to 11 items long."
             )]
             ($T, $n)
         }

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -1,5 +1,7 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
+#![allow(internal_features)]
+#![cfg_attr(any(docsrs, docsrs_dep), feature(rustdoc_internals))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"


### PR DESCRIPTION
This is a follow-up to #15931 that adds `#[doc(fake_variadic)]` for improved docs output :)