### PR TITLE
Typo-check .hidden files

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -32,7 +32,7 @@
 #
 # # Nightly configuration
 #
-# Be warned that the following features require nightly Rust, which is expiremental and may contain bugs. If you
+# Be warned that the following features require nightly Rust, which is experimental and may contain bugs. If you
 # are having issues, skip this section and use stable Rust instead.
 #
 # There are a few unstable features that can improve performance. To use them, first install nightly Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: cargo run -p ci -- lints
 
   miri:
-    # Explicity use macOS 14 to take advantage of M1 chip.
+    # Explicitly use macOS 14 to take advantage of M1 chip.
     runs-on: macos-14
     timeout-minutes: 60
     steps:
@@ -254,7 +254,7 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
   run-examples-macos-metal:
-    # Explicity use macOS 14 to take advantage of M1 chip.
+    # Explicitly use macOS 14 to take advantage of M1 chip.
     runs-on: macos-14
     timeout-minutes: 30
     steps:

--- a/typos.toml
+++ b/typos.toml
@@ -3,7 +3,9 @@ extend-exclude = [
   "*.pbxproj", # metadata file
   "*.patch",   # Automatically generated files that should not be manually modified.
   "*.bin",     # Binary files
+  ".git/",     # Version control files
 ]
+ignore-hidden = false
 
 # Corrections take the form of a key/value pair. The key is the incorrect word
 # and the value is the correct word. If the key and value are the same, the


### PR DESCRIPTION
# Objective

Typo-check .hidden files like `.cargo/config_fast_builds.toml` and `.github/*`. Context: https://github.com/bevyengine/bevy/pull/16025.

## Solution

- Add `ignore-hidden = false` to `typos.toml` to override the default value of `true`.
- Add an exception to keep `.git/` ignored in `typos.toml`.
- Fix newly-found typos so CI passes.

## Testing

Running `typos` locally finds no further typos.