### PR TITLE
Use default storage for `TemporaryRenderEntity`

### DIFF
--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -166,7 +166,6 @@ pub type MainEntityHashSet = hashbrown::HashSet<MainEntity, EntityHash>;
 
 /// Marker component that indicates that its entity needs to be despawned at the end of the frame.
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
-#[component(storage = "SparseSet")]
 pub struct TemporaryRenderEntity;
 
 /// A record enum to what entities with [`SyncToRenderWorld`] have been added or removed.


### PR DESCRIPTION
# Objective

`TemporaryRenderEntity` currently uses `SparseSet` storage, but doesn't seem to fit the criteria for a component that would benefit from this.

Typical usage of `TemporaryRenderEntity` (and all current usages of it in engine as far as I can tell) would be to spawn an entity with it once and then iterate over it once to despawn that entity.

`SparseSet` is said to be useful for insert/removal perf at the cost of iteration perf.

## Solution

Use the default table storage

## Testing

Possibly this could show up in stress tests like `many_buttons`. I didn't do any benchmarking.
