### PR TITLE
Rename `Rot2::angle_between` to `Rot2::angle_to`

### DIFF
--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -331,7 +331,17 @@ impl Rot2 {
 
     /// Returns the angle in radians needed to make `self` and `other` coincide.
     #[inline]
+    #[deprecated(
+        since = "0.15.0",
+        note = "Use angle_to() instead, the semantics of angle_between will change in the future."
+    )]
     pub fn angle_between(self, other: Self) -> f32 {
+        (other * self.inverse()).as_radians()
+    }
+
+    /// Returns the angle in radians needed to make `self` and `other` coincide.
+    #[inline]
+    pub fn angle_to(self, other: Self) -> f32 {
         (other * self.inverse()).as_radians()
     }
 
@@ -424,7 +434,7 @@ impl Rot2 {
     /// ```
     #[inline]
     pub fn slerp(self, end: Self, s: f32) -> Self {
-        self * Self::radians(self.angle_between(end) * s)
+        self * Self::radians(self.angle_to(end) * s)
     }
 }
 
@@ -567,10 +577,7 @@ mod tests {
         assert_relative_eq!((rotation1 * rotation2.inverse()).as_degrees(), 45.0);
 
         // This should be equivalent to the above
-        assert_relative_eq!(
-            rotation2.angle_between(rotation1),
-            core::f32::consts::FRAC_PI_4
-        );
+        assert_relative_eq!(rotation2.angle_to(rotation1), core::f32::consts::FRAC_PI_4);
     }
 
     #[test]

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -333,7 +333,7 @@ impl Rot2 {
     #[inline]
     #[deprecated(
         since = "0.15.0",
-        note = "Use angle_to() instead, the semantics of angle_between will change in the future."
+        note = "Use `angle_to` instead, the semantics of `angle_between` will change in the future."
     )]
     pub fn angle_between(self, other: Self) -> f32 {
         (other * self.inverse()).as_radians()

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -336,7 +336,7 @@ impl Rot2 {
         note = "Use `angle_to` instead, the semantics of `angle_between` will change in the future."
     )]
     pub fn angle_between(self, other: Self) -> f32 {
-        (other * self.inverse()).as_radians()
+        self.angle_to(other)
     }
 
     /// Returns the angle in radians needed to make `self` and `other` coincide.


### PR DESCRIPTION
# Objective

`glam` has opted to rename `Vec2::angle_between` to `Vec2::angle_to` because of the difference in semantics compared to `Vec3::angle_between` and others which return an unsigned angle `[0, PI]` where `Vec2::angle_between` returns a signed angle `[-PI, PI]`.
We should follow suit for `Rot2` in 0.15 to avoid further confusion.

Links:
- https://github.com/bitshifter/glam-rs/issues/514#issuecomment-2143202294
- https://github.com/bitshifter/glam-rs/pull/524

## Migration Guide

`Rot2::angle_between` has been deprecated, use `Rot2::angle_to` instead, the semantics of `Rot2::angle_between` will change in the future.
