### PR TITLE
Make some examples deterministic

### DIFF
--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -23,7 +23,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             color: Color::srgba(0.0, 0.0, 1.0, 0.7),
             ..default()
         },
-        Transform::from_xyz(100.0, 0.0, 0.0),
+        Transform::from_xyz(100.0, 0.0, 0.1),
     ));
     commands.spawn((
         Sprite {
@@ -31,6 +31,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             color: Color::srgba(0.0, 1.0, 0.0, 0.3),
             ..default()
         },
-        Transform::from_xyz(200.0, 0.0, 0.0),
+        Transform::from_xyz(200.0, 0.0, 0.2),
     ));
 }

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -14,10 +14,11 @@ fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     // We're seeding the PRNG here to make this example deterministic for testing purposes.
     // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(19878367467713);
-    for _ in 0..128 {
+    for z in 0..128 {
         commands.spawn((
             Sprite::from_image(texture.clone()),
-            Transform::from_scale(Vec3::splat(0.1)),
+            Transform::from_scale(Vec3::splat(0.1))
+                .with_translation(Vec2::splat(0.0).extend(z as f32)),
             Velocity(20.0 * Vec2::new(rng.gen::<f32>() - 0.5, rng.gen::<f32>() - 0.5)),
         ));
     }


### PR DESCRIPTION
# Objective

- Improve reproducibility of examples

## Solution

- Use seeded rng when needed
- Use fixed z-ordering when needed

## Testing

```sh
steps=5;
echo "cpu_draw\nparallel_query\nanimated_fox\ntransparency_2d" > test
cargo run -p example-showcase -- run --stop-frame 250 --screenshot-frame 100 --fixed-frame-time 0.05 --example-list test --in-ci;
mv screenshots base;
for prefix in `seq 0 $steps`;
do
  echo step $prefix;
  cargo run -p example-showcase -- run --stop-frame 250 --screenshot-frame 100 --fixed-frame-time 0.05 --example-list test;
  mv screenshots $prefix-screenshots;
done;
mv base screenshots
for prefix in `seq 0 $steps`;
do
  echo check $prefix
  for file in screenshots/*/*;
  do
    echo $file;
    diff $file $prefix-$file;
  done;
done;
```
