### PR TITLE
Fix typos from greyscale -> grayscale

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1155,7 +1155,7 @@ impl Image {
     /// If you are working with a 32-bit integer [`TextureFormat`], the value will be
     /// inaccurate (as `f32` does not have enough bits to represent it exactly).
     ///
-    /// Single channel (R) formats are assumed to represent greyscale, so the value
+    /// Single channel (R) formats are assumed to represent grayscale, so the value
     /// will be copied to all three RGB channels in the resulting [`Color`].
     ///
     /// Other [`TextureFormat`]s are unsupported, such as:

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -599,7 +599,7 @@ pub struct StandardMaterial {
 
     /// The depth map used for [parallax mapping].
     ///
-    /// It is a greyscale image where white represents bottom and black the top.
+    /// It is a grayscale image where white represents bottom and black the top.
     /// If this field is set, bevy will apply [parallax mapping].
     /// Parallax mapping, unlike simple normal maps, will move the texture
     /// coordinate according to the current perspective,

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -240,7 +240,7 @@ fn setup_parallax(
         perceptual_roughness: 0.4,
         base_color_texture: Some(asset_server.load("textures/parallax_example/cube_color.png")),
         normal_map_texture: Some(normal_handle),
-        // The depth map is a greyscale texture where black is the highest level and
+        // The depth map is a grayscale texture where black is the highest level and
         // white the lowest.
         depth_map: Some(asset_server.load("textures/parallax_example/cube_depth.png")),
         parallax_depth_scale: 0.09,

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -252,7 +252,7 @@ fn setup(
         perceptual_roughness: 0.4,
         base_color_texture: Some(asset_server.load("textures/parallax_example/cube_color.png")),
         normal_map_texture: Some(normal_handle),
-        // The depth map is a greyscale texture where black is the highest level and
+        // The depth map is a grayscale texture where black is the highest level and
         // white the lowest.
         depth_map: Some(asset_server.load("textures/parallax_example/cube_depth.png")),
         parallax_depth_scale,


### PR DESCRIPTION
# Objective

I was grepping for "grayscale" and thought I'd fix these while I'm here so I don't need to look for both forms.

## Solution

From [wikipedia]:

> In [digital photography](https://en.wikipedia.org/wiki/Digital_photography), [computer-generated imagery](https://en.wikipedia.org/wiki/Computer-generated_imagery), and [colorimetry](https://en.wikipedia.org/wiki/Colorimetry), a greyscale (more common in [Commonwealth English](https://en.wikipedia.org/wiki/Commonwealth_English)) or grayscale (more common in [American English](https://en.wikipedia.org/wiki/American_English))

[wikipedia]: https://en.wikipedia.org/wiki/Grayscale