### PR TITLE
upgrade image crate to v0.25.4

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -44,7 +44,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # rendering
-image = { version = "0.25.2", default-features = false }
+image = { version = "0.25.4", default-features = false }
 
 # misc
 bitflags = { version = "2.3", features = ["serde"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -59,7 +59,7 @@ bevy_image = { path = "../bevy_image", version = "0.15.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.15.0-dev" }
 
 # rendering
-image = { version = "0.25.2", default-features = false }
+image = { version = "0.25.4", default-features = false }
 
 # misc
 codespan-reporting = "0.11.0"


### PR DESCRIPTION

Objective

    Keep image crate update to date.

    image v0.25.4 brings some improvements on webp decoding and fast blur.It also contains some bug fixes.

    It maybe a good idea to keep Image crate up to date for new release.

Solution

    Upgrade image to v0.25.4

Testing

    I've run some 2d/3d examples and all looks good. 

Breaking changes

    No breaking changes :)
