### PR TITLE
Correctly feature gate `custom_cursor`

### DIFF
--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -6,7 +6,6 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::{CompassOctant, Vec2};
-#[cfg(feature = "custom_cursor")]
 use bevy_window::SystemCursorIcon;
 use bevy_window::{EnabledButtons, WindowLevel, WindowTheme};
 use winit::keyboard::{Key, NamedKey, NativeKey};
@@ -630,7 +629,6 @@ pub fn convert_native_key(native_key: &NativeKey) -> bevy_input::keyboard::Nativ
     }
 }
 
-#[cfg(feature = "custom_cursor")]
 /// Converts a [`SystemCursorIcon`] to a [`winit::window::CursorIcon`].
 pub fn convert_system_cursor_icon(cursor_icon: SystemCursorIcon) -> winit::window::CursorIcon {
     match cursor_icon {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -44,7 +44,6 @@ use crate::{
 
 pub mod accessibility;
 mod converters;
-#[cfg(feature = "custom_cursor")]
 pub mod cursor;
 mod state;
 mod system;
@@ -136,7 +135,6 @@ impl<T: Event> Plugin for WinitPlugin<T> {
             );
 
         app.add_plugins(AccessKitPlugin);
-        #[cfg(feature = "custom_cursor")]
         app.add_plugins(cursor::CursorPlugin);
 
         let event_loop = event_loop_builder

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,12 +1,14 @@
 //! Illustrates how to change window settings and shows how to affect
 //! the mouse pointer in various ways.
 
+#[cfg(feature = "custom_cursor")]
+use bevy::winit::cursor::CustomCursor;
 use bevy::{
     core::FrameCount,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{CursorGrabMode, PresentMode, SystemCursorIcon, WindowLevel, WindowTheme},
-    winit::cursor::{CursorIcon, CustomCursor},
+    winit::cursor::CursorIcon,
 };
 
 fn main() {
@@ -152,12 +154,16 @@ fn toggle_theme(mut window: Single<&mut Window>, input: Res<ButtonInput<KeyCode>
 #[derive(Resource)]
 struct CursorIcons(Vec<CursorIcon>);
 
-fn init_cursor_icons(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn init_cursor_icons(
+    mut commands: Commands,
+    #[cfg(feature = "custom_cursor")] asset_server: Res<AssetServer>,
+) {
     commands.insert_resource(CursorIcons(vec![
         SystemCursorIcon::Default.into(),
         SystemCursorIcon::Pointer.into(),
         SystemCursorIcon::Wait.into(),
         SystemCursorIcon::Text.into(),
+        #[cfg(feature = "custom_cursor")]
         CustomCursor::Image {
             handle: asset_server.load("branding/icon.png"),
             hotspot: (128, 128),


### PR DESCRIPTION
# Objective

Currently there's no way to change the window's cursor icon with the `custom_cursor` feature **disabled**. You should still be able to set system cursor icons.

Connections:

- https://github.com/bevyengine/bevy/pull/15649

## Solution

Move some `custom_cursor` feature gates around, as to expose the `CursorIcon` type again.

Note this refactoring was mainly piloted by hunting after the compiler warnings -- I shouldn't have missed anything, but FYI.

## Testing

Disabled the `custom_cursor` feature, ran the `window_settings` example.