### PR TITLE
[bevy_ui/layout] extra hierarchy change handling

### DIFF
--- a/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
@@ -49,7 +49,8 @@ pub struct UiRootNodes<'w, 's> {
     root_ghost_node_query: Query<'w, 's, Entity, (With<GhostNode>, Without<Parent>)>,
     all_nodes_query: Query<'w, 's, Entity, With<Node>>,
     ui_children: UiChildren<'w, 's>,
-    demoted_root_nodes_query: Query<'w, 's, (Entity, Ref<'static, Parent>), (With<Node>, Added<Parent>)>,
+    demoted_root_nodes_query:
+        Query<'w, 's, (Entity, Ref<'static, Parent>), (With<Node>, Added<Parent>)>,
 }
 
 impl<'w, 's> UiRootNodes<'w, 's> {
@@ -73,8 +74,12 @@ impl<'w, 's> UiRootNodes<'w, 's> {
     }
 
     /// Iterates [`Node`] with newly added [`Parent`] (demotion from root to child ui node).
-    pub fn iter_demoted_root_nodes(&'s self) -> impl Iterator<Item = (Entity, Ref<'s, Parent>)> + 's {
-        self.demoted_root_nodes_query.iter().filter(|(_, parent_ref)| parent_ref.is_added())
+    pub fn iter_demoted_root_nodes(
+        &'s self,
+    ) -> impl Iterator<Item = (Entity, Ref<'s, Parent>)> + 's {
+        self.demoted_root_nodes_query
+            .iter()
+            .filter(|(_, parent_ref)| parent_ref.is_added())
     }
 }
 

--- a/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
@@ -1,6 +1,6 @@
 //! This module contains [`GhostNode`] and utilities to flatten the UI hierarchy, traversing past ghost nodes.
 
-use bevy_ecs::{prelude::*, system::SystemParam};
+use bevy_ecs::{prelude::*, query::QueryEntityError, system::SystemParam};
 use bevy_hierarchy::{Children, HierarchyQueryExt, Parent};
 use bevy_reflect::prelude::*;
 use bevy_render::view::Visibility;
@@ -49,6 +49,7 @@ pub struct UiRootNodes<'w, 's> {
     root_ghost_node_query: Query<'w, 's, Entity, (With<GhostNode>, Without<Parent>)>,
     all_nodes_query: Query<'w, 's, Entity, With<Node>>,
     ui_children: UiChildren<'w, 's>,
+    demoted_root_nodes_query: Query<'w, 's, (Entity, Ref<'static, Parent>), (With<Node>, Added<Parent>)>,
 }
 
 impl<'w, 's> UiRootNodes<'w, 's> {
@@ -59,6 +60,21 @@ impl<'w, 's> UiRootNodes<'w, 's> {
                 self.all_nodes_query
                     .iter_many(self.ui_children.iter_ui_children(root_ghost))
             }))
+    }
+
+    /// Gets ui root node [`Node`] by [`Entity`] if it exists.
+    pub fn get(&'s self, entity: Entity) -> Result<Entity, QueryEntityError<'s>> {
+        self.root_node_query.get(entity)
+    }
+
+    /// Returns `true` if the given entity is either a Root UI [`Node`].
+    pub fn is_root_node(&'s self, entity: Entity) -> bool {
+        self.get(entity).is_ok()
+    }
+
+    /// Iterates [`Node`] with newly added [`Parent`] (demotion from root to child ui node).
+    pub fn iter_demoted_root_nodes(&'s self) -> impl Iterator<Item = (Entity, Ref<'s, Parent>)> + 's {
+        self.demoted_root_nodes_query.iter().filter(|(_, parent_ref)| parent_ref.is_added())
     }
 }
 

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -12,22 +12,31 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
     let taffy_to_entity: HashMap<NodeId, Entity> = ui_surface
         .entity_to_taffy
         .iter()
-        .map(|(entity, node)| (*node, *entity))
-        .collect();
-    for (&entity, roots) in &ui_surface.camera_roots {
-        let mut out = String::new();
-        for root in roots {
+        .map(|(&ui_entity, &taffy_node)| (taffy_node, ui_entity))
+        .collect::<HashMap<NodeId, Entity>>();
+    for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes.iter() {
+        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity}");
+        for &root_node_entity in root_node_set.iter() {
+            let Some(implicit_viewport_node) = ui_surface
+                .root_node_data
+                .get(&root_node_entity)
+                .map(|rnd| rnd.implicit_viewport_node)
+            else {
+                continue;
+            };
+            let mut out = String::new();
             print_node(
                 ui_surface,
                 &taffy_to_entity,
-                entity,
-                root.implicit_viewport_node,
+                camera_entity,
+                implicit_viewport_node,
                 false,
                 String::new(),
                 &mut out,
             );
+
+            bevy_utils::tracing::info!("{out}");
         }
-        bevy_utils::tracing::info!("Layout tree for camera entity: {entity:?}\n{out}");
     }
 }
 

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -13,7 +13,7 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
         .entity_to_taffy
         .iter()
         .map(|(&ui_entity, &taffy_node)| (taffy_node, ui_entity))
-        .collect::<HashMap<NodeId, Entity>>();
+        .collect();
     for (&camera_entity, root_node_set) in ui_surface.camera_root_nodes.iter() {
         bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity}");
         for &root_node_entity in root_node_set.iter() {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -86,6 +86,7 @@ pub struct UiLayoutSystemRemovedComponentParam<'w, 's> {
     removed_children: RemovedComponents<'w, 's, Children>,
     removed_content_sizes: RemovedComponents<'w, 's, ContentSize>,
     removed_nodes: RemovedComponents<'w, 's, Node>,
+    removed_parents: RemovedComponents<'w, 's, Parent>,
 }
 
 #[doc(hidden)]

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -204,6 +204,19 @@ pub fn ui_layout_system(
         }
     );
 
+    let promoted_root_ui_nodes = removed_components
+        .removed_parents
+        .read()
+        .filter(|&entity| root_nodes.is_root_node(entity));
+
+    for entity in promoted_root_ui_nodes {
+        ui_surface.promote_ui_node(entity);
+    }
+
+    for (entity, parent) in root_nodes.iter_demoted_root_nodes() {
+        ui_surface.demote_ui_node(entity, parent.get());
+    }
+
     // When a `ContentSize` component is removed from an entity, we need to remove the measure from the corresponding taffy node.
     for entity in removed_components.removed_content_sizes.read() {
         ui_surface.try_remove_node_context(entity);

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1349,13 +1349,13 @@ mod tests {
         let mut child1_entity = None;
         let mut child2_entity = None;
         let parent_entity = world
-            .spawn(NodeBundle::default())
+            .spawn(Node::default())
             .with_children(|children| {
                 child1_entity = Some(
                     children
-                        .spawn(NodeBundle::default())
+                        .spawn(Node::default())
                         .with_children(|children| {
-                            child2_entity = Some(children.spawn(NodeBundle::default()).id());
+                            child2_entity = Some(children.spawn(Node::default()).id());
                         })
                         .id(),
                 );

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -270,10 +270,6 @@ with UI components as a child of an entity without UI components, your UI layout
                     );
                 }
             }
-
-            if ui_children.is_changed(entity) {
-                ui_surface.update_children(entity, ui_children.iter_ui_children(entity));
-            }
         });
 
     let text_buffers = &mut buffer_query;

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -369,8 +369,7 @@ impl UiSurface {
 
     /// Promotes child ui node to a root node
     pub(super) fn promote_ui_node(&mut self, target_entity: Entity) {
-        let Some(&new_root_node_taffy_id) = self.entity_to_taffy.get(&target_entity)
-        else {
+        let Some(&new_root_node_taffy_id) = self.entity_to_taffy.get(&target_entity) else {
             // no taffy entry
             return;
         };
@@ -380,8 +379,7 @@ impl UiSurface {
             return;
         };
 
-        self
-            .taffy
+        self.taffy
             .remove_child(old_parent_taffy_id, new_root_node_taffy_id)
             .unwrap();
 
@@ -390,9 +388,8 @@ impl UiSurface {
             // TODO: is this ignorable?
             return;
         };
-        let Some((_, &RootNodeData { camera_entity, .. } )) =
-            self
-                .root_node_data
+        let Some((_, &RootNodeData { camera_entity, .. })) =
+            self.root_node_data
                 .iter()
                 .find(|(_root_node_entity, root_node_data)| {
                     root_node_data.implicit_viewport_node == implicit_viewport_node
@@ -406,8 +403,7 @@ impl UiSurface {
         self.create_or_update_root_node_data(target_entity, camera_entity);
 
         if let Some(camera_entity) = camera_entity {
-            self
-                .camera_root_nodes
+            self.camera_root_nodes
                 .entry(camera_entity)
                 .or_default()
                 .insert(target_entity);

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 use taffy::TaffyTree;
 
+use bevy_ecs::entity::EntityHashSet;
 use bevy_ecs::{
     entity::{Entity, EntityHashMap},
     prelude::Resource,
@@ -12,19 +13,58 @@ use bevy_utils::default;
 use crate::{layout::convert, LayoutContext, LayoutError, Measure, MeasureArgs, Node, NodeMeasure};
 use bevy_text::CosmicFontSystem;
 
+#[inline(always)]
+/// Style used for `implicit_viewport_node`
+fn default_viewport_style() -> taffy::style::Style {
+    taffy::style::Style {
+        display: taffy::style::Display::Grid,
+        // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
+        // So this is setting width:100% and height:100%
+        size: taffy::geometry::Size {
+            width: taffy::style::Dimension::Percent(1.0),
+            height: taffy::style::Dimension::Percent(1.0),
+        },
+        align_items: Some(taffy::style::AlignItems::Start),
+        justify_items: Some(taffy::style::JustifyItems::Start),
+        ..default()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RootNodePair {
-    // The implicit "viewport" node created by Bevy
+/// Stores reference data to quickly identify:
+/// - Its associated camera
+/// - Its parent `implicit_viewport_node` taffy node
+///
+/// see: [`super::UiRootNodes`] for explanation on what a "root node" is
+pub struct RootNodeData {
+    /// Associated camera `Entity`
+    ///
+    /// inferred by components: `TargetCamera`, `IsDefaultUiCamera`
+    ///
+    /// "Orphans" are root nodes not assigned to a camera.
+    /// Root nodes might temporarily enter an orphan state as they transition between cameras
+    /// The reason for this is to prevent us from prematurely recreating taffy nodes
+    /// and allowing for the entities to be cleaned up when they are requested to be removed by the ECS
+    pub(super) camera_entity: Option<Entity>,
+    /// The implicit "viewport" node created by Bevy
+    ///
+    /// This forces the root nodes to behave independently to other root nodes.
+    /// Just as if they were set to `PositionType::Absolute`
+    ///
+    /// This must be manually removed on `Entity` despawn
+    /// or else it will survive in the taffy tree with no references
     pub(super) implicit_viewport_node: taffy::NodeId,
-    // The root (parentless) node specified by the user
-    pub(super) user_root_node: taffy::NodeId,
 }
 
 #[derive(Resource)]
+/// Manages state and hierarchy for ui entities
 pub struct UiSurface {
     pub(super) entity_to_taffy: EntityHashMap<taffy::NodeId>,
-    pub(super) camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::NodeId>>,
-    pub(super) camera_roots: EntityHashMap<Vec<RootNodePair>>,
+    /// Maps root ui node `Entity` to its corresponding `RootNodeData`
+    pub(super) root_node_data: EntityHashMap<RootNodeData>,
+    /// Maps camera `Entity` to an associated `EntityHashSet` of root ui nodes
+    pub(super) camera_root_nodes: EntityHashMap<EntityHashSet>,
+    /// Manages the UI Node Tree
     pub(super) taffy: TaffyTree<NodeMeasure>,
     taffy_children_scratch: Vec<taffy::NodeId>,
 }
@@ -32,8 +72,8 @@ pub struct UiSurface {
 fn _assert_send_sync_ui_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
     _assert_send_sync::<EntityHashMap<taffy::NodeId>>();
-    _assert_send_sync::<EntityHashMap<EntityHashMap<taffy::NodeId>>>();
-    _assert_send_sync::<EntityHashMap<Vec<RootNodePair>>>();
+    _assert_send_sync::<EntityHashMap<RootNodeData>>();
+    _assert_send_sync::<EntityHashMap<EntityHashSet>>();
     _assert_send_sync::<TaffyTree<NodeMeasure>>();
     _assert_send_sync::<UiSurface>();
 }
@@ -42,8 +82,8 @@ impl fmt::Debug for UiSurface {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("UiSurface")
             .field("entity_to_taffy", &self.entity_to_taffy)
-            .field("camera_entity_to_taffy", &self.camera_entity_to_taffy)
-            .field("camera_roots", &self.camera_roots)
+            .field("root_node_data", &self.root_node_data)
+            .field("camera_root_nodes", &self.camera_root_nodes)
             .field("taffy_children_scratch", &self.taffy_children_scratch)
             .finish()
     }
@@ -54,8 +94,8 @@ impl Default for UiSurface {
         let taffy: TaffyTree<NodeMeasure> = TaffyTree::new();
         Self {
             entity_to_taffy: Default::default(),
-            camera_entity_to_taffy: Default::default(),
-            camera_roots: Default::default(),
+            root_node_data: Default::default(),
+            camera_root_nodes: Default::default(),
             taffy,
             taffy_children_scratch: Vec::new(),
         }
@@ -143,65 +183,130 @@ impl UiSurface {
         }
     }
 
+    /// Removes camera association to root node
+    /// Shorthand for calling `replace_camera_association(root_node_entity, None)`
+    fn mark_root_node_as_orphaned(&mut self, root_node_entity: Entity) {
+        self.replace_camera_association(root_node_entity, None);
+    }
+
+    /// Reassigns or removes a root node's associated camera entity
+    /// `Some(camera_entity)` - Updates camera association to root node
+    /// `None` - Removes camera association to root node
+    /// Does not check to see if they are the same before performing operations
+    fn replace_camera_association(
+        &mut self,
+        root_node_entity: Entity,
+        new_camera_entity_option: Option<Entity>,
+    ) {
+        if let Some(root_node_data) = self.root_node_data.get_mut(&root_node_entity) {
+            // Clear existing camera association, if any
+            if let Some(old_camera_entity) = root_node_data.camera_entity.take() {
+                let prev_camera_root_nodes = self.camera_root_nodes.get_mut(&old_camera_entity);
+                if let Some(prev_camera_root_nodes) = prev_camera_root_nodes {
+                    prev_camera_root_nodes.remove(&root_node_entity);
+                }
+            }
+
+            // Establish new camera association, if provided
+            if let Some(camera_entity) = new_camera_entity_option {
+                root_node_data.camera_entity.replace(camera_entity);
+                self.camera_root_nodes
+                    .entry(camera_entity)
+                    .or_default()
+                    .insert(root_node_entity);
+            }
+        }
+    }
+
+    /// Creates or updates a root node
+    fn create_or_update_root_node_data(
+        &mut self,
+        root_node_entity: Entity,
+        camera_entity: Entity,
+    ) -> &mut RootNodeData {
+        let user_root_node = *self.entity_to_taffy.get(&root_node_entity).expect("create_or_update_root_node_data called before root_node_entity was added to taffy tree or was previously removed");
+
+        let mut added = false;
+
+        // creates mutable borrow on self that lives as long as the result
+        let _ = self
+            .root_node_data
+            .entry(root_node_entity)
+            .or_insert_with(|| {
+                added = true;
+
+                self.camera_root_nodes
+                    .entry(camera_entity)
+                    .or_default()
+                    .insert(root_node_entity);
+
+                let implicit_viewport_node = self.taffy.new_leaf(default_viewport_style()).unwrap();
+
+                self.taffy
+                    .add_child(implicit_viewport_node, user_root_node)
+                    .unwrap();
+
+                RootNodeData {
+                    camera_entity: Some(camera_entity),
+                    implicit_viewport_node,
+                }
+            });
+
+        if !added {
+            self.replace_camera_association(root_node_entity, Some(camera_entity));
+        }
+
+        self.root_node_data
+            .get_mut(&root_node_entity)
+            .unwrap_or_else(|| unreachable!())
+    }
+
     /// Sets the ui root node entities as children to the root node in the taffy layout.
     pub fn set_camera_children(
         &mut self,
-        camera_id: Entity,
+        camera_entity: Entity,
         children: impl Iterator<Item = Entity>,
     ) {
-        let viewport_style = taffy::style::Style {
-            display: taffy::style::Display::Grid,
-            // Note: Taffy percentages are floats ranging from 0.0 to 1.0.
-            // So this is setting width:100% and height:100%
-            size: taffy::geometry::Size {
-                width: taffy::style::Dimension::Percent(1.0),
-                height: taffy::style::Dimension::Percent(1.0),
-            },
-            align_items: Some(taffy::style::AlignItems::Start),
-            justify_items: Some(taffy::style::JustifyItems::Start),
-            ..default()
-        };
+        let removed_children = self.camera_root_nodes.entry(camera_entity).or_default();
+        let mut removed_children = removed_children.clone();
 
-        let camera_root_node_map = self.camera_entity_to_taffy.entry(camera_id).or_default();
-        let existing_roots = self.camera_roots.entry(camera_id).or_default();
-        let mut new_roots = Vec::new();
-        for entity in children {
-            let node = *self.entity_to_taffy.get(&entity).unwrap();
-            let root_node = existing_roots
-                .iter()
-                .find(|n| n.user_root_node == node)
-                .cloned()
-                .unwrap_or_else(|| {
-                    if let Some(previous_parent) = self.taffy.parent(node) {
-                        // remove the root node from the previous implicit node's children
-                        self.taffy.remove_child(previous_parent, node).unwrap();
-                    }
+        for ui_entity in children {
+            // creates mutable borrow on self that lives as long as the result
+            let _ = self.create_or_update_root_node_data(ui_entity, camera_entity);
 
-                    let viewport_node = *camera_root_node_map
-                        .entry(entity)
-                        .or_insert_with(|| self.taffy.new_leaf(viewport_style.clone()).unwrap());
-                    self.taffy.add_child(viewport_node, node).unwrap();
+            // drop the mutable borrow on self by re-fetching
+            let root_node_data = self
+                .root_node_data
+                .get(&ui_entity)
+                .unwrap_or_else(|| unreachable!());
 
-                    RootNodePair {
-                        implicit_viewport_node: viewport_node,
-                        user_root_node: node,
-                    }
-                });
-            new_roots.push(root_node);
+            // fix taffy relationships
+            {
+                let taffy_node = *self.entity_to_taffy.get(&ui_entity).unwrap();
+                if let Some(parent) = self.taffy.parent(taffy_node) {
+                    self.taffy.remove_child(parent, taffy_node).unwrap();
+                }
+                self.taffy
+                    .add_child(root_node_data.implicit_viewport_node, taffy_node)
+                    .unwrap();
+            }
+            removed_children.remove(&ui_entity);
         }
 
-        self.camera_roots.insert(camera_id, new_roots);
+        for &orphan in removed_children.iter() {
+            self.mark_root_node_as_orphaned(orphan);
+        }
     }
 
     /// Compute the layout for each window entity's corresponding root node in the layout.
     pub fn compute_camera_layout<'a>(
         &mut self,
-        camera: Entity,
+        camera_entity: Entity,
         render_target_resolution: UVec2,
         buffer_query: &'a mut bevy_ecs::prelude::Query<&mut bevy_text::ComputedTextBlock>,
         font_system: &'a mut CosmicFontSystem,
     ) {
-        let Some(camera_root_nodes) = self.camera_roots.get(&camera) else {
+        let Some(camera_root_nodes) = self.camera_root_nodes.get(&camera_entity) else {
             return;
         };
 
@@ -209,10 +314,19 @@ impl UiSurface {
             width: taffy::style::AvailableSpace::Definite(render_target_resolution.x as f32),
             height: taffy::style::AvailableSpace::Definite(render_target_resolution.y as f32),
         };
-        for root_nodes in camera_root_nodes {
+
+        for root_node_entity in camera_root_nodes {
+            let root_node_data = self
+                .root_node_data
+                .get(root_node_entity)
+                .expect("root_node_data missing");
+
+            if root_node_data.camera_entity.is_none() {
+                panic!("internal map out of sync");
+            }
             self.taffy
                 .compute_layout_with_measure(
-                    root_nodes.implicit_viewport_node,
+                    root_node_data.implicit_viewport_node,
                     available_space,
                     |known_dimensions: taffy::Size<Option<f32>>,
                      available_space: taffy::Size<taffy::AvailableSpace>,
@@ -253,29 +367,57 @@ impl UiSurface {
         }
     }
 
-    /// Removes each camera entity from the internal map and then removes their associated node from taffy
-    pub fn remove_camera_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
-        for entity in entities {
-            if let Some(camera_root_node_map) = self.camera_entity_to_taffy.remove(&entity) {
-                for (_, node) in camera_root_node_map.iter() {
-                    self.taffy.remove(*node).unwrap();
-                }
+    /// Disassociates the camera from all of its assigned root nodes and removes their viewport nodes
+    /// Removes entry in `camera_root_nodes`
+    pub(super) fn remove_camera(&mut self, camera_entity: Entity) {
+        if let Some(root_node_entities) = self.camera_root_nodes.remove(&camera_entity) {
+            for root_node_entity in root_node_entities {
+                self.remove_root_node_viewport(root_node_entity);
             }
+        };
+    }
+
+    /// Disassociates the root node from the assigned camera (if any) and removes the viewport node from taffy
+    /// Removes entry in `root_node_data`
+    fn remove_root_node_viewport(&mut self, root_node_entity: Entity) {
+        self.mark_root_node_as_orphaned(root_node_entity);
+        if let Some(removed) = self.root_node_data.remove(&root_node_entity) {
+            self.taffy.remove(removed.implicit_viewport_node).unwrap();
         }
     }
 
-    /// Removes each entity from the internal map and then removes their associated node from taffy
+    /// Removes the ui node from the taffy tree, and if it's a root node it also calls `remove_root_node_viewport`
+    pub(super) fn remove_ui_node(&mut self, ui_node_entity: Entity) {
+        if let Some(taffy_node) = self.entity_to_taffy.remove(&ui_node_entity) {
+            self.taffy.remove(taffy_node).unwrap();
+        }
+        // remove root node entry if this is a root node
+        if self.root_node_data.contains_key(&ui_node_entity) {
+            self.remove_root_node_viewport(ui_node_entity);
+        }
+    }
+
+    /// Removes specified camera entities by disassociating them from their associated `implicit_viewport_node`
+    /// in the internal map, and subsequently removes the `implicit_viewport_node`
+    /// from the `taffy` layout engine for each.
+    pub fn remove_camera_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
+        for entity in entities {
+            self.remove_camera(entity);
+        }
+    }
+
+    /// Removes the specified entities from the internal map while
+    /// removing their `implicit_viewport_node` from taffy,
+    /// and then subsequently removes their entry from `entity_to_taffy` and associated node from taffy
     pub fn remove_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
         for entity in entities {
-            if let Some(node) = self.entity_to_taffy.remove(&entity) {
-                self.taffy.remove(node).unwrap();
-            }
+            self.remove_ui_node(entity);
         }
     }
 
     /// Get the layout geometry for the taffy node corresponding to the ui node [`Entity`].
     /// Does not compute the layout geometry, `compute_window_layouts` should be run before using this function.
-    /// On success returns a pair consisiting of the final resolved layout values after rounding
+    /// On success returns a pair consisting of the final resolved layout values after rounding
     /// and the size of the node after layout resolution but before rounding.
     pub fn get_layout(&mut self, entity: Entity) -> Result<(taffy::Layout, Vec2), LayoutError> {
         let Some(taffy_node) = self.entity_to_taffy.get(&entity) else {
@@ -322,35 +464,38 @@ mod tests {
     use bevy_math::Vec2;
     use taffy::TraversePartialTree;
 
-    /// Checks if the parent of the `user_root_node` in a `RootNodePair`
+    /// Checks if the parent of the `user_root_node` in a `RootNodeData`
     /// is correctly assigned as the `implicit_viewport_node`.
-    fn is_root_node_pair_valid(
-        taffy_tree: &TaffyTree<NodeMeasure>,
-        root_node_pair: &RootNodePair,
-    ) -> bool {
-        taffy_tree.parent(root_node_pair.user_root_node)
-            == Some(root_node_pair.implicit_viewport_node)
+    fn has_valid_root_node_data(ui_surface: &UiSurface, root_node_entity: &Entity) -> bool {
+        let Some(&root_node_taffy_node_id) = ui_surface.entity_to_taffy.get(root_node_entity)
+        else {
+            return false;
+        };
+        let Some(root_node_data) = ui_surface.root_node_data.get(root_node_entity) else {
+            return false;
+        };
+        ui_surface.taffy.parent(root_node_taffy_node_id)
+            == Some(root_node_data.implicit_viewport_node)
     }
 
-    /// Tries to get the root node pair for a given root node entity with the specified camera entity
-    fn get_root_node_pair_exact(
+    /// Tries to get the root node data for a given root node entity
+    /// and asserts it matches the provided camera entity
+    fn get_root_node_data_exact(
         ui_surface: &UiSurface,
         root_node_entity: Entity,
         camera_entity: Entity,
-    ) -> Option<&RootNodePair> {
-        let root_node_pairs = ui_surface.camera_roots.get(&camera_entity)?;
-        let root_node_taffy = ui_surface.entity_to_taffy.get(&root_node_entity)?;
-        root_node_pairs
-            .iter()
-            .find(|&root_node_pair| root_node_pair.user_root_node == *root_node_taffy)
+    ) -> Option<&RootNodeData> {
+        let root_node_data = ui_surface.root_node_data.get(&root_node_entity)?;
+        assert_eq!(root_node_data.camera_entity, Some(camera_entity));
+        Some(root_node_data)
     }
 
     #[test]
     fn test_initialization() {
         let ui_surface = UiSurface::default();
         assert!(ui_surface.entity_to_taffy.is_empty());
-        assert!(ui_surface.camera_entity_to_taffy.is_empty());
-        assert!(ui_surface.camera_roots.is_empty());
+        assert!(ui_surface.root_node_data.is_empty());
+        assert!(ui_surface.camera_root_nodes.is_empty());
         assert_eq!(ui_surface.taffy.total_node_count(), 0);
     }
 
@@ -380,10 +525,11 @@ mod tests {
         // each root node will create 2 taffy nodes
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
 
-        // root node pair should now exist
-        let root_node_pair = get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity)
-            .expect("expected root node pair");
-        assert!(is_root_node_pair_valid(&ui_surface.taffy, root_node_pair));
+        // root node data should now exist
+        let _root_node_data =
+            get_root_node_data_exact(&ui_surface, root_node_entity, camera_entity)
+                .expect("expected root node data");
+        assert!(has_valid_root_node_data(&ui_surface, &root_node_entity));
 
         // test duplicate insert 2
         ui_surface.upsert_node(&LayoutContext::TEST_CONTEXT, root_node_entity, &node, None);
@@ -391,34 +537,29 @@ mod tests {
         // node count should not have increased
         assert_eq!(ui_surface.taffy.total_node_count(), 2);
 
-        // root node pair should be unaffected
-        let root_node_pair = get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity)
-            .expect("expected root node pair");
-        assert!(is_root_node_pair_valid(&ui_surface.taffy, root_node_pair));
+        // root node data should be unaffected
+        let _root_node_data =
+            get_root_node_data_exact(&ui_surface, root_node_entity, camera_entity)
+                .expect("expected root node data");
+        assert!(has_valid_root_node_data(&ui_surface, &root_node_entity));
     }
 
     #[test]
     fn test_get_root_node_pair_exact() {
+        /// Attempts to find the root node data corresponding to the given root node entity
+        fn get_root_node_data(
+            ui_surface: &UiSurface,
+            root_node_entity: Entity,
+        ) -> Option<&RootNodeData> {
+            ui_surface.root_node_data.get(&root_node_entity)
+        }
+
         /// Attempts to find the camera entity that holds a reference to the given root node entity
         fn get_associated_camera_entity(
             ui_surface: &UiSurface,
             root_node_entity: Entity,
         ) -> Option<Entity> {
-            for (&camera_entity, root_node_map) in ui_surface.camera_entity_to_taffy.iter() {
-                if root_node_map.contains_key(&root_node_entity) {
-                    return Some(camera_entity);
-                }
-            }
-            None
-        }
-
-        /// Attempts to find the root node pair corresponding to the given root node entity
-        fn get_root_node_pair(
-            ui_surface: &UiSurface,
-            root_node_entity: Entity,
-        ) -> Option<&RootNodePair> {
-            let camera_entity = get_associated_camera_entity(ui_surface, root_node_entity)?;
-            get_root_node_pair_exact(ui_surface, root_node_entity, camera_entity)
+            get_root_node_data(ui_surface, root_node_entity)?.camera_entity
         }
 
         let mut ui_surface = UiSurface::default();
@@ -440,20 +581,19 @@ mod tests {
             None
         );
 
-        let root_node_pair = get_root_node_pair(&ui_surface, root_node_entity);
-        assert!(root_node_pair.is_some());
+        let root_node_data =
+            get_root_node_data(&ui_surface, root_node_entity).expect("expected root node data");
         assert_eq!(
-            Some(root_node_pair.unwrap().user_root_node).as_ref(),
-            ui_surface.entity_to_taffy.get(&root_node_entity)
+            Some(root_node_data),
+            ui_surface.root_node_data.get(&root_node_entity),
         );
 
         assert_eq!(
-            get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity),
-            root_node_pair
+            get_root_node_data_exact(&ui_surface, root_node_entity, camera_entity),
+            Some(root_node_data),
         );
     }
 
-    #[allow(unreachable_code)]
     #[test]
     fn test_remove_camera_entities() {
         let mut ui_surface = UiSurface::default();
@@ -466,22 +606,17 @@ mod tests {
         // assign root node to camera
         ui_surface.set_camera_children(camera_entity, [root_node_entity].into_iter());
 
+        assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
+        assert!(ui_surface.root_node_data.contains_key(&root_node_entity));
+        assert!(ui_surface.camera_root_nodes.contains_key(&camera_entity));
+        let _root_node_data =
+            get_root_node_data_exact(&ui_surface, root_node_entity, camera_entity)
+                .expect("expected root node data");
         assert!(ui_surface
-            .camera_entity_to_taffy
-            .contains_key(&camera_entity));
-        assert!(ui_surface
-            .camera_entity_to_taffy
+            .camera_root_nodes
             .get(&camera_entity)
             .unwrap()
-            .contains_key(&root_node_entity));
-        assert!(ui_surface.camera_roots.contains_key(&camera_entity));
-        let root_node_pair = get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity)
-            .expect("expected root node pair");
-        assert!(ui_surface
-            .camera_roots
-            .get(&camera_entity)
-            .unwrap()
-            .contains(root_node_pair));
+            .contains(&root_node_entity));
 
         ui_surface.remove_camera_entities([camera_entity]);
 
@@ -489,20 +624,15 @@ mod tests {
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
 
         // `camera_roots` and `camera_entity_to_taffy` should no longer contain entries for `camera_entity`
-        assert!(!ui_surface
-            .camera_entity_to_taffy
-            .contains_key(&camera_entity));
+        assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
 
-        return; // TODO: can't pass the test if we continue - not implemented (remove allow(unreachable_code))
+        assert!(!ui_surface.camera_root_nodes.contains_key(&camera_entity));
 
-        assert!(!ui_surface.camera_roots.contains_key(&camera_entity));
-
-        // root node pair should be removed
-        let root_node_pair = get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity);
-        assert_eq!(root_node_pair, None);
+        // root node data should be removed
+        let root_node_data = get_root_node_data_exact(&ui_surface, root_node_entity, camera_entity);
+        assert_eq!(root_node_data, None);
     }
 
-    #[allow(unreachable_code)]
     #[test]
     fn test_remove_entities() {
         let mut ui_surface = UiSurface::default();
@@ -516,35 +646,20 @@ mod tests {
 
         assert!(ui_surface.entity_to_taffy.contains_key(&root_node_entity));
         assert!(ui_surface
-            .camera_entity_to_taffy
+            .camera_root_nodes
             .get(&camera_entity)
             .unwrap()
-            .contains_key(&root_node_entity));
-        let root_node_pair =
-            get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity).unwrap();
-        assert!(ui_surface
-            .camera_roots
-            .get(&camera_entity)
-            .unwrap()
-            .contains(root_node_pair));
+            .contains(&root_node_entity));
 
         ui_surface.remove_entities([root_node_entity]);
         assert!(!ui_surface.entity_to_taffy.contains_key(&root_node_entity));
-
-        return; // TODO: can't pass the test if we continue - not implemented (remove allow(unreachable_code))
-
         assert!(!ui_surface
-            .camera_entity_to_taffy
+            .camera_root_nodes
             .get(&camera_entity)
             .unwrap()
-            .contains_key(&root_node_entity));
-        assert!(!ui_surface
-            .camera_entity_to_taffy
-            .get(&camera_entity)
-            .unwrap()
-            .contains_key(&root_node_entity));
+            .contains(&root_node_entity));
         assert!(ui_surface
-            .camera_roots
+            .camera_root_nodes
             .get(&camera_entity)
             .unwrap()
             .is_empty());
@@ -582,7 +697,6 @@ mod tests {
         assert_eq!(ui_surface.taffy.parent(child_node), Some(parent_node));
     }
 
-    #[allow(unreachable_code)]
     #[test]
     fn test_set_camera_children() {
         let mut ui_surface = UiSurface::default();
@@ -607,24 +721,24 @@ mod tests {
 
         assert!(
             ui_surface
-                .camera_entity_to_taffy
+                .camera_root_nodes
                 .get(&camera_entity)
                 .unwrap()
-                .contains_key(&root_node_entity),
+                .contains(&root_node_entity),
             "root node not associated with camera"
         );
         assert!(
             !ui_surface
-                .camera_entity_to_taffy
+                .camera_root_nodes
                 .get(&camera_entity)
                 .unwrap()
-                .contains_key(&child_entity),
+                .contains(&child_entity),
             "child of root node should not be associated with camera"
         );
 
-        let _root_node_pair =
-            get_root_node_pair_exact(&ui_surface, root_node_entity, camera_entity)
-                .expect("expected root node pair");
+        let _root_node_data =
+            get_root_node_data_exact(&ui_surface, root_node_entity, camera_entity)
+                .expect("expected root node data");
 
         assert_eq!(ui_surface.taffy.parent(child_taffy), Some(root_taffy_node));
         let root_taffy_children = ui_surface.taffy.children(root_taffy_node).unwrap();
@@ -641,22 +755,20 @@ mod tests {
         // clear camera's root nodes
         ui_surface.set_camera_children(camera_entity, Vec::<Entity>::new().into_iter());
 
-        return; // TODO: can't pass the test if we continue - not implemented (remove allow(unreachable_code))
-
         assert!(
             !ui_surface
-                .camera_entity_to_taffy
+                .camera_root_nodes
                 .get(&camera_entity)
                 .unwrap()
-                .contains_key(&root_node_entity),
+                .contains(&root_node_entity),
             "root node should have been unassociated with camera"
         );
         assert!(
             !ui_surface
-                .camera_entity_to_taffy
+                .camera_root_nodes
                 .get(&camera_entity)
                 .unwrap()
-                .contains_key(&child_entity),
+                .contains(&child_entity),
             "child of root node should not be associated with camera"
         );
 
@@ -676,18 +788,18 @@ mod tests {
 
         assert!(
             ui_surface
-                .camera_entity_to_taffy
+                .camera_root_nodes
                 .get(&camera_entity)
                 .unwrap()
-                .contains_key(&root_node_entity),
+                .contains(&root_node_entity),
             "root node should have been re-associated with camera"
         );
         assert!(
             !ui_surface
-                .camera_entity_to_taffy
+                .camera_root_nodes
                 .get(&camera_entity)
                 .unwrap()
-                .contains_key(&child_entity),
+                .contains(&child_entity),
             "child of root node should not be associated with camera"
         );
 


### PR DESCRIPTION
supersedes https://github.com/bevyengine/bevy/pull/13360

- [ ] blocked by https://github.com/bevyengine/bevy/pull/16362

# Objective

- Handle UI Nodes becoming a child of another UI node `Added<Parent>`
- Handle UI Nodes who lose their parent to become a root UI node `RemovedComponent<Parent>`


## Solution

- Extends the queries for the layout_system and various system params to capture and handle these events.

## Testing

- Did you test these changes? If so, how?

Unit tests and example 

- Are there any parts that need more testing?

Unknown

- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  
Run example code below, apply diff to see before and after behavior

<details>
  <summary>Click to view diff</summary>

```diff
Index: crates/bevy_ui/src/layout/mod.rs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/crates/bevy_ui/src/layout/mod.rs b/crates/bevy_ui/src/layout/mod.rs
--- a/crates/bevy_ui/src/layout/mod.rs	(revision Staged)
+++ b/crates/bevy_ui/src/layout/mod.rs	(date 1731545949320)
@@ -210,11 +210,11 @@
         .filter(|&entity| root_nodes.is_root_node(entity));
 
     for entity in promoted_root_ui_nodes {
-        ui_surface.promote_ui_node(entity);
+        // ui_surface.promote_ui_node(entity);
     }
 
     for (entity, parent) in root_nodes.iter_demoted_root_nodes() {
-        ui_surface.demote_ui_node(entity, parent.get());
+        // ui_surface.demote_ui_node(entity, parent.get());
     }
 
     // When a `ContentSize` component is removed from an entity, we need to remove the measure from the corresponding taffy node.

```
</details>

---

## Example

<details>
  <summary>Click to view example</summary>

```rust
//! Demonstrates how UI can handle non-standard hierarchy changes

use bevy::ecs::query::QueryData;
use bevy::{color::palettes::css::*, prelude::*};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, spawn_layout)
        .add_systems(Update, input)
        .run();
}

#[derive(Component, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
struct Id(usize);

#[derive(Component, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
struct Pos(usize);

impl Pos {
    fn set(&mut self, pos: usize) {
        self.0 = pos;
    }
    fn get(&self) -> usize {
        self.0
    }
}

#[derive(Component, Debug, Copy, Clone)]
struct Marker;

const COLS: usize = 3;

fn spawn_layout(mut commands: Commands) {
    commands.spawn(Camera2d);
    let grid_template_columns = (0..COLS).map(|_| GridTrack::flex(1.0)).collect::<Vec<_>>();

    fn create_place(ix: usize) -> impl Bundle {
        (
            Id(ix),
            Pos(ix),
            Node {
                margin: UiRect::all(Val::Px(10.0)),
                padding: UiRect::all(Val::Px(10.0)),
                display: Display::Flex,
                justify_content: JustifyContent::Center,
                ..default()
            },
            BackgroundColor(BLUE.into()),
        )
    }

    commands
        .spawn((
            Node {
                display: Display::Grid,
                width: Val::Percent(100.0),
                grid_template_columns: vec![GridTrack::auto()],
                grid_template_rows: vec![GridTrack::auto()],
                justify_content: JustifyContent::Center,
                top: Val::Px(65.0),
                ..default()
            },
            TextLayout::new_with_justify(JustifyText::Center),
            BackgroundColor(Color::WHITE),
            Transform::from_translation(Vec3::Z * 1.0),
        ))
        .with_children(|builder| {
            builder.spawn((
                Node {
                    display: Display::Grid,
                    width: Val::Percent(100.0),
                    grid_template_columns: grid_template_columns.clone(),
                    grid_template_rows: vec![GridTrack::auto(), GridTrack::auto(), GridTrack::auto()],
                    justify_content: JustifyContent::Center,
                    ..default()
                },
                TextLayout::new_with_justify(JustifyText::Center),
                BackgroundColor(Color::WHITE),
                Transform::from_translation(Vec3::Z * 1.0),
            )).with_children(|builder| {
                builder
                    .spawn((
                        Node {
                            display: Display::Grid,
                            grid_column: GridPlacement::span(COLS as u16),
                            grid_row: GridPlacement::span(1),
                            justify_content: JustifyContent::Center,
                            ..default()
                        },
                        BackgroundColor(BLACK.into()),
                    ))
                    .with_children(|builder| {
                        builder.spawn((
                            Text::new("Press 0 to move ^ here (root)"),
                            TextFont {
                                font_size: 20.0,
                                ..default()
                            },
                            TextLayout::new_with_justify(JustifyText::Center),
                            TextColor(WHITE.into()),
                        ));
                    });

                builder
                    .spawn((
                        Node {
                            display: Display::Grid,
                            width: Val::Percent(100.0),
                            grid_template_columns,
                            grid_template_rows: vec![GridTrack::auto()],
                            grid_column: GridPlacement::span(3),
                            grid_row: GridPlacement::span(1),
                            justify_content: JustifyContent::Center,
                            ..default()
                        },
                        TextLayout::new_with_justify(JustifyText::Center),
                        BackgroundColor(Color::WHITE),
                        Transform::from_translation(Vec3::Z * 1.0),
                    ))
                    .with_children(|builder| {
                        for ix in 0..COLS {
                            let ix = ix + 1;
                            builder.spawn(create_place(ix)).with_children(|builder| {
                                builder.spawn((
                                    Text::new(format!("{:?}", Id(ix))),
                                    TextFont {
                                        font_size: 20.0,
                                        ..default()
                                    },
                                    TextLayout::new_with_justify(JustifyText::Center),
                                    TextColor(WHITE.into()),
                                ));
                            });
                        }
                    });

                for ix in 0..COLS {
                    let ix = ix + 1;
                    // Header
                    builder
                        .spawn((
                            Node {
                                display: Display::Grid,
                                padding: UiRect::all(Val::Px(6.0)),
                                grid_column: GridPlacement::span(1),
                                justify_content: JustifyContent::Center,
                                ..default()
                            },
                            BackgroundColor(BLACK.into()),
                        ))
                        .with_children(|builder| {
                            builder.spawn((
                                Text::new(format!("Press {ix} to move ^ here (child)")),
                                TextFont {
                                    font_size: 20.0,
                                    ..default()
                                },
                                TextColor(WHITE.into()),
                            ));
                        });
                }
            });
        });

    commands
        .spawn(create_place(0))
        .insert(Marker)
        .with_children(|builder| {
            builder.spawn((
                Text::new("Target"),
                TextFont {
                    font_size: 20.0,
                    ..default()
                },
                TextLayout::new_with_justify(JustifyText::Center),
                TextColor(RED.into()),
            ));
        });
}

#[derive(QueryData)]
#[query_data(mutable)]
struct PlaceOrMarkerQueryData {
    entity: Entity,
    parent: Option<&'static Parent>,
    id: &'static Id,
    pos: &'static mut Pos,
}

impl PlaceOrMarkerQueryDataItem<'_> {
    fn swap_pos(&mut self, other: &mut Self) {
        let other_pos = other.pos.0;
        other.pos.set(self.pos.0);
        self.pos.set(other_pos);
    }
    fn pos(&self) -> usize {
        self.pos.get()
    }
}

impl PlaceOrMarkerQueryDataReadOnlyItem<'_> {
    fn pos(&self) -> usize {
        self.pos.get()
    }
}

fn input(
    mut commands: Commands,
    keys: Res<ButtonInput<KeyCode>>,
    mut marker_q: Query<PlaceOrMarkerQueryData, With<Marker>>,
    mut places_q: Query<PlaceOrMarkerQueryData, Without<Marker>>,
) {
    let sorted_places = (0..=3)
        .map(|ix| {
            places_q.iter().find_map(|place| {
                if place.pos() == ix {
                    Some(place.entity)
                } else {
                    None
                }
            })
        })
        .collect::<Vec<_>>();

    let mut update = |place: usize| {
        println!(
            "update {:?}",
            sorted_places
                .iter()
                .map(|entity| entity.map(|entity| places_q.get(entity).unwrap().id))
                .collect::<Vec<_>>()
        );

        let mut marker = marker_q.single_mut();
        if marker.pos() == place {
            return;
        }
        let Some(target_place_entity) = sorted_places[place] else {
            return;
        };
        let mut target_place = places_q.get_mut(target_place_entity).unwrap();

        println!("{} -> {}", marker.pos(), target_place.pos());

        let (remove_target_place_parent, remove_marker_parent) = (marker.pos() == 0, target_place.pos() == 0);

        if remove_marker_parent && remove_target_place_parent {
            unreachable!();
        }

        marker.swap_pos(&mut target_place);

        let marker_parent = if remove_marker_parent {
            let marker_parent = marker.parent.expect("marker missing parent").get();
            commands.entity(marker.entity).remove_parent();
            Some(marker_parent)
        } else {
            marker.parent.map(Parent::get)
        };

        let target_place_parent = if remove_target_place_parent {
            let target_place_parent = target_place
                .parent
                .expect("target_place missing parent")
                .get();
            commands.entity(target_place.entity).remove_parent();
            Some(target_place_parent)
        } else {
            target_place.parent.map(Parent::get)
        };

        if let Some(marker_parent) = marker_parent {
            commands
                .entity(marker_parent)
                .insert_children(target_place.pos() - 1, &[target_place.entity]);
        }

        if let Some(target_place_parent) = target_place_parent {
            commands
                .entity(target_place_parent)
                .insert_children(marker.pos() - 1, &[marker.entity]);
        }
    };

    if keys.just_pressed(KeyCode::Digit0) {
        update(0);
    }
    if keys.just_pressed(KeyCode::Digit1) {
        update(1);
    }
    if keys.just_pressed(KeyCode::Digit2) {
        update(2);
    }
    if keys.just_pressed(KeyCode::Digit3) {
        update(3);
    }
}

```

</details>