### PR TITLE
Fix `dead_code` warnings in examples

### DIFF
--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -138,6 +138,10 @@ mod light {
     }
 }
 
+#[cfg_attr(
+    all(feature = "bevy_ci_testing", target_os = "windows"),
+    expect(dead_code)
+)]
 mod bloom {
     use bevy::{
         core_pipeline::{bloom::Bloom, tonemapping::Tonemapping},
@@ -191,6 +195,10 @@ mod bloom {
     }
 }
 
+#[cfg_attr(
+    all(feature = "bevy_ci_testing", target_os = "windows"),
+    expect(dead_code)
+)]
 mod gltf {
     use bevy::prelude::*;
 


### PR DESCRIPTION
# Objective

Fix a few warnings that show up depending on `bevy_ci_testing`

## Solution

Expect dead code depending on the feature flag

## Testing

Tested locally with cargo check.
