### PR TITLE
Fix `bevy_picking` plugin suffixes

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -56,12 +56,13 @@ plugin_group! {
         bevy_gizmos:::GizmoPlugin,
         #[cfg(feature = "bevy_state")]
         bevy_state::app:::StatesPlugin,
-        #[cfg(feature = "bevy_picking")]
-        bevy_picking:::DefaultPickingPlugins,
         #[cfg(feature = "bevy_dev_tools")]
         bevy_dev_tools:::DevToolsPlugin,
         #[cfg(feature = "bevy_ci_testing")]
         bevy_dev_tools::ci_testing:::CiTestingPlugin,
+        #[plugin_group]
+        #[cfg(feature = "bevy_picking")]
+        bevy_picking:::DefaultPickingPlugins,
         #[doc(hidden)]
         :IgnoreAmbiguitiesPlugin,
     }

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -172,7 +172,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::mesh_picking::{
         ray_cast::{MeshRayCast, RayCastBackfaces, RayCastSettings, RayCastVisibility},
-        MeshPickingPlugin, MeshPickingBackendSettings, RayCastPickable,
+        MeshPickingBackendSettings, MeshPickingPlugin, RayCastPickable,
     };
     #[doc(hidden)]
     pub use crate::{
@@ -277,6 +277,13 @@ pub struct DefaultPickingPlugins;
 
 impl PluginGroup for DefaultPickingPlugins {
     fn build(self) -> PluginGroupBuilder {
+        #[cfg_attr(
+            not(feature = "bevy_mesh"),
+            expect(
+                unused_mut,
+                reason = "Group is not mutated when `bevy_mesh` is not enabled."
+            )
+        )]
         let mut group = PluginGroupBuilder::start::<Self>()
             .add(input::PointerInputPlugin::default())
             .add(PickingPlugin::default())

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -172,7 +172,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::mesh_picking::{
         ray_cast::{MeshRayCast, RayCastBackfaces, RayCastSettings, RayCastVisibility},
-        MeshPickingBackendSettings, MeshPickingPlugin, RayCastPickable,
+        MeshPickingPlugin, MeshPickingSettings, RayCastPickable,
     };
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -160,7 +160,7 @@ pub mod input;
 pub mod mesh_picking;
 pub mod pointer;
 
-use bevy_app::prelude::*;
+use bevy_app::{prelude::*, PluginGroupBuilder};
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
 
@@ -275,15 +275,19 @@ pub enum PickSet {
 #[derive(Default)]
 pub struct DefaultPickingPlugins;
 
-impl Plugin for DefaultPickingPlugins {
-    fn build(&self, app: &mut App) {
-        app.add_plugins((
-            input::PointerInputPlugin::default(),
-            PickingPlugin::default(),
-            InteractionPlugin,
-        ));
+impl PluginGroup for DefaultPickingPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        let mut group = PluginGroupBuilder::start::<Self>()
+            .add(input::PointerInputPlugin::default())
+            .add(PickingPlugin::default())
+            .add(InteractionPlugin);
+
         #[cfg(feature = "bevy_mesh")]
-        app.add_plugins(mesh_picking::MeshPickingBackendPlugin);
+        {
+            group = group.add(mesh_picking::MeshPickingBackendPlugin);
+        };
+
+        group
     }
 }
 

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -172,7 +172,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::mesh_picking::{
         ray_cast::{MeshRayCast, RayCastBackfaces, RayCastSettings, RayCastVisibility},
-        MeshPickingBackend, MeshPickingBackendSettings, RayCastPickable,
+        MeshPickingBackendPlugin, MeshPickingBackendSettings, RayCastPickable,
     };
     #[doc(hidden)]
     pub use crate::{
@@ -283,7 +283,7 @@ impl Plugin for DefaultPickingPlugins {
             InteractionPlugin,
         ));
         #[cfg(feature = "bevy_mesh")]
-        app.add_plugins(mesh_picking::MeshPickingBackend);
+        app.add_plugins(mesh_picking::MeshPickingBackendPlugin);
     }
 }
 

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -172,7 +172,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::mesh_picking::{
         ray_cast::{MeshRayCast, RayCastBackfaces, RayCastSettings, RayCastVisibility},
-        MeshPickingBackendPlugin, MeshPickingBackendSettings, RayCastPickable,
+        MeshPickingPlugin, MeshPickingBackendSettings, RayCastPickable,
     };
     #[doc(hidden)]
     pub use crate::{
@@ -284,7 +284,7 @@ impl PluginGroup for DefaultPickingPlugins {
 
         #[cfg(feature = "bevy_mesh")]
         {
-            group = group.add(mesh_picking::MeshPickingBackendPlugin);
+            group = group.add(mesh_picking::MeshPickingPlugin);
         };
 
         group

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -21,7 +21,7 @@ use bevy_reflect::prelude::*;
 use bevy_render::{prelude::*, view::RenderLayers};
 use ray_cast::{MeshRayCast, RayCastSettings, RayCastVisibility, SimplifiedMesh};
 
-/// Runtime settings for the [`MeshPickingBackendPlugin`].
+/// Runtime settings for the [`MeshPickingPlugin`].
 #[derive(Resource, Reflect)]
 #[reflect(Resource, Default)]
 pub struct MeshPickingBackendSettings {
@@ -49,7 +49,7 @@ impl Default for MeshPickingBackendSettings {
     }
 }
 
-/// An optional component that marks cameras and target entities that should be used in the [`MeshPickingBackendPlugin`].
+/// An optional component that marks cameras and target entities that should be used in the [`MeshPickingPlugin`].
 /// Only needed if [`MeshPickingBackendSettings::require_markers`] is set to `true`, and ignored otherwise.
 #[derive(Debug, Clone, Default, Component, Reflect)]
 #[reflect(Component, Default)]
@@ -57,9 +57,9 @@ pub struct RayCastPickable;
 
 /// Adds the mesh picking backend to your app.
 #[derive(Clone, Default)]
-pub struct MeshPickingBackendPlugin;
+pub struct MeshPickingPlugin;
 
-impl Plugin for MeshPickingBackendPlugin {
+impl Plugin for MeshPickingPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MeshPickingBackendSettings>()
             .register_type::<(RayCastPickable, MeshPickingBackendSettings, SimplifiedMesh)>()

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -21,7 +21,7 @@ use bevy_reflect::prelude::*;
 use bevy_render::{prelude::*, view::RenderLayers};
 use ray_cast::{MeshRayCast, RayCastSettings, RayCastVisibility, SimplifiedMesh};
 
-/// Runtime settings for the [`MeshPickingBackend`].
+/// Runtime settings for the [`MeshPickingBackendPlugin`].
 #[derive(Resource, Reflect)]
 #[reflect(Resource, Default)]
 pub struct MeshPickingBackendSettings {
@@ -49,7 +49,7 @@ impl Default for MeshPickingBackendSettings {
     }
 }
 
-/// An optional component that marks cameras and target entities that should be used in the [`MeshPickingBackend`].
+/// An optional component that marks cameras and target entities that should be used in the [`MeshPickingBackendPlugin`].
 /// Only needed if [`MeshPickingBackendSettings::require_markers`] is set to `true`, and ignored otherwise.
 #[derive(Debug, Clone, Default, Component, Reflect)]
 #[reflect(Component, Default)]

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -3,7 +3,7 @@
 //! By default, all meshes are pickable. Picking can be disabled for individual entities
 //! by adding [`PickingBehavior::IGNORE`].
 //!
-//! To make mesh picking entirely opt-in, set [`MeshPickingBackendSettings::require_markers`]
+//! To make mesh picking entirely opt-in, set [`MeshPickingSettings::require_markers`]
 //! to `true` and add a [`RayCastPickable`] component to the desired camera and target entities.
 //!
 //! To manually perform mesh ray casts independent of picking, use the [`MeshRayCast`] system parameter.
@@ -24,7 +24,7 @@ use ray_cast::{MeshRayCast, RayCastSettings, RayCastVisibility, SimplifiedMesh};
 /// Runtime settings for the [`MeshPickingPlugin`].
 #[derive(Resource, Reflect)]
 #[reflect(Resource, Default)]
-pub struct MeshPickingBackendSettings {
+pub struct MeshPickingSettings {
     /// When set to `true` ray casting will only happen between cameras and entities marked with
     /// [`RayCastPickable`]. `false` by default.
     ///
@@ -40,7 +40,7 @@ pub struct MeshPickingBackendSettings {
     pub ray_cast_visibility: RayCastVisibility,
 }
 
-impl Default for MeshPickingBackendSettings {
+impl Default for MeshPickingSettings {
     fn default() -> Self {
         Self {
             require_markers: false,
@@ -50,7 +50,7 @@ impl Default for MeshPickingBackendSettings {
 }
 
 /// An optional component that marks cameras and target entities that should be used in the [`MeshPickingPlugin`].
-/// Only needed if [`MeshPickingBackendSettings::require_markers`] is set to `true`, and ignored otherwise.
+/// Only needed if [`MeshPickingSettings::require_markers`] is set to `true`, and ignored otherwise.
 #[derive(Debug, Clone, Default, Component, Reflect)]
 #[reflect(Component, Default)]
 pub struct RayCastPickable;
@@ -61,16 +61,16 @@ pub struct MeshPickingPlugin;
 
 impl Plugin for MeshPickingPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<MeshPickingBackendSettings>()
-            .register_type::<(RayCastPickable, MeshPickingBackendSettings, SimplifiedMesh)>()
+        app.init_resource::<MeshPickingSettings>()
+            .register_type::<(RayCastPickable, MeshPickingSettings, SimplifiedMesh)>()
             .add_systems(PreUpdate, update_hits.in_set(PickSet::Backend));
     }
 }
 
-/// Casts rays into the scene using [`MeshPickingBackendSettings`] and sends [`PointerHits`] events.
+/// Casts rays into the scene using [`MeshPickingSettings`] and sends [`PointerHits`] events.
 #[allow(clippy::too_many_arguments)]
 pub fn update_hits(
-    backend_settings: Res<MeshPickingBackendSettings>,
+    backend_settings: Res<MeshPickingSettings>,
     ray_map: Res<RayMap>,
     picking_cameras: Query<(&Camera, Option<&RayCastPickable>, Option<&RenderLayers>)>,
     pickables: Query<&PickingBehavior>,

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -57,9 +57,9 @@ pub struct RayCastPickable;
 
 /// Adds the mesh picking backend to your app.
 #[derive(Clone, Default)]
-pub struct MeshPickingBackend;
+pub struct MeshPickingBackendPlugin;
 
-impl Plugin for MeshPickingBackend {
+impl Plugin for MeshPickingBackendPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MeshPickingBackendSettings>()
             .register_type::<(RayCastPickable, MeshPickingBackendSettings, SimplifiedMesh)>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -135,7 +135,7 @@ impl Plugin for SpritePlugin {
             );
 
         #[cfg(feature = "bevy_sprite_picking_backend")]
-        app.add_plugins(picking_backend::SpritePickingBackend);
+        app.add_plugins(picking_backend::SpritePickingBackendPlugin);
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -135,7 +135,7 @@ impl Plugin for SpritePlugin {
             );
 
         #[cfg(feature = "bevy_sprite_picking_backend")]
-        app.add_plugins(picking_backend::SpritePickingBackendPlugin);
+        app.add_plugins(picking_backend::SpritePickingPlugin);
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -15,9 +15,9 @@ use bevy_transform::prelude::*;
 use bevy_window::PrimaryWindow;
 
 #[derive(Clone)]
-pub struct SpritePickingBackendPlugin;
+pub struct SpritePickingPlugin;
 
-impl Plugin for SpritePickingBackendPlugin {
+impl Plugin for SpritePickingPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreUpdate, sprite_picking.in_set(PickSet::Backend));
     }

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -15,9 +15,9 @@ use bevy_transform::prelude::*;
 use bevy_window::PrimaryWindow;
 
 #[derive(Clone)]
-pub struct SpritePickingBackend;
+pub struct SpritePickingBackendPlugin;
 
-impl Plugin for SpritePickingBackend {
+impl Plugin for SpritePickingBackendPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreUpdate, sprite_picking.in_set(PickSet::Backend));
     }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -219,7 +219,7 @@ impl Plugin for UiPlugin {
         build_ui_render(app);
 
         #[cfg(feature = "bevy_ui_picking_backend")]
-        app.add_plugins(picking_backend::UiPickingBackendPlugin);
+        app.add_plugins(picking_backend::UiPickingPlugin);
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -36,8 +36,8 @@ use bevy_picking::backend::prelude::*;
 
 /// A plugin that adds picking support for UI nodes.
 #[derive(Clone)]
-pub struct UiPickingBackendPlugin;
-impl Plugin for UiPickingBackendPlugin {
+pub struct UiPickingPlugin;
+impl Plugin for UiPickingPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(PreUpdate, ui_picking.in_set(PickSet::Backend));
     }

--- a/examples/picking/mesh_picking.rs
+++ b/examples/picking/mesh_picking.rs
@@ -3,7 +3,7 @@
 //! By default, all meshes are pickable. Picking can be disabled for individual entities
 //! by adding [`PickingBehavior::IGNORE`].
 //!
-//! If you want mesh picking to be entirely opt-in, you can set [`MeshPickingBackendSettings::require_markers`]
+//! If you want mesh picking to be entirely opt-in, you can set [`MeshPickingSettings::require_markers`]
 //! to `true` and add a [`RayCastPickable`] component to the desired camera and target entities.
 
 use std::f32::consts::PI;


### PR DESCRIPTION
# Objective

- `MeshPickingBackend` and `SpritePickingBackend` do not have the `Plugin` suffix
- `DefaultPickingPlugins` is masquerading as a `Plugin` when in reality it should be a `PluginGroup`
- Fixes #16081.

## Solution

- Rename some structures:

|Original Name|New Name|
|-|-|
|`MeshPickingBackend`|`MeshPickingPlugin`|
|`MeshPickingBackendSettings`|`MeshPickingSettings`|
|`SpritePickingBackend`|`SpritePickingPlugin`|
|`UiPickingBackendPlugin`|`UiPickingPlugin`|

- Make `DefaultPickingPlugins` a `PluginGroup`.
- Because `DefaultPickingPlugins` is within the `DefaultPlugins` plugin group, I also added support for nested plugin groups to the `plugin_group!` macro.

## Testing

- I used ripgrep to ensure all references were properly renamed.
- For the `plugin_group!` macro, I used `cargo expand` to manually inspect the expansion of `DefaultPlugins`.

---

## Migration Guide

> [!NOTE]
>
> All 3 of the changed structures were added after 0.14, so this does not need to be included in the 0.14 to 0.15 migration guide.

- `MeshPickingBackend` is now named `MeshPickingPlugin`.
- `MeshPickingBackendSettings` is now named `MeshPickingSettings`.
- `SpritePickingBackend` is now named `SpritePickingPlugin`.
- `UiPickingBackendPlugin` is now named `UiPickingPlugin`.
- `DefaultPickingPlugins` is now a a `PluginGroup` instead of a `Plugin`.