### PR TITLE
Remove the measure func for image nodes with the default UI texture

### DIFF
--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -270,7 +270,7 @@ pub fn update_image_content_size_system(
 
     for (mut content_size, image, mut image_size) in &mut query {
         if !matches!(image.image_mode, NodeImageMode::Auto)
-            || image.image == TRANSPARENT_IMAGE_HANDLE
+            || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
         {
             if image.is_changed() {
                 // Mutably derefs, marking the `ContentSize` as changed ensuring `ui_layout_system` will remove the node's measure func if present.

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -269,7 +269,9 @@ pub fn update_image_content_size_system(
         * ui_scale.0;
 
     for (mut content_size, image, mut image_size) in &mut query {
-        if !matches!(image.image_mode, NodeImageMode::Auto) {
+        if !matches!(image.image_mode, NodeImageMode::Auto)
+            || image.image == TRANSPARENT_IMAGE_HANDLE
+        {
             if image.is_changed() {
                 // Mutably derefs, marking the `ContentSize` as changed ensuring `ui_layout_system` will remove the node's measure func if present.
                 content_size.measure = None;


### PR DESCRIPTION
# Objective

`ButtonBundle` has an `ImageNode` component (renamed from `UiImage`) which wasn't a problem in 0.14 but in 0.15 `requires` pulls in the `ContentSize` and `NodeImageSize` which means that by default `ButtonBundle` nodes are given a measure func based on the size of the image belonging to `TRANSPARENT_IMAGE_HANDLE`, which is 1x1.

This doesn't make sense and the behaviour for default image nodes should either be to go to zero size or not add a measure func.

## Solution

Check if an image has a `TRANSPARENT_IMAGE_HANDLE` and if it does remove its measure func.

Possibly a zero-sized measure would make more sense, but that would break existing code.

## Testing

Used `ButtonBundle` in the 0.15 `button` example and the border doesn't render, after this change it does.