### PR TITLE
Fix some duplicate words in docs/comments

### DIFF
--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -441,7 +441,7 @@ impl AnimationGraph {
     /// All of the animation clips will be direct children of the root with
     /// weight 1.0.
     ///
-    /// Returns the the graph and indices of the new nodes.
+    /// Returns the graph and indices of the new nodes.
     pub fn from_clips<'a, I>(clips: I) -> (Self, Vec<AnimationNodeIndex>)
     where
         I: IntoIterator<Item = Handle<AnimationClip>>,

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -859,7 +859,7 @@ impl AssetProcessor {
                 }
             }
         }
-        // Note: this lock must remain alive until all processed asset asset and meta writes have finished (or failed)
+        // Note: this lock must remain alive until all processed asset and meta writes have finished (or failed)
         // See ProcessedAssetInfo::file_transaction_lock docs for more info
         let _transaction_lock = {
             let mut infos = self.data.asset_infos.write().await;

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -228,7 +228,7 @@ use derive_more::derive::{Display, Error};
 ///
 /// In general, this shouldn't happen often, but when it does the algorithm is simple and predictable:
 /// 1. Use all of the constructors (including default constructors) directly defined in the spawned component's require list
-/// 2. In the order the requires are defined in `#[require()]`, recursively visit the require list of each of the components in the list (this is a depth Depth First Search). When a constructor is found, it will only be used if one has not already been found.
+/// 2. In the order the requires are defined in `#[require()]`, recursively visit the require list of each of the components in the list (this is a Depth First Search). When a constructor is found, it will only be used if one has not already been found.
 ///
 /// From a user perspective, just think about this as the following:
 /// 1. Specifying a required component constructor for Foo directly on a spawned component Bar will result in that constructor being used (and overriding existing constructors lower in the inheritance tree). This is the classic "inheritance override" behavior people expect.

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -19,7 +19,7 @@ impl ReflectMapEntities {
     /// A general method for remapping entities in a reflected value via an [`EntityMapper`].
     ///
     /// # Panics
-    /// Panics if the the type of the reflected value doesn't match.
+    /// Panics if the type of the reflected value doesn't match.
     pub fn map_entities(&self, reflected: &mut dyn PartialReflect, mapper: &mut dyn EntityMapper) {
         (self.map_entities)(reflected, mapper);
     }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1665,7 +1665,7 @@ pub struct EntityEntryCommands<'a, T> {
 }
 
 impl<'a, T: Component> EntityEntryCommands<'a, T> {
-    /// Modify the component `T` if it exists, using the the function `modify`.
+    /// Modify the component `T` if it exists, using the function `modify`.
     pub fn and_modify(&mut self, modify: impl FnOnce(Mut<T>) + Send + Sync + 'static) -> &mut Self {
         self.entity_commands
             .queue(move |mut entity: EntityWorldMut| {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -74,7 +74,7 @@ impl SystemMeta {
         &self.name
     }
 
-    /// Sets the name of of this system.
+    /// Sets the name of this system.
     ///
     /// Useful to give closure systems more readable and unique names for debugging and tracing.
     #[inline]

--- a/crates/bevy_math/src/curve/sample_curves.rs
+++ b/crates/bevy_math/src/curve/sample_curves.rs
@@ -332,10 +332,10 @@ where
 }
 
 impl<T> UnevenSampleAutoCurve<T> {
-    /// Create a new [`UnevenSampleAutoCurve`] from a given set of timed samples, interpolated
-    /// using the  The samples are filtered to finite times and
-    /// sorted internally; if there are not at least 2 valid timed samples, an error will be
-    /// returned.
+    /// Create a new [`UnevenSampleAutoCurve`] from a given set of timed samples.
+    ///
+    /// The samples are filtered to finite times and sorted internally; if there are not
+    /// at least 2 valid timed samples, an error will be returned.
     pub fn new(timed_samples: impl IntoIterator<Item = (f32, T)>) -> Result<Self, UnevenCoreError> {
         Ok(Self {
             core: UnevenCore::new(timed_samples)?,

--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -70,11 +70,11 @@ pub struct Meshlet {
     pub triangle_count: u8,
     /// Unused.
     pub padding: u16,
-    /// Number of bits used to to store the X channel of vertex positions within this meshlet.
+    /// Number of bits used to store the X channel of vertex positions within this meshlet.
     pub bits_per_vertex_position_channel_x: u8,
-    /// Number of bits used to to store the Y channel of vertex positions within this meshlet.
+    /// Number of bits used to store the Y channel of vertex positions within this meshlet.
     pub bits_per_vertex_position_channel_y: u8,
-    /// Number of bits used to to store the Z channel of vertex positions within this meshlet.
+    /// Number of bits used to store the Z channel of vertex positions within this meshlet.
     pub bits_per_vertex_position_channel_z: u8,
     /// Power of 2 factor used to quantize vertex positions within this meshlet.
     pub vertex_position_quantization_factor: u8,

--- a/crates/bevy_pbr/src/meshlet/from_mesh.rs
+++ b/crates/bevy_pbr/src/meshlet/from_mesh.rs
@@ -42,7 +42,7 @@ impl MeshletMesh {
     ///
     /// # Vertex precision
     ///
-    /// `vertex_position_quantization_factor` is the amount of precision to to use when quantizing vertex positions.
+    /// `vertex_position_quantization_factor` is the amount of precision to use when quantizing vertex positions.
     ///
     /// Vertices are snapped to the nearest (1/2^x)th of a centimeter, where x = `vertex_position_quantization_factor`.
     /// E.g. if x = 4, then vertices are snapped to the nearest 1/2^4 = 1/16th of a centimeter.

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -254,7 +254,7 @@ pub struct DragEntry {
 pub struct PointerState {
     /// Stores the press location and start time for each button currently being pressed by the pointer.
     pub pressing: HashMap<Entity, (Location, Instant, HitData)>,
-    /// Stores the the starting and current locations for each entity currently being dragged by the pointer.
+    /// Stores the starting and current locations for each entity currently being dragged by the pointer.
     pub dragging: HashMap<Entity, DragEntry>,
     /// Stores  the hit data for each entity currently being dragged over by the pointer.
     pub dragging_over: HashMap<Entity, HitData>,

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -144,7 +144,7 @@
 //! a pointer hovers or clicks an entity. These simple events are then used to generate more complex
 //! events for dragging and dropping.
 //!
-//! Because it is completely agnostic to the the earlier stages of the pipeline, you can easily
+//! Because it is completely agnostic to the earlier stages of the pipeline, you can easily
 //! extend the plugin with arbitrary backends and input methods, yet still use all the high level
 //! features.
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -964,7 +964,7 @@ mod tests {
         }
     }
 
-    /// These tests just verify that that the [`assert_scene_eq`] function is working properly for our tests.
+    /// These tests just verify that the [`assert_scene_eq`] function is working properly for our tests.
     mod assert_scene_eq_tests {
         use super::*;
 

--- a/crates/bevy_ui/src/render/ui_texture_slice.wgsl
+++ b/crates/bevy_ui/src/render/ui_texture_slice.wgsl
@@ -21,14 +21,14 @@ struct UiVertexOutput {
     // w = distance of the bottom horizontal dividing line
     @location(2) @interpolate(flat) texture_slices: vec4<f32>,
 
-    // Defines the dividing line that are used to split the render target into into corner, side and center slices
+    // Defines the dividing line that are used to split the render target into corner, side and center slices
     // The distances are normalized and from the top left corner of the render target
     // x = distance of left vertical dividing line
     // y = distance of top horizontal dividing line
     // z = distance of right vertical dividing line
     // w = distance of bottom horizontal dividing line
     @location(3) @interpolate(flat) target_slices: vec4<f32>,
-    
+
     // The number of times the side or center texture slices should be repeated when mapping them to the border slices
     // x = number of times to repeat along the horizontal axis for the side textures
     // y = number of times to repeat along the vertical axis for the side textures

--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -28,7 +28,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let slicer = TextureSlicer {
         // `numbered_slices.png` is 48 pixels square. `BorderRect::square(16.)` insets the slicing line from each edge by 16 pixels, resulting in nine slices that are each 16 pixels square.
         border: BorderRect::square(16.),
-        // With `SliceScaleMode::Tile` the side and center slices are tiled to to fill the side and center sections of the target.
+        // With `SliceScaleMode::Tile` the side and center slices are tiled to fill the side and center sections of the target.
         // And with a `stretch_value` of `1.` the tiles will have the same size as the corresponding slices in the source image.
         center_scale_mode: SliceScaleMode::Tile { stretch_value: 1. },
         sides_scale_mode: SliceScaleMode::Tile { stretch_value: 1. },


### PR DESCRIPTION
# Objective

Stumbled upon one of these, and set off in search of more, armed with my trusty `\b(\w+)\s+\1\b`.

## Solution

Remove ~one~ one of them.
