### PR TITLE
Use `en-us` locale for `typos`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3327,11 +3327,11 @@ doc-scrape-examples = true
 hidden = true
 
 [[example]]
-name = "minimising"
-path = "tests/window/minimising.rs"
+name = "minimizing"
+path = "tests/window/minimizing.rs"
 doc-scrape-examples = true
 
-[package.metadata.example.minimising]
+[package.metadata.example.minimizing]
 hidden = true
 
 [[example]]

--- a/crates/bevy_animation/src/animation_event.rs
+++ b/crates/bevy_animation/src/animation_event.rs
@@ -24,7 +24,7 @@ pub(crate) fn trigger_animation_event(
 
 /// An event that can be used with animations.
 /// It can be derived to trigger as an observer event,
-/// if you need more complex behaviour, consider
+/// if you need more complex behavior, consider
 /// a manual implementation.
 ///
 /// # Example

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -52,7 +52,7 @@ fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> std::io::Error + '_
 
 impl HttpWasmAssetReader {
     async fn fetch_bytes<'a>(&self, path: PathBuf) -> Result<impl Reader, AssetReaderError> {
-        // The JS global scope includes a self-reference via a specialising name, which can be used to determine the type of global context available.
+        // The JS global scope includes a self-reference via a specializing name, which can be used to determine the type of global context available.
         let global: Global = js_sys::global().unchecked_into();
         let promise = if !global.window().is_undefined() {
             let window: web_sys::Window = global.unchecked_into();

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -670,7 +670,7 @@ impl AssetProcessor {
                 }
 
                 for dependency in dependencies {
-                    asset_infos.add_dependant(&dependency, asset_path.clone());
+                    asset_infos.add_dependent(&dependency, asset_path.clone());
                 }
             }
         }
@@ -1137,7 +1137,7 @@ pub enum ProcessStatus {
 pub(crate) struct ProcessorAssetInfo {
     processed_info: Option<ProcessedInfo>,
     /// Paths of assets that depend on this asset when they are being processed.
-    dependants: HashSet<AssetPath<'static>>,
+    dependents: HashSet<AssetPath<'static>>,
     status: Option<ProcessStatus>,
     /// A lock that controls read/write access to processed asset files. The lock is shared for both the asset bytes and the meta bytes.
     /// _This lock must be locked whenever a read or write to processed assets occurs_
@@ -1161,7 +1161,7 @@ impl Default for ProcessorAssetInfo {
         status_sender.set_overflow(true);
         Self {
             processed_info: Default::default(),
-            dependants: Default::default(),
+            dependents: Default::default(),
             file_transaction_lock: Default::default(),
             status: None,
             status_sender,
@@ -1187,13 +1187,13 @@ pub struct ProcessorAssetInfos {
     /// The "current" in memory view of the asset space. During processing, if path does not exist in this, it should
     /// be considered non-existent.
     /// NOTE: YOU MUST USE `Self::get_or_insert` or `Self::insert` TO ADD ITEMS TO THIS COLLECTION TO ENSURE
-    /// `non_existent_dependants` DATA IS CONSUMED
+    /// `non_existent_dependents` DATA IS CONSUMED
     infos: HashMap<AssetPath<'static>, ProcessorAssetInfo>,
-    /// Dependants for assets that don't exist. This exists to track "dangling" asset references due to deleted / missing files.
-    /// If the dependant asset is added, it can "resolve" these dependencies and re-compute those assets.
+    /// Dependents for assets that don't exist. This exists to track "dangling" asset references due to deleted / missing files.
+    /// If the dependent asset is added, it can "resolve" these dependencies and re-compute those assets.
     /// Therefore this _must_ always be consistent with the `infos` data. If a new asset is added to `infos`, it should
-    /// check this maps for dependencies and add them. If an asset is removed, it should update the dependants here.
-    non_existent_dependants: HashMap<AssetPath<'static>, HashSet<AssetPath<'static>>>,
+    /// check this maps for dependencies and add them. If an asset is removed, it should update the dependents here.
+    non_existent_dependents: HashMap<AssetPath<'static>, HashSet<AssetPath<'static>>>,
     check_reprocess_queue: VecDeque<AssetPath<'static>>,
 }
 
@@ -1201,9 +1201,9 @@ impl ProcessorAssetInfos {
     fn get_or_insert(&mut self, asset_path: AssetPath<'static>) -> &mut ProcessorAssetInfo {
         self.infos.entry(asset_path.clone()).or_insert_with(|| {
             let mut info = ProcessorAssetInfo::default();
-            // track existing dependants by resolving existing "hanging" dependants.
-            if let Some(dependants) = self.non_existent_dependants.remove(&asset_path) {
-                info.dependants = dependants;
+            // track existing dependents by resolving existing "hanging" dependents.
+            if let Some(dependents) = self.non_existent_dependents.remove(&asset_path) {
+                info.dependents = dependents;
             }
             info
         })
@@ -1217,15 +1217,15 @@ impl ProcessorAssetInfos {
         self.infos.get_mut(asset_path)
     }
 
-    fn add_dependant(&mut self, asset_path: &AssetPath<'static>, dependant: AssetPath<'static>) {
+    fn add_dependent(&mut self, asset_path: &AssetPath<'static>, dependent: AssetPath<'static>) {
         if let Some(info) = self.get_mut(asset_path) {
-            info.dependants.insert(dependant);
+            info.dependents.insert(dependent);
         } else {
-            let dependants = self
-                .non_existent_dependants
+            let dependents = self
+                .non_existent_dependents
                 .entry(asset_path.clone())
                 .or_default();
-            dependants.insert(dependant);
+            dependents.insert(dependent);
         }
     }
 
@@ -1238,7 +1238,7 @@ impl ProcessorAssetInfos {
         match result {
             Ok(ProcessResult::Processed(processed_info)) => {
                 debug!("Finished processing \"{:?}\"", asset_path);
-                // clean up old dependants
+                // clean up old dependents
                 let old_processed_info = self
                     .infos
                     .get_mut(&asset_path)
@@ -1247,15 +1247,15 @@ impl ProcessorAssetInfos {
                     self.clear_dependencies(&asset_path, old_processed_info);
                 }
 
-                // populate new dependants
+                // populate new dependents
                 for process_dependency_info in &processed_info.process_dependencies {
-                    self.add_dependant(&process_dependency_info.path, asset_path.to_owned());
+                    self.add_dependent(&process_dependency_info.path, asset_path.to_owned());
                 }
                 let info = self.get_or_insert(asset_path);
                 info.processed_info = Some(processed_info);
                 info.update_status(ProcessStatus::Processed).await;
-                let dependants = info.dependants.iter().cloned().collect::<Vec<_>>();
-                for path in dependants {
+                let dependents = info.dependents.iter().cloned().collect::<Vec<_>>();
+                for path in dependents {
                     self.check_reprocess_queue.push_back(path);
                 }
             }
@@ -1298,7 +1298,7 @@ impl ProcessorAssetInfos {
                         full_hash: AssetHash::default(),
                         process_dependencies: vec![],
                     });
-                    self.add_dependant(dependency.path(), asset_path.to_owned());
+                    self.add_dependent(dependency.path(), asset_path.to_owned());
                 }
 
                 let info = self.get_mut(&asset_path).expect("info should exist");
@@ -1319,13 +1319,13 @@ impl ProcessorAssetInfos {
                 .broadcast(ProcessStatus::NonExistent)
                 .await
                 .unwrap();
-            if !info.dependants.is_empty() {
+            if !info.dependents.is_empty() {
                 error!(
                     "The asset at {asset_path} was removed, but it had assets that depend on it to be processed. Consider updating the path in the following assets: {:?}",
-                    info.dependants
+                    info.dependents
                 );
-                self.non_existent_dependants
-                    .insert(asset_path.clone(), info.dependants);
+                self.non_existent_dependents
+                    .insert(asset_path.clone(), info.dependents);
             }
         }
     }
@@ -1334,31 +1334,31 @@ impl ProcessorAssetInfos {
     async fn rename(&mut self, old: &AssetPath<'static>, new: &AssetPath<'static>) {
         let info = self.infos.remove(old);
         if let Some(mut info) = info {
-            if !info.dependants.is_empty() {
+            if !info.dependents.is_empty() {
                 // TODO: We can't currently ensure "moved" folders with relative paths aren't broken because AssetPath
                 // doesn't distinguish between absolute and relative paths. We have "erased" relativeness. In the short term,
                 // we could do "remove everything in a folder and re-add", but that requires full rebuilds / destroying the cache.
                 // If processors / loaders could enumerate dependencies, we could check if the new deps line up with a rename.
                 // If deps encoded "relativeness" as part of loading, that would also work (this seems like the right call).
-                // TODO: it would be nice to log an error here for dependants that aren't also being moved + fixed.
+                // TODO: it would be nice to log an error here for dependents that aren't also being moved + fixed.
                 // (see the remove impl).
                 error!(
                     "The asset at {old} was removed, but it had assets that depend on it to be processed. Consider updating the path in the following assets: {:?}",
-                    info.dependants
+                    info.dependents
                 );
-                self.non_existent_dependants
-                    .insert(old.clone(), core::mem::take(&mut info.dependants));
+                self.non_existent_dependents
+                    .insert(old.clone(), core::mem::take(&mut info.dependents));
             }
             if let Some(processed_info) = &info.processed_info {
-                // Update "dependant" lists for this asset's "process dependencies" to use new path.
+                // Update "dependent" lists for this asset's "process dependencies" to use new path.
                 for dep in &processed_info.process_dependencies {
                     if let Some(info) = self.infos.get_mut(&dep.path) {
-                        info.dependants.remove(old);
-                        info.dependants.insert(new.clone());
-                    } else if let Some(dependants) = self.non_existent_dependants.get_mut(&dep.path)
+                        info.dependents.remove(old);
+                        info.dependents.insert(new.clone());
+                    } else if let Some(dependents) = self.non_existent_dependents.get_mut(&dep.path)
                     {
-                        dependants.remove(old);
-                        dependants.insert(new.clone());
+                        dependents.remove(old);
+                        dependents.insert(new.clone());
                     }
                 }
             }
@@ -1367,7 +1367,7 @@ impl ProcessorAssetInfos {
                 .broadcast(ProcessStatus::NonExistent)
                 .await
                 .unwrap();
-            let dependants: Vec<AssetPath<'static>> = {
+            let dependents: Vec<AssetPath<'static>> = {
                 let new_info = self.get_or_insert(new.clone());
                 new_info.processed_info = info.processed_info;
                 new_info.status = info.status;
@@ -1375,13 +1375,13 @@ impl ProcessorAssetInfos {
                 if let Some(status) = new_info.status {
                     new_info.status_sender.broadcast(status).await.unwrap();
                 }
-                new_info.dependants.iter().cloned().collect()
+                new_info.dependents.iter().cloned().collect()
             };
             // Queue the asset for a reprocess check, in case it needs new meta.
             self.check_reprocess_queue.push_back(new.clone());
-            for dependant in dependants {
-                // Queue dependants for reprocessing because they might have been waiting for this asset.
-                self.check_reprocess_queue.push_back(dependant);
+            for dependent in dependents {
+                // Queue dependents for reprocessing because they might have been waiting for this asset.
+                self.check_reprocess_queue.push_back(dependent);
             }
         }
     }
@@ -1389,11 +1389,11 @@ impl ProcessorAssetInfos {
     fn clear_dependencies(&mut self, asset_path: &AssetPath<'static>, removed_info: ProcessedInfo) {
         for old_load_dep in removed_info.process_dependencies {
             if let Some(info) = self.infos.get_mut(&old_load_dep.path) {
-                info.dependants.remove(asset_path);
-            } else if let Some(dependants) =
-                self.non_existent_dependants.get_mut(&old_load_dep.path)
+                info.dependents.remove(asset_path);
+            } else if let Some(dependents) =
+                self.non_existent_dependents.get_mut(&old_load_dep.path)
             {
-                dependants.remove(asset_path);
+                dependents.remove(asset_path);
             }
         }
     }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1523,10 +1523,10 @@ pub fn handle_internal_asset_events(world: &mut World) {
             infos: &AssetInfos,
             paths_to_reload: &mut HashSet<AssetPath<'static>>,
         ) {
-            if let Some(dependants) = infos.loader_dependants.get(asset_path) {
-                for dependant in dependants {
-                    paths_to_reload.insert(dependant.to_owned());
-                    queue_ancestors(dependant, infos, paths_to_reload);
+            if let Some(dependents) = infos.loader_dependents.get(asset_path) {
+                for dependent in dependents {
+                    paths_to_reload.insert(dependent.to_owned());
+                    queue_ancestors(dependent, infos, paths_to_reload);
                 }
             }
         }

--- a/crates/bevy_core_pipeline/src/motion_blur/motion_blur.wgsl
+++ b/crates/bevy_core_pipeline/src/motion_blur/motion_blur.wgsl
@@ -66,7 +66,7 @@ fn fragment(
     // This means that for a frame time of 20ms, the shutter is only open for 10ms.
     //
     // Using a shutter angle larger than 1.0 is non-physical, objects would need to move further
-    // than they physically travelled during a frame, which is not possible. Note: we allow values
+    // than they physically traveled during a frame, which is not possible. Note: we allow values
     // larger than 1.0 because it may be desired for artistic reasons.
     let exposure_vector = shutter_angle * this_motion_vector;
 

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -119,7 +119,7 @@ pub mod internal {
         let thread_pool = AsyncComputeTaskPool::get();
 
         // Only queue a new system refresh task when necessary
-        // Queueing earlier than that will not give new data
+        // Queuing earlier than that will not give new data
         if last_refresh.elapsed() > sysinfo::MINIMUM_CPU_UPDATE_INTERVAL
             // These tasks don't yield and will take up all of the task pool's
             // threads if we don't limit their amount.

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -32,7 +32,7 @@ use core::{any::TypeId, ptr::NonNull};
 ///
 /// Each bundle represents a static set of [`Component`] types.
 /// Currently, bundles can only contain one of each [`Component`], and will
-/// panic once initialised if this is not met.
+/// panic once initialized if this is not met.
 ///
 /// ## Insertion
 ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -153,7 +153,7 @@ type IdCursor = isize;
     reflect(Serialize, Deserialize)
 )]
 // Alignment repr necessary to allow LLVM to better output
-// optimised codegen for `to_bits`, `PartialEq` and `Ord`.
+// optimized codegen for `to_bits`, `PartialEq` and `Ord`.
 #[repr(C, align(8))]
 pub struct Entity {
     // Do not reorder the fields here. The ordering is explicitly used by repr(C)
@@ -170,7 +170,7 @@ pub struct Entity {
 impl PartialEq for Entity {
     #[inline]
     fn eq(&self, other: &Entity) -> bool {
-        // By using `to_bits`, the codegen can be optimised out even
+        // By using `to_bits`, the codegen can be optimized out even
         // further potentially. Relies on the correct alignment/field
         // order of `Entity`.
         self.to_bits() == other.to_bits()
@@ -179,10 +179,10 @@ impl PartialEq for Entity {
 
 impl Eq for Entity {}
 
-// The derive macro codegen output is not optimal and can't be optimised as well
+// The derive macro codegen output is not optimal and can't be optimized as well
 // by the compiler. This impl resolves the issue of non-optimal codegen by relying
 // on comparing against the bit representation of `Entity` instead of comparing
-// the fields. The result is then LLVM is able to optimise the codegen for Entity
+// the fields. The result is then LLVM is able to optimize the codegen for Entity
 // far beyond what the derive macro can.
 // See <https://github.com/rust-lang/rust/issues/106107>
 impl PartialOrd for Entity {
@@ -193,10 +193,10 @@ impl PartialOrd for Entity {
     }
 }
 
-// The derive macro codegen output is not optimal and can't be optimised as well
+// The derive macro codegen output is not optimal and can't be optimized as well
 // by the compiler. This impl resolves the issue of non-optimal codegen by relying
 // on comparing against the bit representation of `Entity` instead of comparing
-// the fields. The result is then LLVM is able to optimise the codegen for Entity
+// the fields. The result is then LLVM is able to optimize the codegen for Entity
 // far beyond what the derive macro can.
 // See <https://github.com/rust-lang/rust/issues/106107>
 impl Ord for Entity {
@@ -310,7 +310,7 @@ impl Entity {
 
         match id {
             Ok(entity) => entity,
-            Err(_) => panic!("Attempted to initialise invalid bits as an entity"),
+            Err(_) => panic!("Attempted to initialize invalid bits as an entity"),
         }
     }
 

--- a/crates/bevy_ecs/src/identifier/error.rs
+++ b/crates/bevy_ecs/src/identifier/error.rs
@@ -8,7 +8,7 @@ use core::fmt;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum IdentifierError {
-    /// A given ID has an invalid value for initialising to a [`crate::identifier::Identifier`].
+    /// A given ID has an invalid value for initializing to a [`crate::identifier::Identifier`].
     InvalidIdentifier,
     /// A given ID has an invalid configuration of bits for converting to an [`crate::entity::Entity`].
     InvalidEntityId(u64),

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod masks;
 #[cfg_attr(feature = "bevy_reflect", reflect(opaque))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug, Hash, PartialEq))]
 // Alignment repr necessary to allow LLVM to better output
-// optimised codegen for `to_bits`, `PartialEq` and `Ord`.
+// optimized codegen for `to_bits`, `PartialEq` and `Ord`.
 #[repr(C, align(8))]
 pub struct Identifier {
     // Do not reorder the fields here. The ordering is explicitly used by repr(C)
@@ -49,7 +49,7 @@ impl Identifier {
         let packed_high = IdentifierMask::pack_kind_into_high(masked_value, kind);
 
         // If the packed high component ends up being zero, that means that we tried
-        // to initialise an Identifier into an invalid state.
+        // to initialize an Identifier into an invalid state.
         if packed_high == 0 {
             Err(IdentifierError::InvalidIdentifier)
         } else {
@@ -107,7 +107,7 @@ impl Identifier {
 
         match id {
             Ok(id) => id,
-            Err(_) => panic!("Attempted to initialise invalid bits as an id"),
+            Err(_) => panic!("Attempted to initialize invalid bits as an id"),
         }
     }
 
@@ -133,7 +133,7 @@ impl Identifier {
 impl PartialEq for Identifier {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        // By using `to_bits`, the codegen can be optimised out even
+        // By using `to_bits`, the codegen can be optimized out even
         // further potentially. Relies on the correct alignment/field
         // order of `Entity`.
         self.to_bits() == other.to_bits()
@@ -142,10 +142,10 @@ impl PartialEq for Identifier {
 
 impl Eq for Identifier {}
 
-// The derive macro codegen output is not optimal and can't be optimised as well
+// The derive macro codegen output is not optimal and can't be optimized as well
 // by the compiler. This impl resolves the issue of non-optimal codegen by relying
 // on comparing against the bit representation of `Entity` instead of comparing
-// the fields. The result is then LLVM is able to optimise the codegen for Entity
+// the fields. The result is then LLVM is able to optimize the codegen for Entity
 // far beyond what the derive macro can.
 // See <https://github.com/rust-lang/rust/issues/106107>
 impl PartialOrd for Identifier {
@@ -156,10 +156,10 @@ impl PartialOrd for Identifier {
     }
 }
 
-// The derive macro codegen output is not optimal and can't be optimised as well
+// The derive macro codegen output is not optimal and can't be optimized as well
 // by the compiler. This impl resolves the issue of non-optimal codegen by relying
 // on comparing against the bit representation of `Entity` instead of comparing
-// the fields. The result is then LLVM is able to optimise the codegen for Entity
+// the fields. The result is then LLVM is able to optimize the codegen for Entity
 // far beyond what the derive macro can.
 // See <https://github.com/rust-lang/rust/issues/106107>
 impl Ord for Identifier {

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -88,7 +88,7 @@ impl Component for ObserverState {
 /// Type for function that is run when an observer is triggered.
 ///
 /// Typically refers to the default runner that runs the system stored in the associated [`Observer`] component,
-/// but can be overridden for custom behaviour.
+/// but can be overridden for custom behavior.
 pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: &mut bool);
 
 /// An [`Observer`] system. Add this [`Component`] to an [`Entity`] to turn it into an "observer".

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -315,7 +315,7 @@ where
     /// If you configure two [`System`]s like `(GameSystem::A).after(GameSystem::B)` or `(GameSystem::A).before(GameSystem::B)`, the `GameSystem::B` will not be automatically scheduled.
     ///
     /// This means that the system `GameSystem::A` and the system or systems in `GameSystem::B` will run independently of each other if `GameSystem::B` was never explicitly scheduled with [`configure_sets`]
-    /// If that is the case, `.after`/`.before` will not provide the desired behaviour
+    /// If that is the case, `.after`/`.before` will not provide the desired behavior
     /// and the systems can run in parallel or in any order determined by the scheduler.
     /// Only use `after(GameSystem::B)` and `before(GameSystem::B)` when you know that `B` has already been scheduled for you,
     /// e.g. when it was provided by Bevy or a third-party dependency,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1138,7 +1138,7 @@ impl ScheduleGraph {
         Ok(self.build_schedule_inner(dependency_flattened_dag, hier_results.reachable))
     }
 
-    // modify the graph to have sync nodes for any dependants after a system with deferred system params
+    // modify the graph to have sync nodes for any dependents after a system with deferred system params
     fn auto_insert_apply_deferred(
         &mut self,
         dependency_flattened: &mut GraphMap<NodeId, (), Directed>,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -735,10 +735,10 @@ impl<'w, 's> Commands<'w, 's> {
     /// #     high_score: u32,
     /// # }
     /// #
-    /// # fn initialise_scoreboard(mut commands: Commands) {
+    /// # fn initialize_scoreboard(mut commands: Commands) {
     /// commands.init_resource::<Scoreboard>();
     /// # }
-    /// # bevy_ecs::system::assert_is_system(initialise_scoreboard);
+    /// # bevy_ecs::system::assert_is_system(initialize_scoreboard);
     /// ```
     #[track_caller]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -659,7 +659,7 @@ impl<Marker, F> FunctionSystem<Marker, F>
 where
     F: SystemParamFunction<Marker>,
 {
-    /// Message shown when a system isn't initialised
+    /// Message shown when a system isn't initialized
     // When lines get too long, rustfmt can sometimes refuse to format them.
     // Work around this by storing the message separately.
     const PARAM_MESSAGE: &'static str = "System's param_state was not found. Did you forget to initialize this system before running it?";

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1190,7 +1190,7 @@ pub trait SystemBuffer: FromWorld + Send + 'static {
 ///
 /// use bevy_ecs::system::{Deferred, SystemBuffer, SystemMeta};
 ///
-/// // Uses deferred mutations to allow signalling the alarm from multiple systems in parallel.
+/// // Uses deferred mutations to allow signaling the alarm from multiple systems in parallel.
 /// #[derive(Resource, Default)]
 /// struct AlarmFlag(bool);
 ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3257,7 +3257,7 @@ impl World {
         let id = self
             .bundles
             .register_info::<B>(&mut self.components, &mut self.storages);
-        // SAFETY: We just initialised the bundle so its id should definitely be valid.
+        // SAFETY: We just initialized the bundle so its id should definitely be valid.
         unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1836,7 +1836,7 @@ async fn load_buffers(
 /// Iterator for a Gltf tree.
 ///
 /// It resolves a Gltf tree and allows for a safe Gltf nodes iteration,
-/// putting dependant nodes before dependencies.
+/// putting dependent nodes before dependencies.
 struct GltfTreeIterator<'a> {
     nodes: Vec<Node<'a>>,
 }

--- a/crates/bevy_image/src/image_texture_conversion.rs
+++ b/crates/bevy_image/src/image_texture_conversion.rs
@@ -112,7 +112,7 @@ impl Image {
                     Vec::with_capacity(width as usize * height as usize * format.pixel_size());
 
                 for pixel in image.into_raw().chunks_exact(3) {
-                    // TODO: use the array_chunks method once stabilised
+                    // TODO: use the array_chunks method once stabilized
                     // https://github.com/rust-lang/rust/issues/74985
                     let r = pixel[0];
                     let g = pixel[1];

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -395,7 +395,7 @@ pub enum KeyCode {
     /// Japanese: <kbd>無変換</kbd> (muhenkan)
     NonConvert,
     /// <kbd>⌦</kbd>. The forward delete key.
-    /// Note that on Apple keyboards, the key labelled <kbd>Delete</kbd> on the main part of
+    /// Note that on Apple keyboards, the key labeled <kbd>Delete</kbd> on the main part of
     /// the keyboard is encoded as [`Backspace`].
     ///
     /// [`Backspace`]: Self::Backspace
@@ -532,9 +532,9 @@ pub enum KeyCode {
     /// <kbd>Eject</kbd> or <kbd>⏏</kbd>. This key is placed in the function section on some Apple
     /// keyboards.
     Eject,
-    /// Sometimes labelled <kbd>My Computer</kbd> on the keyboard
+    /// Sometimes labeled <kbd>My Computer</kbd> on the keyboard
     LaunchApp1,
-    /// Sometimes labelled <kbd>Calculator</kbd> on the keyboard
+    /// Sometimes labeled <kbd>Calculator</kbd> on the keyboard
     LaunchApp2,
     /// LaunchMail
     LaunchMail,
@@ -927,7 +927,7 @@ pub enum Key {
     /// be restored. The computer will then shutdown.
     Hibernate,
     /// The Standby key. This key turns off the display and places the computer into a low-power
-    /// mode without completely shutting down. It is sometimes labelled `Suspend` or `Sleep` key.
+    /// mode without completely shutting down. It is sometimes labeled `Suspend` or `Sleep` key.
     /// (`KEYCODE_SLEEP`)
     Standby,
     /// The WakeUp key. (`KEYCODE_WAKEUP`)

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -108,7 +108,7 @@ pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 /// If you define the `RUST_LOG` environment variable, the [`LogPlugin`] settings
 /// will be ignored.
 ///
-/// Also, to disable colour terminal output (ANSI escape codes), you can
+/// Also, to disable color terminal output (ANSI escape codes), you can
 /// set the environment variable `NO_COLOR` to any value. This common
 /// convention is documented at [no-color.org](https://no-color.org/).
 /// For example:

--- a/crates/bevy_math/src/rects/irect.rs
+++ b/crates/bevy_math/src/rects/irect.rs
@@ -83,7 +83,7 @@ impl IRect {
 
     /// Create a new rectangle from its center and size.
     ///
-    /// # Rounding Behaviour
+    /// # Rounding Behavior
     ///
     /// If the size contains odd numbers they will be rounded down to the nearest whole number.
     ///
@@ -190,7 +190,7 @@ impl IRect {
 
     /// Rectangle half-size.
     ///
-    /// # Rounding Behaviour
+    /// # Rounding Behavior
     ///
     /// If the full size contains odd numbers they will be rounded down to the nearest whole number when calculating the half size.
     ///
@@ -208,7 +208,7 @@ impl IRect {
 
     /// The center point of the rectangle.
     ///
-    /// # Rounding Behaviour
+    /// # Rounding Behavior
     ///
     /// If the (min + max) contains odd numbers they will be rounded down to the nearest whole number when calculating the center.
     ///

--- a/crates/bevy_math/src/rects/urect.rs
+++ b/crates/bevy_math/src/rects/urect.rs
@@ -83,7 +83,7 @@ impl URect {
 
     /// Create a new rectangle from its center and size.
     ///
-    /// # Rounding Behaviour
+    /// # Rounding Behavior
     ///
     /// If the size contains odd numbers they will be rounded down to the nearest whole number.
     ///
@@ -187,7 +187,7 @@ impl URect {
 
     /// Rectangle half-size.
     ///
-    /// # Rounding Behaviour
+    /// # Rounding Behavior
     ///
     /// If the full size contains odd numbers they will be rounded down to the nearest whole number when calculating the half size.
     ///
@@ -205,7 +205,7 @@ impl URect {
 
     /// The center point of the rectangle.
     ///
-    /// # Rounding Behaviour
+    /// # Rounding Behavior
     ///
     /// If the (min + max) contains odd numbers they will be rounded down to the nearest whole number when calculating the center.
     ///

--- a/crates/bevy_math/src/sampling/shape_sampling.rs
+++ b/crates/bevy_math/src/sampling/shape_sampling.rs
@@ -420,7 +420,7 @@ impl ShapeSample for Cylinder {
     }
 
     fn sample_boundary<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec3 {
-        // This uses the area of the ends divided by the overall surface area (optimised)
+        // This uses the area of the ends divided by the overall surface area (optimized)
         // [2 (\pi r^2)]/[2 (\pi r^2) + 2 \pi r h] = r/(r + h)
         if self.radius + 2.0 * self.half_height > 0.0 {
             if rng.gen_bool((self.radius / (self.radius + 2.0 * self.half_height)) as f64) {

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -87,7 +87,7 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 ///     other APIs can have other conventions, `OpenGL` starts at bottom-left.
 /// - It is possible and sometimes useful for multiple vertices to have the same
 ///     [position attribute](Mesh::ATTRIBUTE_POSITION) value,
-///     it's a common technique in 3D modelling for complex UV mapping or other calculations.
+///     it's a common technique in 3D modeling for complex UV mapping or other calculations.
 /// - Bevy performs frustum culling based on the `Aabb` of meshes, which is calculated
 ///     and added automatically for new meshes only. If a mesh is modified, the entity's `Aabb`
 ///     needs to be updated manually or deleted so that it is re-calculated.

--- a/crates/bevy_mesh/src/primitives/dim3/cone.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cone.rs
@@ -86,7 +86,7 @@ impl MeshBuilder for ConeMeshBuilder {
         // The tip doesn't have a singular normal that works correctly.
         // We use an invalid normal here so that it becomes NaN in the fragment shader
         // and doesn't affect the overall shading. This might seem hacky, but it's one of
-        // the only ways to get perfectly smooth cones without creases or other shading artefacts.
+        // the only ways to get perfectly smooth cones without creases or other shading artifacts.
         //
         // Note that this requires that normals are not normalized in the vertex shader,
         // as that would make the entire triangle invalid and make the cone appear as black.

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -12,11 +12,11 @@ pub enum PerimeterSegment {
     ///
     /// This has the effect of rendering the segment's faces with softened edges, so it is appropriate for curved shapes.
     ///
-    /// The normals for the vertices that are part of this segment will be calculated based on the positions of their neighbours.
-    /// Each normal is interpolated between the normals of the two line segments connecting it with its neighbours.
+    /// The normals for the vertices that are part of this segment will be calculated based on the positions of their neighbors.
+    /// Each normal is interpolated between the normals of the two line segments connecting it with its neighbors.
     /// Closer vertices have a stronger effect on the normal than more distant ones.
     ///
-    /// Since the vertices corresponding to the first and last indices do not have two neighbouring vertices, their normals must be provided manually.
+    /// Since the vertices corresponding to the first and last indices do not have two neighboring vertices, their normals must be provided manually.
     Smooth {
         /// The normal of the first vertex.
         first_normal: Vec2,
@@ -348,8 +348,8 @@ where
                                 uvs.push([uv_x, uv_y]);
                             }
 
-                            // The normal for the current vertices can be calculated based on the two neighbouring vertices.
-                            // The normal is interpolated between the normals of the two line segments connecting the current vertex with its neighbours.
+                            // The normal for the current vertices can be calculated based on the two neighboring vertices.
+                            // The normal is interpolated between the normals of the two line segments connecting the current vertex with its neighbors.
                             // Closer vertices have a stronger effect on the normal than more distant ones.
                             let n = {
                                 let ab = Vec2::from_slice(&b) - Vec2::from_slice(&a);

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -5,7 +5,7 @@
 //! modification to Morten S. Mikkelsen's original tangent space algorithm
 //! implementation written in C. The original source code can be found at
 //! <https://archive.blender.org/wiki/index.php/Dev:Shading/Tangent_Space_Normal_Maps>
-//! and includes the following licence:
+//! and includes the following license:
 //!
 //! Copyright (C) 2011 by Morten S. Mikkelsen
 //!

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -51,7 +51,7 @@ pub mod light_consts {
     /// Predefined for lux values in several locations.
     ///
     /// The **lux** (symbol: **lx**) is the unit of [illuminance], or [luminous flux] per unit area,
-    /// in the [International System of Units] (SI). It is equal to one lumen per square metre.
+    /// in the [International System of Units] (SI). It is equal to one lumen per square meter.
     ///
     /// For more information, see [wikipedia](https://en.wikipedia.org/wiki/Lux)
     ///

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -387,7 +387,7 @@ pub struct StandardMaterial {
 
     /// Specifies the level of exposure to ambient light.
     ///
-    /// This is usually generated and stored automatically ("baked") by 3D-modelling software.
+    /// This is usually generated and stored automatically ("baked") by 3D-modeling software.
     ///
     /// Typically, steep concave parts of a model (such as the armpit of a shirt) are darker,
     /// because they have little exposure to light.
@@ -913,7 +913,7 @@ pub struct StandardMaterialUniform {
     // Use a color for user-friendliness even though we technically don't use the alpha channel
     // Might be used in the future for exposure correction in HDR
     pub emissive: Vec4,
-    /// Color white light takes after travelling through the attenuation distance underneath the material surface
+    /// Color white light takes after traveling through the attenuation distance underneath the material surface
     pub attenuation_color: Vec4,
     /// The transform applied to the UVs corresponding to `ATTRIBUTE_UV_0` on the mesh before sampling. Default is identity.
     pub uv_transform: Mat3,

--- a/crates/bevy_pbr/src/render/clustered_forward.wgsl
+++ b/crates/bevy_pbr/src/render/clustered_forward.wgsl
@@ -77,7 +77,7 @@ fn cluster_debug_visualization(
 
     // Cluster allocation debug (using 'over' alpha blending)
 #ifdef CLUSTERED_FORWARD_DEBUG_Z_SLICES
-    // NOTE: This debug mode visualises the z-slices
+    // NOTE: This debug mode visualizes the z-slices
     let cluster_overlay_alpha = 0.1;
     var z_slice: u32 = view_z_to_z_slice(view_z, is_orthographic);
     // A hack to make the colors alternate a bit more
@@ -96,7 +96,7 @@ fn cluster_debug_visualization(
     );
 #endif // CLUSTERED_FORWARD_DEBUG_Z_SLICES
 #ifdef CLUSTERED_FORWARD_DEBUG_CLUSTER_COMPLEXITY
-    // NOTE: This debug mode visualises the number of clusterable objects within
+    // NOTE: This debug mode visualizes the number of clusterable objects within
     // the cluster that contains the fragment. It shows a sort of cluster
     // complexity measure.
     let cluster_overlay_alpha = 0.1;

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -537,7 +537,7 @@ pub const fn dangling_with_align(align: NonZeroUsize) -> NonNull<u8> {
     debug_assert!(align.is_power_of_two(), "Alignment must be power of two.");
     // SAFETY: The pointer will not be null, since it was created
     // from the address of a `NonZero<usize>`.
-    // TODO: use https://doc.rust-lang.org/std/ptr/struct.NonNull.html#method.with_addr once stabilised
+    // TODO: use https://doc.rust-lang.org/std/ptr/struct.NonNull.html#method.with_addr once stabilized
     unsafe { NonNull::new_unchecked(ptr::null_mut::<u8>().wrapping_add(align.get())) }
 }
 

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -1001,7 +1001,7 @@ impl<'a> ReflectTypePath<'a> {
     ///
     /// Returns [`None`] if the type is [primitive] or [anonymous].
     ///
-    /// For non-customised [internal] paths this is created from [`module_path`].
+    /// For non-customized [internal] paths this is created from [`module_path`].
     ///
     /// For `Option<PhantomData>`, this is `"core"`.
     ///
@@ -1131,7 +1131,7 @@ impl<'a> ReflectTypePath<'a> {
     ///
     /// Returns [`None`] if the type is [primitive] or [anonymous].
     ///
-    /// For non-customised [internal] paths this is created from [`module_path`].
+    /// For non-customized [internal] paths this is created from [`module_path`].
     ///
     /// For `Option<PhantomData>`, this is `"std::option"`.
     ///

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -51,7 +51,7 @@
 //! `dyn Reflect` trait objects can be used similarly to `dyn PartialReflect`,
 //! but `Reflect` is also often used in trait bounds (like `T: Reflect`).
 //!
-//! The distinction between `PartialReflect` and `Reflect` is summarised in the following:
+//! The distinction between `PartialReflect` and `Reflect` is summarized in the following:
 //! * `PartialReflect` is a trait for interacting with values under `bevy_reflect`'s data model.
 //!   This means values implementing `PartialReflect` can be dynamically constructed and introspected.
 //! * The `Reflect` trait, however, ensures that the interface exposed by `PartialReflect`

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -159,7 +159,7 @@ impl<'a, T: ShaderType + WriteInto> IntoBinding<'a> for &'a StorageBuffer<T> {
 ///
 /// The contained data is stored in system RAM. [`write_buffer`](DynamicStorageBuffer::write_buffer)
 /// queues copying of the data from system RAM to VRAM. The data within a storage buffer binding must conform to
-/// [std430 alignment/padding requirements]. `DynamicStorageBuffer` takes care of serialising the inner type to conform to
+/// [std430 alignment/padding requirements]. `DynamicStorageBuffer` takes care of serializing the inner type to conform to
 /// these requirements. Each item [`push`](DynamicStorageBuffer::push)ed into this structure
 /// will additionally be aligned to meet dynamic offset alignment requirements.
 ///

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -55,7 +55,7 @@ impl RenderDevice {
                     .contains(wgpu::Features::SPIRV_SHADER_PASSTHROUGH) =>
             {
                 // SAFETY:
-                // This call passes binary data to the backend as-is and can potentially result in a driver crash or bogus behaviour.
+                // This call passes binary data to the backend as-is and can potentially result in a driver crash or bogus behavior.
                 // No attempt is made to ensure that data is valid SPIR-V.
                 unsafe {
                     self.device

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -9,9 +9,9 @@ use bevy_transform::components::{GlobalTransform, Transform};
 
 /// A [`Bundle`] of components for drawing a single sprite from an image.
 ///
-/// # Extra behaviours
+/// # Extra behaviors
 ///
-/// You may add one or both of the following components to enable additional behaviours:
+/// You may add one or both of the following components to enable additional behaviors:
 /// - [`ImageScaleMode`](crate::ImageScaleMode) to enable either slicing or tiling of the texture
 /// - [`TextureAtlas`](crate::TextureAtlas) to draw a specific section of the texture
 #[derive(Bundle, Clone, Debug, Default)]

--- a/crates/bevy_state/src/state/state_set.rs
+++ b/crates/bevy_state/src/state/state_set.rs
@@ -56,7 +56,7 @@ pub trait StateSet: StateSetSealed {
 ///
 /// The isolation works because it is implemented for both S & [`Option<S>`], and has the `RawState` associated type
 /// that allows it to know what the resource in the world should be. We can then essentially "unwrap" it in our
-/// `StateSet` implementation - and the behaviour of that unwrapping will depend on the arguments expected by the
+/// `StateSet` implementation - and the behavior of that unwrapping will depend on the arguments expected by the
 /// the [`ComputedStates`] & [`SubStates]`.
 trait InnerStateSet: Sized {
     type RawState: States;

--- a/crates/bevy_state/src/state/sub_states.rs
+++ b/crates/bevy_state/src/state/sub_states.rs
@@ -161,7 +161,7 @@ pub trait SubStates: States + FreelyMutableState {
     /// it will be created from the returned [`Some`] as the initial state.
     ///
     /// Value within [`Some`] is ignored if the state already exists in the world
-    /// and only symbolises that the state should still exist.
+    /// and only symbolizes that the state should still exist.
     ///
     /// Initial value can also be overwritten by [`NextState`](crate::state::NextState).
     fn should_exist(sources: Self::SourceStates) -> Option<Self>;

--- a/crates/bevy_state/src/state/transitions.rs
+++ b/crates/bevy_state/src/state/transitions.rs
@@ -135,7 +135,7 @@ pub(crate) fn internal_apply_state_transition<S: States>(
         Some(entered) => {
             match current_state {
                 // If the [`State<S>`] resource exists, and the state is not the one we are
-                // entering - we need to set the new value, compute dependant states, send transition events
+                // entering - we need to set the new value, compute dependent states, send transition events
                 // and register transition schedules.
                 Some(mut state_resource) => {
                     let exited = match *state_resource == entered {
@@ -151,7 +151,7 @@ pub(crate) fn internal_apply_state_transition<S: States>(
                     });
                 }
                 None => {
-                    // If the [`State<S>`] resource does not exist, we create it, compute dependant states, send a transition event and register the `OnEnter` schedule.
+                    // If the [`State<S>`] resource does not exist, we create it, compute dependent states, send a transition event and register the `OnEnter` schedule.
                     commands.insert_resource(State(entered.clone()));
 
                     event.send(StateTransitionEvent {
@@ -162,7 +162,7 @@ pub(crate) fn internal_apply_state_transition<S: States>(
             };
         }
         None => {
-            // We first remove the [`State<S>`] resource, and if one existed we compute dependant states, send a transition event and run the `OnExit` schedule.
+            // We first remove the [`State<S>`] resource, and if one existed we compute dependent states, send a transition event and run the `OnExit` schedule.
             if let Some(resource) = current_state {
                 commands.remove_resource::<State<S>>();
 

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -537,7 +537,7 @@ mod test {
 
         // Time will wrap to modulo duration from full `elapsed()`, not to what
         // is left in `elapsed_wrapped()`. This test of values is here to ensure
-        // that we notice if we change that behaviour.
+        // that we notice if we change that behavior.
         assert_eq!(time.elapsed_wrapped(), Duration::from_secs(0));
         assert_eq!(time.elapsed_secs_wrapped(), 0.0);
         assert_eq!(time.elapsed_secs_wrapped_f64(), 0.0);

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -58,9 +58,9 @@ pub struct NodeBundle {
 
 /// A UI node that is an image
 ///
-/// # Extra behaviours
+/// # Extra behaviors
 ///
-/// You may add one or both of the following components to enable additional behaviours:
+/// You may add one or both of the following components to enable additional behaviors:
 /// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
 /// - [`TextureAtlas`](bevy_sprite::TextureAtlas) to draw a specific section of the texture
 #[derive(Bundle, Debug, Default)]
@@ -111,9 +111,9 @@ pub struct ImageBundle {
 
 /// A UI node that is a button
 ///
-/// # Extra behaviours
+/// # Extra behaviors
 ///
-/// You may add one or both of the following components to enable additional behaviours:
+/// You may add one or both of the following components to enable additional behaviors:
 /// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
 /// - [`TextureAtlas`](bevy_sprite::TextureAtlas) to draw a specific section of the texture
 #[derive(Bundle, Clone, Debug)]

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -138,7 +138,7 @@ pub struct WindowDestroyed {
 /// Not to be confused with the `MouseMotion` event from `bevy_input`.
 ///
 /// Because the range of data is limited by the window area and it may have been transformed by the OS to implement certain effects like acceleration,
-/// you should not use it for non-cursor-like behaviour such as 3D camera control. Please see `MouseMotion` instead.
+/// you should not use it for non-cursor-like behavior such as 3D camera control. Please see `MouseMotion` instead.
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
@@ -250,7 +250,7 @@ pub struct WindowFocused {
 /// The window has been occluded (completely hidden from view).
 ///
 /// This is different to window visibility as it depends on
-/// whether the window is closed, minimised, set invisible,
+/// whether the window is closed, minimized, set invisible,
 /// or fully occluded by another window.
 ///
 /// It is the translated version of [`WindowEvent::Occluded`] from the `winit` crate.

--- a/docs-template/features.md.tpl
+++ b/docs-template/features.md.tpl
@@ -3,7 +3,7 @@
 
 ## Cargo Features
 
-Bevy exposes many features to customise the engine. Enabling them add functionalities but often come at the cost of longer compilation times and extra dependencies.
+Bevy exposes many features to customize the engine. Enabling them add functionalities but often come at the cost of longer compilation times and extra dependencies.
 
 ### Default Features
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -3,7 +3,7 @@
 
 ## Cargo Features
 
-Bevy exposes many features to customise the engine. Enabling them add functionalities but often come at the cost of longer compilation times and extra dependencies.
+Bevy exposes many features to customize the engine. Enabling them add functionalities but often come at the cost of longer compilation times and extra dependencies.
 
 ### Default Features
 

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -254,7 +254,7 @@ fn example_control_system(
     camera: Single<(&mut Camera, &mut Transform, &GlobalTransform), With<Camera3d>>,
     mut labels: Query<(&mut Node, &ExampleLabel)>,
     mut display: Single<&mut Text, With<ExampleDisplay>>,
-    labelled: Query<&GlobalTransform>,
+    labeled: Query<&GlobalTransform>,
     mut state: Local<ExampleState>,
     time: Res<Time>,
     input: Res<ButtonInput<KeyCode>>,
@@ -308,7 +308,7 @@ fn example_control_system(
     camera_transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(rotation));
 
     for (mut node, label) in &mut labels {
-        let world_position = labelled.get(label.entity).unwrap().translation() + Vec3::Y;
+        let world_position = labeled.get(label.entity).unwrap().translation() + Vec3::Y;
 
         let viewport_position = camera
             .world_to_viewport(camera_global_transform, world_position)

--- a/examples/animation/color_animation.rs
+++ b/examples/animation/color_animation.rs
@@ -58,7 +58,7 @@ fn setup(mut commands: Commands) {
 
     // Other color spaces like `Srgba` or `Hsva` are neither perceptually nor physically linear.
     // As such, we cannot use curves in these spaces.
-    // However, we can still mix these colours and animate that way. In fact, mixing colors works in any color space.
+    // However, we can still mix these colors and animate that way. In fact, mixing colors works in any color space.
 
     // Spawn a spritre using the provided colors for mixing.
     spawn_mixed_sprite(&mut commands, -75., colors.map(Hsla::from));

--- a/examples/asset/alter_mesh.rs
+++ b/examples/asset/alter_mesh.rs
@@ -212,7 +212,7 @@ fn alter_mesh(
             position[2] *= scale_factor;
         }
 
-        // Flip the local value to reverse the behaviour next time the key is pressed.
+        // Flip the local value to reverse the behavior next time the key is pressed.
         *is_mesh_scaled = !*is_mesh_scaled;
     }
 }

--- a/examples/camera/camera_orbit.rs
+++ b/examples/camera/camera_orbit.rs
@@ -135,7 +135,7 @@ fn orbit(
     camera.rotation = Quat::from_euler(EulerRot::YXZ, yaw, pitch, roll);
 
     // Adjust the translation to maintain the correct orientation toward the orbit target.
-    // In our example it's a static target, but this could easily be customised.
+    // In our example it's a static target, but this could easily be customized.
     let target = Vec3::ZERO;
     camera.translation = target - camera.forward() * camera_settings.orbit_distance;
 }

--- a/examples/ecs/component_hooks.rs
+++ b/examples/ecs/component_hooks.rs
@@ -20,7 +20,7 @@ use bevy::{
 use std::collections::HashMap;
 
 #[derive(Debug)]
-/// Hooks can also be registered during component initialisation by
+/// Hooks can also be registered during component initialization by
 /// using [`Component`] derive macro:
 /// ```no_run
 /// #[derive(Component)]
@@ -31,7 +31,7 @@ struct MyComponent(KeyCode);
 impl Component for MyComponent {
     const STORAGE_TYPE: StorageType = StorageType::Table;
 
-    /// Hooks can also be registered during component initialisation by
+    /// Hooks can also be registered during component initialization by
     /// implementing `register_component_hooks`
     fn register_component_hooks(_hooks: &mut ComponentHooks) {
         // Register hooks...

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -254,7 +254,7 @@ fn update_config(
 
     if keyboard.just_pressed(KeyCode::KeyB) {
         // AABB gizmos are normally only drawn on entities with a ShowAabbGizmo component
-        // We can change this behaviour in the configuration of AabbGizmoGroup
+        // We can change this behavior in the configuration of AabbGizmoGroup
         config_store.config_mut::<AabbGizmoConfigGroup>().1.draw_all ^= true;
     }
 }

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -541,7 +541,7 @@ fn handle_mouse(
         let displacement = accumulated_mouse_motion.delta;
         camera_rig.yaw += displacement.x / 90.;
         camera_rig.pitch += displacement.y / 90.;
-        // The extra 0.01 is to disallow weird behaviour at the poles of the rotation
+        // The extra 0.01 is to disallow weird behavior at the poles of the rotation
         camera_rig.pitch = camera_rig.pitch.clamp(-PI / 2.01, PI / 2.01);
     }
 }

--- a/examples/state/computed_states.rs
+++ b/examples/state/computed_states.rs
@@ -122,7 +122,7 @@ impl ComputedStates for IsPaused {
 // Lastly, we have our tutorial, which actually has a more complex derivation.
 //
 // Like `IsPaused`, the tutorial has a few fully distinct possible states, so we want to represent them
-// as an Enum. However - in this case they are all dependant on multiple states: the root [`TutorialState`],
+// as an Enum. However - in this case they are all dependent on multiple states: the root [`TutorialState`],
 // and both [`InGame`] and [`IsPaused`] - which are in turn derived from [`AppState`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 enum Tutorial {

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -179,7 +179,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-/// Create a coloured rectangle node. The node has size as it is assumed that it will be
+/// Create a colored rectangle node. The node has size as it is assumed that it will be
 /// spawned as a child of a Grid container with `AlignItems::Stretch` and `JustifyItems::Stretch`
 /// which will allow it to take its size from the size of the grid area it occupies.
 fn item_rect(builder: &mut ChildBuilder, color: Srgba) {

--- a/tests/window/minimizing.rs
+++ b/tests/window/minimizing.rs
@@ -1,4 +1,4 @@
-//! A test to confirm that `bevy` allows minimising the window
+//! A test to confirm that `bevy` allows minimizing the window
 //! This is run in CI to ensure that this doesn't regress again.
 use bevy::{core::FrameCount, prelude::*};
 
@@ -8,17 +8,17 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                title: "Minimising".into(),
+                title: "Minimizing".into(),
                 ..default()
             }),
             ..default()
         }))
         .add_systems(Startup, (setup_3d, setup_2d))
-        .add_systems(Update, minimise_automatically)
+        .add_systems(Update, minimize_automatically)
         .run();
 }
 
-fn minimise_automatically(mut window: Single<&mut Window>, frames: Res<FrameCount>) {
+fn minimize_automatically(mut window: Single<&mut Window>, frames: Res<FrameCount>) {
     if frames.0 != 60 {
         return;
     }

--- a/typos.toml
+++ b/typos.toml
@@ -26,6 +26,7 @@ LOD = "LOD" # Level of detail
 TOI = "TOI" # Time of impact
 
 [default]
+locale = "en-us"
 extend-ignore-identifiers-re = [
   "NDK",        # NDK - Native  Development Kit
   "inventario", # Inventory in Portuguese


### PR DESCRIPTION
# Objective

Bevy seems to want to standardize on "American English" spellings. Not sure if this is laid out anywhere in writing, but see also #15947.

While perusing the docs for `typos`, I noticed that it has a `locale` config option and tried it out.

## Solution

Switch to `en-us` locale in the `typos` config and run `typos -w`

## Migration Guide

The following methods or fields have been renamed from `*dependants*` to `*dependents*`.

- `ProcessorAssetInfo::dependants`
- `ProcessorAssetInfos::add_dependant`
- `ProcessorAssetInfos::non_existent_dependants`
- `AssetInfo::dependants_waiting_on_load`
- `AssetInfo::dependants_waiting_on_recursive_dep_load`
- `AssetInfos::loader_dependants`
- `AssetInfos::remove_dependants_and_labels`