### PR TITLE
Reduce the clusterable object UBO size below 16384 for WebGL 2.

### DIFF
--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -34,7 +34,7 @@ mod assign;
 mod test;
 
 // NOTE: this must be kept in sync with the same constants in pbr.frag
-pub const MAX_UNIFORM_BUFFER_CLUSTERABLE_OBJECTS: usize = 256;
+pub const MAX_UNIFORM_BUFFER_CLUSTERABLE_OBJECTS: usize = 204;
 
 // NOTE: Clustered-forward rendering requires 3 storage buffer bindings so check that
 // at least that many are supported using this constant and SupportedBindingType::from_device()
@@ -811,8 +811,8 @@ impl ViewClusterBuffers {
 }
 
 // NOTE: With uniform buffer max binding size as 16384 bytes
-// that means we can fit 256 clusterable objects in one uniform
-// buffer, which means the count can be at most 256 so it
+// that means we can fit 204 clusterable objects in one uniform
+// buffer, which means the count can be at most 204 so it
 // needs 9 bits.
 // The array of indices can also use u8 and that means the
 // offset in to the array of indices needs to be able to address

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -33,8 +33,13 @@ mod assign;
 #[cfg(test)]
 mod test;
 
-// NOTE: this must be kept in sync with the same constants in pbr.frag
+// NOTE: this must be kept in sync with the same constants in
+// `mesh_view_types.wgsl`.
 pub const MAX_UNIFORM_BUFFER_CLUSTERABLE_OBJECTS: usize = 204;
+// Make sure that the clusterable object buffer doesn't overflow the maximum
+// size of a UBO on WebGL 2.
+const _: () =
+    assert!(size_of::<GpuClusterableObject>() * MAX_UNIFORM_BUFFER_CLUSTERABLE_OBJECTS <= 16384);
 
 // NOTE: Clustered-forward rendering requires 3 storage buffer bindings so check that
 // at least that many are supported using this constant and SupportedBindingType::from_device()

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -105,7 +105,7 @@ struct ClusterOffsetsAndCounts {
 };
 #else
 struct ClusterableObjects {
-    data: array<ClusterableObject, 256u>,
+    data: array<ClusterableObject, 204u>,
 };
 struct ClusterLightIndexLists {
     // each u32 contains 4 u8 indices into the ClusterableObjects array


### PR DESCRIPTION
The PCSS PR #13497 increased the size of clusterable objects from 64 bytes to 80 bytes but didn't decrease the UBO size to compensate, so we blew past the 16kB limit on WebGL 2. This commit fixes the issue by lowering the maximum number of clusterable objects to 204, which puts us under the 16kB limit again.

Closes #15998.