### PR TITLE
Fix point light count limit

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -749,8 +749,7 @@ pub fn prepare_lights(
     let point_light_count = point_lights
         .iter()
         .filter(|light| light.1.spot_light_angles.is_none())
-        .count()
-        .min(max_texture_cubes);
+        .count();
 
     let point_light_volumetric_enabled_count = point_lights
         .iter()
@@ -1060,7 +1059,7 @@ pub fn prepare_lights(
         for &(light_entity, light, (point_light_frusta, _)) in point_lights
             .iter()
             // Lights are sorted, shadow enabled lights are first
-            .take(point_light_count)
+            .take(point_light_count.min(max_texture_cubes))
         {
             let Ok(mut light_view_entities) = light_view_entities.get_mut(light_entity) else {
                 continue;


### PR DESCRIPTION
# Objective

- I made a mistake in #15902, specifically [this diff](https://github.com/bevyengine/bevy/pull/15902/commits/e2faedb99ce78c39d4f76fb852345b3ab0bc16a6) -- the `point_light_count` variable is used for all point lights, not just shadow mapped ones, so I cannot add `.min(max_texture_cubes)` there. (Despite `spot_light_count` having `.min(..)`)

It may have broken code like this (where `index` is index of `point_light` vec):

https://github.com/bevyengine/bevy/blob/9930df83ed42008f7eb2c02cc7350040f0250c2e/crates/bevy_pbr/src/render/light.rs#L848-L850

and also causes panic here:
https://github.com/bevyengine/bevy/blob/9930df83ed42008f7eb2c02cc7350040f0250c2e/crates/bevy_pbr/src/render/light.rs#L1173-L1174

## Solution

- Adds `.min(max_texture_cubes)` directly to the loop where texture views for point lights are created.

## Testing

- `lighting` example (with the directional light removed; original example doesn't crash as only 1 directional-or-spot light in total is shadow-mapped on webgl) no longer crashes on webgl