### PR TITLE
Rename `AnimationGraph`

### DIFF
--- a/crates/bevy_animation/src/animation_event.rs
+++ b/crates/bevy_animation/src/animation_event.rs
@@ -45,20 +45,20 @@ pub(crate) fn trigger_animation_event(
 /// fn setup_animation(
 ///     mut commands: Commands,
 ///     mut animations: ResMut<Assets<AnimationClip>>,
-///     mut graphs: ResMut<Assets<AnimationGraph>>,
+///     mut graphs: ResMut<Assets<BlendGraph>>,
 /// ) {
 ///     // Create a new animation and add an event at 1.0s.
 ///     let mut animation = AnimationClip::default();
 ///     animation.add_event(1.0, Say("Hello".into()));
-///     
+///
 ///     // Create an animation graph.
-///     let (graph, animation_index) = AnimationGraph::from_clip(animations.add(animation));
+///     let (graph, animation_index) = BlendGraph::from_clip(animations.add(animation));
 ///
 ///     // Start playing the animation.
 ///     let mut player = AnimationPlayer::default();
 ///     player.play(animation_index).repeat();
-///     
-///     commands.spawn((AnimationGraphHandle(graphs.add(graph)), player));
+///
+///     commands.spawn((BlendGraphHandle(graphs.add(graph)), player));
 /// }
 /// #
 /// # bevy_ecs::system::assert_is_system(setup_animation);

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -48,23 +48,23 @@ use crate::{AnimationClip, AnimationTargetId};
 /// For example, consider the following graph:
 ///
 /// ```text
-/// ┌────────────┐                                      
-/// │            │                                      
-/// │    Idle    ├─────────────────────┐                
-/// │            │                     │                
-/// └────────────┘                     │                
-///                                    │                
+/// ┌────────────┐
+/// │            │
+/// │    Idle    ├─────────────────────┐
+/// │            │                     │
+/// └────────────┘                     │
+///                                    │
 /// ┌────────────┐                     │  ┌────────────┐
 /// │            │                     │  │            │
 /// │    Run     ├──┐                  ├──┤    Root    │
 /// │            │  │  ┌────────────┐  │  │            │
 /// └────────────┘  │  │   Blend    │  │  └────────────┘
-///                 ├──┤            ├──┘                
-/// ┌────────────┐  │  │    0.5     │                   
-/// │            │  │  └────────────┘                   
-/// │    Walk    ├──┘                                   
-/// │            │                                      
-/// └────────────┘                                      
+///                 ├──┤            ├──┘
+/// ┌────────────┐  │  │    0.5     │
+/// │            │  │  └────────────┘
+/// │    Walk    ├──┘
+/// │            │
+/// └────────────┘
 /// ```
 ///
 /// In this case, assuming that Idle, Run, and Walk are all playing with weight
@@ -105,10 +105,10 @@ use crate::{AnimationClip, AnimationTargetId};
 /// [RFC 51]: https://github.com/bevyengine/rfcs/blob/main/rfcs/51-animation-composition.md
 #[derive(Asset, Reflect, Clone, Debug, Serialize)]
 #[reflect(Serialize, Debug)]
-#[serde(into = "SerializedAnimationGraph")]
-pub struct AnimationGraph {
+#[serde(into = "SerializedBlendGraph")]
+pub struct BlendGraph {
     /// The `petgraph` data structure that defines the animation graph.
-    pub graph: AnimationDiGraph,
+    pub graph: BlendDiGraph,
 
     /// The index of the root node in the animation graph.
     pub root: NodeIndex,
@@ -125,26 +125,26 @@ pub struct AnimationGraph {
     pub mask_groups: HashMap<AnimationTargetId, AnimationMask>,
 }
 
-/// A [`Handle`] to the [`AnimationGraph`] to be used by the [`AnimationPlayer`](crate::AnimationPlayer) on the same entity.
+/// A [`Handle`] to the [`BlendGraph`] to be used by the [`AnimationPlayer`](crate::AnimationPlayer) on the same entity.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
 #[reflect(Component, Default)]
-pub struct AnimationGraphHandle(pub Handle<AnimationGraph>);
+pub struct BlendGraphHandle(pub Handle<BlendGraph>);
 
-impl From<AnimationGraphHandle> for AssetId<AnimationGraph> {
-    fn from(handle: AnimationGraphHandle) -> Self {
+impl From<BlendGraphHandle> for AssetId<BlendGraph> {
+    fn from(handle: BlendGraphHandle) -> Self {
         handle.id()
     }
 }
 
-impl From<&AnimationGraphHandle> for AssetId<AnimationGraph> {
-    fn from(handle: &AnimationGraphHandle) -> Self {
+impl From<&BlendGraphHandle> for AssetId<BlendGraph> {
+    fn from(handle: &BlendGraphHandle) -> Self {
         handle.id()
     }
 }
 
 /// A type alias for the `petgraph` data structure that defines the animation
 /// graph.
-pub type AnimationDiGraph = DiGraph<AnimationGraphNode, (), u32>;
+pub type BlendDiGraph = DiGraph<BlendGraphNode, (), u32>;
 
 /// The index of either an animation or blend node in the animation graph.
 ///
@@ -155,12 +155,12 @@ pub type AnimationNodeIndex = NodeIndex<u32>;
 
 /// An individual node within an animation graph.
 ///
-/// The [`AnimationGraphNode::node_type`] field specifies the type of node: one
+/// The [`BlendGraphNode::node_type`] field specifies the type of node: one
 /// of a *clip node*, a *blend node*, or an *add node*. Clip nodes, the leaves
 /// of the graph, contain animation clips to play. Blend and add nodes describe
 /// how to combine their children to produce a final animation.
 #[derive(Clone, Reflect, Debug)]
-pub struct AnimationGraphNode {
+pub struct BlendGraphNode {
     /// Animation node data specific to the type of node (clip, blend, or add).
     ///
     /// In the case of clip nodes, this contains the actual animation clip
@@ -229,17 +229,17 @@ pub enum AnimationNodeType {
     Add,
 }
 
-/// An [`AssetLoader`] that can load [`AnimationGraph`]s as assets.
+/// An [`AssetLoader`] that can load [`BlendGraph`]s as assets.
 ///
-/// The canonical extension for [`AnimationGraph`]s is `.animgraph.ron`. Plain
+/// The canonical extension for [`BlendGraph`]s is `.animgraph.ron`. Plain
 /// `.animgraph` is supported as well.
 #[derive(Default)]
-pub struct AnimationGraphAssetLoader;
+pub struct BlendGraphAssetLoader;
 
 /// Various errors that can occur when serializing or deserializing animation
 /// graphs to and from RON, respectively.
 #[derive(Error, Display, Debug, From)]
-pub enum AnimationGraphLoadError {
+pub enum BlendGraphLoadError {
     /// An I/O error occurred.
     #[display("I/O")]
     Io(io::Error),
@@ -255,20 +255,18 @@ pub enum AnimationGraphLoadError {
 /// Acceleration structures for animation graphs that allows Bevy to evaluate
 /// them quickly.
 ///
-/// These are kept up to date as [`AnimationGraph`] instances are added,
+/// These are kept up to date as [`BlendGraph`] instances are added,
 /// modified, and removed.
 #[derive(Default, Reflect, Resource)]
-pub struct ThreadedAnimationGraphs(
-    pub(crate) HashMap<AssetId<AnimationGraph>, ThreadedAnimationGraph>,
-);
+pub struct ThreadedBlendGraphs(pub(crate) HashMap<AssetId<BlendGraph>, ThreadedBlendGraph>);
 
 /// An acceleration structure for an animation graph that allows Bevy to
 /// evaluate it quickly.
 ///
-/// This is kept up to date as the associated [`AnimationGraph`] instance is
+/// This is kept up to date as the associated [`BlendGraph`] instance is
 /// added, modified, or removed.
 #[derive(Default, Reflect)]
-pub struct ThreadedAnimationGraph {
+pub struct ThreadedBlendGraph {
     /// A cached postorder traversal of the graph.
     ///
     /// The node indices here are stored in postorder. Siblings are stored in
@@ -345,7 +343,7 @@ pub struct ThreadedAnimationGraph {
     pub computed_masks: Vec<u64>,
 }
 
-/// A version of [`AnimationGraph`] suitable for serializing as an asset.
+/// A version of [`BlendGraph`] suitable for serializing as an asset.
 ///
 /// Animation nodes can refer to external animation clips, and the [`AssetId`]
 /// is typically not sufficient to identify the clips, since the
@@ -353,32 +351,32 @@ pub struct ThreadedAnimationGraph {
 /// motivates this type, which replaces the `Handle<AnimationClip>` with an
 /// asset path.  Loading an animation graph via the [`bevy_asset::AssetServer`]
 /// actually loads a serialized instance of this type, as does serializing an
-/// [`AnimationGraph`] through `serde`.
+/// [`BlendGraph`] through `serde`.
 #[derive(Serialize, Deserialize)]
-pub struct SerializedAnimationGraph {
-    /// Corresponds to the `graph` field on [`AnimationGraph`].
-    pub graph: DiGraph<SerializedAnimationGraphNode, (), u32>,
-    /// Corresponds to the `root` field on [`AnimationGraph`].
+pub struct SerializedBlendGraph {
+    /// Corresponds to the `graph` field on [`BlendGraph`].
+    pub graph: DiGraph<SerializedBlendGraphNode, (), u32>,
+    /// Corresponds to the `root` field on [`BlendGraph`].
     pub root: NodeIndex,
-    /// Corresponds to the `mask_groups` field on [`AnimationGraph`].
+    /// Corresponds to the `mask_groups` field on [`BlendGraph`].
     pub mask_groups: HashMap<AnimationTargetId, AnimationMask>,
 }
 
-/// A version of [`AnimationGraphNode`] suitable for serializing as an asset.
+/// A version of [`BlendGraphNode`] suitable for serializing as an asset.
 ///
-/// See the comments in [`SerializedAnimationGraph`] for more information.
+/// See the comments in [`SerializedBlendGraph`] for more information.
 #[derive(Serialize, Deserialize)]
-pub struct SerializedAnimationGraphNode {
-    /// Corresponds to the `node_type` field on [`AnimationGraphNode`].
+pub struct SerializedBlendGraphNode {
+    /// Corresponds to the `node_type` field on [`BlendGraphNode`].
     pub node_type: SerializedAnimationNodeType,
-    /// Corresponds to the `mask` field on [`AnimationGraphNode`].
+    /// Corresponds to the `mask` field on [`BlendGraphNode`].
     pub mask: AnimationMask,
-    /// Corresponds to the `weight` field on [`AnimationGraphNode`].
+    /// Corresponds to the `weight` field on [`BlendGraphNode`].
     pub weight: f32,
 }
 
 /// A version of [`AnimationNodeType`] suitable for serializing as part of a
-/// [`SerializedAnimationGraphNode`] asset.
+/// [`SerializedBlendGraphNode`] asset.
 #[derive(Serialize, Deserialize)]
 pub enum SerializedAnimationNodeType {
     /// Corresponds to [`AnimationNodeType::Clip`].
@@ -412,11 +410,11 @@ pub enum SerializedAnimationClip {
 /// groups per animation graph.
 pub type AnimationMask = u64;
 
-impl AnimationGraph {
+impl BlendGraph {
     /// Creates a new animation graph with a root node and no other nodes.
     pub fn new() -> Self {
         let mut graph = DiGraph::default();
-        let root = graph.add_node(AnimationGraphNode::default());
+        let root = graph.add_node(BlendGraphNode::default());
         Self {
             graph,
             root,
@@ -424,7 +422,7 @@ impl AnimationGraph {
         }
     }
 
-    /// A convenience function for creating an [`AnimationGraph`] from a single
+    /// A convenience function for creating an [`BlendGraph`] from a single
     /// [`AnimationClip`].
     ///
     /// The clip will be a direct child of the root with weight 1.0. Both the
@@ -435,7 +433,7 @@ impl AnimationGraph {
         (graph, node_index)
     }
 
-    /// A convenience method to create an [`AnimationGraph`]s with an iterator
+    /// A convenience method to create an [`BlendGraph`]s with an iterator
     /// of clips.
     ///
     /// All of the animation clips will be direct children of the root with
@@ -463,7 +461,7 @@ impl AnimationGraph {
         weight: f32,
         parent: AnimationNodeIndex,
     ) -> AnimationNodeIndex {
-        let node_index = self.graph.add_node(AnimationGraphNode {
+        let node_index = self.graph.add_node(BlendGraphNode {
             node_type: AnimationNodeType::Clip(clip),
             mask: 0,
             weight,
@@ -483,7 +481,7 @@ impl AnimationGraph {
         weight: f32,
         parent: AnimationNodeIndex,
     ) -> AnimationNodeIndex {
-        let node_index = self.graph.add_node(AnimationGraphNode {
+        let node_index = self.graph.add_node(BlendGraphNode {
             node_type: AnimationNodeType::Clip(clip),
             mask,
             weight,
@@ -522,7 +520,7 @@ impl AnimationGraph {
     /// weights multiplied by the weight of the blend. The blend node will have
     /// no mask.
     pub fn add_blend(&mut self, weight: f32, parent: AnimationNodeIndex) -> AnimationNodeIndex {
-        let node_index = self.graph.add_node(AnimationGraphNode {
+        let node_index = self.graph.add_node(BlendGraphNode {
             node_type: AnimationNodeType::Blend,
             mask: 0,
             weight,
@@ -545,7 +543,7 @@ impl AnimationGraph {
         weight: f32,
         parent: AnimationNodeIndex,
     ) -> AnimationNodeIndex {
-        let node_index = self.graph.add_node(AnimationGraphNode {
+        let node_index = self.graph.add_node(BlendGraphNode {
             node_type: AnimationNodeType::Blend,
             mask,
             weight,
@@ -566,7 +564,7 @@ impl AnimationGraph {
         weight: f32,
         parent: AnimationNodeIndex,
     ) -> AnimationNodeIndex {
-        let node_index = self.graph.add_node(AnimationGraphNode {
+        let node_index = self.graph.add_node(BlendGraphNode {
             node_type: AnimationNodeType::Add,
             mask: 0,
             weight,
@@ -589,7 +587,7 @@ impl AnimationGraph {
         weight: f32,
         parent: AnimationNodeIndex,
     ) -> AnimationNodeIndex {
-        let node_index = self.graph.add_node(AnimationGraphNode {
+        let node_index = self.graph.add_node(BlendGraphNode {
             node_type: AnimationNodeType::Add,
             mask,
             weight,
@@ -618,22 +616,22 @@ impl AnimationGraph {
             .is_some()
     }
 
-    /// Returns the [`AnimationGraphNode`] associated with the given index.
+    /// Returns the [`BlendGraphNode`] associated with the given index.
     ///
     /// If no node with the given index exists, returns `None`.
-    pub fn get(&self, animation: AnimationNodeIndex) -> Option<&AnimationGraphNode> {
+    pub fn get(&self, animation: AnimationNodeIndex) -> Option<&BlendGraphNode> {
         self.graph.node_weight(animation)
     }
 
-    /// Returns a mutable reference to the [`AnimationGraphNode`] associated
+    /// Returns a mutable reference to the [`BlendGraphNode`] associated
     /// with the given index.
     ///
     /// If no node with the given index exists, returns `None`.
-    pub fn get_mut(&mut self, animation: AnimationNodeIndex) -> Option<&mut AnimationGraphNode> {
+    pub fn get_mut(&mut self, animation: AnimationNodeIndex) -> Option<&mut BlendGraphNode> {
         self.graph.node_weight_mut(animation)
     }
 
-    /// Returns an iterator over the [`AnimationGraphNode`]s in this graph.
+    /// Returns an iterator over the [`BlendGraphNode`]s in this graph.
     pub fn nodes(&self) -> impl Iterator<Item = AnimationNodeIndex> {
         self.graph.node_indices()
     }
@@ -641,8 +639,8 @@ impl AnimationGraph {
     /// Serializes the animation graph to the given [`Write`]r in RON format.
     ///
     /// If writing to a file, it can later be loaded with the
-    /// [`AnimationGraphAssetLoader`] to reconstruct the graph.
-    pub fn save<W>(&self, writer: &mut W) -> Result<(), AnimationGraphLoadError>
+    /// [`BlendGraphAssetLoader`] to reconstruct the graph.
+    pub fn save<W>(&self, writer: &mut W) -> Result<(), BlendGraphLoadError>
     where
         W: Write,
     {
@@ -660,7 +658,7 @@ impl AnimationGraph {
     }
 }
 
-impl AnimationGraphNode {
+impl BlendGraphNode {
     /// Masks out the mask groups specified by the given `mask` bitfield.
     ///
     /// A 1 in bit position N causes this function to mask out mask group N, and
@@ -700,21 +698,21 @@ impl AnimationGraphNode {
     }
 }
 
-impl Index<AnimationNodeIndex> for AnimationGraph {
-    type Output = AnimationGraphNode;
+impl Index<AnimationNodeIndex> for BlendGraph {
+    type Output = BlendGraphNode;
 
     fn index(&self, index: AnimationNodeIndex) -> &Self::Output {
         &self.graph[index]
     }
 }
 
-impl IndexMut<AnimationNodeIndex> for AnimationGraph {
+impl IndexMut<AnimationNodeIndex> for BlendGraph {
     fn index_mut(&mut self, index: AnimationNodeIndex) -> &mut Self::Output {
         &mut self.graph[index]
     }
 }
 
-impl Default for AnimationGraphNode {
+impl Default for BlendGraphNode {
     fn default() -> Self {
         Self {
             node_type: Default::default(),
@@ -724,18 +722,18 @@ impl Default for AnimationGraphNode {
     }
 }
 
-impl Default for AnimationGraph {
+impl Default for BlendGraph {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl AssetLoader for AnimationGraphAssetLoader {
-    type Asset = AnimationGraph;
+impl AssetLoader for BlendGraphAssetLoader {
+    type Asset = BlendGraph;
 
     type Settings = ();
 
-    type Error = AnimationGraphLoadError;
+    type Error = BlendGraphLoadError;
 
     async fn load(
         &self,
@@ -746,17 +744,17 @@ impl AssetLoader for AnimationGraphAssetLoader {
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
 
-        // Deserialize a `SerializedAnimationGraph` directly, so that we can
+        // Deserialize a `SerializedBlendGraph` directly, so that we can
         // get the list of the animation clips it refers to and load them.
         let mut deserializer = ron::de::Deserializer::from_bytes(&bytes)?;
-        let serialized_animation_graph = SerializedAnimationGraph::deserialize(&mut deserializer)
+        let serialized_animation_graph = SerializedBlendGraph::deserialize(&mut deserializer)
             .map_err(|err| deserializer.span_error(err))?;
 
         // Load all `AssetPath`s to convert from a
-        // `SerializedAnimationGraph` to a real `AnimationGraph`.
-        Ok(AnimationGraph {
+        // `SerializedBlendGraph` to a real `BlendGraph`.
+        Ok(BlendGraph {
             graph: serialized_animation_graph.graph.map(
-                |_, serialized_node| AnimationGraphNode {
+                |_, serialized_node| BlendGraphNode {
                     node_type: match serialized_node.node_type {
                         SerializedAnimationNodeType::Clip(ref clip) => match clip {
                             SerializedAnimationClip::AssetId(asset_id) => {
@@ -784,14 +782,14 @@ impl AssetLoader for AnimationGraphAssetLoader {
     }
 }
 
-impl From<AnimationGraph> for SerializedAnimationGraph {
-    fn from(animation_graph: AnimationGraph) -> Self {
+impl From<BlendGraph> for SerializedBlendGraph {
+    fn from(animation_graph: BlendGraph) -> Self {
         // If any of the animation clips have paths, then serialize them as
         // `SerializedAnimationClip::AssetPath` so that the
-        // `AnimationGraphAssetLoader` can load them.
+        // `BlendGraphAssetLoader` can load them.
         Self {
             graph: animation_graph.graph.map(
-                |_, node| SerializedAnimationGraphNode {
+                |_, node| SerializedBlendGraphNode {
                     weight: node.weight,
                     mask: node.mask,
                     node_type: match node.node_type {
@@ -815,15 +813,15 @@ impl From<AnimationGraph> for SerializedAnimationGraph {
     }
 }
 
-/// A system that creates, updates, and removes [`ThreadedAnimationGraph`]
-/// structures for every changed [`AnimationGraph`].
+/// A system that creates, updates, and removes [`ThreadedBlendGraph`]
+/// structures for every changed [`BlendGraph`].
 ///
-/// The [`ThreadedAnimationGraph`] contains acceleration structures that allow
+/// The [`ThreadedBlendGraph`] contains acceleration structures that allow
 /// for quick evaluation of that graph's animations.
 pub(crate) fn thread_animation_graphs(
-    mut threaded_animation_graphs: ResMut<ThreadedAnimationGraphs>,
-    animation_graphs: Res<Assets<AnimationGraph>>,
-    mut animation_graph_asset_events: EventReader<AssetEvent<AnimationGraph>>,
+    mut threaded_animation_graphs: ResMut<ThreadedBlendGraphs>,
+    animation_graphs: Res<Assets<BlendGraph>>,
+    mut animation_graph_asset_events: EventReader<AssetEvent<BlendGraph>>,
 ) {
     for animation_graph_asset_event in animation_graph_asset_events.read() {
         match *animation_graph_asset_event {
@@ -862,8 +860,8 @@ pub(crate) fn thread_animation_graphs(
     }
 }
 
-impl ThreadedAnimationGraph {
-    /// Removes all the data in this [`ThreadedAnimationGraph`], keeping the
+impl ThreadedBlendGraph {
+    /// Removes all the data in this [`ThreadedBlendGraph`], keeping the
     /// memory around for later reuse.
     fn clear(&mut self) {
         self.threaded_graph.clear();
@@ -871,8 +869,8 @@ impl ThreadedAnimationGraph {
         self.sorted_edges.clear();
     }
 
-    /// Prepares the [`ThreadedAnimationGraph`] for recursion.
-    fn init(&mut self, animation_graph: &AnimationGraph) {
+    /// Prepares the [`ThreadedBlendGraph`] for recursion.
+    fn init(&mut self, animation_graph: &BlendGraph) {
         let node_count = animation_graph.graph.node_count();
         let edge_count = animation_graph.graph.edge_count();
 
@@ -887,18 +885,13 @@ impl ThreadedAnimationGraph {
         self.computed_masks.extend(iter::repeat(0).take(node_count));
     }
 
-    /// Recursively constructs the [`ThreadedAnimationGraph`] for the subtree
+    /// Recursively constructs the [`ThreadedBlendGraph`] for the subtree
     /// rooted at the given node.
     ///
     /// `mask` specifies the computed mask of the parent node. (It could be
     /// fetched from the [`Self::computed_masks`] field, but we pass it
     /// explicitly as a micro-optimization.)
-    fn build_from(
-        &mut self,
-        graph: &AnimationDiGraph,
-        node_index: AnimationNodeIndex,
-        mut mask: u64,
-    ) {
+    fn build_from(&mut self, graph: &BlendDiGraph, node_index: AnimationNodeIndex, mut mask: u64) {
         // Accumulate the mask.
         mask |= graph.node_weight(node_index).unwrap().mask;
         self.computed_masks[node_index.index()] = mask;

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -28,7 +28,7 @@ use core::{
 use graph::AnimationNodeType;
 use prelude::AnimationCurveEvaluator;
 
-use crate::graph::{AnimationGraphHandle, ThreadedAnimationGraphs};
+use crate::graph::{BlendGraphHandle, ThreadedBlendGraphs};
 
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_asset::{Asset, AssetApp, Assets};
@@ -75,7 +75,7 @@ pub mod prelude {
 
 use crate::{
     animation_curves::AnimationCurve,
-    graph::{AnimationGraph, AnimationGraphAssetLoader, AnimationNodeIndex},
+    graph::{AnimationNodeIndex, BlendGraph, BlendGraphAssetLoader},
     transition::{advance_transitions, expire_completed_transitions, AnimationTransitions},
 };
 
@@ -557,7 +557,7 @@ pub enum AnimationEvaluationError {
 /// An stopped animation is considered no longer active.
 #[derive(Debug, Clone, Copy, Reflect)]
 pub struct ActiveAnimation {
-    /// The factor by which the weight from the [`AnimationGraph`] is multiplied.
+    /// The factor by which the weight from the [`BlendGraph`] is multiplied.
     weight: f32,
     repeat: RepeatAnimation,
     speed: f32,
@@ -956,8 +956,8 @@ impl AnimationPlayer {
 fn trigger_untargeted_animation_events(
     mut commands: Commands,
     clips: Res<Assets<AnimationClip>>,
-    graphs: Res<Assets<AnimationGraph>>,
-    players: Query<(Entity, &AnimationPlayer, &AnimationGraphHandle)>,
+    graphs: Res<Assets<BlendGraph>>,
+    players: Query<(Entity, &AnimationPlayer, &BlendGraphHandle)>,
 ) {
     for (entity, player, graph_id) in &players {
         // The graph might not have loaded yet. Safely bail.
@@ -1003,8 +1003,8 @@ fn trigger_untargeted_animation_events(
 pub fn advance_animations(
     time: Res<Time>,
     animation_clips: Res<Assets<AnimationClip>>,
-    animation_graphs: Res<Assets<AnimationGraph>>,
-    mut players: Query<(&mut AnimationPlayer, &AnimationGraphHandle)>,
+    animation_graphs: Res<Assets<BlendGraph>>,
+    mut players: Query<(&mut AnimationPlayer, &BlendGraphHandle)>,
 ) {
     let delta_seconds = time.delta_secs();
     players
@@ -1045,7 +1045,7 @@ pub type AnimationEntityMut<'w> = EntityMutExcept<
         AnimationTarget,
         Transform,
         AnimationPlayer,
-        AnimationGraphHandle,
+        BlendGraphHandle,
     ),
 >;
 
@@ -1054,9 +1054,9 @@ pub type AnimationEntityMut<'w> = EntityMutExcept<
 pub fn animate_targets(
     par_commands: ParallelCommands,
     clips: Res<Assets<AnimationClip>>,
-    graphs: Res<Assets<AnimationGraph>>,
-    threaded_animation_graphs: Res<ThreadedAnimationGraphs>,
-    players: Query<(&AnimationPlayer, &AnimationGraphHandle)>,
+    graphs: Res<Assets<BlendGraph>>,
+    threaded_animation_graphs: Res<ThreadedBlendGraphs>,
+    players: Query<(&AnimationPlayer, &BlendGraphHandle)>,
     mut targets: Query<(
         Entity,
         &AnimationTarget,
@@ -1263,17 +1263,17 @@ pub struct AnimationPlugin;
 impl Plugin for AnimationPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<AnimationClip>()
-            .init_asset::<AnimationGraph>()
-            .init_asset_loader::<AnimationGraphAssetLoader>()
+            .init_asset::<BlendGraph>()
+            .init_asset_loader::<BlendGraphAssetLoader>()
             .register_asset_reflect::<AnimationClip>()
-            .register_asset_reflect::<AnimationGraph>()
+            .register_asset_reflect::<BlendGraph>()
             .register_type::<AnimationPlayer>()
             .register_type::<AnimationTarget>()
             .register_type::<AnimationTransitions>()
-            .register_type::<AnimationGraphHandle>()
+            .register_type::<BlendGraphHandle>()
             .register_type::<NodeIndex>()
-            .register_type::<ThreadedAnimationGraphs>()
-            .init_resource::<ThreadedAnimationGraphs>()
+            .register_type::<ThreadedBlendGraphs>()
+            .init_resource::<ThreadedBlendGraphs>()
             .add_systems(
                 PostUpdate,
                 (

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -18,7 +18,7 @@ use crate::{graph::AnimationNodeIndex, ActiveAnimation, AnimationPlayer};
 /// between animations.
 ///
 /// To use this component, place it on the same entity as the
-/// [`AnimationPlayer`] and [`AnimationGraphHandle`](crate::AnimationGraphHandle). It'll take
+/// [`AnimationPlayer`] and [`BlendGraphHandle`](crate::BlendGraphHandle). It'll take
 /// responsibility for adjusting the weight on the [`ActiveAnimation`] in order
 /// to fade out animations smoothly.
 ///

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -104,7 +104,7 @@ struct ExampleAssets {
     fox: Handle<Scene>,
 
     // The graph containing the animation that the fox will play.
-    fox_animation_graph: Handle<AnimationGraph>,
+    fox_animation_graph: Handle<BlendGraph>,
 
     // The node within the animation graph containing the animation.
     fox_animation_node: AnimationNodeIndex,
@@ -484,7 +484,7 @@ impl FromWorld for ExampleAssets {
         let fox_animation =
             world.load_asset(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb"));
         let (fox_animation_graph, fox_animation_node) =
-            AnimationGraph::from_clip(fox_animation.clone());
+            BlendGraph::from_clip(fox_animation.clone());
 
         ExampleAssets {
             main_sphere: world.add_asset(Sphere::default().mesh().uv(32, 18)),
@@ -510,12 +510,12 @@ impl FromWorld for ExampleAssets {
 fn play_animations(
     mut commands: Commands,
     assets: Res<ExampleAssets>,
-    mut players: Query<(Entity, &mut AnimationPlayer), Without<AnimationGraphHandle>>,
+    mut players: Query<(Entity, &mut AnimationPlayer), Without<BlendGraphHandle>>,
 ) {
     for (entity, mut player) in players.iter_mut() {
         commands
             .entity(entity)
-            .insert(AnimationGraphHandle(assets.fox_animation_graph.clone()));
+            .insert(BlendGraphHandle(assets.fox_animation_graph.clone()));
         player.play(assets.fox_animation_node).repeat();
     }
 }

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -31,7 +31,7 @@ fn main() {
 #[derive(Resource)]
 struct Animations {
     animations: Vec<AnimationNodeIndex>,
-    graph: Handle<AnimationGraph>,
+    graph: Handle<BlendGraph>,
 }
 
 #[derive(Event, AnimationEvent, Reflect, Clone)]
@@ -67,10 +67,10 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    mut graphs: ResMut<Assets<AnimationGraph>>,
+    mut graphs: ResMut<Assets<BlendGraph>>,
 ) {
     // Build the animation graph
-    let (graph, node_indices) = AnimationGraph::from_clips([
+    let (graph, node_indices) = BlendGraph::from_clips([
         asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
         asset_server.load(GltfAssetLabel::Animation(1).from_asset(FOX_PATH)),
         asset_server.load(GltfAssetLabel::Animation(0).from_asset(FOX_PATH)),
@@ -130,13 +130,13 @@ fn setup_scene_once_loaded(
     mut commands: Commands,
     animations: Res<Animations>,
     feet: Res<FoxFeetTargets>,
-    graphs: Res<Assets<AnimationGraph>>,
+    graphs: Res<Assets<BlendGraph>>,
     mut clips: ResMut<Assets<AnimationClip>>,
     mut players: Query<(Entity, &mut AnimationPlayer), Added<AnimationPlayer>>,
 ) {
     fn get_clip<'a>(
         node: AnimationNodeIndex,
-        graph: &AnimationGraph,
+        graph: &BlendGraph,
         clips: &'a mut Assets<AnimationClip>,
     ) -> &'a mut AnimationClip {
         let node = graph.get(node).unwrap();
@@ -172,7 +172,7 @@ fn setup_scene_once_loaded(
 
         commands
             .entity(entity)
-            .insert(AnimationGraphHandle(animations.graph.clone()))
+            .insert(BlendGraphHandle(animations.graph.clone()))
             .insert(transitions);
     }
 }

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -23,7 +23,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut animations: ResMut<Assets<AnimationClip>>,
-    mut graphs: ResMut<Assets<AnimationGraph>>,
+    mut graphs: ResMut<Assets<BlendGraph>>,
 ) {
     // Camera
     commands.spawn((
@@ -124,7 +124,7 @@ fn setup(
     );
 
     // Create the animation graph
-    let (graph, animation_index) = AnimationGraph::from_clip(animations.add(animation));
+    let (graph, animation_index) = BlendGraph::from_clip(animations.add(animation));
 
     // Create the animation player, and set it to repeat
     let mut player = AnimationPlayer::default();
@@ -138,7 +138,7 @@ fn setup(
             MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
             // Add the animation graph and player
             planet,
-            AnimationGraphHandle(graphs.add(graph)),
+            BlendGraphHandle(graphs.add(graph)),
             player,
         ))
         .id();

--- a/examples/animation/animated_ui.rs
+++ b/examples/animation/animated_ui.rs
@@ -7,13 +7,13 @@ use bevy::{
 
 // A type that represents the font size of the first text section.
 //
-// We implement `AnimatableProperty` on this.
+// We implement `BlendableProperty` on this.
 #[derive(Reflect)]
 struct FontSizeProperty;
 
 // A type that represents the color of the first text section.
 //
-// We implement `AnimatableProperty` on this.
+// We implement `BlendableProperty` on this.
 #[derive(Reflect)]
 struct TextColorProperty;
 
@@ -24,7 +24,7 @@ struct AnimationInfo {
     // The ID of the animation target, derived from the name.
     target_id: AnimationTargetId,
     // The animation graph asset.
-    graph: Handle<AnimationGraph>,
+    graph: Handle<BlendGraph>,
     // The index of the node within that graph.
     node_index: AnimationNodeIndex,
 }
@@ -39,7 +39,7 @@ fn main() {
         .run();
 }
 
-impl AnimatableProperty for FontSizeProperty {
+impl BlendableProperty for FontSizeProperty {
     type Component = TextFont;
 
     type Property = f32;
@@ -49,7 +49,7 @@ impl AnimatableProperty for FontSizeProperty {
     }
 }
 
-impl AnimatableProperty for TextColorProperty {
+impl BlendableProperty for TextColorProperty {
     type Component = TextColor;
 
     type Property = Srgba;
@@ -65,7 +65,7 @@ impl AnimatableProperty for TextColorProperty {
 impl AnimationInfo {
     // Programmatically creates the UI animation.
     fn create(
-        animation_graphs: &mut Assets<AnimationGraph>,
+        animation_graphs: &mut Assets<BlendGraph>,
         animation_clips: &mut Assets<AnimationClip>,
     ) -> AnimationInfo {
         // Create an ID that identifies the text node we're going to animate.
@@ -78,15 +78,15 @@ impl AnimationInfo {
         // Create a curve that animates font size.
         //
         // The curve itself is a `Curve<f32>`, and `f32` is `FontSizeProperty::Property`,
-        // which is required by `AnimatableCurve::from_curve`.
+        // which is required by `BlendableCurve::from_curve`.
         animation_clip.add_curve_to_target(
             animation_target_id,
-            AnimatableKeyframeCurve::new(
+            BlendableKeyframeCurve::new(
                 [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
                     .into_iter()
                     .zip([24.0, 80.0, 24.0, 80.0, 24.0, 80.0, 24.0]),
             )
-            .map(AnimatableCurve::<FontSizeProperty, _>::from_curve)
+            .map(BlendableCurve::<FontSizeProperty, _>::from_curve)
             .expect("should be able to build translation curve because we pass in valid samples"),
         );
 
@@ -97,13 +97,13 @@ impl AnimationInfo {
         // `TextColorProperty::Property`, which is required by the `from_curve` method.
         animation_clip.add_curve_to_target(
             animation_target_id,
-            AnimatableKeyframeCurve::new([0.0, 1.0, 2.0, 3.0].into_iter().zip([
+            BlendableKeyframeCurve::new([0.0, 1.0, 2.0, 3.0].into_iter().zip([
                 Srgba::RED,
                 Srgba::GREEN,
                 Srgba::BLUE,
                 Srgba::RED,
             ]))
-            .map(AnimatableCurve::<TextColorProperty, _>::from_curve)
+            .map(BlendableCurve::<TextColorProperty, _>::from_curve)
             .expect("should be able to build translation curve because we pass in valid samples"),
         );
 
@@ -111,8 +111,7 @@ impl AnimationInfo {
         let animation_clip_handle = animation_clips.add(animation_clip);
 
         // Create an animation graph with that clip.
-        let (animation_graph, animation_node_index) =
-            AnimationGraph::from_clip(animation_clip_handle);
+        let (animation_graph, animation_node_index) = BlendGraph::from_clip(animation_clip_handle);
         let animation_graph_handle = animation_graphs.add(animation_graph);
 
         AnimationInfo {
@@ -128,7 +127,7 @@ impl AnimationInfo {
 fn setup(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
+    mut animation_graphs: ResMut<Assets<BlendGraph>>,
     mut animation_clips: ResMut<Assets<AnimationClip>>,
 ) {
     // Create the animation.
@@ -163,7 +162,7 @@ fn setup(
                 ..default()
             },
             animation_player,
-            AnimationGraphHandle(animation_graph),
+            BlendGraphHandle(animation_graph),
         ))
         .with_children(|builder| {
             // Build the text node.

--- a/examples/animation/animation_events.rs
+++ b/examples/animation/animation_events.rs
@@ -49,7 +49,7 @@ fn edit_message(
 fn setup(
     mut commands: Commands,
     mut animations: ResMut<Assets<AnimationClip>>,
-    mut graphs: ResMut<Assets<AnimationGraph>>,
+    mut graphs: ResMut<Assets<BlendGraph>>,
 ) {
     // Camera
     commands.spawn((
@@ -100,11 +100,11 @@ fn setup(
     );
 
     // Create the animation graph.
-    let (graph, animation_index) = AnimationGraph::from_clip(animations.add(animation));
+    let (graph, animation_index) = BlendGraph::from_clip(animations.add(animation));
     let mut player = AnimationPlayer::default();
     player.play(animation_index).repeat();
 
-    commands.spawn((AnimationGraphHandle(graphs.add(graph)), player));
+    commands.spawn((BlendGraphHandle(graphs.add(graph)), player));
 }
 
 // Slowly fade out the text opacity.

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -106,10 +106,10 @@ struct Args {
     save: bool,
 }
 
-/// The [`AnimationGraph`] asset, which specifies how the animations are to
+/// The [`BlendGraph`] asset, which specifies how the animations are to
 /// be blended together.
 #[derive(Clone, Resource)]
-struct ExampleAnimationGraph(Handle<AnimationGraph>);
+struct ExampleBlendGraph(Handle<BlendGraph>);
 
 /// The current weights of the three playing animations.
 #[derive(Component)]
@@ -122,7 +122,7 @@ struct ExampleAnimationWeights {
 fn setup_assets(
     mut commands: Commands,
     mut asset_server: ResMut<AssetServer>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
+    mut animation_graphs: ResMut<Assets<BlendGraph>>,
     args: Res<Args>,
 ) {
     // Create or load the assets.
@@ -150,11 +150,11 @@ fn setup_ui(mut commands: Commands) {
 fn setup_assets_programmatically(
     commands: &mut Commands,
     asset_server: &mut AssetServer,
-    animation_graphs: &mut Assets<AnimationGraph>,
+    animation_graphs: &mut Assets<BlendGraph>,
     _save: bool,
 ) {
     // Create the nodes.
-    let mut animation_graph = AnimationGraph::new();
+    let mut animation_graph = BlendGraph::new();
     let blend_node = animation_graph.add_blend(0.5, animation_graph.root);
     animation_graph.add_clip(
         asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
@@ -198,16 +198,14 @@ fn setup_assets_programmatically(
     let handle = animation_graphs.add(animation_graph);
 
     // Save the assets in a resource.
-    commands.insert_resource(ExampleAnimationGraph(handle));
+    commands.insert_resource(ExampleBlendGraph(handle));
 }
 
 fn setup_assets_via_serialized_animation_graph(
     commands: &mut Commands,
     asset_server: &mut AssetServer,
 ) {
-    commands.insert_resource(ExampleAnimationGraph(
-        asset_server.load(ANIMATION_GRAPH_PATH),
-    ));
+    commands.insert_resource(ExampleBlendGraph(asset_server.load(ANIMATION_GRAPH_PATH)));
 }
 
 /// Spawns the animated fox.
@@ -372,7 +370,7 @@ fn setup_node_lines(commands: &mut Commands) {
 fn init_animations(
     mut commands: Commands,
     mut query: Query<(Entity, &mut AnimationPlayer)>,
-    animation_graph: Res<ExampleAnimationGraph>,
+    animation_graph: Res<ExampleBlendGraph>,
     mut done: Local<bool>,
 ) {
     if *done {
@@ -381,7 +379,7 @@ fn init_animations(
 
     for (entity, mut player) in query.iter_mut() {
         commands.entity(entity).insert((
-            AnimationGraphHandle(animation_graph.0.clone()),
+            BlendGraphHandle(animation_graph.0.clone()),
             ExampleAnimationWeights::default(),
         ));
         for &node_index in &CLIP_NODE_INDICES {

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -345,13 +345,13 @@ fn add_mask_group_control(parent: &mut ChildBuilder, label: &str, width: Val, ma
 fn setup_animation_graph_once_loaded(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
+    mut animation_graphs: ResMut<Assets<BlendGraph>>,
     mut players: Query<(Entity, &mut AnimationPlayer), Added<AnimationPlayer>>,
     targets: Query<(Entity, &AnimationTarget)>,
 ) {
     for (entity, mut player) in &mut players {
         // Load the animation clip from the glTF file.
-        let mut animation_graph = AnimationGraph::new();
+        let mut animation_graph = BlendGraph::new();
         let blend_node = animation_graph.add_additive_blend(1.0, animation_graph.root);
 
         let animation_graph_nodes: [AnimationNodeIndex; 3] =
@@ -388,7 +388,7 @@ fn setup_animation_graph_once_loaded(
         let animation_graph = animation_graphs.add(animation_graph);
         commands
             .entity(entity)
-            .insert(AnimationGraphHandle(animation_graph));
+            .insert(BlendGraphHandle(animation_graph));
 
         // Remove animation targets that aren't in any of the mask groups. If we
         // don't do that, those bones will play all animations at once, which is
@@ -413,8 +413,8 @@ fn setup_animation_graph_once_loaded(
 // off.
 fn handle_button_toggles(
     mut interactions: Query<(&Interaction, &mut AnimationControl), Changed<Interaction>>,
-    mut animation_players: Query<&AnimationGraphHandle, With<AnimationPlayer>>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
+    mut animation_players: Query<&BlendGraphHandle, With<AnimationPlayer>>,
+    mut animation_graphs: ResMut<Assets<BlendGraph>>,
     mut animation_nodes: Option<ResMut<AnimationNodes>>,
     mut app_state: ResMut<AppState>,
 ) {

--- a/examples/animation/eased_motion.rs
+++ b/examples/animation/eased_motion.rs
@@ -20,7 +20,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
+    mut animation_graphs: ResMut<Assets<BlendGraph>>,
     mut animation_clips: ResMut<Assets<AnimationClip>>,
 ) {
     // Create the animation:
@@ -43,7 +43,7 @@ fn setup(
             Transform::from_translation(vec3(-6., 2., 0.)),
             animation_target_name,
             animation_player,
-            AnimationGraphHandle(animation_graph),
+            BlendGraphHandle(animation_graph),
         ))
         .id();
 
@@ -83,7 +83,7 @@ struct AnimationInfo {
     // The ID of the animation target, derived from the name.
     target_id: AnimationTargetId,
     // The animation graph asset.
-    graph: Handle<AnimationGraph>,
+    graph: Handle<BlendGraph>,
     // The index of the node within that graph.
     node_index: AnimationNodeIndex,
 }
@@ -91,7 +91,7 @@ struct AnimationInfo {
 impl AnimationInfo {
     // Programmatically creates the UI animation.
     fn create(
-        animation_graphs: &mut Assets<AnimationGraph>,
+        animation_graphs: &mut Assets<BlendGraph>,
         animation_clips: &mut Assets<AnimationClip>,
     ) -> AnimationInfo {
         // Create an ID that identifies the text node we're going to animate.
@@ -135,8 +135,7 @@ impl AnimationInfo {
         let animation_clip_handle = animation_clips.add(animation_clip);
 
         // Create an animation graph with that clip.
-        let (animation_graph, animation_node_index) =
-            AnimationGraph::from_clip(animation_clip_handle);
+        let (animation_graph, animation_node_index) = BlendGraph::from_clip(animation_clip_handle);
         let animation_graph_handle = animation_graphs.add(animation_graph);
 
         AnimationInfo {

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -65,7 +65,7 @@ fn setup_animations(
     mut commands: Commands,
     mut players: Query<(Entity, &Name, &mut AnimationPlayer)>,
     morph_data: Res<MorphData>,
-    mut graphs: ResMut<Assets<AnimationGraph>>,
+    mut graphs: ResMut<Assets<BlendGraph>>,
 ) {
     if *has_setup {
         return;
@@ -76,10 +76,10 @@ fn setup_animations(
             continue;
         }
 
-        let (graph, animation) = AnimationGraph::from_clip(morph_data.the_wave.clone());
+        let (graph, animation) = BlendGraph::from_clip(morph_data.the_wave.clone());
         commands
             .entity(entity)
-            .insert(AnimationGraphHandle(graphs.add(graph)));
+            .insert(BlendGraphHandle(graphs.add(graph)));
 
         player.play(animation).repeat();
         *has_setup = true;

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -79,7 +79,7 @@ fn main() {
 #[derive(Resource)]
 struct Animations {
     node_indices: Vec<AnimationNodeIndex>,
-    graph: Handle<AnimationGraph>,
+    graph: Handle<BlendGraph>,
 }
 
 const RING_SPACING: f32 = 2.0;
@@ -110,7 +110,7 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
+    mut animation_graphs: ResMut<Assets<BlendGraph>>,
     foxes: Res<Foxes>,
 ) {
     warn!(include_str!("warning_string.txt"));
@@ -121,7 +121,7 @@ fn setup(
         asset_server.load(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb")),
         asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
     ];
-    let mut animation_graph = AnimationGraph::new();
+    let mut animation_graph = BlendGraph::new();
     let node_indices = animation_graph
         .add_clips(animation_clips.iter().cloned(), 1.0, animation_graph.root)
         .collect();
@@ -240,7 +240,7 @@ fn setup_scene_once_loaded(
         for (entity, mut player) in &mut player {
             commands
                 .entity(entity)
-                .insert(AnimationGraphHandle(animations.graph.clone()))
+                .insert(BlendGraphHandle(animations.graph.clone()))
                 .insert(AnimationTransitions::new());
 
             let playing_animation = player.play(animations.node_indices[0]).repeat();

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -236,15 +236,15 @@ mod animation {
     #[derive(Resource)]
     struct Animation {
         animation: AnimationNodeIndex,
-        graph: Handle<AnimationGraph>,
+        graph: Handle<BlendGraph>,
     }
 
     pub fn setup(
         mut commands: Commands,
         asset_server: Res<AssetServer>,
-        mut graphs: ResMut<Assets<AnimationGraph>>,
+        mut graphs: ResMut<Assets<BlendGraph>>,
     ) {
-        let (graph, node) = AnimationGraph::from_clip(
+        let (graph, node) = BlendGraph::from_clip(
             asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
         );
 
@@ -296,7 +296,7 @@ mod animation {
 
         commands
             .entity(entity)
-            .insert(AnimationGraphHandle(animation.graph.clone()))
+            .insert(BlendGraphHandle(animation.graph.clone()))
             .insert(transitions);
     }
 }

--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -41,7 +41,7 @@ fn assign_clips(
     clips: Res<Assets<AnimationClip>>,
     gltf_assets: Res<Assets<Gltf>>,
     assets: Res<AssetServer>,
-    mut graphs: ResMut<Assets<AnimationGraph>>,
+    mut graphs: ResMut<Assets<BlendGraph>>,
     mut commands: Commands,
     mut setup: Local<bool>,
 ) {
@@ -73,7 +73,7 @@ fn assign_clips(
     // is considered to belong to an animation player if all targets of the clip
     // refer to entities whose nearest ancestor player is that animation player.
 
-    let mut player_to_graph: EntityHashMap<(AnimationGraph, Vec<AnimationNodeIndex>)> =
+    let mut player_to_graph: EntityHashMap<(BlendGraph, Vec<AnimationNodeIndex>)> =
         EntityHashMap::default();
 
     for (clip_id, clip) in clips.iter() {
@@ -145,7 +145,7 @@ fn assign_clips(
         commands
             .entity(player_entity)
             .insert(animations)
-            .insert(AnimationGraphHandle(graph));
+            .insert(BlendGraphHandle(graph));
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #15604

## Solution

Replace "AnimationGraph" with "BlendGraph". Rename "animatable" to "blendable" accordingly.

TODO: Update the comments. I see a lot of "`// animation graph`". I'll do this once this is blessed and the scope has been determined.

## Testing

Simple refactor can be evaluated by CI

## Migration Guide

I'll create this once this has been blessed.