### PR TITLE
Fix not being able to run bevy_ui tests

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -33,9 +33,7 @@ bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.15.0-dev" }
-bevy_ui = { path = "../bevy_ui", version = "0.15.0-dev", features = [
-  "bevy_text",
-] }
+bevy_ui = { path = "../bevy_ui", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.15.0-dev" }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -173,7 +173,7 @@ android_shared_stdcxx = ["bevy_audio/android_shared_stdcxx"]
 # screen readers and forks.)
 accesskit_unix = ["bevy_winit/accesskit_unix"]
 
-bevy_text = ["dep:bevy_text", "bevy_ui?/bevy_text"]
+bevy_text = ["dep:bevy_text"]
 
 bevy_render = [
   "dep:bevy_render",

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -27,7 +27,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_render = { path = "../bevy_render", version = "0.15.0-dev" }
 bevy_animation = { path = "../bevy_animation", version = "0.15.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.15.0-dev" }
-bevy_text = { path = "../bevy_text", version = "0.15.0-dev", optional = true }
+bevy_text = { path = "../bevy_text", version = "0.15.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.15.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }


### PR DESCRIPTION
# Objective

Fixes #16316

## Solution

Tweaked a few crates cargo files until I was able to build and test `bevy_ui` via `cargo test --package bevy_ui`

## Testing

- ran `cargo test --package bevy_ui` successfully
- CI should catch anything amiss (Hopefully?)