### PR TITLE
Ensure ghost nodes are skipped when getting parent clipping rect

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -4,10 +4,10 @@ mod render_pass;
 mod ui_material_pipeline;
 pub mod ui_texture_slice_pipeline;
 
-use crate::experimental::UiChildren;
 use crate::{
-    BackgroundColor, BorderColor, CalculatedClip, ComputedNode, DefaultUiCamera, Outline,
-    ResolvedBorderRadius, TargetCamera, UiAntiAlias, UiBoxShadowSamples, UiImage, UiScale,
+    experimental::UiChildren, BackgroundColor, BorderColor, CalculatedClip, ComputedNode,
+    DefaultUiCamera, Outline, ResolvedBorderRadius, TargetCamera, UiAntiAlias, UiBoxShadowSamples,
+    UiImage, UiScale,
 };
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};


### PR DESCRIPTION
# Objective

- Follow up on #16044
- `extract_uinode_borders` uses `bevy_hierarchy` directly instead of going through the traversal utilities, meaning it won't handle `GhostNode`s properly. 

## Solution

- Replaced the use of `bevy_hierarchy::Parent` with `UIChildren::get_parent`

## Testing

- Ran the `overflow` example, clipping looks ok.

---
