### PR TITLE
Resolve unused_qualifications warnings

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -728,10 +728,7 @@ struct EmptyPathStream;
 impl Stream for EmptyPathStream {
     type Item = PathBuf;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(None)
     }
 }

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -730,7 +730,7 @@ impl Stream for EmptyPathStream {
 
     fn poll_next(
         self: Pin<&mut Self>,
-        _cx: &mut core::task::Context<'_>,
+        _cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         Poll::Ready(None)
     }


### PR DESCRIPTION
# Objective

Fixes the following warning when compiling to wasm.

```
warning: unnecessary qualification
   --> crates\bevy_asset\src\io\mod.rs:733:19
    |
733 |         _cx: &mut core::task::Context<'_>,
    |                   ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-W unused-qualifications`
help: remove the unnecessary path segments
    |
733 -         _cx: &mut core::task::Context<'_>,
733 +         _cx: &mut Context<'_>,
    |
```

## Solution

- Removes the qualification.
