### PR TITLE
Remove `bevy_ui`'s "bevy_text" feature

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -32,12 +32,10 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
-bevy_ui = { path = "../bevy_ui", version = "0.15.0-dev", features = [
-  "bevy_text",
-] }
+bevy_text = { path = "../bevy_text", version = "0.15.0-dev" }
+bevy_ui = { path = "../bevy_ui", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
-bevy_text = { path = "../bevy_text", version = "0.15.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.15.0-dev" }
 
 # other

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -21,9 +21,8 @@ use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 use derive_more::derive::{Display, Error, From};
 use ui_surface::UiSurface;
 
-#[cfg(feature = "bevy_text")]
 use bevy_text::ComputedTextBlock;
-#[cfg(feature = "bevy_text")]
+
 use bevy_text::CosmicFontSystem;
 
 mod convert;
@@ -135,8 +134,8 @@ pub fn ui_layout_system(
         Option<&Outline>,
         Option<&ScrollPosition>,
     )>,
-    #[cfg(feature = "bevy_text")] mut buffer_query: Query<&mut ComputedTextBlock>,
-    #[cfg(feature = "bevy_text")] mut font_system: ResMut<CosmicFontSystem>,
+    mut buffer_query: Query<&mut ComputedTextBlock>,
+    mut font_system: ResMut<CosmicFontSystem>,
 ) {
     let UiLayoutSystemBuffers {
         interned_root_nodes,
@@ -277,7 +276,6 @@ with UI components as a child of an entity without UI components, your UI layout
         }
     });
 
-    #[cfg(feature = "bevy_text")]
     let text_buffers = &mut buffer_query;
     // clean up removed nodes after syncing children to avoid potential panic (invalid SlotMap key used)
     ui_surface.remove_entities(removed_components.removed_nodes.read());
@@ -292,14 +290,7 @@ with UI components as a child of an entity without UI components, your UI layout
     for (camera_id, mut camera) in camera_layout_info.drain() {
         let inverse_target_scale_factor = camera.scale_factor.recip();
 
-        ui_surface.compute_camera_layout(
-            camera_id,
-            camera.size,
-            #[cfg(feature = "bevy_text")]
-            text_buffers,
-            #[cfg(feature = "bevy_text")]
-            &mut font_system.0,
-        );
+        ui_surface.compute_camera_layout(camera_id, camera.size, text_buffers, &mut font_system.0);
 
         for root in &camera.root_nodes {
             update_uinode_geometry_recursive(
@@ -549,11 +540,11 @@ mod tests {
         world.init_resource::<Events<AssetEvent<Image>>>();
         world.init_resource::<Assets<Image>>();
         world.init_resource::<ManualTextureViews>();
-        #[cfg(feature = "bevy_text")]
+
         world.init_resource::<bevy_text::TextPipeline>();
-        #[cfg(feature = "bevy_text")]
+
         world.init_resource::<bevy_text::CosmicFontSystem>();
-        #[cfg(feature = "bevy_text")]
+
         world.init_resource::<bevy_text::SwashCache>();
 
         // spawn a dummy primary window and camera
@@ -1190,11 +1181,11 @@ mod tests {
         world.init_resource::<Events<AssetEvent<Image>>>();
         world.init_resource::<Assets<Image>>();
         world.init_resource::<ManualTextureViews>();
-        #[cfg(feature = "bevy_text")]
+
         world.init_resource::<bevy_text::TextPipeline>();
-        #[cfg(feature = "bevy_text")]
+
         world.init_resource::<bevy_text::CosmicFontSystem>();
-        #[cfg(feature = "bevy_text")]
+
         world.init_resource::<bevy_text::SwashCache>();
 
         // spawn a dummy primary window and camera
@@ -1262,10 +1253,8 @@ mod tests {
         fn test_system(
             params: In<TestSystemParam>,
             mut ui_surface: ResMut<UiSurface>,
-            #[cfg(feature = "bevy_text")] mut computed_text_block_query: Query<
-                &mut bevy_text::ComputedTextBlock,
-            >,
-            #[cfg(feature = "bevy_text")] mut font_system: ResMut<bevy_text::CosmicFontSystem>,
+            mut computed_text_block_query: Query<&mut bevy_text::ComputedTextBlock>,
+            mut font_system: ResMut<bevy_text::CosmicFontSystem>,
         ) {
             ui_surface.upsert_node(
                 &LayoutContext::TEST_CONTEXT,
@@ -1277,9 +1266,7 @@ mod tests {
             ui_surface.compute_camera_layout(
                 params.camera_entity,
                 UVec2::new(800, 600),
-                #[cfg(feature = "bevy_text")]
                 &mut computed_text_block_query,
-                #[cfg(feature = "bevy_text")]
                 &mut font_system.0,
             );
         }

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -203,10 +203,8 @@ impl UiSurface {
         &mut self,
         camera: Entity,
         render_target_resolution: UVec2,
-        #[cfg(feature = "bevy_text")] buffer_query: &'a mut bevy_ecs::prelude::Query<
-            &mut bevy_text::ComputedTextBlock,
-        >,
-        #[cfg(feature = "bevy_text")] font_system: &'a mut bevy_text::cosmic_text::FontSystem,
+        buffer_query: &'a mut bevy_ecs::prelude::Query<&mut bevy_text::ComputedTextBlock>,
+        font_system: &'a mut bevy_text::cosmic_text::FontSystem,
     ) {
         let Some(camera_root_nodes) = self.camera_roots.get(&camera) else {
             return;
@@ -229,7 +227,6 @@ impl UiSurface {
                      -> taffy::Size<f32> {
                         context
                             .map(|ctx| {
-                                #[cfg(feature = "bevy_text")]
                                 let buffer = get_text_buffer(
                                     crate::widget::TextMeasure::needs_buffer(
                                         known_dimensions.height,
@@ -244,12 +241,8 @@ impl UiSurface {
                                         height: known_dimensions.height,
                                         available_width: available_space.width,
                                         available_height: available_space.height,
-                                        #[cfg(feature = "bevy_text")]
                                         font_system,
-                                        #[cfg(feature = "bevy_text")]
                                         buffer,
-                                        #[cfg(not(feature = "bevy_text"))]
-                                        font_system: core::marker::PhantomData,
                                     },
                                     style,
                                 );
@@ -298,7 +291,6 @@ impl UiSurface {
     }
 }
 
-#[cfg(feature = "bevy_text")]
 fn get_text_buffer<'a>(
     needs_buffer: bool,
     ctx: &mut NodeMeasure,
@@ -704,21 +696,5 @@ mod tests {
             1,
             "expected root node child count to be 1"
         );
-    }
-
-    #[test]
-    #[cfg(not(feature = "bevy_text"))]
-    fn test_compute_camera_layout() {
-        let mut ui_surface = UiSurface::default();
-        let camera_entity = Entity::from_raw(0);
-        let root_node_entity = Entity::from_raw(1);
-        let style = Style::default();
-
-        ui_surface.upsert_node(&LayoutContext::TEST_CONTEXT, root_node_entity, &style, None);
-
-        ui_surface.compute_camera_layout(camera_entity, UVec2::new(800, 600));
-
-        let taffy_node = ui_surface.entity_to_taffy.get(&root_node_entity).unwrap();
-        assert!(ui_surface.taffy.layout(*taffy_node).is_ok());
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -22,7 +22,6 @@ pub mod picking_backend;
 
 use bevy_derive::{Deref, DerefMut};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-#[cfg(feature = "bevy_text")]
 mod accessibility;
 mod focus;
 mod geometry;
@@ -46,11 +45,9 @@ use widget::UiImageSize;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[cfg(feature = "bevy_text")]
     #[allow(deprecated)]
     #[doc(hidden)]
     pub use crate::widget::TextBundle;
-    #[cfg(feature = "bevy_text")]
     #[doc(hidden)]
     pub use crate::widget::{Text, TextUiReader, TextUiWriter};
     #[doc(hidden)]
@@ -183,7 +180,6 @@ impl Plugin for UiPlugin {
             .in_set(UiSystem::Layout)
             .before(TransformSystem::TransformPropagate);
 
-        #[cfg(feature = "bevy_text")]
         let ui_layout_system_config = ui_layout_system_config
             // Text and Text2D operate on disjoint sets of entities
             .ambiguous_with(bevy_text::update_text2d_layout)
@@ -213,7 +209,6 @@ impl Plugin for UiPlugin {
             ),
         );
 
-        #[cfg(feature = "bevy_text")]
         build_text_interop(app);
 
         build_ui_render(app);
@@ -231,8 +226,6 @@ impl Plugin for UiPlugin {
     }
 }
 
-/// A function that should be called from [`UiPlugin::build`] when [`bevy_text`] is enabled.
-#[cfg(feature = "bevy_text")]
 fn build_text_interop(app: &mut App) {
     use crate::widget::TextNodeFlags;
     use bevy_text::TextLayoutInfo;

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -6,7 +6,6 @@ pub use taffy::style::AvailableSpace;
 
 use crate::widget::ImageMeasure;
 
-#[cfg(feature = "bevy_text")]
 use crate::widget::TextMeasure;
 
 impl core::fmt::Debug for ContentSize {
@@ -20,13 +19,8 @@ pub struct MeasureArgs<'a> {
     pub height: Option<f32>,
     pub available_width: AvailableSpace,
     pub available_height: AvailableSpace,
-    #[cfg(feature = "bevy_text")]
     pub font_system: &'a mut bevy_text::cosmic_text::FontSystem,
-    #[cfg(feature = "bevy_text")]
     pub buffer: Option<&'a mut bevy_text::ComputedTextBlock>,
-    // When `bevy_text` is disabled, use `PhantomData` in order to keep lifetime in type signature.
-    #[cfg(not(feature = "bevy_text"))]
-    pub font_system: core::marker::PhantomData<&'a mut ()>,
 }
 
 /// A `Measure` is used to compute the size of a ui node
@@ -42,7 +36,7 @@ pub trait Measure: Send + Sync + 'static {
 /// by wrapping them in a closure and a Custom variant that allows arbitrary measurement closures if required.
 pub enum NodeMeasure {
     Fixed(FixedMeasure),
-    #[cfg(feature = "bevy_text")]
+
     Text(TextMeasure),
     Image(ImageMeasure),
     Custom(Box<dyn Measure>),
@@ -52,7 +46,7 @@ impl Measure for NodeMeasure {
     fn measure(&mut self, measure_args: MeasureArgs, style: &taffy::Style) -> Vec2 {
         match self {
             NodeMeasure::Fixed(fixed) => fixed.measure(measure_args, style),
-            #[cfg(feature = "bevy_text")]
+
             NodeMeasure::Text(text) => text.measure(measure_args, style),
             NodeMeasure::Image(image) => image.measure(measure_args, style),
             NodeMeasure::Custom(custom) => custom.measure(measure_args, style),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -40,7 +40,7 @@ use bevy_render::{
 };
 use bevy_sprite::TextureAtlasLayout;
 use bevy_sprite::{BorderRect, ImageScaleMode, SpriteAssetEvents, TextureAtlas};
-#[cfg(feature = "bevy_text")]
+
 use bevy_text::{ComputedTextBlock, PositionedGlyph, TextColor, TextLayoutInfo};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashMap;
@@ -112,7 +112,6 @@ pub fn build_ui_render(app: &mut App) {
                 extract_uinode_background_colors.in_set(RenderUiSystem::ExtractBackgrounds),
                 extract_uinode_images.in_set(RenderUiSystem::ExtractImages),
                 extract_uinode_borders.in_set(RenderUiSystem::ExtractBorders),
-                #[cfg(feature = "bevy_text")]
                 extract_text_sections.in_set(RenderUiSystem::ExtractText),
             ),
         )
@@ -584,7 +583,6 @@ pub fn extract_default_ui_camera_view(
     transparent_render_phases.retain(|entity, _| live_entities.contains(entity));
 }
 
-#[cfg(feature = "bevy_text")]
 #[allow(clippy::too_many_arguments)]
 pub fn extract_text_sections(
     mut commands: Commands,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -87,10 +87,7 @@ impl Measure for ImageMeasure {
     }
 }
 
-#[cfg(feature = "bevy_text")]
 type UpdateImageFilter = (With<Node>, Without<crate::prelude::Text>);
-#[cfg(not(feature = "bevy_text"))]
-type UpdateImageFilter = With<Node>;
 
 /// Updates content size of the node based on the image provided
 pub fn update_image_content_size_system(

--- a/crates/bevy_ui/src/widget/mod.rs
+++ b/crates/bevy_ui/src/widget/mod.rs
@@ -3,11 +3,11 @@
 mod button;
 mod image;
 mod label;
-#[cfg(feature = "bevy_text")]
+
 mod text;
 
 pub use button::*;
 pub use image::*;
 pub use label::*;
-#[cfg(feature = "bevy_text")]
+
 pub use text::*;


### PR DESCRIPTION
# Objective

Remove `bevy-ui`'s non-functional "bevy_text" feature.

Fixes #15900

## Solution

Remove all the "bevy_text" cfg gates.

I tried to fix it at first but couldn't figure it out. I'll happily withdraw this in favour of another PR that gets the feature gate working.


