### PR TITLE
Mesh::merge: count_vertices instead of initializing positions

### DIFF
--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -798,10 +798,7 @@ impl Mesh {
         use VertexAttributeValues::*;
 
         // The indices of `other` should start after the last vertex of `self`.
-        let index_offset = self
-            .attribute(Mesh::ATTRIBUTE_POSITION)
-            .get_or_insert(&Float32x3(Vec::default()))
-            .len();
+        let index_offset = self.count_vertices();
 
         // Extend attributes of `self` with attributes of `other`.
         for (attribute, values) in self.attributes_mut() {


### PR DESCRIPTION
# Objective

When merging two meshes, we need to find the offset of indices for the second mesh. Currently it is done by inserting empty positions if positions is not set.

Although practically it is not an issue, this does not feel right:
- We did not have positions before, then why we have positions after merge?
- Moreover, if positions are not set, but uvs are not empty, computed offset will be zero, while it should be equal to the number of uvs.

## Solution

Use `Mesh::count_vertices` to find the number of vertices.

## Testing

Looking hard.