### PR TITLE
Double MAX_JOINTS and MAX_MORPH_WEIGHTS

### DIFF
--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -15,7 +15,7 @@ const MAX_TEXTURE_WIDTH: u32 = 2048;
 const MAX_COMPONENTS: u32 = MAX_TEXTURE_WIDTH * MAX_TEXTURE_WIDTH;
 
 /// Max target count available for [morph targets](MorphWeights).
-pub const MAX_MORPH_WEIGHTS: usize = 64;
+pub const MAX_MORPH_WEIGHTS: usize = 128;
 
 #[derive(Error, Display, Clone, Debug)]
 pub enum MorphBuildError {

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -15,7 +15,7 @@ use bevy_render::{
 use bevy_transform::prelude::GlobalTransform;
 
 /// Maximum number of joints supported for skinned meshes.
-pub const MAX_JOINTS: usize = 256;
+pub const MAX_JOINTS: usize = 512;
 
 #[derive(Component)]
 pub struct SkinIndex {


### PR DESCRIPTION
# Objective

I tried to import a 3D model that were slightly above the existing MAX_JOINTS and MAX_MORPH_WEIGHTS limits, got this error:

```
Failed to load asset 'models/humanoid.glb' with asset loader 'bevy_gltf::loader::GltfLoader':
failed to generate morph targets: Bevy only supports up to 64 morph targets (individual poses),
tried to create a model with 77 morph targets
```

## Solution

So tried the simplest solution possible, doubling the limits I hit when trying to load the model. It seems to work without any issues, everything still works exactly the same as far as I can tell. @alice-i-cecile asked me to PR the changes, so here we are :)

Ideally, I'd would have liked the comments for these two values to describe why those exact limits have been chosen, but I don't know the answer to that, maybe someone else could help me explain why the limits are there in the first place, and how the specific numbers were chosen.