### PR TITLE
Properly set accessible value on label nodes

### DIFF
--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -133,14 +133,14 @@ fn label_changed(
         if let Some(mut accessible) = accessible {
             accessible.set_role(Role::Label);
             if let Some(label) = label {
-                accessible.set_label(label);
+                accessible.set_value(label);
             } else {
-                accessible.clear_label();
+                accessible.clear_value();
             }
         } else {
             let mut node = Node::new(Role::Label);
             if let Some(label) = label {
-                node.set_label(label);
+                node.set_value(label);
             }
             commands
                 .entity(entity)


### PR DESCRIPTION
# Objective

https://github.com/AccessKit/accesskit/pull/475 changed how text content should be set for AccessKit nodes with a role of `Label`. This was unfortunately missing from #16234.

## Solution

When building an `accesskit::Node` with `Role::Label`, calls `set_value` instead of `set_label` on the node to set its content.

## Testing

I can't test this right now on my Windows machine due to a compilation error with wgpu-hal I have no idea how to resolve.