### PR TITLE
Remove `accesskit` re-export from `bevy_a11y`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -474,6 +474,7 @@ hyper = { version = "1", features = ["server", "http1"] }
 http-body-util = "0.1"
 anyhow = "1"
 macro_rules_attribute = "0.2"
+accesskit = "0.17"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 smol = "2"

--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -6,13 +6,18 @@
 )]
 
 //! Accessibility for Bevy
+//! 
+//! As of Bevy version 0.15 `accesskit` is no longer re-exported from this crate.
+//! 
+//! If you need to use `accesskit`, you will need to add it as a separate dependency in your `Cargo.toml`.
+//! 
+//! Make sure to use the same version of `accesskit` as Bevy.
 
 extern crate alloc;
 
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, Ordering};
 
-pub use accesskit;
 use accesskit::Node;
 use bevy_app::Plugin;
 use bevy_derive::{Deref, DerefMut};

--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -6,11 +6,11 @@
 )]
 
 //! Accessibility for Bevy
-//! 
+//!
 //! As of Bevy version 0.15 `accesskit` is no longer re-exported from this crate.
-//! 
+//!
 //! If you need to use `accesskit`, you will need to add it as a separate dependency in your `Cargo.toml`.
-//! 
+//!
 //! Make sure to use the same version of `accesskit` as Bevy.
 
 extern crate alloc;

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -43,6 +43,7 @@ derive_more = { version = "1", default-features = false, features = [
 ] }
 nonmax = "0.5"
 smallvec = "1.11"
+accesskit = "0.17"
 
 [features]
 default = ["bevy_ui_picking_backend"]

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -4,10 +4,7 @@ use crate::{
     widget::{TextUiReader, UiImage},
     ComputedNode,
 };
-use bevy_a11y::{
-    accesskit::{Node, Rect, Role},
-    AccessibilityNode,
-};
+use bevy_a11y::AccessibilityNode;
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_ecs::{
     prelude::{DetectChanges, Entity},
@@ -18,6 +15,8 @@ use bevy_ecs::{
 };
 use bevy_render::{camera::CameraUpdateSystem, prelude::Camera};
 use bevy_transform::prelude::GlobalTransform;
+
+use accesskit::{Node, Rect, Role};
 
 fn calc_label(
     text_reader: &mut TextUiReader,

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -52,6 +52,7 @@ raw-window-handle = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", optional = true }
 wgpu-types = { version = "23", optional = true }
+accesskit = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -3,12 +3,12 @@
 use alloc::{collections::VecDeque, sync::Arc};
 use std::sync::Mutex;
 
+use accesskit::{
+    ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, Node, NodeId, Role, Tree,
+    TreeUpdate,
+};
 use accesskit_winit::Adapter;
 use bevy_a11y::{
-    accesskit::{
-        ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, Node, NodeId, Role,
-        Tree, TreeUpdate,
-    },
     AccessibilityNode, AccessibilityRequested, AccessibilitySystem,
     ActionRequest as ActionRequestWrapper, Focus, ManageAccessibilityUpdates,
 };

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -1,10 +1,8 @@
 //! This example illustrates scrolling in Bevy UI.
 
+use accesskit::{Node as Accessible, Role};
 use bevy::{
-    a11y::{
-        accesskit::{Node as Accessible, Role},
-        AccessibilityNode,
-    },
+    a11y::AccessibilityNode,
     input::mouse::{MouseScrollUnit, MouseWheel},
     picking::focus::HoverMap,
     prelude::*,

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -2,11 +2,9 @@
 
 use std::f32::consts::PI;
 
+use accesskit::{Node as Accessible, Role};
 use bevy::{
-    a11y::{
-        accesskit::{Node as Accessible, Role},
-        AccessibilityNode,
-    },
+    a11y::AccessibilityNode,
     color::palettes::{basic::LIME, css::DARK_GRAY},
     input::mouse::{MouseScrollUnit, MouseWheel},
     picking::focus::HoverMap,


### PR DESCRIPTION
# Objective

- Fixes #16235 

## Solution

- Both Bevy and AccessKit export a `Node` struct, to reduce confusion Bevy will no longer re-export `AccessKit` from `bevy_a11y`

## Testing

- Tested locally

## Migration Guide

```diff
# main.rs
--    use bevy_a11y::{
--        accesskit::{Node, Rect, Role},
--        AccessibilityNode,
--    };
++    use bevy_a11y::AccessibilityNode;
++    use accesskit::{Node, Rect, Role};

# Cargo.toml
++    accesskit = "0.17"
```

- Users will need to add `accesskit = "0.17"` to the dependencies section of their `Cargo.toml` file and update their `accesskit` use statements to come directly from the external crate instead of `bevy_a11y`.
- Make sure to keep the versions of `accesskit` aligned with the versions Bevy uses.