### PR TITLE
Indices::extend

### DIFF
--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -847,20 +847,7 @@ impl Mesh {
 
         // Extend indices of `self` with indices of `other`.
         if let (Some(indices), Some(other_indices)) = (self.indices_mut(), other.indices()) {
-            match (indices, other_indices) {
-                (Indices::U16(i1), Indices::U16(i2)) => {
-                    i1.extend(i2.iter().map(|i| *i + index_offset as u16));
-                }
-                (Indices::U32(i1), Indices::U32(i2)) => {
-                    i1.extend(i2.iter().map(|i| *i + index_offset as u32));
-                }
-                (Indices::U16(i1), Indices::U32(i2)) => {
-                    i1.extend(i2.iter().map(|i| *i as u16 + index_offset as u16));
-                }
-                (Indices::U32(i1), Indices::U16(i2)) => {
-                    i1.extend(i2.iter().map(|i| *i as u32 + index_offset as u32));
-                }
-            }
+            indices.extend(other_indices.iter().map(|i| (i + index_offset) as u32));
         }
     }
 


### PR DESCRIPTION
# Objective

There's integer overflow in `Mesh::merge` in branches like this:

https://github.com/bevyengine/bevy/blob/405fa3e8ea1d8ff23f0590a18242667e2b21e2d9/crates/bevy_mesh/src/mesh.rs#L857-L859

we truncate `u32` to `u16` and ignore integer overflow on `u16`. This may lead to unexpected results when the number of vertices exceeds `u16::MAX`.

## Solution

Convert indices storage to `u32` when necessary.

## Testing

- Unit test added for `extend` function
- For changes in `Mesh`, I presume it is already tested elsewhere