### PR TITLE
properly flag using `CustomCursor::Url` in wasm

### DIFF
--- a/crates/bevy_winit/src/cursor.rs
+++ b/crates/bevy_winit/src/cursor.rs
@@ -154,7 +154,11 @@ fn update_cursors(
                     CursorSource::Custom((cache_key, source))
                 }
             }
-            #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+            #[cfg(all(
+                feature = "custom_cursor",
+                target_family = "wasm",
+                target_os = "unknown"
+            ))]
             CursorIcon::Custom(CustomCursor::Url { url, hotspot }) => {
                 let cache_key = CustomCursorCacheKey::Url(url.clone());
 


### PR DESCRIPTION
# Objective

- Fixes #16254 
- fix building in wasm without custom_cursor

## Solution

- Properly flag `CustomCursor::Url` which only exist in wasm, but also only when `custom_cursor` is enabled

## Testing

- `cargo check --target wasm32-unknown-unknown -p bevy_winit`
