### PR TITLE
Add `scale_factor` fields to `RenderTarget` variants

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -41,6 +41,8 @@ use bevy_window::{
 };
 use core::ops::Range;
 use derive_more::derive::From;
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use wgpu::{BlendState, TextureFormat, TextureUsages};
 
 /// Render viewport configuration for the [`Camera`] component.
@@ -715,12 +717,31 @@ impl CameraRenderGraph {
 #[derive(Debug, Clone, Reflect, From)]
 pub enum RenderTarget {
     /// Window to which the camera's view is rendered.
+    ///
+    /// The scale factor will be determined automatically based on the targeted
+    /// window.
     Window(WindowRef),
     /// Image to which the camera's view is rendered.
-    Image(Handle<Image>),
-    /// Texture View to which the camera's view is rendered.
+    Image {
+        /// Handle of the image to render into.
+        handle: Handle<Image>,
+        /// Scale factor of the target.
+        ///
+        /// This will be passed into [`RenderTargetInfo::scale_factor`]
+        /// directly. The default is `1.0`.
+        scale_factor: f32,
+    },
+    /// Texture view to which the camera's view is rendered.
     /// Useful when the texture view needs to be created outside of Bevy, for example OpenXR.
-    TextureView(ManualTextureViewHandle),
+    TextureView {
+        /// Handle of the texture view to render into.
+        handle: ManualTextureViewHandle,
+        /// Scale factor of the target.
+        ///
+        /// This will be passed into [`RenderTargetInfo::scale_factor`]
+        /// directly. The default is `1.0`.
+        scale_factor: f32,
+    },
 }
 
 impl Default for RenderTarget {
@@ -729,18 +750,96 @@ impl Default for RenderTarget {
     }
 }
 
+impl RenderTarget {
+    /// Creates a [`RenderTarget::Image`] with the default scale factor.
+    #[must_use]
+    pub const fn image(handle: Handle<Image>) -> Self {
+        Self::Image {
+            handle,
+            scale_factor: 1.0,
+        }
+    }
+
+    /// Creates a [`RenderTarget::TextureView`] with the default scale factor.
+    #[must_use]
+    pub const fn texture_view(handle: ManualTextureViewHandle) -> Self {
+        Self::TextureView {
+            handle,
+            scale_factor: 1.0,
+        }
+    }
+}
+
 /// Normalized version of the render target.
 ///
 /// Once we have this we shouldn't need to resolve it down anymore.
-#[derive(Debug, Clone, Reflect, PartialEq, Eq, Hash, PartialOrd, Ord, From)]
+#[derive(Debug, Clone, Reflect, PartialOrd, From)]
 pub enum NormalizedRenderTarget {
     /// Window to which the camera's view is rendered.
+    ///
+    /// See [`RenderTarget::Window`].
     Window(NormalizedWindowRef),
     /// Image to which the camera's view is rendered.
-    Image(Handle<Image>),
-    /// Texture View to which the camera's view is rendered.
+    ///
+    /// See [`RenderTarget::Image`].
+    Image {
+        /// Handle of the image to render into.
+        handle: Handle<Image>,
+        /// Scale factor of the target.
+        ///
+        /// This field is ignored in the implementations of [`PartialEq`],
+        /// [`Eq`], [`PartialOrd`], [`Ord`], and [`Hash`].
+        scale_factor: f32,
+    },
+    /// Texture view to which the camera's view is rendered.
     /// Useful when the texture view needs to be created outside of Bevy, for example OpenXR.
-    TextureView(ManualTextureViewHandle),
+    ///
+    /// See [`RenderTarget::TextureView`].
+    TextureView {
+        handle: ManualTextureViewHandle,
+        /// Scale factor of the target.
+        ///
+        /// This field is ignored in the implementations of [`PartialEq`],
+        /// [`Eq`], [`PartialOrd`], [`Ord`], and [`Hash`].
+        scale_factor: f32,
+    },
+}
+
+impl PartialEq for NormalizedRenderTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Window(window_a), Self::Window(window_b)) => window_a == window_b,
+            (
+                Self::Image {
+                    handle: handle_a, ..
+                },
+                Self::Image {
+                    handle: handle_b, ..
+                },
+            ) => handle_a == handle_b,
+            (
+                Self::TextureView {
+                    handle: handle_a, ..
+                },
+                Self::TextureView {
+                    handle: handle_b, ..
+                },
+            ) => handle_a == handle_b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for NormalizedRenderTarget {}
+
+impl Hash for NormalizedRenderTarget {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Window(window) => window.hash(state),
+            Self::Image { handle, .. } => handle.hash(state),
+            Self::TextureView { handle, .. } => handle.hash(state),
+        }
+    }
 }
 
 impl RenderTarget {
@@ -750,15 +849,27 @@ impl RenderTarget {
             RenderTarget::Window(window_ref) => window_ref
                 .normalize(primary_window)
                 .map(NormalizedRenderTarget::Window),
-            RenderTarget::Image(handle) => Some(NormalizedRenderTarget::Image(handle.clone())),
-            RenderTarget::TextureView(id) => Some(NormalizedRenderTarget::TextureView(*id)),
+            RenderTarget::Image {
+                handle,
+                scale_factor,
+            } => Some(NormalizedRenderTarget::Image {
+                handle: handle.clone(),
+                scale_factor: *scale_factor,
+            }),
+            RenderTarget::TextureView {
+                handle,
+                scale_factor,
+            } => Some(NormalizedRenderTarget::TextureView {
+                handle: *handle,
+                scale_factor: *scale_factor,
+            }),
         }
     }
 
     /// Get a handle to the render target's image,
     /// or `None` if the render target is another variant.
     pub fn as_image(&self) -> Option<&Handle<Image>> {
-        if let Self::Image(handle) = self {
+        if let Self::Image { handle, .. } = self {
             Some(handle)
         } else {
             None
@@ -777,12 +888,12 @@ impl NormalizedRenderTarget {
             NormalizedRenderTarget::Window(window_ref) => windows
                 .get(&window_ref.entity())
                 .and_then(|window| window.swap_chain_texture_view.as_ref()),
-            NormalizedRenderTarget::Image(image_handle) => {
-                images.get(image_handle).map(|image| &image.texture_view)
+            NormalizedRenderTarget::Image { handle, .. } => {
+                images.get(handle).map(|image| &image.texture_view)
             }
-            NormalizedRenderTarget::TextureView(id) => {
-                manual_texture_views.get(id).map(|tex| &tex.texture_view)
-            }
+            NormalizedRenderTarget::TextureView { handle, .. } => manual_texture_views
+                .get(handle)
+                .map(|tex| &tex.texture_view),
         }
     }
 
@@ -797,11 +908,11 @@ impl NormalizedRenderTarget {
             NormalizedRenderTarget::Window(window_ref) => windows
                 .get(&window_ref.entity())
                 .and_then(|window| window.swap_chain_texture_format),
-            NormalizedRenderTarget::Image(image_handle) => {
-                images.get(image_handle).map(|image| image.texture_format)
+            NormalizedRenderTarget::Image { handle, .. } => {
+                images.get(handle).map(|image| image.texture_format)
             }
-            NormalizedRenderTarget::TextureView(id) => {
-                manual_texture_views.get(id).map(|tex| tex.format)
+            NormalizedRenderTarget::TextureView { handle, .. } => {
+                manual_texture_views.get(handle).map(|tex| tex.format)
             }
         }
     }
@@ -820,19 +931,25 @@ impl NormalizedRenderTarget {
                     physical_size: window.physical_size(),
                     scale_factor: window.resolution.scale_factor(),
                 }),
-            NormalizedRenderTarget::Image(image_handle) => {
-                let image = images.get(image_handle)?;
+            NormalizedRenderTarget::Image {
+                handle,
+                scale_factor,
+            } => {
+                let image = images.get(handle)?;
                 Some(RenderTargetInfo {
                     physical_size: image.size(),
-                    scale_factor: 1.0,
+                    scale_factor: *scale_factor,
                 })
             }
-            NormalizedRenderTarget::TextureView(id) => {
-                manual_texture_views.get(id).map(|tex| RenderTargetInfo {
+            NormalizedRenderTarget::TextureView {
+                handle,
+                scale_factor,
+            } => manual_texture_views
+                .get(handle)
+                .map(|tex| RenderTargetInfo {
                     physical_size: tex.size,
-                    scale_factor: 1.0,
-                })
-            }
+                    scale_factor: *scale_factor,
+                }),
         }
     }
 
@@ -846,10 +963,10 @@ impl NormalizedRenderTarget {
             NormalizedRenderTarget::Window(window_ref) => {
                 changed_window_ids.contains(&window_ref.entity())
             }
-            NormalizedRenderTarget::Image(image_handle) => {
-                changed_image_handles.contains(&image_handle.id())
+            NormalizedRenderTarget::Image { handle, .. } => {
+                changed_image_handles.contains(&handle.id())
             }
-            NormalizedRenderTarget::TextureView(_) => true,
+            NormalizedRenderTarget::TextureView { .. } => true,
         }
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -780,6 +780,11 @@ impl From<ManualTextureViewHandle> for RenderTarget {
 /// Normalized version of the render target.
 ///
 /// Once we have this we shouldn't need to resolve it down anymore.
+///
+/// # [`PartialEq`], [`Hash`], [`Ord`] implementations
+///
+/// This type is used to check for ambiguities between cameras and their render
+/// targets. For this purpose, the `scale_factor` field of variants is ignored.
 #[derive(Debug, Clone, Reflect, From)]
 pub enum NormalizedRenderTarget {
     /// Window to which the camera's view is rendered.

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -94,12 +94,20 @@ impl Screenshot {
 
     /// Capture a screenshot of the provided render target image.
     pub fn image(image: Handle<Image>) -> Self {
-        Self(RenderTarget::Image(image))
+        Self(RenderTarget::image(image))
     }
 
     /// Capture a screenshot of the provided manual texture view.
     pub fn texture_view(texture_view: ManualTextureViewHandle) -> Self {
-        Self(RenderTarget::TextureView(texture_view))
+        Self(RenderTarget::texture_view(texture_view))
+    }
+
+    /// Capture a screenshot of the given [`RenderTarget`].
+    ///
+    /// If you know exactly what your render target is, prefer using the other
+    /// functions on this type.
+    pub fn target(target: RenderTarget) -> Self {
+        Self(target)
     }
 }
 

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -101,14 +101,6 @@ impl Screenshot {
     pub fn texture_view(texture_view: ManualTextureViewHandle) -> Self {
         Self(RenderTarget::from(texture_view))
     }
-
-    /// Capture a screenshot of the given [`RenderTarget`].
-    ///
-    /// If you know exactly what your render target is, prefer using the other
-    /// functions on this type.
-    pub fn target(target: RenderTarget) -> Self {
-        Self(target)
-    }
 }
 
 struct ScreenshotPreparedState {

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -84,22 +84,22 @@ pub struct Captured;
 impl Screenshot {
     /// Capture a screenshot of the provided window entity.
     pub fn window(window: Entity) -> Self {
-        Self(RenderTarget::Window(WindowRef::Entity(window)))
+        Self(RenderTarget::from(WindowRef::Entity(window)))
     }
 
     /// Capture a screenshot of the primary window, if one exists.
     pub fn primary_window() -> Self {
-        Self(RenderTarget::Window(WindowRef::Primary))
+        Self(RenderTarget::from(WindowRef::Primary))
     }
 
     /// Capture a screenshot of the provided render target image.
     pub fn image(image: Handle<Image>) -> Self {
-        Self(RenderTarget::image(image))
+        Self(RenderTarget::from(image))
     }
 
     /// Capture a screenshot of the provided manual texture view.
     pub fn texture_view(texture_view: ManualTextureViewHandle) -> Self {
-        Self(RenderTarget::texture_view(texture_view))
+        Self(RenderTarget::from(texture_view))
     }
 
     /// Capture a screenshot of the given [`RenderTarget`].
@@ -276,11 +276,11 @@ fn prepare_screenshots(
 ) {
     prepared.clear();
     for (entity, target) in targets.iter() {
-        match target {
+        let (format, size) = match target {
             NormalizedRenderTarget::Window(window) => {
                 let window = window.entity();
                 let Some(surface_data) = window_surfaces.surfaces.get(&window) else {
-                    warn!("Unknown window for screenshot, skipping: {:?}", window);
+                    warn!("Unknown window for screenshot, skipping: {window:?}");
                     continue;
                 };
                 let format = surface_data.configuration.format.add_srgb_suffix();
@@ -289,23 +289,11 @@ fn prepare_screenshots(
                     height: surface_data.configuration.height,
                     ..default()
                 };
-                let (texture_view, state) = prepare_screenshot_state(
-                    size,
-                    format,
-                    &render_device,
-                    &screenshot_pipeline,
-                    &pipeline_cache,
-                    &mut pipelines,
-                );
-                prepared.insert(*entity, state);
-                view_target_attachments.insert(
-                    target.clone(),
-                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
-                );
+                (format, size)
             }
-            NormalizedRenderTarget::Image(image) => {
-                let Some(gpu_image) = images.get(image) else {
-                    warn!("Unknown image for screenshot, skipping: {:?}", image);
+            NormalizedRenderTarget::Image { handle, .. } => {
+                let Some(gpu_image) = images.get(handle) else {
+                    warn!("Unknown image for screenshot, skipping: {handle:?}");
                     continue;
                 };
                 let format = gpu_image.texture_format;
@@ -314,26 +302,11 @@ fn prepare_screenshots(
                     height: gpu_image.size.y,
                     ..default()
                 };
-                let (texture_view, state) = prepare_screenshot_state(
-                    size,
-                    format,
-                    &render_device,
-                    &screenshot_pipeline,
-                    &pipeline_cache,
-                    &mut pipelines,
-                );
-                prepared.insert(*entity, state);
-                view_target_attachments.insert(
-                    target.clone(),
-                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
-                );
+                (format, size)
             }
-            NormalizedRenderTarget::TextureView(texture_view) => {
-                let Some(manual_texture_view) = manual_texture_views.get(texture_view) else {
-                    warn!(
-                        "Unknown manual texture view for screenshot, skipping: {:?}",
-                        texture_view
-                    );
+            NormalizedRenderTarget::TextureView { handle, .. } => {
+                let Some(manual_texture_view) = manual_texture_views.get(handle) else {
+                    warn!("Unknown manual texture view for screenshot, skipping: {handle:?}");
                     continue;
                 };
                 let format = manual_texture_view.format;
@@ -342,21 +315,23 @@ fn prepare_screenshots(
                     height: manual_texture_view.size.y,
                     ..default()
                 };
-                let (texture_view, state) = prepare_screenshot_state(
-                    size,
-                    format,
-                    &render_device,
-                    &screenshot_pipeline,
-                    &pipeline_cache,
-                    &mut pipelines,
-                );
-                prepared.insert(*entity, state);
-                view_target_attachments.insert(
-                    target.clone(),
-                    OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
-                );
+                (format, size)
             }
-        }
+        };
+
+        let (texture_view, state) = prepare_screenshot_state(
+            size,
+            format,
+            &render_device,
+            &screenshot_pipeline,
+            &pipeline_cache,
+            &mut pipelines,
+        );
+        prepared.insert(*entity, state);
+        view_target_attachments.insert(
+            target.clone(),
+            OutputColorAttachment::new(texture_view.clone(), format.add_srgb_suffix()),
+        );
     }
 }
 
@@ -543,9 +518,9 @@ pub(crate) fn submit_screenshot_commands(world: &World, encoder: &mut CommandEnc
                     &texture_view,
                 );
             }
-            NormalizedRenderTarget::Image(image) => {
-                let Some(gpu_image) = gpu_images.get(image) else {
-                    warn!("Unknown image for screenshot, skipping: {:?}", image);
+            NormalizedRenderTarget::Image { handle, .. } => {
+                let Some(gpu_image) = gpu_images.get(handle) else {
+                    warn!("Unknown image for screenshot, skipping: {handle:?}");
                     continue;
                 };
                 let width = gpu_image.size.x;
@@ -563,12 +538,9 @@ pub(crate) fn submit_screenshot_commands(world: &World, encoder: &mut CommandEnc
                     texture_view,
                 );
             }
-            NormalizedRenderTarget::TextureView(texture_view) => {
-                let Some(texture_view) = manual_texture_views.get(texture_view) else {
-                    warn!(
-                        "Unknown manual texture view for screenshot, skipping: {:?}",
-                        texture_view
-                    );
+            NormalizedRenderTarget::TextureView { handle, .. } => {
+                let Some(texture_view) = manual_texture_views.get(handle) else {
+                    warn!("Unknown manual texture view for screenshot, skipping: {handle:?}");
                     continue;
                 };
                 let width = texture_view.size.x;

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -117,7 +117,7 @@ fn setup_camera(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
         Camera {
             // render before the "main pass" camera
             order: -1,
-            target: RenderTarget::Image(image_handle.clone()),
+            target: RenderTarget::from(image_handle.clone()),
             ..default()
         },
         Msaa::Off,

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -268,7 +268,7 @@ fn setup_render_target(
 
     scene_controller.state = SceneState::Render(pre_roll_frames);
     scene_controller.name = scene_name;
-    RenderTarget::Image(render_target_image_handle)
+    RenderTarget::from(render_target_image_handle)
 }
 
 /// Setups image saver

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -151,7 +151,7 @@ fn change_scale_factor(
             panic!("render target should be an image");
         };
 
-        *scale_factor += scale_factor_change;
-        info!("Changed render target scale factor by {scale_factor_change}, now {scale_factor}");
+        *scale_factor = (*scale_factor + scale_factor_change).clamp(UI_SCALE_CHANGE_STEP, 4.0);
+        info!("New render target scale factor: {scale_factor}");
     }
 }

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -57,7 +57,7 @@ fn setup(
         .spawn((
             Camera2d,
             Camera {
-                target: RenderTarget::Image(image_handle.clone()),
+                target: RenderTarget::from(image_handle.clone()),
                 ..default()
             },
         ))

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -1,4 +1,7 @@
 //! Shows how to render UI to a texture. Useful for displaying UI in 3D space.
+//!
+//! You can also change the scale factor of the render target by pressing the up
+//! or down arrow keys. This will change the size at which the UI renders.
 
 use std::f32::consts::PI;
 
@@ -16,13 +19,17 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, rotator_system)
+        .add_systems(Update, (rotator_system, change_scale_factor))
         .run();
 }
 
 // Marks the cube, to which the UI texture is applied.
 #[derive(Component)]
 struct Cube;
+
+// Marker component for the camera which renders into the UI texture.
+#[derive(Component)]
+struct TextureCamera;
 
 fn setup(
     mut commands: Commands,
@@ -60,6 +67,7 @@ fn setup(
                 target: RenderTarget::from(image_handle.clone()),
                 ..default()
             },
+            TextureCamera,
         ))
         .id();
 
@@ -121,5 +129,29 @@ fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Cube>>)
     for mut transform in &mut query {
         transform.rotate_x(1.0 * time.delta_secs() * ROTATION_SPEED);
         transform.rotate_y(0.7 * time.delta_secs() * ROTATION_SPEED);
+    }
+}
+
+const UI_SCALE_CHANGE_STEP: f32 = 0.25;
+
+fn change_scale_factor(
+    input: Res<ButtonInput<KeyCode>>,
+    mut texture_camera: Single<&mut Camera, With<TextureCamera>>,
+) {
+    let mut scale_factor_change = 0.0;
+    if input.just_pressed(KeyCode::ArrowUp) {
+        scale_factor_change += UI_SCALE_CHANGE_STEP;
+    }
+    if input.just_pressed(KeyCode::ArrowDown) {
+        scale_factor_change -= UI_SCALE_CHANGE_STEP;
+    }
+
+    if scale_factor_change != 0.0 {
+        let RenderTarget::Image { scale_factor, .. } = &mut texture_camera.target else {
+            panic!("render target should be an image");
+        };
+
+        *scale_factor += scale_factor_change;
+        info!("Changed render target scale factor by {scale_factor_change}, now {scale_factor}");
     }
 }


### PR DESCRIPTION
# Objective

Currently, if you set `RenderTarget` to anything other than a window, the render target is treated as having a hardcoded `1.0` scale factor. This means that `bevy_ui` will always render into that target with a 1x scale factor. My use-case is rendering into an `Image` which is later drawn onto a window via `bevy_egui` - but if the scale factor is hardcoded to 1x, UI will look too small if the window actually has a higher scale factor.

Current code:
```rs
pub fn get_render_target_info<'a>(
    &self,
    resolutions: impl IntoIterator<Item = (Entity, &'a Window)>,
    images: &Assets<Image>,
    manual_texture_views: &ManualTextureViews,
) -> Option<RenderTargetInfo> {
    match self {
        NormalizedRenderTarget::Window(window_ref) => resolutions
            .into_iter()
            .find(|(entity, _)| *entity == window_ref.entity())
            .map(|(_, window)| RenderTargetInfo {
                physical_size: window.physical_size(),
                scale_factor: window.resolution.scale_factor(),
            }),
        NormalizedRenderTarget::Image(image_handle) => {
            let image = images.get(image_handle)?;
            Some(RenderTargetInfo {
                physical_size: image.size(),
                scale_factor: 1.0, // <-- hardcoded here!
            })
        }
        NormalizedRenderTarget::TextureView(id) => {
            manual_texture_views.get(id).map(|tex| RenderTargetInfo {
                physical_size: tex.size,
                scale_factor: 1.0, // <-- hardcoded here!
            })
        }
    }
}
```

## Solution

This PR adds `scale_factor` fields to `RenderTarget::Image` and `RenderTarget::TextureView`, which is fed directly into `RenderTargetInfo` (which is used by `bevy_ui`). Old uses of `Image` and `TextureView` constructors are replaced with `RenderTarget::from(image)` or `from(texture_view_handle)`, which keep the old behaviour of having scale factor `1.0`.

## Testing

In `render_ui_to_texture` example, if you press the up or down arrow keys, it will change the scale factor of the `RenderTarget` by 0.25. Tested this example and it works.

---

## Showcase

`RenderTarget`s which are not `Window`s can now have a custom scale factor applied. Previously, if you had UI which rendered into a camera which rendered into a `RenderTarget`, the UI scale factor would be fixed to `1.0`. Now you can explicitly specify the scale factor of the render target. This is useful for if you want to, for example, render the game itself (including UI) into an image, then draw that image onto the final window manually.

You can try out these changes in the updated `render_ui_to_texture` example.

[Screencast From 2024-11-03 15-15-34.webm](https://github.com/user-attachments/assets/ef9e9e62-a768-47ee-b8e1-78c5b30a5a28)

## Migration Guide

`RenderTarget::Image` and `RenderTarget::TextureView` have been turned into field enum variants, and a new field `scale_factor` has been added, letting you change the scale factor of the render target (previously, it was hardcoded to `1.0` unless it was a window).

If you want to keep the old behavior, either set `scale_factor` to 1.0 explicitly, or use `RenderTarget::from(Handle<Image>)` or `from(ManualTextureViewHandle)`, which also creates a target with a scale factor of 1.0
