### PR TITLE
`many_buttons` `--respawn` arg

### DIFF
--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -42,6 +42,10 @@ struct Args {
     /// use the grid layout model
     #[argh(switch)]
     grid: bool,
+
+    /// at the start of each frame despawn any existing UI nodes and spawn a new UI tree
+    #[argh(switch)]
+    respawn: bool,
 }
 
 /// This example shows what happens when there is a lot of buttons on screen.

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -56,6 +56,8 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     let args = Args::from_args(&[], &[]).unwrap();
 
+    warn!(include_str!("warning_string.txt"));
+
     let mut app = App::new();
 
     app.add_plugins((
@@ -76,6 +78,10 @@ fn main() {
     })
     .add_systems(Update, (button_system, set_text_colors_changed));
 
+    app.add_systems(Startup, |mut commands: Commands| {
+        commands.spawn(Camera2d);
+    });
+
     if args.grid {
         app.add_systems(Startup, setup_grid);
     } else {
@@ -94,6 +100,14 @@ fn main() {
                 .iter_mut()
                 .for_each(|mut text| text.set_changed());
         });
+    }
+
+    if args.respawn {
+        if args.grid {
+            app.add_systems(Update, (despawn_ui, setup_grid).chain());
+        } else {
+            app.add_systems(Update, (despawn_ui, setup_flex).chain());
+        }
     }
 
     app.insert_resource(args).run();
@@ -123,7 +137,6 @@ fn button_system(
 }
 
 fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
-    warn!(include_str!("warning_string.txt"));
     let image = if 0 < args.image_freq {
         Some(asset_server.load("branding/icon.png"))
     } else {
@@ -138,7 +151,6 @@ fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
     };
 
     let as_rainbow = |i: usize| Color::hsl((i as f32 / buttons_f) * 360.0, 0.9, 0.8);
-    commands.spawn(Camera2d);
     commands
         .spawn(Node {
             flex_direction: FlexDirection::Column,
@@ -175,7 +187,6 @@ fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
 }
 
 fn setup_grid(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<Args>) {
-    warn!(include_str!("warning_string.txt"));
     let image = if 0 < args.image_freq {
         Some(asset_server.load("branding/icon.png"))
     } else {
@@ -190,7 +201,6 @@ fn setup_grid(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
     };
 
     let as_rainbow = |i: usize| Color::hsl((i as f32 / buttons_f) * 360.0, 0.9, 0.8);
-    commands.spawn(Camera2d);
     commands
         .spawn(Node {
             display: Display::Grid,
@@ -271,4 +281,8 @@ fn spawn_button(
             ));
         });
     }
+}
+
+fn despawn_ui(mut commands: Commands, root_node: Single<Entity, (With<Node>, Without<Parent>)>) {
+    commands.entity(*root_node).despawn_recursive();
 }


### PR DESCRIPTION
# Objective

To capture the performance impact of removing and adding UI nodes add a `respawn` commandline argument to the `many_buttons` stress test example that despawns the existing UI layout and then spawns a new layout to replace it every frame.

## Testing

To run the example with the new changes use:
```cargo run --example many_buttons --release -- --respawn```
