### PR TITLE
Multiple box shadow support

### DIFF
--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -263,7 +263,7 @@ pub fn extract_shadows(
         };
 
         // Skip invisible images
-        if !view_visibility.get() || box_shadow.0.is_empty() || uinode.is_empty() {
+        if !view_visibility.get() || box_shadow.is_empty() || uinode.is_empty() {
             continue;
         }
 
@@ -278,7 +278,7 @@ pub fn extract_shadows(
 
         let scale_factor = uinode.inverse_scale_factor.recip();
 
-        for drop_shadow in box_shadow.0.iter() {
+        for drop_shadow in box_shadow.iter() {
             if drop_shadow.color.is_fully_transparent() {
                 continue;
             }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2448,6 +2448,11 @@ impl BoxShadow {
 
 #[derive(Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(PartialEq, Default)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub struct ShadowStyle {
     /// The shadow's color
     pub color: Color,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2436,13 +2436,13 @@ impl BoxShadow {
         spread_radius: Val,
         blur_radius: Val,
     ) -> Self {
-        Self(ShadowStyle {
+        Self(vec![ShadowStyle {
             color,
             x_offset,
             y_offset,
             spread_radius,
             blur_radius,
-        })
+        }])
     }
 }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2424,7 +2424,8 @@ impl ResolvedBorderRadius {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-/// List of shadows to draw for a `Node`.
+/// List of shadows to draw for a [`Node`].
+/// Draw order is determined implicitly from the vector of [`ShadowStyle`]s, back-to-front.
 pub struct BoxShadow(pub Vec<ShadowStyle>);
 
 impl BoxShadow {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2424,24 +2424,25 @@ impl ResolvedBorderRadius {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
+/// List of shadows to draw for a `Node`.
 pub struct BoxShadow(pub Vec<ShadowStyle>);
 
 impl BoxShadow {
-    /// A single shadow
-    pub fn new(shadow: ShadowStyle) -> Self {
-        BoxShadow(vec![shadow])
-    }
-}
-
-impl From<ShadowStyle> for BoxShadow {
-    fn from(shadow: ShadowStyle) -> Self {
-        Self::new(shadow)
-    }
-}
-
-impl From<Vec<ShadowStyle>> for BoxShadow {
-    fn from(shadows: Vec<ShadowStyle>) -> Self {
-        Self(shadows)
+    /// A single drop shadow
+    pub fn new(
+        color: Color,
+        x_offset: Val,
+        y_offset: Val,
+        spread_radius: Val,
+        blur_radius: Val,
+    ) -> Self {
+        Self(ShadowStyle {
+            color,
+            x_offset,
+            y_offset,
+            spread_radius,
+            blur_radius,
+        })
     }
 }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2416,14 +2416,36 @@ impl ResolvedBorderRadius {
     };
 }
 
-#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
+#[derive(Component, Clone, Debug, Default, PartialEq, Reflect)]
 #[reflect(Component, PartialEq, Default)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct BoxShadow {
+pub struct BoxShadow(pub Vec<DropShadow>);
+
+impl BoxShadow {
+    pub fn new(shadow: DropShadow) -> Self {
+        BoxShadow(vec![shadow])
+    }
+}
+
+impl From<DropShadow> for BoxShadow {
+    fn from(shadow: DropShadow) -> Self {
+        Self::new(shadow)
+    }
+}
+
+impl From<Vec<DropShadow>> for BoxShadow {
+    fn from(shadows: Vec<DropShadow>) -> Self {
+        Self(shadows)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Reflect)]
+#[reflect(PartialEq, Default)]
+pub struct DropShadow {
     /// The shadow's color
     pub color: Color,
     /// Horizontal offset
@@ -2439,7 +2461,7 @@ pub struct BoxShadow {
     pub blur_radius: Val,
 }
 
-impl Default for BoxShadow {
+impl Default for DropShadow {
     fn default() -> Self {
         Self {
             color: Color::BLACK,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2425,6 +2425,7 @@ impl ResolvedBorderRadius {
     reflect(Serialize, Deserialize)
 )]
 /// List of shadows to draw for a [`Node`].
+///
 /// Draw order is determined implicitly from the vector of [`ShadowStyle`]s, back-to-front.
 pub struct BoxShadow(pub Vec<ShadowStyle>);
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2446,6 +2446,12 @@ impl BoxShadow {
     }
 }
 
+impl From<ShadowStyle> for BoxShadow {
+    fn from(value: ShadowStyle) -> Self {
+        Self(vec![value])
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(PartialEq, Default)]
 #[cfg_attr(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,5 +1,6 @@
 use crate::{FocusPolicy, UiRect, Val};
 use bevy_color::Color;
+use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{prelude::*, system::SystemParam};
 use bevy_math::{vec4, Rect, Vec2, Vec4Swizzles};
 use bevy_reflect::prelude::*;
@@ -2416,7 +2417,7 @@ impl ResolvedBorderRadius {
     };
 }
 
-#[derive(Component, Clone, Debug, Default, PartialEq, Reflect)]
+#[derive(Component, Clone, Debug, Default, PartialEq, Reflect, Deref, DerefMut)]
 #[reflect(Component, PartialEq, Default)]
 #[cfg_attr(
     feature = "serialize",
@@ -2426,6 +2427,7 @@ impl ResolvedBorderRadius {
 pub struct BoxShadow(pub Vec<DropShadow>);
 
 impl BoxShadow {
+    /// A single shadow
     pub fn new(shadow: DropShadow) -> Self {
         BoxShadow(vec![shadow])
     }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2424,30 +2424,30 @@ impl ResolvedBorderRadius {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct BoxShadow(pub Vec<DropShadow>);
+pub struct BoxShadow(pub Vec<ShadowStyle>);
 
 impl BoxShadow {
     /// A single shadow
-    pub fn new(shadow: DropShadow) -> Self {
+    pub fn new(shadow: ShadowStyle) -> Self {
         BoxShadow(vec![shadow])
     }
 }
 
-impl From<DropShadow> for BoxShadow {
-    fn from(shadow: DropShadow) -> Self {
+impl From<ShadowStyle> for BoxShadow {
+    fn from(shadow: ShadowStyle) -> Self {
         Self::new(shadow)
     }
 }
 
-impl From<Vec<DropShadow>> for BoxShadow {
-    fn from(shadows: Vec<DropShadow>) -> Self {
+impl From<Vec<ShadowStyle>> for BoxShadow {
+    fn from(shadows: Vec<ShadowStyle>) -> Self {
         Self(shadows)
     }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(PartialEq, Default)]
-pub struct DropShadow {
+pub struct ShadowStyle {
     /// The shadow's color
     pub color: Color,
     /// Horizontal offset
@@ -2463,7 +2463,7 @@ pub struct DropShadow {
     pub blur_radius: Val,
 }
 
-impl Default for DropShadow {
+impl Default for ShadowStyle {
     fn default() -> Self {
         Self {
             color: Color::BLACK,

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -190,7 +190,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         });
                 });
 
-            let shadow = BoxShadow {
+            let shadow_style = ShadowStyle {
                 color: Color::BLACK.with_alpha(0.5),
                 blur_radius: Val::Px(2.),
                 x_offset: Val::Px(10.),
@@ -218,7 +218,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ..default()
                             },
                             BackgroundColor(Color::srgb(1.0, 0.0, 0.)),
-                            shadow,
+                            BoxShadow::from(shadow_style),
                         ))
                         .with_children(|parent| {
                             parent.spawn((
@@ -232,7 +232,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     ..default()
                                 },
                                 BackgroundColor(Color::srgb(1.0, 0.3, 0.3)),
-                                shadow,
+                                BoxShadow::from(shadow_style),
                             ));
                             parent.spawn((
                                 Node {
@@ -244,7 +244,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     ..default()
                                 },
                                 BackgroundColor(Color::srgb(1.0, 0.5, 0.5)),
-                                shadow,
+                                BoxShadow::from(shadow_style),
                             ));
                             parent.spawn((
                                 Node {
@@ -256,7 +256,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     ..default()
                                 },
                                 BackgroundColor(Color::srgb(0.0, 0.7, 0.7)),
-                                shadow,
+                                BoxShadow::from(shadow_style),
                             ));
                             // alpha test
                             parent.spawn((
@@ -269,10 +269,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     ..default()
                                 },
                                 BackgroundColor(Color::srgba(1.0, 0.9, 0.9, 0.4)),
-                                BoxShadow {
+                                BoxShadow::from(ShadowStyle {
                                     color: Color::BLACK.with_alpha(0.3),
-                                    ..shadow
-                                },
+                                    ..shadow_style
+                                }),
                             ));
                         });
                 });

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -194,7 +194,7 @@ fn setup(mut commands: Commands) {
                 ));
             }
 
-            // Demonstate multiple shadows on one node
+            // Demonstrate multiple shadows on one node
             commands.spawn((
                 Node {
                     width: Val::Px(40.),

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -209,12 +209,12 @@ fn box_shadow_node_bundle(
         BorderColor(LIGHT_SKY_BLUE.into()),
         border_radius,
         BackgroundColor(DEEP_SKY_BLUE.into()),
-        BoxShadow {
+        BoxShadow::new(DropShadow {
             color: Color::BLACK.with_alpha(0.8),
             x_offset: Val::Percent(offset.x),
             y_offset: Val::Percent(offset.y),
             spread_radius: Val::Percent(spread),
             blur_radius: Val::Px(blur),
-        },
+        }),
     )
 }

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -1,8 +1,12 @@
 //! This example shows how to create a node with a shadow
 
 use argh::FromArgs;
+use bevy::color::palettes::css::BLUE;
 use bevy::color::palettes::css::DEEP_SKY_BLUE;
+use bevy::color::palettes::css::GREEN;
 use bevy::color::palettes::css::LIGHT_SKY_BLUE;
+use bevy::color::palettes::css::RED;
+use bevy::color::palettes::css::YELLOW;
 use bevy::prelude::*;
 use bevy::winit::WinitSettings;
 
@@ -189,6 +193,49 @@ fn setup(mut commands: Commands) {
                     border_radius,
                 ));
             }
+
+            // Demonstate multiple shadows on one node
+            commands.spawn((
+                Node {
+                    width: Val::Px(40.),
+                    height: Val::Px(40.),
+                    border: UiRect::all(Val::Px(4.)),
+                    ..default()
+                },
+                BorderColor(LIGHT_SKY_BLUE.into()),
+                BorderRadius::all(Val::Px(20.)),
+                BackgroundColor(DEEP_SKY_BLUE.into()),
+                BoxShadow(vec![
+                    ShadowStyle {
+                        color: RED.with_alpha(0.7).into(),
+                        x_offset: Val::Px(-20.),
+                        y_offset: Val::Px(-5.),
+                        spread_radius: Val::Percent(10.),
+                        blur_radius: Val::Px(3.),
+                    },
+                    ShadowStyle {
+                        color: BLUE.with_alpha(0.7).into(),
+                        x_offset: Val::Px(-5.),
+                        y_offset: Val::Px(-20.),
+                        spread_radius: Val::Percent(10.),
+                        blur_radius: Val::Px(3.),
+                    },
+                    ShadowStyle {
+                        color: YELLOW.with_alpha(0.7).into(),
+                        x_offset: Val::Px(20.),
+                        y_offset: Val::Px(5.),
+                        spread_radius: Val::Percent(10.),
+                        blur_radius: Val::Px(3.),
+                    },
+                    ShadowStyle {
+                        color: GREEN.with_alpha(0.7).into(),
+                        x_offset: Val::Px(5.),
+                        y_offset: Val::Px(20.),
+                        spread_radius: Val::Percent(10.),
+                        blur_radius: Val::Px(3.),
+                    },
+                ]),
+            ));
         });
 }
 
@@ -209,7 +256,7 @@ fn box_shadow_node_bundle(
         BorderColor(LIGHT_SKY_BLUE.into()),
         border_radius,
         BackgroundColor(DEEP_SKY_BLUE.into()),
-        BoxShadow::new(DropShadow {
+        BoxShadow::new(ShadowStyle {
             color: Color::BLACK.with_alpha(0.8),
             x_offset: Val::Percent(offset.x),
             y_offset: Val::Percent(offset.y),

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -256,12 +256,12 @@ fn box_shadow_node_bundle(
         BorderColor(LIGHT_SKY_BLUE.into()),
         border_radius,
         BackgroundColor(DEEP_SKY_BLUE.into()),
-        BoxShadow::new(ShadowStyle {
-            color: Color::BLACK.with_alpha(0.8),
-            x_offset: Val::Percent(offset.x),
-            y_offset: Val::Percent(offset.y),
-            spread_radius: Val::Percent(spread),
-            blur_radius: Val::Px(blur),
-        }),
+        BoxShadow::new(
+            Color::BLACK.with_alpha(0.8),
+            Val::Percent(offset.x),
+            Val::Percent(offset.y),
+            Val::Percent(spread),
+            Val::Px(blur),
+        ),
     )
 }


### PR DESCRIPTION
# Objective

Add support for multiple box shadows on a single `Node`.

## Solution

* Rename `BoxShadow` to `ShadowStyle` and remove its `Component` derive.
* Create a new `BoxShadow` component that newtypes a `Vec<ShadowStyle>`.
* Add a `new` constructor method to `BoxShadow` for single shadows.
* Change `extract_shadows` to iterate through a list of shadows per node.

Render order is determined implicitly from the order of the shadows stored in the `BoxShadow` component, back-to-front. 
Might be more efficient to use a `SmallVec<[ShadowStyle; 1]>` for the list of shadows but not sure if the extra friction is worth it.

## Testing

Added a node with four differently coloured shadows to the `box_shadow` example.

---

## Showcase

```
cargo run --example box_shadow
```

<img width="460" alt="four-shadow" src="https://github.com/user-attachments/assets/2f728c47-33b4-42e1-96ba-28a774b94b24">

## Migration Guide

Bevy UI now supports multiple shadows per node. A new struct `ShadowStyle` is used to set the style for each shadow. And the `BoxShadow` component is changed to a tuple struct wrapping a vector containing a list of `ShadowStyle`s. To spawn a node with a single shadow you can use the `new` constructor function:
```rust
commands.spawn((
    Node::default(),
    BoxShadow::new(
        Color::BLACK.with_alpha(0.8),
        Val::Percent(offset.x),
        Val::Percent(offset.y),
        Val::Percent(spread),
        Val::Px(blur),
    )
));
```
