### PR TITLE
Fix `bevy_hierarchy` failing to compile without `reflect` feature

### DIFF
--- a/crates/bevy_hierarchy/src/events.rs
+++ b/crates/bevy_hierarchy/src/events.rs
@@ -1,14 +1,12 @@
 use bevy_ecs::{event::Event, prelude::Entity};
+#[cfg(feature = "reflect")]
+use bevy_reflect::Reflect;
 
 /// An [`Event`] that is fired whenever there is a change in the world's hierarchy.
 ///
 /// [`Event`]: bevy_ecs::event::Event
 #[derive(Event, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "reflect",
-    derive(bevy_reflect::Reflect),
-    reflect(Debug, PartialEq)
-)]
+#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Debug, PartialEq))]
 pub enum HierarchyEvent {
     /// Fired whenever an [`Entity`] is added as a child to a parent.
     ChildAdded {

--- a/crates/bevy_hierarchy/src/events.rs
+++ b/crates/bevy_hierarchy/src/events.rs
@@ -1,11 +1,14 @@
 use bevy_ecs::{event::Event, prelude::Entity};
-use bevy_reflect::Reflect;
 
 /// An [`Event`] that is fired whenever there is a change in the world's hierarchy.
 ///
 /// [`Event`]: bevy_ecs::event::Event
 #[derive(Event, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    feature = "reflect",
+    derive(bevy_reflect::Reflect),
+    reflect(Debug, PartialEq)
+)]
 pub enum HierarchyEvent {
     /// Fired whenever an [`Entity`] is added as a child to a parent.
     ChildAdded {


### PR DESCRIPTION
# Objective

Run this without this PR:
`cargo build -p bevy_hierarchy --no-default-features`

You'll get:
```
error[E0432]: unresolved import `bevy_reflect`
 --> crates/bevy_hierarchy/src/events.rs:2:5
  |
2 | use bevy_reflect::Reflect;
  |     ^^^^^^^^^^^^ use of undeclared crate or module `bevy_reflect`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `bevy_hierarchy` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

Because of this line:
```rs
use bevy_reflect::Reflect;

#[derive(Event, Debug, Clone, PartialEq, Eq)]
#[cfg_attr(feature = "reflect", derive(Reflect), reflect(Debug, PartialEq))]
pub enum HierarchyEvent { .. }
```

## Solution

use FQN: `derive(bevy_reflect::Reflect)`

## Testing

`cargo build -p bevy_hierarchy --no-default-features`
