### PR TITLE
Remove the invalid system ordering in the animation example.

### DIFF
--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -3,7 +3,7 @@
 use std::{f32::consts::PI, time::Duration};
 
 use bevy::{
-    animation::{animate_targets, AnimationTargetId, RepeatAnimation},
+    animation::{AnimationTargetId, RepeatAnimation},
     color::palettes::css::WHITE,
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
@@ -22,7 +22,7 @@ fn main() {
         .init_resource::<ParticleAssets>()
         .init_resource::<FoxFeetTargets>()
         .add_systems(Startup, setup)
-        .add_systems(Update, setup_scene_once_loaded.before(animate_targets))
+        .add_systems(Update, setup_scene_once_loaded)
         .add_systems(Update, (keyboard_animation_control, simulate_particles))
         .add_observer(observe_on_step)
         .run();

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -4,7 +4,6 @@
 //! playing animations by clicking and dragging left or right within the nodes.
 
 use bevy::{
-    animation::animate_targets,
     color::palettes::{
         basic::WHITE,
         css::{ANTIQUE_WHITE, DARK_GREEN},
@@ -83,7 +82,7 @@ fn main() {
             ..default()
         }))
         .add_systems(Startup, (setup_assets, setup_scene, setup_ui))
-        .add_systems(Update, init_animations.before(animate_targets))
+        .add_systems(Update, init_animations)
         .add_systems(
             Update,
             (handle_weight_drag, update_ui, sync_weights).chain(),


### PR DESCRIPTION
# Objective

In the animation example, there is the code `.add_systems(Update, init_animations.before(animate_targets))`, where `animate_targets` is added to the `PostUpdate` in the `AnimationPlugin`. Therefore, the `.before(animate_targets)` here is ineffective and should be removed.