### PR TITLE
Remove AVIF feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,9 +247,6 @@ trace_tracy_memory = [
 # Tracing support
 trace = ["bevy_internal/trace"]
 
-# AVIF image format support
-avif = ["bevy_internal/avif"]
-
 # Basis Universal compressed texture support
 basis-universal = ["bevy_internal/basis-universal"]
 

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["bevy"]
 
 [features]
 # Image formats
-avif = ["image/avif"]
 basis-universal = ["dep:basis-universal"]
 bmp = ["image/bmp"]
 dds = ["ddsfile"]

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -29,8 +29,6 @@ pub const SAMPLER_ASSET_INDEX: u64 = 1;
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 pub enum ImageFormat {
-    #[cfg(feature = "avif")]
-    Avif,
     #[cfg(feature = "basis-universal")]
     Basis,
     #[cfg(feature = "bmp")]
@@ -81,8 +79,6 @@ impl ImageFormat {
     /// Gets the file extensions for a given format.
     pub const fn to_file_extensions(&self) -> &'static [&'static str] {
         match self {
-            #[cfg(feature = "avif")]
-            ImageFormat::Avif => &["avif"],
             #[cfg(feature = "basis-universal")]
             ImageFormat::Basis => &["basis"],
             #[cfg(feature = "bmp")]
@@ -126,8 +122,6 @@ impl ImageFormat {
     /// If a format doesn't have any dedicated MIME types, this list will be empty.
     pub const fn to_mime_types(&self) -> &'static [&'static str] {
         match self {
-            #[cfg(feature = "avif")]
-            ImageFormat::Avif => &["image/avif"],
             #[cfg(feature = "basis-universal")]
             ImageFormat::Basis => &["image/basis", "image/x-basis"],
             #[cfg(feature = "bmp")]
@@ -174,7 +168,6 @@ impl ImageFormat {
     pub fn from_mime_type(mime_type: &str) -> Option<Self> {
         Some(match mime_type.to_ascii_lowercase().as_str() {
             // note: farbfeld does not have a MIME type
-            "image/avif" => feature_gate!("avif", Avif),
             "image/basis" | "image/x-basis" => feature_gate!("basis-universal", Basis),
             "image/bmp" | "image/x-bmp" => feature_gate!("bmp", Bmp),
             "image/vnd-ms.dds" => feature_gate!("dds", Dds),
@@ -199,7 +192,6 @@ impl ImageFormat {
 
     pub fn from_extension(extension: &str) -> Option<Self> {
         Some(match extension.to_ascii_lowercase().as_str() {
-            "avif" => feature_gate!("avif", Avif),
             "basis" => feature_gate!("basis-universal", Basis),
             "bmp" => feature_gate!("bmp", Bmp),
             "dds" => feature_gate!("dds", Dds),
@@ -222,8 +214,6 @@ impl ImageFormat {
 
     pub fn as_image_crate_format(&self) -> Option<image::ImageFormat> {
         Some(match self {
-            #[cfg(feature = "avif")]
-            ImageFormat::Avif => image::ImageFormat::Avif,
             #[cfg(feature = "bmp")]
             ImageFormat::Bmp => image::ImageFormat::Bmp,
             #[cfg(feature = "dds")]
@@ -264,7 +254,6 @@ impl ImageFormat {
 
     pub fn from_image_crate_format(format: image::ImageFormat) -> Option<ImageFormat> {
         Some(match format {
-            image::ImageFormat::Avif => feature_gate!("avif", Avif),
             image::ImageFormat::Bmp => feature_gate!("bmp", Bmp),
             image::ImageFormat::Dds => feature_gate!("dds", Dds),
             image::ImageFormat::Farbfeld => feature_gate!("ff", Farbfeld),

--- a/crates/bevy_image/src/image_loader.rs
+++ b/crates/bevy_image/src/image_loader.rs
@@ -14,8 +14,6 @@ pub struct ImageLoader {
 impl ImageLoader {
     /// Full list of supported formats.
     pub const SUPPORTED_FORMATS: &'static [ImageFormat] = &[
-        #[cfg(feature = "avif")]
-        ImageFormat::Avif,
         #[cfg(feature = "basis-universal")]
         ImageFormat::Basis,
         #[cfg(feature = "bmp")]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -45,7 +45,6 @@ zlib = ["bevy_image/zlib"]
 zstd = ["bevy_image/zstd"]
 
 # Image format support (PNG enabled by default)
-avif = ["bevy_image/avif"]
 bmp = ["bevy_image/bmp"]
 ff = ["bevy_image/ff"]
 gif = ["bevy_image/gif"]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -57,7 +57,6 @@ The default feature set enables most of the expected features of a game engine, 
 |android-native-activity|Android NativeActivity support. Legacy, should be avoided for most new Android games.|
 |asset_processor|Enables the built-in asset processor for processed assets.|
 |async-io|Use async-io's implementation of block_on instead of futures-lite's implementation. This is preferred if your application uses async-io.|
-|avif|AVIF image format support|
 |basis-universal|Basis Universal compressed texture support|
 |bevy_ci_testing|Enable systems that allow for automated testing on CI|
 |bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|


### PR DESCRIPTION
Resolves #15968. Since this feature never worked, and enabling it in the `image` crate requires system dependencies, we've decided that it's best to just remove it and let other plugin crates offer support for it as needed.

## Migration Guide

AVIF images are no longer supported. They never really worked, and require system dependencies (libdav1d) to work correctly, so, it's better to simply offer this support via an unofficial plugin instead as needed. The corresponding types have been removed from Bevy to account for this.