### PR TITLE
Remove the `Globals` binding from the box shadow shader

### DIFF
--- a/crates/bevy_ui/src/render/box_shadow.wgsl
+++ b/crates/bevy_ui/src/render/box_shadow.wgsl
@@ -5,7 +5,6 @@ const PI: f32 = 3.14159265358979323846;
 const SAMPLES: i32 = #SHADOW_SAMPLES;
 
 @group(0) @binding(0) var<uniform> view: View;
-@group(0) @binding(1) var<uniform> globals: Globals;
 
 struct BoxShadowVertexOutput {
     @builtin(position) position: vec4<f32>,


### PR DESCRIPTION
# Objective

Remove the `Globals` binding from the box shadow shader. It isn't used and was added by mistake.
