### PR TITLE
Fixed issue with `derive_more` `Display` Implementations

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1961,13 +1961,13 @@ pub enum ScheduleBuildError {
     #[display("System dependencies contain cycle(s).\n{_0}")]
     DependencyCycle(String),
     /// Tried to order a system (set) relative to a system set it belongs to.
-    #[display("`{0}` and `{_1}` have both `in_set` and `before`-`after` relationships (these might be transitive). This combination is unsolvable as a system cannot run before or after a set it belongs to.")]
+    #[display("`{_0}` and `{_1}` have both `in_set` and `before`-`after` relationships (these might be transitive). This combination is unsolvable as a system cannot run before or after a set it belongs to.")]
     CrossDependency(String, String),
     /// Tried to order system sets that share systems.
-    #[display("`{0}` and `{_1}` have a `before`-`after` relationship (which may be transitive) but share systems.")]
+    #[display("`{_0}` and `{_1}` have a `before`-`after` relationship (which may be transitive) but share systems.")]
     SetsHaveOrderButIntersect(String, String),
     /// Tried to order a system (set) relative to all instances of some system function.
-    #[display("Tried to order against `{0}` in a schedule that has more than one `{0}` instance. `{_0}` is a `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction.")]
+    #[display("Tried to order against `{_0}` in a schedule that has more than one `{_0}` instance. `{_0}` is a `SystemTypeSet` and cannot be used for ordering if ambiguous. Use a different set without this restriction.")]
     SystemTypeSetAmbiguity(String),
     /// Systems with conflicting access have indeterminate run order.
     ///

--- a/crates/bevy_gltf/src/vertex_attributes.rs
+++ b/crates/bevy_gltf/src/vertex_attributes.rs
@@ -248,7 +248,7 @@ pub(crate) enum ConvertAttributeError {
         "Vertex attribute {_0} has format {_1:?} but expected {_3:?} for target attribute {_2}"
     )]
     WrongFormat(String, VertexFormat, String, VertexFormat),
-    #[display("{0} in accessor {_1}")]
+    #[display("{_0} in accessor {_1}")]
     AccessFailed(AccessFailed, usize),
     #[display("Unknown vertex attribute {_0}")]
     UnknownName(String),


### PR DESCRIPTION
# Objective

- Fixed issue where `thiserror` `#[error(...)]` attributes were improperly converted to `derive_more` `#[display(...)]` equivalents in certain cases with a tuple struct/enum variant. 

## Solution

- Used `re/#\[display\(.*\{[0-9]+\}.*\)\]/` to find occurences of using `{0}` where `{_0}` was intended (checked for other field indexes too)and updated accordingly.

## Testing

- `cargo check`
- CI

## Notes

This was discovered by @dtolnay in [this comment](https://github.com/bevyengine/bevy/pull/15772#discussion_r1833730555).
