### PR TITLE
Support loading assets from arbitrary filesystem paths by specifying an absolute path as the asset path

### DIFF
--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -34,10 +34,16 @@ impl Reader for File {}
 
 impl AssetReader for FileAssetReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         File::open(&full_path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                AssetReaderError::NotFound(full_path)
+                AssetReaderError::NotFound(full_path.to_path_buf())
             } else {
                 e.into()
             }
@@ -45,11 +51,17 @@ impl AssetReader for FileAssetReader {
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let meta_path = get_meta_path(path);
-        let full_path = self.root_path.join(meta_path);
-        File::open(&full_path).await.map_err(|e| {
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
+        let meta_path = get_meta_path(full_path);
+        File::open(&meta_path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                AssetReaderError::NotFound(full_path)
+                AssetReaderError::NotFound(meta_path)
             } else {
                 e.into()
             }
@@ -60,7 +72,13 @@ impl AssetReader for FileAssetReader {
         &'a self,
         path: &'a Path,
     ) -> Result<Box<PathStream>, AssetReaderError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         match read_dir(&full_path).await {
             Ok(read_dir) => {
                 let root_path = self.root_path.clone();
@@ -82,7 +100,7 @@ impl AssetReader for FileAssetReader {
             }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(full_path.to_path_buf()))
                 } else {
                     Err(e.into())
                 }
@@ -91,17 +109,29 @@ impl AssetReader for FileAssetReader {
     }
 
     async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         let metadata = full_path
             .metadata()
-            .map_err(|_e| AssetReaderError::NotFound(path.to_owned()))?;
+            .map_err(|_e| AssetReaderError::NotFound(full_path.to_path_buf()))?;
         Ok(metadata.file_type().is_dir())
     }
 }
 
 impl AssetWriter for FileAssetWriter {
     async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         if let Some(parent) = full_path.parent() {
             async_fs::create_dir_all(parent).await?;
         }
@@ -111,26 +141,44 @@ impl AssetWriter for FileAssetWriter {
     }
 
     async fn write_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let meta_path = get_meta_path(path);
-        let full_path = self.root_path.join(meta_path);
-        if let Some(parent) = full_path.parent() {
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
+        let meta_path = get_meta_path(full_path);
+        if let Some(parent) = meta_path.parent() {
             async_fs::create_dir_all(parent).await?;
         }
-        let file = File::create(&full_path).await?;
+        let file = File::create(&meta_path).await?;
         let writer: Box<Writer> = Box::new(file);
         Ok(writer)
     }
 
     async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         async_fs::remove_file(full_path).await?;
         Ok(())
     }
 
     async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let meta_path = get_meta_path(path);
-        let full_path = self.root_path.join(meta_path);
-        async_fs::remove_file(full_path).await?;
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
+        let meta_path = get_meta_path(full_path);
+        async_fs::remove_file(meta_path).await?;
         Ok(())
     }
 
@@ -139,8 +187,19 @@ impl AssetWriter for FileAssetWriter {
         old_path: &'a Path,
         new_path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let full_old_path = self.root_path.join(old_path);
-        let full_new_path = self.root_path.join(new_path);
+        let (path_buf_old, path_buf_new);
+        let full_old_path = if old_path.is_absolute() {
+            old_path
+        } else {
+            path_buf_old = self.root_path.join(old_path);
+            &path_buf_old
+        };
+        let full_new_path = if new_path.is_absolute() {
+            new_path
+        } else {
+            path_buf_new = self.root_path.join(new_path);
+            &path_buf_new
+        };
         if let Some(parent) = full_new_path.parent() {
             async_fs::create_dir_all(parent).await?;
         }
@@ -153,31 +212,60 @@ impl AssetWriter for FileAssetWriter {
         old_path: &'a Path,
         new_path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let old_meta_path = get_meta_path(old_path);
-        let new_meta_path = get_meta_path(new_path);
-        let full_old_path = self.root_path.join(old_meta_path);
-        let full_new_path = self.root_path.join(new_meta_path);
-        if let Some(parent) = full_new_path.parent() {
+        let (path_buf_old, path_buf_new);
+        let full_old_path = if old_path.is_absolute() {
+            old_path
+        } else {
+            path_buf_old = self.root_path.join(old_path);
+            &path_buf_old
+        };
+        let full_new_path = if new_path.is_absolute() {
+            new_path
+        } else {
+            path_buf_new = self.root_path.join(new_path);
+            &path_buf_new
+        };
+        let old_meta_path = get_meta_path(full_old_path);
+        let new_meta_path = get_meta_path(full_new_path);
+        if let Some(parent) = new_meta_path.parent() {
             async_fs::create_dir_all(parent).await?;
         }
-        async_fs::rename(full_old_path, full_new_path).await?;
+        async_fs::rename(old_meta_path, new_meta_path).await?;
         Ok(())
     }
 
     async fn create_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         async_fs::create_dir_all(full_path).await?;
         Ok(())
     }
 
     async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         async_fs::remove_dir_all(full_path).await?;
         Ok(())
     }
 
     async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         async_fs::remove_dir(full_path).await?;
         Ok(())
     }
@@ -186,7 +274,13 @@ impl AssetWriter for FileAssetWriter {
         &'a self,
         path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         async_fs::remove_dir_all(&full_path).await?;
         async_fs::create_dir_all(&full_path).await?;
         Ok(())

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -99,12 +99,18 @@ impl Stream for DirReader {
 
 impl AssetReader for FileAssetReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         match File::open(&full_path) {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(full_path.to_path_buf()))
                 } else {
                     Err(e.into())
                 }
@@ -113,13 +119,19 @@ impl AssetReader for FileAssetReader {
     }
 
     async fn read_meta<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
-        let meta_path = get_meta_path(path);
-        let full_path = self.root_path.join(meta_path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
+        let meta_path = get_meta_path(full_path);
         match File::open(&full_path) {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(meta_path))
                 } else {
                     Err(e.into())
                 }
@@ -131,7 +143,13 @@ impl AssetReader for FileAssetReader {
         &'a self,
         path: &'a Path,
     ) -> Result<Box<PathStream>, AssetReaderError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         match read_dir(&full_path) {
             Ok(read_dir) => {
                 let root_path = self.root_path.clone();
@@ -153,7 +171,7 @@ impl AssetReader for FileAssetReader {
             }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
-                    Err(AssetReaderError::NotFound(full_path))
+                    Err(AssetReaderError::NotFound(full_path.to_path_buf()))
                 } else {
                     Err(e.into())
                 }
@@ -162,17 +180,29 @@ impl AssetReader for FileAssetReader {
     }
 
     async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         let metadata = full_path
             .metadata()
-            .map_err(|_e| AssetReaderError::NotFound(path.to_owned()))?;
+            .map_err(|_e| AssetReaderError::NotFound(full_path.to_path_buf()))?;
         Ok(metadata.file_type().is_dir())
     }
 }
 
 impl AssetWriter for FileAssetWriter {
     async fn write<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         if let Some(parent) = full_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -182,43 +212,79 @@ impl AssetWriter for FileAssetWriter {
     }
 
     async fn write_meta<'a>(&'a self, path: &'a Path) -> Result<Box<Writer>, AssetWriterError> {
-        let meta_path = get_meta_path(path);
-        let full_path = self.root_path.join(meta_path);
-        if let Some(parent) = full_path.parent() {
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
+        let meta_path = get_meta_path(full_path);
+        if let Some(parent) = meta_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let file = File::create(&full_path)?;
+        let file = File::create(&meta_path)?;
         let writer: Box<Writer> = Box::new(FileWriter(file));
         Ok(writer)
     }
 
     async fn remove<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         std::fs::remove_file(full_path)?;
         Ok(())
     }
 
     async fn remove_meta<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let meta_path = get_meta_path(path);
-        let full_path = self.root_path.join(meta_path);
-        std::fs::remove_file(full_path)?;
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
+        let meta_path = get_meta_path(full_path);
+        std::fs::remove_file(meta_path)?;
         Ok(())
     }
 
     async fn create_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         std::fs::create_dir_all(full_path)?;
         Ok(())
     }
 
     async fn remove_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         std::fs::remove_dir_all(full_path)?;
         Ok(())
     }
 
     async fn remove_empty_directory<'a>(&'a self, path: &'a Path) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         std::fs::remove_dir(full_path)?;
         Ok(())
     }
@@ -227,7 +293,13 @@ impl AssetWriter for FileAssetWriter {
         &'a self,
         path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let full_path = self.root_path.join(path);
+        let path_buf;
+        let full_path = if path.is_absolute() {
+            path
+        } else {
+            path_buf = self.root_path.join(path);
+            &path_buf
+        };
         std::fs::remove_dir_all(&full_path)?;
         std::fs::create_dir_all(&full_path)?;
         Ok(())
@@ -238,8 +310,19 @@ impl AssetWriter for FileAssetWriter {
         old_path: &'a Path,
         new_path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let full_old_path = self.root_path.join(old_path);
-        let full_new_path = self.root_path.join(new_path);
+        let (path_buf_old, path_buf_new);
+        let full_old_path = if old_path.is_absolute() {
+            old_path
+        } else {
+            path_buf_old = self.root_path.join(old_path);
+            &path_buf_old
+        };
+        let full_new_path = if new_path.is_absolute() {
+            new_path
+        } else {
+            path_buf_new = self.root_path.join(new_path);
+            &path_buf_new
+        };
         if let Some(parent) = full_new_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -252,14 +335,25 @@ impl AssetWriter for FileAssetWriter {
         old_path: &'a Path,
         new_path: &'a Path,
     ) -> Result<(), AssetWriterError> {
-        let old_meta_path = get_meta_path(old_path);
-        let new_meta_path = get_meta_path(new_path);
-        let full_old_path = self.root_path.join(old_meta_path);
-        let full_new_path = self.root_path.join(new_meta_path);
-        if let Some(parent) = full_new_path.parent() {
+        let (path_buf_old, path_buf_new);
+        let full_old_path = if old_path.is_absolute() {
+            old_path
+        } else {
+            path_buf_old = self.root_path.join(old_path);
+            &path_buf_old
+        };
+        let full_new_path = if new_path.is_absolute() {
+            new_path
+        } else {
+            path_buf_new = self.root_path.join(new_path);
+            &path_buf_new
+        };
+        let old_meta_path = get_meta_path(full_old_path);
+        let new_meta_path = get_meta_path(full_new_path);
+        if let Some(parent) = new_meta_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::rename(full_old_path, full_new_path)?;
+        std::fs::rename(old_meta_path, new_meta_path)?;
         Ok(())
     }
 }


### PR DESCRIPTION
# Objective / Problem

There is no way to access asset files outside of the designated asset directory. Bevy's `FileReader`/`FileWriter` always interpret paths relative to the configured root directory (based on either the executable's path, or env var).

Being able to load (and save) assets anywhere in the filesystem is important for many applications, most notably editors.

The goal of this PR is to implement the simplest possible solution to this problem.

## Solution

If an absolute path is provided when loading/saving an asset, it is used as-is.

If a relative path is provided, everything works exactly the same as before. Technically this isn't a breaking change, as
previously only relative paths were accepted by Bevy.

## Testing

- Did you test these changes? If so, how?

I ran the various bevy examples to make sure they can still load their assets (from the `assets` folder, as before).

I then modified them (locally, not committed, ofc) by changing the paths in the source code to various absolute paths
on my computer.

I can confirm Bevy can now successfully load random images and GLTFs on my PC. :)

- Are there any parts that need more testing?

I have not tested asset meta files.

I have not tested the "sync" loader (when the `multi_threaded` cargo feature is disabled).

I have not tested asset writing / saving.

I have not tested the file watcher / hot reloading.

Probably also worth testing loading a complex GLTF file that references external files (for textures, etc) using an absolute path, to make sure asset dependencies work when using the new absolute paths.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?

Nothing special. Just try to load assets from an absolute path.

```rust
asset_server.load("/home/me/Downloads/random_pic.png");
```

Windows:

```rust
asset_server.load("C:\\Users\\Me\\Downloads\\random_pic.png");
```

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

I have not tested on Windows yet. I will be able to do that soon. Will edit the PR description to remove this note when I do.

The changes in this PR are only relevant to desktop platforms (the file asset io is not used on mobile and web).

---

Migration guide not necessary.

This PR, while straightforward, does enable cool new use cases and is probably deserving of a release note.