### PR TITLE
Add a component to enable/disable interactions on a UI node

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -34,6 +34,10 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// when [`ViewVisibility::get()`] is false.
 /// This ensures that hidden UI nodes are not interactable,
 /// and do not end up stuck in an active state if hidden at the wrong time.
+/// 
+/// If a UI node has both [`Interaction`] and [`Interactivity`] components,
+/// [`Interaction`] will always be [`Interaction::None`]
+/// when [`Interactivity::Disabled`] is used.
 ///
 /// Note that you can also control the visibility of a node using the [`Display`](crate::ui_node::Display) property,
 /// which fully collapses it during layout calculations.
@@ -65,6 +69,31 @@ impl Interaction {
 }
 
 impl Default for Interaction {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Describes if an interactive UI node can be interacted with.
+/// 
+/// This is commoly queried with [`Interaction`]
+/// 
+/// Note: click/press-release actions will still be registered. To block propagation see [`FocusPolicy`]
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Component, Default, Debug, PartialEq)]
+#[require(Interaction)]
+pub enum Interactivity {
+    /// The node can be interacted with, it's [`Interaction`] componnent will be updated.
+	Enabled,
+    /// The node can't be interacted with, it's [`Interaction`] componnent will always be [`Interaction::None`].
+	Disabled,
+}
+
+impl Interactivity {
+    const DEFAULT: Self = Self::Enabled;
+}
+
+impl Default for Interactivity {
     fn default() -> Self {
         Self::DEFAULT
     }


### PR DESCRIPTION
# Objective

Project goal: [Component type for enabling/disabling UI widget interactions (allow inactive buttons, etc…)](https://github.com/orgs/bevyengine/projects/10?pane=issue&itemId=7845269)

## Solution

The `Interactivity` component.
It stores a state describing whether an Interactive Node can be interacted with or not.

An interactive node can be described as an entity containing both the `Node` and `Interaction` components.

The `Interactivity` component can be defined with the following properties:
```rs
#[derive(Component, ...)]
#[require(Node, Interaction)]
pub enum Interactivity {
	Enabled,
	Disabled,
}
```

It is used by the `ui_focus_system` to determine whether an interactive node should have it's `Interaction` component updated when an interaction does occur. Furthermore, the assertion should be made that a "disabled" entity will always have it's `Interaction` component set to `Interaction::None`.

It can also be used by secondary systems to, for example, change the visual appearance of a UI node, or to decide whether or not to use `FocusPolicy::Block`.

## Testing

Not yet

## Migration Guide

Migrations are not necessary as the absence of the `Interactivity` component is interpreted as the component being enabled.
