### PR TITLE
Require `ContentSize` for `UiImage`

### DIFF
--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -12,7 +12,7 @@ use taffy::{MaybeMath, MaybeResolve};
 /// The 2D texture displayed for this UI node
 #[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default, Debug)]
-#[require(Node, UiImageSize)]
+#[require(Node, UiImageSize, ContentSize)]
 pub struct UiImage {
     /// The tint color used to draw the image.
     ///


### PR DESCRIPTION
# Objective

Automatic imaging sizing for image nodes isn't working because the the `ContentSize` requirement for `UiImage` got lost in some merge again.

Fixes #16239 
Fixes #16240 
Fixes the missing images seen in #16241

## Solution

Require `ContentSize` for `UiImage`.