### PR TITLE
Make `ComponentTicks` field public

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1512,8 +1512,11 @@ impl<'a> TickCells<'a> {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct ComponentTicks {
-    pub(crate) added: Tick,
-    pub(crate) changed: Tick,
+    /// Tick recording the time this component or resource was added.
+    pub added: Tick,
+
+    /// Tick recording the time this component or resource was most recently changed.
+    pub changed: Tick,
 }
 
 impl ComponentTicks {
@@ -1531,19 +1534,8 @@ impl ComponentTicks {
         self.changed.is_newer_than(last_run, this_run)
     }
 
-    /// Returns the tick recording the time this component or resource was most recently changed.
-    #[inline]
-    pub fn last_changed_tick(&self) -> Tick {
-        self.changed
-    }
-
-    /// Returns the tick recording the time this component or resource was added.
-    #[inline]
-    pub fn added_tick(&self) -> Tick {
-        self.added
-    }
-
-    pub(crate) fn new(change_tick: Tick) -> Self {
+    /// Creates a new instance with the same change tick for `added` and `changed`.
+    pub fn new(change_tick: Tick) -> Self {
         Self {
             added: change_tick,
             changed: change_tick,


### PR DESCRIPTION
# Objective

After #12929 we no longer have methods to get component or ticks for previously obtained table column.
It's possible to use a lower level API by indexing the slice, but then it won't be possible to construct `ComponentTicks`.

## Solution

Make `ComponentTicks` fields public. They don't hold any invariants and you can't get a mutable reference to the struct in Bevy.

I also removed the getters since they are no longer needed.

## Testing

- I tested the compilation

---

## Migration Guide

- Instead of using `ComponentTicks::last_changed_tick` and `ComponentTicks::added_tick` methods, access fields directly.
