### PR TITLE
Export `Val` Variants

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -591,8 +591,8 @@ mod tests {
         let ui_root = world
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     ..default()
                 },
                 ..default()
@@ -602,8 +602,8 @@ mod tests {
         let ui_child = world
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     ..default()
                 },
                 ..default()
@@ -840,8 +840,8 @@ mod tests {
             style: Style {
                 // test should pass without explicitly requiring position_type to be set to Absolute
                 // position_type: PositionType::Absolute,
-                width: Val::Px(size),
-                height: Val::Px(size),
+                width: Px(size),
+                height: Px(size),
                 ..default()
             },
             ..default()
@@ -852,8 +852,8 @@ mod tests {
         world.spawn(NodeBundle {
             style: Style {
                 // position_type: PositionType::Absolute,
-                width: Val::Px(size),
-                height: Val::Px(size),
+                width: Px(size),
+                height: Px(size),
                 ..default()
             },
             ..default()
@@ -864,8 +864,8 @@ mod tests {
         world.spawn(NodeBundle {
             style: Style {
                 // position_type: PositionType::Absolute,
-                width: Val::Px(size),
-                height: Val::Px(size),
+                width: Px(size),
+                height: Px(size),
                 ..default()
             },
             ..default()
@@ -959,8 +959,8 @@ mod tests {
                     .insert(TargetCamera(target_camera_entity))
                     .insert(Style {
                         position_type: PositionType::Absolute,
-                        top: Val::Px(pos.y),
-                        left: Val::Px(pos.x),
+                        top: Px(pos.y),
+                        left: Px(pos.x),
                         ..default()
                     });
             }
@@ -1007,8 +1007,8 @@ mod tests {
             NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    top: Val::Px(0.),
-                    left: Val::Px(0.),
+                    top: Px(0.),
+                    left: Px(0.),
                     ..default()
                 },
                 ..default()
@@ -1133,7 +1133,7 @@ mod tests {
                 style: Style {
                     display: Display::Grid,
                     grid_template_columns: RepeatedGridTrack::min_content(2),
-                    margin: UiRect::all(Val::Px(4.0)),
+                    margin: UiRect::all(Px(4.0)),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -1143,8 +1143,8 @@ mod tests {
                     commands.spawn(NodeBundle {
                         style: Style {
                             display: Display::Grid,
-                            width: Val::Px(160.),
-                            height: Val::Px(160.),
+                            width: Px(160.),
+                            height: Px(160.),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -1221,8 +1221,8 @@ mod tests {
         let ui_root = world
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     ..default()
                 },
                 ..default()
@@ -1232,8 +1232,8 @@ mod tests {
         let ui_child = world
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     ..default()
                 },
                 ..default()

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -46,6 +46,8 @@ use widget::UiImageSize;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::geometry::Val::{Auto, Percent, Px, VMax, VMin, Vh, Vw};
     #[cfg(feature = "bevy_text")]
     #[allow(deprecated)]
     #[doc(hidden)]

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -68,8 +68,8 @@ fn setup(
         Text::new("Press space to toggle wireframes"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -61,8 +61,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/2d/bounding_2d.rs
+++ b/examples/2d/bounding_2d.rs
@@ -256,8 +256,8 @@ fn setup(mut commands: Commands) {
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -137,8 +137,8 @@ fn setup(
         Text::new("Left Arrow Key: Animate Left Sprite\nRight Arrow Key: Animate Right Sprite"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -92,8 +92,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -137,8 +137,8 @@ fn setup(
         Text::new("Press space to toggle wireframes"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -85,8 +85,8 @@ fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
         app_status.create_help_text(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -330,8 +330,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -88,8 +88,8 @@ fn setup_instructions(mut commands: Commands) {
     commands.spawn((Text::new("Press Spacebar to Toggle Atmospheric Fog.\nPress S to Toggle Directional Light Fog Influence."),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         })
     );

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -120,8 +120,8 @@ fn setup(
             ..default()
         },
         style: Style {
-            width: Val::Percent(100.0),
-            height: Val::Percent(100.0),
+            width: Percent(100.0),
+            height: Percent(100.0),
             ..default()
         },
         ..default()
@@ -132,8 +132,8 @@ fn setup(
     commands.spawn((Text::new("Left / Right - Rotate Camera\nC - Toggle Compensation Curve\nM - Toggle Metering Mask\nV - Visualize Metering Mask"),
             text_style.clone(), Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         })
     );
@@ -143,8 +143,8 @@ fn setup(
         text_style,
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            right: Val::Px(12.0),
+            top: Px(12.0),
+            right: Px(12.0),
             ..default()
         },
         ExampleDisplay,

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -171,8 +171,8 @@ fn setup(
             text_style.clone(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         })
     );
@@ -182,8 +182,8 @@ fn setup(
         text_style,
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            right: Val::Px(12.0),
+            top: Px(12.0),
+            right: Px(12.0),
             ..default()
         },
         ExampleDisplay,
@@ -317,8 +317,8 @@ fn example_control_system(
             .world_to_viewport(camera_global_transform, world_position)
             .unwrap();
 
-        style.top = Val::Px(viewport_position.y);
-        style.left = Val::Px(viewport_position.x);
+        style.top = Px(viewport_position.y);
+        style.left = Px(viewport_position.x);
     }
 
     display.0 = format!(

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -88,8 +88,8 @@ fn setup_scene(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -221,8 +221,8 @@ fn spawn_text(commands: &mut Commands, light_mode: &LightMode) {
         light_mode.create_help_text(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -142,9 +142,9 @@ fn add_buttons(commands: &mut Commands, font: &Handle<Font>, color_grading: &Col
             style: Style {
                 flex_direction: FlexDirection::Column,
                 position_type: PositionType::Absolute,
-                row_gap: Val::Px(6.0),
-                left: Val::Px(12.0),
-                bottom: Val::Px(12.0),
+                row_gap: Px(6.0),
+                left: Px(12.0),
+                bottom: Px(12.0),
                 ..default()
             },
             ..default()
@@ -181,7 +181,7 @@ fn add_buttons_for_global_controls(
             // Add some placeholder text to fill this column.
             parent.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(125.0),
+                    width: Px(125.0),
                     ..default()
                 },
                 ..default()
@@ -224,7 +224,7 @@ fn add_buttons_for_section(
         .with_children(|parent| {
             // Spawn the label ("Highlights", etc.)
             add_text(parent, &section.to_string(), font, Color::WHITE).insert(Style {
-                width: Val::Px(125.0),
+                width: Px(125.0),
                 ..default()
             });
 
@@ -257,12 +257,12 @@ fn add_button_for_value(
     parent
         .spawn(ButtonBundle {
             style: Style {
-                border: UiRect::all(Val::Px(1.0)),
-                width: Val::Px(200.0),
+                border: UiRect::all(Px(1.0)),
+                width: Px(200.0),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                padding: UiRect::axes(Val::Px(12.0), Val::Px(6.0)),
-                margin: UiRect::right(Val::Px(12.0)),
+                padding: UiRect::axes(Px(12.0), Px(6.0)),
+                margin: UiRect::right(Px(12.0)),
                 ..default()
             },
             border_color: BorderColor(Color::WHITE),
@@ -322,8 +322,8 @@ fn add_help_text(
         },
         Style {
             position_type: PositionType::Absolute,
-            left: Val::Px(12.0),
-            top: Val::Px(12.0),
+            left: Px(12.0),
+            top: Px(12.0),
             ..default()
         },
         HelpText,

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -192,8 +192,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -96,8 +96,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
         create_text(&app_settings),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -120,8 +120,8 @@ fn setup_instructions(mut commands: Commands) {
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -61,8 +61,8 @@ fn setup(
         Text::new("Controls:\nSpace: Change UVs\nX/Y/Z: Rotate\nR: Reset orientation"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -292,8 +292,8 @@ fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
         app_status.create_text(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -213,8 +213,8 @@ fn setup(
             Text::default(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
         ))

--- a/examples/3d/load_gltf_extras.rs
+++ b/examples/3d/load_gltf_extras.rs
@@ -41,8 +41,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
         ExampleDisplay,

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -236,8 +236,8 @@ fn setup_ui(mut commands: Commands) {
             Text::default(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
         ))

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -300,8 +300,8 @@ fn setup(
             Text::default(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
         ))

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -66,8 +66,8 @@ fn setup(
         },
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(20.0),
-            left: Val::Px(100.0),
+            top: Px(20.0),
+            left: Px(100.0),
             ..default()
         },
     ));
@@ -80,7 +80,7 @@ fn setup(
         },
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(130.0),
+            top: Px(130.0),
             right: Val::ZERO,
             ..default()
         },
@@ -98,8 +98,8 @@ fn setup(
         },
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(20.0),
-            right: Val::Px(20.0),
+            bottom: Px(20.0),
+            right: Px(20.0),
             ..default()
         },
         EnvironmentMapLabel,

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -126,8 +126,8 @@ fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
         create_help_text(app_settings),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -156,8 +156,8 @@ fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
         app_status.create_text(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -101,7 +101,7 @@ fn setup(
             NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    padding: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Px(5.0)),
                     ..default()
                 },
                 background_color: Color::BLACK.with_alpha(0.75).into(),

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -87,8 +87,8 @@ fn setup(
                 TargetCamera(camera),
                 NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         ..default()
                     },
                     ..default()
@@ -99,8 +99,8 @@ fn setup(
                     Text::new(*camera_name),
                     Style {
                         position_type: PositionType::Absolute,
-                        top: Val::Px(12.),
-                        left: Val::Px(12.),
+                        top: Px(12.),
+                        left: Px(12.),
                         ..default()
                     },
                 ));
@@ -113,13 +113,13 @@ fn setup(
             .spawn(NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     display: Display::Flex,
                     flex_direction: FlexDirection::Row,
                     justify_content: JustifyContent::SpaceBetween,
                     align_items: AlignItems::Center,
-                    padding: UiRect::all(Val::Px(20.)),
+                    padding: UiRect::all(Px(20.)),
                     ..default()
                 },
                 ..default()
@@ -136,9 +136,9 @@ fn setup(
                 RotateCamera(direction),
                 ButtonBundle {
                     style: Style {
-                        width: Val::Px(40.),
-                        height: Val::Px(40.),
-                        border: UiRect::all(Val::Px(2.)),
+                        width: Px(40.),
+                        height: Px(40.),
+                        border: UiRect::all(Px(2.)),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         ..default()

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -130,8 +130,8 @@ fn setup(
         Text::new(INSTRUCTIONS),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -82,8 +82,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -255,8 +255,8 @@ fn spawn_text(commands: &mut Commands, app_settings: &AppSettings) {
         create_text(app_settings),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -85,8 +85,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));
@@ -180,7 +180,7 @@ fn setup_image_viewer_scene(
         TextLayout::new_with_justify(JustifyText::Center),
         Style {
             align_self: AlignSelf::Center,
-            margin: UiRect::all(Val::Auto),
+            margin: UiRect::all(Auto),
             ..default()
         },
         SceneNumber(3),

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -335,8 +335,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
         ExampleDisplay,

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -153,8 +153,8 @@ fn setup(
         app_status.create_text(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -127,8 +127,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
         create_text(&app_settings),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -103,8 +103,8 @@ fn setup(
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -154,10 +154,10 @@ fn setup(
             // Cover the whole screen, and center contents.
             style: Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(0.0),
-                left: Val::Px(0.0),
-                right: Val::Px(0.0),
-                bottom: Val::Px(0.0),
+                top: Px(0.0),
+                left: Px(0.0),
+                right: Px(0.0),
+                bottom: Px(0.0),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 ..default()

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -254,8 +254,8 @@ fn setup_help_text(commands: &mut Commands) {
         Text::new(HELP_TEXT),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));
@@ -286,10 +286,10 @@ fn setup_node_rects(commands: &mut Commands) {
                 NodeBundle {
                     style: Style {
                         position_type: PositionType::Absolute,
-                        bottom: Val::Px(node_rect.bottom),
-                        left: Val::Px(node_rect.left),
-                        height: Val::Px(node_rect.height),
-                        width: Val::Px(node_rect.width),
+                        bottom: Px(node_rect.bottom),
+                        left: Px(node_rect.left),
+                        height: Px(node_rect.height),
+                        width: Px(node_rect.width),
                         align_items: AlignItems::Center,
                         justify_items: JustifyItems::Center,
                         align_content: AlignContent::Center,
@@ -299,7 +299,7 @@ fn setup_node_rects(commands: &mut Commands) {
                     border_color: WHITE.into(),
                     ..default()
                 },
-                Outline::new(Val::Px(1.), Val::ZERO, Color::WHITE),
+                Outline::new(Px(1.), Val::ZERO, Color::WHITE),
             ));
 
             if let NodeType::Clip(ref clip) = node_type {
@@ -319,10 +319,10 @@ fn setup_node_rects(commands: &mut Commands) {
                 .spawn(NodeBundle {
                     style: Style {
                         position_type: PositionType::Absolute,
-                        top: Val::Px(0.),
-                        left: Val::Px(0.),
-                        height: Val::Px(node_rect.height),
-                        width: Val::Px(node_rect.width),
+                        top: Px(0.),
+                        left: Px(0.),
+                        height: Px(node_rect.height),
+                        width: Px(node_rect.width),
                         ..default()
                     },
                     background_color: DARK_GREEN.into(),
@@ -346,11 +346,11 @@ fn setup_node_lines(commands: &mut Commands) {
         commands.spawn(NodeBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                bottom: Val::Px(line.bottom),
-                left: Val::Px(line.left),
-                height: Val::Px(0.0),
-                width: Val::Px(line.length),
-                border: UiRect::bottom(Val::Px(1.0)),
+                bottom: Px(line.bottom),
+                left: Px(line.left),
+                height: Px(0.0),
+                width: Px(line.length),
+                border: UiRect::bottom(Px(1.0)),
                 ..default()
             },
             border_color: WHITE.into(),
@@ -362,11 +362,11 @@ fn setup_node_lines(commands: &mut Commands) {
         commands.spawn(NodeBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                bottom: Val::Px(line.bottom),
-                left: Val::Px(line.left),
-                height: Val::Px(line.length),
-                width: Val::Px(0.0),
-                border: UiRect::left(Val::Px(1.0)),
+                bottom: Px(line.bottom),
+                left: Px(line.left),
+                height: Px(line.length),
+                width: Px(0.0),
+                border: UiRect::left(Px(1.0)),
                 ..default()
             },
             border_color: WHITE.into(),
@@ -433,8 +433,7 @@ fn update_ui(
             let mut bg_iter = background_query.iter_many_mut(children);
             if let Some(mut style) = bg_iter.fetch_next() {
                 // All nodes are the same width, so `NODE_RECTS[0]` is as good as any other.
-                style.width =
-                    Val::Px(NODE_RECTS[0].width * animation_weights.weights[clip_node.index]);
+                style.width = Px(NODE_RECTS[0].width * animation_weights.weights[clip_node.index]);
             }
 
             // Update the node labels with the current weights.

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -160,8 +160,8 @@ fn setup_ui(mut commands: Commands) {
         Text::new("Click on a button to toggle animations for its associated bones"),
         Style {
             position_type: PositionType::Absolute,
-            left: Val::Px(12.0),
-            top: Val::Px(12.0),
+            left: Px(12.0),
+            top: Px(12.0),
             ..default()
         },
     ));
@@ -172,9 +172,9 @@ fn setup_ui(mut commands: Commands) {
             style: Style {
                 flex_direction: FlexDirection::Column,
                 position_type: PositionType::Absolute,
-                row_gap: Val::Px(6.0),
-                left: Val::Px(12.0),
-                bottom: Val::Px(12.0),
+                row_gap: Px(6.0),
+                left: Px(12.0),
+                bottom: Px(12.0),
                 ..default()
             },
             ..default()
@@ -182,11 +182,11 @@ fn setup_ui(mut commands: Commands) {
         .with_children(|parent| {
             let row_style = Style {
                 flex_direction: FlexDirection::Row,
-                column_gap: Val::Px(6.0),
+                column_gap: Px(6.0),
                 ..default()
             };
 
-            add_mask_group_control(parent, "Head", Val::Auto, MASK_GROUP_HEAD);
+            add_mask_group_control(parent, "Head", Auto, MASK_GROUP_HEAD);
 
             parent
                 .spawn(NodeBundle {
@@ -197,13 +197,13 @@ fn setup_ui(mut commands: Commands) {
                     add_mask_group_control(
                         parent,
                         "Left Front Leg",
-                        Val::Px(MASK_GROUP_BUTTON_WIDTH),
+                        Px(MASK_GROUP_BUTTON_WIDTH),
                         MASK_GROUP_LEFT_FRONT_LEG,
                     );
                     add_mask_group_control(
                         parent,
                         "Right Front Leg",
-                        Val::Px(MASK_GROUP_BUTTON_WIDTH),
+                        Px(MASK_GROUP_BUTTON_WIDTH),
                         MASK_GROUP_RIGHT_FRONT_LEG,
                     );
                 });
@@ -217,18 +217,18 @@ fn setup_ui(mut commands: Commands) {
                     add_mask_group_control(
                         parent,
                         "Left Hind Leg",
-                        Val::Px(MASK_GROUP_BUTTON_WIDTH),
+                        Px(MASK_GROUP_BUTTON_WIDTH),
                         MASK_GROUP_LEFT_HIND_LEG,
                     );
                     add_mask_group_control(
                         parent,
                         "Right Hind Leg",
-                        Val::Px(MASK_GROUP_BUTTON_WIDTH),
+                        Px(MASK_GROUP_BUTTON_WIDTH),
                         MASK_GROUP_RIGHT_HIND_LEG,
                     );
                 });
 
-            add_mask_group_control(parent, "Tail", Val::Auto, MASK_GROUP_TAIL);
+            add_mask_group_control(parent, "Tail", Auto, MASK_GROUP_TAIL);
         });
 }
 
@@ -253,7 +253,7 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
     parent
         .spawn(NodeBundle {
             style: Style {
-                border: UiRect::all(Val::Px(1.0)),
+                border: UiRect::all(Px(1.0)),
                 width,
                 flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
@@ -263,7 +263,7 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                 ..default()
             },
             border_color: BorderColor(Color::WHITE),
-            border_radius: BorderRadius::all(Val::Px(3.0)),
+            border_radius: BorderRadius::all(Px(3.0)),
             background_color: Color::BLACK.into(),
             ..default()
         })
@@ -272,7 +272,7 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                 .spawn(NodeBundle {
                     style: Style {
                         border: UiRect::ZERO,
-                        width: Val::Percent(100.0),
+                        width: Percent(100.0),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         padding: UiRect::ZERO,
@@ -286,7 +286,7 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                     Text::new(label),
                     label_text_style.clone(),
                     Style {
-                        margin: UiRect::vertical(Val::Px(3.0)),
+                        margin: UiRect::vertical(Px(3.0)),
                         ..default()
                     },
                 ));
@@ -294,11 +294,11 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
             builder
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
+                        width: Percent(100.0),
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
-                        border: UiRect::top(Val::Px(1.0)),
+                        border: UiRect::top(Px(1.0)),
                         ..default()
                     },
                     border_color: BorderColor(Color::WHITE),
@@ -324,7 +324,7 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                                 style: Style {
                                     flex_grow: 1.0,
                                     border: if index > 0 {
-                                        UiRect::left(Val::Px(1.0))
+                                        UiRect::left(Px(1.0))
                                     } else {
                                         UiRect::ZERO
                                     },
@@ -343,7 +343,7 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                                 TextLayout::new_with_justify(JustifyText::Center),
                                 Style {
                                     flex_grow: 1.0,
-                                    margin: UiRect::vertical(Val::Px(3.0)),
+                                    margin: UiRect::vertical(Px(3.0)),
                                     ..default()
                                 },
                                 AnimationControl {

--- a/examples/animation/easing_functions.rs
+++ b/examples/animation/easing_functions.rs
@@ -90,8 +90,8 @@ fn setup(mut commands: Commands) {
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -121,8 +121,8 @@ fn setup(mut commands: Commands) {
     commands.spawn((
         NodeBundle {
             style: Style {
-                width: Val::Vw(100.0),
-                height: Val::Vh(100.0),
+                width: Vw(100.0),
+                height: Vh(100.0),
                 flex_direction: FlexDirection::Column,
                 ..default()
             },

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -23,8 +23,8 @@ fn setup(mut commands: Commands) {
         Text::new("Press P to panic"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/asset/alter_mesh.rs
+++ b/examples/asset/alter_mesh.rs
@@ -140,7 +140,7 @@ fn spawn_text(mut commands: Commands) {
                     align_items: AlignItems::Start,
                     flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::Start,
-                    width: Val::Percent(100.),
+                    width: Percent(100.),
                     ..default()
                 },
                 ..default()

--- a/examples/asset/alter_sprite.rs
+++ b/examples/asset/alter_sprite.rs
@@ -98,7 +98,7 @@ fn spawn_text(mut commands: Commands) {
                     align_items: AlignItems::Start,
                     flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::Start,
-                    width: Val::Percent(100.),
+                    width: Percent(100.),
                     ..default()
                 },
                 ..default()

--- a/examples/asset/multi_asset_sync.rs
+++ b/examples/asset/multi_asset_sync.rs
@@ -171,8 +171,8 @@ fn setup_ui(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 justify_content: JustifyContent::End,
 
                 ..default()

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -68,8 +68,8 @@ fn setup(
         Text::new("Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement"),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -67,8 +67,8 @@ fn setup(
         Text::new("Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement"),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/camera/2d_screen_shake.rs
+++ b/examples/camera/2d_screen_shake.rs
@@ -67,8 +67,8 @@ fn setup_instructions(mut commands: Commands) {
         Text::new("Hold space to trigger a screen shake"),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -53,8 +53,8 @@ fn setup_instructions(mut commands: Commands) {
         Text::new("Move the light with WASD.\nThe camera will smoothly track the light."),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(12.0),
-            left: Val::Px(12.0),
+            bottom: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/camera/camera_orbit.rs
+++ b/examples/camera/camera_orbit.rs
@@ -88,7 +88,7 @@ fn instructions(mut commands: Commands) {
                     align_items: AlignItems::Start,
                     flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::Start,
-                    width: Val::Percent(100.),
+                    width: Percent(100.),
                     ..default()
                 },
                 ..default()

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -195,8 +195,8 @@ fn spawn_text(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                bottom: Val::Px(12.0),
-                left: Val::Px(12.0),
+                bottom: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
             ..default()

--- a/examples/camera/projection_zoom.rs
+++ b/examples/camera/projection_zoom.rs
@@ -97,7 +97,7 @@ fn instructions(mut commands: Commands) {
                     align_items: AlignItems::Start,
                     flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::Start,
-                    width: Val::Percent(100.),
+                    width: Percent(100.),
                     ..default()
                 },
                 ..default()

--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -46,8 +46,8 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -78,8 +78,8 @@ fn setup(mut commands: Commands) {
         ),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.),
-            left: Val::Px(12.),
+            top: Px(12.),
+            left: Px(12.),
             ..default()
         },
     ));

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -184,8 +184,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
         TextColor(Color::srgb(0.5, 0.5, 1.0)),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(5.0),
-            left: Val::Px(5.0),
+            top: Px(5.0),
+            left: Px(5.0),
             ..default()
         },
     ));
@@ -396,7 +396,7 @@ fn display_score(mut commands: Commands, game: Res<Game>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
+                width: Percent(100.),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -40,7 +40,7 @@ const GAP_BETWEEN_BRICKS_AND_CEILING: f32 = 20.0;
 const GAP_BETWEEN_BRICKS_AND_SIDES: f32 = 20.0;
 
 const SCOREBOARD_FONT_SIZE: f32 = 33.0;
-const SCOREBOARD_TEXT_PADDING: Val = Val::Px(5.0);
+const SCOREBOARD_TEXT_PADDING: Val = Px(5.0);
 
 const BACKGROUND_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
 const PADDLE_COLOR: Color = Color::srgb(0.3, 0.3, 0.7);
@@ -57,7 +57,7 @@ fn main() {
             stepping::SteppingPlugin::default()
                 .add_schedule(Update)
                 .add_schedule(FixedUpdate)
-                .at(Val::Percent(35.0), Val::Percent(50.0)),
+                .at(Percent(35.0), Percent(50.0)),
         )
         .insert_resource(Score(0))
         .insert_resource(ClearColor(BACKGROUND_COLOR))

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -150,8 +150,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ContributorDisplay,
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.),
-                left: Val::Px(12.),
+                top: Px(12.),
+                left: Px(12.),
                 ..default()
             },
         ))

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -79,8 +79,8 @@ mod splash {
                     style: Style {
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         ..default()
                     },
                     ..default()
@@ -91,7 +91,7 @@ mod splash {
                 parent.spawn(ImageBundle {
                     style: Style {
                         // This will set the logo to be 200px wide, and auto adjust its height
-                        width: Val::Px(200.0),
+                        width: Px(200.0),
                         ..default()
                     },
                     image: UiImage::new(icon),
@@ -146,8 +146,8 @@ mod game {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         // center children
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
@@ -182,14 +182,14 @@ mod game {
                             },
                             TextColor(TEXT_COLOR),
                             Style {
-                                margin: UiRect::all(Val::Px(50.0)),
+                                margin: UiRect::all(Px(50.0)),
                                 ..default()
                             },
                         ));
                         p.spawn((
                             Text::default(),
                             Style {
-                                margin: UiRect::all(Val::Px(50.0)),
+                                margin: UiRect::all(Px(50.0)),
                                 ..default()
                             },
                         ))
@@ -383,19 +383,19 @@ mod menu {
     fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // Common style for all buttons on the screen
         let button_style = Style {
-            width: Val::Px(300.0),
-            height: Val::Px(65.0),
-            margin: UiRect::all(Val::Px(20.0)),
+            width: Px(300.0),
+            height: Px(65.0),
+            margin: UiRect::all(Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             ..default()
         };
         let button_icon_style = Style {
-            width: Val::Px(30.0),
+            width: Px(30.0),
             // This takes the icons out of the flexbox flow, to be positioned exactly
             position_type: PositionType::Absolute,
             // The icon will be close to the left border of the button
-            left: Val::Px(10.0),
+            left: Px(10.0),
             ..default()
         };
         let button_text_font = TextFont {
@@ -407,8 +407,8 @@ mod menu {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
                         ..default()
@@ -438,7 +438,7 @@ mod menu {
                             },
                             TextColor(TEXT_COLOR),
                             Style {
-                                margin: UiRect::all(Val::Px(50.0)),
+                                margin: UiRect::all(Px(50.0)),
                                 ..default()
                             },
                         ));
@@ -519,9 +519,9 @@ mod menu {
 
     fn settings_menu_setup(mut commands: Commands) {
         let button_style = Style {
-            width: Val::Px(200.0),
-            height: Val::Px(65.0),
-            margin: UiRect::all(Val::Px(20.0)),
+            width: Px(200.0),
+            height: Px(65.0),
+            margin: UiRect::all(Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             ..default()
@@ -539,8 +539,8 @@ mod menu {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
                         ..default()
@@ -585,9 +585,9 @@ mod menu {
 
     fn display_settings_menu_setup(mut commands: Commands, display_quality: Res<DisplayQuality>) {
         let button_style = Style {
-            width: Val::Px(200.0),
-            height: Val::Px(65.0),
-            margin: UiRect::all(Val::Px(20.0)),
+            width: Px(200.0),
+            height: Px(65.0),
+            margin: UiRect::all(Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             ..default()
@@ -604,8 +604,8 @@ mod menu {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
                         ..default()
@@ -652,8 +652,8 @@ mod menu {
                                     let mut entity = parent.spawn((
                                         ButtonBundle {
                                             style: Style {
-                                                width: Val::Px(150.0),
-                                                height: Val::Px(65.0),
+                                                width: Px(150.0),
+                                                height: Px(65.0),
                                                 ..button_style.clone()
                                             },
                                             background_color: NORMAL_BUTTON.into(),
@@ -691,9 +691,9 @@ mod menu {
 
     fn sound_settings_menu_setup(mut commands: Commands, volume: Res<Volume>) {
         let button_style = Style {
-            width: Val::Px(200.0),
-            height: Val::Px(65.0),
-            margin: UiRect::all(Val::Px(20.0)),
+            width: Px(200.0),
+            height: Px(65.0),
+            margin: UiRect::all(Px(20.0)),
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             ..default()
@@ -710,8 +710,8 @@ mod menu {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
                         ..default()
@@ -747,8 +747,8 @@ mod menu {
                                     let mut entity = parent.spawn((
                                         ButtonBundle {
                                             style: Style {
-                                                width: Val::Px(30.0),
-                                                height: Val::Px(65.0),
+                                                width: Px(30.0),
+                                                height: Px(65.0),
                                                 ..button_style.clone()
                                             },
                                             background_color: NORMAL_BUTTON.into(),

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -260,8 +260,8 @@ fn load_loading_screen(mut commands: Commands) {
             NodeBundle {
                 background_color: BackgroundColor(Color::BLACK),
                 style: Style {
-                    height: Val::Percent(100.0),
-                    width: Val::Percent(100.0),
+                    height: Percent(100.0),
+                    width: Percent(100.0),
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
                     ..default()

--- a/examples/games/stepping.rs
+++ b/examples/games/stepping.rs
@@ -169,7 +169,7 @@ fn build_ui(
                 position_type: PositionType::Absolute,
                 top: state.ui_top,
                 left: state.ui_left,
-                padding: UiRect::all(Val::Px(10.0)),
+                padding: UiRect::all(Px(10.0)),
                 ..default()
             },
             BackgroundColor(Color::srgba(1.0, 1.0, 1.0, 0.33)),
@@ -199,8 +199,8 @@ fn build_stepping_hint(mut commands: Commands) {
         TextColor(FONT_COLOR),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            left: Val::Px(5.0),
+            bottom: Px(5.0),
+            left: Px(5.0),
             ..default()
         },
     ));

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -30,8 +30,8 @@ fn setup(mut commands: Commands) {
         ),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.),
-            left: Val::Px(12.),
+            top: Px(12.),
+            left: Px(12.),
             ..default()
         },
     ));

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -64,8 +64,8 @@ fn setup(
         ),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -111,8 +111,8 @@ fn setup(
             ),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
         ));
@@ -127,8 +127,8 @@ fn setup(
                 GizmoColorText,
                 Style {
                     position_type: PositionType::Absolute,
-                    bottom: Val::Px(12.0),
-                    left: Val::Px(12.0),
+                    bottom: Px(12.0),
+                    left: Px(12.0),
                     ..default()
                 },
             ))

--- a/examples/helpers/widgets.rs
+++ b/examples/helpers/widgets.rs
@@ -29,9 +29,9 @@ pub fn main_ui_style() -> Style {
     Style {
         flex_direction: FlexDirection::Column,
         position_type: PositionType::Absolute,
-        row_gap: Val::Px(6.0),
-        left: Val::Px(10.0),
-        bottom: Val::Px(10.0),
+        row_gap: Px(6.0),
+        left: Px(10.0),
+        bottom: Px(10.0),
         ..default()
     }
 }
@@ -60,20 +60,16 @@ pub fn spawn_option_button<T>(
     parent
         .spawn(ButtonBundle {
             style: Style {
-                border: UiRect::all(Val::Px(1.0)).with_left(if is_first {
-                    Val::Px(1.0)
-                } else {
-                    Val::Px(0.0)
-                }),
+                border: UiRect::all(Px(1.0)).with_left(if is_first { Px(1.0) } else { Px(0.0) }),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                padding: UiRect::axes(Val::Px(12.0), Val::Px(6.0)),
+                padding: UiRect::axes(Px(12.0), Px(6.0)),
                 ..default()
             },
             border_color: BorderColor(Color::WHITE),
             border_radius: BorderRadius::ZERO
-                .with_left(if is_first { Val::Px(6.0) } else { Val::Px(0.0) })
-                .with_right(if is_last { Val::Px(6.0) } else { Val::Px(0.0) }),
+                .with_left(if is_first { Px(6.0) } else { Px(0.0) })
+                .with_right(if is_last { Px(6.0) } else { Px(0.0) }),
             background_color: BackgroundColor(bg_color),
             ..default()
         })
@@ -106,7 +102,7 @@ where
         })
         .with_children(|parent| {
             spawn_ui_text(parent, title, Color::BLACK).insert(Style {
-                width: Val::Px(125.0),
+                width: Px(125.0),
                 ..default()
             });
 

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -39,8 +39,8 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
             Text::default(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
         ))

--- a/examples/math/cubic_splines.rs
+++ b/examples/math/cubic_splines.rs
@@ -81,10 +81,10 @@ fn setup(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 flex_direction: FlexDirection::Column,
-                row_gap: Val::Px(20.0),
+                row_gap: Px(20.0),
                 ..default()
             },
             ..default()

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -160,8 +160,8 @@ fn setup(
             Press 'Space' to switch between 3D and 2D"),
             Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         }));
 }

--- a/examples/math/random_sampling.rs
+++ b/examples/math/random_sampling.rs
@@ -120,8 +120,8 @@ fn setup(
         ),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -373,7 +373,7 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
             NodeBundle {
                 style: Style {
                     justify_self: JustifySelf::Center,
-                    top: Val::Px(5.0),
+                    top: Px(5.0),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -390,8 +390,8 @@ fn setup(
         ),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -119,9 +119,9 @@ fn setup_scene(
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 position_type: PositionType::Absolute,
-                left: Val::Px(50.0),
-                right: Val::Px(50.0),
-                bottom: Val::Px(50.0),
+                left: Px(50.0),
+                right: Px(50.0),
+                bottom: Px(50.0),
                 ..default()
             },
             ..default()

--- a/examples/movement/physics_in_fixed_timestep.rs
+++ b/examples/movement/physics_in_fixed_timestep.rs
@@ -148,8 +148,8 @@ fn spawn_text(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                bottom: Val::Px(12.0),
-                left: Val::Px(12.0),
+                bottom: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
             ..default()

--- a/examples/picking/mesh_picking.rs
+++ b/examples/picking/mesh_picking.rs
@@ -151,8 +151,8 @@ fn setup(
         Text::new("Hover over the shapes to pick them"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -22,8 +22,8 @@ fn setup(
             Text::new("Click Me to get a box"),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Percent(12.0),
-                left: Val::Percent(12.0),
+                top: Percent(12.0),
+                left: Percent(12.0),
                 ..default()
             },
         ))

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -128,8 +128,8 @@ fn setup(
             Text::default(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
         ))

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -339,12 +339,12 @@ mod ui {
             .spawn(NodeBundle {
                 style: Style {
                     // center button
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
                     flex_direction: FlexDirection::Column,
-                    row_gap: Val::Px(10.),
+                    row_gap: Px(10.),
                     ..default()
                 },
                 ..default()
@@ -354,8 +354,8 @@ mod ui {
                     .spawn((
                         ButtonBundle {
                             style: Style {
-                                width: Val::Px(200.),
-                                height: Val::Px(65.),
+                                width: Px(200.),
+                                height: Px(65.),
                                 // horizontally center child text
                                 justify_content: JustifyContent::Center,
                                 // vertically center child text
@@ -382,8 +382,8 @@ mod ui {
                     .spawn((
                         ButtonBundle {
                             style: Style {
-                                width: Val::Px(200.),
-                                height: Val::Px(65.),
+                                width: Px(200.),
+                                height: Px(65.),
                                 // horizontally center child text
                                 justify_content: JustifyContent::Center,
                                 // vertically center child text
@@ -467,12 +467,12 @@ mod ui {
                 NodeBundle {
                     style: Style {
                         // center button
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         flex_direction: FlexDirection::Column,
-                        row_gap: Val::Px(10.),
+                        row_gap: Px(10.),
                         position_type: PositionType::Absolute,
                         ..default()
                     },
@@ -484,8 +484,8 @@ mod ui {
                     .spawn((
                         NodeBundle {
                             style: Style {
-                                width: Val::Px(400.),
-                                height: Val::Px(400.),
+                                width: Px(400.),
+                                height: Px(400.),
                                 // horizontally center child text
                                 justify_content: JustifyContent::Center,
                                 // vertically center child text
@@ -517,12 +517,12 @@ mod ui {
                 NodeBundle {
                     style: Style {
                         // center button
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         justify_content: JustifyContent::Start,
                         align_items: AlignItems::Center,
                         flex_direction: FlexDirection::Column,
-                        row_gap: Val::Px(10.),
+                        row_gap: Px(10.),
                         position_type: PositionType::Absolute,
                         ..default()
                     },
@@ -559,12 +559,12 @@ mod ui {
                 NodeBundle {
                     style: Style {
                         // center button
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         justify_content: JustifyContent::End,
                         align_items: AlignItems::Center,
                         flex_direction: FlexDirection::Column,
-                        row_gap: Val::Px(10.),
+                        row_gap: Px(10.),
                         position_type: PositionType::Absolute,
                         ..default()
                     },
@@ -616,12 +616,12 @@ mod ui {
                 NodeBundle {
                     style: Style {
                         // center button
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         justify_content: JustifyContent::End,
                         align_items: AlignItems::Center,
                         flex_direction: FlexDirection::Column,
-                        row_gap: Val::Px(10.),
+                        row_gap: Px(10.),
                         position_type: PositionType::Absolute,
                         ..default()
                     },

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -246,8 +246,8 @@ fn setup_menu(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 // center button
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 ..default()
@@ -258,8 +258,8 @@ fn setup_menu(mut commands: Commands) {
             parent
                 .spawn(ButtonBundle {
                     style: Style {
-                        width: Val::Px(150.),
-                        height: Val::Px(65.),
+                        width: Px(150.),
+                        height: Px(65.),
                         // horizontally center child text
                         justify_content: JustifyContent::Center,
                         // vertically center child text

--- a/examples/state/states.rs
+++ b/examples/state/states.rs
@@ -54,8 +54,8 @@ fn setup_menu(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 // center button
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 ..default()
@@ -66,8 +66,8 @@ fn setup_menu(mut commands: Commands) {
             parent
                 .spawn(ButtonBundle {
                     style: Style {
-                        width: Val::Px(150.),
-                        height: Val::Px(65.),
+                        width: Px(150.),
+                        height: Px(65.),
                         // horizontally center child text
                         justify_content: JustifyContent::Center,
                         // vertically center child text

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -159,8 +159,8 @@ mod ui {
             .spawn(NodeBundle {
                 style: Style {
                     // center button
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
                     ..default()
@@ -171,8 +171,8 @@ mod ui {
                 parent
                     .spawn(ButtonBundle {
                         style: Style {
-                            width: Val::Px(150.),
-                            height: Val::Px(65.),
+                            width: Px(150.),
+                            height: Px(65.),
                             // horizontally center child text
                             justify_content: JustifyContent::Center,
                             // vertically center child text
@@ -208,12 +208,12 @@ mod ui {
                 NodeBundle {
                     style: Style {
                         // center button
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         flex_direction: FlexDirection::Column,
-                        row_gap: Val::Px(10.),
+                        row_gap: Px(10.),
                         ..default()
                     },
                     ..default()
@@ -223,8 +223,8 @@ mod ui {
                 parent
                     .spawn(NodeBundle {
                         style: Style {
-                            width: Val::Px(400.),
-                            height: Val::Px(400.),
+                            width: Px(400.),
+                            height: Px(400.),
                             // horizontally center child text
                             justify_content: JustifyContent::Center,
                             // vertically center child text

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -264,7 +264,7 @@ fn setup(
             NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    padding: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Px(5.0)),
                     ..default()
                 },
                 background_color: Color::BLACK.with_alpha(0.75).into(),

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -132,7 +132,7 @@ fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
     let border = if args.no_borders {
         UiRect::ZERO
     } else {
-        UiRect::all(Val::VMin(0.05 * 90. / buttons_f))
+        UiRect::all(VMin(0.05 * 90. / buttons_f))
     };
 
     let as_rainbow = |i: usize| Color::hsl((i as f32 / buttons_f) * 360.0, 0.9, 0.8);
@@ -143,8 +143,8 @@ fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
                 flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 ..default()
             },
             ..default()
@@ -189,7 +189,7 @@ fn setup_grid(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
     let border = if args.no_borders {
         UiRect::ZERO
     } else {
-        UiRect::all(Val::VMin(0.05 * 90. / buttons_f))
+        UiRect::all(VMin(0.05 * 90. / buttons_f))
     };
 
     let as_rainbow = |i: usize| Color::hsl((i as f32 / buttons_f) * 360.0, 0.9, 0.8);
@@ -198,8 +198,8 @@ fn setup_grid(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
         .spawn(NodeBundle {
             style: Style {
                 display: Display::Grid,
-                width: Val::Percent(100.),
-                height: Val::Percent(100.0),
+                width: Percent(100.),
+                height: Percent(100.0),
                 grid_template_columns: RepeatedGridTrack::flex(args.buttons as u16, 1.0),
                 grid_template_rows: RepeatedGridTrack::flex(args.buttons as u16, 1.0),
                 ..default()
@@ -242,8 +242,8 @@ fn spawn_button(
     border_color: BorderColor,
     image: Option<Handle<Image>>,
 ) {
-    let width = Val::Vw(90.0 / buttons);
-    let height = Val::Vh(90.0 / buttons);
+    let width = Vw(90.0 / buttons);
+    let height = Vh(90.0 / buttons);
     let margin = UiRect::axes(width * 0.05, height * 0.05);
     let mut builder = commands.spawn((
         ButtonBundle {

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -91,8 +91,8 @@ fn setup(mut commands: Commands) {
         Text::default(),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -58,7 +58,7 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
+                width: Percent(100.),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands) {
             commands
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(1000.),
+                        width: Px(1000.),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -81,10 +81,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
             style: Style {
                 display: Display::Flex,
                 justify_content: JustifyContent::SpaceBetween,
-                width: Val::Percent(100.),
+                width: Percent(100.),
                 position_type: PositionType::Absolute,
-                top: Val::Px(0.),
-                padding: UiRect::all(Val::Px(20.0)),
+                top: Px(0.),
+                padding: UiRect::all(Px(20.0)),
                 ..default()
             },
             ..default()

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -379,8 +379,8 @@ fn setup_connected(mut commands: Commands) {
             Text::new("Connected Gamepads:\n"),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.),
-                left: Val::Px(12.),
+                top: Px(12.),
+                left: Px(12.),
                 ..default()
             },
             ConnectedGamepadsText,

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -270,8 +270,8 @@ fn detect_morphs(
             Text::default(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(10.0),
-                left: Val::Px(10.0),
+                top: Px(10.0),
+                left: Px(10.0),
                 ..default()
             },
         ))

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -105,8 +105,8 @@ fn setup(
         ),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
         Instructions,

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -14,7 +14,7 @@ fn setup(mut commands: Commands) {
     let root = commands
         .spawn(NodeBundle {
             style: Style {
-                margin: UiRect::all(Val::Px(25.0)),
+                margin: UiRect::all(Px(25.0)),
                 align_self: AlignSelf::Stretch,
                 justify_self: JustifySelf::Stretch,
                 flex_wrap: FlexWrap::Wrap,
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands) {
     let root_rounded = commands
         .spawn(NodeBundle {
             style: Style {
-                margin: UiRect::all(Val::Px(25.0)),
+                margin: UiRect::all(Px(25.0)),
                 align_self: AlignSelf::Stretch,
                 justify_self: JustifySelf::Stretch,
                 flex_wrap: FlexWrap::Wrap,
@@ -69,55 +69,55 @@ fn setup(mut commands: Commands) {
     // these correspond to the labels above
     let borders = [
         UiRect::default(),
-        UiRect::all(Val::Px(10.)),
-        UiRect::left(Val::Px(10.)),
-        UiRect::right(Val::Px(10.)),
-        UiRect::top(Val::Px(10.)),
-        UiRect::bottom(Val::Px(10.)),
-        UiRect::horizontal(Val::Px(10.)),
-        UiRect::vertical(Val::Px(10.)),
+        UiRect::all(Px(10.)),
+        UiRect::left(Px(10.)),
+        UiRect::right(Px(10.)),
+        UiRect::top(Px(10.)),
+        UiRect::bottom(Px(10.)),
+        UiRect::horizontal(Px(10.)),
+        UiRect::vertical(Px(10.)),
         UiRect {
-            left: Val::Px(20.),
-            top: Val::Px(10.),
+            left: Px(20.),
+            top: Px(10.),
             ..Default::default()
         },
         UiRect {
-            left: Val::Px(10.),
-            bottom: Val::Px(20.),
+            left: Px(10.),
+            bottom: Px(20.),
             ..Default::default()
         },
         UiRect {
-            right: Val::Px(20.),
-            top: Val::Px(10.),
+            right: Px(20.),
+            top: Px(10.),
             ..Default::default()
         },
         UiRect {
-            right: Val::Px(10.),
-            bottom: Val::Px(10.),
+            right: Px(10.),
+            bottom: Px(10.),
             ..Default::default()
         },
         UiRect {
-            right: Val::Px(10.),
-            top: Val::Px(20.),
-            bottom: Val::Px(10.),
+            right: Px(10.),
+            top: Px(20.),
+            bottom: Px(10.),
             ..Default::default()
         },
         UiRect {
-            left: Val::Px(10.),
-            top: Val::Px(10.),
-            bottom: Val::Px(10.),
+            left: Px(10.),
+            top: Px(10.),
+            bottom: Px(10.),
             ..Default::default()
         },
         UiRect {
-            left: Val::Px(20.),
-            right: Val::Px(10.),
-            top: Val::Px(10.),
+            left: Px(20.),
+            right: Px(10.),
+            top: Px(10.),
             ..Default::default()
         },
         UiRect {
-            left: Val::Px(10.),
-            right: Val::Px(10.),
-            bottom: Val::Px(20.),
+            left: Px(10.),
+            right: Px(10.),
+            bottom: Px(20.),
             ..Default::default()
         },
     ];
@@ -126,8 +126,8 @@ fn setup(mut commands: Commands) {
         let inner_spot = commands
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(10.),
-                    height: Val::Px(10.),
+                    width: Px(10.),
+                    height: Px(10.),
                     ..Default::default()
                 },
                 background_color: YELLOW.into(),
@@ -138,10 +138,10 @@ fn setup(mut commands: Commands) {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Px(50.),
-                        height: Val::Px(50.),
+                        width: Px(50.),
+                        height: Px(50.),
                         border,
-                        margin: UiRect::all(Val::Px(20.)),
+                        margin: UiRect::all(Px(20.)),
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
                         ..Default::default()
@@ -151,8 +151,8 @@ fn setup(mut commands: Commands) {
                     ..Default::default()
                 },
                 Outline {
-                    width: Val::Px(6.),
-                    offset: Val::Px(6.),
+                    width: Px(6.),
+                    offset: Px(6.),
                     color: Color::WHITE,
                 },
             ))
@@ -185,8 +185,8 @@ fn setup(mut commands: Commands) {
         let inner_spot = commands
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(10.),
-                    height: Val::Px(10.),
+                    width: Px(10.),
+                    height: Px(10.),
                     ..Default::default()
                 },
                 border_radius: BorderRadius::MAX,
@@ -194,7 +194,7 @@ fn setup(mut commands: Commands) {
                 ..Default::default()
             })
             .id();
-        let non_zero = |x, y| x != Val::Px(0.) && y != Val::Px(0.);
+        let non_zero = |x, y| x != Px(0.) && y != Px(0.);
         let border_size = |x, y| if non_zero(x, y) { f32::MAX } else { 0. };
         let border_radius = BorderRadius::px(
             border_size(border.left, border.top),
@@ -206,10 +206,10 @@ fn setup(mut commands: Commands) {
             .spawn((
                 NodeBundle {
                     style: Style {
-                        width: Val::Px(50.),
-                        height: Val::Px(50.),
+                        width: Px(50.),
+                        height: Px(50.),
                         border,
-                        margin: UiRect::all(Val::Px(20.)),
+                        margin: UiRect::all(Px(20.)),
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
                         ..Default::default()
@@ -220,8 +220,8 @@ fn setup(mut commands: Commands) {
                     ..Default::default()
                 },
                 Outline {
-                    width: Val::Px(6.),
-                    offset: Val::Px(6.),
+                    width: Px(6.),
+                    offset: Px(6.),
                     color: Color::WHITE,
                 },
             ))
@@ -254,10 +254,10 @@ fn setup(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 margin: UiRect {
-                    left: Val::Px(25.0),
-                    right: Val::Px(25.0),
-                    top: Val::Px(25.0),
-                    bottom: Val::Px(0.0),
+                    left: Px(25.0),
+                    right: Px(25.0),
+                    top: Px(25.0),
+                    bottom: Px(0.0),
                 },
                 ..Default::default()
             },
@@ -279,10 +279,10 @@ fn setup(mut commands: Commands) {
         .spawn(NodeBundle {
             style: Style {
                 margin: UiRect {
-                    left: Val::Px(25.0),
-                    right: Val::Px(25.0),
-                    top: Val::Px(25.0),
-                    bottom: Val::Px(0.0),
+                    left: Px(25.0),
+                    right: Px(25.0),
+                    top: Px(25.0),
+                    bottom: Px(0.0),
                 },
                 ..Default::default()
             },
@@ -303,7 +303,7 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                margin: UiRect::all(Val::Px(25.0)),
+                margin: UiRect::all(Px(25.0)),
                 flex_direction: FlexDirection::Column,
                 align_self: AlignSelf::Stretch,
                 justify_self: JustifySelf::Stretch,

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -36,10 +36,10 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                padding: UiRect::all(Val::Px(30.)),
-                column_gap: Val::Px(30.),
+                width: Percent(100.0),
+                height: Percent(100.0),
+                padding: UiRect::all(Px(30.)),
+                column_gap: Px(30.),
                 flex_wrap: FlexWrap::Wrap,
                 ..default()
             },
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands) {
                     Vec2::ZERO,
                     10.,
                     0.,
-                    BorderRadius::bottom_right(Val::Px(10.)),
+                    BorderRadius::bottom_right(Px(10.)),
                 ),
                 (Vec2::new(50., 25.), Vec2::ZERO, 10., 0., BorderRadius::ZERO),
                 (Vec2::splat(50.), Vec2::ZERO, 10., 0., BorderRadius::MAX),
@@ -63,7 +63,7 @@ fn setup(mut commands: Commands) {
                     Vec2::ZERO,
                     10.,
                     0.,
-                    BorderRadius::bottom_right(Val::Px(10.)),
+                    BorderRadius::bottom_right(Px(10.)),
                 ),
                 (Vec2::new(50., 25.), Vec2::ZERO, 0., 10., BorderRadius::ZERO),
                 (
@@ -71,7 +71,7 @@ fn setup(mut commands: Commands) {
                     Vec2::ZERO,
                     0.,
                     10.,
-                    BorderRadius::bottom_right(Val::Px(10.)),
+                    BorderRadius::bottom_right(Px(10.)),
                 ),
                 (Vec2::new(100., 25.), Vec2::ZERO, 0., 10., BorderRadius::MAX),
                 (
@@ -93,7 +93,7 @@ fn setup(mut commands: Commands) {
                     Vec2::splat(10.),
                     0.,
                     0.,
-                    BorderRadius::bottom_right(Val::Px(10.)),
+                    BorderRadius::bottom_right(Px(10.)),
                 ),
                 (
                     Vec2::splat(50.),
@@ -114,7 +114,7 @@ fn setup(mut commands: Commands) {
                     Vec2::splat(10.),
                     0.,
                     10.,
-                    BorderRadius::bottom_right(Val::Px(10.)),
+                    BorderRadius::bottom_right(Px(10.)),
                 ),
                 (
                     Vec2::splat(50.),
@@ -135,21 +135,21 @@ fn setup(mut commands: Commands) {
                     Vec2::splat(10.),
                     0.,
                     3.,
-                    BorderRadius::bottom_right(Val::Px(10.)),
+                    BorderRadius::bottom_right(Px(10.)),
                 ),
                 (
                     Vec2::splat(50.),
                     Vec2::splat(10.),
                     0.,
                     3.,
-                    BorderRadius::all(Val::Px(20.)),
+                    BorderRadius::all(Px(20.)),
                 ),
                 (
                     Vec2::new(50., 25.),
                     Vec2::splat(10.),
                     0.,
                     3.,
-                    BorderRadius::all(Val::Px(20.)),
+                    BorderRadius::all(Px(20.)),
                 ),
                 (
                     Vec2::new(25., 50.),
@@ -163,14 +163,14 @@ fn setup(mut commands: Commands) {
                     Vec2::splat(10.),
                     0.,
                     10.,
-                    BorderRadius::all(Val::Px(20.)),
+                    BorderRadius::all(Px(20.)),
                 ),
                 (
                     Vec2::new(50., 25.),
                     Vec2::splat(10.),
                     0.,
                     10.,
-                    BorderRadius::all(Val::Px(20.)),
+                    BorderRadius::all(Px(20.)),
                 ),
                 (
                     Vec2::new(25., 50.),
@@ -203,9 +203,9 @@ fn box_shadow_node_bundle(
     (
         NodeBundle {
             style: Style {
-                width: Val::Px(size.x),
-                height: Val::Px(size.y),
-                border: UiRect::all(Val::Px(4.)),
+                width: Px(size.x),
+                height: Px(size.y),
+                border: UiRect::all(Px(4.)),
                 ..default()
             },
             border_color: BorderColor(LIGHT_SKY_BLUE.into()),
@@ -215,10 +215,10 @@ fn box_shadow_node_bundle(
         },
         BoxShadow {
             color: Color::BLACK.with_alpha(0.8),
-            x_offset: Val::Percent(offset.x),
-            y_offset: Val::Percent(offset.y),
-            spread_radius: Val::Percent(spread),
-            blur_radius: Val::Px(blur),
+            x_offset: Percent(offset.x),
+            y_offset: Percent(offset.y),
+            spread_radius: Percent(spread),
+            blur_radius: Px(blur),
         },
     )
 }

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -57,8 +57,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -69,9 +69,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(ButtonBundle {
                     style: Style {
-                        width: Val::Px(150.0),
-                        height: Val::Px(65.0),
-                        border: UiRect::all(Val::Px(5.0)),
+                        width: Px(150.0),
+                        height: Px(65.0),
+                        border: UiRect::all(Px(5.0)),
                         // horizontally center child text
                         justify_content: JustifyContent::Center,
                         // vertically center child text

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -84,8 +84,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2d);
     commands.spawn(NodeBundle {
         style: Style {
-            width: Val::Percent(100.),
-            height: Val::Percent(100.),
+            width: Percent(100.),
+            height: Percent(100.),
             flex_direction: FlexDirection::Column,
             align_items: AlignItems::Center,
             justify_content: JustifyContent::SpaceEvenly,
@@ -98,7 +98,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text_font.clone(),
             TextLayout::new_with_justify(JustifyText::Center),
             Style {
-                margin: UiRect::bottom(Val::Px(10.)),
+                margin: UiRect::bottom(Px(10.)),
                 ..Default::default()
             },
         ));
@@ -106,7 +106,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         parent
             .spawn(NodeBundle {
                 style: Style {
-                    width: Val::Percent(100.),
+                    width: Percent(100.),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -115,8 +115,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 let mut target_ids = vec![];
                 parent.spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(50.),
-                        height: Val::Px(520.),
+                        width: Percent(50.),
+                        height: Px(520.),
                         justify_content: JustifyContent::Center,
                         ..Default::default()
                     },
@@ -127,7 +127,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
                 parent.spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(50.),
+                        width: Percent(50.),
                         justify_content: JustifyContent::Center,
                         ..Default::default()
                     },
@@ -142,7 +142,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     flex_direction: FlexDirection::Row,
                     align_items: AlignItems::Start,
                     justify_content: JustifyContent::Start,
-                    column_gap: Val::Px(10.),
+                    column_gap: Px(10.),
                     ..Default::default()
                 },
                 ..default() })
@@ -174,7 +174,7 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
     builder
         .spawn(NodeBundle {
             style: Style {
-                padding: UiRect::all(Val::Px(10.)),
+                padding: UiRect::all(Px(10.)),
                 ..Default::default()
             },
             background_color: BackgroundColor(Color::WHITE),
@@ -200,8 +200,8 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
                         .with_children(|parent| {
                             parent.spawn(NodeBundle {
                                 style: Style {
-                                    width: Val::Px(100.),
-                                    height: Val::Px(500.),
+                                    width: Px(100.),
+                                    height: Px(500.),
                                     ..Default::default()
                                 },
                                 ..Default::default()
@@ -210,7 +210,7 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
                             let id = parent
                                 .spawn(NodeBundle {
                                     style: Style {
-                                        height: Val::Px(400.),
+                                        height: Px(400.),
                                         align_items: AlignItems::FlexEnd,
                                         justify_content: JustifyContent::FlexEnd,
                                         ..Default::default()
@@ -221,8 +221,8 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
                                 .with_children(|parent| {
                                     parent.spawn(NodeBundle {
                                         style: Style {
-                                            width: Val::Px(100.),
-                                            height: Val::Px(400.),
+                                            width: Px(100.),
+                                            height: Px(400.),
                                             ..Default::default()
                                         },
                                         ..Default::default()
@@ -231,7 +231,7 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
                                     let id = parent
                                         .spawn(NodeBundle {
                                             style: Style {
-                                                height: Val::Px(300.),
+                                                height: Px(300.),
                                                 align_items: AlignItems::FlexEnd,
                                                 justify_content: JustifyContent::FlexEnd,
                                                 ..Default::default()
@@ -242,8 +242,8 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
                                         .with_children(|parent| {
                                             parent.spawn(NodeBundle {
                                                 style: Style {
-                                                    width: Val::Px(100.),
-                                                    height: Val::Px(300.),
+                                                    width: Px(100.),
+                                                    height: Px(300.),
                                                     ..Default::default()
                                                 },
                                                 ..Default::default()
@@ -252,8 +252,8 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
                                             let id = parent
                                                 .spawn(NodeBundle {
                                                     style: Style {
-                                                        width: Val::Px(200.),
-                                                        height: Val::Px(200.),
+                                                        width: Px(200.),
+                                                        height: Px(200.),
                                                         ..Default::default()
                                                     },
                                                     background_color: BackgroundColor(palette[3]),
@@ -288,7 +288,7 @@ fn spawn_right_panel(
     parent
         .spawn(NodeBundle {
             style: Style {
-                padding: UiRect::all(Val::Px(10.)),
+                padding: UiRect::all(Px(10.)),
                 ..Default::default()
             },
             background_color: BackgroundColor(Color::WHITE),
@@ -298,14 +298,14 @@ fn spawn_right_panel(
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(500.),
-                        height: Val::Px(500.),
+                        width: Px(500.),
+                        height: Px(500.),
                         flex_direction: FlexDirection::Column,
                         align_items: AlignItems::FlexEnd,
                         justify_content: JustifyContent::SpaceBetween,
                         padding: UiRect {
-                            left: Val::Px(5.),
-                            top: Val::Px(5.),
+                            left: Px(5.),
+                            top: Px(5.),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -319,14 +319,14 @@ fn spawn_right_panel(
                     parent
                         .spawn(NodeBundle {
                             style: Style {
-                                width: Val::Px(400.),
-                                height: Val::Px(400.),
+                                width: Px(400.),
+                                height: Px(400.),
                                 flex_direction: FlexDirection::Column,
                                 align_items: AlignItems::FlexEnd,
                                 justify_content: JustifyContent::SpaceBetween,
                                 padding: UiRect {
-                                    left: Val::Px(5.),
-                                    top: Val::Px(5.),
+                                    left: Px(5.),
+                                    top: Px(5.),
                                     ..Default::default()
                                 },
                                 ..Default::default()
@@ -340,14 +340,14 @@ fn spawn_right_panel(
                             parent
                                 .spawn(NodeBundle {
                                     style: Style {
-                                        width: Val::Px(300.),
-                                        height: Val::Px(300.),
+                                        width: Px(300.),
+                                        height: Px(300.),
                                         flex_direction: FlexDirection::Column,
                                         align_items: AlignItems::FlexEnd,
                                         justify_content: JustifyContent::SpaceBetween,
                                         padding: UiRect {
-                                            left: Val::Px(5.),
-                                            top: Val::Px(5.),
+                                            left: Px(5.),
+                                            top: Px(5.),
                                             ..Default::default()
                                         },
                                         ..Default::default()
@@ -361,14 +361,14 @@ fn spawn_right_panel(
                                     parent
                                         .spawn(NodeBundle {
                                             style: Style {
-                                                width: Val::Px(200.),
-                                                height: Val::Px(200.),
+                                                width: Px(200.),
+                                                height: Px(200.),
                                                 align_items: AlignItems::FlexStart,
                                                 justify_content: JustifyContent::SpaceBetween,
                                                 flex_direction: FlexDirection::Column,
                                                 padding: UiRect {
-                                                    left: Val::Px(5.),
-                                                    top: Val::Px(5.),
+                                                    left: Px(5.),
+                                                    top: Px(5.),
                                                     ..Default::default()
                                                 },
                                                 ..Default::default()
@@ -381,8 +381,8 @@ fn spawn_right_panel(
 
                                             parent.spawn(NodeBundle {
                                                 style: Style {
-                                                    width: Val::Px(100.),
-                                                    height: Val::Px(100.),
+                                                    width: Px(100.),
+                                                    height: Px(100.),
                                                     ..Default::default()
                                                 },
                                                 ..Default::default()
@@ -404,7 +404,7 @@ where
             ButtonBundle {
                 style: Style {
                     align_self: AlignSelf::FlexStart,
-                    padding: UiRect::axes(Val::Px(5.), Val::Px(1.)),
+                    padding: UiRect::axes(Px(5.), Px(1.)),
                     ..Default::default()
                 },
                 background_color: Color::BLACK.with_alpha(0.5).into(),

--- a/examples/ui/flex_layout.rs
+++ b/examples/ui/flex_layout.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 
 const ALIGN_ITEMS_COLOR: Color = Color::srgb(1., 0.066, 0.349);
 const JUSTIFY_CONTENT_COLOR: Color = Color::srgb(0.102, 0.522, 1.);
-const MARGIN: Val = Val::Px(12.);
+const MARGIN: Val = Px(12.);
 
 fn main() {
     App::new()
@@ -25,8 +25,8 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(NodeBundle {
             style: Style {
                 // fill the entire window
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
                 padding: UiRect::all(MARGIN),
@@ -66,8 +66,8 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
             builder
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         flex_direction: FlexDirection::Column,
                         row_gap: MARGIN,
                         ..Default::default()
@@ -95,8 +95,8 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         builder
                             .spawn(NodeBundle {
                                 style: Style {
-                                    width: Val::Percent(100.),
-                                    height: Val::Percent(100.),
+                                    width: Percent(100.),
+                                    height: Percent(100.),
                                     flex_direction: FlexDirection::Row,
                                     column_gap: MARGIN,
                                     ..Default::default()
@@ -130,8 +130,8 @@ fn spawn_child_node(
                 flex_direction: FlexDirection::Column,
                 align_items,
                 justify_content,
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 ..Default::default()
             },
             background_color: BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
@@ -148,7 +148,7 @@ fn spawn_child_node(
                     builder,
                     font.clone(),
                     color,
-                    UiRect::top(Val::Px(top_margin)),
+                    UiRect::top(Px(top_margin)),
                     &text,
                 );
             }
@@ -166,7 +166,7 @@ fn spawn_nested_text_bundle(
         .spawn(NodeBundle {
             style: Style {
                 margin,
-                padding: UiRect::axes(Val::Px(5.), Val::Px(1.)),
+                padding: UiRect::axes(Px(5.), Px(1.)),
                 ..Default::default()
             },
             background_color: BackgroundColor(background_color),

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -53,7 +53,7 @@ fn atlas_render_system(
                 style: Style {
                     position_type: PositionType::Absolute,
                     top: Val::ZERO,
-                    left: Val::Px(512.0 * x_offset),
+                    left: Px(512.0 * x_offset),
                     ..default()
                 },
                 ..default()

--- a/examples/ui/ghost_nodes.rs
+++ b/examples/ui/ghost_nodes.rs
@@ -35,8 +35,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -71,9 +71,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 fn create_button() -> ButtonBundle {
     ButtonBundle {
         style: Style {
-            width: Val::Px(150.0),
-            height: Val::Px(65.0),
-            border: UiRect::all(Val::Px(5.0)),
+            width: Px(150.0),
+            height: Px(65.0),
+            border: UiRect::all(Px(5.0)),
             // horizontally center child text
             justify_content: JustifyContent::Center,
             // vertically center child text

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -26,8 +26,8 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                 // Use the CSS Grid algorithm for laying out this node
                 display: Display::Grid,
                 // Make node fill the entirety of its parent (in this case the window)
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 // Set the grid to have 2 columns with sizes [min-content, minmax(0, 1fr)]
                 //   - The first column will size to the size of its contents
                 //   - The second column will take up the remaining available space
@@ -54,7 +54,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         display: Display::Grid,
                         // Make this node span two grid columns so that it takes up the entire top tow
                         grid_column: GridPlacement::span(2),
-                        padding: UiRect::all(Val::Px(6.0)),
+                        padding: UiRect::all(Px(6.0)),
                         ..default()
                     },
                     ..default()
@@ -68,14 +68,14 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .spawn(NodeBundle {
                     style: Style {
                         // Make the height of the node fill its parent
-                        height: Val::Percent(100.0),
+                        height: Percent(100.0),
                         // Make the grid have a 1:1 aspect ratio meaning it will scale as an exact square
                         // As the height is set explicitly, this means the width will adjust to match the height
                         aspect_ratio: Some(1.0),
                         // Use grid layout for this node
                         display: Display::Grid,
                         // Add 24px of padding around the grid
-                        padding: UiRect::all(Val::Px(24.0)),
+                        padding: UiRect::all(Px(24.0)),
                         // Set the grid to have 4 columns all with sizes minmax(0, 1fr)
                         // This creates 4 exactly evenly sized columns
                         grid_template_columns: RepeatedGridTrack::flex(4, 1.0),
@@ -83,8 +83,8 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         // This creates 4 exactly evenly sized rows
                         grid_template_rows: RepeatedGridTrack::flex(4, 1.0),
                         // Set a 12px gap/gutter between rows and columns
-                        row_gap: Val::Px(12.0),
-                        column_gap: Val::Px(12.0),
+                        row_gap: Px(12.0),
+                        column_gap: Px(12.0),
                         ..default()
                     },
                     background_color: BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
@@ -124,12 +124,12 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         // Align content towards the center in the horizontal axis
                         justify_items: JustifyItems::Center,
                         // Add 10px padding
-                        padding: UiRect::all(Val::Px(10.)),
+                        padding: UiRect::all(Px(10.)),
                         // Add an fr track to take up all the available space at the bottom of the column so that the text nodes
                         // can be top-aligned. Normally you'd use flexbox for this, but this is the CSS Grid example so we're using grid.
                         grid_template_rows: vec![GridTrack::auto(), GridTrack::auto(), GridTrack::fr(1.0)],
                         // Add a 10px gap between rows
-                        row_gap: Val::Px(10.),
+                        row_gap: Px(10.),
                         ..default()
                     },
                     background_color: BackgroundColor(BLACK.into()),
@@ -169,14 +169,14 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: Style {
                     position_type: PositionType::Absolute,
                     margin: UiRect {
-                        top: Val::Px(100.),
-                        bottom: Val::Auto,
-                        left: Val::Auto,
-                        right: Val::Auto,
+                        top: Px(100.),
+                        bottom: Auto,
+                        left: Auto,
+                        right: Auto,
                     },
-                    width: Val::Percent(60.),
-                    height: Val::Px(300.),
-                    max_width: Val::Px(600.),
+                    width: Percent(60.),
+                    height: Px(300.),
+                    max_width: Px(600.),
                     ..default()
                 },
                 background_color: BackgroundColor(Color::WHITE.with_alpha(0.8)),
@@ -193,7 +193,7 @@ fn item_rect(builder: &mut ChildBuilder, color: Srgba) {
         .spawn(NodeBundle {
             style: Style {
                 display: Display::Grid,
-                padding: UiRect::all(Val::Px(3.0)),
+                padding: UiRect::all(Px(3.0)),
                 ..default()
             },
             background_color: BackgroundColor(BLACK.into()),

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -22,8 +22,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..Default::default()
@@ -43,7 +43,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         style: Style {
                             flex_direction: FlexDirection::Column,
                             align_items: AlignItems::Center,
-                            margin: UiRect::horizontal(Val::Px(25.)),
+                            margin: UiRect::horizontal(Px(25.)),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -53,8 +53,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         parent
                             .spawn(NodeBundle {
                                 style: Style {
-                                    padding: UiRect::all(Val::Px(10.)),
-                                    margin: UiRect::bottom(Val::Px(25.)),
+                                    padding: UiRect::all(Px(10.)),
+                                    margin: UiRect::bottom(Px(25.)),
                                     ..Default::default()
                                 },
                                 background_color: Color::srgb(0.25, 0.25, 0.25).into(),
@@ -66,14 +66,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         parent
                             .spawn(NodeBundle {
                                 style: Style {
-                                    width: Val::Px(100.),
-                                    height: Val::Px(100.),
+                                    width: Px(100.),
+                                    height: Px(100.),
                                     padding: UiRect {
-                                        left: Val::Px(25.),
-                                        top: Val::Px(25.),
+                                        left: Px(25.),
+                                        top: Px(25.),
                                         ..Default::default()
                                     },
-                                    border: UiRect::all(Val::Px(5.)),
+                                    border: UiRect::all(Px(5.)),
                                     overflow,
                                     ..Default::default()
                                 },
@@ -86,16 +86,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     ImageBundle {
                                         image: UiImage::new(image.clone()),
                                         style: Style {
-                                            min_width: Val::Px(100.),
-                                            min_height: Val::Px(100.),
+                                            min_width: Px(100.),
+                                            min_height: Px(100.),
                                             ..Default::default()
                                         },
                                         ..Default::default()
                                     },
                                     Interaction::default(),
                                     Outline {
-                                        width: Val::Px(2.),
-                                        offset: Val::Px(2.),
+                                        width: Px(2.),
+                                        offset: Px(2.),
                                         color: Color::NONE,
                                     },
                                 ));

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -91,8 +91,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text_font.clone(),
             Style {
                 position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
+                top: Px(12.0),
+                left: Px(12.0),
                 ..default()
             },
             Instructions,
@@ -107,8 +107,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 ..default()
@@ -122,8 +122,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         display: Display::Grid,
                         grid_template_columns: RepeatedGridTrack::px(3, CONTAINER_SIZE),
                         grid_template_rows: RepeatedGridTrack::px(2, CONTAINER_SIZE),
-                        row_gap: Val::Px(80.),
-                        column_gap: Val::Px(80.),
+                        row_gap: Px(80.),
+                        column_gap: Px(80.),
                         ..default()
                     },
                     ..default()
@@ -149,10 +149,10 @@ fn spawn_image(
         parent.spawn(ImageBundle {
             image: UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),
             style: Style {
-                height: Val::Px(100.),
+                height: Px(100.),
                 position_type: PositionType::Absolute,
-                top: Val::Px(-50.),
-                left: Val::Px(-200.),
+                top: Px(-50.),
+                left: Px(-200.),
                 ..default()
             },
             ..default()
@@ -190,8 +190,8 @@ fn spawn_container(
         .spawn((
             NodeBundle {
                 style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     align_items: AlignItems::Center,
                     justify_content: JustifyContent::Center,
                     overflow: Overflow::clip(),
@@ -209,8 +209,8 @@ fn spawn_container(
                         style: Style {
                             align_items: AlignItems::Center,
                             justify_content: JustifyContent::Center,
-                            top: Val::Px(transform.translation.x),
-                            left: Val::Px(transform.translation.y),
+                            top: Px(transform.translation.x),
+                            left: Px(transform.translation.y),
                             ..default()
                         },
                         transform,
@@ -251,8 +251,8 @@ fn update_transform<T: UpdateTransform + Component>(
     for (mut transform, mut style, update_transform) in &mut containers {
         update_transform.update(animation.t, &mut transform);
 
-        style.left = Val::Px(transform.translation.x);
-        style.top = Val::Px(transform.translation.y);
+        style.left = Px(transform.translation.x);
+        style.top = Px(transform.translation.y);
     }
 }
 
@@ -288,12 +288,12 @@ fn next_container_size(mut containers: Query<(&mut Style, &mut Container)>) {
         container.0 = (container.0 + 1) % 3;
 
         style.width = match container.0 {
-            2 => Val::Percent(30.),
-            _ => Val::Percent(100.),
+            2 => Percent(30.),
+            _ => Percent(100.),
         };
         style.height = match container.0 {
-            1 => Val::Percent(30.),
-            _ => Val::Percent(100.),
+            1 => Percent(30.),
+            _ => Percent(100.),
         };
     }
 }

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -31,8 +31,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.0),
+                width: Percent(100.),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 flex_direction: FlexDirection::Column,
@@ -44,9 +44,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(250.),
-                        height: Val::Px(250.),
-                        margin: UiRect::bottom(Val::Px(15.)),
+                        width: Px(250.),
+                        height: Px(250.),
+                        margin: UiRect::bottom(Px(15.)),
                         ..default()
                     },
                     background_color: Color::srgb(235., 35., 12.).into(),

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -68,8 +68,8 @@ fn setup(
             NodeBundle {
                 style: Style {
                     // Cover the whole image
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
+                    width: Percent(100.),
+                    height: Percent(100.),
                     flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -32,8 +32,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 justify_content: JustifyContent::SpaceBetween,
                 flex_direction: FlexDirection::Column,
                 ..default()
@@ -46,7 +46,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.),
+                        width: Percent(100.),
                         flex_direction: FlexDirection::Column,
                         ..default()
                     },
@@ -68,8 +68,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     parent
                         .spawn(NodeBundle {
                             style: Style {
-                                width: Val::Percent(80.),
-                                margin: UiRect::all(Val::Px(10.)),
+                                width: Percent(80.),
+                                margin: UiRect::all(Px(10.)),
                                 flex_direction: FlexDirection::Row,
                                 overflow: Overflow::scroll_x(), // n.b.
                                 ..default()
@@ -89,7 +89,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     AccessibilityNode(NodeBuilder::new(Role::ListItem)),
                                 ))
                                 .insert(Style {
-                                    min_width: Val::Px(200.),
+                                    min_width: Px(200.),
                                     align_content: AlignContent::Center,
                                     ..default()
                                 })
@@ -113,8 +113,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
+                        width: Percent(100.),
+                        height: Percent(100.),
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::SpaceBetween,
                         ..default()
@@ -129,7 +129,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 flex_direction: FlexDirection::Column,
                                 justify_content: JustifyContent::Center,
                                 align_items: AlignItems::Center,
-                                width: Val::Px(200.),
+                                width: Px(200.),
                                 ..default()
                             },
                             ..default()
@@ -151,7 +151,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     style: Style {
                                         flex_direction: FlexDirection::Column,
                                         align_self: AlignSelf::Stretch,
-                                        height: Val::Percent(50.),
+                                        height: Percent(50.),
                                         overflow: Overflow::scroll_y(), // n.b.
                                         ..default()
                                     },
@@ -164,8 +164,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         parent
                                             .spawn(NodeBundle {
                                                 style: Style {
-                                                    min_height: Val::Px(LINE_HEIGHT),
-                                                    max_height: Val::Px(LINE_HEIGHT),
+                                                    min_height: Px(LINE_HEIGHT),
+                                                    max_height: Px(LINE_HEIGHT),
                                                     ..default()
                                                 },
                                                 ..default()
@@ -204,7 +204,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 flex_direction: FlexDirection::Column,
                                 justify_content: JustifyContent::Center,
                                 align_items: AlignItems::Center,
-                                width: Val::Px(200.),
+                                width: Px(200.),
                                 ..default()
                             },
                             ..default()
@@ -226,7 +226,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     style: Style {
                                         flex_direction: FlexDirection::Column,
                                         align_self: AlignSelf::Stretch,
-                                        height: Val::Percent(50.),
+                                        height: Percent(50.),
                                         overflow: Overflow::scroll(), // n.b.
                                         ..default()
                                     },
@@ -279,7 +279,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 flex_direction: FlexDirection::Column,
                                 justify_content: JustifyContent::Center,
                                 align_items: AlignItems::Center,
-                                width: Val::Px(200.),
+                                width: Px(200.),
                                 ..default()
                             },
                             ..default()
@@ -299,10 +299,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             parent
                                 .spawn(NodeBundle {
                                     style: Style {
-                                        column_gap: Val::Px(20.),
+                                        column_gap: Px(20.),
                                         flex_direction: FlexDirection::Row,
                                         align_self: AlignSelf::Stretch,
-                                        height: Val::Percent(50.),
+                                        height: Percent(50.),
                                         overflow: Overflow::scroll_x(), // n.b.
                                         ..default()
                                     },

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -54,8 +54,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
                 ..Default::default()
@@ -79,7 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         Text::new("Size Constraints Example"),
                         text_font.clone(),
                         Style {
-                            margin: UiRect::bottom(Val::Px(25.)),
+                            margin: UiRect::bottom(Px(25.)),
                             ..Default::default()
                         },
                     ));
@@ -91,8 +91,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             style: Style {
                                 flex_direction: FlexDirection::Column,
                                 align_items: AlignItems::Stretch,
-                                padding: UiRect::all(Val::Px(10.)),
-                                margin: UiRect::top(Val::Px(50.)),
+                                padding: UiRect::all(Px(10.)),
+                                margin: UiRect::top(Px(50.)),
                                 ..Default::default()
                             },
                             background_color: YELLOW.into(),
@@ -116,9 +116,9 @@ fn spawn_bar(parent: &mut ChildBuilder) {
     parent
         .spawn(NodeBundle {
             style: Style {
-                flex_basis: Val::Percent(100.0),
+                flex_basis: Percent(100.0),
                 align_self: AlignSelf::Stretch,
-                padding: UiRect::all(Val::Px(10.)),
+                padding: UiRect::all(Px(10.)),
                 ..Default::default()
             },
             background_color: YELLOW.into(),
@@ -129,9 +129,9 @@ fn spawn_bar(parent: &mut ChildBuilder) {
                 .spawn(NodeBundle {
                     style: Style {
                         align_items: AlignItems::Stretch,
-                        width: Val::Percent(100.),
-                        height: Val::Px(100.),
-                        padding: UiRect::all(Val::Px(4.)),
+                        width: Percent(100.),
+                        height: Px(100.),
+                        padding: UiRect::all(Px(4.)),
                         ..Default::default()
                     },
                     background_color: Color::BLACK.into(),
@@ -168,7 +168,7 @@ fn spawn_button_row(
         .spawn(NodeBundle {
             style: Style {
                 flex_direction: FlexDirection::Column,
-                padding: UiRect::all(Val::Px(2.)),
+                padding: UiRect::all(Px(2.)),
                 align_items: AlignItems::Stretch,
                 ..Default::default()
             },
@@ -181,7 +181,7 @@ fn spawn_button_row(
                     style: Style {
                         flex_direction: FlexDirection::Row,
                         justify_content: JustifyContent::End,
-                        padding: UiRect::all(Val::Px(2.)),
+                        padding: UiRect::all(Px(2.)),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -191,8 +191,8 @@ fn spawn_button_row(
                     parent
                         .spawn(NodeBundle {
                             style: Style {
-                                min_width: Val::Px(200.),
-                                max_width: Val::Px(200.),
+                                min_width: Px(200.),
+                                max_width: Px(200.),
                                 justify_content: JustifyContent::Center,
                                 align_items: AlignItems::Center,
                                 ..Default::default()
@@ -210,7 +210,7 @@ fn spawn_button_row(
                             spawn_button(
                                 parent,
                                 constraint,
-                                ButtonValue(Val::Auto),
+                                ButtonValue(Auto),
                                 "Auto".to_string(),
                                 text_style.clone(),
                                 true,
@@ -219,7 +219,7 @@ fn spawn_button_row(
                                 spawn_button(
                                     parent,
                                     constraint,
-                                    ButtonValue(Val::Percent(percent)),
+                                    ButtonValue(Percent(percent)),
                                     format!("{percent}%"),
                                     text_style.clone(),
                                     false,
@@ -244,8 +244,8 @@ fn spawn_button(
                 style: Style {
                     align_items: AlignItems::Center,
                     justify_content: JustifyContent::Center,
-                    border: UiRect::all(Val::Px(2.)),
-                    margin: UiRect::horizontal(Val::Px(2.)),
+                    border: UiRect::all(Px(2.)),
+                    margin: UiRect::horizontal(Px(2.)),
                     ..Default::default()
                 },
                 border_color: if active {
@@ -263,7 +263,7 @@ fn spawn_button(
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(100.),
+                        width: Px(100.),
                         justify_content: JustifyContent::Center,
                         ..Default::default()
                     },

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -43,8 +43,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // Set the style of the Node itself.
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            right: Val::Px(5.0),
+            bottom: Px(5.0),
+            right: Px(5.0),
             ..default()
         },
         ColorText,
@@ -94,8 +94,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Text::new("From an &str into a Text with the default font!"),
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            left: Val::Px(15.0),
+            bottom: Px(5.0),
+            left: Px(15.0),
             ..default()
         },
     ));
@@ -109,8 +109,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            left: Val::Px(15.0),
+            bottom: Px(5.0),
+            left: Px(15.0),
             ..default()
         },
     ));

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -38,8 +38,8 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     let root_uinode = commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 justify_content: JustifyContent::SpaceBetween,
                 ..default()
             },
@@ -53,7 +53,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             justify_content: JustifyContent::SpaceBetween,
             align_items: AlignItems::Start,
             flex_grow: 1.,
-            margin: UiRect::axes(Val::Px(15.), Val::Px(5.)),
+            margin: UiRect::axes(Px(15.), Px(5.)),
             ..default()
         },
         ..default()
@@ -79,7 +79,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextColor(YELLOW.into()),
             TextLayout::new_with_justify(JustifyText::Right),
             Style {
-                max_width: Val::Px(300.),
+                max_width: Px(300.),
                 ..default()
             },
             BackgroundColor(background_color)
@@ -93,7 +93,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             },
             Style {
-                max_width: Val::Px(300.),
+                max_width: Px(300.),
                 ..default()
             },
             BackgroundColor(background_color)
@@ -107,7 +107,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             justify_content: JustifyContent::SpaceBetween,
             align_items: AlignItems::End,
             flex_grow: 1.,
-            margin: UiRect::axes(Val::Px(15.), Val::Px(5.)),
+            margin: UiRect::axes(Px(15.), Px(5.)),
             ..default()
         },
         ..default()
@@ -123,7 +123,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextColor(Color::srgb(0.8, 0.2, 0.7)),
             TextLayout::new_with_justify(JustifyText::Center),
             Style {
-                max_width: Val::Px(400.),
+                max_width: Px(400.),
                 ..default()
             },BackgroundColor(background_color))
         );
@@ -138,7 +138,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextColor(YELLOW.into()),
             TextLayout::new_with_justify(JustifyText::Left),
             Style {
-                max_width: Val::Px(300.),
+                max_width: Px(300.),
                 ..default()
             },
             BackgroundColor(background_color)
@@ -154,7 +154,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextLayout::new_with_justify(JustifyText::Justified),
             TextColor(GREEN_YELLOW.into()),
             Style {
-                max_width: Val::Px(300.),
+                max_width: Px(300.),
                 ..default()
             },
             BackgroundColor(background_color)

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -54,8 +54,8 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     let root = commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 flex_direction: FlexDirection::Column,
                 ..Default::default()
             },
@@ -76,8 +76,8 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                     flex_direction: FlexDirection::Row,
                     justify_content: JustifyContent::SpaceAround,
                     align_items: AlignItems::Center,
-                    width: Val::Percent(100.),
-                    height: Val::Percent(50.),
+                    width: Percent(100.),
+                    height: Percent(50.),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -100,8 +100,8 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         justify_content: justification,
                         flex_direction: FlexDirection::Column,
-                        width: Val::Percent(16.),
-                        height: Val::Percent(95.),
+                        width: Percent(16.),
+                        height: Percent(95.),
                         overflow: Overflow::clip_x(),
                         ..Default::default()
                     },

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -19,8 +19,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::SpaceAround,
                 ..default()
@@ -31,8 +31,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(ButtonBundle {
                     style: Style {
-                        width: Val::Px(150.0),
-                        height: Val::Px(65.0),
+                        width: Px(150.0),
+                        height: Px(65.0),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         ..default()
@@ -58,8 +58,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(ButtonBundle {
                     style: Style {
-                        width: Val::Px(150.0),
-                        height: Val::Px(65.0),
+                        width: Px(150.0),
+                        height: Px(65.0),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
                         ..default()

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -37,8 +37,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 justify_content: JustifyContent::SpaceBetween,
                 ..default()
             },
@@ -50,8 +50,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(200.),
-                        border: UiRect::all(Val::Px(2.)),
+                        width: Px(200.),
+                        border: UiRect::all(Px(2.)),
                         ..default()
                     },
                     background_color: Color::srgb(0.65, 0.65, 0.65).into(),
@@ -62,10 +62,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     parent
                         .spawn(NodeBundle {
                             style: Style {
-                                width: Val::Percent(100.),
+                                width: Percent(100.),
                                 flex_direction: FlexDirection::Column,
-                                padding: UiRect::all(Val::Px(5.)),
-                                row_gap: Val::Px(5.),
+                                padding: UiRect::all(Px(5.)),
+                                row_gap: Px(5.),
                                 ..default()
                             },
                             background_color: Color::srgb(0.15, 0.15, 0.15).into(),
@@ -115,7 +115,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::Column,
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
-                        width: Val::Px(200.),
+                        width: Px(200.),
                         ..default()
                     },
                     ..default()
@@ -137,7 +137,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             style: Style {
                                 flex_direction: FlexDirection::Column,
                                 align_self: AlignSelf::Stretch,
-                                height: Val::Percent(50.),
+                                height: Percent(50.),
                                 overflow: Overflow::scroll_y(),
                                 ..default()
                             },
@@ -168,12 +168,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(200.0),
-                        height: Val::Px(200.0),
+                        width: Px(200.0),
+                        height: Px(200.0),
                         position_type: PositionType::Absolute,
-                        left: Val::Px(210.),
-                        bottom: Val::Px(10.),
-                        border: UiRect::all(Val::Px(20.)),
+                        left: Px(210.),
+                        bottom: Px(10.),
+                        border: UiRect::all(Px(20.)),
                         ..default()
                     },
                     border_color: LIME.into(),
@@ -183,8 +183,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .with_children(|parent| {
                     parent.spawn(NodeBundle {
                         style: Style {
-                            width: Val::Percent(100.0),
-                            height: Val::Percent(100.0),
+                            width: Percent(100.0),
+                            height: Percent(100.0),
                             ..default()
                         },
                         background_color: Color::srgb(0.8, 0.8, 1.).into(),
@@ -195,8 +195,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
-                        height: Val::Percent(100.0),
+                        width: Percent(100.0),
+                        height: Percent(100.0),
                         position_type: PositionType::Absolute,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
@@ -209,8 +209,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     parent
                         .spawn(NodeBundle {
                             style: Style {
-                                width: Val::Px(100.0),
-                                height: Val::Px(100.0),
+                                width: Px(100.0),
+                                height: Px(100.0),
                                 ..default()
                             },
                             background_color: Color::srgb(1.0, 0.0, 0.).into(),
@@ -220,11 +220,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             parent.spawn(NodeBundle {
                                 style: Style {
                                     // Take the size of the parent node.
-                                    width: Val::Percent(100.0),
-                                    height: Val::Percent(100.0),
+                                    width: Percent(100.0),
+                                    height: Percent(100.0),
                                     position_type: PositionType::Absolute,
-                                    left: Val::Px(20.),
-                                    bottom: Val::Px(20.),
+                                    left: Px(20.),
+                                    bottom: Px(20.),
                                     ..default()
                                 },
                                 background_color: Color::srgb(1.0, 0.3, 0.3).into(),
@@ -232,11 +232,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             });
                             parent.spawn(NodeBundle {
                                 style: Style {
-                                    width: Val::Percent(100.0),
-                                    height: Val::Percent(100.0),
+                                    width: Percent(100.0),
+                                    height: Percent(100.0),
                                     position_type: PositionType::Absolute,
-                                    left: Val::Px(40.),
-                                    bottom: Val::Px(40.),
+                                    left: Px(40.),
+                                    bottom: Px(40.),
                                     ..default()
                                 },
                                 background_color: Color::srgb(1.0, 0.5, 0.5).into(),
@@ -244,11 +244,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             });
                             parent.spawn(NodeBundle {
                                 style: Style {
-                                    width: Val::Percent(100.0),
-                                    height: Val::Percent(100.0),
+                                    width: Percent(100.0),
+                                    height: Percent(100.0),
                                     position_type: PositionType::Absolute,
-                                    left: Val::Px(60.),
-                                    bottom: Val::Px(60.),
+                                    left: Px(60.),
+                                    bottom: Px(60.),
                                     ..default()
                                 },
                                 background_color: Color::srgb(1.0, 0.7, 0.7).into(),
@@ -257,11 +257,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             // alpha test
                             parent.spawn(NodeBundle {
                                 style: Style {
-                                    width: Val::Percent(100.0),
-                                    height: Val::Percent(100.0),
+                                    width: Percent(100.0),
+                                    height: Percent(100.0),
                                     position_type: PositionType::Absolute,
-                                    left: Val::Px(80.),
-                                    bottom: Val::Px(80.),
+                                    left: Px(80.),
+                                    bottom: Px(80.),
                                     ..default()
                                 },
                                 background_color: Color::srgba(1.0, 0.9, 0.9, 0.4).into(),
@@ -273,7 +273,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Percent(100.0),
+                        width: Percent(100.0),
                         position_type: PositionType::Absolute,
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::FlexStart,
@@ -289,9 +289,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         .spawn((
                             NodeBundle {
                                 style: Style {
-                                    width: Val::Px(500.0),
-                                    height: Val::Px(125.0),
-                                    margin: UiRect::top(Val::VMin(5.)),
+                                    width: Px(500.0),
+                                    height: Px(125.0),
+                                    margin: UiRect::top(VMin(5.)),
                                     ..default()
                                 },
                                 ..default()

--- a/examples/ui/ui_material.rs
+++ b/examples/ui/ui_material.rs
@@ -25,8 +25,8 @@ fn setup(
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -38,9 +38,9 @@ fn setup(
             parent.spawn(MaterialNodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    width: Val::Px(905.0 * banner_scale_factor),
-                    height: Val::Px(363.0 * banner_scale_factor),
-                    border: UiRect::all(Val::Px(10.)),
+                    width: Px(905.0 * banner_scale_factor),
+                    height: Px(363.0 * banner_scale_factor),
+                    border: UiRect::all(Px(10.)),
                     ..default()
                 },
                 material: UiMaterialHandle(ui_materials.add(CustomUiMaterial {

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -31,11 +31,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(50.0),
-                height: Val::Percent(50.0),
+                width: Percent(50.0),
+                height: Percent(50.0),
                 position_type: PositionType::Absolute,
-                left: Val::Percent(25.),
-                top: Val::Percent(25.),
+                left: Percent(25.),
+                top: Percent(25.),
                 justify_content: JustifyContent::SpaceAround,
                 align_items: AlignItems::Center,
                 ..default()
@@ -47,8 +47,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(40.0),
-                        height: Val::Px(40.0),
+                        width: Px(40.0),
+                        height: Px(40.0),
                         ..default()
                     },
                     background_color: RED.into(),
@@ -59,8 +59,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             parent.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Percent(15.0),
-                    height: Val::Percent(15.0),
+                    width: Percent(15.0),
+                    height: Percent(15.0),
                     ..default()
                 },
                 background_color: BLUE.into(),
@@ -68,8 +68,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             });
             parent.spawn(ImageBundle {
                 style: Style {
-                    width: Val::Px(30.0),
-                    height: Val::Px(30.0),
+                    width: Px(30.0),
+                    height: Px(30.0),
                     ..default()
                 },
                 image: asset_server.load("branding/icon.png").into(),

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -35,12 +35,12 @@ fn setup(
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                row_gap: Val::Px(text_font.font_size * 2.),
+                row_gap: Px(text_font.font_size * 2.),
                 ..default()
             },
             ..default()
@@ -49,8 +49,8 @@ fn setup(
             parent.spawn((
                 ImageBundle {
                     style: Style {
-                        width: Val::Px(256.),
-                        height: Val::Px(256.),
+                        width: Px(256.),
+                        height: Px(256.),
                         ..default()
                     },
                     image: UiImage::new(texture_handle),
@@ -58,7 +58,7 @@ fn setup(
                     ..default()
                 },
                 TextureAtlas::from(texture_atlas_handle),
-                Outline::new(Val::Px(8.0), Val::ZERO, CRIMSON.into()),
+                Outline::new(Px(8.0), Val::ZERO, CRIMSON.into()),
             ));
             parent
                 .spawn((Text::new("press "), text_font.clone()))

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -65,8 +65,8 @@ fn setup(
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -83,13 +83,13 @@ fn setup(
                     .spawn((
                         ButtonBundle {
                             style: Style {
-                                width: Val::Px(w),
-                                height: Val::Px(h),
+                                width: Px(w),
+                                height: Px(h),
                                 // horizontally center child text
                                 justify_content: JustifyContent::Center,
                                 // vertically center child text
                                 align_items: AlignItems::Center,
-                                margin: UiRect::all(Val::Px(20.0)),
+                                margin: UiRect::all(Px(20.0)),
                                 ..default()
                             },
                             image: texture_handle.clone().into(),

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -57,8 +57,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -71,13 +71,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     .spawn((
                         ButtonBundle {
                             style: Style {
-                                width: Val::Px(w),
-                                height: Val::Px(h),
+                                width: Px(w),
+                                height: Px(h),
                                 // horizontally center child text
                                 justify_content: JustifyContent::Center,
                                 // vertically center child text
                                 align_items: AlignItems::Center,
-                                margin: UiRect::all(Val::Px(20.0)),
+                                margin: UiRect::all(Px(20.0)),
                                 ..default()
                             },
                             image: image.clone().into(),

--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -41,13 +41,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 justify_content: JustifyContent::Center,
                 align_content: AlignContent::Center,
                 flex_wrap: FlexWrap::Wrap,
-                column_gap: Val::Px(10.),
-                row_gap: Val::Px(10.),
+                column_gap: Px(10.),
+                row_gap: Px(10.),
                 ..default()
             },
             ..default()
@@ -62,8 +62,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 parent.spawn((
                     NodeBundle {
                         style: Style {
-                            width: Val::Px(width),
-                            height: Val::Px(height),
+                            width: Px(width),
+                            height: Px(height),
                             ..default()
                         },
                         ..Default::default()

--- a/examples/ui/viewport_debug.rs
+++ b/examples/ui/viewport_debug.rs
@@ -70,9 +70,9 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
         .spawn((
             NodeBundle {
                 style: Style {
-                    width: Val::Vw(100.),
-                    height: Val::Vh(100.),
-                    border: UiRect::axes(Val::Vw(5.), Val::Vh(5.)),
+                    width: Vw(100.),
+                    height: Vh(100.),
+                    border: UiRect::axes(Vw(5.), Vh(5.)),
                     flex_wrap: FlexWrap::Wrap,
                     ..default()
                 },
@@ -84,9 +84,9 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
         .with_children(|builder| {
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Vw(30.),
-                    height: Val::Vh(30.),
-                    border: UiRect::all(Val::VMin(5.)),
+                    width: Vw(30.),
+                    height: Vh(30.),
+                    border: UiRect::all(VMin(5.)),
                     ..default()
                 },
                 background_color: PALETTE[2].into(),
@@ -96,8 +96,8 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Vw(60.),
-                    height: Val::Vh(30.),
+                    width: Vw(60.),
+                    height: Vh(30.),
                     ..default()
                 },
                 background_color: PALETTE[3].into(),
@@ -106,9 +106,9 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Vw(45.),
-                    height: Val::Vh(30.),
-                    border: UiRect::left(Val::VMax(45. / 2.)),
+                    width: Vw(45.),
+                    height: Vh(30.),
+                    border: UiRect::left(VMax(45. / 2.)),
                     ..default()
                 },
                 background_color: PALETTE[4].into(),
@@ -118,9 +118,9 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Vw(45.),
-                    height: Val::Vh(30.),
-                    border: UiRect::right(Val::VMax(45. / 2.)),
+                    width: Vw(45.),
+                    height: Vh(30.),
+                    border: UiRect::right(VMax(45. / 2.)),
                     ..default()
                 },
                 background_color: PALETTE[5].into(),
@@ -130,8 +130,8 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Vw(60.),
-                    height: Val::Vh(30.),
+                    width: Vw(60.),
+                    height: Vh(30.),
                     ..default()
                 },
                 background_color: PALETTE[6].into(),
@@ -140,9 +140,9 @@ fn spawn_with_viewport_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Vw(30.),
-                    height: Val::Vh(30.),
-                    border: UiRect::all(Val::VMin(5.)),
+                    width: Vw(30.),
+                    height: Vh(30.),
+                    border: UiRect::all(VMin(5.)),
                     ..default()
                 },
                 background_color: PALETTE[7].into(),
@@ -157,9 +157,9 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
         .spawn((
             NodeBundle {
                 style: Style {
-                    width: Val::Px(640.),
-                    height: Val::Px(360.),
-                    border: UiRect::axes(Val::Px(32.), Val::Px(18.)),
+                    width: Px(640.),
+                    height: Px(360.),
+                    border: UiRect::axes(Px(32.), Px(18.)),
                     flex_wrap: FlexWrap::Wrap,
                     ..default()
                 },
@@ -171,9 +171,9 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
         .with_children(|builder| {
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(192.),
-                    height: Val::Px(108.),
-                    border: UiRect::axes(Val::Px(18.), Val::Px(18.)),
+                    width: Px(192.),
+                    height: Px(108.),
+                    border: UiRect::axes(Px(18.), Px(18.)),
                     ..default()
                 },
                 background_color: PALETTE[2].into(),
@@ -183,8 +183,8 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(384.),
-                    height: Val::Px(108.),
+                    width: Px(384.),
+                    height: Px(108.),
                     ..default()
                 },
                 background_color: PALETTE[3].into(),
@@ -193,9 +193,9 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(288.),
-                    height: Val::Px(108.),
-                    border: UiRect::left(Val::Px(144.)),
+                    width: Px(288.),
+                    height: Px(108.),
+                    border: UiRect::left(Px(144.)),
                     ..default()
                 },
                 background_color: PALETTE[4].into(),
@@ -205,9 +205,9 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(288.),
-                    height: Val::Px(108.),
-                    border: UiRect::right(Val::Px(144.)),
+                    width: Px(288.),
+                    height: Px(108.),
+                    border: UiRect::right(Px(144.)),
                     ..default()
                 },
                 background_color: PALETTE[5].into(),
@@ -217,8 +217,8 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(384.),
-                    height: Val::Px(108.),
+                    width: Px(384.),
+                    height: Px(108.),
                     ..default()
                 },
                 background_color: PALETTE[6].into(),
@@ -227,9 +227,9 @@ fn spawn_with_pixel_coords(commands: &mut Commands) {
 
             builder.spawn(NodeBundle {
                 style: Style {
-                    width: Val::Px(192.),
-                    height: Val::Px(108.),
-                    border: UiRect::axes(Val::Px(18.), Val::Px(18.)),
+                    width: Px(192.),
+                    height: Px(108.),
+                    border: UiRect::axes(Px(18.), Px(18.)),
                     ..default()
                 },
                 background_color: PALETTE[7].into(),

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -37,8 +37,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // Set the style of the TextBundle itself.
         Style {
             position_type: PositionType::Absolute,
-            bottom: Val::Px(5.),
-            right: Val::Px(10.),
+            bottom: Px(5.),
+            right: Px(10.),
             ..default()
         },
     ));

--- a/examples/ui/z_index.rs
+++ b/examples/ui/z_index.rs
@@ -25,8 +25,8 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
+                width: Percent(100.),
+                height: Percent(100.),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -38,8 +38,8 @@ fn setup(mut commands: Commands) {
                 .spawn(NodeBundle {
                     background_color: GRAY.into(),
                     style: Style {
-                        width: Val::Px(180.0),
-                        height: Val::Px(100.0),
+                        width: Px(180.0),
+                        height: Px(100.0),
                         ..default()
                     },
                     ..default()
@@ -50,10 +50,10 @@ fn setup(mut commands: Commands) {
                         background_color: RED.into(),
                         style: Style {
                             position_type: PositionType::Absolute,
-                            left: Val::Px(10.0),
-                            bottom: Val::Px(40.0),
-                            width: Val::Px(100.0),
-                            height: Val::Px(50.0),
+                            left: Px(10.0),
+                            bottom: Px(40.0),
+                            width: Px(100.0),
+                            height: Px(50.0),
                             ..default()
                         },
                         ..default()
@@ -66,10 +66,10 @@ fn setup(mut commands: Commands) {
                         background_color: BLUE.into(),
                         style: Style {
                             position_type: PositionType::Absolute,
-                            left: Val::Px(45.0),
-                            bottom: Val::Px(30.0),
-                            width: Val::Px(100.),
-                            height: Val::Px(50.),
+                            left: Px(45.0),
+                            bottom: Px(30.0),
+                            width: Px(100.),
+                            height: Px(50.),
                             ..default()
                         },
                         ..default()
@@ -82,10 +82,10 @@ fn setup(mut commands: Commands) {
                         background_color: LIME.into(),
                         style: Style {
                             position_type: PositionType::Absolute,
-                            left: Val::Px(70.0),
-                            bottom: Val::Px(20.0),
-                            width: Val::Px(100.),
-                            height: Val::Px(75.),
+                            left: Px(70.0),
+                            bottom: Px(20.0),
+                            width: Px(100.),
+                            height: Px(75.),
                             ..default()
                         },
                         ..default()
@@ -99,10 +99,10 @@ fn setup(mut commands: Commands) {
                             background_color: PURPLE.into(),
                             style: Style {
                                 position_type: PositionType::Absolute,
-                                left: Val::Px(15.0),
-                                bottom: Val::Px(10.0),
-                                width: Val::Px(100.),
-                                height: Val::Px(60.),
+                                left: Px(15.0),
+                                bottom: Px(10.0),
+                                width: Px(100.),
+                                height: Px(60.),
                                 ..default()
                             },
                             ..Default::default()
@@ -118,10 +118,10 @@ fn setup(mut commands: Commands) {
                             background_color: YELLOW.into(),
                             style: Style {
                                 position_type: PositionType::Absolute,
-                                left: Val::Px(-15.0),
-                                bottom: Val::Px(-15.0),
-                                width: Val::Px(100.),
-                                height: Val::Px(125.),
+                                left: Px(-15.0),
+                                bottom: Px(-15.0),
+                                width: Px(100.),
+                                height: Px(125.),
                                 ..default()
                             },
                             ..Default::default()

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -191,8 +191,8 @@ pub(crate) mod test_setup {
                 Style {
                     align_self: AlignSelf::FlexStart,
                     position_type: PositionType::Absolute,
-                    top: Val::Px(12.0),
-                    left: Val::Px(12.0),
+                    top: Px(12.0),
+                    left: Px(12.0),
                     ..default()
                 },
                 ModeText,

--- a/examples/window/monitor_info.rs
+++ b/examples/window/monitor_info.rs
@@ -69,8 +69,8 @@ fn update(
             Text(info_text),
             Style {
                 position_type: PositionType::Relative,
-                height: Val::Percent(100.0),
-                width: Val::Percent(100.0),
+                height: Percent(100.0),
+                width: Percent(100.0),
                 ..default()
             },
             TargetCamera(camera),

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -30,8 +30,8 @@ fn setup(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
+                width: Percent(100.0),
+                height: Percent(100.0),
                 justify_content: JustifyContent::SpaceBetween,
                 ..default()
             },
@@ -42,9 +42,9 @@ fn setup(mut commands: Commands) {
             parent
                 .spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(300.0),
-                        height: Val::Percent(100.0),
-                        border: UiRect::all(Val::Px(2.0)),
+                        width: Px(300.0),
+                        height: Percent(100.0),
+                        border: UiRect::all(Px(2.0)),
                         ..default()
                     },
                     background_color: Color::srgb(0.65, 0.65, 0.65).into(),

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -85,8 +85,8 @@ fn setup(
         Text::new("Press <spacebar> to save a screenshot to disk"),
         Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+            top: Px(12.0),
+            left: Px(12.0),
             ..default()
         },
     ));

--- a/examples/window/window_drag_move.rs
+++ b/examples/window/window_drag_move.rs
@@ -65,7 +65,7 @@ fn setup(mut commands: Commands) {
             NodeBundle {
                 style: Style {
                     position_type: PositionType::Absolute,
-                    padding: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Px(5.0)),
                     ..default()
                 },
                 background_color: Color::BLACK.with_alpha(0.75).into(),

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -37,7 +37,7 @@ fn setup_ui(mut commands: Commands) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                width: Val::Percent(100.),
+                width: Percent(100.),
                 ..default()
             },
             ..default()


### PR DESCRIPTION
# Objective

- Fixes #15937

## Solution

- Export the variants of `Val` in the `bevy_ui` prelude.
- Updated examples to use the shortened names.

## Testing

- Ran CI.

## Notes

I'm not totally convinced this is _that_ big of a deal ergonomically. It's pretty easy for the end-user to write `use Val::{...};` at the top of their own files if it really helps them. This was a simple enough PR that I just wanted to create this as a way to decide whether #15937 should just be closed.
