### PR TITLE
Add Immutable `Component` Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1944,6 +1944,17 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "immutable_components"
+path = "examples/ecs/immutable_components.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.immutable_components]
+name = "Immutable Components"
+description = "Demonstrates the creation and utility of immutable components"
+category = "ECS (Entity Component System)"
+wasm = false
+
+[[example]]
 name = "iter_combinations"
 path = "examples/ecs/iter_combinations.rs"
 doc-scrape-examples = true

--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -82,7 +82,7 @@ use core::{
     marker::PhantomData,
 };
 
-use bevy_ecs::{component::Component, world::Mut};
+use bevy_ecs::{component::ComponentMut, world::Mut};
 use bevy_math::{
     curve::{
         cores::{UnevenCore, UnevenCoreError},
@@ -162,7 +162,7 @@ use crate::{
 /// [`AnimationClip`]: crate::AnimationClip
 pub trait AnimatableProperty: Reflect + TypePath {
     /// The type of the component that the property lives on.
-    type Component: Component;
+    type Component: ComponentMut;
 
     /// The type of the property to be animated.
     type Property: Animatable + FromReflect + Reflectable + Clone + Sync + Debug;

--- a/crates/bevy_animation/src/graph.rs
+++ b/crates/bevy_animation/src/graph.rs
@@ -11,7 +11,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
     event::EventReader,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Res, ResMut, Resource},
 };
 use bevy_reflect::{prelude::ReflectDefault, Reflect, ReflectSerialize};
@@ -127,7 +127,7 @@ pub struct AnimationGraph {
 
 /// A [`Handle`] to the [`AnimationGraph`] to be used by the [`AnimationPlayer`](crate::AnimationPlayer) on the same entity.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct AnimationGraphHandle(pub Handle<AnimationGraph>);
 
 impl From<AnimationGraphHandle> for AssetId<AnimationGraph> {

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -357,7 +357,7 @@ impl Hash for AnimationTargetId {
 /// time. However, you can change [`AnimationTarget`]'s `player` property at
 /// runtime to change which player is responsible for animating the entity.
 #[derive(Clone, Copy, Component, Reflect, VisitEntities, VisitEntitiesMut)]
-#[reflect(Component, MapEntities, VisitEntities, VisitEntitiesMut)]
+#[reflect(ComponentMut, Component, MapEntities, VisitEntities, VisitEntitiesMut)]
 pub struct AnimationTarget {
     /// The ID of this animation target.
     ///
@@ -768,7 +768,7 @@ impl ActiveAnimation {
 /// Automatically added to any root animations of a scene when it is
 /// spawned.
 #[derive(Component, Default, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct AnimationPlayer {
     active_animations: HashMap<AnimationNodeIndex, ActiveAnimation>,
     blend_weights: HashMap<AnimationNodeIndex, f32>,

--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -5,7 +5,7 @@
 
 use bevy_ecs::{
     component::Component,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Query, Res},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -29,7 +29,7 @@ use crate::{graph::AnimationNodeIndex, ActiveAnimation, AnimationPlayer};
 /// component to get confused about which animation is the "main" animation, and
 /// transitions will usually be incorrect as a result.
 #[derive(Component, Default, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct AnimationTransitions {
     main_animation: Option<AnimationNodeIndex>,
     transitions: Vec<AnimationTransition>,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -562,7 +562,7 @@ impl App {
     /// adding reflect data as specified in the [`Reflect`](bevy_reflect::Reflect) derive:
     /// ```ignore (No serde "derive" feature)
     /// #[derive(Component, Serialize, Deserialize, Reflect)]
-    /// #[reflect(Component, Serialize, Deserialize)] // will register ReflectComponent, ReflectSerialize, ReflectDeserialize
+    /// #[reflect(ComponentMut, Component, Serialize, Deserialize)] // will register ReflectComponent, ReflectSerialize, ReflectDeserialize
     /// ```
     ///
     /// See [`bevy_reflect::TypeRegistry::register`] for more information.

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -51,7 +51,7 @@ pub enum PlaybackMode {
 /// [`AudioSink`][crate::AudioSink] or [`SpatialAudioSink`][crate::SpatialAudioSink]
 /// components. Changes to this component will *not* be applied to already-playing audio.
 #[derive(Component, Clone, Copy, Debug, Reflect)]
-#[reflect(Default, Component, Debug)]
+#[reflect(Default, ComponentMut, Component, Debug)]
 pub struct PlaybackSettings {
     /// The desired playback behavior.
     pub mode: PlaybackMode,
@@ -147,7 +147,7 @@ impl PlaybackSettings {
 /// This must be accompanied by `Transform` and `GlobalTransform`.
 /// Only one entity with a `SpatialListener` should be present at any given time.
 #[derive(Component, Clone, Debug, Reflect)]
-#[reflect(Default, Component, Debug)]
+#[reflect(Default, ComponentMut, Component, Debug)]
 pub struct SpatialListener {
     /// Left ear position relative to the `GlobalTransform`.
     pub left_ear_offset: Vec3,
@@ -249,7 +249,7 @@ pub type AudioBundle = AudioSourceBundle<AudioSource>;
 /// Playback can be configured using the [`PlaybackSettings`] component. Note that changes to the
 /// `PlaybackSettings` component will *not* affect already-playing audio.
 #[derive(Component, Reflect)]
-#[reflect(Component)]
+#[reflect(ComponentMut, Component)]
 #[require(PlaybackSettings)]
 pub struct AudioPlayer<Source = AudioSource>(pub Handle<Source>)
 where

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "bevy_reflect")]
-use bevy_ecs::reflect::ReflectComponent;
+use bevy_ecs::reflect::{ReflectComponent, ReflectComponentMut};
 use bevy_ecs::{component::Component, entity::Entity, query::QueryData};
 
 use alloc::borrow::Cow;
@@ -27,7 +27,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
-    reflect(Component, Default, Debug)
+    reflect(ComponentMut, Component, Default, Debug)
 )]
 #[cfg_attr(
     all(feature = "serialize", feature = "bevy_reflect"),

--- a/crates/bevy_core_pipeline/src/auto_exposure/settings.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/settings.rs
@@ -2,7 +2,10 @@ use core::ops::RangeInclusive;
 
 use super::compensation_curve::AutoExposureCompensationCurve;
 use bevy_asset::Handle;
-use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_image::Image;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::extract_component::ExtractComponent;
@@ -24,7 +27,7 @@ use bevy_utils::default;
 ///
 /// **Auto Exposure requires compute shaders and is not compatible with WebGL2.**
 #[derive(Component, Clone, Reflect, ExtractComponent)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct AutoExposure {
     /// The range of exposure values for the histogram.
     ///

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -1,5 +1,9 @@
 use super::downsampling_pipeline::BloomUniforms;
-use bevy_ecs::{prelude::Component, query::QueryItem, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    query::QueryItem,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_math::{AspectRatio, URect, UVec4, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
@@ -25,7 +29,7 @@ use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 /// See <https://starlederer.github.io/bloom/> for a visualization of the parametric curve
 /// used in Bevy as well as a visualization of the curve's respective scattering profile.
 #[derive(Component, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct Bloom {
     /// Controls the baseline of how much the image is scattered (default: 0.15).
     ///

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -36,7 +36,7 @@ pub use node::CasNode;
 ///
 /// To use this, add the [`ContrastAdaptiveSharpening`] component to a 2D or 3D camera.
 #[derive(Component, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct ContrastAdaptiveSharpening {
     /// Enable or disable sharpening.
     pub enabled: bool,
@@ -68,7 +68,7 @@ impl Default for ContrastAdaptiveSharpening {
 }
 
 #[derive(Component, Default, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct DenoiseCas(bool);
 
 /// The uniform struct extracted from [`ContrastAdaptiveSharpening`] attached to a [`Camera`].

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -22,7 +22,7 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 /// A 2D camera component. Enables the 2D render graph for a [`Camera`].
 #[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(
     Camera,
     DebandDither,

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// This means "forward" is -Z.
 #[derive(Component, Reflect, Clone, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(
     Camera,
     DebandDither(|| DebandDither::Enabled),

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -21,7 +21,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::{QueryItem, With},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
@@ -77,7 +77,7 @@ pub struct DepthOfFieldPlugin;
 ///
 /// [depth of field]: https://en.wikipedia.org/wiki/Depth_of_field
 #[derive(Component, Clone, Copy, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct DepthOfField {
     /// The appearance of the effect.
     pub mode: DepthOfFieldMode,

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -51,7 +51,7 @@ impl Sensitivity {
 /// A component for enabling Fast Approximate Anti-Aliasing (FXAA)
 /// for a [`bevy_render::camera::Camera`].
 #[derive(Reflect, Component, Clone, ExtractComponent)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[extract_component_filter(With<Camera>)]
 #[doc(alias = "FastApproximateAntiAliasing")]
 pub struct Fxaa {

--- a/crates/bevy_core_pipeline/src/motion_blur/mod.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/mod.rs
@@ -11,7 +11,10 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, Handle};
 use bevy_ecs::{
-    bundle::Bundle, component::Component, query::With, reflect::ReflectComponent,
+    bundle::Bundle,
+    component::Component,
+    query::With,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -69,7 +72,7 @@ pub struct MotionBlurBundle {
 /// # }
 /// ````
 #[derive(Reflect, Component, Clone, ExtractComponent, ShaderType)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[extract_component_filter(With<Camera>)]
 #[require(DepthPrepass, MotionVectorPrepass)]
 pub struct MotionBlur {

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -80,6 +80,8 @@ impl Component for OrderIndependentTransparencySettings {
     }
 }
 
+impl ComponentMut for OrderIndependentTransparencySettings {}
+
 /// A plugin that adds support for Order Independent Transparency (OIT).
 /// This can correctly render some scenes that would otherwise have artifacts due to alpha blending, but uses more memory.
 ///

--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::{QueryItem, With},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
@@ -96,7 +96,7 @@ pub struct PostProcessingPlugin;
 ///
 /// [Gjøl & Svendsen 2016]: https://github.com/playdeadgames/publications/blob/master/INSIDE/rendering_inside_gdc2016.pdf
 #[derive(Reflect, Component, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct ChromaticAberration {
     /// The lookup texture that determines the color gradient.
     ///

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -52,24 +52,24 @@ pub const MOTION_VECTOR_PREPASS_FORMAT: TextureFormat = TextureFormat::Rg16Float
 
 /// If added to a [`crate::prelude::Camera3d`] then depth values will be copied to a separate texture available to the main pass.
 #[derive(Component, Default, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct DepthPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then vertex world normals will be copied to a separate texture available to the main pass.
 /// Normals will have normal map textures already applied.
 #[derive(Component, Default, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct NormalPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then screen space motion vectors will be copied to a separate texture available to the main pass.
 #[derive(Component, Default, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct MotionVectorPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then deferred materials will be rendered to the deferred gbuffer texture and will be available to subsequent passes.
 /// Note the default deferred lighting plugin also requires `DepthPrepass` to work correctly.
 #[derive(Component, Default, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct DeferredPrepass;
 
 #[derive(Component, ShaderType, Clone)]

--- a/crates/bevy_core_pipeline/src/smaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/smaa/mod.rs
@@ -44,7 +44,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::{QueryItem, With},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
@@ -92,7 +92,7 @@ pub struct SmaaPlugin;
 /// A component for enabling Subpixel Morphological Anti-Aliasing (SMAA)
 /// for a [`bevy_render::camera::Camera`].
 #[derive(Clone, Copy, Default, Component, Reflect, ExtractComponent)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[doc(alias = "SubpixelMorphologicalAntiAliasing")]
 pub struct Smaa {
     /// A predefined set of SMAA parameters: i.e. a quality level.

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -10,7 +10,9 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, Handle};
 use bevy_core::FrameCount;
 use bevy_ecs::{
-    prelude::{Bundle, Component, Entity, ReflectComponent},
+    prelude::{
+        Bundle, Component, Entity, {ReflectComponent, ReflectComponentMut},
+    },
     query::{QueryItem, With},
     schedule::IntoSystemConfigs,
     system::{Commands, Query, Res, ResMut, Resource},
@@ -145,7 +147,7 @@ pub struct TemporalAntiAliasBundle {
 ///
 /// If no [`MipBias`] component is attached to the camera, TAA will add a `MipBias(-1.0)` component.
 #[derive(Component, Reflect, Clone)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(TemporalJitter, DepthPrepass, MotionVectorPrepass)]
 #[doc(alias = "Taa")]
 pub struct TemporalAntiAliasing {

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -140,7 +140,7 @@ pub struct TonemappingPipeline {
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]
 #[extract_component_filter(With<Camera>)]
-#[reflect(Component, Debug, Hash, Default, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, Hash, Default, PartialEq)]
 pub enum Tonemapping {
     /// Bypass tonemapping.
     None,
@@ -396,7 +396,7 @@ pub fn prepare_view_tonemapping_pipelines(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]
 #[extract_component_filter(With<Camera>)]
-#[reflect(Component, Debug, Hash, Default, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, Hash, Default, PartialEq)]
 pub enum DebandDither {
     #[default]
     Disabled,

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -721,7 +721,7 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }
 
-#[proc_macro_derive(Component, attributes(component, require))]
+#[proc_macro_derive(Component, attributes(component, require, immutable))]
 pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -73,6 +73,16 @@ use derive_more::derive::{Display, Error};
 ///
 /// # Component and data access
 ///
+/// Components can be marked as immutable by adding the `#[immutable]` attribute when using the
+/// derive macro. Alternatively, a component will be immutable by default when implementing
+/// [`Component`] manually. To make a manually implemented component mutable, also implement
+/// the marker trait [`ComponentMut`].
+///
+/// Immutable components can be removed, replaced, and inserted just like mutable components.
+/// The only guarantee that's enforced is that while an immutable component is attached
+/// to an entity, an exclusive reference `&mut C` will never be produced. This allows
+/// hooks to observe all changes made to an immutable component.
+///
 /// See the [`entity`] module level documentation to learn how to add or remove components from an entity.
 ///
 /// See the documentation for [`Query`] to learn how to access component data from a system.
@@ -391,6 +401,16 @@ pub trait Component: Send + Sync + 'static {
     ) {
     }
 }
+
+/// Marks that a [`Component`] is mutable.
+/// Without this marker, a component is immutable.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a `ComponentMut`",
+    label = "invalid `ComponentMut`",
+    note = "consider annotating `{Self}` with `#[derive(Component)]`",
+    note = "if `{Self}` is a `Component`, it is immutable"
+)]
+pub trait ComponentMut: Component {}
 
 /// The storage used for a specific component type.
 ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -253,7 +253,7 @@ impl Entity {
     /// # use bevy_ecs::{prelude::*, component::*};
     /// # use bevy_reflect::Reflect;
     /// #[derive(Reflect, Component)]
-    /// #[reflect(Component)]
+    /// #[reflect(ComponentMut, Component)]
     /// pub struct MyStruct {
     ///     pub entity: Entity,
     /// }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -46,7 +46,7 @@ pub mod prelude {
     pub use crate::{
         bundle::Bundle,
         change_detection::{DetectChanges, DetectChangesMut, Mut, Ref},
-        component::Component,
+        component::{Component, ComponentMut},
         entity::{Entity, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         observer::{Observer, Trigger},
@@ -71,7 +71,7 @@ pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
     pub use crate::reflect::{
-        AppTypeRegistry, ReflectComponent, ReflectFromWorld, ReflectResource,
+        AppTypeRegistry, ReflectComponent, ReflectComponentMut, ReflectFromWorld, ReflectResource,
     };
 
     #[doc(hidden)]

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{Component, ComponentHooks, StorageType},
+    component::{Component, ComponentHooks, ComponentMut, StorageType},
     entity::Entity,
     observer::ObserverState,
 };
@@ -40,3 +40,5 @@ impl Component for ObservedBy {
         });
     }
 }
+
+impl ComponentMut for ObservedBy {}

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -455,7 +455,7 @@ impl World {
             // Populate ObservedBy for each observed entity.
             for watched_entity in &(*observer_state).descriptor.entities {
                 let mut entity_mut = self.entity_mut(*watched_entity);
-                let mut observed_by = entity_mut.entry::<ObservedBy>().or_default();
+                let mut observed_by = entity_mut.entry::<ObservedBy>().or_default().into_mut();
                 observed_by.0.push(observer_entity);
             }
             (&*observer_state, &mut self.archetypes, &mut self.observers)

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -1,7 +1,7 @@
 use core::any::Any;
 
 use crate::{
-    component::{ComponentHook, ComponentHooks, ComponentId, StorageType},
+    component::{ComponentHook, ComponentHooks, ComponentId, ComponentMut, StorageType},
     observer::{ObserverDescriptor, ObserverTrigger},
     prelude::*,
     query::DebugCheckedUnwrap,
@@ -84,6 +84,8 @@ impl Component for ObserverState {
         });
     }
 }
+
+impl ComponentMut for ObserverState {}
 
 /// Type for function that is run when an observer is triggered.
 ///
@@ -324,6 +326,8 @@ impl Component for Observer {
         });
     }
 }
+
+impl ComponentMut for Observer {}
 
 fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     mut world: DeferredWorld,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundle,
     change_detection::{MaybeThinSlicePtrLocation, Ticks, TicksMut},
-    component::{Component, ComponentId, Components, StorageType, Tick},
+    component::{Component, ComponentId, ComponentMut, Components, StorageType, Tick},
     entity::{Entities, Entity, EntityLocation},
     query::{Access, DebugCheckedUnwrap, FilteredAccess, WorldQuery},
     storage::{ComponentSparseSet, Table, TableRow},
@@ -1607,7 +1607,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
 }
 
 /// SAFETY: access of `&T` is a subset of `&mut T`
-unsafe impl<'__w, T: Component> QueryData for &'__w mut T {
+unsafe impl<'__w, T: ComponentMut> QueryData for &'__w mut T {
     type ReadOnly = &'__w T;
 }
 

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -14,7 +14,7 @@ use bevy_reflect::{
     FromReflect, FromType, PartialReflect, Reflect, ReflectRef, TypePath, TypeRegistry,
 };
 
-use super::{from_reflect_with_fallback, ReflectComponent};
+use super::{from_reflect_with_fallback, ReflectComponentMut};
 
 /// A struct used to operate on reflected [`Bundle`] trait of a type.
 ///
@@ -146,7 +146,7 @@ impl<B: Bundle + Reflect + TypePath> FromType<B> for ReflectBundle {
             },
             apply: |mut entity, reflected_bundle, registry| {
                 if let Some(reflect_component) =
-                    registry.get_type_data::<ReflectComponent>(TypeId::of::<B>())
+                    registry.get_type_data::<ReflectComponentMut>(TypeId::of::<B>())
                 {
                     reflect_component.apply(entity, reflected_bundle);
                 } else {
@@ -167,7 +167,7 @@ impl<B: Bundle + Reflect + TypePath> FromType<B> for ReflectBundle {
             },
             apply_or_insert: |entity, reflected_bundle, registry| {
                 if let Some(reflect_component) =
-                    registry.get_type_data::<ReflectComponent>(TypeId::of::<B>())
+                    registry.get_type_data::<ReflectComponentMut>(TypeId::of::<B>())
                 {
                     reflect_component.apply_or_insert(entity, reflected_bundle, registry);
                 } else {
@@ -205,7 +205,7 @@ fn apply_field(entity: &mut EntityMut, field: &dyn PartialReflect, registry: &Ty
             field.reflect_type_path()
         );
     };
-    if let Some(reflect_component) = registry.get_type_data::<ReflectComponent>(type_id) {
+    if let Some(reflect_component) = registry.get_type_data::<ReflectComponentMut>(type_id) {
         reflect_component.apply(entity.reborrow(), field);
     } else if let Some(reflect_bundle) = registry.get_type_data::<ReflectBundle>(type_id) {
         reflect_bundle.apply(entity.reborrow(), field, registry);
@@ -229,7 +229,7 @@ fn apply_or_insert_field(
         );
     };
 
-    if let Some(reflect_component) = registry.get_type_data::<ReflectComponent>(type_id) {
+    if let Some(reflect_component) = registry.get_type_data::<ReflectComponentMut>(type_id) {
         reflect_component.apply_or_insert(entity, field, registry);
     } else if let Some(reflect_bundle) = registry.get_type_data::<ReflectBundle>(type_id) {
         reflect_bundle.apply_or_insert(entity, field, registry);

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -1,7 +1,7 @@
 use crate::{
     entity::Entity,
     prelude::Mut,
-    reflect::{AppTypeRegistry, ReflectBundle, ReflectComponent},
+    reflect::{AppTypeRegistry, ReflectBundle, ReflectComponentMut},
     system::{EntityCommands, Resource},
     world::{Command, World},
 };
@@ -45,11 +45,11 @@ pub trait ReflectCommandExt {
     ///     data: Box<dyn Reflect>,
     /// }
     /// #[derive(Component, Reflect, Default)]
-    /// #[reflect(Component)]
+    /// #[reflect(ComponentMut, Component)]
     /// struct ComponentA(u32);
     ///
     /// #[derive(Component, Reflect, Default)]
-    /// #[reflect(Component)]
+    /// #[reflect(ComponentMut, Component)]
     /// struct ComponentB(String);
     ///
     /// #[derive(Bundle, Reflect, Default)]
@@ -135,10 +135,10 @@ pub trait ReflectCommandExt {
     ///     data: Box<dyn Reflect>,
     /// }
     /// #[derive(Component, Reflect, Default)]
-    /// #[reflect(Component)]
+    /// #[reflect(ComponentMut, Component)]
     /// struct ComponentA(u32);
     /// #[derive(Component, Reflect, Default)]
-    /// #[reflect(Component)]
+    /// #[reflect(ComponentMut, Component)]
     /// struct ComponentB(String);
     /// #[derive(Bundle, Reflect, Default)]
     /// #[reflect(Bundle)]
@@ -228,7 +228,7 @@ fn insert_reflect(
         panic!("`{type_path}` should be registered in type registry via `App::register_type<{type_path}>`");
     };
 
-    if let Some(reflect_component) = type_registration.data::<ReflectComponent>() {
+    if let Some(reflect_component) = type_registration.data::<ReflectComponentMut>() {
         reflect_component.insert(&mut entity, component.as_partial_reflect(), type_registry);
     } else if let Some(reflect_bundle) = type_registration.data::<ReflectBundle>() {
         reflect_bundle.insert(&mut entity, component.as_partial_reflect(), type_registry);
@@ -290,7 +290,7 @@ fn remove_reflect(
     let Some(type_registration) = type_registry.get_with_type_path(&component_type_path) else {
         return;
     };
-    if let Some(reflect_component) = type_registration.data::<ReflectComponent>() {
+    if let Some(reflect_component) = type_registration.data::<ReflectComponentMut>() {
         reflect_component.remove(&mut entity);
     } else if let Some(reflect_bundle) = type_registration.data::<ReflectBundle>() {
         reflect_bundle.remove(&mut entity);
@@ -351,7 +351,9 @@ mod tests {
         self as bevy_ecs,
         bundle::Bundle,
         component::Component,
-        prelude::{AppTypeRegistry, ReflectComponent},
+        prelude::{
+            AppTypeRegistry, {ReflectComponent, ReflectComponentMut},
+        },
         reflect::{ReflectBundle, ReflectCommandExt},
         system::{Commands, SystemState},
         world::World,
@@ -371,11 +373,11 @@ mod tests {
     }
 
     #[derive(Component, Reflect, Default, PartialEq, Eq, Debug)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct ComponentA(u32);
 
     #[derive(Component, Reflect, Default, PartialEq, Eq, Debug)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct ComponentB(u32);
 
     #[derive(Bundle, Reflect, Default, Debug, PartialEq)]
@@ -393,7 +395,7 @@ mod tests {
         {
             let mut registry = type_registry.write();
             registry.register::<ComponentA>();
-            registry.register_type_data::<ComponentA, ReflectComponent>();
+            registry.register_type_data::<ComponentA, ReflectComponentMut>();
         }
         world.insert_resource(type_registry);
 
@@ -431,7 +433,7 @@ mod tests {
         type_registry.type_registry.register::<ComponentA>();
         type_registry
             .type_registry
-            .register_type_data::<ComponentA, ReflectComponent>();
+            .register_type_data::<ComponentA, ReflectComponentMut>();
         world.insert_resource(type_registry);
 
         let mut system_state: SystemState<Commands> = SystemState::new(&mut world);
@@ -460,7 +462,7 @@ mod tests {
         {
             let mut registry = type_registry.write();
             registry.register::<ComponentA>();
-            registry.register_type_data::<ComponentA, ReflectComponent>();
+            registry.register_type_data::<ComponentA, ReflectComponentMut>();
         }
         world.insert_resource(type_registry);
 
@@ -490,7 +492,7 @@ mod tests {
         type_registry.type_registry.register::<ComponentA>();
         type_registry
             .type_registry
-            .register_type_data::<ComponentA, ReflectComponent>();
+            .register_type_data::<ComponentA, ReflectComponentMut>();
         world.insert_resource(type_registry);
 
         let mut system_state: SystemState<Commands> = SystemState::new(&mut world);

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -21,7 +21,9 @@ mod resource;
 mod visit_entities;
 
 pub use bundle::{ReflectBundle, ReflectBundleFns};
-pub use component::{ReflectComponent, ReflectComponentFns};
+pub use component::{
+    ReflectComponent, ReflectComponentFns, ReflectComponentMut, ReflectComponentMutFns,
+};
 pub use entity_commands::ReflectCommandExt;
 pub use from_world::{ReflectFromWorld, ReflectFromWorldFns};
 pub use map_entities::ReflectMapEntities;

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     entity::{Entities, Entity},
     event::{Event, SendEvent},
     observer::{Observer, TriggerEvent, TriggerTargets},
+    prelude::ComponentMut,
     system::{input::SystemInput, RunSystemWithInput, SystemId},
     world::{
         command_queue::RawCommandQueue, unsafe_world_cell::UnsafeWorldCell, Command, CommandQueue,
@@ -1676,7 +1677,7 @@ pub struct EntityEntryCommands<'a, T> {
     marker: PhantomData<T>,
 }
 
-impl<'a, T: Component> EntityEntryCommands<'a, T> {
+impl<'a, T: ComponentMut> EntityEntryCommands<'a, T> {
     /// Modify the component `T` if it exists, using the function `modify`.
     pub fn and_modify(&mut self, modify: impl FnOnce(Mut<T>) + Send + Sync + 'static) -> &mut Self {
         self.entity_commands
@@ -1687,7 +1688,9 @@ impl<'a, T: Component> EntityEntryCommands<'a, T> {
             });
         self
     }
+}
 
+impl<'a, T: Component> EntityEntryCommands<'a, T> {
     /// [Insert](EntityCommands::insert) `default` into this entity, if `T` is not already present.
     ///
     /// See also [`or_insert_with`](Self::or_insert_with).

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "bevy_reflect")]
-use crate::reflect::ReflectComponent;
+use crate::reflect::{ReflectComponent, ReflectComponentMut};
 use crate::{
     self as bevy_ecs,
     bundle::Bundle,
@@ -24,7 +24,7 @@ struct RegisteredSystem<I, O> {
 /// Marker [`Component`](bevy_ecs::component::Component) for identifying [`SystemId`] [`Entity`]s.
 #[derive(Component)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
-#[cfg_attr(feature = "bevy_reflect", reflect(Component))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Component, ComponentMut))]
 pub struct SystemIdMarker;
 
 /// A system that has been removed from the registry.

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -7,7 +7,7 @@ use crate::{
     entity::Entity,
     event::{Event, EventId, Events, SendBatchIds},
     observer::{Observers, TriggerTargets},
-    prelude::{Component, QueryState},
+    prelude::{ComponentMut, QueryState},
     query::{QueryData, QueryFilter},
     system::{Commands, Query, Resource},
     traversal::Traversal,
@@ -71,7 +71,7 @@ impl<'w> DeferredWorld<'w> {
     /// Retrieves a mutable reference to the given `entity`'s [`Component`] of the given type.
     /// Returns `None` if the `entity` does not have a [`Component`] of the given type.
     #[inline]
-    pub fn get_mut<T: Component>(&mut self, entity: Entity) -> Option<Mut<T>> {
+    pub fn get_mut<T: ComponentMut>(&mut self, entity: Entity) -> Option<Mut<T>> {
         // SAFETY:
         // - `as_unsafe_world_cell` is the only thing that is borrowing world
         // - `as_unsafe_world_cell` provides mutable permission to everything

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -34,8 +34,8 @@ use crate::{
     bundle::{Bundle, BundleInfo, BundleInserter, BundleSpawner, Bundles, InsertMode},
     change_detection::{MutUntyped, TicksMut},
     component::{
-        Component, ComponentDescriptor, ComponentHooks, ComponentId, ComponentInfo, ComponentTicks,
-        Components, RequiredComponents, RequiredComponentsError, Tick,
+        Component, ComponentDescriptor, ComponentHooks, ComponentId, ComponentInfo, ComponentMut,
+        ComponentTicks, Components, RequiredComponents, RequiredComponentsError, Tick,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityHashSet, EntityLocation},
     event::{Event, EventId, Events, SendBatchIds},
@@ -1470,7 +1470,7 @@ impl World {
     /// position.x = 1.0;
     /// ```
     #[inline]
-    pub fn get_mut<T: Component>(&mut self, entity: Entity) -> Option<Mut<T>> {
+    pub fn get_mut<T: ComponentMut>(&mut self, entity: Entity) -> Option<Mut<T>> {
         // SAFETY:
         // - `as_unsafe_world_cell` is the only thing that is borrowing world
         // - `as_unsafe_world_cell` provides mutable permission to everything

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -7,7 +7,9 @@ use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
     change_detection::{MaybeUnsafeCellLocation, MutUntyped, Ticks, TicksMut},
-    component::{ComponentId, ComponentTicks, Components, StorageType, Tick, TickCells},
+    component::{
+        ComponentId, ComponentMut, ComponentTicks, Components, StorageType, Tick, TickCells,
+    },
     entity::{Entities, Entity, EntityLocation},
     observer::Observers,
     prelude::Component,
@@ -843,7 +845,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_mut<T: Component>(self) -> Option<Mut<'w, T>> {
+    pub unsafe fn get_mut<T: ComponentMut>(self) -> Option<Mut<'w, T>> {
         // SAFETY: same safety requirements
         unsafe { self.get_mut_using_ticks(self.world.last_change_tick(), self.world.change_tick()) }
     }
@@ -853,7 +855,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
-    pub(crate) unsafe fn get_mut_using_ticks<T: Component>(
+    pub(crate) unsafe fn get_mut_using_ticks<T: ComponentMut>(
         &self,
         last_change_tick: Tick,
         change_tick: Tick,
@@ -971,6 +973,7 @@ impl<'w> UnsafeEntityCell<'w> {
     /// It is the callers responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
+    /// - the component implements [`ComponentMut`]
     #[inline]
     pub unsafe fn get_mut_by_id(self, component_id: ComponentId) -> Option<MutUntyped<'w>> {
         let info = self.world.components().get_info(component_id)?;

--- a/crates/bevy_gizmos/src/aabb.rs
+++ b/crates/bevy_gizmos/src/aabb.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::Without,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
     system::{Query, Res},
 };
@@ -64,7 +64,7 @@ pub struct AabbGizmoConfigGroup {
 
 /// Add this [`Component`] to an entity to draw its [`Aabb`] component.
 #[derive(Component, Reflect, Default, Debug)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct ShowAabbGizmo {
     /// The color of the box.
     ///

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::Without,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
     system::{Query, Res},
 };
@@ -185,7 +185,7 @@ impl Default for LightGizmoConfigGroup {
 /// Add this [`Component`] to an entity to draw any of its lights components
 /// ([`PointLight`], [`SpotLight`] and [`DirectionalLight`]).
 #[derive(Component, Reflect, Default, Debug)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct ShowLightGizmo {
     /// Default color strategy for this light gizmo. if [`None`], use the one provided by [`LightGizmoConfigGroup`].
     ///

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -102,7 +102,10 @@ pub use loader::*;
 
 use bevy_app::prelude::*;
 use bevy_asset::{Asset, AssetApp, AssetPath, Handle};
-use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_image::CompressedImageFormats;
 use bevy_pbr::StandardMaterial;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
@@ -420,7 +423,7 @@ impl GltfPrimitive {
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-extras).
 #[derive(Clone, Debug, Reflect, Default, Component)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct GltfExtras {
     /// Content of the extra data.
     pub value: String,
@@ -430,7 +433,7 @@ pub struct GltfExtras {
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-extras).
 #[derive(Clone, Debug, Reflect, Default, Component)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct GltfSceneExtras {
     /// Content of the extra data.
     pub value: String,
@@ -440,7 +443,7 @@ pub struct GltfSceneExtras {
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-extras).
 #[derive(Clone, Debug, Reflect, Default, Component)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct GltfMeshExtras {
     /// Content of the extra data.
     pub value: String,
@@ -450,7 +453,7 @@ pub struct GltfMeshExtras {
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-extras).
 #[derive(Clone, Debug, Reflect, Default, Component)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct GltfMaterialExtras {
     /// Content of the extra data.
     pub value: String,
@@ -460,7 +463,7 @@ pub struct GltfMaterialExtras {
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-material).
 #[derive(Clone, Debug, Reflect, Default, Component)]
-#[reflect(Component)]
+#[reflect(ComponentMut, Component)]
 pub struct GltfMaterialName(pub String);
 
 /// Labels that can be used to load part of a glTF

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "reflect")]
 use bevy_ecs::reflect::{
-    ReflectComponent, ReflectFromWorld, ReflectMapEntities, ReflectVisitEntities,
-    ReflectVisitEntitiesMut,
+    ReflectComponent, ReflectComponentMut, ReflectFromWorld, ReflectMapEntities,
+    ReflectVisitEntities, ReflectVisitEntitiesMut,
 };
 use bevy_ecs::{
     component::Component,
@@ -30,6 +30,7 @@ use core::ops::Deref;
     feature = "reflect",
     reflect(
         Component,
+        ComponentMut,
         MapEntities,
         VisitEntities,
         VisitEntitiesMut,

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -112,7 +112,7 @@ impl MorphTargetImage {
 ///
 /// [morph targets]: https://en.wikipedia.org/wiki/Morph_target_animation
 #[derive(Reflect, Default, Debug, Clone, Component)]
-#[reflect(Debug, Component, Default)]
+#[reflect(Debug, ComponentMut, Component, Default)]
 pub struct MorphWeights {
     weights: Vec<f32>,
     /// The first mesh primitive assigned to these weights
@@ -157,7 +157,7 @@ impl MorphWeights {
 ///
 /// [morph targets]: https://en.wikipedia.org/wiki/Morph_target_animation
 #[derive(Reflect, Default, Debug, Clone, Component)]
-#[reflect(Debug, Component, Default)]
+#[reflect(Debug, ComponentMut, Component, Default)]
 pub struct MeshMorphWeights {
     weights: Vec<f32>,
 }

--- a/crates/bevy_mesh/src/skinning.rs
+++ b/crates/bevy_mesh/src/skinning.rs
@@ -2,7 +2,7 @@ use bevy_asset::{Asset, Handle};
 use bevy_ecs::{
     component::Component,
     entity::{Entity, VisitEntities, VisitEntitiesMut},
-    prelude::ReflectComponent,
+    prelude::{ReflectComponent, ReflectComponentMut},
     reflect::{ReflectMapEntities, ReflectVisitEntities, ReflectVisitEntitiesMut},
 };
 use bevy_math::Mat4;
@@ -11,6 +11,7 @@ use core::ops::Deref;
 
 #[derive(Component, Debug, Default, Clone, Reflect, VisitEntities, VisitEntitiesMut)]
 #[reflect(
+    ComponentMut,
     Component,
     MapEntities,
     VisitEntities,

--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     bundle::Bundle,
     component::Component,
     entity::{Entity, EntityHashMap},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::sync_world::MainEntity;
@@ -66,21 +66,21 @@ impl<M: Material> Default for MaterialMeshBundle<M> {
 /// This component contains all mesh entities visible from the current light view.
 /// The collection is updated automatically by [`crate::SimulationLightSystems`].
 #[derive(Component, Clone, Debug, Default, Reflect, Deref, DerefMut)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub struct VisibleMeshEntities {
     #[reflect(ignore)]
     pub entities: Vec<Entity>,
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect, Deref, DerefMut)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub struct RenderVisibleMeshEntities {
     #[reflect(ignore)]
     pub entities: Vec<(Entity, MainEntity)>,
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub struct CubemapVisibleEntities {
     #[reflect(ignore)]
     data: [VisibleMeshEntities; 6],
@@ -105,7 +105,7 @@ impl CubemapVisibleEntities {
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub struct RenderCubemapVisibleEntities {
     #[reflect(ignore)]
     pub(crate) data: [RenderVisibleMeshEntities; 6],
@@ -130,7 +130,7 @@ impl RenderCubemapVisibleEntities {
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component)]
+#[reflect(ComponentMut, Component)]
 pub struct CascadesVisibleEntities {
     /// Map of view entity to the visible entities for each cascade frustum.
     #[reflect(ignore)]
@@ -138,7 +138,7 @@ pub struct CascadesVisibleEntities {
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component)]
+#[reflect(ComponentMut, Component)]
 pub struct RenderCascadesVisibleEntities {
     /// Map of view entity to the visible entities for each cascade frustum.
     #[reflect(ignore)]

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     component::Component,
     entity::{Entity, EntityHashMap},
     query::{With, Without},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Commands, Query, Res, Resource},
     world::{FromWorld, World},
 };
@@ -86,7 +86,7 @@ pub struct ClusterZConfig {
 
 /// Configuration of the clustering strategy for clustered forward rendering
 #[derive(Debug, Copy, Clone, Component, Reflect)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub enum ClusterConfig {
     /// Disable cluster calculations for this view
     None,

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -47,7 +47,7 @@ use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 /// [`StandardMaterial`](crate::StandardMaterial) instances via the `fog_enabled` flag.
 #[derive(Debug, Clone, Component, Reflect, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct DistanceFog {
     /// The color of the fog effect.
     ///

--- a/crates/bevy_pbr/src/light/directional_light.rs
+++ b/crates/bevy_pbr/src/light/directional_light.rs
@@ -50,7 +50,7 @@ use super::*;
 ///     .insert_resource(DirectionalLightShadowMap { size: 2048 });
 /// ```
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(
     Cascades,
     CascadesFrusta,

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -132,7 +132,7 @@ impl Default for DirectionalLightShadowMap {
 /// }.into();
 /// ```
 #[derive(Component, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct CascadeShadowConfig {
     /// The (positive) distance to the far boundary of each cascade.
     pub bounds: Vec<f32>,
@@ -276,7 +276,7 @@ impl From<CascadeShadowConfigBuilder> for CascadeShadowConfig {
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub struct Cascades {
     /// Map from a view to the configuration of each of its [`Cascade`]s.
     pub(crate) cascades: EntityHashMap<Vec<Cascade>>,
@@ -445,7 +445,7 @@ fn calculate_cascade(
 }
 /// Add this component to make a [`Mesh3d`] not cast shadows.
 #[derive(Debug, Component, Reflect, Default)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct NotShadowCaster;
 /// Add this component to make a [`Mesh3d`] not receive shadows.
 ///
@@ -453,7 +453,7 @@ pub struct NotShadowCaster;
 /// cause both “regular” shadows as well as diffusely transmitted shadows to be disabled,
 /// even when [`TransmittedShadowReceiver`] is being used.
 #[derive(Debug, Component, Reflect, Default)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct NotShadowReceiver;
 /// Add this component to make a [`Mesh3d`] using a PBR material with [`diffuse_transmission`](crate::pbr_material::StandardMaterial::diffuse_transmission)`> 0.0`
 /// receive shadows on its diffuse transmission lobe. (i.e. its “backside”)
@@ -463,7 +463,7 @@ pub struct NotShadowReceiver;
 ///
 /// **Note:** Using [`NotShadowReceiver`] overrides this component.
 #[derive(Debug, Component, Reflect, Default)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct TransmittedShadowReceiver;
 
 /// Add this component to a [`Camera3d`](bevy_core_pipeline::core_3d::Camera3d)
@@ -472,7 +472,7 @@ pub struct TransmittedShadowReceiver;
 /// The different modes use different approaches to
 /// [Percentage Closer Filtering](https://developer.nvidia.com/gpugems/gpugems/part-ii-lighting-and-shadows/chapter-11-shadow-map-antialiasing).
 #[derive(Debug, Component, ExtractComponent, Reflect, Clone, Copy, PartialEq, Eq, Default)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub enum ShadowFilteringMethod {
     /// Hardware 2x2.
     ///

--- a/crates/bevy_pbr/src/light/point_light.rs
+++ b/crates/bevy_pbr/src/light/point_light.rs
@@ -20,7 +20,7 @@ use super::*;
 ///
 /// Source: [Wikipedia](https://en.wikipedia.org/wiki/Lumen_(unit)#Lighting)
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(CubemapFrusta, CubemapVisibleEntities, Transform, Visibility)]
 pub struct PointLight {
     /// The color of this light source.

--- a/crates/bevy_pbr/src/light/spot_light.rs
+++ b/crates/bevy_pbr/src/light/spot_light.rs
@@ -8,7 +8,7 @@ use super::*;
 /// shines light only in a given direction. The direction is taken from
 /// the transform, and can be specified with [`Transform::looking_at`](Transform::looking_at).
 #[derive(Component, Debug, Clone, Copy, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(Frustum, VisibleMeshEntities, Transform, Visibility)]
 pub struct SpotLight {
     /// The color of the light.

--- a/crates/bevy_pbr/src/light_probe/environment_map.rs
+++ b/crates/bevy_pbr/src/light_probe/environment_map.rs
@@ -48,7 +48,10 @@
 
 use bevy_asset::{AssetId, Handle};
 use bevy_ecs::{
-    bundle::Bundle, component::Component, query::QueryItem, reflect::ReflectComponent,
+    bundle::Bundle,
+    component::Component,
+    query::QueryItem,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::lifetimeless::Read,
 };
 use bevy_image::Image;
@@ -85,7 +88,7 @@ pub const ENVIRONMENT_MAP_SHADER_HANDLE: Handle<Shader> =
 ///
 /// See [`crate::environment_map`] for detailed information.
 #[derive(Clone, Component, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct EnvironmentMapLight {
     /// The blurry image that represents diffuse radiance surrounding a region.
     pub diffuse_map: Handle<Image>,

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
@@ -132,7 +132,10 @@
 //!
 //! [Why ambient cubes?]: #why-ambient-cubes
 
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_image::Image;
 use bevy_render::{
     render_asset::RenderAssets,
@@ -167,7 +170,7 @@ pub(crate) const IRRADIANCE_VOLUMES_ARE_USABLE: bool = cfg!(not(target_arch = "w
 ///
 /// See [`crate::irradiance_volume`] for detailed information.
 #[derive(Clone, Default, Reflect, Component, Debug)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct IrradianceVolume {
     /// The 3D texture that represents the ambient cubes, encoded in the format
     /// described in [`crate::irradiance_volume`].

--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::With,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
     system::{Commands, Local, Query, Res, ResMut, Resource},
 };
@@ -103,7 +103,7 @@ pub struct LightProbePlugin;
 /// specific technique but rather to a class of techniques. Developers familiar
 /// with other engines should be aware of this terminology difference.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(Transform, Visibility)]
 pub struct LightProbe;
 

--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -35,7 +35,7 @@ use bevy_asset::{load_internal_asset, AssetId, Handle};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
     system::{Query, Res, ResMut, Resource},
 };
@@ -70,7 +70,7 @@ pub struct LightmapPlugin;
 /// has a second UV layer ([`ATTRIBUTE_UV_1`](bevy_render::mesh::Mesh::ATTRIBUTE_UV_1)),
 /// then the lightmap will render using those UVs.
 #[derive(Component, Clone, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct Lightmap {
     /// The lightmap texture.
     pub image: Handle<Image>,

--- a/crates/bevy_pbr/src/mesh_material.rs
+++ b/crates/bevy_pbr/src/mesh_material.rs
@@ -1,7 +1,10 @@
 use crate::Material;
 use bevy_asset::{AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use derive_more::derive::From;
 
@@ -37,7 +40,7 @@ use derive_more::derive::From;
 /// }
 /// ```
 #[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct MeshMaterial3d<M: Material>(pub Handle<M>);
 
 impl<M: Material> Default for MeshMaterial3d<M> {

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -70,7 +70,7 @@ use bevy_ecs::{
     entity::Entity,
     prelude::With,
     query::Has,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
     system::{Commands, Query},
 };
@@ -299,7 +299,7 @@ impl Plugin for MeshletPlugin {
 
 /// The meshlet mesh equivalent of [`bevy_render::mesh::Mesh3d`].
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(Transform, PreviousGlobalTransform, Visibility)]
 pub struct MeshletMesh3d(pub Handle<MeshletMesh>);
 

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -11,7 +11,7 @@ use bevy_core_pipeline::{
 use bevy_ecs::{
     prelude::{Bundle, Component, Entity},
     query::{Has, QueryItem, With},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs,
     system::{Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
@@ -163,7 +163,7 @@ pub struct ScreenSpaceAmbientOcclusionBundle {
 ///
 /// SSAO is not supported on `WebGL2`, and is not currently supported on `WebGPU`.
 #[derive(Component, ExtractComponent, Reflect, PartialEq, Clone, Debug)]
-#[reflect(Component, Debug, Default, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, Default, PartialEq)]
 #[require(DepthPrepass, NormalPrepass)]
 #[doc(alias = "Ssao")]
 pub struct ScreenSpaceAmbientOcclusion {

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     query::{Has, QueryItem, With},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs as _,
     system::{lifetimeless::Read, Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
@@ -97,7 +97,7 @@ pub struct ScreenSpaceReflectionsBundle {
 /// bug whereby Naga doesn't generate correct GLSL when sampling depth buffers,
 /// which is required for screen-space raymarching.
 #[derive(Clone, Copy, Component, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(DepthPrepass, DeferredPrepass)]
 #[doc(alias = "Ssr")]
 pub struct ScreenSpaceReflections {

--- a/crates/bevy_pbr/src/volumetric_fog/mod.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/mod.rs
@@ -39,7 +39,9 @@ use bevy_core_pipeline::core_3d::{
     prepare_core_3d_depth_textures,
 };
 use bevy_ecs::{
-    bundle::Bundle, component::Component, reflect::ReflectComponent,
+    bundle::Bundle,
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs as _,
 };
 use bevy_image::Image;
@@ -74,14 +76,14 @@ pub struct VolumetricFogPlugin;
 ///
 /// This allows the light to generate light shafts/god rays.
 #[derive(Clone, Copy, Component, Default, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct VolumetricLight;
 
 /// When placed on a [`bevy_core_pipeline::core_3d::Camera3d`], enables
 /// volumetric fog and volumetric lighting, also known as light shafts or god
 /// rays.
 #[derive(Clone, Copy, Component, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct VolumetricFog {
     /// Color of the ambient light.
     ///
@@ -145,7 +147,7 @@ pub struct FogVolumeBundle {
 }
 
 #[derive(Clone, Component, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(Transform, Visibility)]
 pub struct FogVolume {
     /// The color of the fog.

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -58,7 +58,7 @@ impl Plugin for WireframePlugin {
 ///
 /// This requires the [`WireframePlugin`] to be enabled.
 #[derive(Component, Debug, Clone, Default, Reflect, Eq, PartialEq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct Wireframe;
 
 /// Sets the color of the [`Wireframe`] of the entity it is attached to.
@@ -71,7 +71,7 @@ pub struct Wireframe;
 // This could blow up in size if people use random colored wireframes for each mesh.
 // It will also be important to remove unused materials from the cache.
 #[derive(Component, Debug, Clone, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct WireframeColor {
     pub color: Color,
 }
@@ -81,7 +81,7 @@ pub struct WireframeColor {
 ///
 /// This requires the [`WireframePlugin`] to be enabled.
 #[derive(Component, Debug, Clone, Default, Reflect, Eq, PartialEq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct NoWireframe;
 
 #[derive(Resource, Debug, Clone, Default, ExtractResource, Reflect)]

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -58,7 +58,7 @@ use crate::{
 /// The documentation for the [`pointer_events`] explains the events this module exposes and
 /// the order in which they fire.
 #[derive(Clone, PartialEq, Debug, Reflect, Component)]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 pub struct Pointer<E: Debug + Clone + Reflect> {
     /// The original target of this picking event, before bubbling
     pub target: Entity,

--- a/crates/bevy_picking/src/focus.rs
+++ b/crates/bevy_picking/src/focus.rs
@@ -189,7 +189,7 @@ fn build_hover_map(
 /// the entity will be considered pressed. If that entity is instead being hovered by both pointers,
 /// it will be considered hovered.
 #[derive(Component, Copy, Clone, Default, Eq, PartialEq, Debug, Reflect)]
-#[reflect(Component, Default, PartialEq, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Debug)]
 pub enum PickingInteraction {
     /// The entity is being pressed down by a pointer.
     Pressed = 2,

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -185,7 +185,7 @@ pub mod prelude {
 /// make an entity non-hoverable, or allow items below it to be hovered. See the documentation on
 /// the fields for more details.
 #[derive(Component, Debug, Clone, Reflect, PartialEq, Eq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct PickingBehavior {
     /// Should this entity block entities below it from being picked?
     ///

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -52,7 +52,7 @@ impl Default for MeshPickingSettings {
 /// An optional component that marks cameras and target entities that should be used in the [`MeshPickingPlugin`].
 /// Only needed if [`MeshPickingSettings::require_markers`] is set to `true`, and ignored otherwise.
 #[derive(Debug, Clone, Default, Component, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct RayCastPickable;
 
 /// Adds the mesh picking backend to your app.

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -100,14 +100,14 @@ pub enum Backfaces {
 
 /// Disables backface culling for [ray casts](MeshRayCast) on this entity.
 #[derive(Component, Copy, Clone, Default, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct RayCastBackfaces;
 
 /// A simplified mesh component that can be used for [ray casting](super::MeshRayCast).
 ///
 /// Consider using this component for complex meshes that don't need perfectly accurate ray casting.
 #[derive(Component, Clone, Debug, Deref, DerefMut, Reflect)]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 pub struct SimplifiedMesh(pub Handle<Mesh>);
 
 type MeshFilter = Or<(With<Mesh3d>, With<Mesh2d>, With<SimplifiedMesh>)>;

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -27,7 +27,7 @@ use crate::backend::HitData;
 /// stable ID that persists regardless of the Entity they are associated with.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash, Component, Reflect)]
 #[require(PointerLocation, PointerPress, PointerInteraction)]
-#[reflect(Component, Default, Debug, Hash, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, Hash, PartialEq)]
 pub enum PointerId {
     /// The mouse pointer.
     #[default]
@@ -66,7 +66,7 @@ impl PointerId {
 /// Holds a list of entities this pointer is currently interacting with, sorted from nearest to
 /// farthest.
 #[derive(Debug, Default, Clone, Component, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct PointerInteraction {
     pub(crate) sorted_entities: Vec<(Entity, HitData)>,
 }
@@ -109,7 +109,7 @@ pub fn update_pointer_map(pointers: Query<(Entity, &PointerId)>, mut map: ResMut
 
 /// Tracks the state of the pointer's buttons in response to [`PointerInput`] events.
 #[derive(Debug, Default, Clone, Component, Reflect, PartialEq, Eq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct PointerPress {
     primary: bool,
     secondary: bool,
@@ -171,7 +171,7 @@ impl PointerButton {
 
 /// Component that tracks a pointer's current [`Location`].
 #[derive(Debug, Default, Clone, Component, Reflect, PartialEq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct PointerLocation {
     /// The [`Location`] of the pointer. Note that a location is both the target, and the position
     /// on the target.
@@ -203,7 +203,7 @@ impl PointerLocation {
 ///   render target. It is up to picking backends to associate a Pointer's `Location` with a
 ///   specific `Camera`, if any.
 #[derive(Debug, Clone, Component, Reflect, PartialEq)]
-#[reflect(Component, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, PartialEq)]
 pub struct Location {
     /// The [`NormalizedRenderTarget`] associated with the pointer, usually a window.
     pub target: NormalizedRenderTarget,

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     entity::Entity,
     event::EventCursor,
     query::QueryBuilder,
-    reflect::{AppTypeRegistry, ReflectComponent},
+    reflect::{AppTypeRegistry, ReflectComponentMut},
     removal_detection::RemovedComponentEntity,
     system::{In, Local},
     world::{EntityRef, EntityWorldMut, FilteredEntityRef, World},
@@ -567,18 +567,18 @@ pub fn process_remote_query_request(In(params): In<Option<Value>>, world: &mut W
     //
     // We also will just collect the `ReflectComponent` values from the type registry all
     // at once so that we can reuse them between components.
-    let paths_and_reflect_components: Vec<(&str, &ReflectComponent)> = components
+    let paths_and_reflect_components: Vec<(&str, &ReflectComponentMut)> = components
         .into_iter()
         .chain(option)
         .map(|(type_id, _)| reflect_component_from_id(type_id, &type_registry))
-        .collect::<AnyhowResult<Vec<(&str, &ReflectComponent)>>>()
+        .collect::<AnyhowResult<Vec<(&str, &ReflectComponentMut)>>>()
         .map_err(BrpError::component_error)?;
 
     // ... and the analogous construction for `has`:
-    let has_paths_and_reflect_components: Vec<(&str, &ReflectComponent)> = has
+    let has_paths_and_reflect_components: Vec<(&str, &ReflectComponentMut)> = has
         .into_iter()
         .map(|(type_id, _)| reflect_component_from_id(type_id, &type_registry))
-        .collect::<AnyhowResult<Vec<(&str, &ReflectComponent)>>>()
+        .collect::<AnyhowResult<Vec<(&str, &ReflectComponentMut)>>>()
         .map_err(BrpError::component_error)?;
 
     let mut response = BrpQueryResponse::default();
@@ -734,7 +734,7 @@ pub fn process_remote_list_request(In(params): In<Option<Value>>, world: &World)
     // If `None`, list all registered components.
     else {
         for registered_type in type_registry.iter() {
-            if registered_type.data::<ReflectComponent>().is_some() {
+            if registered_type.data::<ReflectComponentMut>().is_some() {
                 response.push(registered_type.type_info().type_path().to_owned());
             }
         }
@@ -844,7 +844,7 @@ fn get_component_ids(
 /// where the value is not present on an entity are simply skipped.
 fn build_components_map<'a>(
     entity_ref: FilteredEntityRef,
-    paths_and_reflect_components: impl Iterator<Item = (&'a str, &'a ReflectComponent)>,
+    paths_and_reflect_components: impl Iterator<Item = (&'a str, &'a ReflectComponentMut)>,
     type_registry: &TypeRegistry,
 ) -> AnyhowResult<HashMap<String, Value>> {
     let mut serialized_components_map = HashMap::new();
@@ -871,7 +871,7 @@ fn build_components_map<'a>(
 /// a boolean value indicating whether or not that component is present on the entity.
 fn build_has_map<'a>(
     entity_ref: FilteredEntityRef,
-    paths_and_reflect_components: impl Iterator<Item = (&'a str, &'a ReflectComponent)>,
+    paths_and_reflect_components: impl Iterator<Item = (&'a str, &'a ReflectComponentMut)>,
 ) -> HashMap<String, Value> {
     let mut has_map = HashMap::new();
 
@@ -891,7 +891,7 @@ fn build_has_map<'a>(
 fn reflect_component_from_id(
     component_type_id: TypeId,
     type_registry: &TypeRegistry,
-) -> AnyhowResult<(&str, &ReflectComponent)> {
+) -> AnyhowResult<(&str, &ReflectComponentMut)> {
     let Some(type_registration) = type_registry.get(component_type_id) else {
         return Err(anyhow!(
             "Component `{:?}` isn't registered",
@@ -901,7 +901,7 @@ fn reflect_component_from_id(
 
     let type_path = type_registration.type_info().type_path();
 
-    let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
+    let Some(reflect_component) = type_registration.data::<ReflectComponentMut>() else {
         return Err(anyhow!("Component `{}` isn't reflectable", type_path));
     };
 
@@ -951,11 +951,11 @@ fn insert_reflected_components(
 fn get_reflect_component<'r>(
     type_registry: &'r TypeRegistry,
     component_path: &str,
-) -> AnyhowResult<&'r ReflectComponent> {
+) -> AnyhowResult<&'r ReflectComponentMut> {
     let component_registration = get_component_type_registration(type_registry, component_path)?;
 
     component_registration
-        .data::<ReflectComponent>()
+        .data::<ReflectComponentMut>()
         .ok_or_else(|| anyhow!("Component `{}` isn't reflectable", component_path))
 }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -20,12 +20,12 @@ use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     change_detection::DetectChanges,
-    component::{Component, ComponentId},
+    component::{Component, ComponentId, ComponentMut},
     entity::Entity,
     event::EventReader,
     prelude::With,
     query::Has,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Commands, Query, Res, ResMut, Resource},
     world::DeferredWorld,
 };
@@ -146,7 +146,7 @@ pub struct ComputedCameraValues {
 /// <https://en.wikipedia.org/wiki/Exposure_(photography)>
 #[derive(Component, Clone, Copy, Reflect)]
 #[reflect(opaque)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct Exposure {
     /// <https://en.wikipedia.org/wiki/Exposure_value#Tabulated_exposure_values>
     pub ev100: f32,
@@ -286,7 +286,7 @@ pub enum ViewportConversionError {
 /// [`Camera2d`]: https://docs.rs/crate/bevy_core_pipeline/latest/core_2d/struct.Camera2d.html
 /// [`Camera3d`]: https://docs.rs/crate/bevy_core_pipeline/latest/core_3d/struct.Camera3d.html
 #[derive(Component, Debug, Reflect, Clone)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[component(on_add = warn_on_no_render_graph)]
 #[require(
     Frustum,
@@ -693,7 +693,7 @@ impl Default for CameraOutputMode {
 /// Configures the [`RenderGraph`](crate::render_graph::RenderGraph) name assigned to be run for a given [`Camera`] entity.
 #[derive(Component, Debug, Deref, DerefMut, Reflect, Clone)]
 #[reflect(opaque)]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 pub struct CameraRenderGraph(InternedRenderSubGraph);
 
 impl CameraRenderGraph {
@@ -873,7 +873,7 @@ impl NormalizedRenderTarget {
 /// [`OrthographicProjection`]: crate::camera::OrthographicProjection
 /// [`PerspectiveProjection`]: crate::camera::PerspectiveProjection
 #[allow(clippy::too_many_arguments)]
-pub fn camera_system<T: CameraProjection + Component>(
+pub fn camera_system<T: CameraProjection + ComponentMut>(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
     mut window_scale_factor_changed_events: EventReader<WindowScaleFactorChanged>,
@@ -987,7 +987,7 @@ pub fn camera_system<T: CameraProjection + Component>(
 /// This component lets you control the [`TextureUsages`] field of the main texture generated for the camera
 #[derive(Component, ExtractComponent, Clone, Copy, Reflect)]
 #[reflect(opaque)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct CameraMainTextureUsages(pub TextureUsages);
 impl Default for CameraMainTextureUsages {
     fn default() -> Self {
@@ -1238,7 +1238,7 @@ pub fn sort_cameras(
 ///
 /// [`OrthographicProjection`]: crate::camera::OrthographicProjection
 #[derive(Component, Clone, Default, Reflect)]
-#[reflect(Default, Component)]
+#[reflect(Default, ComponentMut, Component)]
 pub struct TemporalJitter {
     /// Offset is in range [-0.5, 0.5].
     pub offset: Vec2,
@@ -1265,5 +1265,5 @@ impl TemporalJitter {
 ///
 /// Often used in conjunction with antialiasing post-process effects to reduce textures blurriness.
 #[derive(Default, Component, Reflect)]
-#[reflect(Default, Component)]
+#[reflect(Default, ComponentMut, Component)]
 pub struct MipBias(pub f32);

--- a/crates/bevy_render/src/camera/manual_texture_view.rs
+++ b/crates/bevy_render/src/camera/manual_texture_view.rs
@@ -1,5 +1,9 @@
 use crate::{extract_resource::ExtractResource, render_resource::TextureView};
-use bevy_ecs::{prelude::Component, reflect::ReflectComponent, system::Resource};
+use bevy_ecs::{
+    prelude::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+    system::Resource,
+};
 use bevy_image::BevyDefault as _;
 use bevy_math::UVec2;
 use bevy_reflect::prelude::*;
@@ -8,7 +12,7 @@ use wgpu::TextureFormat;
 
 /// A unique id that corresponds to a specific [`ManualTextureView`] in the [`ManualTextureViews`] collection.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Component, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq, Hash)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq, Hash)]
 pub struct ManualTextureViewHandle(pub u32);
 
 /// A manually managed [`TextureView`] for use as a [`crate::camera::RenderTarget`].

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 pub struct CameraProjectionPlugin<T: CameraProjection + Component + GetTypeRegistration>(
     PhantomData<T>,
 );
-impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraProjectionPlugin<T> {
+impl<T: CameraProjection + ComponentMut + GetTypeRegistration> Plugin
+    for CameraProjectionPlugin<T>
+{
     fn build(&self, app: &mut App) {
         app.register_type::<T>()
             .add_systems(
@@ -97,7 +99,7 @@ pub trait CameraProjection {
 
 /// A configurable [`CameraProjection`] that can select its projection type at runtime.
 #[derive(Component, Debug, Clone, Reflect, From)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub enum Projection {
     Perspective(PerspectiveProjection),
     Orthographic(OrthographicProjection),
@@ -148,7 +150,7 @@ impl Default for Projection {
 
 /// A 3D camera projection in which distant objects appear smaller than close objects.
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct PerspectiveProjection {
     /// The vertical field of view (FOV) in radians.
     ///
@@ -340,7 +342,7 @@ pub enum ScalingMode {
 /// });
 /// ```
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Debug, FromWorld)]
+#[reflect(ComponentMut, Component, Debug, FromWorld)]
 pub struct OrthographicProjection {
     /// The distance of the near clipping plane in world units.
     ///

--- a/crates/bevy_render/src/mesh/components.rs
+++ b/crates/bevy_render/src/mesh/components.rs
@@ -1,7 +1,10 @@
 use crate::{mesh::Mesh, view::Visibility};
 use bevy_asset::{AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 use derive_more::derive::From;
@@ -34,7 +37,7 @@ use derive_more::derive::From;
 /// }
 /// ```
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(Transform, Visibility)]
 pub struct Mesh2d(pub Handle<Mesh>);
 
@@ -81,7 +84,7 @@ impl From<&Mesh2d> for AssetId<Mesh> {
 /// }
 /// ```
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(Transform, Visibility)]
 pub struct Mesh3d(pub Handle<Mesh>);
 

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -1,6 +1,10 @@
 use core::borrow::Borrow;
 
-use bevy_ecs::{component::Component, entity::EntityHashMap, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    entity::EntityHashMap,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_math::{Affine3A, Mat3A, Mat4, Vec3, Vec3A, Vec4, Vec4Swizzles};
 use bevy_reflect::prelude::*;
 
@@ -29,7 +33,7 @@ use bevy_reflect::prelude::*;
 /// [`CalculateBounds`]: crate::view::visibility::VisibilitySystems::CalculateBounds
 /// [`Mesh3d`]: crate::mesh::Mesh
 #[derive(Component, Clone, Copy, Debug, Default, Reflect, PartialEq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct Aabb {
     pub center: Vec3A,
     pub half_extents: Vec3A,
@@ -210,7 +214,7 @@ impl HalfSpace {
 /// [`CameraProjection`]: crate::camera::CameraProjection
 /// [`GlobalTransform`]: bevy_transform::components::GlobalTransform
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct Frustum {
     #[reflect(ignore)]
     pub half_spaces: [HalfSpace; 6],
@@ -301,7 +305,7 @@ impl Frustum {
 }
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct CubemapFrusta {
     #[reflect(ignore)]
     pub frusta: [Frustum; 6],
@@ -317,7 +321,7 @@ impl CubemapFrusta {
 }
 
 #[derive(Component, Debug, Default, Reflect, Clone)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct CascadesFrusta {
     #[reflect(ignore)]
     pub frusta: EntityHashMap<Vec<Frustum>>,

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     entity::Entity,
     observer::Trigger,
     query::With,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Local, Query, ResMut, Resource, SystemState},
     world::{Mut, OnAdd, OnRemove, World},
 };
@@ -118,7 +118,7 @@ impl Plugin for SyncWorldPlugin {
 /// [`ExtractComponentPlugin`]: crate::extract_component::ExtractComponentPlugin
 /// [`SyncComponentPlugin`]: crate::sync_component::SyncComponentPlugin
 #[derive(Component, Clone, Debug, Default, Reflect)]
-#[reflect[Component]]
+#[reflect[ComponentMut, Component]]
 #[component(storage = "SparseSet")]
 pub struct SyncToRenderWorld;
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -168,7 +168,7 @@ impl Plugin for ViewPlugin {
     Hash,
     Debug,
 )]
-#[reflect(Component, Default, PartialEq, Hash, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Hash, Debug)]
 pub enum Msaa {
     Off = 1,
     Sample2 = 2,
@@ -212,7 +212,7 @@ impl ExtractedView {
 /// `post_saturation` value in [`ColorGradingGlobal`], which is applied after
 /// tonemapping.
 #[derive(Component, Reflect, Debug, Default, Clone)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct ColorGrading {
     /// Filmic color grading values applied to the image as a whole (as opposed
     /// to individual sections, like shadows and highlights).

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 /// This is done by the `visibility_propagate_system` which uses the entity hierarchy and
 /// `Visibility` to set the values of each entity's [`InheritedVisibility`] component.
 #[derive(Component, Clone, Copy, Reflect, Debug, PartialEq, Eq, Default)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 #[require(InheritedVisibility, ViewVisibility)]
 pub enum Visibility {
     /// An entity with `Visibility::Inherited` will inherit the Visibility of its [`Parent`].
@@ -108,7 +108,7 @@ impl PartialEq<&Visibility> for Visibility {
 ///
 /// [`VisibilityPropagate`]: VisibilitySystems::VisibilityPropagate
 #[derive(Component, Deref, Debug, Default, Clone, Copy, Reflect, PartialEq, Eq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct InheritedVisibility(bool);
 
 impl InheritedVisibility {
@@ -136,7 +136,7 @@ impl InheritedVisibility {
 /// [`VisibilityPropagate`]: VisibilitySystems::VisibilityPropagate
 /// [`CheckVisibility`]: VisibilitySystems::CheckVisibility
 #[derive(Component, Deref, Debug, Default, Clone, Copy, Reflect, PartialEq, Eq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct ViewVisibility(bool);
 
 impl ViewVisibility {
@@ -198,7 +198,7 @@ pub struct VisibilityBundle {
 /// - when using some light effects, like wanting a [`Mesh`] out of the [`Frustum`]
 ///     to appear in the reflection of a [`Mesh`] within.
 #[derive(Debug, Component, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct NoFrustumCulling;
 
 /// Collection of entities visible from the current view.
@@ -211,7 +211,7 @@ pub struct NoFrustumCulling;
 /// This component is intended to be attached to the same entity as the [`Camera`] and
 /// the [`Frustum`] defining the view.
 #[derive(Clone, Component, Default, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct VisibleEntities {
     #[reflect(ignore)]
     pub entities: TypeIdMap<Vec<Entity>>,
@@ -275,7 +275,7 @@ impl VisibleEntities {
 ///
 /// This component is extracted from [`VisibleEntities`].
 #[derive(Clone, Component, Default, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct RenderVisibleEntities {
     #[reflect(ignore)]
     pub entities: TypeIdMap<Vec<(Entity, MainEntity)>>,

--- a/crates/bevy_render/src/view/visibility/range.rs
+++ b/crates/bevy_render/src/view/visibility/range.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
     component::Component,
     entity::{Entity, EntityHashMap},
     query::{Changed, With},
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     schedule::IntoSystemConfigs as _,
     system::{Query, Res, ResMut, Resource},
 };
@@ -112,7 +112,7 @@ impl Plugin for VisibilityRangePlugin {
 /// `start_margin` of the next lower LOD; this is important for the crossfade
 /// effect to function properly.
 #[derive(Component, Clone, PartialEq, Reflect)]
-#[reflect(Component, PartialEq, Hash)]
+#[reflect(ComponentMut, Component, PartialEq, Hash)]
 pub struct VisibilityRange {
     /// The range of distances, in world units, between which this entity will
     /// smoothly fade into view as the camera zooms out.

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -1,4 +1,6 @@
-use bevy_ecs::prelude::{Component, ReflectComponent};
+use bevy_ecs::prelude::{
+    Component, {ReflectComponent, ReflectComponentMut},
+};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use smallvec::SmallVec;
 
@@ -20,7 +22,7 @@ pub type Layer = usize;
 ///
 /// Entities without this component belong to layer `0`.
 #[derive(Component, Clone, Reflect, PartialEq, Eq, PartialOrd, Ord)]
-#[reflect(Component, Default, PartialEq, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Debug)]
 pub struct RenderLayers(SmallVec<[u64; INLINE_BLOCKS]>);
 
 /// The number of memory blocks stored inline

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -70,7 +70,7 @@ pub struct ScreenshotCaptured(pub Image);
 /// }
 /// ```
 #[derive(Component, Deref, DerefMut, Reflect, Debug)]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 pub struct Screenshot(pub RenderTarget);
 
 /// A marker component that indicates that a screenshot is currently being captured.

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -116,13 +116,15 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         entity::Entity,
-        prelude::{AppTypeRegistry, ReflectComponent, World},
+        prelude::{
+            AppTypeRegistry, World, {ReflectComponent, ReflectComponentMut},
+        },
     };
     use bevy_hierarchy::{Children, HierarchyPlugin};
     use bevy_reflect::Reflect;
 
     #[derive(Component, Reflect, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct ComponentA {
         pub x: f32,
         pub y: f32,

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -3,7 +3,7 @@ use bevy_asset::Asset;
 use bevy_ecs::reflect::ReflectResource;
 use bevy_ecs::{
     entity::{Entity, EntityHashMap, SceneEntityMapper},
-    reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities},
+    reflect::{AppTypeRegistry, ReflectComponentMut, ReflectMapEntities},
     world::World,
 };
 use bevy_reflect::{PartialReflect, TypePath, TypeRegistry};
@@ -97,7 +97,7 @@ impl DynamicScene {
                     }
                 })?;
                 let reflect_component =
-                    registration.data::<ReflectComponent>().ok_or_else(|| {
+                    registration.data::<ReflectComponentMut>().ok_or_else(|| {
                         SceneSpawnError::UnregisteredComponent {
                             type_path: type_info.type_path().to_string(),
                         }
@@ -202,7 +202,10 @@ mod tests {
         entity::{
             Entity, EntityHashMap, EntityMapper, MapEntities, VisitEntities, VisitEntitiesMut,
         },
-        reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
+        reflect::{
+            AppTypeRegistry, ReflectMapEntities, ReflectResource,
+            {ReflectComponent, ReflectComponentMut},
+        },
         system::Resource,
         world::{Command, World},
     };
@@ -340,11 +343,11 @@ mod tests {
     #[test]
     fn no_panic_in_map_entities_after_pending_entity_in_hook() {
         #[derive(Default, Component, Reflect)]
-        #[reflect(Component)]
+        #[reflect(ComponentMut, Component)]
         struct A;
 
         #[derive(Component, Reflect, VisitEntities)]
-        #[reflect(Component, MapEntities)]
+        #[reflect(ComponentMut, Component, MapEntities)]
         struct B(pub Entity);
 
         impl MapEntities for B {

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -3,7 +3,7 @@ use alloc::collections::BTreeMap;
 use bevy_ecs::{
     component::{Component, ComponentId},
     prelude::Entity,
-    reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
+    reflect::{AppTypeRegistry, ReflectComponentMut, ReflectResource},
     system::Resource,
     world::World,
 };
@@ -15,7 +15,7 @@ use bevy_utils::default;
 /// # Component Extraction
 ///
 /// By default, all components registered with [`ReflectComponent`] type data in a world's [`AppTypeRegistry`] will be extracted.
-/// (this type data is added automatically during registration if [`Reflect`] is derived with the `#[reflect(Component)]` attribute).
+/// (this type data is added automatically during registration if [`Reflect`] is derived with the `#[reflect(ComponentMut, Component)]` attribute).
 /// This can be changed by [specifying a filter](DynamicSceneBuilder::with_component_filter) or by explicitly
 /// [allowing](DynamicSceneBuilder::allow_component)/[denying](DynamicSceneBuilder::deny_component) certain components.
 ///
@@ -45,7 +45,7 @@ use bevy_utils::default;
 /// # };
 /// # use bevy_reflect::Reflect;
 /// # #[derive(Component, Reflect, Default, Eq, PartialEq, Debug)]
-/// # #[reflect(Component)]
+/// # #[reflect(ComponentMut, Component)]
 /// # struct ComponentA;
 /// # let mut world = World::default();
 /// # world.init_resource::<AppTypeRegistry>();
@@ -247,7 +247,7 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// # };
     /// # use bevy_reflect::Reflect;
     /// #[derive(Component, Default, Reflect)]
-    /// #[reflect(Component)]
+    /// #[reflect(ComponentMut, Component)]
     /// struct MyComponent;
     ///
     /// # let mut world = World::default();
@@ -297,7 +297,7 @@ impl<'w> DynamicSceneBuilder<'w> {
                     let type_registration = type_registry.get(type_id)?;
 
                     let component = type_registration
-                        .data::<ReflectComponent>()?
+                        .data::<ReflectComponentMut>()?
                         .reflect(original_entity)?;
 
                     // Clone via `FromReflect`. Unlike `PartialReflect::clone_value` this
@@ -394,7 +394,9 @@ mod tests {
         component::Component,
         prelude::{Entity, Resource},
         query::With,
-        reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
+        reflect::{
+            AppTypeRegistry, ReflectResource, {ReflectComponent, ReflectComponentMut},
+        },
         world::World,
     };
 
@@ -403,11 +405,11 @@ mod tests {
     use super::DynamicSceneBuilder;
 
     #[derive(Component, Reflect, Default, Eq, PartialEq, Debug)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct ComponentA;
 
     #[derive(Component, Reflect, Default, Eq, PartialEq, Debug)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct ComponentB;
 
     #[derive(Resource, Reflect, Default, Eq, PartialEq, Debug)]
@@ -699,7 +701,7 @@ mod tests {
     #[test]
     fn should_use_from_reflect() {
         #[derive(Resource, Component, Reflect)]
-        #[reflect(Resource, Component)]
+        #[reflect(Resource, ComponentMut, Component)]
         struct SomeType(i32);
 
         let mut world = World::default();

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -2,7 +2,7 @@ use crate::{DynamicScene, SceneSpawnError};
 use bevy_asset::Asset;
 use bevy_ecs::{
     entity::{Entity, EntityHashMap, SceneEntityMapper},
-    reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
+    reflect::{AppTypeRegistry, ReflectComponentMut, ReflectMapEntities, ReflectResource},
     world::World,
 };
 use bevy_reflect::{PartialReflect, TypePath};
@@ -118,7 +118,7 @@ impl Scene {
                             std_type_name: component_info.name().to_string(),
                         })?;
                     let reflect_component =
-                        registration.data::<ReflectComponent>().ok_or_else(|| {
+                        registration.data::<ReflectComponentMut>().ok_or_else(|| {
                             SceneSpawnError::UnregisteredComponent {
                                 type_path: registration.type_info().type_path().to_string(),
                             }

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -479,7 +479,7 @@ mod tests {
     use bevy_ecs::{
         component::Component,
         observer::Trigger,
-        prelude::ReflectComponent,
+        prelude::{ReflectComponent, ReflectComponentMut},
         query::With,
         system::{Commands, Query, Res, ResMut, RunSystemOnce},
     };
@@ -490,7 +490,7 @@ mod tests {
     use super::*;
 
     #[derive(Reflect, Component, Debug, PartialEq, Eq, Clone, Copy, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct A(usize);
 
     #[test]
@@ -541,7 +541,7 @@ mod tests {
     }
 
     #[derive(Component, Reflect, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct ComponentA;
 
     #[derive(Resource, Default)]

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -516,7 +516,9 @@ mod tests {
     };
     use bevy_ecs::{
         entity::{Entity, EntityHashMap, VisitEntities, VisitEntitiesMut},
-        prelude::{Component, ReflectComponent, ReflectResource, Resource, World},
+        prelude::{
+            Component, ReflectResource, Resource, World, {ReflectComponent, ReflectComponentMut},
+        },
         query::{With, Without},
         reflect::{AppTypeRegistry, ReflectMapEntities},
         world::FromWorld,
@@ -527,13 +529,13 @@ mod tests {
     use std::io::BufReader;
 
     #[derive(Component, Reflect, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct Foo(i32);
     #[derive(Component, Reflect, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct Bar(i32);
     #[derive(Component, Reflect, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct Baz(i32);
 
     // De/serialize as hex.
@@ -557,11 +559,11 @@ mod tests {
     }
 
     #[derive(Component, Copy, Clone, Reflect, Debug, PartialEq, Serialize, Deserialize)]
-    #[reflect(Component, Serialize, Deserialize)]
+    #[reflect(ComponentMut, Component, Serialize, Deserialize)]
     struct Qux(#[serde(with = "qux")] u32);
 
     #[derive(Component, Reflect, Default)]
-    #[reflect(Component)]
+    #[reflect(ComponentMut, Component)]
     struct MyComponent {
         foo: [usize; 3],
         bar: (f32, f32),
@@ -585,7 +587,7 @@ mod tests {
     }
 
     #[derive(Clone, Component, Reflect, PartialEq, VisitEntities, VisitEntitiesMut)]
-    #[reflect(Component, MapEntities, PartialEq)]
+    #[reflect(ComponentMut, Component, MapEntities, PartialEq)]
     struct MyEntityRef(Entity);
 
     impl FromWorld for MyEntityRef {

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -82,7 +82,7 @@ pub enum SpriteSystem {
 ///
 /// Right now, this is used for `Text`.
 #[derive(Component, Reflect, Clone, Copy, Debug, Default)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct SpriteSource;
 
 /// A convenient alias for `Or<With<Sprite>, With<SpriteSource>>`, for use with

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -179,7 +179,7 @@ pub trait Material2d: AsBindGroup + Asset + Clone + Sized {
 ///
 /// [`MeshMaterial2d`]: crate::MeshMaterial2d
 #[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct MeshMaterial2d<M: Material2d>(pub Handle<M>);
 
 impl<M: Material2d> Default for MeshMaterial2d<M> {

--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -58,7 +58,7 @@ impl Plugin for Wireframe2dPlugin {
 ///
 /// This requires the [`Wireframe2dPlugin`] to be enabled.
 #[derive(Component, Debug, Clone, Default, Reflect, Eq, PartialEq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct Wireframe2d;
 
 /// Sets the color of the [`Wireframe2d`] of the entity it is attached to.
@@ -68,7 +68,7 @@ pub struct Wireframe2d;
 ///
 /// This overrides the [`Wireframe2dConfig::default_color`].
 #[derive(Component, Debug, Clone, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct Wireframe2dColor {
     pub color: Color,
 }
@@ -78,7 +78,7 @@ pub struct Wireframe2dColor {
 ///
 /// This requires the [`Wireframe2dPlugin`] to be enabled.
 #[derive(Component, Debug, Clone, Default, Reflect, Eq, PartialEq)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct NoWireframe2d;
 
 #[derive(Resource, Debug, Clone, Default, ExtractResource, Reflect)]

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,6 +1,9 @@
 use bevy_asset::Handle;
 use bevy_color::Color;
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_image::Image;
 use bevy_math::{Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -12,7 +15,7 @@ use crate::{TextureAtlas, TextureSlicer};
 /// Describes a sprite to be rendered to a 2D camera
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[require(Transform, Visibility, SyncToRenderWorld)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct Sprite {
     /// The image used to render the sprite
     pub image: Handle<Image>,
@@ -116,7 +119,7 @@ impl SpriteImageMode {
 /// How a sprite is positioned relative to its [`Transform`].
 /// It defaults to `Anchor::Center`.
 #[derive(Component, Debug, Clone, Copy, PartialEq, Default, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 #[doc(alias = "pivot")]
 pub enum Anchor {
     #[default]

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "bevy_reflect")]
-use bevy_ecs::reflect::ReflectComponent;
+use bevy_ecs::reflect::{ReflectComponent, ReflectComponentMut};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -57,7 +57,11 @@ use crate::state::{StateTransitionEvent, States};
 /// app.add_systems(OnEnter(GameState::InGame), spawn_player);
 /// ```
 #[derive(Component, Clone)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Component, ComponentMut)
+)]
 pub struct StateScoped<S: States>(pub S);
 
 /// Removes entities marked with [`StateScoped<S>`]

--- a/crates/bevy_text/src/bounds.rs
+++ b/crates/bevy_text/src/bounds.rs
@@ -1,4 +1,7 @@
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
@@ -11,7 +14,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// reliable limit if it is necessary to contain the text strictly in the bounds. Currently this
 /// component is mainly useful for text wrapping only.
 #[derive(Component, Copy, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct TextBounds {
     /// The maximum width of text in logical pixels.
     /// If `None`, the width is unbounded.

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -6,7 +6,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{ResMut, Resource},
 };
 use bevy_image::Image;
@@ -396,7 +396,7 @@ impl TextPipeline {
 /// Contains scaled glyphs and their size. Generated via [`TextPipeline::queue_text`] when an entity has
 /// [`TextLayout`] and [`ComputedTextBlock`] components.
 #[derive(Component, Clone, Default, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct TextLayoutInfo {
     /// Scaled and positioned glyphs in screenspace
     pub glyphs: Vec<PositionedGlyph>,

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -7,7 +7,7 @@ use crate::{Font, TextLayoutInfo, TextSpanAccess, TextSpanComponent};
 use bevy_asset::Handle;
 use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{prelude::*, reflect::ReflectComponent};
+use bevy_ecs::{prelude::*, reflect::ReflectComponentMut};
 use bevy_hierarchy::{Children, Parent};
 use bevy_reflect::prelude::*;
 use bevy_utils::warn_once;
@@ -43,7 +43,7 @@ pub struct TextEntity {
 ///
 /// Automatically updated by 2d and UI text systems.
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Debug, Default)]
+#[reflect(ComponentMut, Component, Debug, Default)]
 pub struct ComputedTextBlock {
     /// Buffer for managing text layout and creating [`TextLayoutInfo`].
     ///
@@ -106,7 +106,7 @@ impl Default for ComputedTextBlock {
 ///
 /// See [`Text2d`](crate::Text2d) for the core component of 2d text, and `Text` in `bevy_ui` for UI text.
 #[derive(Component, Debug, Copy, Clone, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(ComputedTextBlock, TextLayoutInfo)]
 pub struct TextLayout {
     /// The text's internal alignment.
@@ -193,7 +193,7 @@ impl TextLayout {
 /// ));
 /// ```
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(TextFont, TextColor)]
 pub struct TextSpan(pub String);
 
@@ -266,7 +266,7 @@ impl From<JustifyText> for cosmic_text::Align {
 /// `TextFont` determines the style of a text span within a [`ComputedTextBlock`], specifically
 /// the font face, the font size, and the color.
 #[derive(Component, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct TextFont {
     /// The specific font face to use, as a `Handle` to a [`Font`] asset.
     ///
@@ -308,7 +308,7 @@ impl Default for TextFont {
 
 /// The color of the text for this section.
 #[derive(Component, Copy, Clone, Debug, Deref, DerefMut, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct TextColor(pub Color);
 
 impl Default for TextColor {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -12,7 +12,9 @@ use bevy_ecs::{
     change_detection::{DetectChanges, Ref},
     entity::Entity,
     event::EventReader,
-    prelude::{ReflectComponent, With},
+    prelude::{
+        With, {ReflectComponent, ReflectComponentMut},
+    },
     query::{Changed, Without},
     system::{Commands, Local, Query, Res, ResMut},
 };
@@ -88,7 +90,7 @@ pub struct Text2dBundle {}
 /// ));
 /// ```
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(
     TextLayout,
     TextFont,

--- a/crates/bevy_text/src/text_access.rs
+++ b/crates/bevy_text/src/text_access.rs
@@ -8,7 +8,7 @@ use bevy_hierarchy::Children;
 use crate::{TextColor, TextFont, TextSpan};
 
 /// Helper trait for using the [`TextReader`] and [`TextWriter`] system params.
-pub trait TextSpanAccess: Component {
+pub trait TextSpanAccess: ComponentMut {
     /// Gets the text span's string.
     fn read_span(&self) -> &str;
     /// Gets mutable reference to the text span's string.

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -7,7 +7,10 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use derive_more::derive::From;
 #[cfg(feature = "bevy-support")]
 use {
-    bevy_ecs::{component::Component, reflect::ReflectComponent},
+    bevy_ecs::{
+        component::Component,
+        reflect::{ReflectComponent, ReflectComponentMut},
+    },
     bevy_reflect::{std_traits::ReflectDefault, Reflect},
 };
 
@@ -45,7 +48,7 @@ use {
 #[cfg_attr(
     feature = "bevy-support",
     derive(Component, Reflect),
-    reflect(Component, Default, PartialEq, Debug)
+    reflect(ComponentMut, Component, Default, PartialEq, Debug)
 )]
 #[cfg_attr(
     all(feature = "bevy-support", feature = "serialize"),

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -3,7 +3,10 @@ use bevy_math::{Affine3A, Dir3, Isometry3d, Mat3, Mat4, Quat, Vec3};
 use core::ops::Mul;
 #[cfg(feature = "bevy-support")]
 use {
-    bevy_ecs::{component::Component, reflect::ReflectComponent},
+    bevy_ecs::{
+        component::Component,
+        reflect::{ReflectComponent, ReflectComponentMut},
+    },
     bevy_reflect::prelude::*,
 };
 
@@ -42,7 +45,7 @@ use {
     feature = "bevy-support",
     derive(Component, Reflect),
     require(GlobalTransform),
-    reflect(Component, Default, PartialEq, Debug)
+    reflect(ComponentMut, Component, Default, PartialEq, Debug)
 )]
 #[cfg_attr(
     all(feature = "bevy-support", feature = "serialize"),

--- a/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
@@ -19,7 +19,7 @@ use crate::Node;
 /// Instances of this type cannot be constructed unless the `ghost_nodes` feature is enabled.
 #[derive(Component, Debug, Copy, Clone, Reflect)]
 #[cfg_attr(feature = "ghost_nodes", derive(Default))]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 #[require(Visibility, Transform)]
 pub struct GhostNode {
     // This is a workaround to ensure that GhostNode is only constructable when the appropriate feature flag is enabled

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     entity::Entity,
     prelude::{Component, With},
     query::QueryData,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Local, Query, Res},
 };
 use bevy_input::{mouse::MouseButton, touch::Touches, ButtonInput};
@@ -43,7 +43,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// - [`Button`](crate::widget::Button) which requires this component
 /// - [`RelativeCursorPosition`] to obtain the position of the cursor relative to current node
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect)]
-#[reflect(Component, Default, PartialEq, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -77,7 +77,7 @@ impl Default for Interaction {
 ///
 /// The component is updated when it is in the same entity with [`Node`](crate::Node).
 #[derive(Component, Copy, Clone, Default, PartialEq, Debug, Reflect)]
-#[reflect(Component, Default, PartialEq, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -102,7 +102,7 @@ impl RelativeCursorPosition {
 
 /// Describes whether the node should block interactions with lower nodes
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect)]
-#[reflect(Component, Default, PartialEq, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -1,4 +1,7 @@
-use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_text::CosmicFontSystem;
@@ -71,7 +74,7 @@ impl Measure for FixedMeasure {
 /// A node with a `ContentSize` component is a node where its size
 /// is based on its content.
 #[derive(Component, Reflect, Default)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct ContentSize {
     /// The `Measure` used to compute the intrinsic size
     #[reflect(ignore)]

--- a/crates/bevy_ui/src/ui_material.rs
+++ b/crates/bevy_ui/src/ui_material.rs
@@ -1,7 +1,10 @@
 use crate::Node;
 use bevy_asset::{Asset, AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::ExtractComponent,
@@ -156,7 +159,7 @@ where
 #[derive(
     Component, Clone, Debug, Deref, DerefMut, Reflect, PartialEq, Eq, ExtractComponent, From,
 )]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 #[require(Node)]
 pub struct MaterialNode<M: UiMaterial>(pub Handle<M>);
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -17,7 +17,7 @@ use smallvec::SmallVec;
 
 /// Provides the computed size and layout properties of the node.
 #[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct ComputedNode {
     /// The order of the node in the UI layout.
     /// Nodes with a higher stack index are drawn on top of and receive interactions before nodes with lower stack indices.
@@ -222,7 +222,7 @@ impl Default for ComputedNode {
 /// `ScrollPosition` may be updated by the layout system when a layout change makes a previously valid `ScrollPosition` invalid.
 /// Changing this does nothing on a `Node` without setting at least one `OverflowAxis` to `OverflowAxis::Scroll`.
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(ComponentMut, Component, Default)]
 pub struct ScrollPosition {
     /// How far across the node is scrolled, in pixels. (0 = not scrolled / scrolled to right)
     pub offset_x: f32,
@@ -295,7 +295,7 @@ impl From<&Vec2> for ScrollPosition {
     Visibility,
     ZIndex
 )]
-#[reflect(Component, Default, PartialEq, Debug)]
+#[reflect(ComponentMut, Component, Default, PartialEq, Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1907,7 +1907,7 @@ pub enum GridPlacementError {
 ///
 /// This serves as the "fill" color.
 #[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1934,7 +1934,7 @@ impl<T: Into<Color>> From<T> for BackgroundColor {
 
 /// The border color of the UI node.
 #[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1960,7 +1960,7 @@ impl Default for BorderColor {
 }
 
 #[derive(Component, Copy, Clone, Default, Debug, PartialEq, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -2042,7 +2042,7 @@ impl Outline {
 
 /// The calculated clip of the node
 #[derive(Component, Default, Copy, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct CalculatedClip {
     /// The rect of the clip
     pub clip: Rect,
@@ -2058,7 +2058,7 @@ pub struct CalculatedClip {
 ///
 /// Nodes without this component will be treated as if they had a value of [`ZIndex(0)`].
 #[derive(Component, Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct ZIndex(pub i32);
 
 /// `GlobalZIndex` allows a [`Node`] entity anywhere in the UI hierarchy to escape the implicit draw ordering of the UI's layout tree and
@@ -2068,7 +2068,7 @@ pub struct ZIndex(pub i32);
 ///
 /// If two Nodes have the same `GlobalZIndex`, the node with the greater [`ZIndex`] will be drawn on top.
 #[derive(Component, Copy, Clone, Debug, Default, PartialEq, Eq, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 pub struct GlobalZIndex(pub i32);
 
 /// Used to add rounded corners to a UI node. You can set a UI node to have uniformly
@@ -2109,7 +2109,7 @@ pub struct GlobalZIndex(pub i32);
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius>
 #[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
-#[reflect(Component, PartialEq, Default, Debug)]
+#[reflect(ComponentMut, Component, PartialEq, Default, Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -2374,7 +2374,7 @@ impl ResolvedBorderRadius {
 }
 
 #[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
-#[reflect(Component, PartialEq, Default)]
+#[reflect(ComponentMut, Component, PartialEq, Default)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -2449,7 +2449,7 @@ mod tests {
 ///
 /// Optional if there is only one camera in the world. Required otherwise.
 #[derive(Component, Clone, Debug, Reflect, Eq, PartialEq)]
-#[reflect(Component, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, PartialEq)]
 pub struct TargetCamera(pub Entity);
 
 impl TargetCamera {

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -1,9 +1,12 @@
 use crate::{FocusPolicy, Interaction, Node};
-use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 /// Marker struct for buttons
 #[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
-#[reflect(Component, Default, Debug, PartialEq)]
+#[reflect(ComponentMut, Component, Default, Debug, PartialEq)]
 #[require(Node, FocusPolicy(|| FocusPolicy::Block), Interaction)]
 pub struct Button;

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -12,7 +12,7 @@ use taffy::{MaybeMath, MaybeResolve};
 
 /// A UI Node that renders an image.
 #[derive(Component, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(Node, ImageNodeSize, ContentSize)]
 pub struct ImageNode {
     /// The tint color used to draw the image.
@@ -175,7 +175,7 @@ impl NodeImageMode {
 ///
 /// This component is updated automatically by [`update_image_content_size_system`]
 #[derive(Component, Debug, Copy, Clone, Default, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct ImageNodeSize {
     /// The size of the image's texture
     ///

--- a/crates/bevy_ui/src/widget/label.rs
+++ b/crates/bevy_ui/src/widget/label.rs
@@ -1,7 +1,10 @@
-use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    prelude::Component,
+    reflect::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 /// Marker struct for labels
 #[derive(Component, Debug, Default, Clone, Copy, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct Label;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     entity::{Entity, EntityHashMap},
     prelude::Component,
     query::With,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Local, Query, Res, ResMut},
     world::{Mut, Ref},
 };
@@ -31,7 +31,7 @@ use taffy::style::AvailableSpace;
 ///
 /// Used internally by [`measure_text_system`] and [`text_system`] to schedule text for processing.
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct TextNodeFlags {
     /// If set then a new measure function for the text node will be created.
     needs_measure_fn: bool,
@@ -102,7 +102,7 @@ pub struct TextBundle {}
 /// ));
 /// ```
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 #[require(Node, TextLayout, TextFont, TextColor, TextNodeFlags, ContentSize)]
 pub struct Text(pub String);
 

--- a/crates/bevy_window/src/monitor.rs
+++ b/crates/bevy_window/src/monitor.rs
@@ -1,4 +1,7 @@
-use bevy_ecs::{component::Component, prelude::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    prelude::{ReflectComponent, ReflectComponentMut},
+};
 use bevy_math::{IVec2, UVec2};
 use bevy_reflect::Reflect;
 
@@ -21,7 +24,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 pub struct Monitor {
     /// The name of the monitor
     pub name: Option<String>,
@@ -41,7 +44,7 @@ pub struct Monitor {
 
 /// A marker component for the primary monitor
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Debug)]
+#[reflect(ComponentMut, Component, Debug)]
 pub struct PrimaryMonitor;
 
 impl Monitor {

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -2,7 +2,7 @@ use core::num::NonZero;
 
 use bevy_ecs::{
     entity::{Entity, VisitEntities, VisitEntitiesMut},
-    prelude::{Component, ReflectComponent},
+    prelude::{Component, ReflectComponent, ReflectComponentMut},
 };
 use bevy_math::{CompassOctant, DVec2, IVec2, UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -20,7 +20,7 @@ use bevy_utils::tracing::warn;
 /// with this component if [`primary_window`](crate::WindowPlugin::primary_window)
 /// is `Some`.
 #[derive(Default, Debug, Component, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Reflect)]
-#[reflect(Component, Debug, Default, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, Default, PartialEq)]
 pub struct PrimaryWindow;
 
 /// Reference to a [`Window`], whether it be a direct link to a specific entity or
@@ -131,7 +131,7 @@ impl NormalizedWindowRef {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Component, Default, Debug)]
+#[reflect(ComponentMut, Component, Default, Debug)]
 pub struct Window {
     /// The cursor options of this window. Cursor icons are set with the `Cursor` component on the
     /// window entity.

--- a/crates/bevy_winit/src/cursor.rs
+++ b/crates/bevy_winit/src/cursor.rs
@@ -20,7 +20,7 @@ use bevy_ecs::{
     entity::Entity,
     observer::Trigger,
     query::With,
-    reflect::ReflectComponent,
+    reflect::{ReflectComponent, ReflectComponentMut},
     system::{Commands, Local, Query},
     world::{OnRemove, Ref},
 };
@@ -50,7 +50,7 @@ impl Plugin for CursorPlugin {
 
 /// Insert into a window entity to set the cursor for that window.
 #[derive(Component, Debug, Clone, Reflect, PartialEq, Eq)]
-#[reflect(Component, Debug, Default, PartialEq)]
+#[reflect(ComponentMut, Component, Debug, Default, PartialEq)]
 pub enum CursorIcon {
     #[cfg(feature = "custom_cursor")]
     /// Custom cursor image.

--- a/examples/ecs/immutable_components.rs
+++ b/examples/ecs/immutable_components.rs
@@ -1,0 +1,43 @@
+//! This example demonstrates immutable components.
+
+use bevy::prelude::*;
+
+/// This component is mutable, the default case. This is indicated by components
+/// implementing two traits, [`Component`], and [`ComponentMut`].
+#[derive(Component)]
+pub struct MyMutableComponent(bool);
+
+/// This component is immutable. Once inserted into the ECS, it can only be viewed,
+/// or removed. Replacement is also permitted, as this is equivalent to removal
+/// and insertion.
+///
+/// Adding the `#[immutable]` attribute prevents the implementation of [`ComponentMut`]
+/// in the derive macro.
+#[derive(Component)]
+#[immutable]
+pub struct MyImmutableComponent(bool);
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(world: &mut World) {
+    // Immutable components can be inserted just like mutable components.
+    let mut entity = world.spawn((MyMutableComponent(false), MyImmutableComponent(false)));
+
+    // But where mutable components can be mutated...
+    let mut my_mutable_component = entity.get_mut::<MyMutableComponent>().unwrap();
+    my_mutable_component.0 = true;
+
+    // ...immutable ones cannot. The below fails to compile as `MyImmutableComponent`
+    // let mut my_immutable_component = entity.get_mut::<MyImmutableComponent>().unwrap();
+    // my_immutable_component.0 = true;
+
+    // Instead, you could take or replace the immutable component to update its value.
+    let mut my_immutable_component = entity.take::<MyImmutableComponent>().unwrap();
+    my_immutable_component.0 = true;
+    entity.insert(my_immutable_component);
+}

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -42,7 +42,7 @@ impl<T> Target<T> {
 }
 
 trait TargetUpdate {
-    type TargetComponent: Component;
+    type TargetComponent: ComponentMut;
     const NAME: &'static str;
     fn update_target(&self, target: &mut Self::TargetComponent) -> String;
 }


### PR DESCRIPTION
The `Component` trait now implies an immutable, readonly component. To add mutability, you must implement `ComponentMut`, which is a simple marker. In the derive macro, `ComponentMut` will be implemented with `Component` unless you add an `#[immutable]` attribute.

# Objective

- Fixes #16208

## Solution

- Made `Component` imply a read-only, immutable component.
- Added new trait, `ComponentMut`, which allows mutation.
- Updated `derive_component` to derive `ComponentMut` unless an `#[immutable]` attribute is added.
- Updated `ReflectComponent` to only expose read-only methods, and added `ReflectComponentMut` for read and write.
- Added `immutable_components` example demonstrating the feature.

## Testing

- CI
- `immutable_components` example.

---

## Showcase

Users can now mark a component as `#[immutable]` to prevent safe mutation of a component while it is attached to an entity:

```rust
#[derive(Component)]
#[immutable]
struct Foo {
    // ...
}
```

This prevents creating an exclusive reference to the component while it is attached to an entity. This is particularly powerful when combined with component hooks, as you can now fully track a component's value, ensuring whatever invariants you desire are upheld.

Before this would be done my making a component private, and manually creating a `QueryData` implementation which only permitted read access.

## Migration Guide

- When implementing `Component` manually, you must now implement `ComponentMut` for mutable components:
```rust
impl ComponentMut for Foo {}
```
- When reflecting a component, you must reflect `ComponentMut` as well in order to have access to mutable reflection methods.
```rust
#[derive(Reflect, Component)]
#[reflect(Component, ComponentMut)]
struct Foo {
    // ...
}
```
- When working with generic components, you may need to specify that your generic parameter implements `ComponentMut` rather than `Component` if you require mutable access to said component.

## Notes

- I've done my best to implement this feature, but I'm not happy with how reflection has turned out. If any reflection SMEs know a way to improve this situation I'd greatly appreciate it.
- I've attempted to prevent all safe mutable access to a component that does not implement `ComponentMut`, but there may still be some methods I have missed. Please indicate so and I will address them, as they are bugs.
- Unsafe is an escape hatch I am _not_ attempting to prevent. Whatever you do with unsafe is between you and your compiler.
- I am marking this PR as ready, but I suspect it will undergo fairly major revisions based on SME feedback.
