### PR TITLE
Add sample_clamped method to animation curves, returning Boxed values

### DIFF
--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -81,6 +81,7 @@ use core::{
     fmt::{self, Debug, Formatter},
     marker::PhantomData,
 };
+use std::any::Any;
 
 use bevy_ecs::{component::Component, world::Mut};
 use bevy_math::{
@@ -209,6 +210,21 @@ where
     phantom: PhantomData<P>,
 }
 
+pub struct AnimatableCurveSample {
+    pub component_type: TypeId,
+    pub property_type: TypeId,
+    pub get_mut_boxed: fn(&mut dyn Any) -> Option<&mut dyn Reflect>,
+    pub value: Box<dyn Reflect>,
+}
+
+fn get_mut_boxed<P: AnimatableProperty>(component: &mut dyn Any) -> Option<&mut dyn Reflect> {
+    if let Some(component) = component.downcast_mut::<P::Component>() {
+        P::get_mut(component).map(|p| p.as_reflect_mut())
+    } else {
+        panic!("Type mismatch")
+    }
+}
+
 impl<P, C> AnimatableCurve<P, C>
 where
     P: AnimatableProperty,
@@ -294,6 +310,17 @@ where
             });
         Ok(())
     }
+
+    fn sample_clamped(&self, t: f32) -> Box<dyn Any> {
+        let value = self.curve.sample_clamped(t);
+
+        Box::new(AnimatableCurveSample {
+            component_type: TypeId::of::<P::Component>(),
+            property_type: TypeId::of::<P::Property>(),
+            get_mut_boxed: get_mut_boxed::<P>,
+            value: Box::new(value),
+        })
+    }
 }
 
 impl<P> AnimationCurveEvaluator for AnimatableCurveEvaluator<P>
@@ -353,6 +380,14 @@ pub struct TranslationCurveEvaluator {
     evaluator: BasicAnimationCurveEvaluator<Vec3>,
 }
 
+/// Type indicating that the sampled value from an animation curve is coming from a
+/// [`TranslationCurve`].
+///
+/// You shouldn't need to interact with this type unless you're manually evaluating animation
+/// curves.
+#[derive(Reflect)]
+pub struct TranslationCurveSample(Vec3);
+
 impl<C> AnimationCurve for TranslationCurve<C>
 where
     C: AnimationCompatibleCurve<Vec3>,
@@ -395,6 +430,12 @@ where
                 graph_node,
             });
         Ok(())
+    }
+
+    fn sample_clamped(&self, t: f32) -> Box<dyn Any> {
+        let value = self.0.sample_clamped(t);
+
+        Box::new(TranslationCurveSample(value))
     }
 }
 
@@ -450,6 +491,14 @@ pub struct RotationCurveEvaluator {
     evaluator: BasicAnimationCurveEvaluator<Quat>,
 }
 
+/// Type indicating that the sampled value from an animation curve is coming from a
+/// [`RotationCurve`].
+///
+/// You shouldn't need to interact with this type unless you're manually evaluating animation
+/// curves.
+#[derive(Reflect)]
+pub struct RotationCurveSample(Quat);
+
 impl<C> AnimationCurve for RotationCurve<C>
 where
     C: AnimationCompatibleCurve<Quat>,
@@ -492,6 +541,12 @@ where
                 graph_node,
             });
         Ok(())
+    }
+
+    fn sample_clamped(&self, t: f32) -> Box<dyn Any> {
+        let value = self.0.sample_clamped(t);
+
+        Box::new(RotationCurveSample(value))
     }
 }
 
@@ -547,6 +602,14 @@ pub struct ScaleCurveEvaluator {
     evaluator: BasicAnimationCurveEvaluator<Vec3>,
 }
 
+/// Type indicating that the sampled value from an animation curve is coming from a
+/// [`ScaleCurve`].
+///
+/// You shouldn't need to interact with this type unless you're manually evaluating animation
+/// curves.
+#[derive(Reflect)]
+pub struct ScaleCurveSample(Vec3);
+
 impl<C> AnimationCurve for ScaleCurve<C>
 where
     C: AnimationCompatibleCurve<Vec3>,
@@ -589,6 +652,12 @@ where
                 graph_node,
             });
         Ok(())
+    }
+
+    fn sample_clamped(&self, t: f32) -> Box<dyn Any> {
+        let value = self.0.sample_clamped(t);
+
+        Box::new(ScaleCurveSample(value))
     }
 }
 
@@ -671,6 +740,14 @@ struct WeightsCurveEvaluator {
     morph_target_count: Option<u32>,
 }
 
+/// Type indicating that the sampled value from an animation curve is coming from a
+/// [`ScaleCurve`].
+///
+/// You shouldn't need to interact with this type unless you're manually evaluating animation
+/// curves.
+#[derive(Reflect)]
+pub struct WeightsCurveSample(Vec<f32>);
+
 impl<C> AnimationCurve for WeightsCurve<C>
 where
     C: IterableCurve<f32> + Debug + Clone + Reflectable,
@@ -721,6 +798,12 @@ where
             .stack_blend_weights_and_graph_nodes
             .push((weight, graph_node));
         Ok(())
+    }
+
+    fn sample_clamped(&self, t: f32) -> Box<dyn Any> {
+        let value = self.0.sample_iter_clamped(t);
+
+        Box::new(WeightsCurveSample(value.collect()))
     }
 }
 
@@ -1010,6 +1093,8 @@ pub trait AnimationCurve: Reflect + Debug + Send + Sync {
         weight: f32,
         graph_node: AnimationNodeIndex,
     ) -> Result<(), AnimationEvaluationError>;
+
+    fn sample_clamped(&self, t: f32) -> Box<dyn Any>;
 }
 
 /// A low-level trait for use in [`crate::VariableCurve`] that provides fine


### PR DESCRIPTION
# Objective

Currently the evaluation of `AnimationCurve`s is coupled to the Bevy animation system. This PR provides an integration point for plugins that would like to reuse the animation loading (e.g. from GLTF) and sampling code but implement a custom animation composition system (the use case I have in mind is [bevy_animation_graph](https://github.com/mbrea-c/bevy_animation_graph)).

## Solution

The `AnimationCurve` trait provides a `sample_clamped` method, which returns a boxed version of the result of sampling the underlying curve:

```rust
fn sample_clamped(&self, t: f32) -> Box<dyn Any>;
```

Each of the provided implementations of `AnimationCurve` return a custom sampled type, e.g.:

```rust
#[derive(Reflect)]
pub struct TranslationCurveSample(Vec3);

impl<C> AnimationCurve for TranslationCurve<C>
where
    C: AnimationCompatibleCurve<Vec3>,
{
    // ...

    fn sample_clamped(&self, t: f32) -> Box<dyn Any> {
        let value = self.0.sample_clamped(t);

        Box::new(TranslationCurveSample(value))
    }
}
```

This fits with the "open polymorphism" approach that the rest of the rest of the animation curves code is using. Users can then check the `TypeId` of the returned type to determine what to do with the sampled value.

### Alternative solutions

#### Closed polymorphism
Provide an enum value as the result of `AnimationCurve::sample_clamped`:

```rust
pub enum CurveSample {
    Translation(Vec3),
    Rotation(Quat),
    Scale(Vec3),
    AnimatableCurve(AnimatableCurveSample),
}
```

However this would be at odds with the current implementation of `AnimationCurve`, where users can implement their own `AnimationCurve` types.

## Testing

- Added a new doctest, run all unit tests.
- Ran animation examples to ensure no regressions.
- No benchmarking done, since the existing animation flow is untouched.
- Pending testing tasks:
  - [ ] `AnimatableCurve` sampling.
  - [ ] `WeightsCurve` sampling.
  - [ ] Test using this API in `bevy_animation_graph`.

---

## Showcase

<details>
  <summary>bevy_animation_graph example</summary>

[bevy_animation_graph](https://github.com/mbrea-c/bevy_animation_graph) evaluates animation curves in "Clip" nodes, and stores the
sampled values for all targets in a `Pose` struct which is made available to
other nodes as an output.

Currently evaluating animation curves in `bevy_animation_graph` involves abusing
the `Reflect` API to access private fields in the curve evaluators:
```rust
fn sample_animation_curve(curve: &VariableCurve, time: f32) -> CurveValue {
    let mut evaluator = curve.0.create_evaluator();
    let evaluator_type_id = curve.0.evaluator_type();
    let evaluator_type_name = evaluator.reflect_type_info().type_path();
    let node_index = AnimationNodeIndex::default();

    curve
        .0
        .apply(evaluator.as_mut(), time, 1., node_index)
        .unwrap();

    if evaluator_type_id == TypeId::of::<TranslationCurveEvaluator>() {
        let t = evaluator
            .as_reflect()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("evaluator")
            .unwrap()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("stack")
            .unwrap()
            .reflect_ref()
            .as_list()
            .unwrap()
            .get(0)
            .unwrap()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("value")
            .unwrap()
            .try_downcast_ref::<Vec3>()
            .unwrap();
        CurveValue::Translation(*t)
    } else if evaluator_type_id == TypeId::of::<RotationCurveEvaluator>() {
        let r = evaluator
            .as_reflect()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("evaluator")
            .unwrap()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("stack")
            .unwrap()
            .reflect_ref()
            .as_list()
            .unwrap()
            .get(0)
            .unwrap()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("value")
            .unwrap()
            .try_downcast_ref::<Quat>()
            .unwrap();
        CurveValue::Rotation(*r)
    } else if evaluator_type_id == TypeId::of::<ScaleCurveEvaluator>() {
        let s = evaluator
            .as_reflect()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("evaluator")
            .unwrap()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("stack")
            .unwrap()
            .reflect_ref()
            .as_list()
            .unwrap()
            .get(0)
            .unwrap()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("value")
            .unwrap()
            .try_downcast_ref::<Vec3>()
            .unwrap();
        CurveValue::Scale(*s)
    } else if evaluator_type_name
        // Need to resort to this because WeightsCurveEvaluator is private
        .starts_with("bevy_animation::animation_curves::WeightsCurveEvaluator")
    {
        let w = evaluator
            .as_reflect()
            .reflect_ref()
            .as_struct()
            .unwrap()
            .field("stack_morph_target_weights")
            .unwrap()
            .try_downcast_ref::<Vec<f32>>()
            .unwrap()
            .clone();
        CurveValue::BoneWeights(w)
    } else {
        panic!("Animatable curve type not yet supported!");
    }
}
```

With this PR, we can instead do the following:

```rust
fn sample_animation_curve(curve: &VariableCurve, time: f32) -> CurveValue {
    let curve_sample = curve.0.sample_clampled(time);
    let sample_type_id = curve_sample.as_ref().type_id();

    if TypeId::of::<TranslationCurveSample>() == sample_type_id {
        let cast_sample = curve_sample.downcast::<TranslationCurveSample>().unwrap();
        CurveValue::Translation(cast_sample.0)
    } else if TypeId::of::<RotationCurveSample>() == sample_type_id {
        let cast_sample = curve_sample.downcast::<RotationCurveSample>().unwrap();
        CurveValue::Rotation(cast_sample.0)
    } else if TypeId::of::<ScaleCurveSample>() == sample_type_id {
        let cast_sample = curve_sample.downcast::<ScaleCurveSample>().unwrap();
        CurveValue::Scale(cast_sample.0)
    } else if TypeId::of::<WeightsCurveSample>() == sample_type_id {
        let cast_sample = curve_sample.downcast::<WeightsCurveSample>().unwrap();
        CurveValue::Weights(cast_sample.0)
    } else {
        panic!("Animatable curve type not yet supported!");
    }
}
```

Furthermore, the API in this PR opens the door to adding support for
`AnimatableCurve`s, whereas before this was not possible (or at least I could
not find a way).

</details>