### PR TITLE
Fix panic in UiSurface if Node is removed and re-added

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -278,7 +278,12 @@ with UI components as a child of an entity without UI components, your UI layout
 
     let text_buffers = &mut buffer_query;
     // clean up removed nodes after syncing children to avoid potential panic (invalid SlotMap key used)
-    ui_surface.remove_entities(removed_components.removed_nodes.read());
+    ui_surface.remove_entities(
+        removed_components
+            .removed_nodes
+            .read()
+            .filter(|entity| !node_query.contains(*entity)),
+    );
 
     // Re-sync changed children: avoid layout glitches caused by removed nodes that are still set as a child of another node
     computed_node_query.iter().for_each(|(entity, _)| {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -776,7 +776,7 @@ mod tests {
         assert!(ui_surface.entity_to_taffy.is_empty());
     }
 
-    /// bugfix test, see https://github.com/bevyengine/bevy/pull/16288
+    /// bugfix test, see [#16288](https://github.com/bevyengine/bevy/pull/16288)
     #[test]
     fn node_removal_and_reinsert_should_work() {
         let (mut world, mut ui_schedule) = setup_ui_test_world();


### PR DESCRIPTION
# Objective

- Fix bug where `UiSurface::set_camera_children` (and `UiSurface::update_children` sometimes) will panic if you remove and add a `Node` component in a single tick. This is more likely to happen now because of `remove_with_requires`.

## Solution

- Filter out entities with `Node` when cleaning up entities from `RemovedComponents<Node>`.

## Testing

- Not tested (rust compiler refused to cooperate when I tried to patch this into my project), correct by inspection.
