### PR TITLE
Reactive components prototype

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,6 +1,6 @@
 use crate::{
-    First, Main, MainSchedulePlugin, PlaceholderPlugin, Plugin, Plugins, PluginsState, SubApp,
-    SubApps,
+    First, Last, Main, MainSchedulePlugin, PlaceholderPlugin, Plugin, Plugins, PluginsState,
+    SubApp, SubApps,
 };
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
@@ -97,6 +97,8 @@ impl Default for App {
         #[cfg(feature = "reflect_functions")]
         app.init_resource::<AppFunctionRegistry>();
 
+        app.init_resource::<bevy_ecs::reactivity::ReactiveComponentExpressions>();
+
         app.add_plugins(MainSchedulePlugin);
         app.add_systems(
             First,
@@ -104,6 +106,7 @@ impl Default for App {
                 .in_set(bevy_ecs::event::EventUpdates)
                 .run_if(bevy_ecs::event::event_update_condition),
         );
+        app.add_systems(Last, bevy_ecs::reactivity::update_reactive_components);
         app.add_event::<AppExit>();
 
         app

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -27,6 +27,7 @@ pub mod intern;
 pub mod label;
 pub mod observer;
 pub mod query;
+pub mod reactivity;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
 pub mod removal_detection;
@@ -51,6 +52,7 @@ pub mod prelude {
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         observer::{Observer, Trigger},
         query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
+        reactivity::ReactiveComponent,
         removal_detection::RemovedComponents,
         schedule::{
             apply_deferred, common_conditions::*, Condition, IntoSystemConfigs, IntoSystemSet,

--- a/crates/bevy_ecs/src/reactivity.rs
+++ b/crates/bevy_ecs/src/reactivity.rs
@@ -112,9 +112,9 @@ pub fn update_reactive_components(world: &mut World) {
 
             if !any_reaction {
                 break;
-            } else {
-                world.increment_change_tick();
             }
+
+            world.increment_change_tick();
         },
     );
 }

--- a/crates/bevy_ecs/src/reactivity.rs
+++ b/crates/bevy_ecs/src/reactivity.rs
@@ -100,9 +100,9 @@ impl<Input: Component, Output: Component> Component for ReactiveComponent<Input,
 
 /// System to check for changes to [`ReactiveComponent`] expressions and if changed, recompute it.
 pub fn update_reactive_components(world: &mut World) {
-    world.resource_scope(
-        |world, expressions: Mut<ReactiveComponentExpressions>| loop {
-            let last_run = world.last_change_tick();
+    world.resource_scope(|world, expressions: Mut<ReactiveComponentExpressions>| {
+        let mut last_run = world.last_change_tick();
+        loop {
             let this_run = world.change_tick();
             let mut any_reaction = false;
 
@@ -114,9 +114,9 @@ pub fn update_reactive_components(world: &mut World) {
                 break;
             }
 
-            world.increment_change_tick();
-        },
-    );
+            last_run = world.increment_change_tick();
+        }
+    });
 }
 
 /// TODO: Docs.

--- a/crates/bevy_ecs/src/reactivity.rs
+++ b/crates/bevy_ecs/src/reactivity.rs
@@ -156,11 +156,9 @@ mod tests {
 
         assert_eq!(world.entity(sink).get::<Bar>(), Some(&Bar(0)));
 
-        let last_tick = world.increment_change_tick();
-
         world.get_mut::<Foo>(source).unwrap().0 += 1;
 
-        world.last_change_tick_scope(last_tick, update_reactive_components);
+        update_reactive_components(&mut world);
 
         assert_eq!(world.entity(sink).get::<Bar>(), Some(&Bar(1)));
     }


### PR DESCRIPTION
# Objective
- Initial prototype for reactivity in Bevy

## Solution
- A new `ReactiveComponent` type that automatically inserts and updates a component of type `Output` on the same entity whenever the source entity's component of type `Input` changes (as detected by change detection ticks)

## Implementation issues
* There's a single place where reactive components get updated (the Last schedule). Ideally it would be an immediate reaction like how observers work.
* The `update_reactive_components` driver system loops over every single expression any time an expression changes. It would be ideal if we could track affected components, and only re-run expressions that would be affected. But for the initial prototype, performance isn't too important anyways.

## Not implemented/tested
* ReactiveComponents that can add/remove the component, instead of just modifying the value.
* Chaining reactions
* Expressions that depend on multiple components from an entity
* Expressions that depend on multiple entities
* Expressions that depend on resources
* Expressions that depend on queries or other complicated sources of data
* Reactive entity tree structures (e.g. a reactive version of WithChildren/WithChild, using the Name component as a key)