### PR TITLE
Expose BRP system scheduling and add system set

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -456,7 +456,7 @@ impl Plugin for RemotePlugin {
 
 /// Schedule that contains all systems to process Bevy Remote Protocol requests
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
-struct RemoteLast;
+pub struct RemoteLast;
 
 /// A type to hold the allowed types of systems to be used as method handlers.
 #[derive(Debug)]


### PR DESCRIPTION
# Objective
When adding custom BRP methods one might need to:
- Run custom systems in the `RemoteLast` schedule.
- Order those systems before/after request processing and cleanup.

For example in `bevy_remote_inspector` we need a way to perform some preparation _before_ request processing. And to perform cleanup _between_ request processing and watcher cleanup.

## Solution

- Make `RemoteLast` public
- Add `RemoteSet` with `ProcessRequests` and `Cleanup` variants.