### PR TITLE
Add .contains_aabb for Frustum

### DIFF
--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -556,7 +556,7 @@ mod tests {
         let half_extent_world = (((49.5 * 49.5) * 0.5) as f32).sqrt() + 0.5f32.sqrt();
         let near = 50.5 - half_extent_world;
         let far = near + 2.0 * half_extent_world;
-        let fov = 2.0f32 * ops::atan(half_extent_world / near);
+        let fov = 2.0 * ops::atan(half_extent_world / near);
         let proj = PerspectiveProjection {
             aspect_ratio: 1.0,
             near,

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -108,7 +108,7 @@ impl Aabb {
         // transform the half-extents into world space.
         let half_extents_world = world_from_local.matrix3.abs() * self.half_extents.abs();
         // collapse the half-extents onto the plane normal.
-        let r = (world_from_local.matrix3 * self.half_extents).dot(p_normal.abs());
+        let r = half_extents_world.dot(p_normal.abs());
         let aabb_center_world = world_from_local.transform_point3a(self.center);
         let signed_distance = p_normal.dot(aabb_center_world) + p_distance;
         signed_distance > r

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -107,9 +107,7 @@ impl Aabb {
     ) -> bool {
         let aabb_center_world = world_from_local.transform_point3a(self.center);
         let half_extents_world = world_from_local.matrix3.abs() * self.half_extents.abs();
-        let r = half_extents_x_world * p_normal.x.abs()
-            + half_extents_y_world * p_normal.y.abs()
-            + half_extents_z_world * p_normal.z.abs();
+        let r = (world_from_local.matrix3 * self.half_extents).dot(p_normal.abs())
         let signed_distance = p_normal.dot(aabb_center_world) + p_distance;
         signed_distance > r
     }

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -105,9 +105,11 @@ impl Aabb {
         p_distance: f32,
         world_from_local: &Affine3A,
     ) -> bool {
-        let aabb_center_world = world_from_local.transform_point3a(self.center);
+        // transform the half-extents into world space.
         let half_extents_world = world_from_local.matrix3.abs() * self.half_extents.abs();
-        let r = (world_from_local.matrix3 * self.half_extents).dot(p_normal.abs())
+        // collapse the half-extents onto the plane normal.
+        let r = (world_from_local.matrix3 * self.half_extents).dot(p_normal.abs());
+        let aabb_center_world = world_from_local.transform_point3a(self.center);
         let signed_distance = p_normal.dot(aabb_center_world) + p_distance;
         signed_distance > r
     }

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -318,7 +318,7 @@ impl Frustum {
     #[inline]
     pub fn contains_aabb(&self, aabb: &Aabb, world_from_local: &Affine3A) -> bool {
         for half_space in &self.half_spaces {
-            if !aabb.is_in_half_space(&half_space, world_from_local) {
+            if !aabb.is_in_half_space(half_space, world_from_local) {
                 return false;
             }
         }

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -96,7 +96,7 @@ impl Aabb {
         self.center + self.half_extents
     }
 
-    /// Check if the point is at the front side of the plane.
+    /// Check if the AABB is at the front side of the plane.
     /// Referenced from: [AABB Plane intersection](https://gdbooks.gitbooks.io/3dcollisions/content/Chapter2/static_aabb_plane.html)
     #[inline]
     pub fn is_forward_plane(

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -356,9 +356,9 @@ pub struct CascadesFrusta {
 
 #[cfg(test)]
 mod tests {
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
-    use bevy_math::{ops, Quat, VectorSpace};
+    use bevy_math::{ops, Quat};
     use bevy_transform::components::GlobalTransform;
 
     use crate::camera::{CameraProjection, PerspectiveProjection};

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -106,18 +106,7 @@ impl Aabb {
         world_from_local: &Affine3A,
     ) -> bool {
         let aabb_center_world = world_from_local.transform_point3a(self.center);
-        let bb_axis_x_world = world_from_local.x_axis * self.half_extents.x;
-        let bb_axis_y_world = world_from_local.y_axis * self.half_extents.y;
-        let bb_axis_z_world = world_from_local.z_axis * self.half_extents.z;
-        let half_extents_x_world = bb_axis_x_world.dot(Vec3A::X).abs()
-            + bb_axis_y_world.dot(Vec3A::X).abs()
-            + bb_axis_z_world.dot(Vec3A::X).abs();
-        let half_extents_y_world = bb_axis_x_world.dot(Vec3A::Y).abs()
-            + bb_axis_y_world.dot(Vec3A::Y).abs()
-            + bb_axis_z_world.dot(Vec3A::Y).abs();
-        let half_extents_z_world = bb_axis_x_world.dot(Vec3A::Z).abs()
-            + bb_axis_y_world.dot(Vec3A::Z).abs()
-            + bb_axis_z_world.dot(Vec3A::Z).abs();
+        let half_extents_world = world_from_local.matrix3.abs() * self.half_extents.abs();
         let r = half_extents_x_world * p_normal.x.abs()
             + half_extents_y_world * p_normal.y.abs()
             + half_extents_z_world * p_normal.z.abs();

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -96,7 +96,7 @@ impl Aabb {
         self.center + self.half_extents
     }
 
-    /// Check if the AABB is at the front side of the plane.
+    /// Check if the AABB is at the front side of the bisecting plane.
     /// Referenced from: [AABB Plane intersection](https://gdbooks.gitbooks.io/3dcollisions/content/Chapter2/static_aabb_plane.html)
     #[inline]
     pub fn is_in_half_space(&self, half_space: &HalfSpace, world_from_local: &Affine3A) -> bool {


### PR DESCRIPTION
# Objective

- Fixes: #15663

## Solution

- Add an `is_forward_plane` method to `Aabb`, and a `contains_aabb` method to `Frustum`.

## Test
- I have created a frustum with an offset along with three unit tests to evaluate the `contains_aabb` algorithm.

## Explanation for the Test Cases
- To facilitate the code review, I will explain how the frustum is created. Initially, we create a frustum without any offset and then create a cuboid that is just contained within it.

<img width="714" alt="image" src="https://github.com/user-attachments/assets/a9ac53a2-f8a3-4e09-b20b-4ee71b27a099">

- Secondly, we move the cuboid by 2 units along both the x-axis and the y-axis to make it more general.


## Reference
- [Frustum Culling](https://learnopengl.com/Guest-Articles/2021/Scene/Frustum-Culling#)
- [AABB Plane intersection](https://gdbooks.gitbooks.io/3dcollisions/content/Chapter2/static_aabb_plane.html)