### PR TITLE
Fix red background in `ui_material` example

### DIFF
--- a/examples/ui/ui_material.rs
+++ b/examples/ui/ui_material.rs
@@ -1,6 +1,6 @@
 //! Demonstrates the use of [`UiMaterials`](UiMaterial) and how to change material values
 
-use bevy::{color::palettes::css::RED, prelude::*, reflect::TypePath, render::render_resource::*};
+use bevy::{prelude::*, reflect::TypePath, render::render_resource::*};
 
 /// This example uses a shader source file from the assets subdirectory
 const SHADER_ASSET_PATH: &str = "shaders/custom_ui_material.wgsl";
@@ -49,7 +49,6 @@ fn setup(
                     border: UiRect::all(Val::Px(10.)),
                     ..default()
                 },
-                BackgroundColor(RED.into()),
             ));
         });
 }


### PR DESCRIPTION
# Objective

The `ui_material` recently gained a harsh red background via #15898.

I'm assuming this was added for testing and forgotten about.

https://pixel-eagle.com/project/b25a040a-a980-4602-b90c-d480ab84076d/run/5268/compare/5259?screenshot=UI%20(User%20Interface)/ui_material.png

## Solution

Remove the red background

## Testing

`cargo run --example ui_material`
