### PR TITLE
Add read-only access to `PointerInteraction`

### DIFF
--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -17,7 +17,7 @@ use bevy_window::PrimaryWindow;
 
 use uuid::Uuid;
 
-use core::fmt::Debug;
+use core::{fmt::Debug, ops::Deref};
 
 use crate::backend::HitData;
 
@@ -69,6 +69,21 @@ impl PointerId {
 #[reflect(Component, Default, Debug)]
 pub struct PointerInteraction {
     pub(crate) sorted_entities: Vec<(Entity, HitData)>,
+}
+
+impl PointerInteraction {
+    /// Returns the nearest hit entity and data about that intersection.
+    pub fn get_nearest_hit(&self) -> Option<&(Entity, HitData)> {
+        self.sorted_entities.first()
+    }
+}
+
+impl Deref for PointerInteraction {
+    type Target = Vec<(Entity, HitData)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.sorted_entities
+    }
 }
 
 /// A resource that maps each [`PointerId`] to their [`Entity`] for easy lookups.


### PR DESCRIPTION
# Objective
Re-add missing read-only access to `PointerInteraction`. This was missed when bevy_mod_picking was upstreamed.
See [here](https://docs.rs/bevy_mod_picking/latest/bevy_mod_picking/pointer/struct.PointerInteraction.html).
