### PR TITLE
fix: add reflect to `SceneInstanceReady` and other observers/events

### DIFF
--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -1,5 +1,6 @@
 use crate::{Asset, AssetId, AssetLoadError, AssetPath, UntypedAssetId};
 use bevy_ecs::event::Event;
+use bevy_reflect::Reflect;
 use core::fmt::Debug;
 
 /// An event emitted when a specific [`Asset`] fails to load.
@@ -42,7 +43,7 @@ impl<A: Asset> From<&AssetLoadFailedEvent<A>> for UntypedAssetLoadFailedEvent {
 }
 
 /// Events that occur for a specific loaded [`Asset`], such as "value changed" events and "dependency" events.
-#[derive(Event)]
+#[derive(Event, Reflect)]
 pub enum AssetEvent<A: Asset> {
     /// Emitted whenever an [`Asset`] is added.
     Added { id: AssetId<A> },

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -13,6 +13,8 @@ use crate::{
 
 use derive_more::derive::Into;
 
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
 use core::{
     fmt::Debug,
     iter,
@@ -24,6 +26,8 @@ use core::{
 /// Wrapper around [`Entity`] for [`RemovedComponents`].
 /// Internally, `RemovedComponents` uses these as an `Events<RemovedComponentEntity>`.
 #[derive(Event, Debug, Clone, Into)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct RemovedComponentEntity(Entity);
 
 /// Wrapper around a [`EventCursor<RemovedComponentEntity>`] so that we

--- a/crates/bevy_hierarchy/src/events.rs
+++ b/crates/bevy_hierarchy/src/events.rs
@@ -1,9 +1,11 @@
 use bevy_ecs::{event::Event, prelude::Entity};
+use bevy_reflect::Reflect;
 
 /// An [`Event`] that is fired whenever there is a change in the world's hierarchy.
 ///
 /// [`Event`]: bevy_ecs::event::Event
 #[derive(Event, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Debug, PartialEq))]
 pub enum HierarchyEvent {
     /// Fired whenever an [`Entity`] is added as a child to a parent.
     ChildAdded {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1494,6 +1494,7 @@ pub fn gamepad_event_processing_system(
 
 /// The intensity at which a gamepad's force-feedback motors may rumble.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
 pub struct GamepadRumbleIntensity {
     /// The rumble intensity of the strong gamepad motor.
     ///
@@ -1581,6 +1582,7 @@ impl GamepadRumbleIntensity {
 #[doc(alias = "vibration")]
 #[doc(alias = "vibrate")]
 #[derive(Event, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub enum GamepadRumbleRequest {
     /// Add a rumble to the given gamepad.
     ///

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -56,7 +56,8 @@ pub mod prelude {
 /// Note that systems reading these events in [`PreUpdate`](bevy_app) will not report ordering
 /// ambiguities with picking backends. Take care to ensure such systems are explicitly ordered
 /// against [`PickSet::Backends`](crate), or better, avoid reading `PointerHits` in `PreUpdate`.
-#[derive(Event, Debug, Clone)]
+#[derive(Event, Debug, Clone, Reflect)]
+#[reflect(Debug)]
 pub struct PointerHits {
     /// The pointer associated with this hit test.
     pub pointer: prelude::PointerId,

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
     world::{Command, Mut, World},
 };
 use bevy_hierarchy::{AddChild, BuildChildren, DespawnRecursiveExt, Parent};
+use bevy_reflect::Reflect;
 use bevy_utils::{HashMap, HashSet};
 use derive_more::derive::{Display, Error};
 use uuid::Uuid;
@@ -17,7 +18,8 @@ use uuid::Uuid;
 /// See also [`Trigger`], [`SceneSpawner::instance_is_ready`].
 ///
 /// [`Trigger`]: bevy_ecs::observer::Trigger
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Event)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Event, Reflect)]
+#[reflect(Debug, PartialEq)]
 pub struct SceneInstanceReady {
     /// Instance which has been spawned.
     pub instance_id: InstanceId,
@@ -31,7 +33,8 @@ pub struct InstanceInfo {
 }
 
 /// Unique id identifying a scene instance.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Reflect)]
+#[reflect(Debug, PartialEq, Hash)]
 pub struct InstanceId(Uuid);
 
 impl InstanceId {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -15,6 +15,8 @@
 extern crate alloc;
 
 use bevy_derive::Deref;
+use bevy_reflect::prelude::ReflectDefault;
+use bevy_reflect::Reflect;
 use bevy_window::{RawHandleWrapperHolder, WindowEvent};
 use core::marker::PhantomData;
 use winit::event_loop::EventLoop;
@@ -149,7 +151,8 @@ impl<T: Event> Plugin for WinitPlugin<T> {
 
 /// The default event that can be used to wake the window loop
 /// Wakes up the loop if in wait state
-#[derive(Debug, Default, Clone, Copy, Event)]
+#[derive(Debug, Default, Clone, Copy, Event, Reflect)]
+#[reflect(Debug, Default)]
 pub struct WakeUp;
 
 /// A wrapper type around [`winit::event_loop::EventLoopProxy`] with the specific


### PR DESCRIPTION
# Objective

Built-in observers & events should be `Reflect` so that components that interact with them can be serialized in scenes. This is a similar pr to #14259.