### PR TITLE
Return Error instead of panicking when reading invalid dds file

### DIFF
--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -1,3 +1,6 @@
+//! DirectDraw Surface functionality.
+//! https://en.wikipedia.org/wiki/DirectDraw_Surface
+
 #[cfg(debug_assertions)]
 use bevy_utils::warn_once;
 use ddsfile::{Caps2, D3DFormat, Dds, DxgiFormat};
@@ -16,7 +19,9 @@ pub fn dds_buffer_to_image(
     is_srgb: bool,
 ) -> Result<Image, TextureError> {
     let mut cursor = Cursor::new(buffer);
-    let dds = Dds::read(&mut cursor).expect("Failed to parse DDS file");
+    let dds = Dds::read(&mut cursor).map_err(|error| TextureError::InvalidData(
+        format!("Failed to parse DDS file: {}", error.to_string()),
+    ))?;
     let texture_format = dds_format_to_texture_format(&dds, is_srgb)?;
     if !supported_compressed_formats.supports(texture_format) {
         return Err(TextureError::UnsupportedTextureFormat(format!(

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -19,9 +19,9 @@ pub fn dds_buffer_to_image(
     is_srgb: bool,
 ) -> Result<Image, TextureError> {
     let mut cursor = Cursor::new(buffer);
-    let dds = Dds::read(&mut cursor).map_err(|error| TextureError::InvalidData(
-        format!("Failed to parse DDS file: {}", error.to_string()),
-    ))?;
+    let dds = Dds::read(&mut cursor).map_err(|error| {
+        TextureError::InvalidData(format!("Failed to parse DDS file: {}", error.to_string()))
+    })?;
     let texture_format = dds_format_to_texture_format(&dds, is_srgb)?;
     if !supported_compressed_formats.supports(texture_format) {
         return Err(TextureError::UnsupportedTextureFormat(format!(

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -1,5 +1,6 @@
-//! DirectDraw Surface functionality.
-//! https://en.wikipedia.org/wiki/DirectDraw_Surface
+//! `DirectDraw` Surface functionality.
+//!
+//! <https://en.wikipedia.org/wiki/DirectDraw_Surface>
 
 #[cfg(debug_assertions)]
 use bevy_utils::warn_once;
@@ -19,9 +20,8 @@ pub fn dds_buffer_to_image(
     is_srgb: bool,
 ) -> Result<Image, TextureError> {
     let mut cursor = Cursor::new(buffer);
-    let dds = Dds::read(&mut cursor).map_err(|error| {
-        TextureError::InvalidData(format!("Failed to parse DDS file: {}", error.to_string()))
-    })?;
+    let dds = Dds::read(&mut cursor)
+        .map_err(|error| TextureError::InvalidData(format!("Failed to parse DDS file: {error}")))?;
     let texture_format = dds_format_to_texture_format(&dds, is_srgb)?;
     if !supported_compressed_formats.supports(texture_format) {
         return Err(TextureError::UnsupportedTextureFormat(format!(

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -1,6 +1,4 @@
-//! `DirectDraw` Surface functionality.
-//!
-//! <https://en.wikipedia.org/wiki/DirectDraw_Surface>
+//! [DirectDraw Surface](https://en.wikipedia.org/wiki/DirectDraw_Surface) functionality.
 
 #[cfg(debug_assertions)]
 use bevy_utils::warn_once;


### PR DESCRIPTION
# Objective

Fixes #15928

## Solution

return Error instead of panic

## Testing

I don't know if we need to add a test for this. It is pretty straightforward.
