### PR TITLE
Fix `required_by` updates for runtime required components

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1064,11 +1064,17 @@ impl Components {
             unsafe { self.register_inherited_required_components(requiree, required) };
 
         // Propagate the new required components up the chain to all components that require the requiree.
-        if let Some(required_by) = self.get_required_by(requiree).cloned() {
-            for &required_by_id in required_by.iter() {
+        if let Some(requiree_required_by) = self.get_required_by(requiree).cloned() {
+            for &requiree_id in requiree_required_by.iter() {
+                // Add the requiree of `requiree` to the list of components that require the required component.
+                // SAFETY: The component is in the list of required components, so it must exist already.
+                let required_by =
+                    unsafe { self.get_required_by_mut(required).debug_checked_unwrap() };
+                required_by.insert(requiree_id);
+
                 // SAFETY: The component is in the list of required components, so it must exist already.
                 let required_components = unsafe {
-                    self.get_required_components_mut(required_by_id)
+                    self.get_required_components_mut(requiree_id)
                         .debug_checked_unwrap()
                 };
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2346,6 +2346,33 @@ mod tests {
     }
 
     #[test]
+    fn runtime_required_components_propagate_up_multiple() {
+        #[derive(Component)]
+        struct A;
+
+        #[derive(Component, Default)]
+        struct B;
+
+        #[derive(Component, Default)]
+        struct C;
+
+        #[derive(Component, Default)]
+        struct D;
+
+        let mut world = World::new();
+
+        world.register_required_components::<A, B>();
+        world.register_required_components::<B, C>();
+        world.register_required_components::<C, D>();
+
+        let id = world.spawn(A).id();
+
+        assert!(world.entity(id).get::<B>().is_some());
+        assert!(world.entity(id).get::<C>().is_some());
+        assert!(world.entity(id).get::<D>().is_some());
+    }
+
+    #[test]
     fn runtime_required_components_existing_archetype() {
         #[derive(Component)]
         struct X;


### PR DESCRIPTION
# Objective

Fixes #16406 ([Cart's comment](https://github.com/bevyengine/bevy/issues/16406#issuecomment-2481613994))

#16410 fixed one critical bug with runtime requirements, but there's still another problem: If `A` requires `B`, `B` requires `C`, and `C` requires `D` (several levels of nesting), adding `A` won't add `D`!

Turns out, this is just a trivial oversight with how the `required_by` lists are updated. When `C` requires `D`, only `C` is added to the list of components that require `D`. However, `A` and `B` should also be added, as they also indirectly require `D` through `C`.

## Solution

Traverse up the inheritance tree and add all requirees to the `required_by` list of the component being required. We actually already do this traversal to handle inherited requirements, so this adds no extra iteration or recursion.

## Testing

I added [Cart's test](https://github.com/bevyengine/bevy/issues/16406#issuecomment-2481613994) that was previously failing.