### PR TITLE
Fix AsBindGroupError display for InvalidSamplerType

### DIFF
--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -359,7 +359,7 @@ pub enum AsBindGroupError {
     /// The bind group could not be generated. Try again next frame.
     #[display("The bind group could not be generated")]
     RetryNextUpdate,
-    #[display("At binding index{0}, the provided image sampler `{_1}` does not match the required sampler type(s) `{_2}`.")]
+    #[display("At binding index {_0}, the provided image sampler `{_1}` does not match the required sampler type(s) `{_2}`.")]
     InvalidSamplerType(u32, String, String),
 }
 


### PR DESCRIPTION
# Objective

- Display message for `AsBindGroupError::InvalidSamplerType` was not correctly displaying the binding index

## Solution

- Simple typo fix

## Testing

- Tested locally