### PR TITLE
Add missing exports in bevy_ecs

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2802,13 +2802,19 @@ impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a> {
     }
 }
 
+/// Error type returned by [`TryFrom`] conversions from filtered entity types
+/// ([`FilteredEntityRef`]/[`FilteredEntityMut`]) to full-access entity types
+/// ([`EntityRef`]/[`EntityMut`]).
 #[derive(Error, Display, Debug)]
 pub enum TryFromFilteredError {
+    /// Error indicating that the filtered entity does not have read access to
+    /// all components.
     #[display(
         "Conversion failed, filtered entity ref does not have read access to all components"
     )]
     MissingReadAllAccess,
-
+    /// Error indicating that the filtered entity does not have write access to
+    /// all components.
     #[display(
         "Conversion failed, filtered entity ref does not have write access to all components"
     )]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -22,8 +22,8 @@ pub use component_constants::*;
 pub use deferred_world::DeferredWorld;
 pub use entity_fetch::WorldEntityFetch;
 pub use entity_ref::{
-    EntityMut, EntityMutExcept, EntityRef, EntityRefExcept, EntityWorldMut, Entry,
-    FilteredEntityMut, FilteredEntityRef, OccupiedEntry, VacantEntry,
+    DynamicComponentFetch, EntityMut, EntityMutExcept, EntityRef, EntityRefExcept, EntityWorldMut,
+    Entry, FilteredEntityMut, FilteredEntityRef, OccupiedEntry, TryFromFilteredError, VacantEntry,
 };
 pub use filtered_resource::*;
 pub use identifier::WorldId;


### PR DESCRIPTION
# Objective

Seemed to have missed the export of `DynamicComponentFetch` from #15593. `TryFromFilteredError` which is returned by `impl TryFrom<FiliteredEntityMut/Ref> for EntityRef/Mut` also seemed to have been missing.

## Solution

Export both of them.