### PR TITLE
Remove components if not extracted

### DIFF
--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -331,7 +331,6 @@ pub struct DepthOfFieldPipeline {
 
 impl ViewNode for DepthOfFieldNode {
     type ViewQuery = (
-        Read<DepthOfField>,
         Read<ViewUniformOffset>,
         Read<ViewTarget>,
         Read<ViewDepthTexture>,
@@ -346,7 +345,6 @@ impl ViewNode for DepthOfFieldNode {
         _: &mut RenderGraphContext,
         render_context: &mut RenderContext<'w>,
         (
-            _depth_of_field,
             view_uniform_offset,
             view_target,
             view_depth_texture,
@@ -831,7 +829,15 @@ fn extract_depth_of_field_settings(
 
         // Depth of field is nonsensical without a perspective projection.
         let Projection::Perspective(ref perspective_projection) = *projection else {
-            entity_commands.remove::<(DepthOfField, DepthOfFieldUniform)>();
+            // TODO: needs better strategy for cleaning up
+            entity_commands.remove::<(
+                DepthOfField,
+                DepthOfFieldUniform,
+                // components added in prepare systems (because `DepthOfFieldNode` does not query extracted components)
+                DepthOfFieldPipelines,
+                AuxiliaryDepthOfFieldTexture,
+                ViewDepthOfFieldBindGroupLayouts,
+            )>();
             continue;
         };
 

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -29,9 +29,12 @@ use bevy_ecs::{
 use bevy_math::ops;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::{PhysicalCameraParameters, Projection}, extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin}, render_graph::{
+    camera::{PhysicalCameraParameters, Projection},
+    extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
+    render_graph::{
         NodeRunError, RenderGraphApp as _, RenderGraphContext, ViewNode, ViewNodeRunner,
-    }, render_resource::{
+    },
+    render_resource::{
         binding_types::{
             sampler, texture_2d, texture_depth_2d, texture_depth_2d_multisampled, uniform_buffer,
         },
@@ -41,10 +44,16 @@ use bevy_render::{
         RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, Shader,
         ShaderStages, ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, StoreOp,
         TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
-    }, renderer::{RenderContext, RenderDevice}, sync_component::SyncComponentPlugin, sync_world::RenderEntity, texture::{BevyDefault, CachedTexture, TextureCache}, view::{
+    },
+    renderer::{RenderContext, RenderDevice},
+    sync_component::SyncComponentPlugin,
+    sync_world::RenderEntity,
+    texture::{BevyDefault, CachedTexture, TextureCache},
+    view::{
         prepare_view_targets, ExtractedView, Msaa, ViewDepthTexture, ViewTarget, ViewUniform,
         ViewUniformOffset, ViewUniforms,
-    }, Extract, ExtractSchedule, Render, RenderApp, RenderSet
+    },
+    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_utils::{info_once, prelude::default, warn_once};
 use smallvec::SmallVec;

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -29,12 +29,9 @@ use bevy_ecs::{
 use bevy_math::ops;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::{PhysicalCameraParameters, Projection},
-    extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
-    render_graph::{
+    camera::{PhysicalCameraParameters, Projection}, extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin}, render_graph::{
         NodeRunError, RenderGraphApp as _, RenderGraphContext, ViewNode, ViewNodeRunner,
-    },
-    render_resource::{
+    }, render_resource::{
         binding_types::{
             sampler, texture_2d, texture_depth_2d, texture_depth_2d_multisampled, uniform_buffer,
         },
@@ -44,15 +41,10 @@ use bevy_render::{
         RenderPipelineDescriptor, Sampler, SamplerBindingType, SamplerDescriptor, Shader,
         ShaderStages, ShaderType, SpecializedRenderPipeline, SpecializedRenderPipelines, StoreOp,
         TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
-    },
-    renderer::{RenderContext, RenderDevice},
-    sync_world::RenderEntity,
-    texture::{BevyDefault, CachedTexture, TextureCache},
-    view::{
+    }, renderer::{RenderContext, RenderDevice}, sync_component::SyncComponentPlugin, sync_world::RenderEntity, texture::{BevyDefault, CachedTexture, TextureCache}, view::{
         prepare_view_targets, ExtractedView, Msaa, ViewDepthTexture, ViewTarget, ViewUniform,
         ViewUniformOffset, ViewUniforms,
-    },
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    }, Extract, ExtractSchedule, Render, RenderApp, RenderSet
 };
 use bevy_utils::{info_once, prelude::default, warn_once};
 use smallvec::SmallVec;
@@ -210,6 +202,8 @@ impl Plugin for DepthOfFieldPlugin {
         app.register_type::<DepthOfField>();
         app.register_type::<DepthOfFieldMode>();
         app.add_plugins(UniformComponentPlugin::<DepthOfFieldUniform>::default());
+
+        app.add_plugins(SyncComponentPlugin::<DepthOfField>::default());
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -820,8 +820,13 @@ fn extract_depth_of_field_settings(
     }
 
     for (entity, depth_of_field, projection) in query.iter_mut() {
+        let mut entity_commands = commands
+            .get_entity(entity)
+            .expect("Depth of field entity wasn't synced.");
+
         // Depth of field is nonsensical without a perspective projection.
         let Projection::Perspective(ref perspective_projection) = *projection else {
+            entity_commands.remove::<(DepthOfField, DepthOfFieldUniform)>();
             continue;
         };
 
@@ -829,24 +834,20 @@ fn extract_depth_of_field_settings(
             calculate_focal_length(depth_of_field.sensor_height, perspective_projection.fov);
 
         // Convert `DepthOfField` to `DepthOfFieldUniform`.
-        commands
-            .get_entity(entity)
-            .expect("Depth of field entity wasn't synced.")
-            .insert((
-                *depth_of_field,
-                DepthOfFieldUniform {
-                    focal_distance: depth_of_field.focal_distance,
-                    focal_length,
-                    coc_scale_factor: focal_length * focal_length
-                        / (depth_of_field.sensor_height * depth_of_field.aperture_f_stops),
-                    max_circle_of_confusion_diameter: depth_of_field
-                        .max_circle_of_confusion_diameter,
-                    max_depth: depth_of_field.max_depth,
-                    pad_a: 0,
-                    pad_b: 0,
-                    pad_c: 0,
-                },
-            ));
+        entity_commands.insert((
+            *depth_of_field,
+            DepthOfFieldUniform {
+                focal_distance: depth_of_field.focal_distance,
+                focal_length,
+                coc_scale_factor: focal_length * focal_length
+                    / (depth_of_field.sensor_height * depth_of_field.aperture_f_stops),
+                max_circle_of_confusion_diameter: depth_of_field.max_circle_of_confusion_diameter,
+                max_depth: depth_of_field.max_depth,
+                pad_a: 0,
+                pad_b: 0,
+                pad_c: 0,
+            },
+        ));
     }
 }
 

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -328,6 +328,7 @@ pub struct DepthOfFieldPipeline {
 
 impl ViewNode for DepthOfFieldNode {
     type ViewQuery = (
+        Read<DepthOfField>,
         Read<ViewUniformOffset>,
         Read<ViewTarget>,
         Read<ViewDepthTexture>,
@@ -342,6 +343,7 @@ impl ViewNode for DepthOfFieldNode {
         _: &mut RenderGraphContext,
         render_context: &mut RenderContext<'w>,
         (
+            _depth_of_field,
             view_uniform_offset,
             view_target,
             view_depth_texture,

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -373,12 +373,14 @@ fn extract_taa_settings(mut commands: Commands, mut main_world: ResMut<MainWorld
         cameras_3d.iter_mut(&mut main_world)
     {
         let has_perspective_projection = matches!(camera_projection, Projection::Perspective(_));
+        let mut entity_commands = commands
+            .get_entity(entity)
+            .expect("Camera entity wasn't synced.");
         if camera.is_active && has_perspective_projection {
-            commands
-                .get_entity(entity)
-                .expect("Camera entity wasn't synced.")
-                .insert(taa_settings.clone());
+            entity_commands.insert(taa_settings.clone());
             taa_settings.reset = false;
+        } else {
+            entity_commands.remove::<TemporalAntiAliasing>();
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -173,7 +173,6 @@ pub struct TemporalAntiAliasNode;
 
 impl ViewNode for TemporalAntiAliasNode {
     type ViewQuery = (
-        &'static TemporalAntiAliasing,
         &'static ExtractedCamera,
         &'static ViewTarget,
         &'static TemporalAntiAliasHistoryTextures,
@@ -186,7 +185,7 @@ impl ViewNode for TemporalAntiAliasNode {
         &self,
         _graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
-        (_, camera, view_target, taa_history_textures, prepass_textures, taa_pipeline_id, msaa): QueryItem<
+        (camera, view_target, taa_history_textures, prepass_textures, taa_pipeline_id, msaa): QueryItem<
             Self::ViewQuery,
         >,
         world: &World,
@@ -384,7 +383,13 @@ fn extract_taa_settings(mut commands: Commands, mut main_world: ResMut<MainWorld
             entity_commands.insert(taa_settings.clone());
             taa_settings.reset = false;
         } else {
-            entity_commands.remove::<TemporalAntiAliasing>();
+            // TODO: needs better strategy for cleaning up
+            entity_commands.remove::<(
+                TemporalAntiAliasing,
+                // components added in prepare systems (because `TemporalAntiAliasNode` does not query extracted components)
+                TemporalAntiAliasHistoryTextures,
+                TemporalAntiAliasPipelineId,
+            )>();
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -32,6 +32,7 @@ use bevy_render::{
         TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
     },
     renderer::{RenderContext, RenderDevice},
+    sync_component::SyncComponentPlugin,
     sync_world::RenderEntity,
     texture::{BevyDefault, CachedTexture, TextureCache},
     view::{ExtractedView, Msaa, ViewTarget},
@@ -51,6 +52,8 @@ impl Plugin for TemporalAntiAliasPlugin {
         load_internal_asset!(app, TAA_SHADER_HANDLE, "taa.wgsl", Shader::from_wgsl);
 
         app.register_type::<TemporalAntiAliasing>();
+
+        app.add_plugins(SyncComponentPlugin::<TemporalAntiAliasing>::default());
 
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
@@ -170,6 +173,7 @@ pub struct TemporalAntiAliasNode;
 
 impl ViewNode for TemporalAntiAliasNode {
     type ViewQuery = (
+        &'static TemporalAntiAliasing,
         &'static ExtractedCamera,
         &'static ViewTarget,
         &'static TemporalAntiAliasHistoryTextures,
@@ -182,7 +186,7 @@ impl ViewNode for TemporalAntiAliasNode {
         &self,
         _graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
-        (camera, view_target, taa_history_textures, prepass_textures, taa_pipeline_id, msaa): QueryItem<
+        (_, camera, view_target, taa_history_textures, prepass_textures, taa_pipeline_id, msaa): QueryItem<
             Self::ViewQuery,
         >,
         world: &World,

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -530,7 +530,11 @@ pub fn extract_clusters(
     mapper: Extract<Query<RenderEntity>>,
 ) {
     for (entity, clusters, camera) in &views {
+        let mut entity_commands = commands
+            .get_entity(entity)
+            .expect("Clusters entity wasn't synced.");
         if !camera.is_active {
+            entity_commands.remove::<(ExtractedClusterableObjects, ExtractedClusterConfig)>();
             continue;
         }
 
@@ -554,17 +558,14 @@ pub fn extract_clusters(
             }
         }
 
-        commands
-            .get_entity(entity)
-            .expect("Clusters entity wasn't synced.")
-            .insert((
-                ExtractedClusterableObjects { data },
-                ExtractedClusterConfig {
-                    near: clusters.near,
-                    far: clusters.far,
-                    dimensions: clusters.dimensions,
-                },
-            ));
+        entity_commands.insert((
+            ExtractedClusterableObjects { data },
+            ExtractedClusterConfig {
+                near: clusters.near,
+                far: clusters.far,
+                dimensions: clusters.dimensions,
+            },
+        ));
     }
 }
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -455,6 +455,7 @@ impl Plugin for PbrPlugin {
         render_app
             .world_mut()
             .add_observer(remove_light_view_entities);
+        render_app.world_mut().add_observer(extracted_light_removed);
 
         let shadow_pass_node = ShadowPassNode::new(render_app.world_mut());
         let mut graph = render_app.world_mut().resource_mut::<RenderGraph>();

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -584,14 +584,15 @@ pub fn extract_camera_previous_view_data(
     cameras_3d: Extract<Query<(RenderEntity, &Camera, Option<&PreviousViewData>), With<Camera3d>>>,
 ) {
     for (entity, camera, maybe_previous_view_data) in cameras_3d.iter() {
+        let mut entity = commands
+            .get_entity(entity)
+            .expect("Camera entity wasn't synced.");
         if camera.is_active {
-            let mut entity = commands
-                .get_entity(entity)
-                .expect("Camera entity wasn't synced.");
-
             if let Some(previous_view_data) = maybe_previous_view_data {
                 entity.insert(previous_view_data.clone());
             }
+        } else {
+            entity.remove::<PreviousViewData>();
         }
     }
 }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -477,7 +477,7 @@ pub(crate) fn add_light_view_entities(
     }
 }
 
-/// Removes LightViewEntities when light is removed.
+/// Removes [`LightViewEntities`] when light is removed. See [`add_light_view_entities`].
 pub(crate) fn extracted_light_removed(
     trigger: Trigger<OnRemove, (ExtractedDirectionalLight, ExtractedPointLight)>,
     mut commands: Commands,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -379,6 +379,10 @@ pub fn extract_lights(
     ) in &directional_lights
     {
         if !view_visibility.get() {
+            commands
+                .get_entity(entity)
+                .expect("Light entity wasn't synced.")
+                .remove::<(ExtractedDirectionalLight, RenderCascadesVisibleEntities)>();
             continue;
         }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -389,6 +389,7 @@ pub fn extract_lights(
                 )>();
             continue;
         }
+
         // TODO: update in place instead of reinserting.
         let mut extracted_cascades = EntityHashMap::default();
         let mut extracted_frusta = EntityHashMap::default();

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -382,11 +382,7 @@ pub fn extract_lights(
             commands
                 .get_entity(entity)
                 .expect("Light entity wasn't synced.")
-                .remove::<(
-                    ExtractedDirectionalLight,
-                    RenderCascadesVisibleEntities,
-                    LightViewEntities,
-                )>();
+                .remove::<(ExtractedDirectionalLight, RenderCascadesVisibleEntities)>();
             continue;
         }
 
@@ -478,6 +474,16 @@ pub(crate) fn add_light_view_entities(
 ) {
     if let Some(mut v) = commands.get_entity(trigger.entity()) {
         v.insert(LightViewEntities::default());
+    }
+}
+
+/// Removes LightViewEntities when light is removed.
+pub(crate) fn extracted_light_removed(
+    trigger: Trigger<OnRemove, (ExtractedDirectionalLight, ExtractedPointLight)>,
+    mut commands: Commands,
+) {
+    if let Some(mut v) = commands.get_entity(trigger.entity()) {
+        v.remove::<LightViewEntities>();
     }
 }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -382,10 +382,13 @@ pub fn extract_lights(
             commands
                 .get_entity(entity)
                 .expect("Light entity wasn't synced.")
-                .remove::<(ExtractedDirectionalLight, RenderCascadesVisibleEntities)>();
+                .remove::<(
+                    ExtractedDirectionalLight,
+                    RenderCascadesVisibleEntities,
+                    LightViewEntities,
+                )>();
             continue;
         }
-
         // TODO: update in place instead of reinserting.
         let mut extracted_cascades = EntityHashMap::default();
         let mut extracted_frusta = EntityHashMap::default();

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -30,6 +30,7 @@ use bevy_render::{
         *,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
+    sync_component::SyncComponentPlugin,
     sync_world::RenderEntity,
     texture::{CachedTexture, TextureCache},
     view::{Msaa, ViewUniform, ViewUniformOffset, ViewUniforms},
@@ -72,6 +73,8 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
         );
 
         app.register_type::<ScreenSpaceAmbientOcclusion>();
+
+        app.add_plugins(SyncComponentPlugin::<ScreenSpaceAmbientOcclusion>::default());
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -531,11 +531,13 @@ fn extract_ssao_settings(
             );
             return;
         }
+        let mut entity_commands = commands
+            .get_entity(entity)
+            .expect("SSAO entity wasn't synced.");
         if camera.is_active {
-            commands
-                .get_entity(entity)
-                .expect("SSAO entity wasn't synced.")
-                .insert(ssao_settings.clone());
+            entity_commands.insert(ssao_settings.clone());
+        } else {
+            entity_commands.remove::<ScreenSpaceAmbientOcclusion>();
         }
     }
 }

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -276,6 +276,18 @@ pub fn extract_volumetric_fog(
     volumetric_lights: Extract<Query<(RenderEntity, &VolumetricLight)>>,
 ) {
     if volumetric_lights.is_empty() {
+        // TODO: needs better way to handle clean up in render world
+        for (entity, ..) in view_targets.iter() {
+            commands
+                .entity(entity)
+                .remove::<(VolumetricFog, ViewVolumetricFogPipelines, ViewVolumetricFog)>();
+        }
+        for (entity, ..) in fog_volumes.iter() {
+            commands.entity(entity).remove::<FogVolume>();
+        }
+        for (entity, ..) in volumetric_lights.iter() {
+            commands.entity(entity).remove::<VolumetricLight>();
+        }
         return;
     }
 

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -285,9 +285,6 @@ pub fn extract_volumetric_fog(
         for (entity, ..) in fog_volumes.iter() {
             commands.entity(entity).remove::<FogVolume>();
         }
-        for (entity, ..) in volumetric_lights.iter() {
-            commands.entity(entity).remove::<VolumetricLight>();
-        }
         return;
     }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -519,6 +519,10 @@ pub fn extract_default_ui_camera_view(
     for (entity, camera, ui_anti_alias, shadow_samples) in &query {
         // ignore inactive cameras
         if !camera.is_active {
+            commands
+                .get_entity(entity)
+                .expect("Camera entity wasn't synced.")
+                .remove::<(DefaultCameraView, UiAntiAlias, UiBoxShadowSamples)>();
             continue;
         }
 


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/15871
(Camera is done in #15946)

## Solution

- Do the same as #15904 for other extraction systems
- Added missing `SyncComponentPlugin` for DOF, TAA, and SSAO
(According to the [documentation](https://dev-docs.bevyengine.org/bevy/render/sync_component/struct.SyncComponentPlugin.html), this plugin "needs to be added for manual extraction implementations." We may need to check this is done.)

## Testing

Modified example locally to add toggles if not exist.
- [x] DOF - toggling DOF component and perspective in `depth_of_field` example
- [x] TAA - toggling `Camera.is_active` and TAA component
- [x] clusters - not entirely sure, toggling `Camera.is_active` in `many_lights` example (no crash/glitch even without this PR)
- [x] previous_view - toggling `Camera.is_active` in `skybox` (no crash/glitch even without this PR)
- [x] lights - toggling `Visibility` of `DirectionalLight` in `lighting` example
- [x] SSAO - toggling `Camera.is_active` and SSAO component in `ssao` example
- [x] default UI camera view - toggling `Camera.is_active` (nop without #15946 because UI defaults to some camera even if `DefaultCameraView` is not there)
- [x] volumetric fog - toggling existence of volumetric light. Looks like optimization, no change in behavior/visuals