### PR TITLE
Rename `ComputedNode::calculated_size` to `size`

### DIFF
--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -53,8 +53,8 @@ fn calc_bounds(
                     let bounds = Rect::new(
                         translation.x.into(),
                         translation.y.into(),
-                        (translation.x + node.calculated_size.x).into(),
-                        (translation.y + node.calculated_size.y).into(),
+                        (translation.x + node.size.x).into(),
+                        (translation.y + node.size.y).into(),
                     );
                     accessible.set_bounds(bounds);
                 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -359,8 +359,8 @@ with UI components as a child of an entity without UI components, your UI layout
                     + 0.5 * (rounded_size - parent_size);
 
             // only trigger change detection when the new values are different
-            if node.calculated_size != rounded_size || node.unrounded_size != layout_size {
-                node.calculated_size = rounded_size;
+            if node.size != rounded_size || node.unrounded_size != layout_size {
+                node.size = rounded_size;
                 node.unrounded_size = layout_size;
             }
 
@@ -374,12 +374,12 @@ with UI components as a child of an entity without UI components, your UI layout
             node.bypass_change_detection().border = taffy_rect_to_border_rect(layout.border);
             node.bypass_change_detection().padding = taffy_rect_to_border_rect(layout.padding);
 
-            let viewport_size = root_size.unwrap_or(node.calculated_size);
+            let viewport_size = root_size.unwrap_or(node.size);
 
             if let Some(border_radius) = maybe_border_radius {
                 // We don't trigger change detection for changes to border radius
                 node.bypass_change_detection().border_radius =
-                    border_radius.resolve(node.calculated_size, viewport_size);
+                    border_radius.resolve(node.size, viewport_size);
             }
 
             if let Some(outline) = maybe_outline {
@@ -1129,9 +1129,9 @@ mod tests {
                 ui_schedule.run(&mut world);
                 let width_sum: f32 = children
                     .iter()
-                    .map(|child| world.get::<ComputedNode>(*child).unwrap().calculated_size.x)
+                    .map(|child| world.get::<ComputedNode>(*child).unwrap().size.x)
                     .sum();
-                let parent_width = world.get::<ComputedNode>(parent).unwrap().calculated_size.x;
+                let parent_width = world.get::<ComputedNode>(parent).unwrap().size.x;
                 assert!((width_sum - parent_width).abs() < 0.001);
                 assert!((width_sum - 320.).abs() <= 1.);
                 s += r;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -282,7 +282,7 @@ pub fn extract_uinode_background_colors(
                 color: background_color.0.into(),
                 rect: Rect {
                     min: Vec2::ZERO,
-                    max: uinode.calculated_size,
+                    max: uinode.size,
                 },
                 clip: clip.map(|clip| clip.clip),
                 image: AssetId::default(),
@@ -351,7 +351,7 @@ pub fn extract_uinode_images(
         let mut rect = match (atlas_rect, image.rect) {
             (None, None) => Rect {
                 min: Vec2::ZERO,
-                max: uinode.calculated_size,
+                max: uinode.size,
             },
             (None, Some(image_rect)) => image_rect,
             (Some(atlas_rect), None) => atlas_rect,

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -307,7 +307,7 @@ pub fn extract_ui_texture_slices(
                 color: image.color.into(),
                 rect: Rect {
                     min: Vec2::ZERO,
-                    max: uinode.calculated_size,
+                    max: uinode.size,
                 },
                 clip: clip.map(|clip| clip.clip),
                 image: image.image.id(),

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -25,7 +25,7 @@ pub struct ComputedNode {
     /// The size of the node as width and height in logical pixels
     ///
     /// automatically calculated by [`super::layout::ui_layout_system`]
-    pub(crate) calculated_size: Vec2,
+    pub(crate) size: Vec2,
     /// The width of this node's outline.
     /// If this value is `Auto`, negative or `0.` then no outline will be rendered.
     /// Outline updates bypass change detection.
@@ -63,7 +63,7 @@ impl ComputedNode {
     ///
     /// Automatically calculated by [`super::layout::ui_layout_system`].
     pub const fn size(&self) -> Vec2 {
-        self.calculated_size
+        self.size
     }
 
     /// Check if the node is empty.
@@ -197,7 +197,7 @@ impl ComputedNode {
 impl ComputedNode {
     pub const DEFAULT: Self = Self {
         stack_index: 0,
-        calculated_size: Vec2::ZERO,
+        size: Vec2::ZERO,
         outline_width: 0.,
         outline_offset: 0.,
         unrounded_size: Vec2::ZERO,


### PR DESCRIPTION
# Objective

Remove `calculated_` from the name `ComputedNode::calculated_size` as redundant, It's obvious from context that it's the resolved size value and it's inconsistant since none of other fields of `ComputedNode` have a `calculated_` prefix.

## Alternatives

Rename all the fields of `ComputedNode` to `calculated_*`, this seems worse.