### PR TITLE
Fix `pbr` example camera scale

### DIFF
--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -111,7 +111,7 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
         Projection::from(OrthographicProjection {
-            scale: 100.,
+            scale: 0.01,
             scaling_mode: ScalingMode::WindowSize,
             ..OrthographicProjection::default_3d()
         }),


### PR DESCRIPTION
# Objective

Fixes #15976

## Solution

I haven't been following the recent camera changes but on a whim I inverted the scale and it restored the old behavior.

It seems that a similar inversion was done when migrating the `pixel_grid_snap` example in #15976.

## Testing

`cargo run --example pbr`
