### PR TITLE
Update notify-debouncer-full requirement from 0.3.1 to 0.4.0

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -65,7 +65,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-notify-debouncer-full = { version = "0.3.1", optional = true }
+notify-debouncer-full = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 bevy_core = { path = "../bevy_core", version = "0.15.0-dev" }

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -5,7 +5,7 @@ use crate::io::{
 };
 use alloc::sync::Arc;
 use bevy_utils::{tracing::warn, Duration, HashMap};
-use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, FileIdMap};
+use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, RecommendedCache};
 use parking_lot::RwLock;
 use std::{
     fs::File,
@@ -18,7 +18,7 @@ use std::{
 /// This watcher will watch for changes to the "source files", read the contents of changed files from the file system
 /// and overwrite the initial static bytes of the file embedded in the binary with the new dynamically loaded bytes.
 pub struct EmbeddedWatcher {
-    _watcher: Debouncer<RecommendedWatcher, FileIdMap>,
+    _watcher: Debouncer<RecommendedWatcher, RecommendedCache>,
 }
 
 impl EmbeddedWatcher {

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -245,8 +245,7 @@ pub(crate) fn new_asset_event_debouncer(
             }
         },
     )?;
-    debouncer.watcher().watch(&root, RecursiveMode::Recursive)?;
-    debouncer.cache().add_root(&root, RecursiveMode::Recursive);
+    debouncer.watch(&root, RecursiveMode::Recursive)?;
     Ok(debouncer)
 }
 

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -9,7 +9,7 @@ use notify_debouncer_full::{
     notify::{
         self,
         event::{AccessKind, AccessMode, CreateKind, ModifyKind, RemoveKind, RenameMode},
-        RecommendedWatcher, RecursiveMode, Watcher,
+        RecommendedWatcher, RecursiveMode,
     },
     DebounceEventResult, Debouncer, FileIdMap,
 };

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -11,7 +11,7 @@ use notify_debouncer_full::{
         event::{AccessKind, AccessMode, CreateKind, ModifyKind, RemoveKind, RenameMode},
         RecommendedWatcher, RecursiveMode,
     },
-    DebounceEventResult, Debouncer, FileIdMap,
+    DebounceEventResult, Debouncer, RecommendedCache,
 };
 use std::path::{Path, PathBuf};
 
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 /// This introduces a small delay in processing events, but it helps reduce event duplicates. A small delay is also necessary
 /// on some systems to avoid processing a change event before it has actually been applied.
 pub struct FileWatcher {
-    _watcher: Debouncer<RecommendedWatcher, FileIdMap>,
+    _watcher: Debouncer<RecommendedWatcher, RecommendedCache>,
 }
 
 impl FileWatcher {
@@ -73,7 +73,7 @@ pub(crate) fn new_asset_event_debouncer(
     root: PathBuf,
     debounce_wait_time: Duration,
     mut handler: impl FilesystemEventHandler,
-) -> Result<Debouncer<RecommendedWatcher, FileIdMap>, notify::Error> {
+) -> Result<Debouncer<RecommendedWatcher, RecommendedCache>, notify::Error> {
     let root = super::get_base_path().join(root);
     let mut debouncer = new_debouncer(
         debounce_wait_time,


### PR DESCRIPTION
# Objective

- Supersedes #16126 

## Solution

- Updated code in `file_watcher.rs` to fix breaking changes introduced in the new version.
- Check changelog here: https://github.com/notify-rs/notify/blob/main/CHANGELOG.md#debouncer-full-040-2024-10-25.
- Relevant PR with the breaking change: https://github.com/notify-rs/notify/pull/557.

## Testing

- CI checks passing locally