### PR TITLE
Add `AsyncSeekForwardExt` trait to allows a similar API to the previous Bevy version

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -23,6 +23,7 @@ pub use source::*;
 
 use alloc::sync::Arc;
 use bevy_utils::{BoxedFuture, ConditionalSendFuture};
+use core::future::Future;
 use core::{
     mem::size_of,
     pin::Pin,
@@ -31,10 +32,7 @@ use core::{
 use derive_more::derive::{Display, Error, From};
 use futures_io::{AsyncRead, AsyncWrite};
 use futures_lite::{ready, Stream};
-use std::{
-    future::Future,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 /// Errors that occur while loading assets.
 #[derive(Error, Display, Debug, Clone)]

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -121,7 +121,9 @@ impl<T: ?Sized + AsyncSeekForward + Unpin> AsyncSeekForward for Box<T> {
     }
 }
 
+/// Extension trait for [`AsyncSeekForward`].
 pub trait AsyncSeekForwardExt: AsyncSeekForward {
+    /// Seek by the provided `offset` in the forwards direction, using the [`AsyncSeekForward`] trait.
     fn seek_forward(&mut self, offset: u64) -> SeekForwardFuture<'_, Self>
     where
         Self: Unpin,


### PR DESCRIPTION
# Objective

This PR introduces an `AsyncSeekForwardExt` trait, which I forgot in my previous PR #14194.

This new trait is analogous to `AsyncSeekExt` and allows all implementors of `AsyncSeekForward` to directly use the `seek_forward` function in async contexts.

## Solution

- Implement a new `AsyncSeekForwardExt` trait
- Automatically implement this trait for all types that implement `AsyncSeekForward`

## Showcase

This new trait allows a similar API to the previous Bevy version:

```rust
#[derive(Default)]
struct UniverseLoader;

#[derive(Asset, TypePath, Debug)]
struct JustALilAsteroid([u8; 128]);

impl AssetLoader for UniverseLoader {
    type Asset = JustALilAsteroid;
    type Settings = ();
    type Error = std::io::Error;

    async fn load<'a>(
        &'a self,
        reader: &'a mut Reader<'a>,
        _settings: &'a Self::Settings,
        _context: &'a mut LoadContext<'_>,
    ) -> Result<Self::Asset, Self::Error> {
        // read the asteroids entry table
        let entry_offset: u64 = /* ... */;
        let current_offset: u64 = reader.seek_forward(0).await?;

        // jump to the entry
        reader.seek_forward(entry_offset - current_offset).await?;

        let mut asteroid_buf = [0; 128];
        reader.read_exact(&mut asteroid_buf).await?;

        Ok(JustALilAsteroid(asteroid_buf))
    }
    
    fn extensions(&self) -> &[&str] {
        &["celestial"]
    }
}
```
