### PR TITLE
Add docs for how to manually add a `WinitPlugin` to a `MinimalPlugins` setup.

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -59,6 +59,9 @@ mod winit_windows;
 ///
 /// The `T` event type can be used to pass custom events to the `winit`'s loop, and handled as events
 /// in systems.
+///
+/// When using eg. `MinimalPlugins` you can add this using `WinitPlugin::<WakeUp>::default()`, where
+/// `WakeUp` is the default `Event` that bevy uses.
 #[derive(Default)]
 pub struct WinitPlugin<T: Event = WakeUp> {
     /// Allows the window (and the event loop) to be created on any thread


### PR DESCRIPTION
# Objective

Adding a `WinitPlugin` to a `MinimalPlugins` setup is a bit tricky and confusing due to having a terrible error message and no examples in the repo.

## Solution

Document what you need to add.