### PR TITLE
Use CosmicFontSystem in public bevy_text APIs and remove cosmic_text re-export

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -45,8 +45,6 @@ mod text;
 mod text2d;
 mod text_access;
 
-pub use cosmic_text;
-
 pub use bounds::*;
 pub use error::*;
 pub use font::*;

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 
 use bevy_asset::{AssetId, Assets};
 use bevy_color::Color;
+use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -26,7 +27,7 @@ use crate::{
 /// The font system is used to retrieve fonts and their information, including glyph outlines.
 ///
 /// This resource is updated by the [`TextPipeline`] resource.
-#[derive(Resource)]
+#[derive(Resource, Deref, DerefMut)]
 pub struct CosmicFontSystem(pub cosmic_text::FontSystem);
 
 impl Default for CosmicFontSystem {
@@ -422,13 +423,13 @@ impl TextMeasureInfo {
         &mut self,
         bounds: TextBounds,
         computed: &mut ComputedTextBlock,
-        font_system: &mut cosmic_text::FontSystem,
+        font_system: &mut CosmicFontSystem,
     ) -> Vec2 {
         // Note that this arbitrarily adjusts the buffer layout. We assume the buffer is always 'refreshed'
         // whenever a canonical state is required.
         computed
             .buffer
-            .set_size(font_system, bounds.width, bounds.height);
+            .set_size(&mut font_system.0, bounds.width, bounds.height);
         buffer_dimensions(&computed.buffer)
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -290,7 +290,7 @@ with UI components as a child of an entity without UI components, your UI layout
     for (camera_id, mut camera) in camera_layout_info.drain() {
         let inverse_target_scale_factor = camera.scale_factor.recip();
 
-        ui_surface.compute_camera_layout(camera_id, camera.size, text_buffers, &mut font_system.0);
+        ui_surface.compute_camera_layout(camera_id, camera.size, text_buffers, &mut font_system);
 
         for root in &camera.root_nodes {
             update_uinode_geometry_recursive(
@@ -1231,7 +1231,7 @@ mod tests {
                 params.camera_entity,
                 UVec2::new(800, 600),
                 &mut computed_text_block_query,
-                &mut font_system.0,
+                &mut font_system,
             );
         }
 

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -10,6 +10,7 @@ use bevy_math::UVec2;
 use bevy_utils::default;
 
 use crate::{layout::convert, LayoutContext, LayoutError, Measure, MeasureArgs, Node, NodeMeasure};
+use bevy_text::CosmicFontSystem;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootNodePair {
@@ -199,7 +200,7 @@ impl UiSurface {
         camera: Entity,
         render_target_resolution: UVec2,
         buffer_query: &'a mut bevy_ecs::prelude::Query<&mut bevy_text::ComputedTextBlock>,
-        font_system: &'a mut bevy_text::cosmic_text::FontSystem,
+        font_system: &'a mut CosmicFontSystem,
     ) {
         let Some(camera_root_nodes) = self.camera_roots.get(&camera) else {
             return;

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_text::CosmicFontSystem;
 use core::fmt::Formatter;
 pub use taffy::style::AvailableSpace;
 
@@ -19,7 +20,7 @@ pub struct MeasureArgs<'a> {
     pub height: Option<f32>,
     pub available_width: AvailableSpace,
     pub available_height: AvailableSpace,
-    pub font_system: &'a mut bevy_text::cosmic_text::FontSystem,
+    pub font_system: &'a mut CosmicFontSystem,
     pub buffer: Option<&'a mut bevy_text::ComputedTextBlock>,
 }
 


### PR DESCRIPTION
# Objective

Fixes #16006

## Solution

We currently re-export `cosmic_text`, which is seemingly motivated by the desire to use `cosmic_text::FontSystem` in `bevy_text` public APIs instead of our `CosmicFontSystem` resource wrapper type.

This change makes `bevy_text` a "true" abstraction over `cosmic_text` (it in fact, was already built to be that way generally and has this one "leak").

This allows us to remove the `cosmic_text` re-export, which helps clean up the Rust Analyzer imports and generally makes this a "cleaner" API. 