### PR TITLE
Remove flush_and_reserve_invalid_assuming_no_entities

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -954,7 +954,7 @@ impl EntityMeta {
     };
 }
 
-/// Records where an entities data is stored.
+/// Records where an entity's data is stored.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct EntityLocation {
     /// The ID of the [`Archetype`] the [`Entity`] belongs to.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -913,25 +913,6 @@ impl Entities {
         }
     }
 
-    /// # Safety
-    ///
-    /// This function is safe if and only if the world this Entities is on has no entities.
-    pub unsafe fn flush_and_reserve_invalid_assuming_no_entities(&mut self, count: usize) {
-        let free_cursor = self.free_cursor.get_mut();
-        *free_cursor = 0;
-        self.meta.reserve(count);
-        // SAFETY: The EntityMeta struct only contains integers, and it is valid to have all bytes set to u8::MAX
-        unsafe {
-            self.meta.as_mut_ptr().write_bytes(u8::MAX, count);
-        }
-        // SAFETY: We have reserved `count` elements above and we have initialized values from index 0 to `count`.
-        unsafe {
-            self.meta.set_len(count);
-        }
-
-        self.len = count as u32;
-    }
-
     /// The count of all entities in the [`World`] that have ever been allocated
     /// including the entities that are currently freed.
     ///
@@ -959,11 +940,7 @@ impl Entities {
 
 // This type is repr(C) to ensure that the layout and values within it can be safe to fully fill
 // with u8::MAX, as required by [`Entities::flush_and_reserve_invalid_assuming_no_entities`].
-// Safety:
-// This type must not contain any pointers at any level, and be safe to fully fill with u8::MAX.
-/// Metadata for an [`Entity`].
 #[derive(Copy, Clone, Debug)]
-#[repr(C)]
 struct EntityMeta {
     /// The current generation of the [`Entity`].
     pub generation: NonZero<u32>,
@@ -981,11 +958,7 @@ impl EntityMeta {
 
 // This type is repr(C) to ensure that the layout and values within it can be safe to fully fill
 // with u8::MAX, as required by [`Entities::flush_and_reserve_invalid_assuming_no_entities`].
-// SAFETY:
-// This type must not contain any pointers at any level, and be safe to fully fill with u8::MAX.
-/// A location of an entity in an archetype.
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[repr(C)]
 pub struct EntityLocation {
     /// The ID of the [`Archetype`] the [`Entity`] belongs to.
     ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -938,8 +938,6 @@ impl Entities {
     }
 }
 
-// This type is repr(C) to ensure that the layout and values within it can be safe to fully fill
-// with u8::MAX, as required by [`Entities::flush_and_reserve_invalid_assuming_no_entities`].
 #[derive(Copy, Clone, Debug)]
 struct EntityMeta {
     /// The current generation of the [`Entity`].
@@ -956,8 +954,7 @@ impl EntityMeta {
     };
 }
 
-// This type is repr(C) to ensure that the layout and values within it can be safe to fully fill
-// with u8::MAX, as required by [`Entities::flush_and_reserve_invalid_assuming_no_entities`].
+/// Records where an entities data is stored.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct EntityLocation {
     /// The ID of the [`Archetype`] the [`Entity`] belongs to.

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -32,8 +32,6 @@ mod column;
 /// [`Archetype`]: crate::archetype::Archetype
 /// [`Archetype::table_id`]: crate::archetype::Archetype::table_id
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// SAFETY: Must be repr(transparent) due to the safety requirements on EntityLocation
-#[repr(transparent)]
 pub struct TableId(u32);
 
 impl TableId {
@@ -102,8 +100,6 @@ impl TableId {
 /// [`Archetype::entity_table_row`]: crate::archetype::Archetype::entity_table_row
 /// [`Archetype::table_id`]: crate::archetype::Archetype::table_id
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// SAFETY: Must be repr(transparent) due to the safety requirements on EntityLocation
-#[repr(transparent)]
 pub struct TableRow(u32);
 
 impl TableRow {
@@ -119,7 +115,7 @@ impl TableRow {
     ///
     /// # Panics
     ///
-    /// Will panic if the provided value does not fit within a [`u32`].
+    /// Will panic in debug mode if the provided value does not fit within a [`u32`].
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
         debug_assert!(index as u32 as usize == index);


### PR DESCRIPTION
# Objective

`flush_and_reserve_invalid_assuming_no_entities` was made for the old rendering world (which was reset every frame) and is usused since the 0.15 retained rendering world, but wasn't removed yet. It is pub, but is undocumented apart from the safety comment.

## Solution

Remove `flush_and_reserve_invalid_assuming_no_entities` and the safety invariants this method required for `EntityMeta`, `EntityLocation`, `TableId` and `TableRow`. This reduces the amount of unsafe code & safety invariants and makes #16047 easier.

## Alternatives
- Document `flush_and_reserve_invalid_assuming_no_entities` and keep it unchanged
- Document `flush_and_reserve_invalid_assuming_no_entities` and change it to be based on `EntityMeta::INVALID`


## Migration Guide
- exchange `Entities::flush_and_reserve_invalid_assuming_no_entities` for `reserve` and `flush_as_invalid` and notify us if that's insufficient