### PR TITLE
Improve `SubApp` documentation example

### DIFF
--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -37,6 +37,7 @@ type ExtractFn = Box<dyn Fn(&mut World, &mut World) + Send>;
 ///
 /// // Create a sub-app with the same resource and a single schedule.
 /// let mut sub_app = SubApp::new();
+/// sub_app.update_schedule = Some(Main.intern());
 /// sub_app.insert_resource(Val(100));
 ///
 /// // Setup an extract function to copy the resource's value in the main world.


### PR DESCRIPTION
# Objective

Fix #15841

## Solution

Added an update schedule as recommended in the issue.

## Testing

Doc test is run and passes.

Ran the example in a test app before and after adding the line.

## Showcase

Before:

```
PS C:\Users\BenjaminBrienen\source\bevy_experiment_test> cargo run
    Blocking waiting for file lock on build directory
   Compiling bevy_experiment_test v0.1.0 (C:\Users\BenjaminBrienen\source\bevy_experiment_test)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 41s
     Running `target\debug\bevy_experiment_test.exe`
```

(nothing happens)

After:

```
PS C:\Users\BenjaminBrienen\source\bevy_experiment_test> cargo run
    Blocking waiting for file lock on build directory
   Compiling bevy_experiment_test v0.1.0 (C:\Users\BenjaminBrienen\source\bevy_experiment_test)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.64s
     Running `target\debug\bevy_experiment_test.exe`
system of subapp is executing and the Counter: 10
```
