### PR TITLE
switch to HeadlessPlugins

### DIFF
--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -80,7 +80,8 @@ fn main() {
         ))
         .insert_resource(ClearColor(Color::srgb_u8(0, 0, 0)))
         .add_plugins(
-            DefaultPlugins
+            HeadlessPlugins
+                .set(ScheduleRunnerPlugin::run_once())
                 .set(ImagePlugin::default_nearest())
                 // Not strictly necessary, as the inclusion of ScheduleRunnerPlugin below
                 // replaces the bevy_winit app runner and so a window is never created.
@@ -88,8 +89,6 @@ fn main() {
                     primary_window: None,
                     ..default()
                 })
-                // WinitPlugin will panic in environments without a display server.
-                .disable::<WinitPlugin>(),
         )
         .add_plugins(ImageCopyPlugin)
         // headless frame capture

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -24,7 +24,6 @@ use bevy::{
         texture::{BevyDefault, TextureFormatPixelInfo},
         Extract, Render, RenderApp, RenderSet,
     },
-    winit::WinitPlugin,
 };
 use crossbeam_channel::{Receiver, Sender};
 use std::{
@@ -81,7 +80,6 @@ fn main() {
         .insert_resource(ClearColor(Color::srgb_u8(0, 0, 0)))
         .add_plugins(
             HeadlessPlugins
-                .set(ScheduleRunnerPlugin::run_once())
                 .set(ImagePlugin::default_nearest())
                 // Not strictly necessary, as the inclusion of ScheduleRunnerPlugin below
                 // replaces the bevy_winit app runner and so a window is never created.

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -25,6 +25,7 @@ use bevy::{
         Extract, Render, RenderApp, RenderSet,
     },
 };
+use bevy_render::RenderPlugin;
 use crossbeam_channel::{Receiver, Sender};
 use std::{
     ops::{Deref, DerefMut},
@@ -80,23 +81,18 @@ fn main() {
         .insert_resource(ClearColor(Color::srgb_u8(0, 0, 0)))
         .add_plugins(
             HeadlessPlugins
-                .set(ImagePlugin::default_nearest())
-                // Not strictly necessary, as the inclusion of ScheduleRunnerPlugin below
-                // replaces the bevy_winit app runner and so a window is never created.
-                .set(WindowPlugin {
-                    primary_window: None,
-                    ..default()
-                })
+                // ScheduleRunnerPlugin provides an alternative to the default bevy_winit app runner, which
+                // manages the loop without creating a window.
+                .set(ScheduleRunnerPlugin::run_loop(
+                    // Run 60 times per second.
+                    Duration::from_secs_f64(1.0 / 60.0),
+                )),
         )
+        .add_plugins(RenderPlugin::default())
+        .add_plugins(ImagePlugin::default_nearest())
         .add_plugins(ImageCopyPlugin)
         // headless frame capture
         .add_plugins(CaptureFramePlugin)
-        // ScheduleRunnerPlugin provides an alternative to the default bevy_winit app runner, which
-        // manages the loop without creating a window.
-        .add_plugins(ScheduleRunnerPlugin::run_loop(
-            // Run 60 times per second.
-            Duration::from_secs_f64(1.0 / 60.0),
-        ))
         .init_resource::<SceneController>()
         .add_systems(Startup, setup)
         .run();


### PR DESCRIPTION
# Objective

Fixes #16144

## Solution

Use `HeadlessPlugins` instead of `DefaultPlugins` and no longer have to remove unwanted `WinitPlugin`.

## Testing

Ran example locally

## Showcase
