### PR TITLE
Replace TwoIterators with Either in bevy_animation

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -39,6 +39,7 @@ derive_more = { version = "1", default-features = false, features = [
   "from",
   "display",
 ] }
+either = "1.13"
 thread_local = "1"
 uuid = { version = "1.7", features = ["v4"] }
 smallvec = "1"


### PR DESCRIPTION
# Objective

- Less code
- Better iterator (implements `size_hint` for example)

## Solution

- Use `either`
- This change is free because `bevy_animation` depends on `bevy_asset`, which already depends on `either`

## Testing

CI