### PR TITLE
Add EntityMut::get_mut_by_id_unchecked

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -744,8 +744,8 @@ impl<'w> EntityMut<'w> {
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - Exclusive access to all components of this entity,
-    /// - or simultaneous access to multiple components that are mutually
-    /// - independent.
+    ///   or simultaneous access to multiple components that are mutually
+    ///   independent.
     #[inline]
     pub unsafe fn get_mut_by_id_unchecked(
         &self,
@@ -753,7 +753,7 @@ impl<'w> EntityMut<'w> {
     ) -> Result<MutUntyped<'w>, EntityComponentError> {
         // SAFETY:
         // - The caller must ensure simultaneous access to multiple components
-        // - that are mutually independent.
+        //   that are mutually independent.
         unsafe { self.0.get_mut_by_id(component_id) }
             .ok_or(EntityComponentError::MissingComponent(component_id))
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -734,7 +734,7 @@ impl<'w> EntityMut<'w> {
     /// the current entity, based on the given [`ComponentId`].
     ///
     /// Unlike [`EntityMut::get_mut_by_id`], this method borrows &self instead of
-    /// mut &self, allowing the caller to access multiple components simultaneously.
+    /// &mut self, allowing the caller to access multiple components simultaneously.
     ///
     /// # Errors
     ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -749,7 +749,7 @@ impl<'w> EntityMut<'w> {
     pub unsafe fn get_mut_by_id_unchecked(
         &self,
         component_id: ComponentId,
-    ) -> Result<MutUntyped<'w>, EntityComponentError> {
+    ) -> Result<MutUntyped<'_>, EntityComponentError> {
         // SAFETY:
         // - The caller must ensure simultaneous access is limited
         // - to components that are mutually independent.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -4463,17 +4463,20 @@ mod tests {
         let e1 = world.spawn((X(7), Y(10))).id();
         let x_id = world.register_component::<X>();
         let y_id = world.register_component::<Y>();
+
         let e1_mut = &world.get_entity_mut([e1]).unwrap()[0];
         // SAFETY: The entity e1 contains component X.
         let x_ptr = unsafe { e1_mut.get_mut_by_id_unchecked(x_id) }.unwrap();
         // SAFETY: The entity e1 contains component Y, with components X and Y being mutually independent.
         let y_ptr = unsafe { e1_mut.get_mut_by_id_unchecked(y_id) }.unwrap();
-        assert_eq!(
-            (&mut X(7), &mut Y(10)),
-            // SAFETY: components match the id they were fetched with
-            (unsafe { x_ptr.into_inner().deref_mut::<X>() }, unsafe {
-                y_ptr.into_inner().deref_mut::<Y>()
-            })
-        );
+
+        // SAFETY: components match the id they were fetched with
+        let x_component = unsafe { x_ptr.into_inner().deref_mut::<X>() };
+        x_component.0 += 1;
+        // SAFETY: components match the id they were fetched with
+        let y_component = unsafe { y_ptr.into_inner().deref_mut::<Y>() };
+        y_component.0 -= 1;
+
+        assert_eq!((&mut X(8), &mut Y(9)), (x_component, y_component));
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -744,16 +744,16 @@ impl<'w> EntityMut<'w> {
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - Exclusive access to all components of this entity,
-    ///   or simultaneous access to multiple components that are mutually
-    ///   independent.
+    /// - or simultaneous access to multiple components that are mutually
+    /// - independent.
     #[inline]
     pub unsafe fn get_mut_by_id_unchecked(
         &self,
         component_id: ComponentId,
     ) -> Result<MutUntyped<'w>, EntityComponentError> {
         // SAFETY:
-        // - The caller must ensure simultaneous access to multiple components
-        //   that are mutually independent.
+        // - The caller must ensure simultaneous access is limited
+        // - to components that are mutually independent.
         unsafe { self.0.get_mut_by_id(component_id) }
             .ok_or(EntityComponentError::MissingComponent(component_id))
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -740,21 +740,22 @@ impl<'w> EntityMut<'w> {
     ///
     /// - Returns [`EntityComponentError::MissingComponent`] if the entity does
     ///   not have a component.
+    /// - Returns [`EntityComponentError::AliasedMutability`] if a component
+    ///   is requested multiple times.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_mut_by_id_unchecked(
+    pub unsafe fn get_mut_by_id_unchecked<F: DynamicComponentFetch>(
         &self,
-        component_id: ComponentId,
-    ) -> Result<MutUntyped<'_>, EntityComponentError> {
+        component_ids: F,
+    ) -> Result<F::Mut<'_>, EntityComponentError> {
         // SAFETY:
         // - The caller must ensure simultaneous access is limited
         // - to components that are mutually independent.
-        unsafe { self.0.get_mut_by_id(component_id) }
-            .ok_or(EntityComponentError::MissingComponent(component_id))
+        unsafe { component_ids.fetch_mut(self.0) }
     }
 
     /// Consumes `self` and returns [untyped mutable reference(s)](MutUntyped)

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -730,7 +730,7 @@ impl<'w> EntityMut<'w> {
         unsafe { component_ids.fetch_mut(self.0) }
     }
 
-    /// Returns [untyped mutable reference(s)](MutUntyped) to component for
+    /// Returns [untyped mutable reference](MutUntyped) to component for
     /// the current entity, based on the given [`ComponentId`].
     ///
     /// Unlike [`EntityMut::get_mut_by_id`], this method borrows &self instead of

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -743,9 +743,8 @@ impl<'w> EntityMut<'w> {
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - Exclusive access to all components of this entity,
-    /// - or simultaneous access to multiple components that are mutually
-    /// - independent.
+    /// - the [`UnsafeEntityCell`] has permission to access the component mutably
+    /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut_by_id_unchecked(
         &self,


### PR DESCRIPTION
# Objective

- Fixes: #15603 

## Solution

- Add an unsafe `get_mut_by_id_unchecked` to `EntityMut` that borrows &self instead of &mut self, thereby allowing access to multiple components simultaneously.

## Testing

- a unit test function `get_mut_by_id_unchecked` was added.