### PR TITLE
Create `ReactiveSystemParam` trait

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     component::{Tick, TickCells},
+    entity::Entity,
     prelude::Component,
     ptr::PtrMut,
     query::{Changed, QueryData, QueryFilter, ReadOnlyQueryData},
@@ -1153,6 +1154,21 @@ pub trait ReactiveQueryData<F: QueryFilter>: ReadOnlyQueryData + Sized {
 
     /// Returns `true` if the query has changed since the last system run.
     fn is_changed(world: DeferredWorld, state: &mut <Self as ReactiveQueryData<F>>::State) -> bool;
+}
+
+impl<F: QueryFilter> ReactiveQueryData<F> for Entity {
+    type State = ();
+
+    fn init(world: &mut World) -> <Self as ReactiveQueryData<F>>::State {
+        let _ = world;
+    }
+
+    fn is_changed(world: DeferredWorld, state: &mut <Self as ReactiveQueryData<F>>::State) -> bool {
+        let _ = world;
+        let _ = state;
+
+        false
+    }
 }
 
 impl<F, T> ReactiveQueryData<F> for &T

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -3,7 +3,7 @@
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
-    system::Resource,
+    system::{Resource, SystemParam},
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use core::{
@@ -1190,6 +1190,27 @@ pub(crate) type MaybeThinSlicePtrLocation<'w> =
 /// See [`MaybeLocation`] for further information.
 #[cfg(not(feature = "track_change_detection"))]
 pub(crate) type MaybeThinSlicePtrLocation<'w> = ();
+
+pub trait ReactiveSystemParam: ReadOnlySystemParam {
+    type State: Send + Sync + 'static;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State;
+
+    fn is_changed(&self) -> bool;
+}
+
+impl<T> ReactiveSystemParam for Res<'_, T> {
+    type State = ();
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        let _ = world;
+        let _ = system_meta;
+    }
+
+    fn is_changed(&self) -> bool {
+        self.is_changed()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -3,8 +3,8 @@
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
-    system::{ReadOnlySystemParam, Resource, SystemMeta},
-    world::World,
+    system::{Commands, Local, ReadOnlySystemParam, Resource, SystemMeta, SystemState},
+    world::{DeferredWorld, FromWorld, World},
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use core::{
@@ -1154,6 +1154,38 @@ pub trait ReactiveSystemParam: ReadOnlySystemParam {
 
     /// Returns `true` if the parameter has changed since the last system run.
     fn is_changed(&self) -> bool;
+}
+
+impl ReactiveSystemParam for Commands<'_, '_> {
+    type State = ();
+
+    fn init_state(
+        world: &mut World,
+        system_meta: &mut SystemMeta,
+    ) -> <Self as ReactiveSystemParam>::State {
+        let _ = world;
+        let _ = system_meta;
+    }
+
+    fn is_changed(&self) -> bool {
+        false
+    }
+}
+
+impl<T: FromWorld + Send> ReactiveSystemParam for Local<'_, T> {
+    type State = ();
+
+    fn init_state(
+        world: &mut World,
+        system_meta: &mut SystemMeta,
+    ) -> <Self as ReactiveSystemParam>::State {
+        let _ = world;
+        let _ = system_meta;
+    }
+
+    fn is_changed(&self) -> bool {
+        false
+    }
 }
 
 impl<T: Resource> ReactiveSystemParam for Res<'_, T> {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     component::{Tick, TickCells},
-    entity::Entity,
     prelude::Component,
     ptr::PtrMut,
     query::{Changed, QueryData, QueryFilter, ReadOnlyQueryData},
@@ -1251,6 +1250,8 @@ where
         world: &mut World,
         system_meta: &mut SystemMeta,
     ) -> <Self as ReactiveSystemParam>::State {
+        let _ = system_meta;
+
         <D as ReactiveQueryData<F>>::init(world)
     }
 
@@ -1279,6 +1280,9 @@ impl<T: Resource> ReactiveSystemParam for Res<'_, T> {
         world: DeferredWorld,
         state: &mut <Self as ReactiveSystemParam>::State,
     ) -> bool {
+        let _ = world;
+        let _ = state;
+
         DetectChanges::is_changed(self)
     }
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1244,6 +1244,33 @@ impl<T: Resource> ReactiveSystemParam for Res<'_, T> {
     }
 }
 
+macro_rules! impl_reactive_system_param {
+    ($($t:tt),*) => {
+        impl<$($t: ReactiveSystemParam),*> ReactiveSystemParam for ($($t,)*) {
+            type State = ($(<$t as ReactiveSystemParam>::State,)*);
+
+            fn init_state(world: &mut World) -> <Self as ReactiveSystemParam>::State {
+                ($(<$t as ReactiveSystemParam>::init_state(world),)*)
+            }
+
+            fn is_changed(mut world: DeferredWorld, state: &mut <Self as ReactiveSystemParam>::State) -> bool {
+                #[allow(non_snake_case)]
+                let ($($t,)*) = state;
+                $($t::is_changed(world.reborrow(), $t)) ||*
+            }
+        }
+    };
+}
+
+impl_reactive_system_param!(T1);
+impl_reactive_system_param!(T1, T2);
+impl_reactive_system_param!(T1, T2, T3);
+impl_reactive_system_param!(T1, T2, T3, T4);
+impl_reactive_system_param!(T1, T2, T3, T4, T5);
+impl_reactive_system_param!(T1, T2, T3, T4, T5, T6);
+impl_reactive_system_param!(T1, T2, T3, T4, T5, T6, T7);
+impl_reactive_system_param!(T1, T2, T3, T4, T5, T6, T7, T8);
+
 /// A type alias to [`&'static Location<'static>`](std::panic::Location) when the `track_change_detection` feature is
 /// enabled, and the unit type `()` when it is not.
 ///


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/discussions/9538 mentions a possible `IsChanged` trait or similar to create systems that react to changes in their parameters

## Solution

- [x] `ReactiveQueryData`
  - Implement `ReactiveQueryData` for exported `QueryData` implementations:
    - [x] Entity
    - [x] `&T`
    - [ ] `Ref`
    - [x] `(T1, T2, ... T8)`
    - [ ] `AnyOf`
  - Some questions remain:
    - What is the best way to mark some query data items as changed? (e.g. `Entity` is currently always marked as unchanged, in the hope that `Query<(Entity, &T)>` will react when `T` is changed, but I'm not positive this is the right solution)
    - Can all `QueryData` impls be `ReactiveQueryData`? It may be best to avoid some types, or mark them as always or never changing
- [x] `ReactiveSystemParam`
  - Implemented for certain `ReadOnlySystemParam`s, the hope here is to avoid mutation during reactive systems for 2 reasons:
    1. Ordering becomes super tricky with mutating during reactive systems, most UI frameworks use immutability for this reason (but we can mutate by queuing `Command`s after reactions are finished)
    2. Running reactive systems (or potentially `Reaction` components) can be done without blocking the world, and in parallel with other reader systems.
- [ ] `ReactiveSystemParamFunction`

```rs
/// A reactive system parameter that implements change detection.
pub trait ReactiveSystemParam: ReadOnlySystemParam {
    /// The reactive state of this parameter.
    type State: Send + Sync + 'static;

    /// Initializes the reactive state of this parameter.
    fn init_state(
        world: &mut World,
        system_meta: &mut SystemMeta,
    ) -> <Self as ReactiveSystemParam>::State;

    /// Returns `true` if the parameter has changed since the last system run.
    fn is_changed(
        &self,
        world: DeferredWorld,
        state: &mut <Self as ReactiveSystemParam>::State,
    ) -> bool;
}

/// Reactive [`QueryData`].
pub trait ReactiveQueryData<F: QueryFilter>: ReadOnlyQueryData + Sized {
    /// The reactive state of this query.
    type State: Send + Sync + 'static;

    /// Initializes the reactive state of this query.
    fn init(world: &mut World) -> <Self as ReactiveQueryData<F>>::State;

    /// Returns `true` if the query has changed since the last system run.
    fn is_changed(world: DeferredWorld, state: &mut <Self as ReactiveQueryData<F>>::State) -> bool;
}
```

## Testing

- Test `ReactiveSystemParam` impl for `Res<R>`

---

## Showcase

This could eventually lead to `Reaction`s or similar (but would provide primitives for other designs as well):
https://github.com/matthunz/bevy_mod_reaction
```rs
// Reactions can also subscribe to multiple targets.
let a = commands.spawn(Health(100)).id();
let b = commands.spawn(Health(100)).id();

let mut reaction = Reaction::derive(|scope: In<Scope>, query: Query<&Health>| {
    let health = query.get(scope.entity).unwrap();
    Damage(health.0 * 2)
});

reaction.add_target(a);
reaction.add_target(b);

commands.spawn(reaction);
```