### PR TITLE
Rename `Camera` to `RenderSurface`

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -2,7 +2,7 @@ use super::downsampling_pipeline::BloomUniforms;
 use bevy_ecs::{prelude::Component, query::QueryItem, reflect::ReflectComponent};
 use bevy_math::{AspectRatio, URect, UVec4, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
+use bevy_render::{extract_component::ExtractComponent, prelude::RenderSurface};
 
 /// Applies a bloom effect to an HDR-enabled 2d or 3d camera.
 ///
@@ -213,7 +213,7 @@ pub enum BloomCompositeMode {
 }
 
 impl ExtractComponent for Bloom {
-    type QueryData = (&'static Self, &'static Camera);
+    type QueryData = (&'static Self, &'static RenderSurface);
 
     type QueryFilter = ();
     type Out = (Self, BloomUniforms);

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -71,7 +71,7 @@ impl Default for ContrastAdaptiveSharpening {
 #[reflect(Component, Default)]
 pub struct DenoiseCas(bool);
 
-/// The uniform struct extracted from [`ContrastAdaptiveSharpening`] attached to a [`Camera`].
+/// The uniform struct extracted from [`ContrastAdaptiveSharpening`] attached to a [`RenderSurface`].
 /// Will be available for use in the CAS shader.
 #[doc(hidden)]
 #[derive(Component, ShaderType, Clone)]

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin, UniformComponentPlugin},
-    prelude::Camera,
+    prelude::RenderSurface,
     render_graph::RenderGraphApp,
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
@@ -81,7 +81,7 @@ pub struct CasUniform {
 
 impl ExtractComponent for ContrastAdaptiveSharpening {
     type QueryData = &'static Self;
-    type QueryFilter = With<Camera>;
+    type QueryFilter = With<RenderSurface>;
     type Out = (DenoiseCas, CasUniform);
 
     fn extract_component(item: QueryItem<Self::QueryData>) -> Option<Self::Out> {

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -19,7 +19,7 @@ use bevy_render::{
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
-/// A 2D camera component. Enables the 2D render graph for a [`Camera`].
+/// A 2D camera component. Enables the 2D render graph for a [`RenderSurface`].
 #[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[extract_component_filter(With<RenderSurface>)]
 #[reflect(Component, Default)]

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -9,7 +9,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::sync_world::SyncToRenderWorld;
 use bevy_render::{
     camera::{
-        Camera, CameraMainTextureUsages, CameraProjection, CameraRenderGraph,
+        RenderSurface, CameraMainTextureUsages, CameraProjection, CameraRenderGraph,
         OrthographicProjection,
     },
     extract_component::ExtractComponent,
@@ -21,10 +21,10 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 
 /// A 2D camera component. Enables the 2D render graph for a [`Camera`].
 #[derive(Component, Default, Reflect, Clone, ExtractComponent)]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[reflect(Component, Default)]
 #[require(
-    Camera,
+    RenderSurface,
     DebandDither,
     CameraRenderGraph(|| CameraRenderGraph::new(Core2d)),
     OrthographicProjection(OrthographicProjection::default_2d),
@@ -39,7 +39,7 @@ pub struct Camera2d;
     note = "Use the `Camera2d` component instead. Inserting it will now also insert the other components required by it automatically."
 )]
 pub struct Camera2dBundle {
-    pub camera: Camera,
+    pub camera: RenderSurface,
     pub camera_render_graph: CameraRenderGraph,
     pub projection: OrthographicProjection,
     pub visible_entities: VisibleEntities,
@@ -67,7 +67,7 @@ impl Default for Camera2dBundle {
             frustum,
             transform,
             global_transform: Default::default(),
-            camera: Camera::default(),
+            camera: RenderSurface::default(),
             camera_2d: Camera2d,
             tonemapping: Tonemapping::None,
             deband_dither: DebandDither::Disabled,
@@ -101,7 +101,7 @@ impl Camera2dBundle {
             frustum,
             transform,
             global_transform: Default::default(),
-            camera: Camera::default(),
+            camera: RenderSurface::default(),
             camera_2d: Camera2d,
             tonemapping: Tonemapping::None,
             deband_dither: DebandDither::Disabled,

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -44,7 +44,7 @@ use bevy_ecs::{entity::EntityHashSet, prelude::*};
 use bevy_math::FloatOrd;
 use bevy_render::sync_world::MainEntity;
 use bevy_render::{
-    camera::{Camera, ExtractedCamera},
+    camera::{RenderSurface, ExtractedCamera},
     extract_component::ExtractComponentPlugin,
     render_graph::{EmptyNode, RenderGraphApp, ViewNodeRunner},
     render_phase::{
@@ -375,7 +375,7 @@ pub fn extract_core_2d_camera_phases(
     mut transparent_2d_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
     mut opaque_2d_phases: ResMut<ViewBinnedRenderPhases<Opaque2d>>,
     mut alpha_mask_2d_phases: ResMut<ViewBinnedRenderPhases<AlphaMask2d>>,
-    cameras_2d: Extract<Query<(RenderEntity, &Camera), With<Camera2d>>>,
+    cameras_2d: Extract<Query<(RenderEntity, &RenderSurface), With<Camera2d>>>,
     mut live_entities: Local<EntityHashSet>,
 ) {
     live_entities.clear();

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{
-    camera::{Camera, CameraMainTextureUsages, CameraRenderGraph, Exposure, Projection},
+    camera::{RenderSurface, CameraMainTextureUsages, CameraRenderGraph, Exposure, Projection},
     extract_component::ExtractComponent,
     primitives::Frustum,
     render_resource::{LoadOp, TextureUsages},
@@ -22,10 +22,10 @@ use serde::{Deserialize, Serialize};
 /// The camera coordinate space is right-handed X-right, Y-up, Z-back.
 /// This means "forward" is -Z.
 #[derive(Component, Reflect, Clone, ExtractComponent)]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[reflect(Component, Default)]
 #[require(
-    Camera,
+    RenderSurface,
     DebandDither(|| DebandDither::Enabled),
     CameraRenderGraph(|| CameraRenderGraph::new(Core3d)),
     Projection,
@@ -156,7 +156,7 @@ pub enum ScreenSpaceTransmissionQuality {
     note = "Use the `Camera3d` component instead. Inserting it will now also insert the other components required by it automatically."
 )]
 pub struct Camera3dBundle {
-    pub camera: Camera,
+    pub camera: RenderSurface,
     pub camera_render_graph: CameraRenderGraph,
     pub projection: Projection,
     pub visible_entities: VisibleEntities,

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -7,7 +7,7 @@ use crate::{
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{
-    camera::{RenderSurface, CameraMainTextureUsages, CameraRenderGraph, Exposure, Projection},
+    camera::{CameraMainTextureUsages, CameraRenderGraph, Exposure, Projection, RenderSurface},
     extract_component::ExtractComponent,
     primitives::Frustum,
     render_resource::{LoadOp, TextureUsages},
@@ -17,7 +17,7 @@ use bevy_render::{
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use serde::{Deserialize, Serialize};
 
-/// A 3D camera component. Enables the main 3D render graph for a [`Camera`].
+/// A 3D camera component. Enables the main 3D render graph for a [`RenderSurface`].
 ///
 /// The camera coordinate space is right-handed X-right, Y-up, Z-back.
 /// This means "forward" is -Z.

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -76,7 +76,7 @@ use bevy_ecs::{entity::EntityHashSet, prelude::*};
 use bevy_math::FloatOrd;
 use bevy_render::sync_world::MainEntity;
 use bevy_render::{
-    camera::{Camera, ExtractedCamera},
+    camera::{RenderSurface, ExtractedCamera},
     extract_component::ExtractComponentPlugin,
     prelude::Msaa,
     render_graph::{EmptyNode, RenderGraphApp, ViewNodeRunner},
@@ -528,7 +528,7 @@ pub fn extract_core_3d_camera_phases(
     mut alpha_mask_3d_phases: ResMut<ViewBinnedRenderPhases<AlphaMask3d>>,
     mut transmissive_3d_phases: ResMut<ViewSortedRenderPhases<Transmissive3d>>,
     mut transparent_3d_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
-    cameras_3d: Extract<Query<(RenderEntity, &Camera), With<Camera3d>>>,
+    cameras_3d: Extract<Query<(RenderEntity, &RenderSurface), With<Camera3d>>>,
     mut live_entities: Local<EntityHashSet>,
 ) {
     live_entities.clear();
@@ -563,7 +563,7 @@ pub fn extract_camera_prepass_phase(
         Query<
             (
                 RenderEntity,
-                &Camera,
+                &RenderSurface,
                 Has<DepthPrepass>,
                 Has<NormalPrepass>,
                 Has<MotionVectorPrepass>,
@@ -793,7 +793,7 @@ pub fn prepare_core_3d_transmission_textures(
 }
 
 // Disable MSAA and warn if using deferred rendering
-pub fn check_msaa(mut deferred_views: Query<&mut Msaa, (With<Camera>, With<DeferredPrepass>)>) {
+pub fn check_msaa(mut deferred_views: Query<&mut Msaa, (With<RenderSurface>, With<DeferredPrepass>)>) {
     for mut msaa in deferred_views.iter_mut() {
         match *msaa {
             Msaa::Off => (),

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -9,7 +9,7 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin},
-    prelude::Camera,
+    prelude::RenderSurface,
     render_graph::{RenderGraphApp, ViewNodeRunner},
     render_resource::{
         binding_types::{sampler, texture_2d},
@@ -52,7 +52,7 @@ impl Sensitivity {
 /// for a [`bevy_render::camera::Camera`].
 #[derive(Reflect, Component, Clone, ExtractComponent)]
 #[reflect(Component, Default)]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[doc(alias = "FastApproximateAntiAliasing")]
 pub struct Fxaa {
     /// Enable render passes for FXAA.

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -49,7 +49,7 @@ impl Sensitivity {
 }
 
 /// A component for enabling Fast Approximate Anti-Aliasing (FXAA)
-/// for a [`bevy_render::camera::Camera`].
+/// for a [`bevy_render::camera::RenderSurface`].
 #[derive(Reflect, Component, Clone, ExtractComponent)]
 #[reflect(Component, Default)]
 #[extract_component_filter(With<RenderSurface>)]

--- a/crates/bevy_core_pipeline/src/motion_blur/mod.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/mod.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     extract_component::{ExtractComponent, ExtractComponentPlugin, UniformComponentPlugin},
     render_graph::{RenderGraphApp, ViewNodeRunner},
     render_resource::{Shader, ShaderType, SpecializedRenderPipelines},
@@ -70,7 +70,7 @@ pub struct MotionBlurBundle {
 /// ````
 #[derive(Reflect, Component, Clone, ExtractComponent, ShaderType)]
 #[reflect(Component, Default)]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[require(DepthPrepass, MotionVectorPrepass)]
 pub struct MotionBlur {
     /// The strength of motion blur from `0.0` to `1.0`.

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{component::*, prelude::*};
 use bevy_math::UVec2;
 use bevy_reflect::Reflect;
 use bevy_render::{
-    camera::{Camera, ExtractedCamera},
+    camera::{RenderSurface, ExtractedCamera},
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     render_graph::{RenderGraphApp, ViewNodeRunner},
     render_resource::{
@@ -150,8 +150,8 @@ impl Plugin for OrderIndependentTransparencyPlugin {
 // bevy reuses the same depth texture so we need to set this on all cameras with the same render target.
 fn configure_depth_texture_usages(
     p: Query<Entity, With<PrimaryWindow>>,
-    cameras: Query<(&Camera, Has<OrderIndependentTransparencySettings>)>,
-    mut new_cameras: Query<(&mut Camera3d, &Camera), Added<Camera3d>>,
+    cameras: Query<(&RenderSurface, Has<OrderIndependentTransparencySettings>)>,
+    mut new_cameras: Query<(&mut Camera3d, &RenderSurface), Added<Camera3d>>,
 ) {
     if new_cameras.is_empty() {
         return;

--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     render_asset::{RenderAssetUsages, RenderAssets},
     render_graph::{
@@ -488,7 +488,7 @@ pub fn prepare_post_processing_uniforms(
 impl ExtractComponent for ChromaticAberration {
     type QueryData = Read<ChromaticAberration>;
 
-    type QueryFilter = With<Camera>;
+    type QueryFilter = With<RenderSurface>;
 
     type Out = ChromaticAberration;
 

--- a/crates/bevy_core_pipeline/src/smaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/smaa/mod.rs
@@ -11,7 +11,7 @@
 //! which have made SMAA less popular when advanced photorealistic rendering
 //! features are used in recent years.
 //!
-//! To use SMAA, add [`Smaa`] to a [`bevy_render::camera::Camera`]. In a
+//! To use SMAA, add [`Smaa`] to a [`bevy_render::camera::RenderSurface`]. In a
 //! pinch, you can simply use the default settings (via the [`Default`] trait)
 //! for a high-quality, high-performance appearance. When using SMAA, you will
 //! likely want set [`bevy_render::view::Msaa`] to [`bevy_render::view::Msaa::Off`]
@@ -96,7 +96,7 @@ const SMAA_SEARCH_LUT_TEXTURE_HANDLE: Handle<Image> = Handle::weak_from_u128(318
 pub struct SmaaPlugin;
 
 /// A component for enabling Subpixel Morphological Anti-Aliasing (SMAA)
-/// for a [`bevy_render::camera::Camera`].
+/// for a [`bevy_render::camera::RenderSurface`].
 #[derive(Clone, Copy, Default, Component, Reflect, ExtractComponent)]
 #[reflect(Component, Default)]
 #[doc(alias = "SubpixelMorphologicalAntiAliasing")]

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -20,7 +20,7 @@ use bevy_math::vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::{ExtractedCamera, MipBias, TemporalJitter},
-    prelude::{Camera, Projection},
+    prelude::{Projection, RenderSurface},
     render_graph::{NodeRunError, RenderGraphApp, RenderGraphContext, ViewNode, ViewNodeRunner},
     render_resource::{
         binding_types::{sampler, texture_2d, texture_depth_2d},
@@ -362,7 +362,7 @@ impl SpecializedRenderPipeline for TaaPipeline {
 fn extract_taa_settings(mut commands: Commands, mut main_world: ResMut<MainWorld>) {
     let mut cameras_3d = main_world.query_filtered::<(
         RenderEntity,
-        &Camera,
+        &RenderSurface,
         &Projection,
         &mut TemporalAntiAliasing,
     ), (

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -134,7 +134,7 @@ pub struct TonemappingPipeline {
     sampler: Sampler,
 }
 
-/// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
+/// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`RenderSurface`] entity.
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]
@@ -389,7 +389,7 @@ pub fn prepare_view_tonemapping_pipelines(
             .insert(ViewTonemappingPipeline(pipeline));
     }
 }
-/// Enables a debanding shader that applies dithering to mitigate color banding in the final image for a given [`Camera`] entity.
+/// Enables a debanding shader that applies dithering to mitigate color banding in the final image for a given [`RenderSurface`] entity.
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -4,7 +4,7 @@ use bevy_asset::{load_internal_asset, Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     render_asset::{RenderAssetUsages, RenderAssets},
@@ -138,7 +138,7 @@ pub struct TonemappingPipeline {
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[reflect(Component, Debug, Hash, Default, PartialEq)]
 pub enum Tonemapping {
     /// Bypass tonemapping.
@@ -393,7 +393,7 @@ pub fn prepare_view_tonemapping_pipelines(
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[reflect(Component, Debug, Hash, Default, PartialEq)]
 pub enum DebandDither {
     #[default]

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -64,7 +64,7 @@ impl UiDebugOptions {
     }
 }
 
-/// The system responsible to change the [`Camera`] config based on changes in [`UiDebugOptions`] and [`GizmoConfig`](bevy_gizmos::prelude::GizmoConfig).
+/// The system responsible to change the [`RenderSurface`] config based on changes in [`UiDebugOptions`] and [`GizmoConfig`](bevy_gizmos::prelude::GizmoConfig).
 fn update_debug_camera(
     mut gizmo_config: ResMut<GizmoConfigStore>,
     mut options: ResMut<UiDebugOptions>,

--- a/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/ui_debug_overlay/mod.rs
@@ -69,7 +69,7 @@ fn update_debug_camera(
     mut gizmo_config: ResMut<GizmoConfigStore>,
     mut options: ResMut<UiDebugOptions>,
     mut cmds: Commands,
-    mut debug_cams: Query<&mut Camera, With<DebugOverlayCamera>>,
+    mut debug_cams: Query<&mut RenderSurface, With<DebugOverlayCamera>>,
 ) {
     if !options.is_changed() && !gizmo_config.is_changed() {
         return;
@@ -94,7 +94,7 @@ fn update_debug_camera(
                     viewport_origin: Vec2::new(0.0, 0.0),
                     ..OrthographicProjection::default_3d()
                 },
-                Camera {
+                RenderSurface {
                     order: LAYOUT_DEBUG_CAMERA_ORDER,
                     clear_color: ClearColorConfig::None,
                     ..default()
@@ -159,12 +159,12 @@ struct OutlineParam<'w, 's> {
     ui_scale: Res<'w, UiScale>,
 }
 
-type CameraQuery<'w, 's> = Query<'w, 's, &'static Camera, With<DebugOverlayCamera>>;
+type CameraQuery<'w, 's> = Query<'w, 's, &'static RenderSurface, With<DebugOverlayCamera>>;
 
 #[derive(SystemParam)]
 struct CameraParam<'w, 's> {
-    debug_camera: Query<'w, 's, &'static Camera, With<DebugOverlayCamera>>,
-    cameras: Query<'w, 's, &'static Camera, Without<DebugOverlayCamera>>,
+    debug_camera: Query<'w, 's, &'static RenderSurface, With<DebugOverlayCamera>>,
+    cameras: Query<'w, 's, &'static RenderSurface, Without<DebugOverlayCamera>>,
     primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     default_ui_camera: DefaultUiCamera<'w, 's>,
 }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -22,7 +22,7 @@ use bevy_pbr::{
 };
 use bevy_render::{
     alpha::AlphaMode,
-    camera::{Camera, OrthographicProjection, PerspectiveProjection, Projection, ScalingMode},
+    camera::{RenderSurface, OrthographicProjection, PerspectiveProjection, Projection, ScalingMode},
     mesh::{
         morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
         skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
@@ -1425,7 +1425,7 @@ fn load_node(
                 Camera3d::default(),
                 projection,
                 transform,
-                Camera {
+                RenderSurface {
                     is_active: !*active_camera_found,
                     ..Default::default()
                 },

--- a/crates/bevy_pbr/src/cluster/assign.rs
+++ b/crates/bevy_pbr/src/cluster/assign.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
 };
 use bevy_math::{ops, Mat4, UVec3, Vec2, Vec3, Vec3A, Vec3Swizzles as _, Vec4, Vec4Swizzles as _};
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     primitives::{Aabb, Frustum, HalfSpace, Sphere},
     render_resource::BufferBindingType,
     renderer::RenderDevice,
@@ -58,7 +58,7 @@ pub(crate) fn assign_objects_to_clusters(
     mut views: Query<(
         Entity,
         &GlobalTransform,
-        &Camera,
+        &RenderSurface,
         &Frustum,
         &ClusterConfig,
         &mut Clusters,

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
 use bevy_math::{AspectRatio, UVec2, UVec3, UVec4, Vec3Swizzles as _, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     render_resource::{
         BindingResource, BufferBindingType, ShaderSize as _, ShaderType, StorageBuffer,
         UniformBuffer,
@@ -360,7 +360,7 @@ impl Clusters {
 
 pub fn add_clusters(
     mut commands: Commands,
-    cameras: Query<(Entity, Option<&ClusterConfig>, &Camera), (Without<Clusters>, With<Camera3d>)>,
+    cameras: Query<(Entity, Option<&ClusterConfig>, &RenderSurface), (Without<Clusters>, With<Camera3d>)>,
 ) {
     for (entity, config, camera) in &cameras {
         if !camera.is_active {
@@ -531,7 +531,7 @@ pub(crate) fn clusterable_object_order(
 /// Extracts clusters from the main world from the render world.
 pub fn extract_clusters(
     mut commands: Commands,
-    views: Extract<Query<(RenderEntity, &Clusters, &Camera)>>,
+    views: Extract<Query<(RenderEntity, &Clusters, &RenderSurface)>>,
     mapper: Extract<Query<RenderEntity>>,
 ) {
     for (entity, clusters, camera) in &views {

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -2,7 +2,7 @@ use bevy_color::{Color, ColorToComponents, LinearRgba};
 use bevy_ecs::prelude::*;
 use bevy_math::{ops, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
+use bevy_render::{extract_component::ExtractComponent, prelude::RenderSurface};
 
 /// Configures the “classic” computer graphics [distance fog](https://en.wikipedia.org/wiki/Distance_fog) effect,
 /// in which objects appear progressively more covered in atmospheric haze the further away they are from the camera.
@@ -46,7 +46,7 @@ use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 /// Once enabled for a specific camera, the fog effect can also be disabled for individual
 /// [`StandardMaterial`](crate::StandardMaterial) instances via the `fog_enabled` flag.
 #[derive(Debug, Clone, Component, Reflect, ExtractComponent)]
-#[extract_component_filter(With<Camera>)]
+#[extract_component_filter(With<RenderSurface>)]
 #[reflect(Component, Default, Debug)]
 pub struct DistanceFog {
     /// The color of the fog effect.

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{entity::EntityHashMap, prelude::*};
 use bevy_math::{ops, Mat4, Vec3A, Vec4};
 use bevy_reflect::prelude::*;
 use bevy_render::{
-    camera::{Camera, CameraProjection},
+    camera::{RenderSurface, CameraProjection},
     extract_component::ExtractComponent,
     extract_resource::ExtractResource,
     mesh::Mesh3d,
@@ -304,7 +304,7 @@ pub fn clear_directional_light_cascades(mut lights: Query<(&DirectionalLight, &m
 
 pub fn build_directional_light_cascades<P: CameraProjection + Component>(
     directional_light_shadow_map: Res<DirectionalLightShadowMap>,
-    views: Query<(Entity, &GlobalTransform, &P, &Camera)>,
+    views: Query<(Entity, &GlobalTransform, &P, &RenderSurface)>,
     mut lights: Query<(
         &GlobalTransform,
         &DirectionalLight,
@@ -544,7 +544,7 @@ pub fn update_directional_light_frusta(
         ),
         (
             // Prevents this query from conflicting with camera queries.
-            Without<Camera>,
+            Without<RenderSurface>,
         ),
     >,
 ) {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -21,7 +21,7 @@ use bevy_ecs::{
 use bevy_math::Affine3A;
 use bevy_render::{
     globals::{GlobalsBuffer, GlobalsUniform},
-    prelude::{Camera, Mesh},
+    prelude::{RenderSurface, Mesh},
     render_asset::RenderAssets,
     render_phase::*,
     render_resource::*,
@@ -205,7 +205,7 @@ type PreviousViewFilter = Or<(With<Camera3d>, With<ShadowView>)>;
 
 pub fn update_previous_view_data(
     mut commands: Commands,
-    query: Query<(Entity, &Camera, &GlobalTransform), PreviousViewFilter>,
+    query: Query<(Entity, &RenderSurface, &GlobalTransform), PreviousViewFilter>,
 ) {
     for (entity, camera, camera_transform) in &query {
         let view_from_world = camera_transform.compute_matrix().inverse();
@@ -226,7 +226,7 @@ type PreviousMeshFilter = Or<(With<Mesh3d>, With<MeshletMesh3d>)>;
 
 pub fn update_mesh_previous_global_transforms(
     mut commands: Commands,
-    views: Query<&Camera, PreviousViewFilter>,
+    views: Query<&RenderSurface, PreviousViewFilter>,
     meshes: Query<(Entity, &GlobalTransform), PreviousMeshFilter>,
 ) {
     let should_run = views.iter().any(|camera| camera.is_active);
@@ -585,7 +585,7 @@ where
 // Extract the render phases for the prepass
 pub fn extract_camera_previous_view_data(
     mut commands: Commands,
-    cameras_3d: Extract<Query<(RenderEntity, &Camera, Option<&PreviousViewData>), With<Camera3d>>>,
+    cameras_3d: Extract<Query<(RenderEntity, &RenderSurface, Option<&PreviousViewData>), With<Camera3d>>>,
 ) {
     for (entity, camera, maybe_previous_view_data) in cameras_3d.iter() {
         let mut entity = commands

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -22,7 +22,7 @@ use bevy_render::{
         },
         no_gpu_preprocessing, GetBatchData, GetFullBatchData, NoAutomaticBatching,
     },
-    camera::Camera,
+    camera::RenderSurface,
     mesh::*,
     primitives::Aabb,
     render_asset::RenderAssets,
@@ -983,7 +983,7 @@ pub fn extract_meshes_for_gpu_building(
             Has<VisibilityRange>,
         )>,
     >,
-    cameras_query: Extract<Query<(), (With<Camera>, With<GpuCulling>)>>,
+    cameras_query: Extract<Query<(), (With<RenderSurface>, With<GpuCulling>)>>,
 ) {
     let any_gpu_culling = !cameras_query.is_empty();
     for render_mesh_instance_queue in render_mesh_instance_queues.iter_mut() {

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -21,7 +21,7 @@ use bevy_render::{
     camera::{ExtractedCamera, TemporalJitter},
     extract_component::ExtractComponent,
     globals::{GlobalsBuffer, GlobalsUniform},
-    prelude::Camera,
+    prelude::RenderSurface,
     render_graph::{NodeRunError, RenderGraphApp, RenderGraphContext, ViewNode, ViewNodeRunner},
     render_resource::{
         binding_types::{
@@ -521,7 +521,7 @@ fn extract_ssao_settings(
     mut commands: Commands,
     cameras: Extract<
         Query<
-            (RenderEntity, &Camera, &ScreenSpaceAmbientOcclusion, &Msaa),
+            (RenderEntity, &RenderSurface, &ScreenSpaceAmbientOcclusion, &Msaa),
             (With<Camera3d>, With<DepthPrepass>, With<NormalPrepass>),
         >,
     >,

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -133,7 +133,7 @@ pub mod ray {
     use bevy_ecs::prelude::*;
     use bevy_math::Ray3d;
     use bevy_reflect::Reflect;
-    use bevy_render::camera::Camera;
+    use bevy_render::camera::RenderSurface;
     use bevy_transform::prelude::GlobalTransform;
     use bevy_utils::{hashbrown::hash_map::Iter, HashMap};
     use bevy_window::PrimaryWindow;
@@ -198,7 +198,7 @@ pub mod ray {
         pub fn repopulate(
             mut ray_map: ResMut<Self>,
             primary_window_entity: Query<Entity, With<PrimaryWindow>>,
-            cameras: Query<(Entity, &Camera, &GlobalTransform)>,
+            cameras: Query<(Entity, &RenderSurface, &GlobalTransform)>,
             pointers: Query<(&PointerId, &PointerLocation)>,
         ) {
             ray_map.map.clear();
@@ -223,7 +223,7 @@ pub mod ray {
 
     fn make_ray(
         primary_window_entity: &Query<Entity, With<PrimaryWindow>>,
-        camera: &Camera,
+        camera: &RenderSurface,
         camera_tfm: &GlobalTransform,
         pointer_loc: &PointerLocation,
     ) -> Option<Ray3d> {

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -72,7 +72,7 @@ impl Plugin for MeshPickingPlugin {
 pub fn update_hits(
     backend_settings: Res<MeshPickingSettings>,
     ray_map: Res<RayMap>,
-    picking_cameras: Query<(&Camera, Option<&RayCastPickable>, Option<&RenderLayers>)>,
+    picking_cameras: Query<(&RenderSurface, Option<&RayCastPickable>, Option<&RenderLayers>)>,
     pickables: Query<&PickingBehavior>,
     marked_targets: Query<&RayCastPickable>,
     layers: Query<&RenderLayers>,

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -11,7 +11,7 @@
 use bevy_ecs::prelude::*;
 use bevy_math::{Rect, Vec2};
 use bevy_reflect::prelude::*;
-use bevy_render::camera::{Camera, NormalizedRenderTarget};
+use bevy_render::camera::{RenderSurface, NormalizedRenderTarget};
 use bevy_utils::HashMap;
 use bevy_window::PrimaryWindow;
 
@@ -218,7 +218,7 @@ impl Location {
     #[inline]
     pub fn is_in_viewport(
         &self,
-        camera: &Camera,
+        camera: &RenderSurface,
         primary_window: &Query<Entity, With<PrimaryWindow>>,
     ) -> bool {
         if camera

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -199,9 +199,9 @@ impl PointerLocation {
 ///
 /// Note that:
 /// - a pointer can move freely between render targets
-/// - a pointer is not associated with a [`Camera`] because multiple cameras can target the same
+/// - a pointer is not associated with a [`RenderSurface`] because multiple cameras can target the same
 ///   render target. It is up to picking backends to associate a Pointer's `Location` with a
-///   specific `Camera`, if any.
+///   specific `RenderSurface`, if any.
 #[derive(Debug, Clone, Component, Reflect, PartialEq)]
 #[reflect(Component, Debug, PartialEq)]
 pub struct Location {
@@ -212,7 +212,7 @@ pub struct Location {
 }
 
 impl Location {
-    /// Returns `true` if this pointer's [`Location`] is within the [`Camera`]'s viewport.
+    /// Returns `true` if this pointer's [`Location`] is within the [`RenderSurface`]'s viewport.
     ///
     /// Note this returns `false` if the location and camera have different render targets.
     #[inline]

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -297,7 +297,7 @@ pub enum ViewportConversionError {
     Msaa,
     SyncToRenderWorld
 )]
-pub struct Camera {
+pub struct RenderSurface {
     /// If set, this camera will render to the given [`Viewport`] rectangle within the configured [`RenderTarget`].
     pub viewport: Option<Viewport>,
     /// Cameras with a higher order are rendered later, and thus on top of lower order cameras.
@@ -334,7 +334,7 @@ fn warn_on_no_render_graph(world: DeferredWorld, entity: Entity, _: ComponentId)
     }
 }
 
-impl Default for Camera {
+impl Default for RenderSurface {
     fn default() -> Self {
         Self {
             is_active: true,
@@ -351,7 +351,7 @@ impl Default for Camera {
     }
 }
 
-impl Camera {
+impl RenderSurface {
     /// Converts a physical size in this `Camera` to a logical size.
     #[inline]
     pub fn to_logical(&self, physical_size: UVec2) -> Option<Vec2> {
@@ -882,7 +882,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     windows: Query<(Entity, &Window)>,
     images: Res<Assets<Image>>,
     manual_texture_views: Res<ManualTextureViews>,
-    mut cameras: Query<(&mut Camera, &mut T)>,
+    mut cameras: Query<(&mut RenderSurface, &mut T)>,
 ) {
     let primary_window = primary_window.iter().next();
 
@@ -1020,7 +1020,7 @@ pub fn extract_cameras(
     query: Extract<
         Query<(
             RenderEntity,
-            &Camera,
+            &RenderSurface,
             &CameraRenderGraph,
             &GlobalTransform,
             &VisibleEntities,

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -23,7 +23,7 @@ pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Camera>()
+        app.register_type::<RenderSurface>()
             .register_type::<ClearColor>()
             .register_type::<CameraRenderGraph>()
             .register_type::<CameraMainTextureUsages>()

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -11,7 +11,7 @@ use bevy_transform::{components::GlobalTransform, TransformSystem};
 use derive_more::derive::From;
 use serde::{Deserialize, Serialize};
 
-/// Adds [`Camera`](crate::camera::Camera) driver systems for a given projection type.
+/// Adds [`RenderSurface`](crate::camera::Camera) driver systems for a given projection type.
 ///
 /// If you are using `bevy_pbr`, then you need to add `PbrProjectionPlugin` along with this.
 pub struct CameraProjectionPlugin<T: CameraProjection + Component + GetTypeRegistration>(
@@ -65,13 +65,13 @@ pub struct CameraUpdateSystem;
 /// Trait to control the projection matrix of a camera.
 ///
 /// Components implementing this trait are automatically polled for changes, and used
-/// to recompute the camera projection matrix of the [`Camera`] component attached to
+/// to recompute the camera projection matrix of the [`RenderSurface`] component attached to
 /// the same entity as the component implementing this trait.
 ///
 /// Use the plugins [`CameraProjectionPlugin`] and `bevy::pbr::PbrProjectionPlugin` to setup the
 /// systems for your [`CameraProjection`] implementation.
 ///
-/// [`Camera`]: crate::camera::Camera
+/// [`RenderSurface`]: crate::camera::Camera
 pub trait CameraProjection {
     fn get_clip_from_view(&self) -> Mat4;
     fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4;

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -52,7 +52,7 @@ pub mod prelude {
     pub use crate::{
         alpha::AlphaMode,
         camera::{
-            Camera, ClearColor, ClearColorConfig, OrthographicProjection, PerspectiveProjection,
+            RenderSurface, ClearColor, ClearColorConfig, OrthographicProjection, PerspectiveProjection,
             Projection,
         },
         mesh::{

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -13,7 +13,7 @@ use bevy_reflect::prelude::*;
 /// occupied by this entity, with faces orthogonal to its local axis.
 ///
 /// This component is notably used during "frustum culling", a process to determine
-/// if an entity should be rendered by a [`Camera`] if its bounding box intersects
+/// if an entity should be rendered by a [`RenderSurface`] if its bounding box intersects
 /// with the camera's [`Frustum`].
 ///
 /// It will be added automatically by the systems in [`CalculateBounds`] to entities that:
@@ -24,7 +24,7 @@ use bevy_reflect::prelude::*;
 /// It won't be updated automatically if the space occupied by the entity changes,
 /// for example if the vertex positions of a [`Mesh3d`] are updated.
 ///
-/// [`Camera`]: crate::camera::Camera
+/// [`RenderSurface`]: crate::camera::Camera
 /// [`NoFrustumCulling`]: crate::view::visibility::NoFrustumCulling
 /// [`CalculateBounds`]: crate::view::visibility::VisibilitySystems::CalculateBounds
 /// [`Mesh3d`]: crate::mesh::Mesh
@@ -192,7 +192,7 @@ impl HalfSpace {
 /// Half spaces are ordered left, right, top, bottom, near, far. The normal vectors
 /// of the half-spaces point towards the interior of the frustum.
 ///
-/// A frustum component is used on an entity with a [`Camera`] component to
+/// A frustum component is used on an entity with a [`RenderSurface`] component to
 /// determine which entities will be considered for rendering by this camera.
 /// All entities with an [`Aabb`] component that are not contained by (or crossing
 /// the boundary of) the frustum will not be rendered, and not be used in rendering computations.
@@ -204,7 +204,7 @@ impl HalfSpace {
 /// It is usually updated automatically by [`update_frusta`] from the
 /// [`CameraProjection`] component and [`GlobalTransform`] of the camera entity.
 ///
-/// [`Camera`]: crate::camera::Camera
+/// [`RenderSurface`]: crate::camera::Camera
 /// [`NoFrustumCulling`]: crate::view::visibility::NoFrustumCulling
 /// [`update_frusta`]: crate::view::visibility::update_frusta
 /// [`CameraProjection`]: crate::camera::CameraProjection

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -147,7 +147,7 @@ impl Plugin for ViewPlugin {
 }
 
 /// Component for configuring the number of samples for [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
-/// for a [`Camera`](crate::camera::Camera).
+/// for a [`RenderSurface`](crate::camera::Camera).
 ///
 /// Defaults to 4 samples. A higher number of samples results in smoother edges.
 ///
@@ -207,7 +207,7 @@ impl ExtractedView {
 /// Configures filmic color grading parameters to adjust the image appearance.
 ///
 /// Color grading is applied just before tonemapping for a given
-/// [`Camera`](crate::camera::Camera) entity, with the sole exception of the
+/// [`RenderSurface`](crate::camera::Camera) entity, with the sole exception of the
 /// `post_saturation` value in [`ColorGradingGlobal`], which is applied after
 /// tonemapping.
 #[derive(Component, Reflect, Debug, Default, Clone)]

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -20,7 +20,7 @@ use bevy_utils::{Parallel, TypeIdMap};
 use super::NoCpuCulling;
 use crate::sync_world::MainEntity;
 use crate::{
-    camera::{Camera, CameraProjection},
+    camera::{RenderSurface, CameraProjection},
     mesh::{Mesh, Mesh3d, MeshAabb},
     primitives::{Aabb, Frustum, Sphere},
 };
@@ -485,7 +485,7 @@ pub fn check_visibility<QF>(
         &mut VisibleEntities,
         &Frustum,
         Option<&RenderLayers>,
-        &Camera,
+        &RenderSurface,
         Has<NoCpuCulling>,
     )>,
     mut visible_aabb_query: Query<

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -20,7 +20,7 @@ use bevy_utils::{Parallel, TypeIdMap};
 use super::NoCpuCulling;
 use crate::sync_world::MainEntity;
 use crate::{
-    camera::{RenderSurface, CameraProjection},
+    camera::{CameraProjection, RenderSurface},
     mesh::{Mesh, Mesh3d, MeshAabb},
     primitives::{Aabb, Frustum, Sphere},
 };
@@ -208,7 +208,7 @@ pub struct NoFrustumCulling;
 /// system set. Renderers can use the equivalent [`RenderVisibleEntities`] to optimize rendering of
 /// a particular view, to prevent drawing items not visible from that view.
 ///
-/// This component is intended to be attached to the same entity as the [`Camera`] and
+/// This component is intended to be attached to the same entity as the [`RenderSurface`] and
 /// the [`Frustum`] defining the view.
 #[derive(Clone, Component, Default, Debug, Reflect)]
 #[reflect(Component, Default, Debug)]

--- a/crates/bevy_render/src/view/visibility/range.rs
+++ b/crates/bevy_render/src/view/visibility/range.rs
@@ -25,7 +25,7 @@ use wgpu::{BufferBindingType, BufferUsages};
 use super::{check_visibility, VisibilitySystems};
 use crate::sync_world::{MainEntity, MainEntityHashMap};
 use crate::{
-    camera::Camera,
+    camera::RenderSurface,
     mesh::Mesh3d,
     primitives::Aabb,
     render_resource::BufferVec,
@@ -367,7 +367,7 @@ impl VisibleEntityRanges {
 /// cull.
 pub fn check_visibility_ranges(
     mut visible_entity_ranges: ResMut<VisibleEntityRanges>,
-    view_query: Query<(Entity, &GlobalTransform), With<Camera>>,
+    view_query: Query<(Entity, &GlobalTransform), With<RenderSurface>>,
     mut entity_query: Query<(Entity, &GlobalTransform, Option<&Aabb>, &VisibilityRange)>,
 ) {
     visible_entity_ranges.clear();

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -25,7 +25,7 @@ impl Plugin for SpritePickingPlugin {
 
 pub fn sprite_picking(
     pointers: Query<(&PointerId, &PointerLocation)>,
-    cameras: Query<(Entity, &Camera, &GlobalTransform, &OrthographicProjection)>,
+    cameras: Query<(Entity, &RenderSurface, &GlobalTransform, &OrthographicProjection)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     images: Res<Assets<Image>>,
     texture_atlas_layout: Res<Assets<TextureAtlasLayout>>,

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
     system::{Commands, Query},
     world::Ref,
 };
-use bevy_render::{camera::CameraUpdateSystem, prelude::Camera};
+use bevy_render::{camera::CameraUpdateSystem, prelude::RenderSurface};
 use bevy_transform::prelude::GlobalTransform;
 
 fn calc_label(
@@ -37,7 +37,7 @@ fn calc_label(
 }
 
 fn calc_bounds(
-    camera: Query<(&Camera, &GlobalTransform)>,
+    camera: Query<(&RenderSurface, &GlobalTransform)>,
     mut nodes: Query<(
         &mut AccessibilityNode,
         Ref<ComputedNode>,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
 use bevy_input::{mouse::MouseButton, touch::Touches, ButtonInput};
 use bevy_math::{Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{camera::NormalizedRenderTarget, prelude::Camera, view::ViewVisibility};
+use bevy_render::{camera::NormalizedRenderTarget, prelude::RenderSurface, view::ViewVisibility};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashMap;
 use bevy_window::{PrimaryWindow, Window};
@@ -152,7 +152,7 @@ pub struct NodeQuery {
 #[allow(clippy::too_many_arguments)]
 pub fn ui_focus_system(
     mut state: Local<State>,
-    camera_query: Query<(Entity, &Camera)>,
+    camera_query: Query<(Entity, &RenderSurface)>,
     default_ui_camera: DefaultUiCamera,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     windows: Query<&Window>,

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -62,7 +62,7 @@ pub struct NodeQuery {
 /// we need for determining picking.
 pub fn ui_picking(
     pointers: Query<(&PointerId, &PointerLocation)>,
-    camera_query: Query<(Entity, &Camera, Has<IsDefaultUiCamera>)>,
+    camera_query: Query<(Entity, &RenderSurface, Has<IsDefaultUiCamera>)>,
     default_ui_camera: DefaultUiCamera,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -20,7 +20,7 @@ use bevy_math::{vec2, FloatOrd, Mat4, Rect, Vec2, Vec3Swizzles, Vec4Swizzles};
 use bevy_render::sync_world::MainEntity;
 use bevy_render::RenderApp;
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     render_phase::*,
     render_resource::{binding_types::uniform_buffer, *},
     renderer::{RenderDevice, RenderQueue},
@@ -235,7 +235,7 @@ pub fn extract_shadows(
     mut extracted_box_shadows: ResMut<ExtractedBoxShadows>,
     default_ui_camera: Extract<DefaultUiCamera>,
     ui_scale: Extract<Res<UiScale>>,
-    camera_query: Extract<Query<(Entity, &Camera)>>,
+    camera_query: Extract<Query<(Entity, &RenderSurface)>>,
     box_shadow_query: Extract<
         Query<(
             Entity,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::render_phase::ViewSortedRenderPhases;
 use bevy_render::sync_world::MainEntity;
 use bevy_render::texture::TRANSPARENT_IMAGE_HANDLE;
 use bevy_render::{
-    camera::Camera,
+    camera::RenderSurface,
     render_asset::RenderAssets,
     render_graph::{RenderGraph, RunGraphOnViewNode},
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
@@ -537,7 +537,7 @@ pub fn extract_default_ui_camera_view(
         Query<
             (
                 RenderEntity,
-                &Camera,
+                &RenderSurface,
                 Option<&UiAntiAlias>,
                 Option<&UiBoxShadowSamples>,
             ),
@@ -625,7 +625,7 @@ pub fn extract_default_ui_camera_view(
 pub fn extract_text_sections(
     mut commands: Commands,
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
-    camera_query: Extract<Query<&Camera>>,
+    camera_query: Extract<Query<&RenderSurface>>,
     default_ui_camera: Extract<DefaultUiCamera>,
     texture_atlases: Extract<Res<Assets<TextureAtlasLayout>>>,
     ui_scale: Extract<Res<UiScale>>,
@@ -671,7 +671,7 @@ pub fn extract_text_sections(
         let scale_factor = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(Camera::target_scaling_factor)
+            .and_then(RenderSurface::target_scaling_factor)
             .unwrap_or(1.0)
             * ui_scale.0;
         let inverse_scale_factor = scale_factor.recip();

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{prelude::*, system::SystemParam};
 use bevy_math::{vec4, Rect, Vec2, Vec4Swizzles};
 use bevy_reflect::prelude::*;
 use bevy_render::{
-    camera::{Camera, RenderTarget},
+    camera::{RenderSurface, RenderTarget},
     view::Visibility,
 };
 use bevy_sprite::BorderRect;
@@ -2496,8 +2496,8 @@ pub struct IsDefaultUiCamera;
 
 #[derive(SystemParam)]
 pub struct DefaultUiCamera<'w, 's> {
-    cameras: Query<'w, 's, (Entity, &'static Camera)>,
-    default_cameras: Query<'w, 's, Entity, (With<Camera>, With<IsDefaultUiCamera>)>,
+    cameras: Query<'w, 's, (Entity, &'static RenderSurface)>,
+    default_cameras: Query<'w, 's, Entity, (With<RenderSurface>, With<IsDefaultUiCamera>)>,
     primary_window: Query<'w, 's, Entity, With<PrimaryWindow>>,
 }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2462,7 +2462,7 @@ impl TargetCamera {
 /// Marker used to identify default cameras, they will have priority over the [`PrimaryWindow`] camera.
 ///
 /// This is useful if the [`PrimaryWindow`] has two cameras, one of them used
-/// just for debug purposes and the user wants a way to choose the default [`Camera`]
+/// just for debug purposes and the user wants a way to choose the default [`RenderSurface`]
 /// without having to add a [`TargetCamera`] to the root node.
 ///
 /// Another use is when the user wants the Ui to be in another window by default,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 };
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{camera::Camera, texture::Image};
+use bevy_render::{camera::RenderSurface, texture::Image};
 use bevy_sprite::TextureAtlasLayout;
 use bevy_text::{
     scale_value, ComputedTextBlock, CosmicFontSystem, Font, FontAtlasSets, LineBreak, SwashCache,
@@ -258,7 +258,7 @@ pub fn measure_text_system(
     mut scale_factors_buffer: Local<EntityHashMap<f32>>,
     mut last_scale_factors: Local<EntityHashMap<f32>>,
     fonts: Res<Assets<Font>>,
-    camera_query: Query<(Entity, &Camera)>,
+    camera_query: Query<(Entity, &RenderSurface)>,
     default_ui_camera: DefaultUiCamera,
     ui_scale: Res<UiScale>,
     mut text_query: Query<
@@ -400,7 +400,7 @@ pub fn text_system(
     mut scale_factors_buffer: Local<EntityHashMap<f32>>,
     mut last_scale_factors: Local<EntityHashMap<f32>>,
     fonts: Res<Assets<Font>>,
-    camera_query: Query<(Entity, &Camera)>,
+    camera_query: Query<(Entity, &RenderSurface)>,
     default_ui_camera: DefaultUiCamera,
     ui_scale: Res<UiScale>,
     mut texture_atlases: ResMut<Assets<TextureAtlasLayout>>,

--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -11,7 +11,7 @@ fn main() {
 }
 
 fn draw_cursor(
-    camera_query: Single<(&Camera, &GlobalTransform)>,
+    camera_query: Single<(&RenderSurface, &GlobalTransform)>,
     window: Single<&Window>,
     mut gizmos: Gizmos,
 ) {

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -24,7 +24,7 @@ fn setup(
 ) {
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             hdr: true, // 1. HDR is required for bloom
             ..default()
         },
@@ -71,7 +71,7 @@ fn setup(
 // ------------------------------------------------------------------------------------------------
 
 fn update_bloom_settings(
-    camera: Single<(Entity, Option<&mut Bloom>), With<Camera>>,
+    camera: Single<(Entity, Option<&mut Bloom>), With<RenderSurface>>,
     mut text: Single<&mut Text>,
     mut commands: Commands,
     keycode: Res<ButtonInput<KeyCode>>,

--- a/examples/2d/mesh2d_arcs.rs
+++ b/examples/2d/mesh2d_arcs.rs
@@ -41,7 +41,7 @@ fn setup(
 
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             clear_color: ClearColorConfig::Custom(DARK_SLATE_GREY.into()),
             ..default()
         },

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -114,7 +114,7 @@ fn setup_camera(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     // this camera renders whatever is on `PIXEL_PERFECT_LAYERS` to the canvas
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             // render before the "main pass" camera
             order: -1,
             target: RenderTarget::Image(image_handle.clone()),

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -11,7 +11,7 @@ fn main() {
 }
 
 fn draw_cursor(
-    camera_query: Single<(&Camera, &GlobalTransform)>,
+    camera_query: Single<(&RenderSurface, &GlobalTransform)>,
     ground: Single<&GlobalTransform, With<Ground>>,
     windows: Single<&Window>,
     mut gizmos: Gizmos,

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -137,7 +137,7 @@ fn animate_light(
 
 /// A system that rotates the camera if the environment map is enabled.
 fn rotate_camera(
-    mut camera: Query<&mut Transform, With<Camera>>,
+    mut camera: Query<&mut Transform, With<RenderSurface>>,
     app_status: Res<AppStatus>,
     time: Res<Time>,
     mut stopwatch: Local<Stopwatch>,
@@ -159,7 +159,7 @@ fn rotate_camera(
 fn handle_input(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    cameras: Query<Entity, With<Camera>>,
+    cameras: Query<Entity, With<RenderSurface>>,
     lights: Query<Entity, Or<(With<DirectionalLight>, With<PointLight>)>>,
     mut meshes: Query<(&mut MeshMaterial3d<StandardMaterial>, &MaterialVariants)>,
     keyboard: Res<ButtonInput<KeyCode>>,

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -45,7 +45,7 @@ fn modify_aa(
             Option<&TemporalAntiAliasing>,
             &mut Msaa,
         ),
-        With<Camera>,
+        With<RenderSurface>,
     >,
     mut commands: Commands,
 ) {
@@ -185,7 +185,7 @@ fn update_ui(
             &ContrastAdaptiveSharpening,
             &Msaa,
         ),
-        With<Camera>,
+        With<RenderSurface>,
     >,
     mut ui: Single<&mut Text>,
 ) {
@@ -300,7 +300,7 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/auto_exposure.rs
+++ b/examples/3d/auto_exposure.rs
@@ -40,7 +40,7 @@ fn setup(
 
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -251,7 +251,7 @@ impl Default for ExampleState {
 fn example_control_system(
     mut materials: ResMut<Assets<StandardMaterial>>,
     controllable: Query<(&MeshMaterial3d<StandardMaterial>, &ExampleControls)>,
-    camera: Single<(&mut Camera, &mut Transform, &GlobalTransform), With<Camera3d>>,
+    camera: Single<(&mut RenderSurface, &mut Transform, &GlobalTransform), With<Camera3d>>,
     mut labels: Query<(&mut Node, &ExampleLabel)>,
     mut display: Single<&mut Text, With<ExampleDisplay>>,
     labeled: Query<&GlobalTransform>,

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -29,7 +29,7 @@ fn setup_scene(
 ) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true, // 1. HDR is required for bloom
             ..default()
         },
@@ -98,7 +98,7 @@ fn setup_scene(
 // ------------------------------------------------------------------------------------------------
 
 fn update_bloom_settings(
-    camera: Single<(Entity, Option<&mut Bloom>), With<Camera>>,
+    camera: Single<(Entity, Option<&mut Bloom>), With<RenderSurface>>,
     mut text: Single<&mut Text>,
     mut commands: Commands,
     keycode: Res<ButtonInput<KeyCode>>,

--- a/examples/3d/camera_sub_view.rs
+++ b/examples/3d/camera_sub_view.rs
@@ -57,7 +57,7 @@ fn setup(
     // The main perspective image to use as a comparison for the sub views.
     commands.spawn((
         Camera3d::default(),
-        Camera::default(),
+        RenderSurface::default(),
         ExampleViewports::PerspectiveMain,
         transform,
     ));
@@ -72,7 +72,7 @@ fn setup(
     // axis.
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 // The values of `full_size` and `size` do not have to be the
                 // exact values of your physical viewport. The important part is
@@ -99,7 +99,7 @@ fn setup(
     // `full_size`, so the image will appear zoomed in.
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 full_size: UVec2::new(500, 500),
                 offset: Vec2::ZERO,
@@ -122,7 +122,7 @@ fn setup(
     // full perspective image.
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 full_size: UVec2::new(800, 800),
                 offset: Vec2::ZERO,
@@ -146,7 +146,7 @@ fn setup(
             },
             ..OrthographicProjection::default_3d()
         }),
-        Camera {
+        RenderSurface {
             order: 4,
             ..default()
         },
@@ -168,7 +168,7 @@ fn setup(
             },
             ..OrthographicProjection::default_3d()
         }),
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 full_size: UVec2::new(2, 2),
                 offset: Vec2::ZERO,
@@ -196,7 +196,7 @@ fn setup(
             },
             ..OrthographicProjection::default_3d()
         }),
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 full_size: UVec2::new(500, 500),
                 offset: Vec2::ZERO,
@@ -225,7 +225,7 @@ fn setup(
             },
             ..OrthographicProjection::default_3d()
         }),
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 full_size: UVec2::new(200, 200),
                 offset: Vec2::ZERO,
@@ -240,7 +240,7 @@ fn setup(
 }
 
 fn move_camera_view(
-    mut movable_camera_query: Query<&mut Camera, With<MovingCameraMarker>>,
+    mut movable_camera_query: Query<&mut RenderSurface, With<MovingCameraMarker>>,
     time: Res<Time>,
 ) {
     for mut camera in movable_camera_query.iter_mut() {
@@ -254,7 +254,7 @@ fn move_camera_view(
 // To ensure viewports remain the same at any window size
 fn resize_viewports(
     window: Single<&Window, With<bevy::window::PrimaryWindow>>,
-    mut viewports: Query<(&mut Camera, &ExampleViewports)>,
+    mut viewports: Query<(&mut RenderSurface, &ExampleViewports)>,
 ) {
     let window_size = window.physical_size();
 

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -191,7 +191,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn((
             Camera3d::default(),
-            Camera {
+            RenderSurface {
                 hdr: true,
                 ..default()
             },

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -334,7 +334,7 @@ fn add_text<'a>(
 fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading: ColorGrading) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -35,7 +35,7 @@ fn setup(
 ) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             // Deferred both supports both hdr: true and hdr: false
             hdr: false,
             ..default()
@@ -287,7 +287,7 @@ fn switch_mode(
     keys: Res<ButtonInput<KeyCode>>,
     mut default_opaque_renderer_method: ResMut<DefaultOpaqueRendererMethod>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    cameras: Query<Entity, With<Camera>>,
+    cameras: Query<Entity, With<RenderSurface>>,
     mut pause: ResMut<Pause>,
     mut hide_ui: Local<bool>,
     mut mode: Local<DefaultRenderMode>,

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -73,7 +73,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     let mut camera = commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0.0, 4.5, 8.25).looking_at(Vec3::ZERO, Vec3::Y),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },
@@ -163,7 +163,7 @@ impl Default for AppSettings {
 /// Writes the depth of field settings into the camera.
 fn update_dof_settings(
     mut commands: Commands,
-    view_targets: Query<Entity, With<Camera>>,
+    view_targets: Query<Entity, With<RenderSurface>>,
     app_settings: Res<AppSettings>,
 ) {
     let depth_of_field: Option<DepthOfField> = (*app_settings).into();

--- a/examples/3d/fog_volumes.rs
+++ b/examples/3d/fog_volumes.rs
@@ -58,7 +58,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(-0.75, 1.0, 2.0).looking_at(vec3(0.0, 0.0, 0.0), Vec3::Y),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -447,7 +447,7 @@ fn toggle_rotation(keyboard: Res<ButtonInput<KeyCode>>, mut app_status: ResMut<A
 fn handle_mouse_clicks(
     buttons: Res<ButtonInput<MouseButton>>,
     windows: Query<&Window, With<PrimaryWindow>>,
-    cameras: Query<(&Camera, &GlobalTransform)>,
+    cameras: Query<(&RenderSurface, &GlobalTransform)>,
     mut main_objects: Query<&mut Transform, With<MainObject>>,
 ) {
     if !buttons.pressed(MouseButton::Left) {

--- a/examples/3d/mesh_ray_cast.rs
+++ b/examples/3d/mesh_ray_cast.rs
@@ -101,7 +101,7 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -60,7 +60,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
 fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -105,7 +105,7 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_camera(commands: &mut Commands) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -85,7 +85,7 @@ fn setup(
 
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             target: image_handle.clone().into(),
             clear_color: Color::WHITE.into(),
             ..default()

--- a/examples/3d/rotate_environment_map.rs
+++ b/examples/3d/rotate_environment_map.rs
@@ -95,7 +95,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
     commands
         .spawn((
             Camera3d::default(),
-            Camera {
+            RenderSurface {
                 hdr: true,
                 ..default()
             },

--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -51,7 +51,7 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0.0, 2.0, 0.0).looking_at(Vec3::new(-5.0, 3.5, -6.0), Vec3::Y),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -70,7 +70,7 @@ fn setup(
             .spawn((
                 Camera3d::default(),
                 Transform::from_translation(*camera_pos).looking_at(Vec3::ZERO, Vec3::Y),
-                Camera {
+                RenderSurface {
                     // Renders cameras with different priorities to prevent ambiguities
                     order: index as isize,
                     ..default()
@@ -162,7 +162,7 @@ enum Direction {
 fn set_camera_viewports(
     windows: Query<&Window>,
     mut resize_events: EventReader<WindowResized>,
-    mut query: Query<(&CameraPosition, &mut Camera)>,
+    mut query: Query<(&CameraPosition, &mut RenderSurface)>,
 ) {
     // We need to dynamically resize the camera's viewports whenever the window size changes
     // so then each camera always takes up half the screen.
@@ -187,7 +187,7 @@ fn button_system(
         (&Interaction, &TargetCamera, &RotateCamera),
         (Changed<Interaction>, With<Button>),
     >,
-    mut camera_query: Query<&mut Transform, With<Camera>>,
+    mut camera_query: Query<&mut Transform, With<RenderSurface>>,
 ) {
     for (interaction, target_camera, RotateCamera(direction)) in &interaction_query {
         if let Interaction::Pressed = *interaction {

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -119,7 +119,7 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },
@@ -189,7 +189,7 @@ fn movement(
 }
 
 fn rotation(
-    mut transform: Single<&mut Transform, With<Camera>>,
+    mut transform: Single<&mut Transform, With<RenderSurface>>,
     input: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -28,7 +28,7 @@ fn setup(
 ) {
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },
@@ -96,7 +96,7 @@ fn update(
             Option<&ScreenSpaceAmbientOcclusion>,
             Option<&TemporalJitter>,
         ),
-        With<Camera>,
+        With<RenderSurface>,
     >,
     mut text: Single<&mut Text>,
     mut sphere: Single<&mut Transform, With<SphereMarker>>,

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -228,7 +228,7 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         .spawn((
             Camera3d::default(),
             Transform::from_translation(vec3(-1.25, 2.25, 4.5)).looking_at(Vec3::ZERO, Vec3::Y),
-            Camera {
+            RenderSurface {
                 hdr: true,
                 ..default()
             },
@@ -300,7 +300,7 @@ fn rotate_model(
 fn move_camera(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut mouse_wheel_input: EventReader<MouseWheel>,
-    mut cameras: Query<&mut Transform, With<Camera>>,
+    mut cameras: Query<&mut Transform, With<RenderSurface>>,
 ) {
     let (mut distance_delta, mut theta_delta) = (0.0, 0.0);
 
@@ -345,7 +345,7 @@ fn adjust_app_settings(
     mut commands: Commands,
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut app_settings: ResMut<AppSettings>,
-    mut cameras: Query<Entity, With<Camera>>,
+    mut cameras: Query<Entity, With<RenderSurface>>,
     mut cube_models: Query<&mut Visibility, (With<CubeModel>, Without<FlightHelmetModel>)>,
     mut flight_helmet_models: Query<&mut Visibility, (Without<CubeModel>, With<FlightHelmetModel>)>,
     mut text: Query<&mut Text>,

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -59,7 +59,7 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -303,7 +303,7 @@ fn setup(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true,
             ..default()
         },
@@ -388,7 +388,7 @@ fn example_control_system(
     camera: Single<
         (
             Entity,
-            &mut Camera,
+            &mut RenderSurface,
             &mut Camera3d,
             &mut Transform,
             Option<&DepthPrepass>,

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -46,7 +46,7 @@ fn setup(
     // camera
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             // renders after / on top of the main camera
             order: 1,
             clear_color: ClearColorConfig::None,

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -65,7 +65,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     commands
         .spawn((
             Camera3d::default(),
-            Camera {
+            RenderSurface {
                 hdr: true,
                 ..default()
             },

--- a/examples/animation/animation_events.rs
+++ b/examples/animation/animation_events.rs
@@ -54,7 +54,7 @@ fn setup(
     // Camera
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             clear_color: ClearColorConfig::Custom(BLACK.into()),
             hdr: true,
             ..Default::default()

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -187,7 +187,7 @@ fn setup(
 
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             // render to image
             target: render_target,
             ..default()

--- a/examples/camera/2d_screen_shake.rs
+++ b/examples/camera/2d_screen_shake.rs
@@ -77,7 +77,7 @@ fn setup_instructions(mut commands: Commands) {
 fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             sub_camera_view: Some(SubCameraView {
                 full_size: UVec2::new(1000, 700),
                 offset: Vec2::new(0.0, 0.0),
@@ -136,7 +136,7 @@ fn trigger_shake_on_space(
 fn screen_shake(
     time: Res<Time>,
     mut screen_shake: ResMut<ScreenShake>,
-    mut query: Query<(&mut Camera, &mut Transform)>,
+    mut query: Query<(&mut RenderSurface, &mut Transform)>,
 ) {
     let mut rng = ChaCha8Rng::from_entropy();
     let shake = screen_shake.trauma * screen_shake.trauma;

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -63,7 +63,7 @@ fn setup_instructions(mut commands: Commands) {
 fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             hdr: true, // HDR is required for the bloom effect
             ..default()
         },

--- a/examples/camera/camera_orbit.rs
+++ b/examples/camera/camera_orbit.rs
@@ -97,7 +97,7 @@ fn instructions(mut commands: Commands) {
 }
 
 fn orbit(
-    mut camera: Single<&mut Transform, With<Camera>>,
+    mut camera: Single<&mut Transform, With<RenderSurface>>,
     camera_settings: Res<CameraSettings>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
     mouse_motion: Res<AccumulatedMouseMotion>,

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -124,7 +124,7 @@ fn spawn_view_model(
             // Spawn view model camera.
             parent.spawn((
                 Camera3d::default(),
-                Camera {
+                RenderSurface {
                     // Bump the order to render on top of the world model.
                     order: 1,
                     ..default()

--- a/examples/camera/projection_zoom.rs
+++ b/examples/camera/projection_zoom.rs
@@ -109,7 +109,7 @@ fn instructions(mut commands: Commands) {
 }
 
 fn switch_projection(
-    mut camera: Single<&mut Projection, With<Camera>>,
+    mut camera: Single<&mut Projection, With<RenderSurface>>,
     camera_settings: Res<CameraSettings>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
@@ -131,7 +131,7 @@ fn switch_projection(
 }
 
 fn zoom(
-    camera: Single<&mut Projection, With<Camera>>,
+    camera: Single<&mut Projection, With<RenderSurface>>,
     camera_settings: Res<CameraSettings>,
     mouse_wheel_input: Res<AccumulatedMouseScroll>,
 ) {

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -148,7 +148,7 @@ fn integrate(time: Res<Time>, mut query: Query<(&mut Acceleration, &mut Transfor
 }
 
 fn look_at_star(
-    mut camera: Single<&mut Transform, (With<Camera>, Without<Star>)>,
+    mut camera: Single<&mut Transform, (With<RenderSurface>, Without<Star>)>,
     star: Single<&Transform, With<Star>>,
 ) {
     let new_rotation = camera

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -171,7 +171,7 @@ fn draw_shapes(mut gizmos: Gizmos, mines: Query<&Mine>) {
 // Trigger `ExplodeMines` at the position of a given click
 fn handle_click(
     mouse_button_input: Res<ButtonInput<MouseButton>>,
-    camera: Single<(&Camera, &GlobalTransform)>,
+    camera: Single<(&RenderSurface, &GlobalTransform)>,
     windows: Single<&Window>,
     mut commands: Commands,
 ) {

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -194,7 +194,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 }
 
 // remove all entities that are not a camera or window
-fn teardown(mut commands: Commands, entities: Query<Entity, (Without<Camera>, Without<Window>)>) {
+fn teardown(mut commands: Commands, entities: Query<Entity, (Without<RenderSurface>, Without<Window>)>) {
     for entity in &entities {
         commands.entity(entity).despawn();
     }

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -206,7 +206,7 @@ fn setup(
 fn get_cursor_world_pos(
     mut cursor_world_pos: ResMut<CursorWorldPos>,
     primary_window: Single<&Window, With<PrimaryWindow>>,
-    q_camera: Single<(&Camera, &GlobalTransform)>,
+    q_camera: Single<(&RenderSurface, &GlobalTransform)>,
 ) {
     let (main_camera, main_camera_transform) = *q_camera;
     // Get the cursor position in the world

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -246,7 +246,7 @@ fn load_loading_screen(mut commands: Commands) {
     // Spawn the UI and Loading screen camera.
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             order: 1,
             ..default()
         },

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -136,7 +136,7 @@ fn setup(
     }
 }
 
-fn rotate_camera(mut transform: Single<&mut Transform, With<Camera>>, time: Res<Time>) {
+fn rotate_camera(mut transform: Single<&mut Transform, With<RenderSurface>>, time: Res<Time>) {
     transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(time.delta_secs() / 2.));
 }
 

--- a/examples/helpers/camera_controller.rs
+++ b/examples/helpers/camera_controller.rs
@@ -109,7 +109,7 @@ fn run_camera_controller(
     key_input: Res<ButtonInput<KeyCode>>,
     mut toggle_cursor_grab: Local<bool>,
     mut mouse_cursor_grab: Local<bool>,
-    query: Single<(&mut Transform, &mut CameraController), With<Camera>>,
+    query: Single<(&mut Transform, &mut CameraController), With<RenderSurface>>,
 ) {
     let dt = time.delta_secs();
 

--- a/examples/math/cubic_splines.rs
+++ b/examples/math/cubic_splines.rs
@@ -308,7 +308,7 @@ fn handle_mouse_press(
     mouse_position: Res<MousePosition>,
     mut edit_move: ResMut<MouseEditMove>,
     mut control_points: ResMut<ControlPoints>,
-    camera: Single<(&Camera, &GlobalTransform)>,
+    camera: Single<(&RenderSurface, &GlobalTransform)>,
 ) {
     let Some(mouse_pos) = mouse_position.0 else {
         return;
@@ -363,7 +363,7 @@ fn draw_edit_move(
     edit_move: Res<MouseEditMove>,
     mouse_position: Res<MousePosition>,
     mut gizmos: Gizmos,
-    camera: Single<(&Camera, &GlobalTransform)>,
+    camera: Single<(&RenderSurface, &GlobalTransform)>,
 ) {
     let Some(start) = edit_move.start else {
         return;

--- a/examples/math/random_sampling.rs
+++ b/examples/math/random_sampling.rs
@@ -222,7 +222,7 @@ fn handle_keypress(
 fn handle_mouse(
     accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     mut button_events: EventReader<MouseButtonInput>,
-    mut camera_transform: Single<&mut Transform, With<Camera>>,
+    mut camera_transform: Single<&mut Transform, With<RenderSurface>>,
     mut mouse_pressed: ResMut<MousePressed>,
 ) {
     // Store left-pressed state in the MousePressed resource

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -293,7 +293,7 @@ const CIRCULAR_SEGMENT: CircularSegment = CircularSegment {
 
 fn setup_cameras(mut commands: Commands) {
     let start_in_2d = true;
-    let make_camera = |is_active| Camera {
+    let make_camera = |is_active| RenderSurface {
         is_active,
         ..Default::default()
     };
@@ -332,8 +332,8 @@ pub struct HeaderNode;
 
 fn update_active_cameras(
     state: Res<State<CameraActive>>,
-    camera_2d: Single<(Entity, &mut Camera), With<Camera2d>>,
-    camera_3d: Single<(Entity, &mut Camera), (With<Camera3d>, Without<Camera2d>)>,
+    camera_2d: Single<(Entity, &mut RenderSurface), With<Camera2d>>,
+    camera_3d: Single<(Entity, &mut RenderSurface), (With<Camera3d>, Without<Camera2d>)>,
     mut text: Query<&mut TargetCamera, With<HeaderNode>>,
 ) {
     let (entity_2d, mut cam_2d) = camera_2d.into_inner();
@@ -362,7 +362,7 @@ fn switch_cameras(current: Res<State<CameraActive>>, mut next: ResMut<NextState<
     next.set(next_state);
 }
 
-fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
+fn setup_text(mut commands: Commands, cameras: Query<(Entity, &RenderSurface)>) {
     let active_camera = cameras
         .iter()
         .find_map(|(entity, camera)| camera.is_active.then_some(entity))

--- a/examples/math/sampling_primitives.rs
+++ b/examples/math/sampling_primitives.rs
@@ -339,7 +339,7 @@ fn setup(
     // A camera:
     commands.spawn((
         Camera3d::default(),
-        Camera {
+        RenderSurface {
             hdr: true, // HDR is required for bloom
             clear_color: ClearColorConfig::Custom(SKY_COLOR),
             ..default()

--- a/examples/shader/custom_post_processing.rs
+++ b/examples/shader/custom_post_processing.rs
@@ -316,7 +316,7 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Transform::from_translation(Vec3::new(0.0, 0.0, 5.0)).looking_at(Vec3::default(), Vec3::Y),
-        Camera {
+        RenderSurface {
             clear_color: Color::WHITE.into(),
             ..default()
         },

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -100,7 +100,7 @@ fn setup(
 }
 
 // System for rotating and translating the camera
-fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera>>) {
+fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<RenderSurface>>) {
     camera_transform.rotate(Quat::from_rotation_z(time.delta_secs() * 0.5));
     **camera_transform = **camera_transform
         * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_secs());

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -438,7 +438,7 @@ fn spherical_polar_to_cartesian(p: DVec2) -> DVec3 {
 fn move_camera(
     time: Res<Time>,
     args: Res<Args>,
-    mut camera_transform: Single<&mut Transform, With<Camera>>,
+    mut camera_transform: Single<&mut Transform, With<RenderSurface>>,
 ) {
     let delta = 0.15
         * if args.benchmark {

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -135,7 +135,7 @@ fn spherical_polar_to_cartesian(p: DVec2) -> DVec3 {
 }
 
 // System for rotating the camera
-fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera>>) {
+fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<RenderSurface>>) {
     let delta = time.delta_secs() * 0.15;
     camera_transform.rotate_z(delta);
     camera_transform.rotate_x(delta);

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -104,7 +104,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<Color
 }
 
 // System for rotating and translating the camera
-fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<Camera>>) {
+fn move_camera(time: Res<Time>, mut camera_transform: Single<&mut Transform, With<RenderSurface>>) {
     camera_transform.rotate_z(time.delta_secs() * 0.5);
     **camera_transform = **camera_transform
         * Transform::from_translation(Vec3::X * CAMERA_SPEED * time.delta_secs());

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -115,7 +115,7 @@ mod bloom {
     ) {
         commands.spawn((
             Camera2d,
-            Camera {
+            RenderSurface {
                 hdr: true,
                 ..default()
             },

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -153,7 +153,7 @@ mod bloom {
     ) {
         commands.spawn((
             Camera3d::default(),
-            Camera {
+            RenderSurface {
                 hdr: true,
                 ..default()
             },

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -131,7 +131,7 @@ fn setup_scene_after_load(
             Projection::from(projection),
             Transform::from_translation(Vec3::from(aabb.center) + size * Vec3::new(0.5, 0.25, 0.5))
                 .looking_at(Vec3::from(aabb.center), Vec3::Y),
-            Camera {
+            RenderSurface {
                 is_active: false,
                 ..default()
             },

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -201,9 +201,9 @@ fn camera_tracker(
     mut camera_tracker: ResMut<CameraTracker>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut queries: ParamSet<(
-        Query<(Entity, &mut Camera), (Added<Camera>, Without<CameraController>)>,
-        Query<(Entity, &mut Camera), (Added<Camera>, With<CameraController>)>,
-        Query<&mut Camera>,
+        Query<(Entity, &mut RenderSurface), (Added<RenderSurface>, Without<CameraController>)>,
+        Query<(Entity, &mut RenderSurface), (Added<RenderSurface>, With<CameraController>)>,
+        Query<&mut RenderSurface>,
     )>,
 ) {
     // track added scene camera entities first, to ensure they are preferred for the

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -191,7 +191,7 @@ fn handle_keypress(
 fn handle_mouse(
     accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     mut button_events: EventReader<MouseButtonInput>,
-    mut camera_transform: Single<&mut Transform, With<Camera>>,
+    mut camera_transform: Single<&mut Transform, With<RenderSurface>>,
     mut mouse_pressed: ResMut<MousePressed>,
 ) {
     // Store left-pressed state in the MousePressed resource

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -17,7 +17,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             // Cursor position will take the viewport offset into account
             viewport: Some(Viewport {
                 physical_position: [200, 100].into(),

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -56,7 +56,7 @@ fn setup(
     let texture_camera = commands
         .spawn((
             Camera2d,
-            Camera {
+            RenderSurface {
                 target: RenderTarget::Image(image_handle.clone()),
                 ..default()
             },

--- a/examples/window/monitor_info.rs
+++ b/examples/window/monitor_info.rs
@@ -55,7 +55,7 @@ fn update(
         let camera = commands
             .spawn((
                 Camera2d,
-                Camera {
+                RenderSurface {
                     target: RenderTarget::Window(WindowRef::Entity(window)),
                     ..default()
                 },

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -40,7 +40,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn((
             Camera3d::default(),
             Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-            Camera {
+            RenderSurface {
                 target: RenderTarget::Window(WindowRef::Entity(second_window)),
                 ..default()
             },

--- a/tests/window/minimizing.rs
+++ b/tests/window/minimizing.rs
@@ -62,7 +62,7 @@ fn setup_3d(
 fn setup_2d(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             // render the 2d camera after the 3d camera
             order: 1,
             // do not use a clear color

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -138,7 +138,7 @@ fn setup_3d(
 fn setup_2d(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        Camera {
+        RenderSurface {
             // render the 2d camera after the 3d camera
             order: 1,
             // do not use a clear color


### PR DESCRIPTION
I'm sure this will be controversial, but I wanted to start a discussion with a concrete first step.

There are other things to rename to be consistent, but rather than do everything at once, I've started very small.

Rough proposal on discord: https://discord.com/channels/691052431525675048/743663673393938453/1300556420881846323

Discord thread converted to issue: #16249

Related to https://github.com/bevyengine/bevy/issues/16247

# Objective

- Attempt to give `Camera` a more accurate name. Reading the docs and fields, this is what the component is for. The colloquial usage of `Camera` is more appropriate for our existing `Camera3d` or `Camera2d`, which split out of the old `Camera` struct, if I recall correctly.
- Picking uses `Camera` as the common component to reason about where pointers are on screen. This is misleading, because `Camera` has nothing to do with 3d (although it still retains transforms, maybe erroneously). The reason picking uses this component is because a `Camera`, or `RenderSurface` just defines:
    - What target to write to (window or texture), and the dimensions of this target
    - A viewport within the target to constrain rendering to
    - The order to render each of these `RenderSurface`s to the render target
    - The end result, is that the job of `RenderSurface` (`Camera`) is to define how to composite layers of 2d images onto a target.
- Move UI and picking towards reasoning about a "render surface" as opposed to a "camera".
- Next steps would be to update bevy_ui to make the root of every UI contain a `RenderSurface`.

## Solution

- Rename the component.

## Migration Guide

- Rename `Camera` to `RenderSurface`.
