### PR TITLE
Support for `get_many` and `get_many_mut` functions for `Assets<T>`

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -215,6 +215,19 @@ impl<A: Asset> DenseAssetStorage<A> {
         }
     }
 
+    pub(crate) fn get_many<const N: usize>(&self, indices: [AssetIndex; N]) -> [Option<&A>; N] {
+        indices.map(|index| match self.storage.get(index.index as usize)? {
+            Entry::None => None,
+            Entry::Some { value, generation } => {
+                if *generation == index.generation {
+                    value.as_ref()
+                } else {
+                    None
+                }
+            }
+        })
+    }
+
     pub(crate) fn get_mut(&mut self, index: AssetIndex) -> Option<&mut A> {
         let entry = self.storage.get_mut(index.index as usize)?;
         match entry {
@@ -227,6 +240,13 @@ impl<A: Asset> DenseAssetStorage<A> {
                 }
             }
         }
+    }
+
+    pub(crate) fn get_many_mut<const N: usize>(
+        &mut self,
+        indices: [AssetIndex; N],
+    ) -> [Option<&mut A>; N] {
+        todo!()
     }
 
     pub(crate) fn flush(&mut self) {


### PR DESCRIPTION
Part of #16244

# Objective

Add functions for `Assets<T>` to retrieve multiple references similar to `Query<...>`

## Solution

The Query type has the `get_many` and `get_many_mut` methods to get around this limitation, allowing multiple Entities to be looked up at once, with a dynamic check to prevent the same entity from being accessed multiple times. A similar pattern can be followed here.