### PR TITLE
Default UI shadow samples fix

### DIFF
--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -356,7 +356,7 @@ pub fn queue_shadows(
             &ui_slicer_pipeline,
             UiTextureSlicePipelineKey {
                 hdr: view.hdr,
-                samples: shadow_samples.map(|samples| samples.0).unwrap_or_default(),
+                samples: shadow_samples.copied().unwrap_or_default().0,
             },
         );
 


### PR DESCRIPTION
# Objective

  In `queue_shadows`, the `UiBoxShadows` option is unwrapped incorrectly which results in the number of shadow samples being set to `u32::default()` instead of `UiBoxShadows::default()` if the camera entity doesn't have the component. 

## Solution

Just use `unwrap_or_default` directly without `map`.