### PR TITLE
BRP System Ordering

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -438,7 +438,7 @@ impl Plugin for RemotePlugin {
             .init_resource::<RemoteWatchingRequests>()
             .add_systems(PreStartup, setup_mailbox_channel)
             .add_systems(
-                Update,
+                Last,
                 (
                     process_remote_requests,
                     process_ongoing_watching_requests,

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -305,7 +305,7 @@ use bevy_app::prelude::*;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     entity::Entity,
-    schedule::IntoSystemConfigs,
+    schedule::{IntoSystemConfigs, SystemSet},
     system::{Commands, In, IntoSystem, ResMut, Resource, System, SystemId},
     world::World,
 };
@@ -444,10 +444,15 @@ impl Plugin for RemotePlugin {
                     process_ongoing_watching_requests,
                     remove_closed_watching_requests,
                 )
-                    .chain(),
+                    .chain()
+                    .in_set(RemoteSystem),
             );
     }
 }
+
+/// System set for labeling systems in the Bevy Remote Protocol
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+pub struct RemoteSystem;
 
 /// A type to hold the allowed types of systems to be used as method handlers.
 #[derive(Debug)]


### PR DESCRIPTION
# Objective

- Attempts to fix #16042

## Solution

- Added a new `RemoteSystem` `SystemSet` for the BRP systems.
- Changed the schedule on which these systems run from `Update` to `Last`.

## Testing

- I did not test these changes and would appreciate a hand in doing so. I assume it would be good to test that you can order against these systems easily now.

---

## Migration Guide

- `process_remote_requests`, `process_ongoing_watching_requests` and `remove_closed_watching_requests` now run in the `Last` schedule. Make sure you use `RemoteSystem` `SystemSet` in case you need to order your systems against them.
