### PR TITLE
remove the detailed_trace macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,9 +370,6 @@ animation = ["bevy_internal/animation", "bevy_animation"]
 # Enable using a shared stdlib for cxx on Android
 android_shared_stdcxx = ["bevy_internal/android_shared_stdcxx"]
 
-# Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in
-detailed_trace = ["bevy_internal/detailed_trace"]
-
 # Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method for your `Camera2d` or `Camera3d`.
 tonemapping_luts = ["bevy_internal/tonemapping_luts", "ktx2", "zstd"]
 

--- a/crates/bevy_ecs/src/event/collections.rs
+++ b/crates/bevy_ecs/src/event/collections.rs
@@ -3,7 +3,6 @@ use bevy_ecs::{
     event::{Event, EventCursor, EventId, EventInstance},
     system::Resource,
 };
-use bevy_utils::detailed_trace;
 use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
@@ -125,7 +124,7 @@ impl<E: Event> Events<E> {
             id: self.event_count,
             _marker: PhantomData,
         };
-        detailed_trace!("Events::send() -> id: {}", event_id);
+        trace!("Events::send() -> id: {}", event_id);
 
         let event_instance = EventInstance { event_id, event };
 
@@ -318,7 +317,7 @@ impl<E: Event> Extend<E> for Events<E> {
         self.events_b.extend(events);
 
         if old_count != event_count {
-            detailed_trace!(
+            trace!(
                 "Events::extend() -> ids: ({}..{})",
                 self.event_count,
                 event_count

--- a/crates/bevy_ecs/src/event/collections.rs
+++ b/crates/bevy_ecs/src/event/collections.rs
@@ -3,6 +3,7 @@ use bevy_ecs::{
     event::{Event, EventCursor, EventId, EventInstance},
     system::Resource,
 };
+use bevy_utils::tracing::trace;
 use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},

--- a/crates/bevy_ecs/src/event/iterators.rs
+++ b/crates/bevy_ecs/src/event/iterators.rs
@@ -2,6 +2,7 @@ use crate as bevy_ecs;
 #[cfg(feature = "multi_threaded")]
 use bevy_ecs::batching::BatchingStrategy;
 use bevy_ecs::event::{Event, EventCursor, EventId, EventInstance, Events};
+use bevy_utils::tracing::trace;
 use core::{iter::Chain, slice::Iter};
 
 /// An iterator that yields any unread events from an [`EventReader`](super::EventReader) or [`EventCursor`].

--- a/crates/bevy_ecs/src/event/iterators.rs
+++ b/crates/bevy_ecs/src/event/iterators.rs
@@ -2,7 +2,6 @@ use crate as bevy_ecs;
 #[cfg(feature = "multi_threaded")]
 use bevy_ecs::batching::BatchingStrategy;
 use bevy_ecs::event::{Event, EventCursor, EventId, EventInstance, Events};
-use bevy_utils::detailed_trace;
 use core::{iter::Chain, slice::Iter};
 
 /// An iterator that yields any unread events from an [`EventReader`](super::EventReader) or [`EventCursor`].
@@ -92,7 +91,7 @@ impl<'a, E: Event> Iterator for EventIteratorWithId<'a, E> {
             .map(|instance| (&instance.event, instance.event_id))
         {
             Some(item) => {
-                detailed_trace!("EventReader::iter() -> {}", item.1);
+                trace!("EventReader::iter() -> {}", item.1);
                 self.reader.last_event_count += 1;
                 self.unread -= 1;
                 Some(item)

--- a/crates/bevy_ecs/src/event/mut_iterators.rs
+++ b/crates/bevy_ecs/src/event/mut_iterators.rs
@@ -2,7 +2,6 @@ use crate as bevy_ecs;
 #[cfg(feature = "multi_threaded")]
 use bevy_ecs::batching::BatchingStrategy;
 use bevy_ecs::event::{Event, EventCursor, EventId, EventInstance, Events};
-use bevy_utils::detailed_trace;
 use core::{iter::Chain, slice::IterMut};
 
 /// An iterator that yields any unread events from an [`EventMutator`] or [`EventCursor`].
@@ -95,7 +94,7 @@ impl<'a, E: Event> Iterator for EventMutIteratorWithId<'a, E> {
             .map(|instance| (&mut instance.event, instance.event_id))
         {
             Some(item) => {
-                detailed_trace!("EventMutator::iter() -> {}", item.1);
+                trace!("EventMutator::iter() -> {}", item.1);
                 self.mutator.last_event_count += 1;
                 self.unread -= 1;
                 Some(item)

--- a/crates/bevy_ecs/src/event/mut_iterators.rs
+++ b/crates/bevy_ecs/src/event/mut_iterators.rs
@@ -2,6 +2,7 @@ use crate as bevy_ecs;
 #[cfg(feature = "multi_threaded")]
 use bevy_ecs::batching::BatchingStrategy;
 use bevy_ecs::event::{Event, EventCursor, EventId, EventInstance, Events};
+use bevy_utils::tracing::trace;
 use core::{iter::Chain, slice::IterMut};
 
 /// An iterator that yields any unread events from an [`EventMutator`] or [`EventCursor`].

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -24,7 +24,6 @@ trace = [
 trace_chrome = ["bevy_log/tracing-chrome"]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy"]
 trace_tracy_memory = ["bevy_log/trace_tracy_memory"]
-detailed_trace = ["bevy_utils/detailed_trace"]
 
 sysinfo_plugin = ["bevy_diagnostic/sysinfo_plugin"]
 

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -8,7 +8,7 @@ use crate::{
     renderer::RenderDevice,
 };
 use bevy_color::LinearRgba;
-use bevy_utils::{default, detailed_trace};
+use bevy_utils::default;
 use core::ops::Range;
 use wgpu::{IndexFormat, QuerySet, RenderPass};
 
@@ -164,7 +164,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent draw calls will exhibit the behavior defined by the `pipeline`.
     pub fn set_render_pipeline(&mut self, pipeline: &'a RenderPipeline) {
-        detailed_trace!("set pipeline: {:?}", pipeline);
+        trace!("set pipeline: {:?}", pipeline);
         if self.state.is_pipeline_set(pipeline.id()) {
             return;
         }
@@ -189,7 +189,7 @@ impl<'a> TrackedRenderPass<'a> {
             .state
             .is_bind_group_set(index, bind_group.id(), dynamic_uniform_indices)
         {
-            detailed_trace!(
+            trace!(
                 "set bind_group {} (already set): {:?} ({:?})",
                 index,
                 bind_group,
@@ -197,7 +197,7 @@ impl<'a> TrackedRenderPass<'a> {
             );
             return;
         }
-        detailed_trace!(
+        trace!(
             "set bind_group {}: {:?} ({:?})",
             index,
             bind_group,
@@ -222,7 +222,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// [`draw_indexed`]: TrackedRenderPass::draw_indexed
     pub fn set_vertex_buffer(&mut self, slot_index: usize, buffer_slice: BufferSlice<'a>) {
         if self.state.is_vertex_buffer_set(slot_index, &buffer_slice) {
-            detailed_trace!(
+            trace!(
                 "set vertex buffer {} (already set): {:?} (offset = {}, size = {})",
                 slot_index,
                 buffer_slice.id(),
@@ -231,7 +231,7 @@ impl<'a> TrackedRenderPass<'a> {
             );
             return;
         }
-        detailed_trace!(
+        trace!(
             "set vertex buffer {}: {:?} (offset = {}, size = {})",
             slot_index,
             buffer_slice.id(),
@@ -258,14 +258,14 @@ impl<'a> TrackedRenderPass<'a> {
             .state
             .is_index_buffer_set(buffer_slice.id(), offset, index_format)
         {
-            detailed_trace!(
+            trace!(
                 "set index buffer (already set): {:?} ({})",
                 buffer_slice.id(),
                 offset
             );
             return;
         }
-        detailed_trace!("set index buffer: {:?} ({})", buffer_slice.id(), offset);
+        trace!("set index buffer: {:?} ({})", buffer_slice.id(), offset);
         self.pass.set_index_buffer(*buffer_slice, index_format);
         self.state
             .set_index_buffer(buffer_slice.id(), offset, index_format);
@@ -275,7 +275,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// The active vertex buffer(s) can be set with [`TrackedRenderPass::set_vertex_buffer`].
     pub fn draw(&mut self, vertices: Range<u32>, instances: Range<u32>) {
-        detailed_trace!("draw: {:?} {:?}", vertices, instances);
+        trace!("draw: {:?} {:?}", vertices, instances);
         self.pass.draw(vertices, instances);
     }
 
@@ -284,7 +284,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// The active index buffer can be set with [`TrackedRenderPass::set_index_buffer`], while the
     /// active vertex buffer(s) can be set with [`TrackedRenderPass::set_vertex_buffer`].
     pub fn draw_indexed(&mut self, indices: Range<u32>, base_vertex: i32, instances: Range<u32>) {
-        detailed_trace!(
+        trace!(
             "draw indexed: {:?} {} {:?}",
             indices,
             base_vertex,
@@ -311,7 +311,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// }
     /// ```
     pub fn draw_indirect(&mut self, indirect_buffer: &'a Buffer, indirect_offset: u64) {
-        detailed_trace!("draw indirect: {:?} {}", indirect_buffer, indirect_offset);
+        trace!("draw indirect: {:?} {}", indirect_buffer, indirect_offset);
         self.pass.draw_indirect(indirect_buffer, indirect_offset);
     }
 
@@ -335,7 +335,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// }
     /// ```
     pub fn draw_indexed_indirect(&mut self, indirect_buffer: &'a Buffer, indirect_offset: u64) {
-        detailed_trace!(
+        trace!(
             "draw indexed indirect: {:?} {}",
             indirect_buffer,
             indirect_offset
@@ -367,7 +367,7 @@ impl<'a> TrackedRenderPass<'a> {
         indirect_offset: u64,
         count: u32,
     ) {
-        detailed_trace!(
+        trace!(
             "multi draw indirect: {:?} {}, {}x",
             indirect_buffer,
             indirect_offset,
@@ -407,7 +407,7 @@ impl<'a> TrackedRenderPass<'a> {
         count_offset: u64,
         max_count: u32,
     ) {
-        detailed_trace!(
+        trace!(
             "multi draw indirect count: {:?} {}, ({:?} {})x, max {}x",
             indirect_buffer,
             indirect_offset,
@@ -449,7 +449,7 @@ impl<'a> TrackedRenderPass<'a> {
         indirect_offset: u64,
         count: u32,
     ) {
-        detailed_trace!(
+        trace!(
             "multi draw indexed indirect: {:?} {}, {}x",
             indirect_buffer,
             indirect_offset,
@@ -491,7 +491,7 @@ impl<'a> TrackedRenderPass<'a> {
         count_offset: u64,
         max_count: u32,
     ) {
-        detailed_trace!(
+        trace!(
             "multi draw indexed indirect count: {:?} {}, ({:?} {})x, max {}x",
             indirect_buffer,
             indirect_offset,
@@ -512,7 +512,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent stencil tests will test against this value.
     pub fn set_stencil_reference(&mut self, reference: u32) {
-        detailed_trace!("set stencil reference: {}", reference);
+        trace!("set stencil reference: {}", reference);
         self.pass.set_stencil_reference(reference);
     }
 
@@ -520,7 +520,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent draw calls will discard any fragments that fall outside this region.
     pub fn set_scissor_rect(&mut self, x: u32, y: u32, width: u32, height: u32) {
-        detailed_trace!("set_scissor_rect: {} {} {} {}", x, y, width, height);
+        trace!("set_scissor_rect: {} {} {} {}", x, y, width, height);
         self.pass.set_scissor_rect(x, y, width, height);
     }
 
@@ -528,7 +528,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// `Features::PUSH_CONSTANTS` must be enabled on the device in order to call these functions.
     pub fn set_push_constants(&mut self, stages: ShaderStages, offset: u32, data: &[u8]) {
-        detailed_trace!(
+        trace!(
             "set push constants: {:?} offset: {} data.len: {}",
             stages,
             offset,
@@ -549,7 +549,7 @@ impl<'a> TrackedRenderPass<'a> {
         min_depth: f32,
         max_depth: f32,
     ) {
-        detailed_trace!(
+        trace!(
             "set viewport: {} {} {} {} {} {}",
             x,
             y,
@@ -580,7 +580,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// This is a GPU debugging feature. This has no effect on the rendering itself.
     pub fn insert_debug_marker(&mut self, label: &str) {
-        detailed_trace!("insert debug marker: {}", label);
+        trace!("insert debug marker: {}", label);
         self.pass.insert_debug_marker(label);
     }
 
@@ -605,7 +605,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// [`push_debug_group`]: TrackedRenderPass::push_debug_group
     /// [`pop_debug_group`]: TrackedRenderPass::pop_debug_group
     pub fn push_debug_group(&mut self, label: &str) {
-        detailed_trace!("push_debug_group marker: {}", label);
+        trace!("push_debug_group marker: {}", label);
         self.pass.push_debug_group(label);
     }
 
@@ -622,7 +622,7 @@ impl<'a> TrackedRenderPass<'a> {
     /// [`push_debug_group`]: TrackedRenderPass::push_debug_group
     /// [`pop_debug_group`]: TrackedRenderPass::pop_debug_group
     pub fn pop_debug_group(&mut self) {
-        detailed_trace!("pop_debug_group");
+        trace!("pop_debug_group");
         self.pass.pop_debug_group();
     }
 
@@ -630,7 +630,7 @@ impl<'a> TrackedRenderPass<'a> {
     ///
     /// Subsequent blending tests will test against this value.
     pub fn set_blend_constant(&mut self, color: LinearRgba) {
-        detailed_trace!("set blend constant: {:?}", color);
+        trace!("set blend constant: {:?}", color);
         self.pass.set_blend_constant(wgpu::Color::from(color));
     }
 }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -8,7 +8,7 @@ use crate::{
     renderer::RenderDevice,
 };
 use bevy_color::LinearRgba;
-use bevy_utils::default;
+use bevy_utils::{default, tracing::trace};
 use core::ops::Range;
 use wgpu::{IndexFormat, QuerySet, RenderPass};
 

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -18,7 +18,6 @@ std = [
   "ahash/runtime-rng",
 ]
 alloc = ["hashbrown/default"]
-detailed_trace = []
 serde = ["hashbrown/serde"]
 
 [dependencies]

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -407,16 +407,6 @@ pub fn error<E: Debug>(result: Result<(), E>) {
     }
 }
 
-/// Like [`tracing::trace`], but conditional on cargo feature `detailed_trace`.
-#[macro_export]
-macro_rules! detailed_trace {
-    ($($tts:tt)*) => {
-        if cfg!(detailed_trace) {
-            $crate::tracing::trace!($($tts)*);
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -65,7 +65,6 @@ The default feature set enables most of the expected features of a game engine, 
 |bmp|BMP image format support|
 |dds|DDS compressed texture support|
 |debug_glam_assert|Enable assertions in debug builds to check the validity of parameters passed to glam|
-|detailed_trace|Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in|
 |dynamic_linking|Force dynamic linking, which improves iterative compile times|
 |embedded_watcher|Enables watching in memory asset providers for Bevy Asset hot-reloading|
 |experimental_pbr_pcss|Enable support for PCSS, at the risk of blowing past the global, per-shader sampler limit on older/lower-end GPUs|


### PR DESCRIPTION
# Objective

- Fix CI
- Contribute to #11478 

## Solution

- Remove the `detailed_trace` macro, and replace its use by the `trace` macro
- The macro doesn't work: it doesn't check for the `detailed_trace` feature
- If it checked for the feature, as the macro is expanded where it's used, the feature should be added to all crates
- Log levels are already controllable by features