### PR TITLE
chore(deps): remove unused `uuid` dependency from `bevy_core`

### DIFF
--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -20,7 +20,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
 serde = { version = "1.0", optional = true }
-uuid = "1.0"
 
 [features]
 default = ["bevy_reflect"]


### PR DESCRIPTION
# Objective

- Closes #16242 

## Solution

- Remove unused `uuid` dep in `bevy_core` crate

## Testing

- ~~Awaiting CI~~ tested locally and it doesn't break anything
