### PR TITLE
Implement `System::system_metas(&self)` and `System::system_metas_mut(&mut self)` for system exploration and configuration

### DIFF
--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -1,7 +1,10 @@
 use alloc::vec::Vec;
 use bevy_utils::prelude::DebugName;
 
-use super::{IntoSystem, ReadOnlySystem, RunSystemError, System, SystemParamValidationError};
+use super::{
+    IntoSystem, ReadOnlySystem, RunSystemError, System, SystemMeta, SystemMetaProvider,
+    SystemParamValidationError,
+};
 use crate::{
     schedule::InternedSystemSet,
     system::{input::SystemInput, SystemIn},
@@ -214,5 +217,30 @@ where
         run_system: impl FnOnce(SystemIn<'_, S>) -> Result<S::Out, RunSystemError>,
     ) -> Result<Self::Out, RunSystemError> {
         run_system(input).map(self)
+    }
+}
+
+impl<Func, S> SystemMetaProvider for AdapterSystem<Func, S>
+where
+    Func: Adapt<S>,
+    S: System + SystemMetaProvider,
+{
+    fn system_metas(&self) -> Vec<&SystemMeta> {
+        self.system.system_metas()
+    }
+
+    fn system_metas_mut(&mut self) -> Vec<&mut SystemMeta> {
+        self.system.system_metas_mut()
+    }
+
+    fn extend_with_system_metas<'a>(&'a self, extendable: &mut impl Extend<&'a SystemMeta>) {
+        self.system.extend_with_system_metas(extendable);
+    }
+
+    fn extend_with_system_metas_mut<'a>(
+        &'a mut self,
+        extendable_mut: &mut impl Extend<&'a mut SystemMeta>,
+    ) {
+        self.system.extend_with_system_metas_mut(extendable_mut);
     }
 }

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -11,7 +11,7 @@ use crate::{
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 
-use super::{IntoSystem, ReadOnlySystem, RunSystemError, System};
+use super::{IntoSystem, ReadOnlySystem, RunSystemError, System, SystemMeta, SystemMetaProvider};
 
 /// Customizes the behavior of a [`CombinatorSystem`].
 ///
@@ -258,6 +258,40 @@ where
     }
 }
 
+impl<Func, A, B> SystemMetaProvider for CombinatorSystem<Func, A, B>
+where
+    Func: Combine<A, B> + 'static,
+    A: System + SystemMetaProvider,
+    B: System + SystemMetaProvider,
+{
+    fn system_metas(&self) -> Vec<&SystemMeta> {
+        let mut vec: Vec<&SystemMeta> = Vec::new();
+        self.a.extend_with_system_metas(&mut vec);
+        self.b.extend_with_system_metas(&mut vec);
+        vec
+    }
+
+    fn system_metas_mut(&mut self) -> Vec<&mut SystemMeta> {
+        let mut vec_mut: Vec<&mut SystemMeta> = Vec::new();
+        self.a.extend_with_system_metas_mut(&mut vec_mut);
+        self.b.extend_with_system_metas_mut(&mut vec_mut);
+        vec_mut
+    }
+
+    fn extend_with_system_metas<'a>(&'a self, extendable: &mut impl Extend<&'a SystemMeta>) {
+        self.a.extend_with_system_metas(extendable);
+        self.b.extend_with_system_metas(extendable);
+    }
+
+    fn extend_with_system_metas_mut<'a>(
+        &'a mut self,
+        extendable_mut: &mut impl Extend<&'a mut SystemMeta>,
+    ) {
+        self.a.extend_with_system_metas_mut(extendable_mut);
+        self.b.extend_with_system_metas_mut(extendable_mut);
+    }
+}
+
 /// An [`IntoSystem`] creating an instance of [`PipeSystem`].
 #[derive(Clone)]
 pub struct IntoPipeSystem<A, B> {
@@ -434,6 +468,39 @@ where
     fn set_last_run(&mut self, last_run: Tick) {
         self.a.set_last_run(last_run);
         self.b.set_last_run(last_run);
+    }
+}
+
+impl<A, B> SystemMetaProvider for PipeSystem<A, B>
+where
+    A: System + SystemMetaProvider,
+    B: System + SystemMetaProvider,
+{
+    fn system_metas(&self) -> Vec<&SystemMeta> {
+        let mut vec: Vec<&SystemMeta> = Vec::new();
+        self.a.extend_with_system_metas(&mut vec);
+        self.b.extend_with_system_metas(&mut vec);
+        vec
+    }
+
+    fn system_metas_mut(&mut self) -> Vec<&mut SystemMeta> {
+        let mut vec_mut: Vec<&mut SystemMeta> = Vec::new();
+        self.a.extend_with_system_metas_mut(&mut vec_mut);
+        self.b.extend_with_system_metas_mut(&mut vec_mut);
+        vec_mut
+    }
+
+    fn extend_with_system_metas<'a>(&'a self, extendable: &mut impl Extend<&'a SystemMeta>) {
+        self.a.extend_with_system_metas(extendable);
+        self.b.extend_with_system_metas(extendable);
+    }
+
+    fn extend_with_system_metas_mut<'a>(
+        &'a mut self,
+        extendable_mut: &mut impl Extend<&'a mut SystemMeta>,
+    ) {
+        self.a.extend_with_system_metas_mut(extendable_mut);
+        self.b.extend_with_system_metas_mut(extendable_mut);
     }
 }
 


### PR DESCRIPTION
Part of #16168

# Objective

Implement `System::system_metas(&self)` and `System::system_metas_mut(&mut self)` for system exploration and configuration.

## Solution

Introduce System::system_metas(&self) and System::system_metas_mut(&mut self) which would return iterator/vector/slice that we can work with.
