### PR TITLE
Replace mesh IndicesIter with Either iterator

### DIFF
--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -24,6 +24,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
+either = "1.13"
 wgpu = { version = "22", default-features = false }
 serde = { version = "1", features = ["derive"] }
 hexasphere = "15.0"


### PR DESCRIPTION
# Objective

- Less code
- Also I wanted to use either iterator in another place in `bevy_mesh` (for changes like #16026)

## Solution

- Replace `IndicesIter` with either
- Bevy already depends on `either` crate:

https://github.com/bevyengine/bevy/blob/ec268420f704b5fc701c320023635b2e829abbbf/crates/bevy_asset/Cargo.toml#L40

## Testing

CI