### PR TITLE
Gitignore all target folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 # Rust build artifacts
-/target
-crates/*/target
+target
+crates/**/target
+benches/**/target
+tools/**/target
 **/*.rs.bk
-/benches/target
-/tools/compile_fail_utils/target
 
 # Cargo
 Cargo.lock
@@ -11,8 +11,8 @@ Cargo.lock
 .cargo/config.toml
 
 # IDE files
-/.idea
-/.vscode
+.idea
+.vscode
 .zed
 dxcompiler.dll
 dxil.dll


### PR DESCRIPTION
# Objective

Some target folders (such as `crates\bevy_color\crates\gen_tests\target`) are not in the `.gitignore`.

## Solution

Use a better pattern.

## Testing

Tested locally
