### PR TITLE
Fix asset_settings example regression

### DIFF
--- a/examples/asset/files/bevy_pixel_dark_with_meta.png.meta
+++ b/examples/asset/files/bevy_pixel_dark_with_meta.png.meta
@@ -1,7 +1,7 @@
 (
     meta_format_version: "1.0",
     asset: Load(
-        loader: "bevy_render::texture::image_loader::ImageLoader",
+        loader: "bevy_image::image_loader::ImageLoader",
         settings: (
             format: FromExtension,
             is_srgb: true,


### PR DESCRIPTION
# Objective

In PR #15812 ImageLoader was moved from bevy_render to bevy_image but a reference to old path was left in a meta file used by `asset_settings` example. This resulted in one of sprites used by this example to not be displayed.

Fixes #15932

## Solution

Correct the loader reference in the meta file used by `asset_settings` example (I've found no other meta files referencing this loader).

## Testing

I've run `bevy_assets` example. It now displays 3 sprites (as expected) and outputs no errors.

## Migration Guide

This PR obviously requires no migration guide as this is just a bug-fix, but I believe that #15812 should mention that meta files needs updating. Proposal:

* Asset loader name must be updated in `.meta` files for images.
Change: `loader: "bevy_render::texture::image_loader::ImageLoader",`
to: `loader: "bevy_image::image_loader::ImageLoader",`
It will fix the following error: ``no `AssetLoader` found with the name 'bevy_render::texture::image_loader::ImageLoader``


