### PR TITLE
More forms of related components: suggested and included components

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
-    component::RequiredComponentsError,
+    component::RelatedComponentsError,
     event::{event_update_system, EventCursor},
     intern::Interned,
     prelude::*,
@@ -754,25 +754,25 @@ impl App {
         self
     }
 
-    /// Registers the given component `R` as a [required component] for `T`.
+    /// Registers the given component `R` as a [related component] for `T`.
     ///
-    /// When `T` is added to an entity, `R` and its own required components will also be added
+    /// When `T` is added to an entity, `R` and its own related components will also be added
     /// if `R` was not already provided. The [`Default`] `constructor` will be used for the creation of `R`.
-    /// If a custom constructor is desired, use [`App::register_required_components_with`] instead.
+    /// If a custom constructor is desired, use [`App::register_related_components_with`] instead.
     ///
-    /// For the non-panicking version, see [`App::try_register_required_components`].
+    /// For the non-panicking version, see [`App::try_register_related_components`].
     ///
     /// Note that requirements must currently be registered before `T` is inserted into the world
     /// for the first time. Commonly, this is done in plugins. This limitation may be fixed in the future.
     ///
-    /// [required component]: Component#required-components
+    /// [related component]: Component#related-components
     ///
     /// # Panics
     ///
-    /// Panics if `R` is already a directly required component for `T`, or if `T` has ever been added
+    /// Panics if `R` is already a directly related component for `T`, or if `T` has ever been added
     /// on an entity before the registration.
     ///
-    /// Indirect requirements through other components are allowed. In those cases, any existing requirements
+    /// Indirect relationships through other components are allowed. In those cases, any existing requirements
     /// will only be overwritten if the new requirement is more specific.
     ///
     /// # Example
@@ -792,8 +792,8 @@ impl App {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins).add_systems(Startup, setup);
     /// // Register B as required by A and C as required by B.
-    /// app.register_required_components::<A, B>();
-    /// app.register_required_components::<B, C>();
+    /// app.register_related_components::<A, B>();
+    /// app.register_related_components::<B, C>();
     ///
     /// fn setup(mut commands: Commands) {
     ///     // This will implicitly also insert B and C with their Default constructors.
@@ -807,32 +807,32 @@ impl App {
     /// }
     /// # app.update();
     /// ```
-    pub fn register_required_components<T: Component, R: Component + Default>(
+    pub fn register_related_components<T: Component, R: Component + Default>(
         &mut self,
     ) -> &mut Self {
-        self.world_mut().register_required_components::<T, R>();
+        self.world_mut().register_related_components::<T, R>();
         self
     }
 
-    /// Registers the given component `R` as a [required component] for `T`.
+    /// Registers the given component `R` as a [related component] for `T`.
     ///
-    /// When `T` is added to an entity, `R` and its own required components will also be added
+    /// When `T` is added to an entity, `R` and its own related components will also be added
     /// if `R` was not already provided. The given `constructor` will be used for the creation of `R`.
-    /// If a [`Default`] constructor is desired, use [`App::register_required_components`] instead.
+    /// If a [`Default`] constructor is desired, use [`App::register_related_components`] instead.
     ///
-    /// For the non-panicking version, see [`App::try_register_required_components_with`].
+    /// For the non-panicking version, see [`App::try_register_related_components_with`].
     ///
     /// Note that requirements must currently be registered before `T` is inserted into the world
     /// for the first time. Commonly, this is done in plugins. This limitation may be fixed in the future.
     ///
-    /// [required component]: Component#required-components
+    /// [related component]: Component#related-components
     ///
     /// # Panics
     ///
-    /// Panics if `R` is already a directly required component for `T`, or if `T` has ever been added
+    /// Panics if `R` is already a directly related component for `T`, or if `T` has ever been added
     /// on an entity before the registration.
     ///
-    /// Indirect requirements through other components are allowed. In those cases, any existing requirements
+    /// Indirect relationships through other components are allowed. In those cases, any existing relationships
     /// will only be overwritten if the new requirement is more specific.
     ///
     /// # Example
@@ -853,9 +853,9 @@ impl App {
     /// # app.add_plugins(MinimalPlugins).add_systems(Startup, setup);
     /// // Register B and C as required by A and C as required by B.
     /// // A requiring C directly will overwrite the indirect requirement through B.
-    /// app.register_required_components::<A, B>();
-    /// app.register_required_components_with::<B, C>(|| C(1));
-    /// app.register_required_components_with::<A, C>(|| C(2));
+    /// app.register_related_components::<A, B>();
+    /// app.register_related_components_with::<B, C>(|| C(1));
+    /// app.register_related_components_with::<A, C>(|| C(2));
     ///
     /// fn setup(mut commands: Commands) {
     ///     // This will implicitly also insert B with its Default constructor and C
@@ -870,34 +870,34 @@ impl App {
     /// }
     /// # app.update();
     /// ```
-    pub fn register_required_components_with<T: Component, R: Component>(
+    pub fn register_related_components_with<T: Component, R: Component>(
         &mut self,
         constructor: fn() -> R,
     ) -> &mut Self {
         self.world_mut()
-            .register_required_components_with::<T, R>(constructor);
+            .register_related_components_with::<T, R>(constructor);
         self
     }
 
-    /// Tries to register the given component `R` as a [required component] for `T`.
+    /// Tries to register the given component `R` as a [related component] for `T`.
     ///
-    /// When `T` is added to an entity, `R` and its own required components will also be added
+    /// When `T` is added to an entity, `R` and its own related components will also be added
     /// if `R` was not already provided. The [`Default`] `constructor` will be used for the creation of `R`.
-    /// If a custom constructor is desired, use [`App::register_required_components_with`] instead.
+    /// If a custom constructor is desired, use [`App::register_related_components_with`] instead.
     ///
-    /// For the panicking version, see [`App::register_required_components`].
+    /// For the panicking version, see [`App::register_related_components`].
     ///
     /// Note that requirements must currently be registered before `T` is inserted into the world
     /// for the first time. Commonly, this is done in plugins. This limitation may be fixed in the future.
     ///
-    /// [required component]: Component#required-components
+    /// [related component]: Component#related-components
     ///
     /// # Errors
     ///
-    /// Returns a [`RequiredComponentsError`] if `R` is already a directly required component for `T`, or if `T` has ever been added
+    /// Returns a [`RelatedComponentsError`] if `R` is already a directly related component for `T`, or if `T` has ever been added
     /// on an entity before the registration.
     ///
-    /// Indirect requirements through other components are allowed. In those cases, any existing requirements
+    /// Indirect relationships through other components are allowed. In those cases, any existing relationships
     /// will only be overwritten if the new requirement is more specific.
     ///
     /// # Example
@@ -917,11 +917,11 @@ impl App {
     /// # let mut app = App::new();
     /// # app.add_plugins(MinimalPlugins).add_systems(Startup, setup);
     /// // Register B as required by A and C as required by B.
-    /// app.register_required_components::<A, B>();
-    /// app.register_required_components::<B, C>();
+    /// app.register_related_components::<A, B>();
+    /// app.register_related_components::<B, C>();
     ///
     /// // Duplicate registration! This will fail.
-    /// assert!(app.try_register_required_components::<A, B>().is_err());
+    /// assert!(app.try_register_related_components::<A, B>().is_err());
     ///
     /// fn setup(mut commands: Commands) {
     ///     // This will implicitly also insert B and C with their Default constructors.
@@ -935,31 +935,31 @@ impl App {
     /// }
     /// # app.update();
     /// ```
-    pub fn try_register_required_components<T: Component, R: Component + Default>(
+    pub fn try_register_related_components<T: Component, R: Component + Default>(
         &mut self,
-    ) -> Result<(), RequiredComponentsError> {
-        self.world_mut().try_register_required_components::<T, R>()
+    ) -> Result<(), RelatedComponentsError> {
+        self.world_mut().try_register_related_components::<T, R>()
     }
 
-    /// Tries to register the given component `R` as a [required component] for `T`.
+    /// Tries to register the given component `R` as a [related component] for `T`.
     ///
-    /// When `T` is added to an entity, `R` and its own required components will also be added
+    /// When `T` is added to an entity, `R` and its own related components will also be added
     /// if `R` was not already provided. The given `constructor` will be used for the creation of `R`.
-    /// If a [`Default`] constructor is desired, use [`App::register_required_components`] instead.
+    /// If a [`Default`] constructor is desired, use [`App::register_related_components`] instead.
     ///
-    /// For the panicking version, see [`App::register_required_components_with`].
+    /// For the panicking version, see [`App::register_related_components_with`].
     ///
     /// Note that requirements must currently be registered before `T` is inserted into the world
     /// for the first time. Commonly, this is done in plugins. This limitation may be fixed in the future.
     ///
-    /// [required component]: Component#required-components
+    /// [related component]: Component#related-components
     ///
     /// # Errors
     ///
-    /// Returns a [`RequiredComponentsError`] if `R` is already a directly required component for `T`, or if `T` has ever been added
+    /// Returns a [`RelatedComponentsError`] if `R` is already a directly related component for `T`, or if `T` has ever been added
     /// on an entity before the registration.
     ///
-    /// Indirect requirements through other components are allowed. In those cases, any existing requirements
+    /// Indirect relationships through other components are allowed. In those cases, any existing relationships
     /// will only be overwritten if the new requirement is more specific.
     ///
     /// # Example
@@ -980,12 +980,12 @@ impl App {
     /// # app.add_plugins(MinimalPlugins).add_systems(Startup, setup);
     /// // Register B and C as required by A and C as required by B.
     /// // A requiring C directly will overwrite the indirect requirement through B.
-    /// app.register_required_components::<A, B>();
-    /// app.register_required_components_with::<B, C>(|| C(1));
-    /// app.register_required_components_with::<A, C>(|| C(2));
+    /// app.register_related_components::<A, B>();
+    /// app.register_related_components_with::<B, C>(|| C(1));
+    /// app.register_related_components_with::<A, C>(|| C(2));
     ///
     /// // Duplicate registration! Even if the constructors were different, this would fail.
-    /// assert!(app.try_register_required_components_with::<B, C>(|| C(1)).is_err());
+    /// assert!(app.try_register_related_components_with::<B, C>(|| C(1)).is_err());
     ///
     /// fn setup(mut commands: Commands) {
     ///     // This will implicitly also insert B with its Default constructor and C
@@ -1000,12 +1000,12 @@ impl App {
     /// }
     /// # app.update();
     /// ```
-    pub fn try_register_required_components_with<T: Component, R: Component>(
+    pub fn try_register_related_components_with<T: Component, R: Component>(
         &mut self,
         constructor: fn() -> R,
-    ) -> Result<(), RequiredComponentsError> {
+    ) -> Result<(), RelatedComponentsError> {
         self.world_mut()
-            .try_register_required_components_with::<T, R>(constructor)
+            .try_register_related_components_with::<T, R>(constructor)
     }
 
     /// Returns a reference to the [`World`].

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
-    component::RelatedComponentsError,
+    component::{RelatedComponentsError, Relatedness},
     event::{event_update_system, EventCursor},
     intern::Interned,
     prelude::*,
@@ -809,8 +809,10 @@ impl App {
     /// ```
     pub fn register_related_components<T: Component, R: Component + Default>(
         &mut self,
+        relatedness: Relatedness,
     ) -> &mut Self {
-        self.world_mut().register_related_components::<T, R>();
+        self.world_mut()
+            .register_related_components::<T, R>(relatedness);
         self
     }
 
@@ -873,9 +875,10 @@ impl App {
     pub fn register_related_components_with<T: Component, R: Component>(
         &mut self,
         constructor: fn() -> R,
+        relatedness: Relatedness,
     ) -> &mut Self {
         self.world_mut()
-            .register_related_components_with::<T, R>(constructor);
+            .register_related_components_with::<T, R>(constructor, relatedness);
         self
     }
 
@@ -937,8 +940,10 @@ impl App {
     /// ```
     pub fn try_register_related_components<T: Component, R: Component + Default>(
         &mut self,
+        relatedness: Relatedness,
     ) -> Result<(), RelatedComponentsError> {
-        self.world_mut().try_register_related_components::<T, R>()
+        self.world_mut()
+            .try_register_related_components::<T, R>(relatedness)
     }
 
     /// Tries to register the given component `R` as a [related component] for `T`.
@@ -1003,9 +1008,10 @@ impl App {
     pub fn try_register_related_components_with<T: Component, R: Component>(
         &mut self,
         constructor: fn() -> R,
+        relatedness: Relatedness,
     ) -> Result<(), RelatedComponentsError> {
         self.world_mut()
-            .try_register_related_components_with::<T, R>(constructor)
+            .try_register_related_components_with::<T, R>(constructor, relatedness)
     }
 
     /// Returns a reference to the [`World`].

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -82,7 +82,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         for require in requires {
             let ident = &require.path;
             register_recursive_requires.push(quote! {
-                <#ident as Component>::register_required_components(
+                <#ident as Component>::register_related_components(
                     requiree,
                     components,
                     storages,
@@ -93,7 +93,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
             match &require.func {
                 Some(RequireFunc::Path(func)) => {
                     register_required.push(quote! {
-                        components.register_required_components_manual::<Self, #ident>(
+                        components.register_related_components_manual::<Self, #ident>(
                             storages,
                             required_components,
                             || { let x: #ident = #func().into(); x },
@@ -103,7 +103,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 }
                 Some(RequireFunc::Closure(func)) => {
                     register_required.push(quote! {
-                        components.register_required_components_manual::<Self, #ident>(
+                        components.register_related_components_manual::<Self, #ident>(
                             storages,
                             required_components,
                             || { let x: #ident = (#func)().into(); x },
@@ -113,7 +113,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 }
                 None => {
                     register_required.push(quote! {
-                        components.register_required_components_manual::<Self, #ident>(
+                        components.register_related_components_manual::<Self, #ident>(
                             storages,
                             required_components,
                             <#ident as Default>::default,
@@ -145,11 +145,11 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         #required_component_docs
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
             const STORAGE_TYPE: #bevy_ecs_path::component::StorageType = #storage;
-            fn register_required_components(
+            fn register_related_components(
                 requiree: #bevy_ecs_path::component::ComponentId,
                 components: &mut #bevy_ecs_path::component::Components,
                 storages: &mut #bevy_ecs_path::storage::Storages,
-                required_components: &mut #bevy_ecs_path::component::RequiredComponents,
+                required_components: &mut #bevy_ecs_path::component::RelatedComponents,
                 inheritance_depth: u16,
             ) {
                 #(#register_required)*

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -75,79 +75,31 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
         .predicates
         .push(parse_quote! { Self: Send + Sync + 'static });
 
-    let requires = &attrs.requires;
-    let mut register_required = Vec::with_capacity(attrs.requires.iter().len());
-    let mut register_recursive_requires = Vec::with_capacity(attrs.requires.iter().len());
+    let RelatedComponentsReturn {
+        register_related: register_suggested,
+        register_recursive_related: register_recursive_suggested,
+        docs: suggested_component_docs,
+    } = related_components(&attrs.suggests, Relatedness::Suggested);
+    let RelatedComponentsReturn {
+        register_related: register_included,
+        register_recursive_related: register_recursive_included,
+        docs: included_component_docs,
+    } = related_components(&attrs.includes, Relatedness::Included);
+    let RelatedComponentsReturn {
+        register_related: register_required,
+        register_recursive_related: register_recursive_required,
+        docs: required_component_docs,
+    } = related_components(&attrs.requires, Relatedness::Required);
 
-    if let Some(requires) = requires {
-        let relatedness = quote! { #bevy_ecs_path::component::Relatedness::Required };
-        for require in requires {
-            let ident = &require.path;
-            register_recursive_requires.push(quote! {
-                <#ident as Component>::register_related_components(
-                    requiree,
-                    components,
-                    storages,
-                    required_components,
-                    inheritance_depth + 1,
-                );
-            });
-            match &require.func {
-                Some(RequireFunc::Path(func)) => {
-                    register_required.push(quote! {
-                        components.register_related_components_manual::<Self, #ident>(
-                            storages,
-                            required_components,
-                            || { let x: #ident = #func().into(); x },
-                            inheritance_depth,
-                            #relatedness,
-                        );
-                    });
-                }
-                Some(RequireFunc::Closure(func)) => {
-                    register_required.push(quote! {
-                        components.register_related_components_manual::<Self, #ident>(
-                            storages,
-                            required_components,
-                            || { let x: #ident = (#func)().into(); x },
-                            inheritance_depth,
-                            #relatedness,
-                        );
-                    });
-                }
-                None => {
-                    register_required.push(quote! {
-                        components.register_related_components_manual::<Self, #ident>(
-                            storages,
-                            required_components,
-                            <#ident as Default>::default,
-                            inheritance_depth,
-                            #relatedness,
-                        );
-                    });
-                }
-            }
-        }
-    }
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
-
-    let required_component_docs = attrs.requires.map(|r| {
-        let paths = r
-            .iter()
-            .map(|r| format!("[`{}`]", r.path.to_token_stream()))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let doc = format!("Required Components: {paths}. \n\n A component's Required Components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively, in depth-first order.");
-        quote! {
-            #[doc = #doc]
-        }
-    });
 
     // This puts `register_required` before `register_recursive_requires` to ensure that the constructors of _all_ top
     // level components are initialized first, giving them precedence over recursively defined constructors for the same component type
     TokenStream::from(quote! {
         #required_component_docs
+        #included_component_docs
+        #suggested_component_docs
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
             const STORAGE_TYPE: #bevy_ecs_path::component::StorageType = #storage;
             fn register_related_components(
@@ -157,8 +109,14 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 required_components: &mut #bevy_ecs_path::component::RelatedComponents,
                 inheritance_depth: u16,
             ) {
+                #(#register_suggested)*
+                #(#register_recursive_suggested)*
+
+                #(#register_included)*
+                #(#register_recursive_included)*
+
                 #(#register_required)*
-                #(#register_recursive_requires)*
+                #(#register_recursive_required)*
             }
 
             #[allow(unused_variables)]
@@ -172,8 +130,136 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     })
 }
 
+// Because the macro crate cannot access the `bevy_ecs` crate, we need to create our own equivalent.
+// This should be kept in sync with the actual `bevy_ecs` crate!
+enum Relatedness {
+    Suggested,
+    Included,
+    Required,
+}
+
+impl Relatedness {
+    /// Returns the token that represents the corresponding `Relatedness` enum variant in `bevy_ecs`.
+    fn token(&self) -> TokenStream2 {
+        let bevy_ecs_path: Path = crate::bevy_ecs_path();
+        match self {
+            Relatedness::Suggested => quote! { #bevy_ecs_path::component::Relatedness::Included },
+            Relatedness::Included => quote! { #bevy_ecs_path::component::Relatedness::Included },
+            Relatedness::Required => quote! { #bevy_ecs_path::component::Relatedness::Required },
+        }
+    }
+
+    /// Returns the stringified name of this `Relatedness` enum variant for use in docs.
+    fn doc_name(&self) -> &'static str {
+        match self {
+            Relatedness::Suggested => "Suggested",
+            Relatedness::Included => "Included",
+            Relatedness::Required => "Required",
+        }
+    }
+
+    /// Returns the doc string fragment that explains the corresponding `Relatedness` enum variant.
+    fn doc_explanation(&self) -> &'static str {
+        match self {
+            Relatedness::Suggested => "This component might work well with the components listed above, unlocking new functionality.",
+            Relatedness::Included => "A component's Included Components are inserted whenever it is inserted. Note that this will also insert the included components _of_ the included components, recursively, in depth-first order.",
+            Relatedness::Required => "A component's Required Components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively, in depth-first order. Unlike included components, this relationship cannot be removed.",
+        }
+    }
+}
+
+struct RelatedComponentsReturn {
+    register_related: Vec<TokenStream2>,
+    register_recursive_related: Vec<TokenStream2>,
+    docs: Option<TokenStream2>,
+}
+
+/// Generates the code needed to add related components to the component's related components list.
+fn related_components(
+    attribute: &Option<Punctuated<Related, Comma>>,
+    relatedness: Relatedness,
+) -> RelatedComponentsReturn {
+    let mut register_related = Vec::with_capacity(attribute.iter().len());
+    let mut register_recursive_related = Vec::with_capacity(attribute.iter().len());
+
+    let relatedness_token = relatedness.token();
+
+    if let Some(related) = attribute {
+        for require in related {
+            let ident = &require.path;
+            register_recursive_related.push(quote! {
+                <#ident as Component>::register_related_components(
+                    requiree,
+                    components,
+                    storages,
+                    required_components,
+                    inheritance_depth + 1,
+                );
+            });
+            match &require.func {
+                Some(RequireFunc::Path(func)) => {
+                    register_related.push(quote! {
+                        components.register_related_components_manual::<Self, #ident>(
+                            storages,
+                            required_components,
+                            || { let x: #ident = #func().into(); x },
+                            inheritance_depth,
+                            #relatedness_token,
+                        );
+                    });
+                }
+                Some(RequireFunc::Closure(func)) => {
+                    register_related.push(quote! {
+                        components.register_related_components_manual::<Self, #ident>(
+                            storages,
+                            required_components,
+                            || { let x: #ident = (#func)().into(); x },
+                            inheritance_depth,
+                            #relatedness_token,
+                        );
+                    });
+                }
+                None => {
+                    register_related.push(quote! {
+                        components.register_related_components_manual::<Self, #ident>(
+                            storages,
+                            required_components,
+                            <#ident as Default>::default,
+                            inheritance_depth,
+                            #relatedness_token,
+                        );
+                    });
+                }
+            }
+        }
+    }
+
+    let docs = attribute.as_ref().map(|r| {
+        let paths = r
+            .iter()
+            .map(|r| format!("[`{}`]", r.path.to_token_stream()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let doc_name = relatedness.doc_name();
+        let doc_explanation = relatedness.doc_explanation();
+        let doc = format!("{doc_name}: {paths}. \n\n {doc_explanation}");
+        quote! {
+            #[doc = #doc]
+        }
+    });
+
+    RelatedComponentsReturn {
+        register_related,
+        register_recursive_related,
+        docs,
+    }
+}
+
 pub const COMPONENT: &str = "component";
 pub const STORAGE: &str = "storage";
+
+pub const SUGGEST: &str = "suggest";
+pub const INCLUDE: &str = "include";
 pub const REQUIRE: &str = "require";
 
 pub const ON_ADD: &str = "on_add";
@@ -183,7 +269,9 @@ pub const ON_REMOVE: &str = "on_remove";
 
 struct Attrs {
     storage: StorageTy,
-    requires: Option<Punctuated<Require, Comma>>,
+    suggests: Option<Punctuated<Related, Comma>>,
+    includes: Option<Punctuated<Related, Comma>>,
+    requires: Option<Punctuated<Related, Comma>>,
     on_add: Option<ExprPath>,
     on_insert: Option<ExprPath>,
     on_replace: Option<ExprPath>,
@@ -196,7 +284,7 @@ enum StorageTy {
     SparseSet,
 }
 
-struct Require {
+struct Related {
     path: Path,
     func: Option<RequireFunc>,
 }
@@ -217,6 +305,8 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
         on_insert: None,
         on_replace: None,
         on_remove: None,
+        suggests: None,
+        includes: None,
         requires: None,
     };
 
@@ -251,9 +341,41 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
                     Err(nested.error("Unsupported attribute"))
                 }
             })?;
+        } else if attr.path().is_ident(SUGGEST) {
+            let punctuated =
+                attr.parse_args_with(Punctuated::<Related, Comma>::parse_terminated)?;
+            for suggest in punctuated.iter() {
+                if !require_paths.insert(suggest.path.to_token_stream().to_string()) {
+                    return Err(syn::Error::new(
+                        suggest.path.span(),
+                        "Duplicate suggested components are not allowed.",
+                    ));
+                }
+            }
+            if let Some(current) = &mut attrs.suggests {
+                current.extend(punctuated);
+            } else {
+                attrs.suggests = Some(punctuated);
+            }
+        } else if attr.path().is_ident(INCLUDE) {
+            let punctuated =
+                attr.parse_args_with(Punctuated::<Related, Comma>::parse_terminated)?;
+            for include in punctuated.iter() {
+                if !require_paths.insert(include.path.to_token_stream().to_string()) {
+                    return Err(syn::Error::new(
+                        include.path.span(),
+                        "Duplicate included components are not allowed.",
+                    ));
+                }
+            }
+            if let Some(current) = &mut attrs.includes {
+                current.extend(punctuated);
+            } else {
+                attrs.includes = Some(punctuated);
+            }
         } else if attr.path().is_ident(REQUIRE) {
             let punctuated =
-                attr.parse_args_with(Punctuated::<Require, Comma>::parse_terminated)?;
+                attr.parse_args_with(Punctuated::<Related, Comma>::parse_terminated)?;
             for require in punctuated.iter() {
                 if !require_paths.insert(require.path.to_token_stream().to_string()) {
                     return Err(syn::Error::new(
@@ -273,7 +395,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
     Ok(attrs)
 }
 
-impl Parse for Require {
+impl Parse for Related {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
         let path = input.parse::<Path>()?;
         let func = if input.peek(Paren) {
@@ -288,7 +410,7 @@ impl Parse for Require {
         } else {
             None
         };
-        Ok(Require { path, func })
+        Ok(Related { path, func })
     }
 }
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -78,7 +78,9 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     let requires = &attrs.requires;
     let mut register_required = Vec::with_capacity(attrs.requires.iter().len());
     let mut register_recursive_requires = Vec::with_capacity(attrs.requires.iter().len());
+
     if let Some(requires) = requires {
+        let relatedness = quote! { #bevy_ecs_path::component::Relatedness::Required };
         for require in requires {
             let ident = &require.path;
             register_recursive_requires.push(quote! {
@@ -87,7 +89,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                     components,
                     storages,
                     required_components,
-                    inheritance_depth + 1
+                    inheritance_depth + 1,
                 );
             });
             match &require.func {
@@ -97,7 +99,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                             storages,
                             required_components,
                             || { let x: #ident = #func().into(); x },
-                            inheritance_depth
+                            inheritance_depth,
+                            #relatedness,
                         );
                     });
                 }
@@ -107,7 +110,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                             storages,
                             required_components,
                             || { let x: #ident = (#func)().into(); x },
-                            inheritance_depth
+                            inheritance_depth,
+                            #relatedness,
                         );
                     });
                 }
@@ -117,7 +121,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                             storages,
                             required_components,
                             <#ident as Default>::default,
-                            inheritance_depth
+                            inheritance_depth,
+                            #relatedness,
                         );
                     });
                 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -91,7 +91,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                 <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut *ids);
                 });
                 field_required_components.push(quote! {
-                    <#field_type as #ecs_path::bundle::Bundle>::register_required_components(components, storages, required_components);
+                    <#field_type as #ecs_path::bundle::Bundle>::register_related_components(components, storages, required_components);
                 });
                 field_get_component_ids.push(quote! {
                     <#field_type as #ecs_path::bundle::Bundle>::get_component_ids(components, &mut *ids);
@@ -159,10 +159,10 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn register_required_components(
+            fn register_related_components(
                 components: &mut #ecs_path::component::Components,
                 storages: &mut #ecs_path::storage::Storages,
-                required_components: &mut #ecs_path::component::RequiredComponents
+                required_components: &mut #ecs_path::component::RelatedComponents
             ){
                 #(#field_required_components)*
             }

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -21,7 +21,7 @@
 
 use crate::{
     bundle::BundleId,
-    component::{ComponentId, Components, RequiredComponentConstructor, StorageType},
+    component::{ComponentId, Components, RelatedComponentConstructor, StorageType},
     entity::{Entity, EntityLocation},
     observer::Observers,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, SparseSetIndex, TableId, TableRow},
@@ -126,7 +126,7 @@ pub(crate) struct AddBundle {
     /// The set of additional required components that must be initialized immediately when adding this Bundle.
     ///
     /// The initial values are determined based on the provided constructor, falling back to the `Default` trait if none is given.
-    pub required_components: Vec<RequiredComponentConstructor>,
+    pub required_components: Vec<RelatedComponentConstructor>,
     /// The components added by this bundle. This includes any Required Components that are inserted when adding this bundle.
     pub added: Vec<ComponentId>,
     /// The components that were explicitly contributed by this bundle, but already existed in the archetype. This _does not_ include any
@@ -229,7 +229,7 @@ impl Edges {
         bundle_id: BundleId,
         archetype_id: ArchetypeId,
         bundle_status: Vec<ComponentStatus>,
-        required_components: Vec<RequiredComponentConstructor>,
+        required_components: Vec<RelatedComponentConstructor>,
         added: Vec<ComponentId>,
         existing: Vec<ComponentId>,
     ) {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -401,15 +401,15 @@ impl BundleInfo {
         }
 
         let explicit_components_len = component_ids.len();
-        let mut required_components = RelatedComponents::default();
+        let mut related_components = RelatedComponents::default();
         for component_id in component_ids.iter().copied() {
             // SAFETY: caller has verified that all ids are valid
             let info = unsafe { components.get_info_unchecked(component_id) };
-            required_components.merge(info.required_components());
+            related_components.merge(info.related_components());
         }
-        required_components.remove_explicit_components(&component_ids);
-        let required_components = required_components
-            .0
+        related_components.remove_explicit_components(&component_ids);
+        let required_components = related_components
+            .required_components
             .into_iter()
             .map(|(component_id, v)| {
                 // This adds required components to the component_ids list _after_ using that list to remove explicitly provided

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1722,13 +1722,23 @@ pub struct RelatedComponent {
 /// For the metadata associated with a relayed component, see [`RelatedComponent`].
 #[derive(Default, Clone)]
 pub struct RelatedComponents {
+    // NOTE: these are stored in separate maps to allow for more efficient lookups.
+    // A double map keyed by [`Relatedness`] then [`ComponentId`] would be more ergonomic,
+    // but would require more expensive lookups.
+    /// The components corresponding to [`Relatedness::Suggested`].
+    pub(crate) suggested_components: HashMap<ComponentId, RelatedComponent>,
+    /// The components corresponding to [`Relatedness::Included`].
+    pub(crate) included_components: HashMap<ComponentId, RelatedComponent>,
+    /// The components corresponding to [`Relatedness::Required`].
     pub(crate) required_components: HashMap<ComponentId, RelatedComponent>,
 }
 
 impl Debug for RelatedComponents {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("RelatedComponents")
-            .field(&self.required_components.keys())
+        f.debug_struct("RelatedComponents")
+            .field("Suggested", &self.suggested_components.keys())
+            .field("Included", &self.included_components.keys())
+            .field("Required", &self.required_components.keys())
             .finish()
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2419,9 +2419,9 @@ mod tests {
 
         /// Returns the component IDs and inheritance depths of the required components
         /// in ascending order based on the component ID.
-        fn to_vec(required: &RelatedComponents) -> Vec<(ComponentId, u16)> {
-            let mut vec = required
-                .0
+        fn to_vec(related: &RelatedComponents) -> Vec<(ComponentId, u16)> {
+            let mut vec = related
+                .required_components
                 .iter()
                 .map(|(id, component)| (*id, component.inheritance_depth))
                 .collect::<Vec<_>>();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -82,7 +82,7 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;
-    use crate::component::{RelatedComponents, RelatedComponentsError};
+    use crate::component::{RelatedComponents, RelatedComponentsError, Relatedness};
     use crate::{
         bundle::Bundle,
         change_detection::Ref,
@@ -2071,8 +2071,8 @@ mod tests {
         struct V;
 
         let mut world = World::new();
-        world.register_related_components::<X, Y>();
-        world.register_related_components::<Y, Z>();
+        world.register_related_components::<X, Y>(Relatedness::Required);
+        world.register_related_components::<Y, Z>(Relatedness::Required);
 
         let e = world.spawn((X, V)).id();
         assert!(world.entity(e).contains::<X>());
@@ -2213,8 +2213,8 @@ mod tests {
 
         let mut world = World::new();
 
-        world.register_related_components::<X, Y>();
-        world.register_related_components_with::<Y, Z>(|| Z(7));
+        world.register_related_components::<X, Y>(Relatedness::Required);
+        world.register_related_components_with::<Y, Z>(|| Z(7), Relatedness::Required);
 
         let id = world.spawn(X).id();
 
@@ -2277,9 +2277,9 @@ mod tests {
         // - X requires Y with default constructor
         // - Y requires Z with custom constructor
         // - X requires Z with custom constructor (more specific than X -> Y -> Z)
-        world.register_related_components::<X, Y>();
-        world.register_related_components_with::<Y, Z>(|| Z(5));
-        world.register_related_components_with::<X, Z>(|| Z(7));
+        world.register_related_components::<X, Y>(Relatedness::Required);
+        world.register_related_components_with::<Y, Z>(|| Z(5), Relatedness::Required);
+        world.register_related_components_with::<X, Z>(|| Z(7), Relatedness::Required);
 
         let id = world.spawn(X).id();
 
@@ -2308,9 +2308,9 @@ mod tests {
         // - X requires Y with default constructor
         // - X requires Z with custom constructor (more specific than X -> Y -> Z)
         // - Y requires Z with custom constructor
-        world.register_related_components::<X, Y>();
-        world.register_related_components_with::<X, Z>(|| Z(7));
-        world.register_related_components_with::<Y, Z>(|| Z(5));
+        world.register_related_components::<X, Y>(Relatedness::Required);
+        world.register_related_components_with::<X, Z>(|| Z(7), Relatedness::Required);
+        world.register_related_components_with::<Y, Z>(|| Z(5), Relatedness::Required);
 
         let id = world.spawn(X).id();
 
@@ -2335,7 +2335,7 @@ mod tests {
         // This may change in the future.
         world.spawn(X);
         assert!(matches!(
-            world.try_register_related_components::<X, Y>(),
+            world.try_register_related_components::<X, Y>(Relatedness::Required),
             Err(RelatedComponentsError::ArchetypeExists(_))
         ));
     }
@@ -2353,7 +2353,7 @@ mod tests {
 
         // This should fail: Tried to register Y as a requirement for X, but the requirement already exists.
         assert!(matches!(
-            world.try_register_related_components::<X, Y>(),
+            world.try_register_related_components::<X, Y>(Relatedness::Required),
             Err(RelatedComponentsError::DuplicateRegistration(_, _))
         ));
     }
@@ -2403,10 +2403,10 @@ mod tests {
         let y = world.register_component::<Y>();
         let z = world.register_component::<Z>();
 
-        world.register_related_components::<X, A>();
-        world.register_related_components::<X, Y>();
-        world.register_related_components::<Y, Z>();
-        world.register_related_components::<Z, B>();
+        world.register_related_components::<X, A>(Relatedness::Required);
+        world.register_related_components::<X, Y>(Relatedness::Required);
+        world.register_related_components::<Y, Z>(Relatedness::Required);
+        world.register_related_components::<Z, B>(Relatedness::Required);
 
         world.spawn(X);
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -82,7 +82,7 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;
-    use crate::component::{RequiredComponents, RequiredComponentsError};
+    use crate::component::{RelatedComponents, RelatedComponentsError};
     use crate::{
         bundle::Bundle,
         change_detection::Ref,
@@ -2071,8 +2071,8 @@ mod tests {
         struct V;
 
         let mut world = World::new();
-        world.register_required_components::<X, Y>();
-        world.register_required_components::<Y, Z>();
+        world.register_related_components::<X, Y>();
+        world.register_related_components::<Y, Z>();
 
         let e = world.spawn((X, V)).id();
         assert!(world.entity(e).contains::<X>());
@@ -2213,8 +2213,8 @@ mod tests {
 
         let mut world = World::new();
 
-        world.register_required_components::<X, Y>();
-        world.register_required_components_with::<Y, Z>(|| Z(7));
+        world.register_related_components::<X, Y>();
+        world.register_related_components_with::<Y, Z>(|| Z(7));
 
         let id = world.spawn(X).id();
 
@@ -2277,9 +2277,9 @@ mod tests {
         // - X requires Y with default constructor
         // - Y requires Z with custom constructor
         // - X requires Z with custom constructor (more specific than X -> Y -> Z)
-        world.register_required_components::<X, Y>();
-        world.register_required_components_with::<Y, Z>(|| Z(5));
-        world.register_required_components_with::<X, Z>(|| Z(7));
+        world.register_related_components::<X, Y>();
+        world.register_related_components_with::<Y, Z>(|| Z(5));
+        world.register_related_components_with::<X, Z>(|| Z(7));
 
         let id = world.spawn(X).id();
 
@@ -2308,9 +2308,9 @@ mod tests {
         // - X requires Y with default constructor
         // - X requires Z with custom constructor (more specific than X -> Y -> Z)
         // - Y requires Z with custom constructor
-        world.register_required_components::<X, Y>();
-        world.register_required_components_with::<X, Z>(|| Z(7));
-        world.register_required_components_with::<Y, Z>(|| Z(5));
+        world.register_related_components::<X, Y>();
+        world.register_related_components_with::<X, Z>(|| Z(7));
+        world.register_related_components_with::<Y, Z>(|| Z(5));
 
         let id = world.spawn(X).id();
 
@@ -2335,8 +2335,8 @@ mod tests {
         // This may change in the future.
         world.spawn(X);
         assert!(matches!(
-            world.try_register_required_components::<X, Y>(),
-            Err(RequiredComponentsError::ArchetypeExists(_))
+            world.try_register_related_components::<X, Y>(),
+            Err(RelatedComponentsError::ArchetypeExists(_))
         ));
     }
 
@@ -2353,8 +2353,8 @@ mod tests {
 
         // This should fail: Tried to register Y as a requirement for X, but the requirement already exists.
         assert!(matches!(
-            world.try_register_required_components::<X, Y>(),
-            Err(RequiredComponentsError::DuplicateRegistration(_, _))
+            world.try_register_related_components::<X, Y>(),
+            Err(RelatedComponentsError::DuplicateRegistration(_, _))
         ));
     }
 
@@ -2403,10 +2403,10 @@ mod tests {
         let y = world.register_component::<Y>();
         let z = world.register_component::<Z>();
 
-        world.register_required_components::<X, A>();
-        world.register_required_components::<X, Y>();
-        world.register_required_components::<Y, Z>();
-        world.register_required_components::<Z, B>();
+        world.register_related_components::<X, A>();
+        world.register_related_components::<X, Y>();
+        world.register_related_components::<Y, Z>();
+        world.register_related_components::<Z, B>();
 
         world.spawn(X);
 
@@ -2419,7 +2419,7 @@ mod tests {
 
         /// Returns the component IDs and inheritance depths of the required components
         /// in ascending order based on the component ID.
-        fn to_vec(required: &RequiredComponents) -> Vec<(ComponentId, u16)> {
+        fn to_vec(required: &RelatedComponents) -> Vec<(ComponentId, u16)> {
             let mut vec = required
                 .0
                 .iter()

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -477,7 +477,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     #[inline]
     pub fn iter(&self) -> QueryIter<'_, 's, D::ReadOnly, F> {
         // SAFETY:
-        // - `self.world` has permission to access the required components.
+        // - `self.world` has permission to access the related components.
         // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state
@@ -548,7 +548,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         &self,
     ) -> QueryCombinationIter<'_, 's, D::ReadOnly, F, K> {
         // SAFETY:
-        // - `self.world` has permission to access the required components.
+        // - `self.world` has permission to access the related components.
         // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state.as_readonly().iter_combinations_unchecked_manual(
@@ -634,7 +634,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entities: EntityList,
     ) -> QueryManyIter<'_, 's, D::ReadOnly, F, EntityList::IntoIter> {
         // SAFETY:
-        // - `self.world` has permission to access the required components.
+        // - `self.world` has permission to access the related components.
         // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state.as_readonly().iter_many_unchecked_manual(
@@ -711,7 +711,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     #[inline]
     pub unsafe fn iter_unsafe(&self) -> QueryIter<'_, 's, D, F> {
         // SAFETY:
-        // - `self.world` has permission to access the required components.
+        // - `self.world` has permission to access the related components.
         // - The caller ensures that this operation will not result in any aliased mutable accesses.
         unsafe {
             self.state
@@ -737,7 +737,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         &self,
     ) -> QueryCombinationIter<'_, 's, D, F, K> {
         // SAFETY:
-        // - `self.world` has permission to access the required components.
+        // - `self.world` has permission to access the related components.
         // - The caller ensures that this operation will not result in any aliased mutable accesses.
         unsafe {
             self.state
@@ -764,7 +764,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entities: EntityList,
     ) -> QueryManyIter<'_, 's, D, F, EntityList::IntoIter> {
         // SAFETY:
-        // - `self.world` has permission to access the required components.
+        // - `self.world` has permission to access the related components.
         // - The caller ensures that this operation will not result in any aliased mutable accesses.
         unsafe {
             self.state.iter_many_unchecked_manual(

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -523,13 +523,13 @@ impl World {
     pub fn get_required_components<C: Component>(&self) -> Option<&RelatedComponents> {
         let id = self.components().component_id::<C>()?;
         let component_info = self.components().get_info(id)?;
-        Some(component_info.required_components())
+        Some(component_info.related_components())
     }
 
     /// Retrieves the [related components](RelatedComponents) for the component of the given [`ComponentId`], if it exists.
     pub fn get_required_components_by_id(&self, id: ComponentId) -> Option<&RelatedComponents> {
         let component_info = self.components().get_info(id)?;
-        Some(component_info.required_components())
+        Some(component_info.related_components())
     }
 
     /// Registers a new [`Component`] type and returns the [`ComponentId`] created for it.

--- a/crates/bevy_render/src/sync_component.rs
+++ b/crates/bevy_render/src/sync_component.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
-use bevy_ecs::component::Component;
+use bevy_ecs::component::{Component, Relatedness};
 
 use crate::sync_world::{EntityRecord, PendingSyncEntity, SyncToRenderWorld};
 
@@ -30,7 +30,7 @@ impl<C: Component> Default for SyncComponentPlugin<C> {
 
 impl<C: Component> Plugin for SyncComponentPlugin<C> {
     fn build(&self, app: &mut App) {
-        app.register_related_components::<C, SyncToRenderWorld>();
+        app.register_related_components::<C, SyncToRenderWorld>(Relatedness::Required);
 
         app.world_mut().register_component_hooks::<C>().on_remove(
             |mut world, entity, _component_id| {

--- a/crates/bevy_render/src/sync_component.rs
+++ b/crates/bevy_render/src/sync_component.rs
@@ -30,7 +30,7 @@ impl<C: Component> Default for SyncComponentPlugin<C> {
 
 impl<C: Component> Plugin for SyncComponentPlugin<C> {
     fn build(&self, app: &mut App) {
-        app.register_required_components::<C, SyncToRenderWorld>();
+        app.register_related_components::<C, SyncToRenderWorld>();
 
         app.world_mut().register_component_hooks::<C>().on_remove(
             |mut world, entity, _component_id| {


### PR DESCRIPTION
# Objective

As discussed in #16246, required components are a great first step, but it makes sense to use this machinery for less stringent relatonships.

Similarly, https://github.com/bevyengine/bevy/issues/15580 complains that required components are too restrictive for power users with unusual needs, and should be able to be disabled at runtime.

## Solution

As discussed [on Discord](https://discord.com/channels/691052431525675048/1303383992174645389), I've added two new variants of required components (collectively, related components):

- Suggested Components: just docs!
- Included Components: like Required Components, but less strict.

See the `Relatedness` docs included with this PR for the exact behavior.

Fixes #16246; fixes #15580.

## Testing

So far, it compiles...

## TODO

- [ ] write tests
- [ ] double check main docs
- [ ] add removal machinery
- [ ] try to make the error handling nicer
- [ ] rename related components to something that can't be confused with relations (probably linked or affiliated components)
- [ ] split suggested components out from this PR