### PR TITLE
Undeprecate is_playing_animation

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -856,8 +856,8 @@ impl AnimationPlayer {
         self.active_animations.iter_mut()
     }
 
-    #[deprecated = "Use `animation_is_playing` instead"]
-    /// Check if the given animation node is being played.
+    /// Returns true if the animation is currently playing or paused, or false
+    /// if the animation is stopped.
     pub fn is_playing_animation(&self, animation: AnimationNodeIndex) -> bool {
         self.active_animations.contains_key(&animation)
     }
@@ -944,6 +944,7 @@ impl AnimationPlayer {
         self.active_animations.get_mut(&animation)
     }
 
+    #[deprecated = "Use `is_playing_animation` instead"]
     /// Returns true if the animation is currently playing or paused, or false
     /// if the animation is stopped.
     pub fn animation_is_playing(&self, animation: AnimationNodeIndex) -> bool {

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -452,7 +452,7 @@ fn sync_weights(mut query: Query<(&mut AnimationPlayer, &ExampleAnimationWeights
             .zip(animation_weights.weights.iter())
         {
             // If the animation happens to be no longer active, restart it.
-            if !animation_player.animation_is_playing(animation_node_index.into()) {
+            if !animation_player.is_playing_animation(animation_node_index.into()) {
                 animation_player.play(animation_node_index.into());
             }
 


### PR DESCRIPTION
# Objective

- Fixes #16098

## Solution

- Undeprecate `is_playing_animation` and copy the docs from `animation_is_playing` to it.

## Testing

- CI

## Migration

https://github.com/bevyengine/bevy-website/blob/68e9a34e3068ed2e7db5ae0b4b32feac94a589dd/release-content/0.15/migration-guides/_guides.toml#L13-L17 needs to be removed.
