### PR TITLE
Add flags to `SpritePlugin` and `UiPlugin` to allow disabling their picking backend (without needing to disable features).

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -63,8 +63,20 @@ use bevy_render::{
 };
 
 /// Adds support for 2D sprite rendering.
-#[derive(Default)]
-pub struct SpritePlugin;
+pub struct SpritePlugin {
+    /// Whether to add the sprite picking backend to the app.
+    #[cfg(feature = "bevy_sprite_picking_backend")]
+    pub add_picking: bool,
+}
+
+impl Default for SpritePlugin {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "bevy_sprite_picking_backend")]
+            add_picking: true,
+        }
+    }
+}
 
 pub const SPRITE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2763343953151597127);
 pub const SPRITE_VIEW_BINDINGS_SHADER_HANDLE: Handle<Shader> =
@@ -135,7 +147,9 @@ impl Plugin for SpritePlugin {
             );
 
         #[cfg(feature = "bevy_sprite_picking_backend")]
-        app.add_plugins(picking_backend::SpritePickingPlugin);
+        if self.add_picking {
+            app.add_plugins(picking_backend::SpritePickingPlugin);
+        }
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -85,12 +85,17 @@ pub struct UiPlugin {
     /// If set to false, the UI's rendering systems won't be added to the `RenderApp` and no UI elements will be drawn.
     /// The layout and interaction components will still be updated as normal.
     pub enable_rendering: bool,
+    /// Whether to add the UI picking backend to the app.
+    #[cfg(feature = "bevy_ui_picking_backend")]
+    pub add_picking: bool,
 }
 
 impl Default for UiPlugin {
     fn default() -> Self {
         Self {
             enable_rendering: true,
+            #[cfg(feature = "bevy_ui_picking_backend")]
+            add_picking: true,
         }
     }
 }
@@ -217,7 +222,9 @@ impl Plugin for UiPlugin {
         build_text_interop(app);
 
         #[cfg(feature = "bevy_ui_picking_backend")]
-        app.add_plugins(picking_backend::UiPickingPlugin);
+        if self.add_picking {
+            app.add_plugins(picking_backend::UiPickingPlugin);
+        }
 
         if !self.enable_rendering {
             return;


### PR DESCRIPTION
# Objective

- Fixes #16472.

## Solution

- Add flags to `SpritePlugin` and `UiPlugin` to disable their picking backends.

## Testing

- The change is pretty trivial, so not much to test!

---

## Migration Guide

- `UiPlugin` now contains an extra `add_picking` field if `bevy_ui_picking_backend` is enabled.
- `SpritePlugin` is no longer a unit struct, and has one field if `bevy_sprite_picking_backend` is enabled (otherwise no fields).
