### PR TITLE
Update rodio requirement from 0.19 to 0.20

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -23,13 +23,13 @@ bevy_derive = { path = "../bevy_derive", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-rodio = { version = "0.19", default-features = false }
+rodio = { version = "0.20", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 cpal = { version = "0.15", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.19", default-features = false, features = [
+rodio = { version = "0.20", default-features = false, features = [
   "wasm-bindgen",
 ] }
 


### PR DESCRIPTION
# Objective

- Supersedes #16344

## Solution

- Updated `rodio` version requirement to `0.20`.
- [Changelog](https://github.com/RustAudio/rodio/blob/master/CHANGELOG.md)

## Testing

- CI checks.