### PR TITLE
Fix `bevy_color` not compiling standalone.

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -26,7 +26,7 @@ encase = { version = "0.10", default-features = false }
 
 [features]
 default = ["bevy_reflect"]
-serialize = ["serde"]
+serialize = ["serde", "bevy_math/serialize"]
 
 [lints]
 workspace = true

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["bevy", "color"]
 rust-version = "1.76.0"
 
 [dependencies]
-bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = false }
+bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = false, features = [
+  "curve",
+] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "bevy",
 ], optional = true }


### PR DESCRIPTION
# Objective

On HEAD, `bevy_color` does not compile on its own with `--all-features` enabled. This PR fixes that.

## Solution

- Added the `curve` feature on `bevy_math` to `bevy_color`.
- Added the `serialize` feature on `bevy_math` to `bevy_color/serialize`.

## Testing

- Compiled with `cargo b -p bevy_color --all-features` on HEAD and on this PR: it fails to compile on HEAD but compiles with this PR.
