### PR TITLE
remove reference to missing file in bevy_remote cargo.toml

### DIFF
--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -7,7 +7,6 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-readme = "README.md"
 
 [features]
 default = ["http"]


### PR DESCRIPTION
# Objective

- bevy_remote Cargo.toml file references a readme that doesn't exist
- This is blocking releasing the rc

## Solution

- Remove the reference
