### PR TITLE
Fix `animation_masks` example's buttons

### DIFF
--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -316,6 +316,10 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                                     ..default()
                                 },
                                 BorderColor(Color::WHITE),
+                                AnimationControl {
+                                    group_id: mask_group_id,
+                                    label: *label,
+                                },
                             ))
                             .with_child((
                                 Text(format!("{:?}", label)),
@@ -329,10 +333,6 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
                                     flex_grow: 1.0,
                                     margin: UiRect::vertical(Val::Px(3.0)),
                                     ..default()
-                                },
-                                AnimationControl {
-                                    group_id: mask_group_id,
-                                    label: *label,
                                 },
                             ));
                     }


### PR DESCRIPTION
# Objective

Fixes #15995

## Solution

Corrects a mistake made during the example migration in #15591.

`AnimationControl` was meant to be on the parent, not the child. So the query in `update_ui` was no longer matching.

## Testing

`cargo run --example animation_masks`
