### PR TITLE
Added `PressedButtons` to `PickingInteraction::Pressed`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3772,6 +3772,19 @@ wasm = true
 required-features = ["bevy_sprite_picking_backend"]
 
 [[example]]
+name = "picking_interaction"
+path = "examples/picking/interaction.rs"
+doc-scrape-examples = true
+required-features = ["bevy_sprite_picking_backend"]
+
+[package.metadata.example.picking_interaction]
+name = "Picking Interaction"
+description = "Demonstrates how to use the PickingInteraction component without events or observers."
+category = "Picking"
+wasm = true
+required-features = ["bevy_sprite_picking_backend"]
+
+[[example]]
 name = "animation_masks"
 path = "examples/animation/animation_masks.rs"
 doc-scrape-examples = true

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -29,6 +29,7 @@ bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
 crossbeam-channel = { version = "0.5", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
+bitflags = { version = "2.3", features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_picking/src/focus.rs
+++ b/crates/bevy_picking/src/focus.rs
@@ -5,6 +5,7 @@
 
 use alloc::collections::BTreeMap;
 use core::fmt::Debug;
+use core::ops::BitOrAssign;
 use std::collections::HashSet;
 
 use crate::{
@@ -190,14 +191,64 @@ fn build_hover_map(
 /// it will be considered hovered.
 #[derive(Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq, Debug)]
+#[repr(u8)]
 pub enum PickingInteraction {
     /// The entity is being pressed down by a pointer.
-    Pressed = 2,
+    Pressed(PressedButtons) = 2,
     /// The entity is being hovered by a pointer.
     Hovered = 1,
     /// No pointers are interacting with this entity.
     #[default]
     None = 0,
+}
+
+impl BitOrAssign for PickingInteraction {
+    fn bitor_assign(&mut self, rhs: Self) {
+        use PickingInteraction::*;
+        match (self, rhs) {
+            (Pressed(a), Pressed(b)) => *a |= b,
+            (Pressed(_), _) => (),
+            (a, Pressed(b)) => *a = Pressed(b),
+            (a @ None, Hovered) => *a = Hovered,
+            _ => (),
+        }
+    }
+}
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    #[derive(Hash, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    #[reflect(opaque)]
+    #[reflect(Hash, PartialEq, Debug)]
+    /// Button pressed in a [`PickingInteraction`]
+    pub struct PressedButtons: u8 {
+        /// Primary mouse button is pressed.
+        const PRIMARY = 1;
+        /// Secondary mouse button is pressed.
+        const SECONDARY = 2;
+        /// Middle mouse button is pressed.
+        const MIDDLE = 4;
+        /// Touch input is pressed.
+        const TOUCH = 8;
+        /// Custom input is pressed.
+        const CUSTOM = 16;
+    }
+}
+
+impl From<PointerPress> for PressedButtons {
+    fn from(value: PointerPress) -> Self {
+        let mut result = PressedButtons::empty();
+        if value.is_primary_pressed() {
+            result |= PressedButtons::PRIMARY;
+        }
+        if value.is_secondary_pressed() {
+            result |= PressedButtons::SECONDARY;
+        }
+        if value.is_middle_pressed() {
+            result |= PressedButtons::MIDDLE;
+        }
+        result
+    }
 }
 
 /// Uses pointer events to update [`PointerInteraction`] and [`PickingInteraction`] components.
@@ -235,7 +286,12 @@ pub fn update_interactions(
             pointer_interaction.sorted_entities = sorted_entities;
 
             for hovered_entity in pointers_hovered_entities.iter().map(|(entity, _)| entity) {
-                merge_interaction_states(pointer_press, hovered_entity, &mut new_interaction_state);
+                merge_interaction_states(
+                    pointer,
+                    pointer_press,
+                    hovered_entity,
+                    &mut new_interaction_state,
+                );
             }
         }
     }
@@ -252,28 +308,22 @@ pub fn update_interactions(
 
 /// Merge the interaction state of this entity into the aggregated map.
 fn merge_interaction_states(
+    id: &PointerId,
     pointer_press: &PointerPress,
     hovered_entity: &Entity,
     new_interaction_state: &mut HashMap<Entity, PickingInteraction>,
 ) {
-    let new_interaction = match pointer_press.is_any_pressed() {
-        true => PickingInteraction::Pressed,
-        false => PickingInteraction::Hovered,
-    };
-
-    if let Some(old_interaction) = new_interaction_state.get_mut(hovered_entity) {
-        // Only update if the new value has a higher precedence than the old value.
-        if *old_interaction != new_interaction
-            && matches!(
-                (*old_interaction, new_interaction),
-                (PickingInteraction::Hovered, PickingInteraction::Pressed)
-                    | (PickingInteraction::None, PickingInteraction::Pressed)
-                    | (PickingInteraction::None, PickingInteraction::Hovered)
-            )
-        {
-            *old_interaction = new_interaction;
-        }
+    let new_interaction = if !pointer_press.is_any_pressed() {
+        PickingInteraction::Hovered
     } else {
-        new_interaction_state.insert(*hovered_entity, new_interaction);
-    }
+        match id {
+            PointerId::Mouse => PickingInteraction::Pressed((*pointer_press).into()),
+            PointerId::Touch(_) => PickingInteraction::Pressed(PressedButtons::TOUCH),
+            PointerId::Custom(_) => PickingInteraction::Pressed(PressedButtons::CUSTOM),
+        }
+    };
+    new_interaction_state
+        .entry(*hovered_entity)
+        .and_modify(|old| *old |= new_interaction)
+        .or_insert(new_interaction);
 }

--- a/crates/bevy_picking/src/focus.rs
+++ b/crates/bevy_picking/src/focus.rs
@@ -5,7 +5,7 @@
 
 use alloc::collections::BTreeMap;
 use core::fmt::Debug;
-use core::ops::BitOrAssign;
+use core::ops::{BitOr, BitOrAssign};
 use std::collections::HashSet;
 
 use crate::{
@@ -202,6 +202,15 @@ pub enum PickingInteraction {
     None = 0,
 }
 
+impl BitOr for PickingInteraction {
+    type Output = Self;
+
+    fn bitor(mut self, rhs: Self) -> PickingInteraction {
+        self |= rhs;
+        self
+    }
+}
+
 impl BitOrAssign for PickingInteraction {
     fn bitor_assign(&mut self, rhs: Self) {
         use PickingInteraction::*;
@@ -326,4 +335,37 @@ fn merge_interaction_states(
         .entry(*hovered_entity)
         .and_modify(|old| *old |= new_interaction)
         .or_insert(new_interaction);
+}
+
+#[cfg(test)]
+mod test {
+    use crate::focus::{PickingInteraction::*, PressedButtons};
+
+    #[test]
+    fn merge_interaction() {
+        assert_eq!(
+            Pressed(PressedButtons::PRIMARY) | Pressed(PressedButtons::SECONDARY),
+            Pressed(PressedButtons::PRIMARY | PressedButtons::SECONDARY)
+        );
+        assert_eq!(
+            Pressed(PressedButtons::PRIMARY) | Hovered,
+            Pressed(PressedButtons::PRIMARY)
+        );
+        assert_eq!(
+            Hovered | Pressed(PressedButtons::PRIMARY),
+            Pressed(PressedButtons::PRIMARY)
+        );
+        assert_eq!(
+            Pressed(PressedButtons::PRIMARY) | None,
+            Pressed(PressedButtons::PRIMARY)
+        );
+        assert_eq!(
+            None | Pressed(PressedButtons::PRIMARY),
+            Pressed(PressedButtons::PRIMARY)
+        );
+        assert_eq!(Hovered | None, Hovered);
+        assert_eq!(None | Hovered, Hovered);
+        assert_eq!(Hovered | Hovered, Hovered);
+        assert_eq!(None | None, None);
+    }
 }

--- a/crates/bevy_picking/src/focus.rs
+++ b/crates/bevy_picking/src/focus.rs
@@ -231,16 +231,22 @@ bitflags::bitflags! {
     #[reflect(Hash, PartialEq, Debug)]
     /// Button pressed in a [`PickingInteraction`]
     pub struct PressedButtons: u8 {
-        /// Primary mouse button is pressed.
-        const PRIMARY = 1;
-        /// Secondary mouse button is pressed.
-        const SECONDARY = 2;
+        /// Left mouse button is pressed.
+        const LEFT = 1;
+        /// Right mouse button is pressed.
+        const RIGHT = 2;
         /// Middle mouse button is pressed.
         const MIDDLE = 4;
         /// Touch input is pressed.
         const TOUCH = 8;
         /// Custom input is pressed.
         const CUSTOM = 16;
+        /// X1 or back, reserved, currently does nothing.
+        const X1 = 32;
+        /// X2 or forward, reserved, currently does nothing.
+        const X2 = 64;
+        /// Left mouse button or touch input is pressed.
+        const LEFT_OR_TOUCH = 1|8;
     }
 }
 
@@ -248,10 +254,10 @@ impl From<PointerPress> for PressedButtons {
     fn from(value: PointerPress) -> Self {
         let mut result = PressedButtons::empty();
         if value.is_primary_pressed() {
-            result |= PressedButtons::PRIMARY;
+            result |= PressedButtons::LEFT;
         }
         if value.is_secondary_pressed() {
-            result |= PressedButtons::SECONDARY;
+            result |= PressedButtons::RIGHT;
         }
         if value.is_middle_pressed() {
             result |= PressedButtons::MIDDLE;
@@ -344,24 +350,24 @@ mod test {
     #[test]
     fn merge_interaction() {
         assert_eq!(
-            Pressed(PressedButtons::PRIMARY) | Pressed(PressedButtons::SECONDARY),
-            Pressed(PressedButtons::PRIMARY | PressedButtons::SECONDARY)
+            Pressed(PressedButtons::LEFT) | Pressed(PressedButtons::RIGHT),
+            Pressed(PressedButtons::LEFT | PressedButtons::RIGHT)
         );
         assert_eq!(
-            Pressed(PressedButtons::PRIMARY) | Hovered,
-            Pressed(PressedButtons::PRIMARY)
+            Pressed(PressedButtons::LEFT) | Hovered,
+            Pressed(PressedButtons::LEFT)
         );
         assert_eq!(
-            Hovered | Pressed(PressedButtons::PRIMARY),
-            Pressed(PressedButtons::PRIMARY)
+            Hovered | Pressed(PressedButtons::LEFT),
+            Pressed(PressedButtons::LEFT)
         );
         assert_eq!(
-            Pressed(PressedButtons::PRIMARY) | None,
-            Pressed(PressedButtons::PRIMARY)
+            Pressed(PressedButtons::LEFT) | None,
+            Pressed(PressedButtons::LEFT)
         );
         assert_eq!(
-            None | Pressed(PressedButtons::PRIMARY),
-            Pressed(PressedButtons::PRIMARY)
+            None | Pressed(PressedButtons::LEFT),
+            Pressed(PressedButtons::LEFT)
         );
         assert_eq!(Hovered | None, Hovered);
         assert_eq!(None | Hovered, Hovered);

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -108,7 +108,7 @@ pub fn update_pointer_map(pointers: Query<(Entity, &PointerId)>, mut map: ResMut
 }
 
 /// Tracks the state of the pointer's buttons in response to [`PointerInput`] events.
-#[derive(Debug, Default, Clone, Component, Reflect, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Component, Reflect, PartialEq, Eq)]
 #[reflect(Component, Default, Debug, PartialEq)]
 pub struct PointerPress {
     primary: bool,

--- a/examples/README.md
+++ b/examples/README.md
@@ -377,6 +377,7 @@ Example | Description
 Example | Description
 --- | ---
 [Mesh Picking](../examples/picking/mesh_picking.rs) | Demonstrates picking meshes
+[Picking Interaction](../examples/picking/interaction.rs) | Demonstrates how to use the PickingInteraction component without events or observers.
 [Showcases simple picking events and usage](../examples/picking/simple_picking.rs) | Demonstrates how to use picking events to spawn simple objects
 [Sprite Picking](../examples/picking/sprite_picking.rs) | Demonstrates picking sprites and sprite atlases
 

--- a/examples/picking/interaction.rs
+++ b/examples/picking/interaction.rs
@@ -13,6 +13,7 @@ fn main() {
         .run();
 }
 
+// Move the sprite for variety.
 fn move_sprite(time: Res<Time>, mut sprite: Query<&mut Transform, With<Sprite>>) {
     let t = time.elapsed_secs() * 0.1;
     for mut transform in &mut sprite {
@@ -25,25 +26,30 @@ fn move_sprite(time: Res<Time>, mut sprite: Query<&mut Transform, With<Sprite>>)
     }
 }
 
+// Display the current picking state.
 fn picking(sprite: Query<(&PickingInteraction, &Children)>, mut text: Query<&mut Text2d>) {
     for (interaction, children) in sprite.iter() {
         let mut iter = text.iter_many_mut(children);
         while let Some(mut text) = iter.fetch_next() {
             match interaction {
-                PickingInteraction::Pressed(pressed_buttons) => {
-                    if pressed_buttons.contains(PressedButtons::PRIMARY) {
-                        text.0 = "Left Clicked!".into();
-                    } else if pressed_buttons.contains(PressedButtons::SECONDARY) {
-                        text.0 = "Right Clicked!".into();
-                    } else if pressed_buttons.contains(PressedButtons::MIDDLE) {
-                        text.0 = "Middle Clicked!".into();
-                    } else if pressed_buttons.contains(PressedButtons::TOUCH) {
-                        text.0 = "Touched!".into();
-                    } else {
-                        text.0 = "Clicked!".into();
-                    }
+                PickingInteraction::Pressed(pressed_buttons)
+                    if pressed_buttons.contains(PressedButtons::PRIMARY) =>
+                {
+                    text.0 = "Left Clicked!".into();
                 }
-                PickingInteraction::Hovered => {
+                PickingInteraction::Pressed(pressed_buttons)
+                    if pressed_buttons.contains(PressedButtons::SECONDARY) =>
+                {
+                    text.0 = "Right Clicked!".into();
+                }
+                PickingInteraction::Pressed(pressed_buttons)
+                    if pressed_buttons.contains(PressedButtons::TOUCH) =>
+                {
+                    text.0 = "Touched!".into();
+                }
+                // We choose to ignore other mouse buttons like MMB,
+                // in this pattern we treat them as hover.
+                PickingInteraction::Hovered | PickingInteraction::Pressed(..) => {
                     text.0 = "Hovered!".into();
                 }
                 PickingInteraction::None => {
@@ -54,7 +60,7 @@ fn picking(sprite: Query<(&PickingInteraction, &Children)>, mut text: Query<&mut
     }
 }
 
-/// Set up a scene that tests all sprite anchor types.
+/// Set up the scene.
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 

--- a/examples/picking/interaction.rs
+++ b/examples/picking/interaction.rs
@@ -1,5 +1,4 @@
-//! Demonstrates picking for sprites and sprite atlases. The picking backend only tests against the
-//! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
+//! Demonstrates how to use `PickingInteraction` without using events and observers.
 
 use bevy::{
     picking::focus::{PickingInteraction, PressedButtons},

--- a/examples/picking/interaction.rs
+++ b/examples/picking/interaction.rs
@@ -1,0 +1,74 @@
+//! Demonstrates picking for sprites and sprite atlases. The picking backend only tests against the
+//! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
+
+use bevy::{
+    picking::focus::{PickingInteraction, PressedButtons},
+    prelude::*,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (move_sprite, picking))
+        .run();
+}
+
+fn move_sprite(time: Res<Time>, mut sprite: Query<&mut Transform, With<Sprite>>) {
+    let t = time.elapsed_secs() * 0.1;
+    for mut transform in &mut sprite {
+        let new = Vec2 {
+            x: 50.0 * ops::sin(t),
+            y: 50.0 * ops::sin(t * 2.0),
+        };
+        transform.translation.x = new.x;
+        transform.translation.y = new.y;
+    }
+}
+
+fn picking(sprite: Query<(&PickingInteraction, &Children)>, mut text: Query<&mut Text2d>) {
+    for (interaction, children) in sprite.iter() {
+        let mut iter = text.iter_many_mut(children);
+        while let Some(mut text) = iter.fetch_next() {
+            match interaction {
+                PickingInteraction::Pressed(pressed_buttons) => {
+                    if pressed_buttons.contains(PressedButtons::PRIMARY) {
+                        text.0 = "Left Clicked!".into();
+                    } else if pressed_buttons.contains(PressedButtons::SECONDARY) {
+                        text.0 = "Right Clicked!".into();
+                    } else if pressed_buttons.contains(PressedButtons::MIDDLE) {
+                        text.0 = "Middle Clicked!".into();
+                    } else if pressed_buttons.contains(PressedButtons::TOUCH) {
+                        text.0 = "Touched!".into();
+                    } else {
+                        text.0 = "Clicked!".into();
+                    }
+                }
+                PickingInteraction::Hovered => {
+                    text.0 = "Hovered!".into();
+                }
+                PickingInteraction::None => {
+                    text.0 = "Hover Me!".into();
+                }
+            }
+        }
+    }
+}
+
+/// Set up a scene that tests all sprite anchor types.
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    commands
+        .spawn((
+            Sprite {
+                custom_size: Some(Vec2::new(200., 50.)),
+                color: Color::BLACK,
+                ..Default::default()
+            },
+            PickingInteraction::None,
+        ))
+        .with_children(|s| {
+            s.spawn((Text2d::new("Hover Me!"), Transform::from_xyz(0., 0., 1.)));
+        });
+}

--- a/examples/picking/interaction.rs
+++ b/examples/picking/interaction.rs
@@ -33,12 +33,12 @@ fn picking(sprite: Query<(&PickingInteraction, &Children)>, mut text: Query<&mut
         while let Some(mut text) = iter.fetch_next() {
             match interaction {
                 PickingInteraction::Pressed(pressed_buttons)
-                    if pressed_buttons.contains(PressedButtons::PRIMARY) =>
+                    if pressed_buttons.contains(PressedButtons::LEFT) =>
                 {
                     text.0 = "Left Clicked!".into();
                 }
                 PickingInteraction::Pressed(pressed_buttons)
-                    if pressed_buttons.contains(PressedButtons::SECONDARY) =>
+                    if pressed_buttons.contains(PressedButtons::RIGHT) =>
                 {
                     text.0 = "Right Clicked!".into();
                 }


### PR DESCRIPTION
# Objective

Fixes #15983. `PickingInteraction` is preferable to events in some use cases for code organization. This PR adds the keys pressed to `PickingInteraction::Pressed`, allowing the user to ignore certain keys like the RMB in such use cases.

## Solution

- Added field `PressedButtons` to `PickingInteraction::Pressed`.

## Testing

* Added a test for merging `PickingInteraction`s.
* Added an example for `PickingInteraction`.

## Migration Guide

`PickingInteraction::Pressed` now has a field, code matching against it should use `matches!(interaction, PickingInteraction::Pressed(..))` instead.
