### PR TITLE
Flush commands after every mutation in `WorldEntityMut`

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1010,7 +1010,7 @@ pub struct EntityLocation {
 
 impl EntityLocation {
     /// location for **pending entity** and **invalid entity**
-    const INVALID: EntityLocation = EntityLocation {
+    pub(crate) const INVALID: EntityLocation = EntityLocation {
         archetype_id: ArchetypeId::INVALID,
         archetype_row: ArchetypeRow::INVALID,
         table_id: TableId::INVALID,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2007,7 +2007,7 @@ impl<'w> EntityWorldMut<'w> {
     /// between commands as this shouldn't happen. However, for some special cases where it
     /// is known that a hook or an observer might despawn the entity while a [`EntityWorldMut`]
     /// reference is still held, this method can be used to check if the entity is still alive
-    /// to avoid panicing when calling further methods.
+    /// to avoid panicking when calling further methods.
     #[inline]
     pub fn is_despawned(&self) -> bool {
         self.location.archetype_id == ArchetypeId::INVALID

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1216,6 +1216,8 @@ impl<'w> EntityWorldMut<'w> {
             unsafe {
                 bundle_inserter.insert(self.entity, self.location, bundle, mode, #[cfg(feature = "track_change_detection")] caller)
             };
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1256,6 +1258,8 @@ impl<'w> EntityWorldMut<'w> {
             Some(component).into_iter(),
             Some(storage_type).iter().cloned(),
         );
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1299,6 +1303,8 @@ impl<'w> EntityWorldMut<'w> {
             (*storage_types).iter().cloned(),
         );
         *self.world.bundles.get_storages_unchecked(bundle_id) = core::mem::take(&mut storage_types);
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1397,6 +1403,8 @@ impl<'w> EntityWorldMut<'w> {
                 new_archetype_id,
             );
         }
+        self.world.flush();
+        self.update_location();
         Some(result)
     }
 
@@ -1582,7 +1590,8 @@ impl<'w> EntityWorldMut<'w> {
 
         // SAFETY: the `BundleInfo` is initialized above
         self.location = unsafe { self.remove_bundle(bundle_info) };
-
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1596,7 +1605,8 @@ impl<'w> EntityWorldMut<'w> {
 
         // SAFETY: the dynamic `BundleInfo` is initialized above
         self.location = unsafe { self.remove_bundle(bundle_id) };
-
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1623,6 +1633,8 @@ impl<'w> EntityWorldMut<'w> {
 
         // SAFETY: the `BundleInfo` for the components to remove is initialized above
         self.location = unsafe { self.remove_bundle(remove_bundle) };
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1643,7 +1655,8 @@ impl<'w> EntityWorldMut<'w> {
 
         // SAFETY: the `BundleInfo` for this `component_id` is initialized above
         self.location = unsafe { self.remove_bundle(bundle_id) };
-
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1659,7 +1672,8 @@ impl<'w> EntityWorldMut<'w> {
 
         // SAFETY: the `BundleInfo` for this `component_id` is initialized above
         self.location = unsafe { self.remove_bundle(bundle_id) };
-
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1893,6 +1907,8 @@ impl<'w> EntityWorldMut<'w> {
     /// Triggers the given `event` for this entity, which will run any observers watching for it.
     pub fn trigger(&mut self, event: impl Event) -> &mut Self {
         self.world.trigger_targets(event, self.entity);
+        self.world.flush();
+        self.update_location();
         self
     }
 
@@ -1904,6 +1920,8 @@ impl<'w> EntityWorldMut<'w> {
     ) -> &mut Self {
         self.world
             .spawn(Observer::new(observer).with_entity(self.entity));
+        self.world.flush();
+        self.update_location();
         self
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -930,6 +930,10 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Gets metadata indicating the location where the current entity is stored.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn location(&self) -> EntityLocation {
         self.assert_not_despawned();
@@ -937,6 +941,10 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Returns the archetype that the current entity belongs to.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn archetype(&self) -> &Archetype {
         self.assert_not_despawned();
@@ -950,6 +958,10 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// If you do not know the concrete type of a component, consider using
     /// [`Self::contains_id`] or [`Self::contains_type_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn contains<T: Component>(&self) -> bool {
         self.contains_type_id(TypeId::of::<T>())
@@ -963,6 +975,10 @@ impl<'w> EntityWorldMut<'w> {
     /// - If you know the concrete type of the component, you should prefer [`Self::contains`].
     /// - If you know the component's [`TypeId`] but not its [`ComponentId`], consider using
     ///     [`Self::contains_type_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn contains_id(&self, component_id: ComponentId) -> bool {
         self.as_unsafe_entity_cell_readonly()
@@ -976,6 +992,10 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// - If you know the concrete type of the component, you should prefer [`Self::contains`].
     /// - If you have a [`ComponentId`] instead of a [`TypeId`], consider using [`Self::contains_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn contains_type_id(&self, type_id: TypeId) -> bool {
         self.as_unsafe_entity_cell_readonly()
@@ -984,6 +1004,10 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Gets access to the component of type `T` for the current entity.
     /// Returns `None` if the entity does not have a component of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get<T: Component>(&self) -> Option<&'_ T> {
         EntityRef::from(self).get()
@@ -993,7 +1017,8 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// # Panics
     ///
-    /// If the entity does not have the components required by the query `Q`.
+    /// If the entity does not have the components required by the query `Q` or if the entity
+    /// has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn components<Q: ReadOnlyQueryData>(&self) -> Q::Item<'_> {
         EntityRef::from(self).components::<Q>()
@@ -1001,6 +1026,10 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Returns read-only components for the current entity that match the query `Q`,
     /// or `None` if the entity does not have the components required by the query `Q`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_components<Q: ReadOnlyQueryData>(&self) -> Option<Q::Item<'_>> {
         EntityRef::from(self).get_components::<Q>()
@@ -1009,6 +1038,10 @@ impl<'w> EntityWorldMut<'w> {
     /// Consumes `self` and gets access to the component of type `T` with
     /// the world `'w` lifetime for the current entity.
     /// Returns `None` if the entity does not have a component of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn into_borrow<T: Component>(self) -> Option<&'w T> {
         // SAFETY: consuming `self` implies exclusive access
@@ -1019,6 +1052,10 @@ impl<'w> EntityWorldMut<'w> {
     /// including change detection information as a [`Ref`].
     ///
     /// Returns `None` if the entity does not have a component of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_ref<T: Component>(&self) -> Option<Ref<'_, T>> {
         EntityRef::from(self).get_ref()
@@ -1029,6 +1066,10 @@ impl<'w> EntityWorldMut<'w> {
     /// including change detection information as a [`Ref`].
     ///
     /// Returns `None` if the entity does not have a component of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn into_ref<T: Component>(self) -> Option<Ref<'w, T>> {
         EntityRef::from(self).get_ref()
@@ -1036,6 +1077,10 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Gets mutable access to the component of type `T` for the current entity.
     /// Returns `None` if the entity does not have a component of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_mut<T: Component>(&mut self) -> Option<Mut<'_, T>> {
         // SAFETY: &mut self implies exclusive access for duration of returned value
@@ -1045,6 +1090,10 @@ impl<'w> EntityWorldMut<'w> {
     /// Consumes `self` and gets mutable access to the component of type `T`
     /// with the world `'w` lifetime for the current entity.
     /// Returns `None` if the entity does not have a component of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn into_mut<T: Component>(self) -> Option<Mut<'w, T>> {
         // SAFETY: consuming `self` implies exclusive access
@@ -1053,6 +1102,10 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Retrieves the change ticks for the given component. This can be useful for implementing change
     /// detection in custom runtimes.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_change_ticks<T: Component>(&self) -> Option<ComponentTicks> {
         EntityRef::from(self).get_change_ticks::<T>()
@@ -1064,6 +1117,10 @@ impl<'w> EntityWorldMut<'w> {
     /// **You should prefer to use the typed API [`EntityWorldMut::get_change_ticks`] where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
         EntityRef::from(self).get_change_ticks_by_id(component_id)
@@ -1088,6 +1145,10 @@ impl<'w> EntityWorldMut<'w> {
     /// # Examples
     ///
     /// For examples on how to use this method, see [`EntityRef::get_by_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_by_id<F: DynamicComponentFetch>(
         &self,
@@ -1116,6 +1177,10 @@ impl<'w> EntityWorldMut<'w> {
     /// # Examples
     ///
     /// For examples on how to use this method, see [`EntityRef::get_by_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn into_borrow_by_id<F: DynamicComponentFetch>(
         self,
@@ -1148,6 +1213,10 @@ impl<'w> EntityWorldMut<'w> {
     /// # Examples
     ///
     /// For examples on how to use this method, see [`EntityMut::get_mut_by_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn get_mut_by_id<F: DynamicComponentFetch>(
         &mut self,
@@ -1181,6 +1250,10 @@ impl<'w> EntityWorldMut<'w> {
     /// # Examples
     ///
     /// For examples on how to use this method, see [`EntityMut::get_mut_by_id`].
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
     pub fn into_mut_by_id<F: DynamicComponentFetch>(
         self,
@@ -1195,6 +1268,10 @@ impl<'w> EntityWorldMut<'w> {
     /// Adds a [`Bundle`] of components to the entity.
     ///
     /// This will overwrite any previous value(s) of the same component type.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[track_caller]
     pub fn insert<T: Bundle>(&mut self, bundle: T) -> &mut Self {
         self.insert_with_caller(
@@ -1209,6 +1286,10 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// This will leave any previous value(s) of the same component type
     /// unchanged.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[track_caller]
     pub fn insert_if_new<T: Bundle>(&mut self, bundle: T) -> &mut Self {
         self.insert_with_caller(
@@ -1252,6 +1333,10 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// - [`ComponentId`] must be from the same world as [`EntityWorldMut`]
     /// - [`OwningPtr`] must be a valid reference to the type represented by [`ComponentId`]
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[track_caller]
     pub unsafe fn insert_by_id(
         &mut self,
@@ -1297,6 +1382,10 @@ impl<'w> EntityWorldMut<'w> {
     /// # Safety
     /// - Each [`ComponentId`] must be from the same world as [`EntityWorldMut`]
     /// - Each [`OwningPtr`] must be a valid reference to the type represented by [`ComponentId`]
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[track_caller]
     pub unsafe fn insert_by_ids<'a, I: Iterator<Item = OwningPtr<'a>>>(
         &mut self,
@@ -1335,6 +1424,10 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// **Note:** If the entity does not have every component in the bundle, this method will not
     /// remove any of them.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     // TODO: BundleRemover?
     #[must_use]
     pub fn take<T: Bundle>(&mut self) -> Option<T> {
@@ -1606,6 +1699,10 @@ impl<'w> EntityWorldMut<'w> {
     /// Removes any components in the [`Bundle`] from the entity.
     ///
     /// See [`EntityCommands::remove`](crate::system::EntityCommands::remove) for more details.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     // TODO: BundleRemover?
     pub fn remove<T: Bundle>(&mut self) -> &mut Self {
         self.assert_not_despawned();
@@ -1621,6 +1718,10 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Removes all components in the [`Bundle`] and remove all required components for each component in the bundle
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn remove_with_requires<T: Bundle>(&mut self) -> &mut Self {
         self.assert_not_despawned();
         let storages = &mut self.world.storages;
@@ -1639,6 +1740,10 @@ impl<'w> EntityWorldMut<'w> {
     /// Removes any components except those in the [`Bundle`] (and its Required Components) from the entity.
     ///
     /// See [`EntityCommands::retain`](crate::system::EntityCommands::retain) for more details.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn retain<T: Bundle>(&mut self) -> &mut Self {
         self.assert_not_despawned();
         let archetypes = &mut self.world.archetypes;
@@ -1671,7 +1776,8 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// # Panics
     ///
-    /// Panics if the provided [`ComponentId`] does not exist in the [`World`].
+    /// Panics if the provided [`ComponentId`] does not exist in the [`World`] or if the
+    /// entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn remove_by_id(&mut self, component_id: ComponentId) -> &mut Self {
         self.assert_not_despawned();
         let components = &mut self.world.components;
@@ -1689,6 +1795,10 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Removes all components associated with the entity.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn clear(&mut self) -> &mut Self {
         self.assert_not_despawned();
         let component_ids: Vec<ComponentId> = self.archetype().components().collect();
@@ -1709,6 +1819,10 @@ impl<'w> EntityWorldMut<'w> {
     /// Despawns the current entity.
     ///
     /// See [`World::despawn`] for more details.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn despawn(self) {
         self.assert_not_despawned();
         let world = self.world;
@@ -1920,6 +2034,10 @@ impl<'w> EntityWorldMut<'w> {
     /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
     /// assert_eq!(world.query::<&Comp>().single(&world).0, 5);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn entry<'a, T: Component>(&'a mut self) -> Entry<'w, 'a, T> {
         if self.contains::<T>() {
             Entry::Occupied(OccupiedEntry {
@@ -1935,7 +2053,12 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Triggers the given `event` for this entity, which will run any observers watching for it.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn trigger(&mut self, event: impl Event) -> &mut Self {
+        self.assert_not_despawned();
         self.world.trigger_targets(event, self.entity);
         self.world.flush();
         self.update_location();
@@ -1944,10 +2067,15 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Creates an [`Observer`] listening for events of type `E` targeting this entity.
     /// In order to trigger the callback the entity must also match the query when the event is fired.
+    ///
+    /// # Panics
+    ///
+    /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     pub fn observe<E: Event, B: Bundle, M>(
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
+        self.assert_not_despawned();
         self.world
             .spawn(Observer::new(observer).with_entity(self.entity));
         self.world.flush();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1836,7 +1836,11 @@ impl<'w> EntityWorldMut<'w> {
     /// This is *only* required when using the unsafe function [`EntityWorldMut::world_mut`],
     /// which enables the location to change.
     pub fn update_location(&mut self) {
-        self.location = self.world.entities().get(self.entity).unwrap();
+        self.location = self
+            .world
+            .entities()
+            .get(self.entity)
+            .unwrap_or(EntityLocation::INVALID);
     }
 
     /// Gets an Entry into the world for this entity and component for in-place manipulation.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1843,6 +1843,18 @@ impl<'w> EntityWorldMut<'w> {
             .unwrap_or(EntityLocation::INVALID);
     }
 
+    /// Returns if the entity has been despawned.
+    ///
+    /// Normally it shouldn't be needed to explicitly check if the entity has been despawned
+    /// between commands as this shouldn't happen. However, for some special cases where it
+    /// is known that a hook or an observer might despawn the entity while a [`EntityWorldMut`]
+    /// reference is still held, this method can be used to check if the entity is still alive
+    /// to avoid panicing when calling further methods.
+    #[inline]
+    pub fn is_despawned(&self) -> bool {
+        self.location.archetype_id == ArchetypeId::INVALID
+    }
+
     /// Gets an Entry into the world for this entity and component for in-place manipulation.
     ///
     /// The type parameter specifies which component to get.


### PR DESCRIPTION
# Objective

- Currently adding observers spawns an entity which implicitly flushes the command queue, which can cause undefined behaviour if the `WorldEntityMut` is used after this
- The reason `WorldEntityMut` attempted to (unsuccessfully) avoid flushing commands until finished was that such commands may move or despawn the entity being referenced, invalidating the cached location.
- With the introduction of hooks and observers, this isn't sensible anymore as running the commands generated by hooks immediately is required to maintain correct ordering of operations and to not expose the world in an inconsistent state
- Objective is to make command flushing deterministic and fix the related issues
- Fixes #16212
- Fixes #14621 
- Fixes #16034

## Solution

- Allow `WorldEntityMut` to exist even when it refers to a despawned entity by allowing `EntityLocation` to be marked invalid
- Add checks to all methods to panic if trying to access a despawned entity
- Flush command queue after every operation that might trigger hooks or observers
- Update entity location always after flushing command queue

## Testing

- Added test cases for currently broken behaviour
- Added test cases that flushes happen in all operations
- Added test cases to ensure hooks and commands are run exactly in correct order when nested

---

Todo:

- [x] Write migration guide
- [x] Add tests that using `EntityWorldMut` on a despawned entity panics
- [x] Add tests that commands are flushed after every operation that is supposed to flush them
- [x] Add tests that hooks, observers and their spawned commands are run in the correct order when nested

---

## Migration Guide

Previously `EntityWorldMut` triggered command queue flushes in unpredictable places, which could interfere with hooks and observers. Now the command queue is flushed always immediately after any call in `EntityWorldMut` that spawns or despawns an entity, or adds, removes or replaces a component. This means hooks and observers will run their commands in the correct order.

As a side effect, there is a possibility that a hook or observer could despawn the entity that is being referred to by `EntityWorldMut`. This could already currently happen if an observer was added while keeping an `EntityWorldMut` referece and would cause unsound behaviour. If the entity has been despawned, calling any methods which require the entity location will panic. This matches the behaviour that `Commands` will panic if called on an already despawned entity. In the extremely rare case where taking a new `EntityWorldMut` reference or otherwise restructuring the code so that this case does not happen is not possible, there's a new `is_despawned` method that can be used to check if the referred entity has been despawned.