### PR TITLE
Make render world sync marker components `Copy`

### DIFF
--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -117,7 +117,7 @@ impl Plugin for SyncWorldPlugin {
 ///
 /// [`ExtractComponentPlugin`]: crate::extract_component::ExtractComponentPlugin
 /// [`SyncComponentPlugin`]: crate::sync_component::SyncComponentPlugin
-#[derive(Component, Clone, Debug, Default, Reflect)]
+#[derive(Component, Copy, Clone, Debug, Default, Reflect)]
 #[reflect[Component]]
 #[component(storage = "SparseSet")]
 pub struct SyncToRenderWorld;
@@ -165,7 +165,7 @@ pub type MainEntityHashMap<V> = hashbrown::HashMap<MainEntity, V, EntityHash>;
 pub type MainEntityHashSet = hashbrown::HashSet<MainEntity, EntityHash>;
 
 /// Marker component that indicates that its entity needs to be despawned at the end of the frame.
-#[derive(Component, Clone, Debug, Default, Reflect)]
+#[derive(Component, Copy, Clone, Debug, Default, Reflect)]
 #[component(storage = "SparseSet")]
 pub struct TemporaryRenderEntity;
 


### PR DESCRIPTION
# Objective

Original motivation was a bundle I am migrating that is `Copy` which needs to be synced to the render world. It probably doesn't actually *need* to be `Copy`, so this isn't critical or anything.

I am continuing to use this bundle while bundles still exist to give users an easier migration path.

## Solution

These ZSTs might as well be `Copy`. Add `Copy` derives.