### PR TITLE
Fix and improve MSAA documentation

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -146,7 +146,8 @@ impl Plugin for ViewPlugin {
     }
 }
 
-/// Configuration resource for [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing).
+/// Component for configuring [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
+/// for a [`Camera`](crate::camera::Camera).
 ///
 /// The number of samples to run for Multi-Sample Anti-Aliasing for a given camera. Higher numbers
 /// result in smoother edges.

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -146,15 +146,14 @@ impl Plugin for ViewPlugin {
     }
 }
 
-/// Component for configuring [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
+/// Component for configuring the number of samples for [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
 /// for a [`Camera`](crate::camera::Camera).
 ///
-/// The number of samples to run for Multi-Sample Anti-Aliasing for a given camera. Higher numbers
-/// result in smoother edges.
+/// Defaults to 4 samples. A higher number of samples results in smoother edges.
 ///
-/// Defaults to 4 samples. Some advanced rendering features may require that MSAA be disabled.
+/// Some advanced rendering features may require that MSAA is disabled.
 ///
-/// Note that web currently only supports 1 or 4 samples.
+/// Note that the web currently only supports 1 or 4 samples.
 #[derive(
     Component,
     Default,


### PR DESCRIPTION
# Objective

#14273 changed `Msaa` to be a component rather than a resource. However, the documentation still says that it is a resource. This tripped me up during migration to 0.15 until I looked at the type definition.

Additionally, the docs have some unnecessary repetition and some grammar mistakes, and they don't link to camera documentation.

## Solution

Fix up the docs!