### PR TITLE
Fix AVIF image decoding

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [features]
 # Image formats
-avif = ["image/avif"]
+avif = ["image/avif-native"]
 basis-universal = ["dep:basis-universal"]
 bmp = ["image/bmp"]
 dds = ["ddsfile"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -45,7 +45,7 @@ zlib = ["bevy_image/zlib"]
 zstd = ["bevy_image/zstd"]
 
 # Image format support (PNG enabled by default)
-avif = ["bevy_image/avif-native"]
+avif = ["bevy_image/avif"]
 bmp = ["bevy_image/bmp"]
 ff = ["bevy_image/ff"]
 gif = ["bevy_image/gif"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -45,7 +45,7 @@ zlib = ["bevy_image/zlib"]
 zstd = ["bevy_image/zstd"]
 
 # Image format support (PNG enabled by default)
-avif = ["bevy_image/avif"]
+avif = ["bevy_image/avif-native"]
 bmp = ["bevy_image/bmp"]
 ff = ["bevy_image/ff"]
 gif = ["bevy_image/gif"]


### PR DESCRIPTION
# Objective / Solution

This expands upon:

- https://github.com/bevyengine/bevy/pull/15586

The image crate requires `avif-native` feature for decoding AVIF images ([documented here](https://github.com/image-rs/image?tab=readme-ov-file#supported-image-formats)). The `avif` flag only allows for the encoding of AVIFs.

## Testing

- Tested on a local project