### PR TITLE
Update label used for breaking changes

### DIFF
--- a/.github/workflows/action-on-PR-labeled.yml
+++ b/.github/workflows/action-on-PR-labeled.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   comment-on-breaking-change-label:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'C-Breaking-Change' && !contains(github.event.pull_request.body, '## Migration Guide')
+    if: github.event.label.name == 'M-Needs-Migration-Guide' && !contains(github.event.pull_request.body, '## Migration Guide')
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
# Objective

This label was out-of-date, causing our nag-bot to fail to run.

## Solution

Update the workflow with the newly renamed label.

Companion to https://github.com/bevyengine/bevy-website/pull/1646.