### PR TITLE
fix bevy_dev_tools build

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -33,7 +33,9 @@ bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.15.0-dev" }
-bevy_ui = { path = "../bevy_ui", version = "0.15.0-dev" }
+bevy_ui = { path = "../bevy_ui", version = "0.15.0-dev", features = [
+  "bevy_text",
+] }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.15.0-dev" }


### PR DESCRIPTION
# Objective

- bevy_dev_tools 0.15.0-rc.1 failed to build docs
- it use bevy_text feature in bevy_ui but it's not enabled by default
- https://docs.rs/crate/bevy_dev_tools/0.15.0-rc.1
- 
## Solution

- enable bevy_text feature of bevy_ui
