### PR TITLE
Mesh picking fixes

### DIFF
--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -1,6 +1,5 @@
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};
-use bevy_picking::{mesh_picking::ray_cast, prelude::*};
-use bevy_render::mesh::Indices;
+use bevy_picking::mesh_picking::ray_cast;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn ptoxznorm(p: u32, size: u32) -> (f32, f32) {

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -1,5 +1,6 @@
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};
 use bevy_picking::{mesh_picking::ray_cast, prelude::*};
+use bevy_render::mesh::Indices;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn ptoxznorm(p: u32, size: u32) -> (f32, f32) {
@@ -10,7 +11,7 @@ fn ptoxznorm(p: u32, size: u32) -> (f32, f32) {
 struct SimpleMesh {
     positions: Vec<[f32; 3]>,
     normals: Vec<[f32; 3]>,
-    indices: Vec<u32>,
+    indices: Indices,
 }
 
 fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
@@ -31,6 +32,7 @@ fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
             indices.extend_from_slice(&[p + vertices_per_side, p + 1, p + vertices_per_side + 1]);
         }
     }
+    let indices = Indices::U32(indices);
 
     SimpleMesh {
         positions,

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -11,7 +11,7 @@ fn ptoxznorm(p: u32, size: u32) -> (f32, f32) {
 struct SimpleMesh {
     positions: Vec<[f32; 3]>,
     normals: Vec<[f32; 3]>,
-    indices: Indices,
+    indices: Vec<u32>,
 }
 
 fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
@@ -32,7 +32,6 @@ fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
             indices.extend_from_slice(&[p + vertices_per_side, p + 1, p + vertices_per_side + 1]);
         }
     }
-    let indices = Indices::U32(indices);
 
     SimpleMesh {
         positions,

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -284,17 +284,10 @@ impl PluginGroup for DefaultPickingPlugins {
                 reason = "Group is not mutated when `bevy_mesh` is not enabled."
             )
         )]
-        let mut group = PluginGroupBuilder::start::<Self>()
+        PluginGroupBuilder::start::<Self>()
             .add(input::PointerInputPlugin::default())
             .add(PickingPlugin::default())
-            .add(InteractionPlugin);
-
-        #[cfg(feature = "bevy_mesh")]
-        {
-            group = group.add(mesh_picking::MeshPickingPlugin);
-        };
-
-        group
+            .add(InteractionPlugin)
     }
 }
 

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -277,13 +277,6 @@ pub struct DefaultPickingPlugins;
 
 impl PluginGroup for DefaultPickingPlugins {
     fn build(self) -> PluginGroupBuilder {
-        #[cfg_attr(
-            not(feature = "bevy_mesh"),
-            expect(
-                unused_mut,
-                reason = "Group is not mutated when `bevy_mesh` is not enabled."
-            )
-        )]
         PluginGroupBuilder::start::<Self>()
             .add(input::PointerInputPlugin::default())
             .add(PickingPlugin::default())

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
@@ -37,9 +37,7 @@ pub(super) fn ray_intersection_over_mesh(
     backface_culling: Backfaces,
 ) -> Option<RayMeshHit> {
     if mesh.primitive_topology() != PrimitiveTopology::TriangleList {
-        error!(
-            "Invalid intersection check: `TriangleList` is the only supported `PrimitiveTopology`"
-        );
+        // ray_mesh_intersection assumes vertices are laid out in a triangle list
         return None;
     }
 

--- a/examples/picking/mesh_picking.rs
+++ b/examples/picking/mesh_picking.rs
@@ -1,10 +1,23 @@
 //! A simple 3D scene to demonstrate mesh picking.
 //!
-//! By default, all meshes are pickable. Picking can be disabled for individual entities
-//! by adding [`PickingBehavior::IGNORE`].
+//! [`bevy::picking::backend`] provides an API for adding picking hit tests to any entity. To get
+//! started with picking 3d meshes, the [`MeshPickingPlugin`] is provided as a simple starting
+//! point, especially useful for debugging. For your game, you may want to use a 3d picking backend
+//! provided by your physics engine, or a picking shader, depending on your specific use case.
 //!
-//! If you want mesh picking to be entirely opt-in, you can set [`MeshPickingSettings::require_markers`]
-//! to `true` and add a [`RayCastPickable`] component to the desired camera and target entities.
+//! [`bevy::picking`] allows you to compose backends together to make any entity on screen pickable
+//! with pointers, regardless of how that entity is rendered. For example, `bevy_ui` and
+//! `bevy_sprite` provide their own picking backends that can be enabled at the same time as this
+//! mesh picking backend. This makes it painless to deal with cases like the UI or sprites blocking
+//! meshes underneath them, or vice versa.
+//!
+//! If you want to build more complex interactions than afforded by the provided pointer events, you
+//! may want to use [`MeshRayCast`] or a full physics engine with raycasting capabilities.
+//!
+//! By default, the mesh picking plugin will raycast against all entities, which is especially
+//! useful for debugging. If you want mesh picking to be opt-in, you can set
+//! [`MeshPickingSettings::require_markers`] to `true` and add a [`RayCastPickable`] component to
+//! the desired camera and target entities.
 
 use std::f32::consts::PI;
 
@@ -19,7 +32,12 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((
+            DefaultPlugins,
+            // The mesh picking plugin is not enabled by default, because raycasting against all
+            // meshes has a performance cost.
+            MeshPickingPlugin,
+        ))
         .init_resource::<SceneMaterials>()
         .add_systems(Startup, setup)
         .add_systems(Update, (on_mesh_hover, rotate))

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -1,14 +1,15 @@
-//! A simple scene to demonstrate picking events
+//! A simple scene to demonstrate picking events for UI and mesh entities.
 
-use bevy::{color::palettes::tailwind::CYAN_400, prelude::*};
+use bevy::prelude::*;
 
 fn main() {
-    let mut app = App::new();
-    app.add_plugins(DefaultPlugins);
-
-    app.add_systems(Startup, setup);
-
-    app.run();
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            MeshPickingPlugin, // Needed for mesh picking, not added by default
+        ))
+        .add_systems(Startup, setup)
+        .run();
 }
 
 /// set up a simple 3D scene
@@ -19,7 +20,7 @@ fn setup(
 ) {
     commands
         .spawn((
-            Text::new("Click Me to get a box"),
+            Text::new("Click Me to get a box\nDrag cubes to rotate"),
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Percent(12.0),
@@ -27,20 +28,7 @@ fn setup(
                 ..default()
             },
         ))
-        .observe(
-            |_click: Trigger<Pointer<Click>>,
-             mut commands: Commands,
-             mut meshes: ResMut<Assets<Mesh>>,
-             mut materials: ResMut<Assets<StandardMaterial>>,
-             mut num: Local<usize>| {
-                commands.spawn((
-                    Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
-                    MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
-                    Transform::from_xyz(0.0, 0.5 + 1.1 * *num as f32, 0.0),
-                ));
-                *num += 1;
-            },
-        )
+        .observe(on_pointer_click_spawn_cube)
         .observe(
             |evt: Trigger<Pointer<Out>>, mut texts: Query<&mut TextColor>| {
                 let mut color = texts.get_mut(evt.entity()).unwrap();
@@ -50,7 +38,7 @@ fn setup(
         .observe(
             |evt: Trigger<Pointer<Over>>, mut texts: Query<&mut TextColor>| {
                 let mut color = texts.get_mut(evt.entity()).unwrap();
-                color.0 = CYAN_400.into();
+                color.0 = bevy::color::palettes::tailwind::CYAN_400.into();
             },
         );
     // circular base
@@ -72,4 +60,29 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
+}
+
+fn on_pointer_click_spawn_cube(
+    _click: Trigger<Pointer<Click>>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut num: Local<usize>,
+) {
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
+            MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
+            Transform::from_xyz(0.0, 0.25 + 0.55 * *num as f32, 0.0),
+        ))
+        // With the MeshPickingPlugin added, you can add pointer event observers to meshes as well:
+        .observe(
+            |drag: Trigger<Pointer<Drag>>, mut transforms: Query<&mut Transform>| {
+                if let Ok(mut transform) = transforms.get_mut(drag.entity()) {
+                    transform.rotate_y(drag.delta.x * 0.02);
+                    transform.rotate_x(drag.delta.y * 0.02);
+                }
+            },
+        );
+    *num += 1;
 }


### PR DESCRIPTION
# Objective

- Mesh picking is noisy when a non triangle list is used
- Mesh picking runs even when users don't need it
- Resolve #16065 

## Solution

- Don't add the mesh picking plugin by default
- Remove error spam