### PR TITLE
Fix the picking backend features not actually disabling the features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,13 +141,22 @@ default = [
 ]
 
 # Provides an implementation for picking meshes
-bevy_mesh_picking_backend = ["bevy_picking"]
+bevy_mesh_picking_backend = [
+  "bevy_picking",
+  "bevy_internal/bevy_mesh_picking_backend",
+]
 
 # Provides an implementation for picking sprites
-bevy_sprite_picking_backend = ["bevy_picking"]
+bevy_sprite_picking_backend = [
+  "bevy_picking",
+  "bevy_internal/bevy_sprite_picking_backend",
+]
 
-# Provides an implementation for picking ui
-bevy_ui_picking_backend = ["bevy_picking"]
+# Provides an implementation for picking UI
+bevy_ui_picking_backend = [
+  "bevy_picking",
+  "bevy_internal/bevy_ui_picking_backend",
+]
 
 # Force dynamic linking, which improves iterative compile times
 dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -14,7 +14,9 @@ bevy_app = { path = "../crates/bevy_app" }
 bevy_ecs = { path = "../crates/bevy_ecs", features = ["multi_threaded"] }
 bevy_hierarchy = { path = "../crates/bevy_hierarchy" }
 bevy_math = { path = "../crates/bevy_math" }
-bevy_picking = { path = "../crates/bevy_picking", features = ["bevy_mesh"] }
+bevy_picking = { path = "../crates/bevy_picking", features = [
+  "bevy_mesh_picking_backend",
+] }
 bevy_reflect = { path = "../crates/bevy_reflect", features = ["functions"] }
 bevy_render = { path = "../crates/bevy_render" }
 bevy_tasks = { path = "../crates/bevy_tasks" }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -218,12 +218,22 @@ bevy_dev_tools = ["dep:bevy_dev_tools"]
 bevy_remote = ["dep:bevy_remote"]
 
 # Provides picking functionality
-bevy_picking = [
-  "dep:bevy_picking",
-  "bevy_picking/bevy_mesh",
-  "bevy_ui?/bevy_picking",
-  "bevy_sprite?/bevy_picking",
+bevy_picking = ["dep:bevy_picking"]
+
+# Provides a mesh picking backend
+bevy_mesh_picking_backend = [
+  "bevy_picking",
+  "bevy_picking/bevy_mesh_picking_backend",
 ]
+
+# Provides a sprite picking backend
+bevy_sprite_picking_backend = [
+  "bevy_picking",
+  "bevy_sprite/bevy_sprite_picking_backend",
+]
+
+# Provides a UI picking backend
+bevy_ui_picking_backend = ["bevy_picking", "bevy_ui/bevy_ui_picking_backend"]
 
 # Enable support for the ios_simulator by downgrading some rendering capabilities
 ios_simulator = ["bevy_pbr?/ios_simulator", "bevy_render?/ios_simulator"]

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 # Provides a mesh picking backend
-bevy_mesh = ["dep:bevy_mesh", "dep:crossbeam-channel"]
+bevy_mesh_picking_backend = ["dep:bevy_mesh", "dep:crossbeam-channel"]
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.15.0-dev" }

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -156,7 +156,7 @@ pub mod backend;
 pub mod events;
 pub mod focus;
 pub mod input;
-#[cfg(feature = "bevy_mesh")]
+#[cfg(feature = "bevy_mesh_picking_backend")]
 pub mod mesh_picking;
 pub mod pointer;
 
@@ -168,7 +168,7 @@ use bevy_reflect::prelude::*;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[cfg(feature = "bevy_mesh")]
+    #[cfg(feature = "bevy_mesh_picking_backend")]
     #[doc(hidden)]
     pub use crate::mesh_picking::{
         ray_cast::{MeshRayCast, RayCastBackfaces, RayCastSettings, RayCastVisibility},

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_sprite_picking_backend"]
 bevy_sprite_picking_backend = ["bevy_picking", "bevy_window"]
 serialize = ["dep:serde"]
 webgl = []

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -46,7 +46,6 @@ smallvec = "1.11"
 accesskit = "0.17"
 
 [features]
-default = ["bevy_ui_picking_backend"]
 serialize = ["serde", "smallvec/serde", "bevy_math/serialize"]
 bevy_ui_picking_backend = ["bevy_picking"]
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -33,7 +33,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_state|Enable built in global state machines|
 |bevy_text|Provides text functionality|
 |bevy_ui|A custom ECS-driven UI framework|
-|bevy_ui_picking_backend|Provides an implementation for picking ui|
+|bevy_ui_picking_backend|Provides an implementation for picking UI|
 |bevy_window|Windowing layer|
 |bevy_winit|winit window and input backend|
 |custom_cursor|Enable winit custom cursor support|


### PR DESCRIPTION
# Objective

- Fixes #16469.

## Solution

- Make the picking backend features not enabled by default in each sub-crate.
- Make features in `bevy_internal` to set the backend features
- Make the root `bevy` crate set the features by default.

## Testing

- The mesh and sprite picking examples still work correctly.
