### PR TITLE
crate publish order: bevy_animation depends on bevy_animation_derive

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -34,8 +34,8 @@ crates=(
     bevy_core_pipeline
     bevy_input
     bevy_gilrs
-    bevy_animation
     bevy_animation/derive
+    bevy_animation
     bevy_pbr
     bevy_gltf
     bevy_remote


### PR DESCRIPTION
# Objective

- bevy_animation publication fails because of missed dependency
- bevy_animation depends on bevy_animation_derive which is published after

## Solution

- Reorder crates bevy_animation and bevy_animation_derive
