### PR TITLE
Add image scale mode to uiimage

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -308,18 +308,15 @@ pub fn extract_uinode_images(
     texture_atlases: Extract<Res<Assets<TextureAtlasLayout>>>,
     default_ui_camera: Extract<DefaultUiCamera>,
     uinode_query: Extract<
-        Query<
-            (
-                Entity,
-                &ComputedNode,
-                &GlobalTransform,
-                &ViewVisibility,
-                Option<&CalculatedClip>,
-                Option<&TargetCamera>,
-                &UiImage,
-            ),
-            Without<ImageScaleMode>,
-        >,
+        Query<(
+            Entity,
+            &ComputedNode,
+            &GlobalTransform,
+            &ViewVisibility,
+            Option<&CalculatedClip>,
+            Option<&TargetCamera>,
+            &UiImage,
+        )>,
     >,
     mapping: Extract<Query<RenderEntity>>,
 ) {
@@ -337,6 +334,7 @@ pub fn extract_uinode_images(
         if !view_visibility.get()
             || image.color.is_fully_transparent()
             || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
+            || image.scale_mode.is_some()
         {
             continue;
         }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -40,7 +40,7 @@ use bevy_render::{
     ExtractSchedule, Render,
 };
 use bevy_sprite::TextureAtlasLayout;
-use bevy_sprite::{BorderRect, ImageScaleMode, SpriteAssetEvents};
+use bevy_sprite::{BorderRect, SpriteAssetEvents};
 
 use crate::{Display, Node};
 use bevy_text::{ComputedTextBlock, PositionedGlyph, TextColor, TextLayoutInfo};

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -256,20 +256,21 @@ pub fn extract_ui_texture_slices(
             Option<&CalculatedClip>,
             Option<&TargetCamera>,
             &UiImage,
-            &ImageScaleMode,
         )>,
     >,
     mapping: Extract<Query<RenderEntity>>,
 ) {
-    for (entity, uinode, transform, view_visibility, clip, camera, image, image_scale_mode) in
-        &slicers_query
-    {
+    for (entity, uinode, transform, view_visibility, clip, camera, image) in &slicers_query {
         let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_ui_camera.get())
         else {
             continue;
         };
 
         let Ok(camera_entity) = mapping.get(camera_entity) else {
+            continue;
+        };
+
+        let Some(ref image_scale_mode) = image.scale_mode else {
             continue;
         };
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     texture::{Image, TRANSPARENT_IMAGE_HANDLE},
     view::Visibility,
 };
-use bevy_sprite::{BorderRect, TextureAtlas};
+use bevy_sprite::{BorderRect, ImageScaleMode, TextureAtlas};
 use bevy_transform::components::Transform;
 use bevy_utils::warn_once;
 use bevy_window::{PrimaryWindow, WindowRef};
@@ -2066,6 +2066,8 @@ pub struct UiImage {
     /// When used with a [`TextureAtlas`], the rect
     /// is offset by the atlas's minimal (top-left) corner position.
     pub rect: Option<Rect>,
+    /// Controls how the image is altered when scaled.
+    pub scale_mode: Option<ImageScaleMode>,
 }
 
 impl Default for UiImage {
@@ -2087,6 +2089,7 @@ impl Default for UiImage {
             flip_x: false,
             flip_y: false,
             rect: None,
+            scale_mode: None,
         }
     }
 }
@@ -2112,6 +2115,7 @@ impl UiImage {
             flip_y: false,
             texture_atlas: None,
             rect: None,
+            scale_mode: None,
         }
     }
 
@@ -2148,6 +2152,12 @@ impl UiImage {
     #[must_use]
     pub const fn with_rect(mut self, rect: Rect) -> Self {
         self.rect = Some(rect);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_scale_mode(mut self, scale_mode: ImageScaleMode) -> Self {
+        self.scale_mode = Some(scale_mode);
         self
     }
 }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -106,6 +106,10 @@ pub fn update_image_content_size_system(
         * ui_scale.0;
 
     for (mut content_size, image, mut image_size) in &mut query {
+        if image.scale_mode.is_some() {
+            continue;
+        }
+
         if let Some(size) = match &image.texture_atlas {
             Some(atlas) => atlas.texture_rect(&atlases).map(|t| t.size()),
             None => textures.get(&image.image).map(Image::size),

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -87,7 +87,8 @@ fn setup(
                                 index: idx,
                                 layout: atlas_layout_handle.clone(),
                             },
-                        ),
+                        )
+                        .with_scale_mode(ImageScaleMode::Sliced(slicer.clone())),
                         Node {
                             width: Val::Px(w),
                             height: Val::Px(h),
@@ -98,7 +99,6 @@ fn setup(
                             margin: UiRect::all(Val::Px(20.0)),
                             ..default()
                         },
-                        ImageScaleMode::Sliced(slicer.clone()),
                     ))
                     .with_children(|parent| {
                         parent.spawn((

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -77,20 +77,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             margin: UiRect::all(Val::Px(20.0)),
                             ..default()
                         },
-                        UiImage::new(image.clone()),
-                        ImageScaleMode::Sliced(slicer.clone()),
+                        UiImage::new(image.clone())
+                            .with_scale_mode(ImageScaleMode::Sliced(slicer.clone())),
                     ))
-                    .with_children(|parent| {
-                        parent.spawn((
-                            Text::new("Button"),
-                            TextFont {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: 33.0,
-                                ..default()
-                            },
-                            TextColor(Color::srgb(0.9, 0.9, 0.9)),
-                        ));
-                    });
+                    .with_child((
+                        Text::new("Button"),
+                        TextFont {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font_size: 33.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.9, 0.9, 0.9)),
+                    ));
             }
         });
 }

--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -61,6 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         image: image.clone(),
                         flip_x,
                         flip_y,
+                        scale_mode: Some(ImageScaleMode::Sliced(slicer.clone())),
                         ..default()
                     },
                     Node {
@@ -68,7 +69,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         height: Val::Px(height),
                         ..default()
                     },
-                    ImageScaleMode::Sliced(slicer.clone()),
                 ));
             }
         });


### PR DESCRIPTION
# Objective

UI texture slicing chops and scales an image to fit the size of a node but because the required components changes required ImageSize and ContentSize for nodes with UiImage, texture sliced nodes are laid out using an ImageMeasure.

Alternative implementation of #16086.

This doesn't feel great to me, we end up with a lot of systems iterating through entities they ignore, rather than never pulling them in in the query. It does seem to fit in better with the direction of the other `UiImage` changes though and it makes the feature much more discoverable. It wasn't documented anywhere except in the examples that `UiImage`s could be composed with `ImageScaleMode` which I guess was probably why this error got introduced.

## Solution

Add a `scale_mode: ImageScaleMode` field to `UiImage`. 
Remove queries for `ImageScaleMode` from UI extraction, and refer to the field instead.
Don't set a measure func in `update_image_content_size_system` if `scale_mode` is some.

## Testing
Remove all the constraints from the ui_texture_slice example:

//! This example illustrates how to create buttons with their textures sliced
//! and kept in proportion instead of being stretched by the button dimensions

use bevy::{
    color::palettes::css::{GOLD, ORANGE},
    prelude::*,
    winit::WinitSettings,
};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
        .insert_resource(WinitSettings::desktop_app())
        .add_systems(Startup, setup)
        .add_systems(Update, button_system)
        .run();
}

fn button_system(
    mut interaction_query: Query<
        (&Interaction, &Children, &mut UiImage),
        (Changed<Interaction>, With<Button>),
    >,
    mut text_query: Query<&mut Text>,
) {
    for (interaction, children, mut image) in &mut interaction_query {
        let mut text = text_query.get_mut(children[0]).unwrap();
        match *interaction {
            Interaction::Pressed => {
                **text = "Press".to_string();
                image.color = GOLD.into();
            }
            Interaction::Hovered => {
                **text = "Hover".to_string();
                image.color = ORANGE.into();
            }
            Interaction::None => {
                **text = "Button".to_string();
                image.color = Color::WHITE;
            }
        }
    }
}

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    let image = asset_server.load("textures/fantasy_ui_borders/panel-border-010.png");

    let slicer = TextureSlicer {
        border: BorderRect::square(22.0),
        center_scale_mode: SliceScaleMode::Stretch,
        sides_scale_mode: SliceScaleMode::Stretch,
        max_corner_scale: 1.0,
    };
    // ui camera
    commands.spawn(Camera2d);
    commands
        .spawn(Node {
            width: Val::Percent(100.0),
            height: Val::Percent(100.0),
            align_items: AlignItems::Center,
            justify_content: JustifyContent::Center,
            ..default()
        })
        .with_children(|parent| {
            for [w, h] in [[150.0, 150.0], [300.0, 150.0], [150.0, 300.0]] {
                parent
                    .spawn((
                        Button,
                        Node {
                            // width: Val::Px(w),
                            // height: Val::Px(h),
                            // horizontally center child text
                            justify_content: JustifyContent::Center,
                            // vertically center child text
                            align_items: AlignItems::Center,
                            margin: UiRect::all(Val::Px(20.0)),
                            ..default()
                        },
                        UiImage::new(image.clone()),
                        ImageScaleMode::Sliced(slicer.clone()),
                    ))
                    .with_children(|parent| {
                        // parent.spawn((
                        //     Text::new("Button"),
                        //     TextFont {
                        //         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                        //         font_size: 33.0,
                        //         ..default()
                        //     },
                        //     TextColor(Color::srgb(0.9, 0.9, 0.9)),
                        // ));
                    });
            }
        });
}
This should result in a blank window, since without any constraints the texture slice image nodes should be zero sized. But instead we see three nodes:

slicing
With this PR the window is blank.

