### PR TITLE
Expose picking pointer state as a resource

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -271,7 +271,7 @@ pub struct PointerState {
 }
 
 impl PointerState {
-    /// Retrives the current state for a specific pointer and button, if it has been created.
+    /// Retrieves the current state for a specific pointer and button, if it has been created.
     pub fn get(&self, pointer_id: PointerId, button: PointerButton) -> Option<&PointerButtonState> {
         self.pointer_buttons.get(&(pointer_id, button))
     }

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -381,6 +381,7 @@ impl Plugin for InteractionPlugin {
 
         app.init_resource::<focus::HoverMap>()
             .init_resource::<focus::PreviousHoverMap>()
+            .init_resource::<PointerState>()
             .add_event::<Pointer<Cancel>>()
             .add_event::<Pointer<Click>>()
             .add_event::<Pointer<Down>>()


### PR DESCRIPTION
In `bevy_mod_picking` events are driven by several interlocking state machines, which read and write events, and share state in a few common resources. When I merged theses state machines into one to make event ordering work properly, I combined this state and hid it in a `Local`.

This PR exposes the state in a resource again. Also adds a simple little API for it. Useful for adding debug UI. 