### PR TITLE
UI/text Example - Clarity Improvements

### DIFF
--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -23,7 +23,7 @@ struct FpsText;
 
 // Marker struct to help identify the color-changing Text component
 #[derive(Component)]
-struct ColorText;
+struct AnimatedText;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // UI camera
@@ -47,7 +47,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             right: Val::Px(5.0),
             ..default()
         },
-        ColorText,
+        AnimatedText,
     ));
 
     // Text with multiple sections
@@ -116,7 +116,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 }
 
-fn text_color_system(time: Res<Time>, mut query: Query<&mut TextColor, With<ColorText>>) {
+fn text_color_system(time: Res<Time>, mut query: Query<&mut TextColor, With<AnimatedText>>) {
     for mut text_color in &mut query {
         let seconds = time.elapsed_secs();
 

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -17,11 +17,11 @@ fn main() {
         .run();
 }
 
-// A unit struct to help identify the FPS UI component, since there may be many Text components
+// Marker struct to help identify the FPS UI component, since there may be many Text components
 #[derive(Component)]
 struct FpsText;
 
-// A unit struct to help identify the color-changing Text component
+// Marker struct to help identify the color-changing Text component
 #[derive(Component)]
 struct ColorText;
 


### PR DESCRIPTION
# Objective

- Fixes #16292 

## Solution

- Renames the `ColorText` marker to `AnimatedText`, which is more distinct from the `TextColor` Bevy component.
- Changes the comment language from `A unit struct` to `Marker struct` for better consistency with other Bevy docs.

## Testing

- Locally, example still runs just fine
