### PR TITLE
Allow components to be "explicitly required".

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -92,11 +92,16 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             });
             match &require.func {
                 Some(RequireFunc::Path(func)) => {
+                    let constructor = if func.is_ident("explicit") {
+                        quote! { None }
+                    } else {
+                        quote! {Some(|| { let x: #ident = #func().into(); x })}
+                    };
                     register_required.push(quote! {
                         components.register_required_components_manual::<Self, #ident>(
                             storages,
                             required_components,
-                            || { let x: #ident = #func().into(); x },
+                            #constructor,
                             inheritance_depth
                         );
                     });
@@ -106,7 +111,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                         components.register_required_components_manual::<Self, #ident>(
                             storages,
                             required_components,
-                            || { let x: #ident = (#func)().into(); x },
+                            Some(|| { let x: #ident = (#func)().into(); x }),
                             inheritance_depth
                         );
                     });
@@ -116,7 +121,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                         components.register_required_components_manual::<Self, #ident>(
                             storages,
                             required_components,
-                            <#ident as Default>::default,
+                            Some(<#ident as Default>::default),
                             inheritance_depth
                         );
                     });


### PR DESCRIPTION
# Objective

- Fixes #16194.

## Solution

- Add an "explicit" tag to required components to allow them to check (at runtime) that a component is present (or inserted at the same time).

## Testing

- Unit tests are sufficient.

---

## Showcase

```rust
#[derive(Component)]
#[require(EnemyTarget(explicit))]
struct Enemy {
  health: f32,
}

#[derive(Component)]
struct EnemyTarget(Entity);

fn main() {
  App::new()
    .add_plugins(DefaultPlugins)
    .run()
}

fn setup(mut commands: Commands) {
  let target = commands.spawn(Transform::default()).id();
  // Panics if we don't add the EnemyTarget.
  commands.spawn((Enemy{ health: 10.0 }, EnemyTarget(target)));
}
```

## Migration Guide

- Required component constructors named `explicit` must be renamed to anything else.

## Risks

Required components so far are safe - they should not cause a panic. Explicitly required components can cause panics now whenever you spawn or insert a component that names an explicitly required component. For example, in the example above, if you spawn the Enemy + EnemyTarget components, then remove the EnemyTarget component, then insert the Enemy component again, you get a panic! This can make the panics more non-deterministic.
