### PR TITLE
Support prefers_home_indicator_hidden

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -388,6 +388,16 @@ pub struct Window {
     ///
     /// [`WindowAttributesExtMacOS::with_titlebar_buttons_hidden`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/macos/trait.WindowAttributesExtMacOS.html#tymethod.with_titlebar_buttons_hidden
     pub titlebar_show_buttons: bool,
+    /// Sets whether the Window prefers the home indicator hidden.
+    ///
+    /// Corresponds to [`WindowAttributesExtIOS::with_prefers_home_indicator_hidden`].
+    ///
+    /// # Platform-specific
+    ///
+    /// - Only used on iOS.
+    ///
+    /// [`WindowAttributesExtIOS::with_prefers_home_indicator_hidden`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/ios/trait.WindowAttributesExtIOS.html#tymethod.with_prefers_home_indicator_hidden
+    pub prefers_home_indicator_hidden: bool,
 }
 
 impl Default for Window {
@@ -429,6 +439,7 @@ impl Default for Window {
             titlebar_transparent: false,
             titlebar_show_title: true,
             titlebar_show_buttons: true,
+            prefers_home_indicator_hidden: false,
         }
     }
 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -140,6 +140,13 @@ impl WinitWindows {
                 .with_titlebar_buttons_hidden(!window.titlebar_show_buttons);
         }
 
+        #[cfg(target_os = "ios")]
+        {
+            use winit::platform::ios::WindowAttributesExtIOS;
+            winit_window_attributes = winit_window_attributes
+                .with_prefers_home_indicator_hidden(window.prefers_home_indicator_hidden);
+        }
+
         let display_info = DisplayInfo {
             window_physical_resolution: (
                 window.resolution.physical_width(),

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -27,6 +27,7 @@ fn main() {
                     // on iOS, gestures must be enabled.
                     // This doesn't work on Android
                     recognize_rotation_gesture: true,
+                    prefers_home_indicator_hidden: true,
                     ..default()
                 }),
                 ..default()

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -27,6 +27,7 @@ fn main() {
                     // on iOS, gestures must be enabled.
                     // This doesn't work on Android
                     recognize_rotation_gesture: true,
+                    // Only has an effect on iOS
                     prefers_home_indicator_hidden: true,
                     ..default()
                 }),


### PR DESCRIPTION
# Objective

- Fixes #15757 

## Solution

- Add the platform specific property `prefers_home_indicator_hidden` to bevy's Window configuration, and applying it by invoking `with_prefers_home_indicator_hidden` in `winit`.

## Testing

- I have tested the `bevy_mobile_example` on the iOS platform.

## Showcase
- Currently, the `prefers_home_indicator_hidden` is enabled in the bevy_mobile_example demo. You can test it with an iOS device. The home indicator will disappear after several seconds of inactivity in the bottom areas. 
