### PR TITLE
`Cargo.toml` dependency consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.82.0"
 
 [workspace]
 exclude = [
@@ -461,36 +460,36 @@ bevy_internal = { path = "crates/bevy_internal", version = "0.15.0-dev", default
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.15.0-dev", default-features = false, optional = true }
 
 [dev-dependencies]
-rand = "0.8.0"
+rand = "0.8.5"
 rand_chacha = "0.3.1"
-ron = "0.8.0"
+ron = "0.8.1"
 flate2 = "1.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-bytemuck = "1.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+bytemuck = "1.19"
 bevy_render = { path = "crates/bevy_render", version = "0.15.0-dev", default-features = false }
 # Needed to poll Task examples
-futures-lite = "2.0.1"
+futures-lite = "2.5"
 async-std = "1.13"
-crossbeam-channel = "0.5.0"
+crossbeam-channel = "0.5.13"
 argh = "0.1.12"
-thiserror = "1.0"
-event-listener = "5.3.0"
-hyper = { version = "1", features = ["server", "http1"] }
-http-body-util = "0.1"
-anyhow = "1"
-macro_rules_attribute = "0.2"
-accesskit = "0.17"
+thiserror = "2.0"
+event-listener = "5.3"
+hyper = { version = "1.5", features = ["server", "http1"] }
+http-body-util = "0.1.2"
+anyhow = "1.0"
+macro_rules_attribute = "0.2.0"
+accesskit = "0.17.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-smol = "2"
-smol-macros = "0.1"
-smol-hyper = "0.1"
-ureq = { version = "2.10.1", features = ["json"] }
+smol = "2.0"
+smol-macros = "0.1.1"
+smol-hyper = "0.1.1"
+ureq = { version = "2.10", features = ["json"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = ["Window"] }
+wasm-bindgen = { version = "0.2.95" }
+web-sys = { version = "0.3.72", features = ["Window"] }
 
 [[example]]
 name = "hello_world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
+rust-version = "1.82.0"
 
 [workspace]
 exclude = [

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 glam = "0.29"
 rand = "0.8"
 rand_chacha = "0.3"
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 bevy_app = { path = "../crates/bevy_app" }
 bevy_ecs = { path = "../crates/bevy_ecs", features = ["multi_threaded"] }
 bevy_hierarchy = { path = "../crates/bevy_hierarchy" }

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -30,19 +30,19 @@ bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev" }
 
 # other
-petgraph = { version = "0.6", features = ["serde-1"] }
-ron = "0.8"
-serde = "1"
-blake3 = { version = "1.0" }
-derive_more = { version = "1", default-features = false, features = [
+petgraph = { version = "0.6.5", features = ["serde-1"] }
+ron = "0.8.1"
+serde = "1.0"
+blake3 = { version = "1.5" }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
 either = "1.13"
-thread_local = "1"
-uuid = { version = "1.7", features = ["v4"] }
-smallvec = "1"
+thread_local = "1.1"
+uuid = { version = "1.11", features = ["v4"] }
+smallvec = "1.13"
 
 [lints]
 workspace = true

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -28,20 +28,20 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 
 # other
-downcast-rs = "1.2.0"
-derive_more = { version = "1", default-features = false, features = [
+downcast-rs = "1.2"
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ctrlc = "3.4.4"
+ctrlc = "3.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = ["Window"] }
-console_error_panic_hook = "0.1.6"
+wasm-bindgen = { version = "0.2.95" }
+web-sys = { version = "0.3.72", features = ["Window"] }
+console_error_panic_hook = "0.1.7"
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -28,41 +28,41 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
-stackfuture = "0.3"
+stackfuture = "0.3.0"
 atomicow = "1.0"
-async-broadcast = "0.5"
-async-fs = "2.0"
-async-lock = "3.0"
-bitflags = { version = "2.3", features = ["serde"] }
-crossbeam-channel = "0.5"
+async-broadcast = "0.7.1"
+async-fs = "2.1"
+async-lock = "3.4"
+bitflags = { version = "2.6", features = ["serde"] }
+crossbeam-channel = "0.5.13"
 downcast-rs = "1.2"
 disqualified = "1.0"
 either = "1.13"
-futures-io = "0.3"
-futures-lite = "2.0.1"
+futures-io = "0.3.31"
+futures-lite = "2.5"
 blake3 = "1.5"
-parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
-ron = "0.8"
-serde = { version = "1", features = ["derive"] }
-derive_more = { version = "1", default-features = false, features = [
+parking_lot = { version = "0.12.3", features = ["arc_lock", "send_guard"] }
+ron = "0.8.1"
+serde = { version = "1.0", features = ["derive"] }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "1.11", features = ["v4"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2" }
-web-sys = { version = "0.3", features = [
+wasm-bindgen = { version = "0.2.95" }
+web-sys = { version = "0.3.72", features = [
   "Window",
   "Response",
   "WorkerGlobalScope",
 ] }
-wasm-bindgen-futures = "0.4"
-js-sys = "0.3"
+wasm-bindgen-futures = "0.4.45"
+js-sys = "0.3.72"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.4.0", optional = true }

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -23,13 +23,13 @@ bevy_derive = { path = "../bevy_derive", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-rodio = { version = "0.19", default-features = false }
+rodio = { version = "0.20.1", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-cpal = { version = "0.15", optional = true }
+cpal = { version = "0.15.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.19", default-features = false, features = [
+rodio = { version = "0.20.1", default-features = false, features = [
   "wasm-bindgen",
 ] }
 

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "color"]
-rust-version = "1.82.0"
+rust-version = "1.82"
 
 [dependencies]
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = false, features = [
@@ -16,15 +16,15 @@ bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = 
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "bevy",
 ], optional = true }
-bytemuck = { version = "1", features = ["derive"] }
+bytemuck = { version = "1.19", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
-derive_more = { version = "1", default-features = false, features = [
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-wgpu-types = { version = "23", default-features = false, optional = true }
-encase = { version = "0.10", default-features = false }
+wgpu-types = { version = "23.0", default-features = false, optional = true }
+encase = { version = "0.10.0", default-features = false }
 
 [features]
 default = ["bevy_reflect"]

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "color"]
-rust-version = "1.76.0"
+rust-version = "1.82.0"
 
 [dependencies]
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = false, features = [

--- a/crates/bevy_color/crates/gen_tests/Cargo.toml
+++ b/crates/bevy_color/crates/gen_tests/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [workspace]
 
 [dependencies]
-palette = "0.7.4"
+palette = "0.7.6"

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -31,7 +31,7 @@ bevy_reflect = [
 serialize = ["dep:serde"]
 
 [dev-dependencies]
-crossbeam-channel = "0.5.0"
+crossbeam-channel = "0.5.13"
 serde_test = "1.0"
 
 [lints]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -36,12 +36,12 @@ bevy_math = { path = "../bevy_math", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
-serde = { version = "1", features = ["derive"] }
-bitflags = "2.3"
-radsort = "0.1"
-nonmax = "0.5"
-smallvec = "1"
-derive_more = { version = "1", default-features = false, features = [
+serde = { version = "1.0", features = ["derive"] }
+bitflags = "2.6"
+radsort = "0.1.1"
+nonmax = "0.5.5"
+smallvec = "1.13"
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -40,7 +40,7 @@ bevy_state = { path = "../bevy_state", version = "0.15.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-ron = { version = "0.8.0", optional = true }
+ron = { version = "0.8.1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -22,7 +22,7 @@ bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 
-const-fnv1a-hash = "1.1.0"
+const-fnv1a-hash = "1.1"
 
 # macOS
 [target.'cfg(all(target_os="macos"))'.dependencies]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
-rust-version = "1.77.0"
+rust-version = "1.81.0"
 
 [features]
 default = ["bevy_reflect"]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
-rust-version = "1.81.0"
+rust-version = "1.81"
 
 [features]
 default = ["bevy_reflect"]
@@ -26,26 +26,26 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_ecs_macros = { path = "macros", version = "0.15.0-dev" }
 
-petgraph = "0.6"
-bitflags = "2.3"
-concurrent-queue = "2.5.0"
+petgraph = "0.6.5"
+bitflags = "2.6"
+concurrent-queue = "2.5"
 disqualified = "1.0"
-fixedbitset = "0.5"
-serde = { version = "1", optional = true, default-features = false }
-derive_more = { version = "1", default-features = false, features = [
+fixedbitset = "0.5.7"
+serde = { version = "1.0", optional = true, default-features = false }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
   "into",
   "as_ref",
 ] }
-nonmax = "0.5"
-arrayvec = { version = "0.7.4", optional = true }
-smallvec = { version = "1", features = ["union"] }
+nonmax = "0.5.5"
+arrayvec = { version = "0.7.6", optional = true }
+smallvec = { version = "1.13", features = ["union"] }
 
 [dev-dependencies]
-rand = "0.8"
-static_assertions = "1.1.0"
+rand = "0.8.5"
+static_assertions = "1.1"
 
 [[example]]
 name = "events"

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -18,7 +18,7 @@ bevy_time = { path = "../bevy_time", version = "0.15.0-dev" }
 
 # other
 gilrs = "0.11.0"
-derive_more = { version = "1", default-features = false, features = [
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -41,7 +41,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-gltf = { version = "1.4.0", default-features = false, features = [
+gltf = { version = "1.4", default-features = false, features = [
   "KHR_lights_punctual",
   "KHR_materials_transmission",
   "KHR_materials_ior",
@@ -54,16 +54,16 @@ gltf = { version = "1.4.0", default-features = false, features = [
   "names",
   "utils",
 ] }
-derive_more = { version = "1", default-features = false, features = [
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-base64 = "0.22.0"
-percent-encoding = "2.1"
+base64 = "0.22.1"
+percent-encoding = "2.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-smallvec = "1.11"
+serde_json = "1.0"
+smallvec = "1.13"
 
 [dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.15.0-dev" }

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -26,7 +26,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 disqualified = "1.0"
 
-smallvec = { version = "1.11", features = ["union", "const_generics"] }
+smallvec = { version = "1.13", features = ["union", "const_generics"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -47,23 +47,23 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 image = { version = "0.25.2", default-features = false }
 
 # misc
-bitflags = { version = "2.3", features = ["serde"] }
-bytemuck = { version = "1.5" }
+bitflags = { version = "2", features = ["serde"] }
+bytemuck = { version = "1.0" }
 wgpu = { version = "23", default-features = false }
-serde = { version = "1", features = ["derive"] }
-derive_more = { version = "1", default-features = false, features = [
+serde = { version = "1.0", features = ["derive"] }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-futures-lite = "2.0.1"
-ddsfile = { version = "0.5.2", optional = true }
-ktx2 = { version = "0.3.0", optional = true }
+futures-lite = "2"
+ddsfile = { version = "0.5", optional = true }
+ktx2 = { version = "0.3", optional = true }
 # For ktx2 supercompression
-flate2 = { version = "1.0.22", optional = true }
-ruzstd = { version = "0.7.0", optional = true }
+flate2 = { version = "1.0", optional = true }
+ruzstd = { version = "0.7", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
-basis-universal = { version = "0.3.0", optional = true }
+basis-universal = { version = "0.3", optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -36,13 +36,13 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 ], optional = true }
 
 # other
-serde = { version = "1", features = ["derive"], optional = true }
-derive_more = { version = "1", default-features = false, features = [
+serde = { version = "1.0", features = ["derive"], optional = true }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-smol_str = "0.2"
+smol_str = "0.2.2"
 
 [lints]
 workspace = true

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -17,27 +17,24 @@ bevy_app = { path = "../bevy_app", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev" }
 
-tracing-subscriber = { version = "0.3.1", features = [
-  "registry",
-  "env-filter",
-] }
-tracing-chrome = { version = "0.7.0", optional = true }
+tracing-subscriber = { version = "0.3.18", features = ["registry", "env-filter"] }
+tracing-chrome = { version = "0.7.2", optional = true }
 tracing-log = "0.2.0"
 tracing-error = { version = "0.2.0", optional = true }
 
 # Tracy dependency compatibility table:
 # https://github.com/nagisa/rust_tracy_client
-tracing-tracy = { version = "0.11.0", optional = true }
-tracy-client = { version = "0.17.0", optional = true }
+tracing-tracy = { version = "0.11.3", optional = true }
+tracy-client = { version = "0.17.4", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_log-sys = "0.3.0"
+android_log-sys = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tracing-wasm = "0.2.1"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-tracing-oslog = "0.2"
+tracing-oslog = "0.2.0"
 
 [lints]
 workspace = true

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -9,9 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-toml_edit = { version = "0.22.7", default-features = false, features = [
-  "parse",
-] }
+toml_edit = { version = "0.22.22", default-features = false, features = ["parse"] }
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.68.2"
+rust-version = "1.81.0"
 
 [dependencies]
 glam = { version = "0.29", features = ["bytemuck"] }

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -7,37 +7,37 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.81.0"
+rust-version = "1.81"
 
 [dependencies]
-glam = { version = "0.29", features = ["bytemuck"] }
-derive_more = { version = "1", default-features = false, features = [
+glam = { version = "0.29.2", features = ["bytemuck"] }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
   "into",
 ] }
 itertools = "0.13.0"
-serde = { version = "1", features = ["derive"], optional = true }
-libm = { version = "0.2", optional = true }
-approx = { version = "0.5", optional = true }
-rand = { version = "0.8", features = [
+serde = { version = "1.0", features = ["derive"], optional = true }
+libm = { version = "0.2.11", optional = true }
+approx = { version = "0.5.1", optional = true }
+rand = { version = "0.8.5", features = [
   "alloc",
 ], default-features = false, optional = true }
 rand_distr = { version = "0.4.3", optional = true }
-smallvec = { version = "1.11" }
+smallvec = { version = "1.13" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "glam",
 ], optional = true }
 
 [dev-dependencies]
-approx = "0.5"
+approx = "0.5.1"
 # Supply rngs for examples and tests
-rand = "0.8"
-rand_chacha = "0.3"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 # Enable the approx feature when testing.
 bevy_math = { path = ".", version = "0.15.0-dev", features = ["approx"] }
-glam = { version = "0.29", features = ["approx"] }
+glam = { version = "0.29.2", features = ["approx"] }
 
 [features]
 default = ["rand", "bevy_reflect", "curve"]

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -22,12 +22,12 @@ bevy_derive = { path = "../bevy_derive", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # misc
-bitflags = { version = "2.3", features = ["serde"] }
-bytemuck = { version = "1.5" }
-wgpu = { version = "23", default-features = false }
-serde = { version = "1", features = ["derive"] }
+bitflags = { version = "2.6", features = ["serde"] }
+bytemuck = { version = "1.19" }
+wgpu = { version = "23.0", default-features = false }
+serde = { version = "1.0", features = ["derive"] }
 hexasphere = "15.0"
-derive_more = { version = "1", default-features = false, features = [
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -13,7 +13,6 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
-rust-version = "1.76.0"
 
 [features]
 default = ["std"]
@@ -22,8 +21,8 @@ std = ["glam/std"]
 libm = ["glam/libm", "dep:libm"]
 
 [dependencies]
-glam = { version = "0.29.0", default-features = false }
-libm = { version = "0.2", default-features = false, optional = true }
+glam = { version = "0.29.2", default-features = false }
+libm = { version = "0.2.11", default-features = false, optional = true }
 
 [[example]]
 name = "generate"

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -50,9 +50,9 @@ bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
 
 # other
-bitflags = "2.3"
+bitflags = "2"
 fixedbitset = "0.5"
-derive_more = { version = "1", default-features = false, features = [
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
@@ -61,18 +61,18 @@ derive_more = { version = "1", default-features = false, features = [
 lz4_flex = { version = "0.11", default-features = false, features = [
   "frame",
 ], optional = true }
-range-alloc = { version = "0.1.3", optional = true }
+range-alloc = { version = "0.1", optional = true }
 half = { version = "2", features = ["bytemuck"], optional = true }
 meshopt = { version = "0.4", optional = true }
 metis = { version = "0.2", optional = true }
 itertools = { version = "0.13", optional = true }
-bitvec = { version = "1", optional = true }
+bitvec = { version = "1.0", optional = true }
 # direct dependency required for derive macro
-bytemuck = { version = "1", features = ["derive", "must_cast"] }
+bytemuck = { version = "1.0", features = ["derive", "must_cast"] }
 radsort = "0.1"
-smallvec = "1.6"
+smallvec = "1.13"
 nonmax = "0.5"
-static_assertions = "1"
+static_assertions = "1.1"
 
 [lints]
 workspace = true

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -27,8 +27,8 @@ bevy_transform = { path = "../bevy_transform", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 
-crossbeam-channel = { version = "0.5", optional = true }
-uuid = { version = "1.1", features = ["v4"] }
+crossbeam-channel = { version = "0.5.13", optional = true }
+uuid = { version = "1.11", features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "no_std"]
+rust-version = "1.81.0"
 
 [dependencies]
 

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "no_std"]
-rust-version = "1.81.0"
+rust-version = "1.81"
 
 [dependencies]
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.76.0"
+rust-version = "1.81.0"
 
 [features]
 default = ["smallvec", "debug", "alloc"]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.81.0"
+rust-version = "1.81"
 
 [features]
 default = ["smallvec", "debug", "alloc"]
@@ -35,31 +35,31 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.15.0-dev" }
 
 # other
-erased-serde = "0.4"
+erased-serde = "0.4.5"
 disqualified = "1.0"
 downcast-rs = "1.2"
-derive_more = { version = "1", default-features = false, features = [
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-serde = "1"
-smallvec = { version = "1.11", optional = true }
+serde = "1.0"
+smallvec = { version = "1.13", optional = true }
 assert_type_match = "0.1.1"
 
-glam = { version = "0.29", features = ["serde"], optional = true }
-petgraph = { version = "0.6", features = ["serde-1"], optional = true }
-smol_str = { version = "0.2.0", features = ["serde"], optional = true }
-uuid = { version = "1.0", optional = true, features = ["v4", "serde"] }
-wgpu-types = { version = "23", features = ["serde"], optional = true }
+glam = { version = "0.29.2", features = ["serde"], optional = true }
+petgraph = { version = "0.6.5", features = ["serde-1"], optional = true }
+smol_str = { version = "0.2.2", features = ["serde"], optional = true }
+uuid = { version = "1.11", optional = true, features = ["v4", "serde"] }
+wgpu-types = { version = "23.0", features = ["serde"], optional = true }
 
 [dev-dependencies]
-ron = "0.8.0"
-rmp-serde = "1.1"
+ron = "0.8.1"
+rmp-serde = "1.3"
 bincode = "1.3"
 serde_json = "1.0"
-serde = { version = "1", features = ["derive"] }
-static_assertions = "1.1.0"
+serde = { version = "1.0", features = ["derive"] }
+static_assertions = "1.1"
 
 [[example]]
 name = "reflect_docs"

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -23,7 +23,7 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.15.0-dev" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.11", features = ["v4"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -25,17 +25,17 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-anyhow = "1"
-hyper = { version = "1", features = ["server", "http1"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1" }
-http-body-util = "0.1"
-async-channel = "2"
+anyhow = "1.0"
+hyper = { version = "1.5", features = ["server", "http1"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+http-body-util = "0.1.2"
+async-channel = "2.3"
 
 # dependencies that will not compile on wasm
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-async-io = { version = "2", optional = true }
-smol-hyper = { version = "0.1", optional = true }
+async-io = { version = "2.4", optional = true }
+smol-hyper = { version = "0.1.1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -62,7 +62,7 @@ bevy_mesh = { path = "../bevy_mesh", version = "0.15.0-dev" }
 image = { version = "0.25.2", default-features = false }
 
 # misc
-codespan-reporting = "0.11.0"
+codespan-reporting = "0.11"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use Wasm threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
@@ -75,24 +75,24 @@ wgpu = { version = "23", default-features = false, features = [
   "fragile-send-sync-non-atomic-wasm",
 ] }
 naga = { version = "23", features = ["wgsl-in"] }
-serde = { version = "1", features = ["derive"] }
-bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
-downcast-rs = "1.2.0"
-derive_more = { version = "1", default-features = false, features = [
+serde = { version = "1.0", features = ["derive"] }
+bytemuck = { version = "1.0", features = ["derive", "must_cast"] }
+downcast-rs = "1.0"
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-futures-lite = "2.0.1"
-ktx2 = { version = "0.3.0", optional = true }
+futures-lite = "2"
+ktx2 = { version = "0.3", optional = true }
 encase = { version = "0.10", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
-profiling = { version = "1", features = [
+profiling = { version = "1.0", features = [
   "profile-with-tracing",
 ], optional = true }
-async-channel = "2.3.0"
+async-channel = "2.3"
 nonmax = "0.5"
-smallvec = { version = "1.11", features = ["const_new"] }
+smallvec = { version = "1.0", features = ["const_new"] }
 offset-allocator = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -104,7 +104,7 @@ naga_oil = { version = "0.16", default-features = false, features = [
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 naga_oil = "0.16"
 js-sys = "0.3"
-web-sys = { version = "0.3.67", features = [
+web-sys = { version = "0.3", features = [
   'Blob',
   'Document',
   'Element',
@@ -116,7 +116,7 @@ web-sys = { version = "0.3.67", features = [
 wasm-bindgen = "0.2"
 
 [target.'cfg(all(target_arch = "wasm32", target_feature = "atomics"))'.dependencies]
-send_wrapper = "0.6.0"
+send_wrapper = "0.6"
 
 [lints]
 workspace = true

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -28,8 +28,8 @@ bevy_render = { path = "../bevy_render", version = "0.15.0-dev", optional = true
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-uuid = { version = "1.1", features = ["v4"] }
-derive_more = { version = "1", default-features = false, features = [
+uuid = { version = "1.11", features = ["v4"] }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
@@ -38,7 +38,7 @@ derive_more = { version = "1", default-features = false, features = [
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }
 bincode = "1.3"
-rmp-serde = "1.1"
+rmp-serde = "1.3"
 
 [lints]
 workspace = true

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -35,19 +35,19 @@ bevy_window = { path = "../bevy_window", version = "0.15.0-dev", optional = true
 bevy_derive = { path = "../bevy_derive", version = "0.15.0-dev" }
 
 # other
-bytemuck = { version = "1", features = ["derive", "must_cast"] }
-fixedbitset = "0.5"
-guillotiere = "0.6.0"
-derive_more = { version = "1", default-features = false, features = [
+bytemuck = { version = "1.19", features = ["derive", "must_cast"] }
+fixedbitset = "0.5.7"
+guillotiere = "0.6.2"
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-rectangle-pack = "0.4"
-bitflags = "2.3"
-radsort = "0.1"
-nonmax = "0.5"
-serde = { version = "1", features = ["derive"], optional = true }
+rectangle-pack = "0.4.2"
+bitflags = "2.6"
+radsort = "0.1.1"
+nonmax = "0.5.5"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,16 +12,16 @@ keywords = ["bevy"]
 multi_threaded = ["dep:async-channel", "dep:concurrent-queue"]
 
 [dependencies]
-futures-lite = "2.0.1"
-async-executor = "1.11"
-async-channel = { version = "2.3.0", optional = true }
-async-io = { version = "2.0.0", optional = true }
-concurrent-queue = { version = "2.0.0", optional = true }
+futures-lite = "2.5"
+async-executor = "1.13"
+async-channel = { version = "2.3", optional = true }
+async-io = { version = "2.4", optional = true }
+concurrent-queue = { version = "2.5", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4"
-pin-project = "1"
-futures-channel = "0.3"
+wasm-bindgen-futures = "0.4.45"
+pin-project = "1.1"
+futures-channel = "0.3.31"
 
 [dev-dependencies]
 web-time = { version = "1.1" }

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -31,16 +31,16 @@ bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-cosmic-text = { version = "0.12", features = ["shape-run-cache"] }
-derive_more = { version = "1", default-features = false, features = [
+cosmic-text = { version = "0.12.1", features = ["shape-run-cache"] }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.13"
-unicode-bidi = "0.3.13"
-sys-locale = "0.3.0"
+unicode-bidi = "0.3.17"
+sys-locale = "0.3.2"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -24,8 +24,8 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-crossbeam-channel = "0.5.0"
-serde = { version = "1", features = ["derive"], optional = true }
+crossbeam-channel = "0.5.13"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -19,8 +19,8 @@ bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = 
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "bevy",
 ], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-derive_more = { version = "1", default-features = false, features = [
+serde = { version = "1.0", features = ["derive"], optional = true }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -34,17 +34,17 @@ bevy_window = { path = "../bevy_window", version = "0.15.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
-taffy = { version = "0.5" }
-serde = { version = "1", features = ["derive"], optional = true }
-bytemuck = { version = "1.5", features = ["derive"] }
-derive_more = { version = "1", default-features = false, features = [
+taffy = { version = "0.5.2" }
+serde = { version = "1.0", features = ["derive"], optional = true }
+bytemuck = { version = "1.19", features = ["derive"] }
+derive_more = { version = "1.0", default-features = false, features = [
   "error",
   "from",
   "display",
 ] }
-nonmax = "0.5"
-smallvec = "1.11"
-accesskit = "0.17"
+nonmax = "0.5.5"
+smallvec = "1.13"
+accesskit = "0.17.0"
 
 [features]
 default = ["bevy_ui_picking_backend"]

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -22,19 +22,19 @@ detailed_trace = []
 serde = ["hashbrown/serde"]
 
 [dependencies]
-ahash = { version = "0.8.7", default-features = false, features = [
+ahash = { version = "0.8.11", default-features = false, features = [
   "compile-time-rng",
 ] }
-tracing = { version = "0.1", default-features = false }
-hashbrown = { version = "0.14.2", default-features = false }
+tracing = { version = "0.1.40", default-features = false }
+hashbrown = { version = "0.14.5", default-features = false }
 bevy_utils_proc_macros = { version = "0.15.0-dev", path = "macros" }
-thread_local = { version = "1.0", optional = true }
+thread_local = { version = "1.1", optional = true }
 
 [dev-dependencies]
-static_assertions = "1.1.0"
+static_assertions = "1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.0", features = ["js"] }
+getrandom = { version = "0.2.15", features = ["js"] }
 web-time = { version = "1.1" }
 
 [lints]

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -26,11 +26,11 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-raw-window-handle = "0.6"
-smol_str = "0.2"
+raw-window-handle = "0.6.2"
+smol_str = "0.2.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-activity = "0.6"
+android-activity = "0.6.0"
 
 [lints]
 workspace = true

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -50,7 +50,7 @@ approx = { version = "0.5", default-features = false }
 cfg-if = "1.0"
 raw-window-handle = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
-bytemuck = { version = "1.5", optional = true }
+bytemuck = { version = "1.0", optional = true }
 wgpu-types = { version = "23", optional = true }
 accesskit = "0.17"
 

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "errors"
 edition = "2021"
+version = "0.1.0"
 description = "Documentation and tests for Bevy's error codes"
 publish = false
 license = "MIT OR Apache-2.0"

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
 name = "build-templated-pages"
 edition = "2021"
+version = "0.1.0"
 description = "Tool that checks and fixes undocumented features and examples"
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-toml_edit = { version = "0.22.7", default-features = false, features = [
-  "parse",
-] }
-tera = "1.15"
+toml_edit = { version = "0.22.22", default-features = false, features = ["parse"] }
+tera = "1.20"
 serde = { version = "1.0", features = ["derive"] }
-bitflags = "2.3"
-hashbrown = { version = "0.14", features = ["serde"] }
+bitflags = "2.6"
+hashbrown = { version = "0.14.5", features = ["serde"] }
 
 [lints]
 workspace = true

--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "build-wasm-example"
 edition = "2021"
+version = "0.1.0"
 description = "Tool for building example for Wasm"
 publish = false
 license = "MIT OR Apache-2.0"
 
-
 [dependencies]
-xshell = "0.2"
-clap = { version = "4.0", features = ["derive"] }
+xshell = "0.2.7"
+clap = { version = "4.5", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "ci"
 edition = "2021"
+version = "0.1.0"
 description = "Tool that enables running CI checks locally."
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-argh = "0.1"
-xshell = "0.2"
-bitflags = "2.3"
+argh = "0.1.12"
+xshell = "0.2.7"
+bitflags = "2.6"
 
 [lints]
 workspace = true

--- a/tools/compile_fail_utils/Cargo.toml
+++ b/tools/compile_fail_utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-ui_test = "0.23.0"
+ui_test = "0.27.1"
 
 [[test]]
 name = "example"

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "example-showcase"
 edition = "2021"
+version = "0.1.0"
 description = "Tool for running examples or generating a showcase page for the website."
 publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-xshell = "0.2"
-clap = { version = "4.0", features = ["derive"] }
-ron = "0.8"
-toml_edit = { version = "0.22.7", default-features = false, features = [
-  "parse",
-] }
+xshell = "0.2.7"
+clap = { version = "4.5", features = ["derive"] }
+ron = "0.8.1"
+toml_edit = { version = "0.22.22", default-features = false, features = ["parse"] }
 pbr = "1.1"
-regex = "1.10.5"
+regex = "1.11"
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

Consistency in the way dependencies are declared

## Solution

Update all dependencies to the latest version using Dependi, remove the patch versions for the non `0.x` crates.
Lower the versions for hashbrown, taffy, and smol_str because they require migrations.

This particular style was chosen because only specifying the major version, while it works in practice, would sometimes require `cargo update` to be run, lest it try to compile with an out-of-date version.

## Testing

`cargo check`
