### PR TITLE
Fix `Single` doc links

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -352,6 +352,8 @@ use core::{
 /// [`par_iter`]: Self::par_iter
 /// [`par_iter_mut`]: Self::par_iter_mut
 /// [performance]: #performance
+/// [`Single`]: Single
+/// [`Option<Single>`]: Single
 /// [`single`]: Self::single
 /// [`single_mut`]: Self::single_mut
 /// [`SparseSet`]: crate::storage::SparseSet


### PR DESCRIPTION
# Objective

In the [*Similar parameters* section of `Query`](https://dev-docs.bevyengine.org/bevy/ecs/prelude/struct.Query.html#similar-parameters), the doc link for `Single` actually links to `Query::single`, and `Option<Single>` just links to `Option`. They should both link to `Single`!

The first link is broken because there is a reference-style link defined for `single`, but not for `Single`, and rustdoc treats the link as case-insensitive for some reason.

## Solution

Fix the links!

## Testing

I built the docs locally with `cargo doc` and tested the links.