### PR TITLE
don't check doc in beta ci as it requires nightly

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -59,28 +59,10 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
 
-  check-doc:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@beta
-      - name: Install Linux dependencies
-        uses: ./.github/actions/install-linux-deps
-        with:
-          wayland: true
-          xkb: true
-      - name: Build and check docs
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doc
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 --cfg docsrs_dep"
-
   open-issue:
     name: Warn that weekly CI fails
     runs-on: ubuntu-latest
-    needs: [test, lint, check-compiles, check-doc]
+    needs: [test, lint, check-compiles]
     permissions:
       issues: write
     # Use always() so the job doesn't get canceled if any other jobs fail


### PR DESCRIPTION
# Objective

- Fixes #16350 

## Solution

- Doc requires nightly, it can't run on beta

