### PR TITLE
aligning public apis of Time,Timer and Stopwatch

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1005,7 +1005,7 @@ pub fn advance_animations(
     animation_graphs: Res<Assets<AnimationGraph>>,
     mut players: Query<(&mut AnimationPlayer, &AnimationGraphHandle)>,
 ) {
-    let delta_seconds = time.delta_seconds();
+    let delta_seconds = time.delta_secs();
     players
         .par_iter_mut()
         .for_each(|(mut player, graph_handle)| {

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -122,7 +122,7 @@ pub fn advance_transitions(
         for transition in &mut animation_transitions.transitions.iter_mut().rev() {
             // Decrease weight.
             transition.current_weight = (transition.current_weight
-                - transition.weight_decline_per_sec * time.delta_seconds())
+                - transition.weight_decline_per_sec * time.delta_secs())
             .max(0.0);
 
             // Update weight.

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -33,7 +33,7 @@ impl FrameTimeDiagnosticsPlugin {
     ) {
         diagnostics.add_measurement(&Self::FRAME_COUNT, || frame_count.0 as f64);
 
-        let delta_seconds = time.delta_seconds_f64();
+        let delta_seconds = time.delta_secs_f64();
         if delta_seconds == 0.0 {
             return;
         }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -74,8 +74,8 @@ fn prepare_globals_buffer(
     frame_count: Res<FrameCount>,
 ) {
     let buffer = globals_buffer.buffer.get_mut();
-    buffer.time = time.elapsed_seconds_wrapped();
-    buffer.delta_time = time.delta_seconds();
+    buffer.time = time.elapsed_secs_wrapped();
+    buffer.delta_time = time.delta_secs();
     buffer.frame_count = frame_count.0;
 
     globals_buffer

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -21,7 +21,7 @@ use bevy_utils::Duration;
 /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
 ///
 /// stopwatch.reset(); // reset the stopwatch
-/// assert!(stopwatch.paused());
+/// assert!(stopwatch.is_paused());
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 /// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -29,7 +29,7 @@ use bevy_utils::Duration;
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Default))]
 pub struct Stopwatch {
     elapsed: Duration,
-    paused: bool,
+    is_paused: bool,
 }
 
 impl Stopwatch {
@@ -40,7 +40,7 @@ impl Stopwatch {
     /// # use bevy_time::*;
     /// let stopwatch = Stopwatch::new();
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
-    /// assert_eq!(stopwatch.paused(), false);
+    /// assert_eq!(stopwatch.is_paused(), false);
     /// ```
     pub fn new() -> Self {
         Default::default()
@@ -128,7 +128,7 @@ impl Stopwatch {
     /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
     /// ```
     pub fn tick(&mut self, delta: Duration) -> &Self {
-        if !self.paused() {
+        if !self.is_paused() {
             self.elapsed = self.elapsed.saturating_add(delta);
         }
         self
@@ -144,12 +144,12 @@ impl Stopwatch {
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
-    /// assert!(stopwatch.paused());
+    /// assert!(stopwatch.is_paused());
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
     /// ```
     #[inline]
     pub fn pause(&mut self) {
-        self.paused = true;
+        self.is_paused = true;
     }
 
     /// Unpauses the stopwatch. Resume the effect of ticking on elapsed time.
@@ -163,12 +163,12 @@ impl Stopwatch {
     /// stopwatch.tick(Duration::from_secs_f32(1.0));
     /// stopwatch.unpause();
     /// stopwatch.tick(Duration::from_secs_f32(1.0));
-    /// assert!(!stopwatch.paused());
+    /// assert!(!stopwatch.is_paused());
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
     /// ```
     #[inline]
     pub fn unpause(&mut self) {
-        self.paused = false;
+        self.is_paused = false;
     }
 
     /// Returns `true` if the stopwatch is paused.
@@ -177,15 +177,15 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// let mut stopwatch = Stopwatch::new();
-    /// assert!(!stopwatch.paused());
+    /// assert!(!stopwatch.is_paused());
     /// stopwatch.pause();
-    /// assert!(stopwatch.paused());
+    /// assert!(stopwatch.is_paused());
     /// stopwatch.unpause();
-    /// assert!(!stopwatch.paused());
+    /// assert!(!stopwatch.is_paused());
     /// ```
     #[inline]
-    pub fn paused(&self) -> bool {
-        self.paused
+    pub fn is_paused(&self) -> bool {
+        self.is_paused
     }
 
     /// Resets the stopwatch. The reset doesn't affect the paused state of the stopwatch.

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -30,15 +30,15 @@ use {
 /// which will set [`delta()`](Time::delta) to zero.
 ///
 /// These values are also available in seconds as `f32` via
-/// [`delta_seconds()`](Time::delta_seconds) and
-/// [`elapsed_seconds()`](Time::elapsed_seconds), and also in seconds as `f64`
-/// via [`delta_seconds_f64()`](Time::delta_seconds_f64) and
-/// [`elapsed_seconds_f64()`](Time::elapsed_seconds_f64).
+/// [`delta_secs()`](Time::delta_secs) and
+/// [`elapsed_secs()`](Time::elapsed_secs), and also in seconds as `f64`
+/// via [`delta_secs_f64()`](Time::delta_secs_f64) and
+/// [`elapsed_secs_f64()`](Time::elapsed_secs_f64).
 ///
-/// Since [`elapsed_seconds()`](Time::elapsed_seconds) will grow constantly and
+/// Since [`elapsed_secs()`](Time::elapsed_secs) will grow constantly and
 /// is `f32`, it will exhibit gradual precision loss. For applications that
 /// require an `f32` value but suffer from gradual precision loss there is
-/// [`elapsed_seconds_wrapped()`](Time::elapsed_seconds_wrapped) available. The
+/// [`elapsed_secs_wrapped()`](Time::elapsed_secs_wrapped) available. The
 /// same wrapped value is also available as [`Duration`] and `f64` for
 /// consistency. The wrap period is by default 1 hour, and can be set by
 /// [`set_wrap_period()`](Time::set_wrap_period).
@@ -193,14 +193,14 @@ pub struct Time<T: Default = ()> {
     context: T,
     wrap_period: Duration,
     delta: Duration,
-    delta_seconds: f32,
-    delta_seconds_f64: f64,
+    delta_secs: f32,
+    delta_secs_f64: f64,
     elapsed: Duration,
-    elapsed_seconds: f32,
-    elapsed_seconds_f64: f64,
+    elapsed_secs: f32,
+    elapsed_secs_f64: f64,
     elapsed_wrapped: Duration,
-    elapsed_seconds_wrapped: f32,
-    elapsed_seconds_wrapped_f64: f64,
+    elapsed_secs_wrapped: f32,
+    elapsed_secs_wrapped_f64: f64,
 }
 
 impl<T: Default> Time<T> {
@@ -222,14 +222,14 @@ impl<T: Default> Time<T> {
     /// [`Duration::ZERO`] is allowed and will set [`Self::delta`] to zero.
     pub fn advance_by(&mut self, delta: Duration) {
         self.delta = delta;
-        self.delta_seconds = self.delta.as_secs_f32();
-        self.delta_seconds_f64 = self.delta.as_secs_f64();
+        self.delta_secs = self.delta.as_secs_f32();
+        self.delta_secs_f64 = self.delta.as_secs_f64();
         self.elapsed += delta;
-        self.elapsed_seconds = self.elapsed.as_secs_f32();
-        self.elapsed_seconds_f64 = self.elapsed.as_secs_f64();
+        self.elapsed_secs = self.elapsed.as_secs_f32();
+        self.elapsed_secs_f64 = self.elapsed.as_secs_f64();
         self.elapsed_wrapped = duration_rem(self.elapsed, self.wrap_period);
-        self.elapsed_seconds_wrapped = self.elapsed_wrapped.as_secs_f32();
-        self.elapsed_seconds_wrapped_f64 = self.elapsed_wrapped.as_secs_f64();
+        self.elapsed_secs_wrapped = self.elapsed_wrapped.as_secs_f32();
+        self.elapsed_secs_wrapped_f64 = self.elapsed_wrapped.as_secs_f64();
     }
 
     /// Advance this clock to a specific `elapsed` time.
@@ -280,15 +280,15 @@ impl<T: Default> Time<T> {
     /// Returns how much time has advanced since the last [`update`](#method.update), as [`f32`]
     /// seconds.
     #[inline]
-    pub fn delta_seconds(&self) -> f32 {
-        self.delta_seconds
+    pub fn delta_secs(&self) -> f32 {
+        self.delta_secs
     }
 
     /// Returns how much time has advanced since the last [`update`](#method.update), as [`f64`]
     /// seconds.
     #[inline]
-    pub fn delta_seconds_f64(&self) -> f64 {
-        self.delta_seconds_f64
+    pub fn delta_secs_f64(&self) -> f64 {
+        self.delta_secs_f64
     }
 
     /// Returns how much time has advanced since [`startup`](#method.startup), as [`Duration`].
@@ -301,16 +301,16 @@ impl<T: Default> Time<T> {
     ///
     /// **Note:** This is a monotonically increasing value. Its precision will degrade over time.
     /// If you need an `f32` but that precision loss is unacceptable,
-    /// use [`elapsed_seconds_wrapped`](#method.elapsed_seconds_wrapped).
+    /// use [`elapsed_secs_wrapped`](#method.elapsed_secs_wrapped).
     #[inline]
-    pub fn elapsed_seconds(&self) -> f32 {
-        self.elapsed_seconds
+    pub fn elapsed_secs(&self) -> f32 {
+        self.elapsed_secs
     }
 
     /// Returns how much time has advanced since [`startup`](#method.startup), as [`f64`] seconds.
     #[inline]
-    pub fn elapsed_seconds_f64(&self) -> f64 {
-        self.elapsed_seconds_f64
+    pub fn elapsed_secs_f64(&self) -> f64 {
+        self.elapsed_secs_f64
     }
 
     /// Returns how much time has advanced since [`startup`](#method.startup) modulo
@@ -324,17 +324,17 @@ impl<T: Default> Time<T> {
     /// the [`wrap_period`](#method.wrap_period), as [`f32`] seconds.
     ///
     /// This method is intended for applications (e.g. shaders) that require an [`f32`] value but
-    /// suffer from the gradual precision loss of [`elapsed_seconds`](#method.elapsed_seconds).
+    /// suffer from the gradual precision loss of [`elapsed_secs`](#method.elapsed_secs).
     #[inline]
-    pub fn elapsed_seconds_wrapped(&self) -> f32 {
-        self.elapsed_seconds_wrapped
+    pub fn elapsed_secs_wrapped(&self) -> f32 {
+        self.elapsed_secs_wrapped
     }
 
     /// Returns how much time has advanced since [`startup`](#method.startup) modulo
     /// the [`wrap_period`](#method.wrap_period), as [`f64`] seconds.
     #[inline]
-    pub fn elapsed_seconds_wrapped_f64(&self) -> f64 {
-        self.elapsed_seconds_wrapped_f64
+    pub fn elapsed_secs_wrapped_f64(&self) -> f64 {
+        self.elapsed_secs_wrapped_f64
     }
 
     /// Returns a reference to the context of this specific clock.
@@ -356,14 +356,14 @@ impl<T: Default> Time<T> {
             context: (),
             wrap_period: self.wrap_period,
             delta: self.delta,
-            delta_seconds: self.delta_seconds,
-            delta_seconds_f64: self.delta_seconds_f64,
+            delta_secs: self.delta_secs,
+            delta_secs_f64: self.delta_secs_f64,
             elapsed: self.elapsed,
-            elapsed_seconds: self.elapsed_seconds,
-            elapsed_seconds_f64: self.elapsed_seconds_f64,
+            elapsed_secs: self.elapsed_secs,
+            elapsed_secs_f64: self.elapsed_secs_f64,
             elapsed_wrapped: self.elapsed_wrapped,
-            elapsed_seconds_wrapped: self.elapsed_seconds_wrapped,
-            elapsed_seconds_wrapped_f64: self.elapsed_seconds_wrapped_f64,
+            elapsed_secs_wrapped: self.elapsed_secs_wrapped,
+            elapsed_secs_wrapped_f64: self.elapsed_secs_wrapped_f64,
         }
     }
 }
@@ -374,14 +374,14 @@ impl<T: Default> Default for Time<T> {
             context: Default::default(),
             wrap_period: Self::DEFAULT_WRAP_PERIOD,
             delta: Duration::ZERO,
-            delta_seconds: 0.0,
-            delta_seconds_f64: 0.0,
+            delta_secs: 0.0,
+            delta_secs_f64: 0.0,
             elapsed: Duration::ZERO,
-            elapsed_seconds: 0.0,
-            elapsed_seconds_f64: 0.0,
+            elapsed_secs: 0.0,
+            elapsed_secs_f64: 0.0,
             elapsed_wrapped: Duration::ZERO,
-            elapsed_seconds_wrapped: 0.0,
-            elapsed_seconds_wrapped_f64: 0.0,
+            elapsed_secs_wrapped: 0.0,
+            elapsed_secs_wrapped_f64: 0.0,
         }
     }
 }
@@ -402,14 +402,14 @@ mod test {
 
         assert_eq!(time.wrap_period(), Time::<()>::DEFAULT_WRAP_PERIOD);
         assert_eq!(time.delta(), Duration::ZERO);
-        assert_eq!(time.delta_seconds(), 0.0);
-        assert_eq!(time.delta_seconds_f64(), 0.0);
+        assert_eq!(time.delta_secs(), 0.0);
+        assert_eq!(time.delta_secs_f64(), 0.0);
         assert_eq!(time.elapsed(), Duration::ZERO);
-        assert_eq!(time.elapsed_seconds(), 0.0);
-        assert_eq!(time.elapsed_seconds_f64(), 0.0);
+        assert_eq!(time.elapsed_secs(), 0.0);
+        assert_eq!(time.elapsed_secs_f64(), 0.0);
         assert_eq!(time.elapsed_wrapped(), Duration::ZERO);
-        assert_eq!(time.elapsed_seconds_wrapped(), 0.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 0.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 0.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 0.0);
     }
 
     #[test]
@@ -419,29 +419,29 @@ mod test {
         time.advance_by(Duration::from_millis(250));
 
         assert_eq!(time.delta(), Duration::from_millis(250));
-        assert_eq!(time.delta_seconds(), 0.25);
-        assert_eq!(time.delta_seconds_f64(), 0.25);
+        assert_eq!(time.delta_secs(), 0.25);
+        assert_eq!(time.delta_secs_f64(), 0.25);
         assert_eq!(time.elapsed(), Duration::from_millis(250));
-        assert_eq!(time.elapsed_seconds(), 0.25);
-        assert_eq!(time.elapsed_seconds_f64(), 0.25);
+        assert_eq!(time.elapsed_secs(), 0.25);
+        assert_eq!(time.elapsed_secs_f64(), 0.25);
 
         time.advance_by(Duration::from_millis(500));
 
         assert_eq!(time.delta(), Duration::from_millis(500));
-        assert_eq!(time.delta_seconds(), 0.5);
-        assert_eq!(time.delta_seconds_f64(), 0.5);
+        assert_eq!(time.delta_secs(), 0.5);
+        assert_eq!(time.delta_secs_f64(), 0.5);
         assert_eq!(time.elapsed(), Duration::from_millis(750));
-        assert_eq!(time.elapsed_seconds(), 0.75);
-        assert_eq!(time.elapsed_seconds_f64(), 0.75);
+        assert_eq!(time.elapsed_secs(), 0.75);
+        assert_eq!(time.elapsed_secs_f64(), 0.75);
 
         time.advance_by(Duration::ZERO);
 
         assert_eq!(time.delta(), Duration::ZERO);
-        assert_eq!(time.delta_seconds(), 0.0);
-        assert_eq!(time.delta_seconds_f64(), 0.0);
+        assert_eq!(time.delta_secs(), 0.0);
+        assert_eq!(time.delta_secs_f64(), 0.0);
         assert_eq!(time.elapsed(), Duration::from_millis(750));
-        assert_eq!(time.elapsed_seconds(), 0.75);
-        assert_eq!(time.elapsed_seconds_f64(), 0.75);
+        assert_eq!(time.elapsed_secs(), 0.75);
+        assert_eq!(time.elapsed_secs_f64(), 0.75);
     }
 
     #[test]
@@ -451,29 +451,29 @@ mod test {
         time.advance_to(Duration::from_millis(250));
 
         assert_eq!(time.delta(), Duration::from_millis(250));
-        assert_eq!(time.delta_seconds(), 0.25);
-        assert_eq!(time.delta_seconds_f64(), 0.25);
+        assert_eq!(time.delta_secs(), 0.25);
+        assert_eq!(time.delta_secs_f64(), 0.25);
         assert_eq!(time.elapsed(), Duration::from_millis(250));
-        assert_eq!(time.elapsed_seconds(), 0.25);
-        assert_eq!(time.elapsed_seconds_f64(), 0.25);
+        assert_eq!(time.elapsed_secs(), 0.25);
+        assert_eq!(time.elapsed_secs_f64(), 0.25);
 
         time.advance_to(Duration::from_millis(750));
 
         assert_eq!(time.delta(), Duration::from_millis(500));
-        assert_eq!(time.delta_seconds(), 0.5);
-        assert_eq!(time.delta_seconds_f64(), 0.5);
+        assert_eq!(time.delta_secs(), 0.5);
+        assert_eq!(time.delta_secs_f64(), 0.5);
         assert_eq!(time.elapsed(), Duration::from_millis(750));
-        assert_eq!(time.elapsed_seconds(), 0.75);
-        assert_eq!(time.elapsed_seconds_f64(), 0.75);
+        assert_eq!(time.elapsed_secs(), 0.75);
+        assert_eq!(time.elapsed_secs_f64(), 0.75);
 
         time.advance_to(Duration::from_millis(750));
 
         assert_eq!(time.delta(), Duration::ZERO);
-        assert_eq!(time.delta_seconds(), 0.0);
-        assert_eq!(time.delta_seconds_f64(), 0.0);
+        assert_eq!(time.delta_secs(), 0.0);
+        assert_eq!(time.delta_secs_f64(), 0.0);
         assert_eq!(time.elapsed(), Duration::from_millis(750));
-        assert_eq!(time.elapsed_seconds(), 0.75);
-        assert_eq!(time.elapsed_seconds_f64(), 0.75);
+        assert_eq!(time.elapsed_secs(), 0.75);
+        assert_eq!(time.elapsed_secs_f64(), 0.75);
     }
 
     #[test]
@@ -494,26 +494,26 @@ mod test {
         time.advance_by(Duration::from_secs(2));
 
         assert_eq!(time.elapsed_wrapped(), Duration::from_secs(2));
-        assert_eq!(time.elapsed_seconds_wrapped(), 2.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 2.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 2.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 2.0);
 
         time.advance_by(Duration::from_secs(2));
 
         assert_eq!(time.elapsed_wrapped(), Duration::from_secs(1));
-        assert_eq!(time.elapsed_seconds_wrapped(), 1.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 1.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 1.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 1.0);
 
         time.advance_by(Duration::from_secs(2));
 
         assert_eq!(time.elapsed_wrapped(), Duration::ZERO);
-        assert_eq!(time.elapsed_seconds_wrapped(), 0.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 0.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 0.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 0.0);
 
         time.advance_by(Duration::new(3, 250_000_000));
 
         assert_eq!(time.elapsed_wrapped(), Duration::from_millis(250));
-        assert_eq!(time.elapsed_seconds_wrapped(), 0.25);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 0.25);
+        assert_eq!(time.elapsed_secs_wrapped(), 0.25);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 0.25);
     }
 
     #[test]
@@ -524,14 +524,14 @@ mod test {
         time.advance_by(Duration::from_secs(8));
 
         assert_eq!(time.elapsed_wrapped(), Duration::from_secs(3));
-        assert_eq!(time.elapsed_seconds_wrapped(), 3.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 3.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 3.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 3.0);
 
         time.set_wrap_period(Duration::from_secs(2));
 
         assert_eq!(time.elapsed_wrapped(), Duration::from_secs(3));
-        assert_eq!(time.elapsed_seconds_wrapped(), 3.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 3.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 3.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 3.0);
 
         time.advance_by(Duration::ZERO);
 
@@ -539,7 +539,7 @@ mod test {
         // is left in `elapsed_wrapped()`. This test of values is here to ensure
         // that we notice if we change that behaviour.
         assert_eq!(time.elapsed_wrapped(), Duration::from_secs(0));
-        assert_eq!(time.elapsed_seconds_wrapped(), 0.0);
-        assert_eq!(time.elapsed_seconds_wrapped_f64(), 0.0);
+        assert_eq!(time.elapsed_secs_wrapped(), 0.0);
+        assert_eq!(time.elapsed_secs_wrapped_f64(), 0.0);
     }
 }

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -120,6 +120,13 @@ impl Timer {
         self.stopwatch.elapsed_secs()
     }
 
+    /// Returns the time elapsed on the timer as an `f64`.
+    /// See also [`Timer::elapsed`](Timer::elapsed).
+    #[inline]
+    pub fn elapsed_secs_f64(&self) -> f64 {
+        self.stopwatch.elapsed_secs_f64()
+    }
+
     /// Sets the elapsed time of the timer without any other considerations.
     ///
     /// See also [`Stopwatch::set`](Stopwatch::set).
@@ -299,7 +306,7 @@ impl Timer {
 
     /// Returns `true` if the timer is paused.
     ///
-    /// See also [`Stopwatch::paused`](Stopwatch::paused).
+    /// See also [`Stopwatch::is_paused`](Stopwatch::is_paused).
     ///
     /// # Examples
     /// ```
@@ -313,7 +320,7 @@ impl Timer {
     /// ```
     #[inline]
     pub fn paused(&self) -> bool {
-        self.stopwatch.paused()
+        self.stopwatch.is_paused()
     }
 
     /// Resets the timer. The reset doesn't affect the `paused` state of the timer.
@@ -450,6 +457,7 @@ mod tests {
         // Tick once, check all attributes
         t.tick(Duration::from_secs_f32(0.25));
         assert_eq!(t.elapsed_secs(), 0.25);
+        assert_eq!(t.elapsed_secs_f64(), 0.25);
         assert_eq!(t.duration(), Duration::from_secs_f32(10.0));
         assert!(!t.finished());
         assert!(!t.just_finished());
@@ -472,6 +480,7 @@ mod tests {
         t.unpause();
         t.tick(Duration::from_secs_f32(500.0));
         assert_eq!(t.elapsed_secs(), 10.0);
+        assert_eq!(t.elapsed_secs_f64(), 10.0);
         assert!(t.finished());
         assert!(t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 1);
@@ -480,6 +489,7 @@ mod tests {
         // Continuing to tick when finished should only change just_finished
         t.tick(Duration::from_secs_f32(1.0));
         assert_eq!(t.elapsed_secs(), 10.0);
+        assert_eq!(t.elapsed_secs_f64(), 10.0);
         assert!(t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
@@ -493,6 +503,7 @@ mod tests {
         // Tick once, check all attributes
         t.tick(Duration::from_secs_f32(0.75));
         assert_eq!(t.elapsed_secs(), 0.75);
+        assert_eq!(t.elapsed_secs_f64(), 0.75);
         assert_eq!(t.duration(), Duration::from_secs_f32(2.0));
         assert!(!t.finished());
         assert!(!t.just_finished());
@@ -503,6 +514,7 @@ mod tests {
         // Tick past the end and make sure elapsed wraps
         t.tick(Duration::from_secs_f32(1.5));
         assert_eq!(t.elapsed_secs(), 0.25);
+        assert_eq!(t.elapsed_secs_f64(), 0.25);
         assert!(t.finished());
         assert!(t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 1);
@@ -511,6 +523,7 @@ mod tests {
         // Continuing to tick should turn off both finished & just_finished for repeating timers
         t.tick(Duration::from_secs_f32(1.0));
         assert_eq!(t.elapsed_secs(), 1.25);
+        assert_eq!(t.elapsed_secs_f64(), 1.25);
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
@@ -525,6 +538,7 @@ mod tests {
         t.tick(Duration::from_secs_f32(3.5));
         assert_eq!(t.times_finished_this_tick(), 3);
         assert_eq!(t.elapsed_secs(), 0.5);
+        assert_eq!(t.elapsed_secs_f64(), 0.5);
         assert!(t.finished());
         assert!(t.just_finished());
         t.tick(Duration::from_secs_f32(0.2));

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -112,7 +112,7 @@ fn update_bloom_settings(
                 commands.entity(entity).remove::<Bloom>();
             }
 
-            let dt = time.delta_seconds();
+            let dt = time.delta_secs();
 
             if keycode.pressed(KeyCode::KeyA) {
                 bloom.intensity -= dt / 10.0;

--- a/examples/2d/bounding_2d.rs
+++ b/examples/2d/bounding_2d.rs
@@ -38,7 +38,7 @@ struct Spin;
 
 fn spin(time: Res<Time>, mut query: Query<&mut Transform, With<Spin>>) {
     for mut transform in query.iter_mut() {
-        transform.rotation *= Quat::from_rotation_z(time.delta_seconds() / 5.);
+        transform.rotation *= Quat::from_rotation_z(time.delta_secs() / 5.);
     }
 }
 
@@ -279,11 +279,8 @@ fn draw_ray(gizmos: &mut Gizmos, ray: &RayCast2d) {
 }
 
 fn get_and_draw_ray(gizmos: &mut Gizmos, time: &Time) -> RayCast2d {
-    let ray = Vec2::new(
-        ops::cos(time.elapsed_seconds()),
-        ops::sin(time.elapsed_seconds()),
-    );
-    let dist = 150. + ops::sin(0.5 * time.elapsed_seconds()).abs() * 500.;
+    let ray = Vec2::new(ops::cos(time.elapsed_secs()), ops::sin(time.elapsed_secs()));
+    let dist = 150. + ops::sin(0.5 * time.elapsed_secs()).abs() * 500.;
 
     let aabb_ray = Ray2d {
         origin: ray * 250.,
@@ -375,8 +372,8 @@ fn bounding_circle_cast_system(
 }
 
 fn get_intersection_position(time: &Time) -> Vec2 {
-    let x = ops::cos(0.8 * time.elapsed_seconds()) * 250.;
-    let y = ops::sin(0.4 * time.elapsed_seconds()) * 100.;
+    let x = ops::cos(0.8 * time.elapsed_secs()) * 250.;
+    let y = ops::sin(0.4 * time.elapsed_secs()) * 100.;
     Vec2::new(x, y)
 }
 

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -30,8 +30,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 fn sprite_movement(time: Res<Time>, mut sprite_position: Query<(&mut Direction, &mut Transform)>) {
     for (mut logo, mut transform) in &mut sprite_position {
         match *logo {
-            Direction::Up => transform.translation.y += 150. * time.delta_seconds(),
-            Direction::Down => transform.translation.y -= 150. * time.delta_seconds(),
+            Direction::Up => transform.translation.y += 150. * time.delta_secs(),
+            Direction::Down => transform.translation.y -= 150. * time.delta_secs(),
         }
 
         if transform.translation.y > 200. {

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -136,7 +136,7 @@ fn setup_camera(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
 /// Rotates entities to demonstrate grid snapping.
 fn rotate(time: Res<Time>, mut transforms: Query<&mut Transform, With<Rotate>>) {
     for mut transform in &mut transforms {
-        let dt = time.delta_seconds();
+        let dt = time.delta_secs();
         transform.rotate_z(dt);
     }
 }

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -122,14 +122,14 @@ fn player_movement_system(
     }
 
     // update the ship rotation around the Z axis (perpendicular to the 2D plane of the screen)
-    transform.rotate_z(rotation_factor * ship.rotation_speed * time.delta_seconds());
+    transform.rotate_z(rotation_factor * ship.rotation_speed * time.delta_secs());
 
     // get the ship's forward vector by applying the current rotation to the ships initial facing
     // vector
     let movement_direction = transform.rotation * Vec3::Y;
     // get the distance the ship will move based on direction, the ship's movement speed and delta
     // time
-    let movement_distance = movement_factor * ship.movement_speed * time.delta_seconds();
+    let movement_distance = movement_factor * ship.movement_speed * time.delta_secs();
     // create the change in translation using the new movement direction and distance
     let translation_delta = movement_direction * movement_distance;
     // update the ship translation with our new translation delta
@@ -228,7 +228,7 @@ fn rotate_to_player_system(
 
         // calculate angle of rotation with limit
         let rotation_angle =
-            rotation_sign * (config.rotation_speed * time.delta_seconds()).min(max_angle);
+            rotation_sign * (config.rotation_speed * time.delta_secs()).min(max_angle);
 
         // rotate the enemy to face the player
         enemy_transform.rotate_z(rotation_angle);

--- a/examples/2d/sprite_tile.rs
+++ b/examples/2d/sprite_tile.rs
@@ -40,7 +40,7 @@ fn animate(mut sprites: Query<&mut Sprite>, mut state: ResMut<AnimationState>, t
     if state.current >= state.max || state.current <= state.min {
         state.speed = -state.speed;
     };
-    state.current += state.speed * time.delta_seconds();
+    state.current += state.speed * time.delta_secs();
     for mut sprite in &mut sprites {
         sprite.custom_size = Some(Vec2::splat(state.current));
     }

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -139,8 +139,8 @@ fn animate_translation(
     mut query: Query<&mut Transform, (With<Text2d>, With<AnimateTranslation>)>,
 ) {
     for mut transform in &mut query {
-        transform.translation.x = 100.0 * ops::sin(time.elapsed_seconds()) - 400.0;
-        transform.translation.y = 100.0 * ops::cos(time.elapsed_seconds());
+        transform.translation.x = 100.0 * ops::sin(time.elapsed_secs()) - 400.0;
+        transform.translation.y = 100.0 * ops::cos(time.elapsed_secs());
     }
 }
 
@@ -149,7 +149,7 @@ fn animate_rotation(
     mut query: Query<&mut Transform, (With<Text2d>, With<AnimateRotation>)>,
 ) {
     for mut transform in &mut query {
-        transform.rotation = Quat::from_rotation_z(ops::cos(time.elapsed_seconds()));
+        transform.rotation = Quat::from_rotation_z(ops::cos(time.elapsed_secs()));
     }
 }
 
@@ -160,7 +160,7 @@ fn animate_scale(
     // Consider changing font-size instead of scaling the transform. Scaling a Text2D will scale the
     // rendered quad, resulting in a pixellated look.
     for mut transform in &mut query {
-        let scale = (ops::sin(time.elapsed_seconds()) + 1.1) * 2.0;
+        let scale = (ops::sin(time.elapsed_secs()) + 1.1) * 2.0;
         transform.scale.x = scale;
         transform.scale.y = scale;
     }

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -146,7 +146,7 @@ fn setup(
 
 fn rotate(mut query: Query<&mut Transform, With<Shape>>, time: Res<Time>) {
     for mut transform in &mut query {
-        transform.rotate_y(time.delta_seconds() / 2.);
+        transform.rotate_y(time.delta_secs() / 2.);
     }
 }
 

--- a/examples/3d/animated_material.rs
+++ b/examples/3d/animated_material.rs
@@ -52,7 +52,7 @@ fn animate_materials(
     for material_handle in material_handles.iter() {
         if let Some(material) = materials.get_mut(material_handle) {
             if let Color::Hsla(ref mut hsla) = material.base_color {
-                *hsla = hsla.rotate_hue(time.delta_seconds() * 100.0);
+                *hsla = hsla.rotate_hue(time.delta_secs() * 100.0);
             }
         }
     }

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -128,7 +128,7 @@ fn animate_light(
     mut lights: Query<&mut Transform, Or<(With<DirectionalLight>, With<PointLight>)>>,
     time: Res<Time>,
 ) {
-    let now = time.elapsed_seconds();
+    let now = time.elapsed_secs();
     for mut transform in lights.iter_mut() {
         transform.translation = vec3(ops::cos(now), 1.0, ops::sin(now)) * vec3(3.0, 4.0, 3.0);
         transform.look_at(Vec3::ZERO, Vec3::Y);

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -171,9 +171,9 @@ fn example_control_system(
     let (mut camera_transform, mut auto_exposure) = camera.into_inner();
 
     let rotation = if input.pressed(KeyCode::ArrowLeft) {
-        time.delta_seconds()
+        time.delta_secs()
     } else if input.pressed(KeyCode::ArrowRight) {
-        -time.delta_seconds()
+        -time.delta_secs()
     } else {
         0.0
     };

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -263,9 +263,9 @@ fn example_control_system(
     input: Res<ButtonInput<KeyCode>>,
 ) {
     if input.pressed(KeyCode::ArrowUp) {
-        state.alpha = (state.alpha + time.delta_seconds()).min(1.0);
+        state.alpha = (state.alpha + time.delta_secs()).min(1.0);
     } else if input.pressed(KeyCode::ArrowDown) {
-        state.alpha = (state.alpha - time.delta_seconds()).max(0.0);
+        state.alpha = (state.alpha - time.delta_secs()).max(0.0);
     }
 
     if input.just_pressed(KeyCode::Space) {
@@ -301,9 +301,9 @@ fn example_control_system(
     }
 
     let rotation = if input.pressed(KeyCode::ArrowLeft) {
-        time.delta_seconds()
+        time.delta_secs()
     } else if input.pressed(KeyCode::ArrowRight) {
-        -time.delta_seconds()
+        -time.delta_secs()
     } else {
         0.0
     };

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -139,7 +139,7 @@ fn update_bloom_settings(
                 commands.entity(entity).remove::<Bloom>();
             }
 
-            let dt = time.delta_seconds();
+            let dt = time.delta_secs();
 
             if keycode.pressed(KeyCode::KeyA) {
                 bloom.intensity -= dt / 10.0;
@@ -214,6 +214,6 @@ struct Bouncing;
 fn bounce_spheres(time: Res<Time>, mut query: Query<&mut Transform, With<Bouncing>>) {
     for mut transform in query.iter_mut() {
         transform.translation.y =
-            ops::sin(transform.translation.x + transform.translation.z + time.elapsed_seconds());
+            ops::sin(transform.translation.x + transform.translation.z + time.elapsed_secs());
     }
 }

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -237,7 +237,7 @@ fn move_camera_view(
 ) {
     for mut camera in movable_camera_query.iter_mut() {
         if let Some(sub_view) = &mut camera.sub_camera_view {
-            sub_view.offset.x = (time.elapsed_seconds() * 150.) % 450.0 - 50.0;
+            sub_view.offset.x = (time.elapsed_secs() * 150.) % 450.0 - 50.0;
             sub_view.offset.y = sub_view.offset.x;
         }
     }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -233,7 +233,7 @@ fn animate_light(
     mut lights: Query<&mut Transform, Or<(With<PointLight>, With<DirectionalLight>)>>,
     time: Res<Time>,
 ) {
-    let now = time.elapsed_seconds();
+    let now = time.elapsed_secs();
     for mut transform in lights.iter_mut() {
         transform.translation = vec3(
             ops::sin(now * 1.4),
@@ -246,7 +246,7 @@ fn animate_light(
 
 /// Rotates the spheres.
 fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time: Res<Time>) {
-    let now = time.elapsed_seconds();
+    let now = time.elapsed_secs();
     for mut transform in spheres.iter_mut() {
         transform.rotation = Quat::from_rotation_y(SPHERE_ROTATION_SPEED * now);
     }

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -211,7 +211,7 @@ fn animate_light_direction(
         return;
     }
     for mut transform in &mut query {
-        transform.rotate_y(time.delta_seconds() * PI / 5.0);
+        transform.rotate_y(time.delta_secs() * PI / 5.0);
     }
 }
 
@@ -266,9 +266,9 @@ fn spin(time: Res<Time>, mut query: Query<(&mut Transform, &Spin)>, pause: Res<P
         return;
     }
     for (mut transform, spin) in query.iter_mut() {
-        transform.rotate_local_y(spin.speed * time.delta_seconds());
-        transform.rotate_local_x(spin.speed * time.delta_seconds());
-        transform.rotate_local_z(-spin.speed * time.delta_seconds());
+        transform.rotate_local_y(spin.speed * time.delta_secs());
+        transform.rotate_local_x(spin.speed * time.delta_secs());
+        transform.rotate_local_z(-spin.speed * time.delta_secs());
     }
 }
 

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -133,8 +133,8 @@ fn update_system(
     time: Res<Time>,
     keycode: Res<ButtonInput<KeyCode>>,
 ) {
-    let now = time.elapsed_seconds();
-    let delta = time.delta_seconds();
+    let now = time.elapsed_secs();
+    let delta = time.delta_secs();
 
     let (mut fog, mut transform) = camera.into_inner();
 

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -84,17 +84,17 @@ fn input_handler(
     }
     if keyboard_input.pressed(KeyCode::KeyX) {
         for mut transform in &mut query {
-            transform.rotate_x(time.delta_seconds() / 1.2);
+            transform.rotate_x(time.delta_secs() / 1.2);
         }
     }
     if keyboard_input.pressed(KeyCode::KeyY) {
         for mut transform in &mut query {
-            transform.rotate_y(time.delta_seconds() / 1.2);
+            transform.rotate_y(time.delta_secs() / 1.2);
         }
     }
     if keyboard_input.pressed(KeyCode::KeyZ) {
         for mut transform in &mut query {
-            transform.rotate_z(time.delta_seconds() / 1.2);
+            transform.rotate_z(time.delta_secs() / 1.2);
         }
     }
     if keyboard_input.pressed(KeyCode::KeyR) {

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -355,7 +355,7 @@ fn rotate_camera(
     }
 
     for mut transform in camera_query.iter_mut() {
-        transform.translation = Vec2::from_angle(ROTATION_SPEED * time.delta_seconds())
+        transform.translation = Vec2::from_angle(ROTATION_SPEED * time.delta_secs())
             .rotate(transform.translation.xz())
             .extend(transform.translation.y)
             .xzy();

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -293,7 +293,7 @@ fn animate_light_direction(
     mut query: Query<&mut Transform, With<DirectionalLight>>,
 ) {
     for mut transform in &mut query {
-        transform.rotate_y(time.delta_seconds() * 0.5);
+        transform.rotate_y(time.delta_secs() * 0.5);
     }
 }
 
@@ -317,6 +317,6 @@ fn movement(
             direction.x += 1.0;
         }
 
-        transform.translation += time.delta_seconds() * 2.0 * direction;
+        transform.translation += time.delta_secs() * 2.0 * direction;
     }
 }

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -56,7 +56,7 @@ fn animate_light_direction(
         transform.rotation = Quat::from_euler(
             EulerRot::ZYX,
             0.0,
-            time.elapsed_seconds() * PI / 5.0,
+            time.elapsed_secs() * PI / 5.0,
             -FRAC_PI_4,
         );
     }

--- a/examples/3d/mesh_ray_cast.rs
+++ b/examples/3d/mesh_ray_cast.rs
@@ -31,7 +31,7 @@ fn bouncing_raycast(
     ray_map: Res<RayMap>,
 ) {
     // Cast an automatically moving ray and bounce it off of surfaces
-    let t = ops::cos((time.elapsed_seconds() - 4.0).max(0.0) * LASER_SPEED) * PI;
+    let t = ops::cos((time.elapsed_secs() - 4.0).max(0.0) * LASER_SPEED) * PI;
     let ray_pos = Vec3::new(ops::sin(t), ops::cos(3.0 * t) * 0.5, ops::cos(t)) * 0.5;
     let ray_dir = Dir3::new(-ray_pos).unwrap();
     let ray = Ray3d::new(ray_pos, ray_dir);

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -300,7 +300,7 @@ fn move_cars(
     mut spins: Query<&mut Transform, (Without<Moves>, With<Rotates>)>,
 ) {
     for (mut transform, moves, children) in &mut movables {
-        let time = time.elapsed_seconds() * 0.25;
+        let time = time.elapsed_secs() * 0.25;
         let t = time + 0.5 * moves.0;
         let dx = ops::cos(t);
         let dz = -ops::sin(3.0 * t);

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -152,9 +152,9 @@ fn update_parallax_layers(
 
 fn spin(time: Res<Time>, mut query: Query<(&mut Transform, &Spin)>) {
     for (mut transform, spin) in query.iter_mut() {
-        transform.rotate_local_y(spin.speed * time.delta_seconds());
-        transform.rotate_local_x(spin.speed * time.delta_seconds());
-        transform.rotate_local_z(-spin.speed * time.delta_seconds());
+        transform.rotate_local_y(spin.speed * time.delta_secs());
+        transform.rotate_local_x(spin.speed * time.delta_secs());
+        transform.rotate_local_z(-spin.speed * time.delta_secs());
     }
 }
 

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -18,7 +18,7 @@ struct Rotator;
 /// rotates the parent, which will result in the child also rotating
 fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator>>) {
     for mut transform in &mut query {
-        transform.rotate_x(3.0 * time.delta_seconds());
+        transform.rotate_x(3.0 * time.delta_secs());
     }
 }
 

--- a/examples/3d/query_gltf_primitives.rs
+++ b/examples/3d/query_gltf_primitives.rs
@@ -34,7 +34,7 @@ fn find_top_material_and_mesh(
         if name.0 == "Top" {
             if let Some(material) = materials.get_mut(mat_handle) {
                 if let Color::Hsla(ref mut hsla) = material.base_color {
-                    *hsla = hsla.rotate_hue(time.delta_seconds() * 100.0);
+                    *hsla = hsla.rotate_hue(time.delta_secs() * 100.0);
                 } else {
                     material.base_color = Color::from(Hsla::hsl(0.0, 0.8, 0.5));
                 }
@@ -45,7 +45,7 @@ fn find_top_material_and_mesh(
                     mesh.attribute_mut(Mesh::ATTRIBUTE_POSITION)
                 {
                     positions[0] = (
-                        ops::sin(2.0 * PI * time.elapsed_seconds()),
+                        ops::sin(2.0 * PI * time.elapsed_secs()),
                         positions[0][1],
                         positions[0][2],
                     )

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -303,7 +303,7 @@ fn rotate_camera(
     }
 
     for mut transform in camera_query.iter_mut() {
-        transform.translation = Vec2::from_angle(time.delta_seconds() * PI / 5.0)
+        transform.translation = Vec2::from_angle(time.delta_secs() * PI / 5.0)
             .rotate(transform.translation.xz())
             .extend(transform.translation.y)
             .xzy();

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -123,15 +123,15 @@ fn setup(
 /// Rotates the inner cube (first pass)
 fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<FirstPassCube>>) {
     for mut transform in &mut query {
-        transform.rotate_x(1.5 * time.delta_seconds());
-        transform.rotate_z(1.3 * time.delta_seconds());
+        transform.rotate_x(1.5 * time.delta_secs());
+        transform.rotate_z(1.3 * time.delta_secs());
     }
 }
 
 /// Rotates the outer cube (main pass)
 fn cube_rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<MainPassCube>>) {
     for mut transform in &mut query {
-        transform.rotate_x(1.0 * time.delta_seconds());
-        transform.rotate_y(0.7 * time.delta_seconds());
+        transform.rotate_x(1.0 * time.delta_secs());
+        transform.rotate_y(0.7 * time.delta_secs());
     }
 }

--- a/examples/3d/rotate_environment_map.rs
+++ b/examples/3d/rotate_environment_map.rs
@@ -36,7 +36,7 @@ fn rotate_skybox_and_environment_map(
     mut environments: Query<(&mut Skybox, &mut EnvironmentMapLight)>,
     time: Res<Time>,
 ) {
-    let now = time.elapsed_seconds();
+    let now = time.elapsed_secs();
     let rotation = Quat::from_rotation_y(0.2 * now);
     for (mut skybox, mut environment_map) in environments.iter_mut() {
         skybox.rotation = rotation;

--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -125,6 +125,6 @@ fn setup(
 /// Moves fog density texture offset every frame.
 fn scroll_fog(time: Res<Time>, mut query: Query<&mut FogVolume>) {
     for mut fog_volume in query.iter_mut() {
-        fog_volume.density_texture_offset += Vec3::new(0.0, 0.0, 0.04) * time.delta_seconds();
+        fog_volume.density_texture_offset += Vec3::new(0.0, 0.0, 0.04) * time.delta_secs();
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -104,7 +104,7 @@ fn cycle_cubemap_asset(
     asset_server: Res<AssetServer>,
     render_device: Res<RenderDevice>,
 ) {
-    let now = time.elapsed_seconds();
+    let now = time.elapsed_secs();
     if *next_swap == 0.0 {
         *next_swap = now + CUBEMAP_SWAP_DELAY;
         return;
@@ -171,6 +171,6 @@ fn animate_light_direction(
     mut query: Query<&mut Transform, With<DirectionalLight>>,
 ) {
     for mut transform in &mut query {
-        transform.rotate_y(time.delta_seconds() * 0.5);
+        transform.rotate_y(time.delta_secs() * 0.5);
     }
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -141,11 +141,11 @@ fn light_sway(time: Res<Time>, mut query: Query<(&mut Transform, &mut SpotLight)
     for (mut transform, mut angles) in query.iter_mut() {
         transform.rotation = Quat::from_euler(
             EulerRot::XYZ,
-            -FRAC_PI_2 + ops::sin(time.elapsed_seconds() * 0.67 * 3.0) * 0.5,
-            ops::sin(time.elapsed_seconds() * 3.0) * 0.5,
+            -FRAC_PI_2 + ops::sin(time.elapsed_secs() * 0.67 * 3.0) * 0.5,
+            ops::sin(time.elapsed_secs() * 3.0) * 0.5,
             0.0,
         );
-        let angle = (ops::sin(time.elapsed_seconds() * 1.2) + 1.0) * (FRAC_PI_4 - 0.1);
+        let angle = (ops::sin(time.elapsed_secs() * 1.2) + 1.0) * (FRAC_PI_4 - 0.1);
         angles.inner_angle = angle * 0.8;
         angles.outer_angle = angle;
     }
@@ -180,7 +180,7 @@ fn movement(
         translation.y -= 1.0;
     }
 
-    translation *= 2.0 * time.delta_seconds();
+    translation *= 2.0 * time.delta_secs();
 
     // Apply translation
     for mut transform in &mut query {
@@ -193,7 +193,7 @@ fn rotation(
     input: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
-    let delta = time.delta_seconds();
+    let delta = time.delta_secs();
 
     if input.pressed(KeyCode::ArrowLeft) {
         transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(delta));

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -104,7 +104,7 @@ fn update(
     keycode: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
-    sphere.translation.y = ops::sin(time.elapsed_seconds() / 1.7) * 0.7;
+    sphere.translation.y = ops::sin(time.elapsed_secs() / 1.7) * 0.7;
 
     let (camera_entity, ssao, temporal_jitter) = *camera;
     let current_ssao = ssao.cloned().unwrap_or_default();

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -292,7 +292,7 @@ fn rotate_model(
     time: Res<Time>,
 ) {
     for mut transform in query.iter_mut() {
-        transform.rotation = Quat::from_euler(EulerRot::XYZ, 0.0, time.elapsed_seconds(), 0.0);
+        transform.rotation = Quat::from_euler(EulerRot::XYZ, 0.0, time.elapsed_secs(), 0.0);
     }
 }
 

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -339,7 +339,7 @@ fn update_color_grading_settings(
     mut selected_parameter: ResMut<SelectedParameter>,
 ) {
     let color_grading = per_method_settings.settings.get_mut(*tonemapping).unwrap();
-    let mut dt = time.delta_seconds() * 0.25;
+    let mut dt = time.delta_secs() * 0.25;
     if keys.pressed(KeyCode::ArrowLeft) {
         dt = -dt;
     }

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -402,39 +402,39 @@ fn example_control_system(
     input: Res<ButtonInput<KeyCode>>,
 ) {
     if input.pressed(KeyCode::Digit2) {
-        state.diffuse_transmission = (state.diffuse_transmission + time.delta_seconds()).min(1.0);
+        state.diffuse_transmission = (state.diffuse_transmission + time.delta_secs()).min(1.0);
     } else if input.pressed(KeyCode::Digit1) {
-        state.diffuse_transmission = (state.diffuse_transmission - time.delta_seconds()).max(0.0);
+        state.diffuse_transmission = (state.diffuse_transmission - time.delta_secs()).max(0.0);
     }
 
     if input.pressed(KeyCode::KeyW) {
-        state.specular_transmission = (state.specular_transmission + time.delta_seconds()).min(1.0);
+        state.specular_transmission = (state.specular_transmission + time.delta_secs()).min(1.0);
     } else if input.pressed(KeyCode::KeyQ) {
-        state.specular_transmission = (state.specular_transmission - time.delta_seconds()).max(0.0);
+        state.specular_transmission = (state.specular_transmission - time.delta_secs()).max(0.0);
     }
 
     if input.pressed(KeyCode::KeyS) {
-        state.thickness = (state.thickness + time.delta_seconds()).min(5.0);
+        state.thickness = (state.thickness + time.delta_secs()).min(5.0);
     } else if input.pressed(KeyCode::KeyA) {
-        state.thickness = (state.thickness - time.delta_seconds()).max(0.0);
+        state.thickness = (state.thickness - time.delta_secs()).max(0.0);
     }
 
     if input.pressed(KeyCode::KeyX) {
-        state.ior = (state.ior + time.delta_seconds()).min(3.0);
+        state.ior = (state.ior + time.delta_secs()).min(3.0);
     } else if input.pressed(KeyCode::KeyZ) {
-        state.ior = (state.ior - time.delta_seconds()).max(1.0);
+        state.ior = (state.ior - time.delta_secs()).max(1.0);
     }
 
     if input.pressed(KeyCode::KeyI) {
-        state.reflectance = (state.reflectance + time.delta_seconds()).min(1.0);
+        state.reflectance = (state.reflectance + time.delta_secs()).min(1.0);
     } else if input.pressed(KeyCode::KeyU) {
-        state.reflectance = (state.reflectance - time.delta_seconds()).max(0.0);
+        state.reflectance = (state.reflectance - time.delta_secs()).max(0.0);
     }
 
     if input.pressed(KeyCode::KeyR) {
-        state.perceptual_roughness = (state.perceptual_roughness + time.delta_seconds()).min(1.0);
+        state.perceptual_roughness = (state.perceptual_roughness + time.delta_secs()).min(1.0);
     } else if input.pressed(KeyCode::KeyE) {
-        state.perceptual_roughness = (state.perceptual_roughness - time.delta_seconds()).max(0.0);
+        state.perceptual_roughness = (state.perceptual_roughness - time.delta_secs()).max(0.0);
     }
 
     let randomize_colors = input.just_pressed(KeyCode::KeyC);
@@ -522,21 +522,21 @@ fn example_control_system(
 
     let rotation = if input.pressed(KeyCode::ArrowRight) {
         state.auto_camera = false;
-        time.delta_seconds()
+        time.delta_secs()
     } else if input.pressed(KeyCode::ArrowLeft) {
         state.auto_camera = false;
-        -time.delta_seconds()
+        -time.delta_secs()
     } else if state.auto_camera {
-        time.delta_seconds() * 0.25
+        time.delta_secs() * 0.25
     } else {
         0.0
     };
 
     let distance_change =
         if input.pressed(KeyCode::ArrowDown) && camera_transform.translation.length() < 25.0 {
-            time.delta_seconds()
+            time.delta_secs()
         } else if input.pressed(KeyCode::ArrowUp) && camera_transform.translation.length() > 2.0 {
-            -time.delta_seconds()
+            -time.delta_secs()
         } else {
             0.0
         };
@@ -603,7 +603,7 @@ fn flicker_system(
     light: Single<(&mut PointLight, &mut Transform), (With<Flicker>, Without<Mesh3d>)>,
     time: Res<Time>,
 ) {
-    let s = time.elapsed_seconds();
+    let s = time.elapsed_secs();
     let a = ops::cos(s * 6.0) * 0.0125 + ops::cos(s * 4.0) * 0.025;
     let b = ops::cos(s * 5.0) * 0.0125 + ops::cos(s * 3.0) * 0.025;
     let c = ops::cos(s * 7.0) * 0.0125 + ops::cos(s * 2.0) * 0.025;

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -108,7 +108,7 @@ fn setup(
 ///   completely opaque, then will be 7/8 opaque (1/8 transparent), then will be
 ///   6/8 opaque, then 5/8, etc.
 pub fn fade_transparency(time: Res<Time>, mut materials: ResMut<Assets<StandardMaterial>>) {
-    let alpha = (ops::sin(time.elapsed_seconds()) / 2.0) + 0.5;
+    let alpha = (ops::sin(time.elapsed_secs()) / 2.0) + 0.5;
     for (_, material) in materials.iter_mut() {
         material.base_color.set_alpha(alpha);
     }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -65,9 +65,9 @@ fn move_scene_entities(
         for entity in children.iter_descendants(moved_scene_entity) {
             if let Ok(mut transform) = transforms.get_mut(entity) {
                 transform.translation = Vec3::new(
-                    offset * ops::sin(time.elapsed_seconds()) / 20.,
+                    offset * ops::sin(time.elapsed_secs()) / 20.,
                     0.,
-                    ops::cos(time.elapsed_seconds()) / 20.,
+                    ops::cos(time.elapsed_secs()) / 20.,
                 );
                 offset += 0.5;
             }

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -202,7 +202,7 @@ fn move_point_light(
     for (mut transform, mut move_data) in objects.iter_mut() {
         let mut translation = transform.translation;
         let mut need_toggle = false;
-        translation.x += move_data.speed * timer.delta_seconds();
+        translation.x += move_data.speed * timer.delta_secs();
         if translation.x > move_data.max_x {
             translation.x = move_data.max_x;
             need_toggle = true;

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -270,12 +270,12 @@ fn simulate_particles(
         if particle.lifeteime_timer.tick(time.delta()).just_finished() {
             commands.entity(entity).despawn();
         } else {
-            transform.translation += particle.velocity * time.delta_seconds();
+            transform.translation += particle.velocity * time.delta_secs();
             transform.scale =
                 Vec3::splat(particle.size.lerp(0.0, particle.lifeteime_timer.fraction()));
             particle
                 .velocity
-                .smooth_nudge(&Vec3::ZERO, 4.0, time.delta_seconds());
+                .smooth_nudge(&Vec3::ZERO, 4.0, time.delta_secs());
         }
     }
 }

--- a/examples/animation/animation_events.rs
+++ b/examples/animation/animation_events.rs
@@ -111,6 +111,6 @@ fn setup(
 fn animate_text_opacity(mut colors: Query<&mut TextColor>, time: Res<Time>) {
     for mut color in &mut colors {
         let a = color.0.alpha();
-        color.0.set_alpha(a - time.delta_seconds());
+        color.0.set_alpha(a - time.delta_secs());
     }
 }

--- a/examples/animation/color_animation.rs
+++ b/examples/animation/color_animation.rs
@@ -88,7 +88,7 @@ fn animate_curve<T: CurveColor>(
     time: Res<Time>,
     mut query: Query<(&mut Transform, &mut Sprite, &Curve<T>)>,
 ) {
-    let t = (ops::sin(time.elapsed_seconds()) + 1.) / 2.;
+    let t = (ops::sin(time.elapsed_secs()) + 1.) / 2.;
 
     for (mut transform, mut sprite, cubic_curve) in &mut query {
         // position takes a point from the curve where 0 is the initial point
@@ -102,7 +102,7 @@ fn animate_mixed<T: MixedColor>(
     time: Res<Time>,
     mut query: Query<(&mut Transform, &mut Sprite, &Mixed<T>)>,
 ) {
-    let t = (ops::sin(time.elapsed_seconds()) + 1.) / 2.;
+    let t = (ops::sin(time.elapsed_secs()) + 1.) / 2.;
 
     for (mut transform, mut sprite, mixed) in &mut query {
         sprite.color = {

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -194,36 +194,36 @@ fn joint_animation(
         match animated_joint.0 {
             -5 => {
                 transform.rotation =
-                    Quat::from_rotation_x(FRAC_PI_2 * ops::sin(time.elapsed_seconds()));
+                    Quat::from_rotation_x(FRAC_PI_2 * ops::sin(time.elapsed_secs()));
             }
             -4 => {
                 transform.rotation =
-                    Quat::from_rotation_y(FRAC_PI_2 * ops::sin(time.elapsed_seconds()));
+                    Quat::from_rotation_y(FRAC_PI_2 * ops::sin(time.elapsed_secs()));
             }
             -3 => {
                 transform.rotation =
-                    Quat::from_rotation_z(FRAC_PI_2 * ops::sin(time.elapsed_seconds()));
+                    Quat::from_rotation_z(FRAC_PI_2 * ops::sin(time.elapsed_secs()));
             }
             -2 => {
-                transform.scale.x = ops::sin(time.elapsed_seconds()) + 1.0;
+                transform.scale.x = ops::sin(time.elapsed_secs()) + 1.0;
             }
             -1 => {
-                transform.scale.y = ops::sin(time.elapsed_seconds()) + 1.0;
+                transform.scale.y = ops::sin(time.elapsed_secs()) + 1.0;
             }
             0 => {
-                transform.translation.x = 0.5 * ops::sin(time.elapsed_seconds());
-                transform.translation.y = ops::cos(time.elapsed_seconds());
+                transform.translation.x = 0.5 * ops::sin(time.elapsed_secs());
+                transform.translation.y = ops::cos(time.elapsed_secs());
             }
             1 => {
-                transform.translation.y = ops::sin(time.elapsed_seconds());
-                transform.translation.z = ops::cos(time.elapsed_seconds());
+                transform.translation.y = ops::sin(time.elapsed_secs());
+                transform.translation.z = ops::cos(time.elapsed_secs());
             }
             2 => {
-                transform.translation.x = ops::sin(time.elapsed_seconds());
+                transform.translation.x = ops::sin(time.elapsed_secs());
             }
             3 => {
-                transform.translation.y = ops::sin(time.elapsed_seconds());
-                transform.scale.x = ops::sin(time.elapsed_seconds()) + 1.0;
+                transform.translation.y = ops::sin(time.elapsed_secs());
+                transform.scale.x = ops::sin(time.elapsed_secs()) + 1.0;
             }
             _ => (),
         }

--- a/examples/animation/easing_functions.rs
+++ b/examples/animation/easing_functions.rs
@@ -110,7 +110,7 @@ fn display_curves(
     let duration = 2.5;
     let time_margin = 0.5;
 
-    let now = ((time.elapsed_seconds() % (duration + time_margin * 2.0) - time_margin) / duration)
+    let now = ((time.elapsed_secs() % (duration + time_margin * 2.0) - time_margin) / duration)
         .clamp(0.0, 1.0);
 
     ui_text.0 = format!("Progress: {:.2}", now);

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -66,6 +66,6 @@ fn joint_animation(
         let mut second_joint_transform = transform_query.get_mut(second_joint_entity).unwrap();
 
         second_joint_transform.rotation =
-            Quat::from_rotation_z(FRAC_PI_2 * ops::sin(time.elapsed_seconds()));
+            Quat::from_rotation_z(FRAC_PI_2 * ops::sin(time.elapsed_secs()));
     }
 }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -69,7 +69,7 @@ fn move_text(
     time: Res<Time>,
 ) {
     for (entity, mut position) in &mut texts {
-        position.translation -= Vec3::new(0.0, 100.0 * time.delta_seconds(), 0.0);
+        position.translation -= Vec3::new(0.0, 100.0 * time.delta_secs(), 0.0);
         if position.translation.y < -300.0 {
             commands.entity(entity).despawn();
         }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -22,7 +22,7 @@ struct MyMusic;
 
 fn update_speed(music_controller: Query<&AudioSink, With<MyMusic>>, time: Res<Time>) {
     if let Ok(sink) = music_controller.get_single() {
-        sink.set_speed((ops::sin(time.elapsed_seconds() / 5.0) + 1.0).max(0.1));
+        sink.set_speed((ops::sin(time.elapsed_secs() / 5.0) + 1.0).max(0.1));
     }
 }
 

--- a/examples/audio/soundtrack.rs
+++ b/examples/audio/soundtrack.rs
@@ -114,7 +114,7 @@ fn fade_in(
     time: Res<Time>,
 ) {
     for (audio, entity) in audio_sink.iter_mut() {
-        audio.set_volume(audio.volume() + time.delta_seconds() / FADE_TIME);
+        audio.set_volume(audio.volume() + time.delta_secs() / FADE_TIME);
         if audio.volume() >= 1.0 {
             audio.set_volume(1.0);
             commands.entity(entity).remove::<FadeIn>();
@@ -130,7 +130,7 @@ fn fade_out(
     time: Res<Time>,
 ) {
     for (audio, entity) in audio_sink.iter_mut() {
-        audio.set_volume(audio.volume() - time.delta_seconds() / FADE_TIME);
+        audio.set_volume(audio.volume() - time.delta_secs() / FADE_TIME);
         if audio.volume() <= 0.0 {
             commands.entity(entity).despawn_recursive();
         }

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -90,7 +90,7 @@ fn update_emitters(
 ) {
     for (mut emitter_transform, mut emitter) in emitters.iter_mut() {
         if keyboard.just_pressed(KeyCode::Space) {
-            if emitter.stopwatch.paused() {
+            if emitter.stopwatch.is_paused() {
                 emitter.stopwatch.unpause();
             } else {
                 emitter.stopwatch.pause();
@@ -99,7 +99,7 @@ fn update_emitters(
 
         emitter.stopwatch.tick(time.delta());
 
-        if !emitter.stopwatch.paused() {
+        if !emitter.stopwatch.is_paused() {
             emitter_transform.translation.x = ops::sin(emitter.stopwatch.elapsed_secs()) * 500.0;
         }
     }
@@ -113,15 +113,15 @@ fn update_listener(
     let speed = 200.;
 
     if keyboard.pressed(KeyCode::ArrowRight) {
-        listener.translation.x += speed * time.delta_seconds();
+        listener.translation.x += speed * time.delta_secs();
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        listener.translation.x -= speed * time.delta_seconds();
+        listener.translation.x -= speed * time.delta_secs();
     }
     if keyboard.pressed(KeyCode::ArrowUp) {
-        listener.translation.y += speed * time.delta_seconds();
+        listener.translation.y += speed * time.delta_secs();
     }
     if keyboard.pressed(KeyCode::ArrowDown) {
-        listener.translation.y -= speed * time.delta_seconds();
+        listener.translation.y -= speed * time.delta_secs();
     }
 }

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -92,7 +92,7 @@ fn update_positions(
 ) {
     for (mut emitter_transform, mut emitter) in emitters.iter_mut() {
         if keyboard.just_pressed(KeyCode::Space) {
-            if emitter.stopwatch.paused() {
+            if emitter.stopwatch.is_paused() {
                 emitter.stopwatch.unpause();
             } else {
                 emitter.stopwatch.pause();
@@ -101,7 +101,7 @@ fn update_positions(
 
         emitter.stopwatch.tick(time.delta());
 
-        if !emitter.stopwatch.paused() {
+        if !emitter.stopwatch.is_paused() {
             emitter_transform.translation.x = ops::sin(emitter.stopwatch.elapsed_secs()) * 3.0;
             emitter_transform.translation.z = ops::cos(emitter.stopwatch.elapsed_secs()) * 3.0;
         }
@@ -116,15 +116,15 @@ fn update_listener(
     let speed = 2.;
 
     if keyboard.pressed(KeyCode::ArrowRight) {
-        listeners.translation.x += speed * time.delta_seconds();
+        listeners.translation.x += speed * time.delta_secs();
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        listeners.translation.x -= speed * time.delta_seconds();
+        listeners.translation.x -= speed * time.delta_secs();
     }
     if keyboard.pressed(KeyCode::ArrowDown) {
-        listeners.translation.z += speed * time.delta_seconds();
+        listeners.translation.z += speed * time.delta_secs();
     }
     if keyboard.pressed(KeyCode::ArrowUp) {
-        listeners.translation.z -= speed * time.delta_seconds();
+        listeners.translation.z -= speed * time.delta_secs();
     }
 }

--- a/examples/camera/2d_screen_shake.rs
+++ b/examples/camera/2d_screen_shake.rs
@@ -127,7 +127,7 @@ fn trigger_shake_on_space(
         screen_shake.start_shake(
             MAX_ANGLE,
             MAX_OFFSET,
-            screen_shake_clone.trauma + TRAUMA_INCREMENT * time.delta_seconds(),
+            screen_shake_clone.trauma + TRAUMA_INCREMENT * time.delta_secs(),
             Vec2 { x: 0.0, y: 0.0 },
         ); // final_position should be your current player position
     }
@@ -155,7 +155,7 @@ fn screen_shake(
                 };
             sub_view
                 .offset
-                .smooth_nudge(&target, CAMERA_DECAY_RATE, time.delta_seconds());
+                .smooth_nudge(&target, CAMERA_DECAY_RATE, time.delta_secs());
 
             // Rotation
             let rotation = Quat::from_rotation_z(angle);
@@ -170,11 +170,11 @@ fn screen_shake(
             let target = screen_shake.latest_position.unwrap();
             sub_view
                 .offset
-                .smooth_nudge(&target, 1.0, time.delta_seconds());
+                .smooth_nudge(&target, 1.0, time.delta_secs());
             transform.rotation = transform.rotation.interpolate_stable(&Quat::IDENTITY, 0.1);
         }
     }
     // Decay the trauma over time
-    screen_shake.trauma -= TRAUMA_DECAY_SPEED * time.delta_seconds();
+    screen_shake.trauma -= TRAUMA_DECAY_SPEED * time.delta_secs();
     screen_shake.trauma = screen_shake.trauma.clamp(0.0, 1.0);
 }

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -92,7 +92,7 @@ fn update_camera(
     // between the camera position and the player position on the x and y axes.
     camera
         .translation
-        .smooth_nudge(&direction, CAMERA_DECAY_RATE, time.delta_seconds());
+        .smooth_nudge(&direction, CAMERA_DECAY_RATE, time.delta_secs());
 }
 
 /// Update the player position with keyboard inputs.
@@ -130,6 +130,6 @@ fn move_player(
     // Progressively update the player's position over time. Normalize the
     // direction vector to prevent it from exceeding a magnitude of 1 when
     // moving diagonally.
-    let move_delta = direction.normalize_or_zero() * PLAYER_SPEED * time.delta_seconds();
+    let move_delta = direction.normalize_or_zero() * PLAYER_SPEED * time.delta_secs();
     player.translation += move_delta.extend(0.);
 }

--- a/examples/camera/camera_orbit.rs
+++ b/examples/camera/camera_orbit.rs
@@ -125,7 +125,7 @@ fn orbit(
     let delta_yaw = delta.x * camera_settings.yaw_speed;
 
     // Conversely, we DO need to factor in delta time for mouse button inputs.
-    delta_roll *= camera_settings.roll_speed * time.delta_seconds();
+    delta_roll *= camera_settings.roll_speed * time.delta_secs();
 
     // Obtain the existing pitch, yaw, and roll values from the transform.
     let (yaw, pitch, roll) = camera.rotation.to_euler(EulerRot::YXZ);

--- a/examples/ecs/change_detection.rs
+++ b/examples/ecs/change_detection.rs
@@ -35,7 +35,7 @@ fn setup(mut commands: Commands) {
 fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)>) {
     for (entity, mut component) in &mut query {
         if rand::thread_rng().gen_bool(0.1) {
-            let new_component = MyComponent(time.elapsed_seconds().round());
+            let new_component = MyComponent(time.elapsed_secs().round());
             info!("New value: {new_component:?} {entity:?}");
             // Change detection occurs on mutable dereference, and does not consider whether or not
             // a value is actually equal. To avoid triggering change detection when nothing has
@@ -52,7 +52,7 @@ fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)
 fn change_component_2(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)>) {
     for (entity, mut component) in &mut query {
         if rand::thread_rng().gen_bool(0.1) {
-            let new_component = MyComponent(time.elapsed_seconds().round());
+            let new_component = MyComponent(time.elapsed_secs().round());
             info!("New value: {new_component:?} {entity:?}");
             component.set_if_neq(new_component);
         }
@@ -62,7 +62,7 @@ fn change_component_2(time: Res<Time>, mut query: Query<(Entity, &mut MyComponen
 /// Change detection concepts for components apply similarly to resources.
 fn change_resource(time: Res<Time>, mut my_resource: ResMut<MyResource>) {
     if rand::thread_rng().gen_bool(0.1) {
-        let new_resource = MyResource(time.elapsed_seconds().round());
+        let new_resource = MyResource(time.elapsed_secs().round());
         info!("New value: {new_resource:?}");
         my_resource.set_if_neq(new_resource);
     }

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -116,7 +116,7 @@ fn user_input(
 // Only runs if there are enemies.
 fn move_targets(mut enemies: Populated<(&mut Transform, &mut Enemy)>, time: Res<Time>) {
     for (mut transform, mut target) in &mut *enemies {
-        target.rotation += target.rotation_speed * time.delta_seconds();
+        target.rotation += target.rotation_speed * time.delta_secs();
         transform.rotation = Quat::from_rotation_z(target.rotation);
         let offset = transform.right() * target.radius;
         transform.translation = target.origin.extend(0.0) + offset;
@@ -145,12 +145,12 @@ fn move_pointer(
         player_transform.rotation = Quat::from_mat3(&Mat3::from_cols(side, front, up));
         let max_step = distance - player.min_follow_radius;
         if 0.0 < max_step {
-            let velocity = (player.speed * time.delta_seconds()).min(max_step);
+            let velocity = (player.speed * time.delta_secs()).min(max_step);
             player_transform.translation += front * velocity;
         }
     } else {
         // No enemy found, keep searching.
-        player_transform.rotate_axis(Dir3::Z, player.rotation_speed * time.delta_seconds());
+        player_transform.rotate_axis(Dir3::Z, player.rotation_speed * time.delta_secs());
     }
 }
 

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -18,23 +18,23 @@ fn frame_update(mut last_time: Local<f32>, time: Res<Time>) {
     // Default `Time` is `Time<Virtual>` here
     info!(
         "time since last frame_update: {}",
-        time.elapsed_seconds() - *last_time
+        time.elapsed_secs() - *last_time
     );
-    *last_time = time.elapsed_seconds();
+    *last_time = time.elapsed_secs();
 }
 
 fn fixed_update(mut last_time: Local<f32>, time: Res<Time>, fixed_time: Res<Time<Fixed>>) {
     // Default `Time`is `Time<Fixed>` here
     info!(
         "time since last fixed_update: {}\n",
-        time.elapsed_seconds() - *last_time
+        time.elapsed_secs() - *last_time
     );
 
-    info!("fixed timestep: {}\n", time.delta_seconds());
+    info!("fixed timestep: {}\n", time.delta_secs());
     // If we want to see the overstep, we need to access `Time<Fixed>` specifically
     info!(
         "time accrued toward next fixed_update: {}\n",
         fixed_time.overstep().as_secs_f32()
     );
-    *last_time = time.elapsed_seconds();
+    *last_time = time.elapsed_secs();
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -63,24 +63,24 @@ fn rotate(
 ) {
     for (parent, children) in &mut parents_query {
         if let Ok(mut transform) = transform_query.get_mut(parent) {
-            transform.rotate_z(-PI / 2. * time.delta_seconds());
+            transform.rotate_z(-PI / 2. * time.delta_secs());
         }
 
         // To iterate through the entities children, just treat the Children component as a Vec
         // Alternatively, you could query entities that have a Parent component
         for child in children {
             if let Ok(mut transform) = transform_query.get_mut(*child) {
-                transform.rotate_z(PI * time.delta_seconds());
+                transform.rotate_z(PI * time.delta_secs());
             }
         }
 
         // To demonstrate removing children, we'll remove a child after a couple of seconds.
-        if time.elapsed_seconds() >= 2.0 && children.len() == 2 {
+        if time.elapsed_secs() >= 2.0 && children.len() == 2 {
             let child = children.last().unwrap();
             commands.entity(*child).despawn_recursive();
         }
 
-        if time.elapsed_seconds() >= 4.0 {
+        if time.elapsed_secs() >= 4.0 {
             // This will remove the entity from its parent's list of children, as well as despawn
             // any children the entity has.
             commands.entity(parent).despawn_recursive();

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -135,7 +135,7 @@ fn interact_bodies(mut query: Query<(&Mass, &GlobalTransform, &mut Acceleration)
 }
 
 fn integrate(time: Res<Time>, mut query: Query<(&mut Acceleration, &mut Transform, &mut LastPos)>) {
-    let dt_sq = time.delta_seconds() * time.delta_seconds();
+    let dt_sq = time.delta_secs() * time.delta_secs();
     for (mut acceleration, mut transform, mut last_pos) in &mut query {
         // verlet integration
         // x(t+dt) = 2x(t) - x(t-dt) + a(t)dt^2 + O(dt^4)

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -41,7 +41,7 @@ fn remove_component(
     query: Query<Entity, With<MyComponent>>,
 ) {
     // After two seconds have passed the `Component` is removed.
-    if time.elapsed_seconds() > 2.0 {
+    if time.elapsed_secs() > 2.0 {
         if let Some(entity) = query.iter().next() {
             commands.entity(entity).remove::<MyComponent>();
         }

--- a/examples/ecs/run_conditions.rs
+++ b/examples/ecs/run_conditions.rs
@@ -82,7 +82,7 @@ fn has_user_input(
 fn time_passed(t: f32) -> impl FnMut(Local<f32>, Res<Time>) -> bool {
     move |mut timer: Local<f32>, time: Res<Time>| {
         // Tick the timer
-        *timer += time.delta_seconds();
+        *timer += time.delta_secs();
         // Return true if the timer has passed the time
         *timer >= t
     }

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -299,7 +299,7 @@ fn focus_camera(
     // smooth out the camera movement using the frame time
     let mut camera_motion = game.camera_should_focus - game.camera_is_focus;
     if camera_motion.length() > 0.2 {
-        camera_motion *= SPEED * time.delta_seconds();
+        camera_motion *= SPEED * time.delta_secs();
         // set the new camera's actual focus
         game.camera_is_focus += camera_motion;
     }
@@ -368,10 +368,9 @@ fn spawn_bonus(
 fn rotate_bonus(game: Res<Game>, time: Res<Time>, mut transforms: Query<&mut Transform>) {
     if let Some(entity) = game.bonus.entity {
         if let Ok(mut cake_transform) = transforms.get_mut(entity) {
-            cake_transform.rotate_y(time.delta_seconds());
-            cake_transform.scale = Vec3::splat(
-                1.0 + (game.score as f32 / 10.0 * ops::sin(time.elapsed_seconds())).abs(),
-            );
+            cake_transform.rotate_y(time.delta_secs());
+            cake_transform.scale =
+                Vec3::splat(1.0 + (game.score as f32 / 10.0 * ops::sin(time.elapsed_secs())).abs());
         }
     }
 }

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -316,7 +316,7 @@ fn move_paddle(
 
     // Calculate the new horizontal paddle position based on player input
     let new_paddle_position =
-        paddle_transform.translation.x + direction * PADDLE_SPEED * time.delta_seconds();
+        paddle_transform.translation.x + direction * PADDLE_SPEED * time.delta_secs();
 
     // Update the paddle position,
     // making sure it doesn't cause the paddle to leave the arena
@@ -328,8 +328,8 @@ fn move_paddle(
 
 fn apply_velocity(mut query: Query<(&mut Transform, &Velocity)>, time: Res<Time>) {
     for (mut transform, velocity) in &mut query {
-        transform.translation.x += velocity.x * time.delta_seconds();
-        transform.translation.y += velocity.y * time.delta_seconds();
+        transform.translation.x += velocity.x * time.delta_secs();
+        transform.translation.y += velocity.y * time.delta_secs();
     }
 }
 

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -238,7 +238,7 @@ fn deselect(sprite: &mut Sprite, contributor: &Contributor, transform: &mut Tran
 
 /// Applies gravity to all entities with a velocity.
 fn gravity(time: Res<Time>, mut velocity_query: Query<&mut Velocity>) {
-    let delta = time.delta_seconds();
+    let delta = time.delta_secs();
 
     for mut velocity in &mut velocity_query {
         velocity.translation.y -= GRAVITY * delta;
@@ -298,7 +298,7 @@ fn collisions(
 
 /// Apply velocity to positions and rotations.
 fn movement(time: Res<Time>, mut query: Query<(&Velocity, &mut Transform)>) {
-    let delta = time.delta_seconds();
+    let delta = time.delta_secs();
 
     for (velocity, mut transform) in &mut query {
         transform.translation += delta * velocity.translation;

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -285,7 +285,7 @@ fn drag(
 
     // Calculate how fast we are dragging the Bevy logo (unit/second)
     let drag_velocity =
-        (new_translation - bevy_transform.translation.truncate()) / time.delta_seconds();
+        (new_translation - bevy_transform.translation.truncate()) / time.delta_secs();
 
     // Update the translation of Bevy logo transform to new translation
     bevy_transform.translation = new_translation.extend(bevy_transform.translation.z);
@@ -366,9 +366,9 @@ fn move_pupils(time: Res<Time>, mut q_pupils: Query<(&mut Pupil, &mut Transform)
         // Truncate the Z component to make the calculations be on [`Vec2`]
         let mut translation = transform.translation.truncate();
         // Decay the pupil velocity
-        pupil.velocity *= ops::powf(0.04f32, time.delta_seconds());
+        pupil.velocity *= ops::powf(0.04f32, time.delta_secs());
         // Move the pupil
-        translation += pupil.velocity * time.delta_seconds();
+        translation += pupil.velocity * time.delta_secs();
         // If the pupil hit the outside border of the eye, limit the translation to be within the wiggle radius and invert the velocity.
         // This is not physically accurate but it's good enough for the googly eyes effect.
         if translation.length() > wiggle_radius {

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -42,7 +42,7 @@ fn draw_example_collection(
     mut my_gizmos: Gizmos<MyRoundGizmos>,
     time: Res<Time>,
 ) {
-    let sin_t_scaled = ops::sin(time.elapsed_seconds()) * 50.;
+    let sin_t_scaled = ops::sin(time.elapsed_secs()) * 50.;
     gizmos.line_2d(Vec2::Y * -sin_t_scaled, Vec2::splat(-80.), RED);
     gizmos.ray_2d(Vec2::Y * sin_t_scaled, Vec2::splat(80.), LIME);
 
@@ -70,7 +70,7 @@ fn draw_example_collection(
 
     let domain = Interval::EVERYWHERE;
     let curve = function_curve(domain, |t| Vec2::new(t, ops::sin(t / 25.0) * 100.0));
-    let resolution = ((ops::sin(time.elapsed_seconds()) + 1.0) * 50.0) as usize;
+    let resolution = ((ops::sin(time.elapsed_secs()) + 1.0) * 50.0) as usize;
     let times_and_colors = (0..=resolution)
         .map(|n| n as f32 / resolution as f32)
         .map(|t| (t - 0.5) * 600.0)
@@ -79,7 +79,7 @@ fn draw_example_collection(
 
     my_gizmos
         .rounded_rect_2d(Isometry2d::IDENTITY, Vec2::splat(630.), BLACK)
-        .corner_radius(ops::cos(time.elapsed_seconds() / 3.) * 100.);
+        .corner_radius(ops::cos(time.elapsed_secs() / 3.) * 100.);
 
     // Circles have 32 line-segments by default.
     // You may want to increase this for larger circles.
@@ -88,7 +88,7 @@ fn draw_example_collection(
         .resolution(64);
 
     my_gizmos.ellipse_2d(
-        Rot2::radians(time.elapsed_seconds() % TAU),
+        Rot2::radians(time.elapsed_secs() % TAU),
         Vec2::new(100., 200.),
         YELLOW_GREEN,
     );
@@ -129,11 +129,11 @@ fn update_config(
 ) {
     let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
     if keyboard.pressed(KeyCode::ArrowRight) {
-        config.line_width += 5. * time.delta_seconds();
+        config.line_width += 5. * time.delta_secs();
         config.line_width = config.line_width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        config.line_width -= 5. * time.delta_seconds();
+        config.line_width -= 5. * time.delta_secs();
         config.line_width = config.line_width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit1) {
@@ -156,11 +156,11 @@ fn update_config(
 
     let (my_config, _) = config_store.config_mut::<MyRoundGizmos>();
     if keyboard.pressed(KeyCode::ArrowUp) {
-        my_config.line_width += 5. * time.delta_seconds();
+        my_config.line_width += 5. * time.delta_secs();
         my_config.line_width = my_config.line_width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowDown) {
-        my_config.line_width -= 5. * time.delta_seconds();
+        my_config.line_width -= 5. * time.delta_secs();
         my_config.line_width = my_config.line_width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit2) {

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -98,8 +98,8 @@ fn draw_example_collection(
                 half_size: Vec2::splat(1.0),
             },
             Isometry3d::new(
-                Vec3::splat(4.0) + Vec2::from(ops::sin_cos(time.elapsed_seconds())).extend(0.0),
-                Quat::from_rotation_x(PI / 2. + time.elapsed_seconds()),
+                Vec3::splat(4.0) + Vec2::from(ops::sin_cos(time.elapsed_secs())).extend(0.0),
+                Quat::from_rotation_x(PI / 2. + time.elapsed_secs()),
             ),
             GREEN,
         )
@@ -112,7 +112,7 @@ fn draw_example_collection(
     );
     gizmos.rect(
         Isometry3d::new(
-            Vec3::new(ops::cos(time.elapsed_seconds()) * 2.5, 1., 0.),
+            Vec3::new(ops::cos(time.elapsed_secs()) * 2.5, 1., 0.),
             Quat::from_rotation_y(PI / 2.),
         ),
         Vec2::splat(2.),
@@ -125,7 +125,7 @@ fn draw_example_collection(
     let curve = function_curve(domain, |t| {
         (Vec2::from(ops::sin_cos(t * 10.0))).extend(t - 6.0)
     });
-    let resolution = ((ops::sin(time.elapsed_seconds()) + 1.0) * 100.0) as usize;
+    let resolution = ((ops::sin(time.elapsed_secs()) + 1.0) * 100.0) as usize;
     let times_and_colors = (0..=resolution)
         .map(|n| n as f32 / resolution as f32)
         .map(|t| t * 5.0)
@@ -142,7 +142,7 @@ fn draw_example_collection(
     for y in [0., 0.5, 1.] {
         gizmos.ray(
             Vec3::new(1., y, 0.),
-            Vec3::new(-3., ops::sin(time.elapsed_seconds() * 3.), 0.),
+            Vec3::new(-3., ops::sin(time.elapsed_secs() * 3.), 0.),
             BLUE,
         );
     }
@@ -200,11 +200,11 @@ fn update_config(
 
     let (config, _) = config_store.config_mut::<DefaultGizmoConfigGroup>();
     if keyboard.pressed(KeyCode::ArrowRight) {
-        config.line_width += 5. * time.delta_seconds();
+        config.line_width += 5. * time.delta_secs();
         config.line_width = config.line_width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        config.line_width -= 5. * time.delta_seconds();
+        config.line_width -= 5. * time.delta_secs();
         config.line_width = config.line_width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit1) {
@@ -227,11 +227,11 @@ fn update_config(
 
     let (my_config, _) = config_store.config_mut::<MyRoundGizmos>();
     if keyboard.pressed(KeyCode::ArrowUp) {
-        my_config.line_width += 5. * time.delta_seconds();
+        my_config.line_width += 5. * time.delta_secs();
         my_config.line_width = my_config.line_width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowDown) {
-        my_config.line_width -= 5. * time.delta_seconds();
+        my_config.line_width -= 5. * time.delta_secs();
         my_config.line_width = my_config.line_width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::Digit2) {

--- a/examples/gizmos/axes.rs
+++ b/examples/gizmos/axes.rs
@@ -117,7 +117,7 @@ fn move_cubes(
         );
 
         if tracking.progress < TRANSITION_DURATION {
-            tracking.progress += time.delta_seconds();
+            tracking.progress += time.delta_secs();
         } else {
             tracking.initial_transform = *transform;
             tracking.target_transform = random_transform(&mut rng.0);

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -137,7 +137,7 @@ fn setup(
 }
 
 fn rotate_camera(mut transform: Single<&mut Transform, With<Camera>>, time: Res<Time>) {
-    transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(time.delta_seconds() / 2.));
+    transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(time.delta_secs() / 2.));
 }
 
 fn update_config(
@@ -155,11 +155,11 @@ fn update_config(
 
     let (config, light_config) = config_store.config_mut::<LightGizmoConfigGroup>();
     if keyboard.pressed(KeyCode::ArrowRight) {
-        config.line_width += 5. * time.delta_seconds();
+        config.line_width += 5. * time.delta_secs();
         config.line_width = config.line_width.clamp(0., 50.);
     }
     if keyboard.pressed(KeyCode::ArrowLeft) {
-        config.line_width -= 5. * time.delta_seconds();
+        config.line_width -= 5. * time.delta_secs();
         config.line_width = config.line_width.clamp(0., 50.);
     }
     if keyboard.just_pressed(KeyCode::KeyA) {

--- a/examples/helpers/camera_controller.rs
+++ b/examples/helpers/camera_controller.rs
@@ -111,7 +111,7 @@ fn run_camera_controller(
     mut mouse_cursor_grab: Local<bool>,
     mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,
 ) {
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
 
     if let Ok((mut transform, mut controller)) = query.get_single_mut() {
         if !controller.initialized {

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -100,7 +100,7 @@ fn bubbling_text(
         if bubble.timer.tick(time.delta()).just_finished() {
             commands.entity(entity).despawn();
         }
-        transform.translation.y += time.delta_seconds() * 100.0;
+        transform.translation.y += time.delta_secs() * 100.0;
     }
 }
 

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -168,7 +168,7 @@ fn setup(
 
 // Rotate the 2D shapes.
 fn rotate_2d_shapes(mut shapes: Query<&mut Transform, With<Shape2d>>, time: Res<Time>) {
-    let elapsed_seconds = time.elapsed_seconds();
+    let elapsed_seconds = time.elapsed_secs();
 
     for mut transform in shapes.iter_mut() {
         transform.rotation = Quat::from_rotation_z(elapsed_seconds);
@@ -207,7 +207,7 @@ fn bounding_shapes_2d(
 
 // Rotate the 3D shapes.
 fn rotate_3d_shapes(mut shapes: Query<&mut Transform, With<Shape3d>>, time: Res<Time>) {
-    let delta_seconds = time.delta_seconds();
+    let delta_seconds = time.delta_secs();
 
     for mut transform in shapes.iter_mut() {
         transform.rotate_y(delta_seconds);

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -440,7 +440,7 @@ fn in_mode(active: CameraActive) -> impl Fn(Res<State<CameraActive>>) -> bool {
 
 fn draw_gizmos_2d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time: Res<Time>) {
     const POSITION: Vec2 = Vec2::new(-LEFT_RIGHT_OFFSET_2D, 0.0);
-    let angle = time.elapsed_seconds();
+    let angle = time.elapsed_secs();
     let isometry = Isometry2d::new(POSITION, Rot2::radians(angle));
     let color = Color::WHITE;
 
@@ -605,7 +605,7 @@ fn rotate_primitive_2d_meshes(
     >,
     time: Res<Time>,
 ) {
-    let rotation_2d = Quat::from_mat3(&Mat3::from_angle(time.elapsed_seconds()));
+    let rotation_2d = Quat::from_mat3(&Mat3::from_angle(time.elapsed_secs()));
     primitives_2d
         .iter_mut()
         .filter(|(_, vis)| vis.get())
@@ -624,9 +624,9 @@ fn rotate_primitive_3d_meshes(
     let rotation_3d = Quat::from_rotation_arc(
         Vec3::Z,
         Vec3::new(
-            ops::sin(time.elapsed_seconds()),
-            ops::cos(time.elapsed_seconds()),
-            ops::sin(time.elapsed_seconds()) * 0.5,
+            ops::sin(time.elapsed_secs()),
+            ops::cos(time.elapsed_secs()),
+            ops::sin(time.elapsed_secs()) * 0.5,
         )
         .try_normalize()
         .unwrap_or(Vec3::Z),
@@ -644,9 +644,9 @@ fn draw_gizmos_3d(mut gizmos: Gizmos, state: Res<State<PrimitiveSelected>>, time
     let rotation = Quat::from_rotation_arc(
         Vec3::Z,
         Vec3::new(
-            ops::sin(time.elapsed_seconds()),
-            ops::cos(time.elapsed_seconds()),
-            ops::sin(time.elapsed_seconds()) * 0.5,
+            ops::sin(time.elapsed_secs()),
+            ops::cos(time.elapsed_secs()),
+            ops::sin(time.elapsed_secs()) * 0.5,
         )
         .try_normalize()
         .unwrap_or(Vec3::Z),

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -638,7 +638,7 @@ fn animate_spawning(
     time: Res<Time>,
     mut samples: Query<(Entity, &mut Transform, &mut SpawningPoint)>,
 ) {
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
 
     for (entity, mut transform, mut point) in samples.iter_mut() {
         point.progress += dt / ANIMATION_TIME;
@@ -654,7 +654,7 @@ fn animate_despawning(
     time: Res<Time>,
     mut samples: Query<(Entity, &mut Transform, &mut DespawningPoint)>,
 ) {
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
 
     for (entity, mut transform, mut point) in samples.iter_mut() {
         point.progress += dt / ANIMATION_TIME;

--- a/examples/movement/physics_in_fixed_timestep.rs
+++ b/examples/movement/physics_in_fixed_timestep.rs
@@ -19,7 +19,7 @@
 //!
 //! The more sophisticated way is to update the player's position based on the time that has passed:
 //! ```no_run
-//! transform.translation += velocity * time.delta_seconds();
+//! transform.translation += velocity * time.delta_secs();
 //! ```
 //! This way, velocity represents a speed in units per second, and the player will move at the same speed
 //! regardless of the frame rate.
@@ -217,7 +217,7 @@ fn advance_physics(
     ) in query.iter_mut()
     {
         previous_physical_translation.0 = current_physical_translation.0;
-        current_physical_translation.0 += velocity.0 * fixed_time.delta_seconds();
+        current_physical_translation.0 += velocity.0 * fixed_time.delta_secs();
 
         // Reset the input accumulator, as we are currently consuming all input that happened since the last fixed timestep.
         input.0 = Vec2::ZERO;

--- a/examples/movement/smooth_follow.rs
+++ b/examples/movement/smooth_follow.rs
@@ -100,7 +100,7 @@ fn move_target(
         // The target and the present position of the target sphere are far enough to have a well-
         // defined direction between them, so let's move closer:
         Ok(dir) => {
-            let delta_time = time.delta_seconds();
+            let delta_time = time.delta_secs();
             let abs_delta = (target_pos.0 - target.translation).norm();
 
             // Avoid overshooting in case of high values of `delta_time`:
@@ -123,7 +123,7 @@ fn move_follower(
     time: Res<Time>,
 ) {
     let decay_rate = decay_rate.0;
-    let delta_time = time.delta_seconds();
+    let delta_time = time.delta_secs();
 
     // Calling `smooth_nudge` is what moves the following sphere smoothly toward the target.
     following

--- a/examples/picking/mesh_picking.rs
+++ b/examples/picking/mesh_picking.rs
@@ -232,6 +232,6 @@ fn on_mesh_hover(
 /// Rotates the shapes.
 fn rotate(mut query: Query<&mut Transform, With<Shape>>, time: Res<Time>) {
     for mut transform in &mut query {
-        transform.rotate_y(time.delta_seconds() / 2.);
+        transform.rotate_y(time.delta_secs() / 2.);
     }
 }

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -16,7 +16,7 @@ fn move_sprite(
     time: Res<Time>,
     mut sprite: Query<&mut Transform, (Without<Sprite>, With<Children>)>,
 ) {
-    let t = time.elapsed_seconds() * 0.1;
+    let t = time.elapsed_secs() * 0.1;
     for mut transform in &mut sprite {
         let new = Vec2 {
             x: 50.0 * ops::sin(t),

--- a/examples/remote/server.rs
+++ b/examples/remote/server.rs
@@ -58,7 +58,7 @@ fn setup(
 
 fn move_cube(mut query: Query<&mut Transform, With<Cube>>, time: Res<Time>) {
     for mut transform in &mut query {
-        transform.translation.y = -cos(time.elapsed_seconds()) + 1.5;
+        transform.translation.y = -cos(time.elapsed_secs()) + 1.5;
     }
 }
 

--- a/examples/shader/custom_post_processing.rs
+++ b/examples/shader/custom_post_processing.rs
@@ -348,15 +348,15 @@ struct Rotates;
 /// Rotates any entity around the x and y axis
 fn rotate(time: Res<Time>, mut query: Query<&mut Transform, With<Rotates>>) {
     for mut transform in &mut query {
-        transform.rotate_x(0.55 * time.delta_seconds());
-        transform.rotate_z(0.15 * time.delta_seconds());
+        transform.rotate_x(0.55 * time.delta_secs());
+        transform.rotate_z(0.15 * time.delta_secs());
     }
 }
 
 // Change the intensity over time to show that the effect is controlled from the main world
 fn update_settings(mut settings: Query<&mut PostProcessSettings>, time: Res<Time>) {
     for mut setting in &mut settings {
-        let mut intensity = ops::sin(time.elapsed_seconds());
+        let mut intensity = ops::sin(time.elapsed_secs());
         // Make it loop periodically
         intensity = ops::sin(intensity);
         // Remap it to 0..1 because the intensity can't be negative

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -65,7 +65,7 @@ struct Rotate;
 
 fn rotate_things(mut q: Query<&mut Transform, With<Rotate>>, time: Res<Time>) {
     for mut t in &mut q {
-        t.rotate_y(time.delta_seconds());
+        t.rotate_y(time.delta_secs());
     }
 }
 

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -54,7 +54,7 @@ fn setup(
 fn rotate_camera(mut cam_transform: Single<&mut Transform, With<MainCamera>>, time: Res<Time>) {
     cam_transform.rotate_around(
         Vec3::ZERO,
-        Quat::from_axis_angle(Vec3::Y, 45f32.to_radians() * time.delta_seconds()),
+        Quat::from_axis_angle(Vec3::Y, 45f32.to_radians() * time.delta_secs()),
     );
     cam_transform.look_at(Vec3::ZERO, Vec3::Y);
 }

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -176,7 +176,7 @@ struct Rotates;
 
 fn rotate(mut q: Query<&mut Transform, With<Rotates>>, time: Res<Time>) {
     for mut t in q.iter_mut() {
-        let rot = (ops::sin(time.elapsed_seconds()) * 0.5 + 0.5) * std::f32::consts::PI * 2.0;
+        let rot = (ops::sin(time.elapsed_secs()) * 0.5 + 0.5) * std::f32::consts::PI * 2.0;
         t.rotation = Quat::from_rotation_z(rot);
     }
 }

--- a/examples/shader/storage_buffer.rs
+++ b/examples/shader/storage_buffer.rs
@@ -72,7 +72,7 @@ fn update(
     buffer.set_data(
         (0..5)
             .map(|i| {
-                let t = time.elapsed_seconds() * 5.0;
+                let t = time.elapsed_secs() * 5.0;
                 [
                     ops::sin(t + i as f32) / 2.0 + 0.5,
                     ops::sin(t + i as f32 + 2.0) / 2.0 + 0.5,

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -454,7 +454,7 @@ mod ui {
             if direction != Vec3::ZERO {
                 transform.translation += direction.normalize()
                     * if turbo.is_some() { TURBO_SPEED } else { SPEED }
-                    * time.delta_seconds();
+                    * time.delta_secs();
             }
         }
     }
@@ -544,7 +544,7 @@ mod ui {
     pub fn change_color(time: Res<Time>, mut query: Query<&mut Sprite>) {
         for mut sprite in &mut query {
             let new_color = LinearRgba {
-                blue: ops::sin(time.elapsed_seconds() * 0.5) + 2.0,
+                blue: ops::sin(time.elapsed_secs() * 0.5) + 2.0,
                 ..LinearRgba::from(sprite.color)
             };
 

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -188,7 +188,7 @@ fn movement(
         }
 
         if direction != Vec3::ZERO {
-            transform.translation += direction.normalize() * SPEED * time.delta_seconds();
+            transform.translation += direction.normalize() * SPEED * time.delta_secs();
         }
     }
 }
@@ -196,7 +196,7 @@ fn movement(
 fn change_color(time: Res<Time>, mut query: Query<&mut Sprite>) {
     for mut sprite in &mut query {
         let new_color = LinearRgba {
-            blue: ops::sin(time.elapsed_seconds() * 0.5) + 2.0,
+            blue: ops::sin(time.elapsed_secs() * 0.5) + 2.0,
             ..LinearRgba::from(sprite.color)
         };
 

--- a/examples/state/states.rs
+++ b/examples/state/states.rs
@@ -145,7 +145,7 @@ fn movement(
         }
 
         if direction != Vec3::ZERO {
-            transform.translation += direction.normalize() * SPEED * time.delta_seconds();
+            transform.translation += direction.normalize() * SPEED * time.delta_secs();
         }
     }
 }
@@ -153,7 +153,7 @@ fn movement(
 fn change_color(time: Res<Time>, mut query: Query<&mut Sprite>) {
     for mut sprite in &mut query {
         let new_color = LinearRgba {
-            blue: ops::sin(time.elapsed_seconds() * 0.5) + 2.0,
+            blue: ops::sin(time.elapsed_secs() * 0.5) + 2.0,
             ..LinearRgba::from(sprite.color)
         };
 

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -109,7 +109,7 @@ fn movement(
         }
 
         if direction != Vec3::ZERO {
-            transform.translation += direction.normalize() * SPEED * time.delta_seconds();
+            transform.translation += direction.normalize() * SPEED * time.delta_secs();
         }
     }
 }
@@ -117,7 +117,7 @@ fn movement(
 fn change_color(time: Res<Time>, mut query: Query<&mut Sprite>) {
     for mut sprite in &mut query {
         let new_color = LinearRgba {
-            blue: ops::sin(time.elapsed_seconds() * 0.5) + 2.0,
+            blue: ops::sin(time.elapsed_secs() * 0.5) + 2.0,
             ..LinearRgba::from(sprite.color)
         };
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -350,7 +350,7 @@ fn mouse_handler(
     }
 
     if mouse_button_input.pressed(MouseButton::Left) {
-        let spawn_count = (BIRDS_PER_SECOND as f64 * time.delta_seconds_f64()) as usize;
+        let spawn_count = (BIRDS_PER_SECOND as f64 * time.delta_secs_f64()) as usize;
         spawn_birds(
             &mut commands,
             args.into_inner(),
@@ -514,7 +514,7 @@ fn movement_system(
     let dt = if args.benchmark {
         FIXED_DELTA_TIME
     } else {
-        time.delta_seconds()
+        time.delta_secs()
     };
     for (mut bird, mut transform) in &mut bird_query {
         step_movement(&mut transform.translation, &mut bird.velocity, dt);

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -101,9 +101,9 @@ fn setup(
 
 // System for rotating and translating the camera
 fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera>>) {
-    camera_transform.rotate(Quat::from_rotation_z(time.delta_seconds() * 0.5));
+    camera_transform.rotate(Quat::from_rotation_z(time.delta_secs() * 0.5));
     **camera_transform = **camera_transform
-        * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_seconds());
+        * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_secs());
 }
 
 #[derive(Component, Deref, DerefMut)]

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -444,7 +444,7 @@ fn move_camera(
         * if args.benchmark {
             1.0 / 60.0
         } else {
-            time.delta_seconds()
+            time.delta_secs()
         };
     camera_transform.rotate_z(delta);
     camera_transform.rotate_x(delta);

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -261,7 +261,7 @@ fn update_fox_rings(
         return;
     }
 
-    let dt = time.delta_seconds();
+    let dt = time.delta_secs();
     for (ring, rotation_direction, mut transform) in &mut rings {
         let angular_velocity = foxes.speed / ring.radius;
         transform.rotate_y(rotation_direction.sign() * angular_velocity * dt);

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -70,7 +70,7 @@ fn system(config: Res<Config>, time: Res<Time>, mut draw: Gizmos) {
         for i in 0..(config.line_count / SYSTEM_COUNT) {
             let angle = i as f32 / (config.line_count / SYSTEM_COUNT) as f32 * TAU;
 
-            let vector = Vec2::from(ops::sin_cos(angle)).extend(ops::sin(time.elapsed_seconds()));
+            let vector = Vec2::from(ops::sin_cos(angle)).extend(ops::sin(time.elapsed_secs()));
             let start_color = LinearRgba::rgb(vector.x, vector.z, 0.5);
             let end_color = LinearRgba::rgb(-vector.z, -vector.y, 0.5);
 

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -134,7 +134,7 @@ fn spherical_polar_to_cartesian(p: DVec2) -> DVec3 {
 
 // System for rotating the camera
 fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera>>) {
-    let delta = time.delta_seconds() * 0.15;
+    let delta = time.delta_secs() * 0.15;
     camera_transform.rotate_z(delta);
     camera_transform.rotate_x(delta);
 }

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -105,9 +105,9 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<Color
 
 // System for rotating and translating the camera
 fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera>>) {
-    camera_transform.rotate_z(time.delta_seconds() * 0.5);
+    camera_transform.rotate_z(time.delta_secs() * 0.5);
     **camera_transform = **camera_transform
-        * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_seconds());
+        * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_secs());
 }
 
 #[derive(Deref, DerefMut)]

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -83,7 +83,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 // changing the bounds of the text will cause a recomputation
 fn update_text_bounds(time: Res<Time>, mut text_bounds_query: Query<&mut TextBounds>) {
-    let width = (1. + ops::sin(time.elapsed_seconds())) * 600.0;
+    let width = (1. + ops::sin(time.elapsed_secs())) * 600.0;
     for mut text_bounds in text_bounds_query.iter_mut() {
         text_bounds.width = Some(width);
     }

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -258,7 +258,7 @@ struct UpdateValue(f32);
 /// update positions system
 fn update(time: Res<Time>, mut query: Query<(&mut Transform, &mut UpdateValue)>) {
     for (mut t, mut u) in &mut query {
-        u.0 += time.delta_seconds() * 0.1;
+        u.0 += time.delta_secs() * 0.1;
         set_translation(&mut t.translation, u.0);
     }
 }

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -135,7 +135,7 @@ fn move_real_time_sprites(
         // move roughly half the screen in a `Real` second
         // when the time is scaled the speed is going to change
         // and the sprite will stay still the time is paused
-        transform.translation.x = get_sprite_translation_x(time.elapsed_seconds());
+        transform.translation.x = get_sprite_translation_x(time.elapsed_secs());
     }
 }
 
@@ -152,7 +152,7 @@ fn move_virtual_time_sprites(
         // when time is scaled using `Time<Virtual>::set_relative_speed` it's going
         // to move at a different pace and the sprite will stay still when time is
         // `Time<Virtual>::is_paused()`
-        transform.translation.x = get_sprite_translation_x(time.elapsed_seconds());
+        transform.translation.x = get_sprite_translation_x(time.elapsed_secs());
     }
 }
 
@@ -184,8 +184,8 @@ fn update_real_time_info_text(time: Res<Time<Real>>, mut query: Query<&mut Text,
     for mut text in &mut query {
         **text = format!(
             "REAL TIME\nElapsed: {:.1}\nDelta: {:.5}\n",
-            time.elapsed_seconds(),
-            time.delta_seconds(),
+            time.elapsed_secs(),
+            time.delta_secs(),
         );
     }
 }
@@ -198,8 +198,8 @@ fn update_virtual_time_info_text(
     for mut text in &mut query {
         **text = format!(
             "VIRTUAL TIME\nElapsed: {:.1}\nDelta: {:.5}\nSpeed: {:.2}",
-            time.elapsed_seconds(),
-            time.delta_seconds(),
+            time.elapsed_secs(),
+            time.delta_secs(),
             time.relative_speed()
         );
     }

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -219,7 +219,7 @@ fn update_morphs(
         // component and call `weights_mut` to get access to the weights.
         let weights_slice = weights.weights_mut();
         let i = target.index;
-        let change = time.delta_seconds() * WEIGHT_PER_SECOND;
+        let change = time.delta_secs() * WEIGHT_PER_SECOND;
         let new_weight = target.change_dir.change_weight(weights_slice[i], change);
         weights_slice[i] = new_weight;
         target.weight = new_weight;

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -161,7 +161,7 @@ fn update_lights(
             transform.rotation = Quat::from_euler(
                 EulerRot::ZYX,
                 0.0,
-                time.elapsed_seconds() * PI / 15.0,
+                time.elapsed_secs() * PI / 15.0,
                 -FRAC_PI_4,
             );
         }

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -48,8 +48,8 @@ fn setup(
 fn rotate_cube(mut cubes: Query<(&mut Transform, &Rotatable)>, timer: Res<Time>) {
     for (mut transform, cube) in &mut cubes {
         // The speed is first multiplied by TAU which is a full rotation (360deg) in radians,
-        // and then multiplied by delta_seconds which is the time that passed last frame.
+        // and then multiplied by delta_secs which is the time that passed last frame.
         // In other words. Speed is equal to the amount of rotations per second.
-        transform.rotate_y(cube.speed * TAU * timer.delta_seconds());
+        transform.rotate_y(cube.speed * TAU * timer.delta_secs());
     }
 }

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -148,7 +148,7 @@ fn rotate_ship(ship: Single<(&mut Ship, &mut Transform)>, time: Res<Time>) {
 
     ship_transform
         .rotation
-        .smooth_nudge(&target_rotation, 3.0, time.delta_seconds());
+        .smooth_nudge(&target_rotation, 3.0, time.delta_secs());
 
     if ship_transform.rotation.angle_between(target_rotation) <= f32::EPSILON {
         ship.in_motion = false;

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -90,6 +90,6 @@ fn change_scale_direction(mut cubes: Query<(&mut Transform, &mut Scaling)>) {
 // by cycling through the directions to scale.
 fn scale_cube(mut cubes: Query<(&mut Transform, &Scaling)>, timer: Res<Time>) {
     for (mut transform, cube) in &mut cubes {
-        transform.scale += cube.scale_direction * cube.scale_speed * timer.delta_seconds();
+        transform.scale += cube.scale_direction * cube.scale_speed * timer.delta_secs();
     }
 }

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -91,7 +91,7 @@ fn move_cube(mut cubes: Query<(&mut Transform, &mut CubeState)>, timer: Res<Time
     for (mut transform, cube) in &mut cubes {
         // Move the cube forward smoothly at a given move_speed.
         let forward = transform.forward();
-        transform.translation += forward * cube.move_speed * timer.delta_seconds();
+        transform.translation += forward * cube.move_speed * timer.delta_secs();
     }
 }
 
@@ -115,7 +115,7 @@ fn rotate_cube(
         // Interpolate between the current rotation and the fully turned rotation
         // when looking a the sphere,  with a given turn speed to get a smooth motion.
         // With higher speed the curvature of the orbit would be smaller.
-        let incremental_turn_weight = cube.turn_speed * timer.delta_seconds();
+        let incremental_turn_weight = cube.turn_speed * timer.delta_secs();
         let old_rotation = transform.rotation;
         transform.rotation = old_rotation.lerp(look_at_sphere.rotation, incremental_turn_weight);
     }

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -66,6 +66,6 @@ fn move_cube(mut cubes: Query<(&mut Transform, &mut Movable)>, timer: Res<Time>)
             cube.speed *= -1.0;
         }
         let direction = transform.local_x();
-        transform.translation += direction * cube.speed * timer.delta_seconds();
+        transform.translation += direction * cube.speed * timer.delta_secs();
     }
 }

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -227,7 +227,7 @@ fn update_animation(
     time: Res<Time>,
     keys: Res<ButtonInput<KeyCode>>,
 ) {
-    let delta = time.elapsed_seconds();
+    let delta = time.elapsed_secs();
 
     if keys.just_pressed(KeyCode::Space) {
         animation.playing = !animation.playing;

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -122,7 +122,7 @@ const ROTATION_SPEED: f32 = 0.5;
 
 fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Cube>>) {
     for mut transform in &mut query {
-        transform.rotate_x(1.0 * time.delta_seconds() * ROTATION_SPEED);
-        transform.rotate_y(0.7 * time.delta_seconds() * ROTATION_SPEED);
+        transform.rotate_x(1.0 * time.delta_secs() * ROTATION_SPEED);
+        transform.rotate_y(0.7 * time.delta_secs() * ROTATION_SPEED);
     }
 }

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -118,7 +118,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn text_color_system(time: Res<Time>, mut query: Query<&mut TextColor, With<ColorText>>) {
     for mut text_color in &mut query {
-        let seconds = time.elapsed_seconds();
+        let seconds = time.elapsed_secs();
 
         // Update the color of the ColorText span.
         text_color.0 = Color::srgb(

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -278,7 +278,7 @@ fn change_text_system(
             }
         }
 
-        let mut frame_time = time.delta_seconds_f64();
+        let mut frame_time = time.delta_secs_f64();
         if let Some(frame_time_diagnostic) =
             diagnostics.get(&FrameTimeDiagnosticsPlugin::FRAME_TIME)
         {

--- a/examples/ui/ui_material.rs
+++ b/examples/ui/ui_material.rs
@@ -89,11 +89,11 @@ fn animate(
     for handle in &q {
         if let Some(material) = materials.get_mut(handle) {
             // rainbow color effect
-            let new_color = Color::hsl((time.elapsed_seconds() * 60.0) % 360.0, 1., 0.5);
-            let border_color = Color::hsl((time.elapsed_seconds() * 60.0) % 360.0, 0.75, 0.75);
+            let new_color = Color::hsl((time.elapsed_secs() * 60.0) % 360.0, 1., 0.5);
+            let border_color = Color::hsl((time.elapsed_secs() * 60.0) % 360.0, 0.75, 0.75);
             material.color = new_color.to_linear().to_vec4();
             material.slider =
-                ((time.elapsed_seconds() % (duration * 2.0)) - duration).abs() / duration;
+                ((time.elapsed_secs() % (duration * 2.0)) - duration).abs() / duration;
             material.border_color = border_color.to_linear().to_vec4();
         }
     }

--- a/examples/ui/viewport_debug.rs
+++ b/examples/ui/viewport_debug.rs
@@ -42,7 +42,7 @@ fn update(
     time: Res<Time>,
     mut coords_style_query: Query<(&Coords, &mut Style)>,
 ) {
-    *timer -= time.delta_seconds();
+    *timer -= time.delta_secs();
     if *timer <= 0. {
         *timer = 1.;
         *visible_tree = match *visible_tree {

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -136,8 +136,8 @@ pub(crate) mod test_setup {
         mut cube_transform: Query<&mut Transform, With<Rotator>>,
     ) {
         for mut transform in &mut cube_transform {
-            transform.rotate_x(time.delta_seconds());
-            transform.rotate_local_y(time.delta_seconds());
+            transform.rotate_x(time.delta_secs());
+            transform.rotate_local_y(time.delta_secs());
         }
     }
 


### PR DESCRIPTION
Fixes #15834

## Migration Guide

The APIs of `Time`, `Timer` and `Stopwatch` have been cleaned up for consistency with each other and the standard library's `Duration` type. The following methods have been renamed:

- `Stowatch::paused` -> `Stopwatch::is_paused`
- `Time::elapsed_seconds` -> `Time::elasped_secs` (including `_f64` and `_wrapped` variants)