### PR TITLE
Add git hooks (opt-in)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Exit on error, undefined variables, and prevent command masking
+set -euo pipefail
+
+# Set file permissions to read-write for all files
+echo "Setting file permissions to read-write for all files..."
+git ls-files -z | xargs -0 chmod 644
+
+# Run cargo fmt to ensure code is formatted
+echo "Running cargo fmt check..."
+if ! cargo fmt --all --check; then
+    echo "Error: Code is not formatted. Run 'cargo fmt --all' to format it."
+    exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Exit on error, undefined variables, and prevent command masking
+set -euo pipefail
+
+# Set file permissions to read-write for all files
+echo "Setting file permissions to read-write for all files..."
+find . -type f -exec chmod 644 {} \;
+
+# Run cargo fmt to ensure code is formatted
+echo "Running cargo fmt check..."
+if ! cargo fmt --all --check; then
+    echo "Error: Code is not formatted. Run 'cargo fmt --all' to format it."
+    exit 1
+fi
+
+# Build templated pages for features and examples
+echo "Building templated pages for features..."
+cargo run -p build-templated-pages -- features
+
+echo "Building templated pages for examples..."
+cargo run -p build-templated-pages -- examples
+
+# Check if the README.md files in examples or features are dirty
+if [[ -n $(git status --porcelain -- examples/README.md docs/cargo_features.md) ]]; then
+    echo "Error: The files examples/README.md or features/README.md were modified but not committed."
+    exit 1
+fi
+
+echo "All checks passed!"

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,11 @@
+# git hooks
+
+## Justification
+
+If you find it annoying to wait for CI on GitHub to tell you that you forgot to format your code or generate the templated files, you might find it convenient to have this error happen earlier.
+
+## Enabling the hooks
+
+```bash
+git config --local core.hooksPath .githooks
+```


### PR DESCRIPTION
# Objective

Make development as convenient as possible for contributors. The issue identified is that it is very common to forget to run `cargo fmt --all` or generate the templated files. Seeing that the CI failed and then doing so and checking that in increases the iteration time.

## Solution

Provide git hooks to developers so that they can have this check done locally automatically. This feature is opt-in, of course. It increases the processing time for each commit and each push.

## Testing

![image](https://github.com/user-attachments/assets/200ba409-3a44-431d-9aa5-a997afa7f8b4)
