### PR TITLE
Use `stack_z_offsets` in all the cases we create a `TransparentUi`

### DIFF
--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -365,7 +365,7 @@ pub fn queue_shadows(
             pipeline,
             entity: (*entity, extracted_shadow.main_entity),
             sort_key: (
-                FloatOrd(extracted_shadow.stack_index as f32 + stack_z_offsets::SHADOW),
+                FloatOrd(extracted_shadow.stack_index as f32 + stack_z_offsets::BOX_SHADOW),
                 entity.index(),
             ),
             batch_range: 0..0,

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -32,7 +32,7 @@ use bevy_render::{
 use bevy_transform::prelude::GlobalTransform;
 use bytemuck::{Pod, Zeroable};
 
-use super::{QUAD_INDICES, QUAD_VERTEX_POSITIONS};
+use super::{stack_z_offsets, QUAD_INDICES, QUAD_VERTEX_POSITIONS};
 
 pub const BOX_SHADOW_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(17717747047134343426);
 
@@ -365,7 +365,7 @@ pub fn queue_shadows(
             pipeline,
             entity: (*entity, extracted_shadow.main_entity),
             sort_key: (
-                FloatOrd(extracted_shadow.stack_index as f32 - 0.1),
+                FloatOrd(extracted_shadow.stack_index as f32 + stack_z_offsets::SHADOW),
                 entity.index(),
             ),
             batch_range: 0..0,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -75,7 +75,7 @@ pub mod graph {
 /// When this is _not_ possible, pick a suitably unique index unlikely to clash with other things (ex: `0.1826823` not `0.1`).
 ///
 /// Offsets should be unique for a given node entity to avoid z fighting.
-/// These should pretty much _always_ be larger than -1.0 and smaller than 1.0 to avoid clipping into nodes
+/// These should pretty much _always_ be larger than -0.5 and smaller than 0.5 to avoid clipping into nodes
 /// above / below the current node in the stack.
 ///
 /// A z-index of 0.0 is the baseline, which is used as the primary "background color" of the node.
@@ -83,6 +83,8 @@ pub mod graph {
 /// Note that nodes "stack" on each other, so a negative offset on the node above could clip _into_
 /// a positive offset on a node below.
 pub mod stack_z_offsets {
+    pub const SHADOW: f32 = -0.1;
+    pub const SLICE: f32 = 0.0;
     pub const BACKGROUND_COLOR: f32 = 0.0;
     pub const MATERIAL: f32 = 0.18267;
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -83,9 +83,9 @@ pub mod graph {
 /// Note that nodes "stack" on each other, so a negative offset on the node above could clip _into_
 /// a positive offset on a node below.
 pub mod stack_z_offsets {
-    pub const SHADOW: f32 = -0.1;
-    pub const SLICE: f32 = 0.0;
-    pub const BACKGROUND_COLOR: f32 = 0.0;
+    pub const BOX_SHADOW: f32 = -0.1;
+    pub const TEXTURE_SLICE: f32 = 0.0;
+    pub const NODE: f32 = 0.0;
     pub const MATERIAL: f32 = 0.18267;
 }
 
@@ -865,7 +865,7 @@ pub fn queue_uinodes(
             pipeline,
             entity: (*entity, extracted_uinode.main_entity),
             sort_key: (
-                FloatOrd(extracted_uinode.stack_index as f32 + stack_z_offsets::BACKGROUND_COLOR),
+                FloatOrd(extracted_uinode.stack_index as f32 + stack_z_offsets::NODE),
                 entity.index(),
             ),
             // batch_range will be calculated in prepare_uinodes

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -352,7 +352,7 @@ pub fn queue_ui_slices(
             pipeline,
             entity: (*entity, extracted_slicer.main_entity),
             sort_key: (
-                FloatOrd(extracted_slicer.stack_index as f32),
+                FloatOrd(extracted_slicer.stack_index as f32 + stack_z_offsets::SLICE),
                 entity.index(),
             ),
             batch_range: 0..0,

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -352,7 +352,7 @@ pub fn queue_ui_slices(
             pipeline,
             entity: (*entity, extracted_slicer.main_entity),
             sort_key: (
-                FloatOrd(extracted_slicer.stack_index as f32 + stack_z_offsets::SLICE),
+                FloatOrd(extracted_slicer.stack_index as f32 + stack_z_offsets::TEXTURE_SLICE),
                 entity.index(),
             ),
             batch_range: 0..0,


### PR DESCRIPTION
# Objective

Use same pattern when creating `TransparentUi` items where the `sort_key` is the `UiNode` stack index + some offset.

## Solution

Refactored to follow same pattern.

## Testing

Ran few UI examples.

## Doubts

Maybe `stack_z_offsets::BACKGROUND_COLOR` should be renamed. This is used for `ExtractedUiNode`, which is not only used for "background color" it's also used to render borders, images and text (I think).
