### PR TITLE
Allow jobs to upgrade to macos-15 (using -latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,7 @@ jobs:
         run: cargo run -p ci -- lints
 
   miri:
-    # Explicitly use macOS 14 to take advantage of M1 chip.
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -254,8 +253,7 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
   run-examples-macos-metal:
-    # Explicitly use macOS 14 to take advantage of M1 chip.
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Objective

With [macos-15 becoming the new `-latest` soon](https://github.com/github/roadmap/issues/986), there's probably no particular reason left to pin a runner version here. May as well take the upgrade as it rolls out.

Note that these are still m1-based, you'd have to request a larger runner to get m2.