### PR TITLE
remove check on windows screenshots

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -192,17 +192,6 @@ jobs:
           name: example-run-windows
           path: example-run/
 
-  compare-windows-screenshots:
-    name: Compare Windows screenshots
-    needs: [run-examples-on-windows-dx12]
-    uses: ./.github/workflows/send-screenshots-to-pixeleagle.yml
-    with:
-      commit: ${{ github.sha }}
-      branch: ${{ github.ref_name }}
-      artifact: screenshots-windows
-      os: windows
-    secrets: inherit
-
   run-examples-on-wasm:
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
# Objective

- Rendering on Windows in CI is unreliable
- Screenshots are compared but results are not usable
- Related to #15918 

## Solution

- Remove the check on windows screenshots
