### PR TITLE
Fix WGSL formatting inconsistency on mesh_view_binding

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -110,4 +110,4 @@ const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
 @group(0) @binding(31) var<storage, read_write> oit_layers: array<vec2<u32>>;
 @group(0) @binding(32) var<storage, read_write> oit_layer_ids: array<atomic<i32>>;
 @group(0) @binding(33) var<uniform> oit_settings: types::OrderIndependentTransparencySettings;
-#endif OIT_ENABLED
+#endif // OIT_ENABLED


### PR DESCRIPTION
# Objective

- fix formatting issue in "mesh_view_binding.wgsl"

_note: As naga-oil preprocessor match the whole line when finding an "#endif",
It's just for external formatting tool and consistency._

## Solution
Trivial change.
Add  '//' before the closing comment of the "#endif"
