### PR TITLE
AudioPlayer::new()

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -264,6 +264,17 @@ where
     }
 }
 
+impl AudioPlayer<AudioSource> {
+    /// Creates a new [`AudioPlayer`] with the given [`Handle<AudioSource>`].
+    ///
+    /// For convenience reasons, this hard-codes the [`AudioSource`] type. If you want to
+    /// initialize an [`AudioPlayer`] with a different type, just initialize it directly using normal
+    /// tuple struct syntax.
+    pub fn new(source: Handle<AudioSource>) -> Self {
+        Self(source)
+    }
+}
+
 /// Bundle for playing a sound.
 ///
 /// Insert this bundle onto an entity to trigger a sound source to begin playing.

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! fn play_background_audio(asset_server: Res<AssetServer>, mut commands: Commands) {
 //!     commands.spawn((
-//!         AudioPlayer::<AudioSource>(asset_server.load("background_audio.ogg")),
+//!         AudioPlayer::new(asset_server.load("background_audio.ogg")),
 //!         PlaybackSettings::LOOP,
 //!     ));
 //! }

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -11,7 +11,7 @@ fn main() {
 }
 
 fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
-    commands.spawn(AudioPlayer::<AudioSource>(
+    commands.spawn(AudioPlayer::new(
         asset_server.load("sounds/Windless Slopes.ogg"),
     ));
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -12,7 +12,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
-        AudioPlayer::<AudioSource>(asset_server.load("sounds/Windless Slopes.ogg")),
+        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
         MyMusic,
     ));
 }

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -38,7 +38,7 @@ fn setup(
         MeshMaterial2d(materials.add(Color::from(BLUE))),
         Transform::from_translation(Vec3::new(0.0, 50.0, 0.0)),
         Emitter::default(),
-        AudioPlayer::<AudioSource>(asset_server.load("sounds/Windless Slopes.ogg")),
+        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
         PlaybackSettings::LOOP.with_spatial(true),
     ));
 

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -29,7 +29,7 @@ fn setup(
         MeshMaterial3d(materials.add(Color::from(BLUE))),
         Transform::from_xyz(0.0, 0.0, 0.0),
         Emitter::default(),
-        AudioPlayer::<AudioSource>(asset_server.load("sounds/Windless Slopes.ogg")),
+        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
         PlaybackSettings::LOOP.with_spatial(true),
     ));
 

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -162,7 +162,7 @@ fn button_handler(
 
 fn setup_music(asset_server: Res<AssetServer>, mut commands: Commands) {
     commands.spawn((
-        AudioPlayer::<AudioSource>(asset_server.load("sounds/Windless Slopes.ogg")),
+        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
         PlaybackSettings::LOOP,
     ));
 }


### PR DESCRIPTION
# Objective

`AudioPlayer::<AudioSource>(assets.load("audio.mp3"))` is awkward and complicated to type because the `AudioSource` generic type cannot be elided. This is especially annoying because `AudioSource` is used in the majority of cases. Most users don't need to think about it.

## Solution

Add an `AudioPlayer::new()` function that is hard-coded to `AudioSource`, allowing `AudioPlayer::new(assets.load("audio.mp3"))`. Prefer using that in the relevant places.
