### PR TITLE
Feature gate `bevy_remote` http transport.

### DIFF
--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 readme = "README.md"
 
+[features]
+default = ["http"]
+http = ["dep:async-io", "dep:smol-hyper"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.15.0-dev" }
@@ -31,8 +35,8 @@ async-channel = "2"
 
 # dependencies that will not compile on wasm
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-async-io = "2"
-smol-hyper = "0.1"
+async-io = { version = "2", optional = true }
+smol-hyper = { version = "0.1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -315,6 +315,7 @@ use serde_json::Value;
 use std::sync::RwLock;
 
 pub mod builtin_methods;
+#[cfg(feature = "http")]
 pub mod http;
 
 const CHANNEL_SIZE: usize = 16;


### PR DESCRIPTION
## Objective
Be able to depend on the crate for the types without bringing in `smol-hyper` and other http dependencies.

## Solution

Create a new `HTTP` feature that is enabled by default.