### PR TITLE
Adding `ScheduleGraph::contains_set`

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -650,6 +650,11 @@ impl ScheduleGraph {
             .and_then(|system| system.inner.as_deref())
     }
 
+    /// Returns `true` if the given system set is part of the graph. Otherwise returns `false`.
+    pub fn contains_set(&self, set: impl SystemSet) -> bool {
+        self.system_set_ids.contains_key(&set.intern())
+    }
+
     /// Returns the system at the given [`NodeId`].
     ///
     /// Panics if it doesn't exist.


### PR DESCRIPTION
# Objective

The schedule graph can easily confirm whether a set is contained or not.

This helps me in my personal project where I write an extension trait for `Schedule` and I want to configure a specific set in its methods. The set in question has a run condition though and I don't want to add that condition to the same schedule as many times as the trait methods are called. Since the non-pub set is unknown to the schedule until then, a `contains_set` is sufficient.

It is probably trivial to add a method that returns an `Option<NodeId>` as well but as I personally don't need it I did not add that. If it is desired I can do so here though. It might be unneeded to have a `contains_set` then because one could check `is_some` on the returned id in that case.

## Solution

Added `ScheduleGraph::contains_set`.

## Testing

I put the below showcase code into a temporary unit test and it worked. If wanted I add it as a test too but I did not see that other more somewhat complicated methods have tests

---

## Showcase

```rs
#[derive(ScheduleLabel, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
struct MySchedule;

#[derive(SystemSet, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
struct MySet;

let mut schedule = Schedule::new(MySchedule);
assert_eq!(schedule.graph().contains_set(MySet), false);
schedule.configure_sets(MySet);
assert_eq!(schedule.graph().contains_set(MySet), true);
```