### PR TITLE
QueryEntityError: Use short name for components

### DIFF
--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -70,7 +70,7 @@ fn format_archetype(
             .components()
             .get_name(component_id)
             .expect("entity does not belong to world");
-        write!(f, "{name}")?;
+        write!(f, "{}", disqualified::ShortName(&name))?;
     }
     Ok(())
 }

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -70,7 +70,7 @@ fn format_archetype(
             .components()
             .get_name(component_id)
             .expect("entity does not belong to world");
-        write!(f, "{}", disqualified::ShortName(&name))?;
+        write!(f, "{}", disqualified::ShortName(name))?;
     }
     Ok(())
 }

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -126,6 +126,9 @@ mod test {
             .get(&world, entity)
             .unwrap_err();
 
-        assert_eq!(format!("{err:?}"), "QueryDoesNotMatch(0v1 with components bevy_ecs::query::error::test::query_does_not_match::Present1, bevy_ecs::query::error::test::query_does_not_match::Present2)");
+        assert_eq!(
+            format!("{err:?}"),
+            "QueryDoesNotMatch(0v1 with components Present1, Present2)"
+        );
     }
 }


### PR DESCRIPTION
Use the new `disqualified` crate in `QueryEntityError` to make the error message more readable.

---

## Showcase

Old:
QueryDoesNotMatch(0v1 with components my_game::main::foo::A, my_game::main::foo::B, bevy_pbr::light::point_light::PointLight, bevy_render::primitives::CubemapFrusta, bevy_pbr::bundle::CubemapVisibleEntities, bevy_transform::components::transform::Transform, bevy_transform::components::global_transform::GlobalTransform, bevy_render::view::visibility::Visibility, bevy_render::view::visibility::InheritedVisibility, bevy_render::view::visibility::ViewVisibility, bevy_render::sync_world::SyncToRenderWorld)

New:
QueryDoesNotMatch(0v1 with components A, B, PointLight, CubemapFrusta, CubemapVisibleEntities, Transform, GlobalTransform, Visibility, InheritedVisibility, ViewVisibility, SyncToRenderWorld)
