### PR TITLE
Meshlet normal-aware LOD and meshoptimizer upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1216,7 +1216,7 @@ setup = [
     "curl",
     "-o",
     "assets/models/bunny.meshlet_mesh",
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/8483db58832542383820c3f44e4730e566910be7/bunny.meshlet_mesh",
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/defbd9b32072624d40d57de7d345c66a9edf5d0b/bunny.meshlet_mesh",
   ],
 ]
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -62,7 +62,7 @@ lz4_flex = { version = "0.11", default-features = false, features = [
 ], optional = true }
 range-alloc = { version = "0.1.3", optional = true }
 half = { version = "2", features = ["bytemuck"], optional = true }
-meshopt = { git = "https://github.com/JMS55/meshopt-rs", branch = "v0.4.0", optional = true }
+meshopt = { version = "0.4", optional = true }
 metis = { version = "0.2", optional = true }
 itertools = { version = "0.13", optional = true }
 bitvec = { version = "1", optional = true }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -62,7 +62,7 @@ lz4_flex = { version = "0.11", default-features = false, features = [
 ], optional = true }
 range-alloc = { version = "0.1.3", optional = true }
 half = { version = "2", features = ["bytemuck"], optional = true }
-meshopt = { version = "0.3.0", optional = true }
+meshopt = { git = "https://github.com/JMS55/meshopt-rs", branch = "v0.4.0", optional = true }
 metis = { version = "0.2", optional = true }
 itertools = { version = "0.13", optional = true }
 bitvec = { version = "1", optional = true }

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use self::{
 pub use self::asset::{MeshletMesh, MeshletMeshLoader, MeshletMeshSaver};
 #[cfg(feature = "meshlet_processor")]
 pub use self::from_mesh::{
-    MeshToMeshletMeshConversionError, DEFAULT_VERTEX_POSITION_QUANTIZATION_FACTOR,
+    MeshToMeshletMeshConversionError, MESHLET_DEFAULT_VERTEX_POSITION_QUANTIZATION_FACTOR,
 };
 
 use self::{

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -17,7 +17,7 @@ use camera_controller::{CameraController, CameraControllerPlugin};
 use std::{f32::consts::PI, path::Path, process::ExitCode};
 
 const ASSET_URL: &str =
-    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/8483db58832542383820c3f44e4730e566910be7/bunny.meshlet_mesh";
+    "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/defbd9b32072624d40d57de7d345c66a9edf5d0b/bunny.meshlet_mesh";
 
 fn main() -> ExitCode {
     if !Path::new("./assets/models/bunny.meshlet_mesh").exists() {


### PR DESCRIPTION
# Objective

- Choose LOD based on normal simplification error in addition to position error 
- Update meshoptimizer to 0.22, which has a bunch of simplifier improvements

## Testing

- Did you test these changes? If so, how?
  - Visualize normals, and compare LOD changes before and after. Normals no longer visibly change as the LOD cut changes.
- Are there any parts that need more testing?
  - No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the meshlet example in this PR and on main and move around to change the LOD cut. Before running each example, in meshlet_mesh_material.wgsl, replace `let color = vec3(rand_f(&rng), rand_f(&rng), rand_f(&rng));` with `let color = (vertex_output.world_normal + 1.0) / 2.0;`. Make sure to download the appropriate bunny asset for each branch!