### PR TITLE
Fix typo in bevy_ecs

### DIFF
--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! Most of the utilities around state involve running systems during transitions between states, or
 //! determining whether to run certain systems, though they can be used more directly as well. This
-//! makes it easier to transition between menus, add loading screens, pause games, and the more.
+//! makes it easier to transition between menus, add loading screens, pause games, and more.
 //!
 //! Specifically, Bevy provides the following utilities:
 //!


### PR DESCRIPTION
Found this while reading the docs, I assume this is a typo.