### PR TITLE
Fix deactivated camera still being used in render world

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1054,13 +1054,15 @@ pub fn extract_cameras(
     ) in query.iter()
     {
         if !camera.is_active {
-            commands
-                .entity(render_entity)
-                .remove::<(
-                    ExtractedCamera,
-                    ExtractedView,
-                    RenderVisibleEntities,
-                )>();
+            commands.entity(render_entity).remove::<(
+                ExtractedCamera,
+                ExtractedView,
+                RenderVisibleEntities,
+                TemporalJitter,
+                RenderLayers,
+                Projection,
+                GpuCulling,
+            )>();
             continue;
         }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1056,9 +1056,11 @@ pub fn extract_cameras(
         if !camera.is_active {
             commands
                 .entity(render_entity)
-                .remove::<RenderVisibleEntities>()
-                .remove::<ExtractedCamera>()
-                .remove::<ExtractedView>();
+                .remove::<(
+                    ExtractedCamera,
+                    ExtractedView,
+                    RenderVisibleEntities,
+                )>();
             continue;
         }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1054,8 +1054,14 @@ pub fn extract_cameras(
     ) in query.iter()
     {
         if !camera.is_active {
+            commands
+                .entity(render_entity)
+                .remove::<RenderVisibleEntities>()
+                .remove::<ExtractedCamera>()
+                .remove::<ExtractedView>();
             continue;
         }
+
         let color_grading = color_grading.unwrap_or(&ColorGrading::default()).clone();
 
         if let (


### PR DESCRIPTION
# Objective

Switch to retained render world causes the extracted cameras in render world to not be removed until camera in main world is despawned. When extracting data from main world inactive cameras are skipped. Therefore camera that was active and became inactive has a retained `ExtractedCamera` component from previous frames (when it was active) and is processed the same way as if it were active (there is no `active` field on `ExtractedCamera`). This breakes switching between cameras in `render_primitives` example.
Fixes #15822

## Solution

Fix it by removing `ExtractedCamera` and related components from inactive cameras.
Note that despawning inactive camera seems to be bad option because they are spawned using `SyncToRenderWorld` component.

## Testing

Switching camera in `render_primitives` example now works correctly.
