### PR TITLE
Observers to log debug message when no observers found for event type…

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -288,6 +288,11 @@ impl Observers {
             world.increment_trigger_id();
             let observers = world.observers();
             let Some(observers) = observers.try_get_observers(event_type) else {
+                bevy_utils::tracing::debug!(
+                    "No observers found for event type {:?} in invoke",
+                    event_type
+                );
+
                 return;
             };
             // SAFETY: The only outstanding reference to world is `observers`


### PR DESCRIPTION
Fixes #15921 

I was using the tracing feature if there are objections: do we want to add a feature for this as there is no current debug or verbose feature?