### PR TITLE
Allow Unicode-3.0 license in addition to Unicode-DFS-2016 for unicode-ident crate.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,6 +25,7 @@ allow = [
 exceptions = [
   { name = "unicode-ident", allow = [
     "Unicode-DFS-2016",
+    "Unicode-3.0",
   ] },
   { name = "symphonia", allow = [
     "MPL-2.0",


### PR DESCRIPTION
# Objective

- Fixes #16451.

## Solution

- Just allows the new license.

## Notes

According to the [Open Source Initiative](https://opensource.org/license/unicode-inc-license-agreement-data-files-and-software), the UNICODE-DFS-**2015** is superseded by UNICODE-3.0. I'm not sure whether 2015 vs 2016 matters, and whether these are 3.0 and DFS-2016 are materially different.
