### PR TITLE
Add `button_just_down` and `button_just_up` methods to `PointerInput`

### DIFF
--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -286,6 +286,26 @@ impl PointerInput {
         }
     }
 
+    /// Returns true if the `button` of this pointer was just pressed.
+    #[inline]
+    pub fn button_just_down(&self, target_button: PointerButton) -> bool {
+        if let PointerAction::Pressed { direction, button } = self.action {
+            direction == PressDirection::Down && button == target_button
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if the `button` of this pointer was just released.
+    #[inline]
+    pub fn button_just_up(&self, target_button: PointerButton) -> bool {
+        if let PointerAction::Pressed { direction, button } = self.action {
+            direction == PressDirection::Up && button == target_button
+        } else {
+            false
+        }
+    }
+
     /// Updates pointer entities according to the input events.
     pub fn receive(
         mut events: EventReader<PointerInput>,

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -288,7 +288,7 @@ impl PointerInput {
 
     /// Returns true if the `target_button` of this pointer was just pressed.
     #[inline]
-    pub fn button_just_down(&self, target_button: PointerButton) -> bool {
+    pub fn button_just_pressed(&self, target_button: PointerButton) -> bool {
         if let PointerAction::Pressed { direction, button } = self.action {
             direction == PressDirection::Down && button == target_button
         } else {
@@ -298,7 +298,7 @@ impl PointerInput {
 
     /// Returns true if the `target_button` of this pointer was just released.
     #[inline]
-    pub fn button_just_up(&self, target_button: PointerButton) -> bool {
+    pub fn button_just_released(&self, target_button: PointerButton) -> bool {
         if let PointerAction::Pressed { direction, button } = self.action {
             direction == PressDirection::Up && button == target_button
         } else {

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -286,7 +286,7 @@ impl PointerInput {
         }
     }
 
-    /// Returns true if the `button` of this pointer was just pressed.
+    /// Returns true if the `target_button` of this pointer was just pressed.
     #[inline]
     pub fn button_just_down(&self, target_button: PointerButton) -> bool {
         if let PointerAction::Pressed { direction, button } = self.action {
@@ -296,7 +296,7 @@ impl PointerInput {
         }
     }
 
-    /// Returns true if the `button` of this pointer was just released.
+    /// Returns true if the `target_button` of this pointer was just released.
     #[inline]
     pub fn button_just_up(&self, target_button: PointerButton) -> bool {
         if let PointerAction::Pressed { direction, button } = self.action {


### PR DESCRIPTION
# Objective

Upstream two small methods present in `bevy_mod_picking` but not in `bevy_picking`.

There might be a few more of these.