### PR TITLE
Bump crate-ci/typos from 1.26.8 to 1.27.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.26.8
+        uses: crate-ci/typos@v1.27.0
       - name: Typos info
         if: failure()
         run: |

--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -180,7 +180,7 @@ impl NormedVectorSpace for f32 {
 ///
 /// 3. Importantly, the interpolation must be *subdivision-stable*: for any interpolation curve
 ///    between two (unnamed) values and any parameter-value pairs `(t0, p)` and `(t1, q)`, the
-///    interpolation curve between `p` and `q` must be the *linear* reparametrization of the original
+///    interpolation curve between `p` and `q` must be the *linear* reparameterization of the original
 ///    interpolation curve restricted to the interval `[t0, t1]`.
 ///
 /// The last of these conditions is very strong and indicates something like constant speed. It
@@ -197,7 +197,7 @@ impl NormedVectorSpace for f32 {
 ///              /               \
 ///            /                   \
 ///          /        linear         \
-///        /     reparametrization     \
+///        /     reparameterization    \
 ///      /   t = t0 * (1 - s) + t1 * s   \
 ///    /                                   \
 ///   |-------------------------------------|

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -362,7 +362,7 @@ where
     }
 }
 
-/// A curve that has had its domain changed by a linear reparametrization (stretching and scaling).
+/// A curve that has had its domain changed by a linear reparameterization (stretching and scaling).
 /// Curves of this type are produced by [`Curve::reparametrize_linear`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -903,7 +903,7 @@ where
     }
 }
 
-/// An error indicating that a linear reparametrization couldn't be performed because of
+/// An error indicating that a linear reparameterization couldn't be performed because of
 /// malformed inputs.
 #[derive(Debug, Error, Display)]
 #[display("Could not build a linear function to reparametrize this curve")]
@@ -912,8 +912,8 @@ pub enum LinearReparamError {
     #[display("This curve has unbounded domain")]
     SourceCurveUnbounded,
 
-    /// The target interval for reparametrization was unbounded.
-    #[display("The target interval for reparametrization is unbounded")]
+    /// The target interval for reparameterization was unbounded.
+    #[display("The target interval for reparameterization is unbounded")]
     TargetIntervalUnbounded,
 }
 
@@ -1195,7 +1195,7 @@ mod tests {
     }
 
     #[test]
-    fn reparametrization() {
+    fn reparameterization() {
         let curve = function_curve(interval(1.0, f32::INFINITY).unwrap(), ops::log2);
         let reparametrized_curve = curve
             .by_ref()


### PR DESCRIPTION
# Objective

- Closes #16224

## Solution

- Bumps `crate-ci/typos@v1.26.8` to `crate-ci/typos@v1.27.0`.

## Testing

- CI checks should pass.