### PR TITLE
Rename `UiBoxShadowSamples` to `BoxShadowSamples`.

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -170,7 +170,7 @@ impl Plugin for UiPlugin {
             .register_type::<widget::Label>()
             .register_type::<ZIndex>()
             .register_type::<Outline>()
-            .register_type::<UiBoxShadowSamples>()
+            .register_type::<BoxShadowSamples>()
             .register_type::<UiAntiAlias>()
             .configure_sets(
                 PostUpdate,

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -3,8 +3,8 @@
 use core::{hash::Hash, ops::Range};
 
 use crate::{
-    BoxShadow, CalculatedClip, ComputedNode, DefaultUiCamera, RenderUiSystem, ResolvedBorderRadius,
-    TargetCamera, TransparentUi, BoxShadowSamples, Val,
+    BoxShadow, BoxShadowSamples, CalculatedClip, ComputedNode, DefaultUiCamera, RenderUiSystem,
+    ResolvedBorderRadius, TargetCamera, TransparentUi, Val,
 };
 use bevy_app::prelude::*;
 use bevy_asset::*;

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -4,7 +4,7 @@ use core::{hash::Hash, ops::Range};
 
 use crate::{
     BoxShadow, CalculatedClip, ComputedNode, DefaultUiCamera, RenderUiSystem, ResolvedBorderRadius,
-    TargetCamera, TransparentUi, UiBoxShadowSamples, Val,
+    TargetCamera, TransparentUi, BoxShadowSamples, Val,
 };
 use bevy_app::prelude::*;
 use bevy_asset::*;
@@ -337,7 +337,7 @@ pub fn queue_shadows(
     box_shadow_pipeline: Res<BoxShadowPipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<BoxShadowPipeline>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
-    mut views: Query<(Entity, &ExtractedView, Option<&UiBoxShadowSamples>)>,
+    mut views: Query<(Entity, &ExtractedView, Option<&BoxShadowSamples>)>,
     pipeline_cache: Res<PipelineCache>,
     draw_functions: Res<DrawFunctions<TransparentUi>>,
 ) {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -6,8 +6,8 @@ pub mod ui_texture_slice_pipeline;
 
 use crate::widget::ImageNode;
 use crate::{
-    experimental::UiChildren, BackgroundColor, BorderColor, CalculatedClip, ComputedNode,
-    DefaultUiCamera, Outline, ResolvedBorderRadius, TargetCamera, UiAntiAlias, UiBoxShadowSamples,
+    experimental::UiChildren, BackgroundColor, BorderColor, BoxShadowSamples, CalculatedClip,
+    ComputedNode, DefaultUiCamera, Outline, ResolvedBorderRadius, TargetCamera, UiAntiAlias,
 };
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};
@@ -537,7 +537,7 @@ pub fn extract_default_ui_camera_view(
                 RenderEntity,
                 &Camera,
                 Option<&UiAntiAlias>,
-                Option<&UiBoxShadowSamples>,
+                Option<&BoxShadowSamples>,
             ),
             Or<(With<Camera2d>, With<Camera3d>)>,
         >,
@@ -552,7 +552,7 @@ pub fn extract_default_ui_camera_view(
             commands
                 .get_entity(entity)
                 .expect("Camera entity wasn't synced.")
-                .remove::<(DefaultCameraView, UiAntiAlias, UiBoxShadowSamples)>();
+                .remove::<(DefaultCameraView, UiAntiAlias, BoxShadowSamples)>();
             continue;
         }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2606,14 +2606,14 @@ pub enum UiAntiAlias {
 /// fn spawn_camera(mut commands: Commands) {
 ///     commands.spawn((
 ///         Camera2d,
-///         UiBoxShadowSamples(6),
+///         BoxShadowSamples(6),
 ///     ));
 /// }
 /// ```
 #[derive(Component, Clone, Copy, Debug, Reflect, Eq, PartialEq)]
-pub struct UiBoxShadowSamples(pub u32);
+pub struct BoxShadowSamples(pub u32);
 
-impl Default for UiBoxShadowSamples {
+impl Default for BoxShadowSamples {
     fn default() -> Self {
         Self(4)
     }

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -29,7 +29,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Camera
-    commands.spawn((Camera2d, IsDefaultUiCamera, UiBoxShadowSamples(6)));
+    commands.spawn((Camera2d, IsDefaultUiCamera, BoxShadowSamples(6)));
 
     // root node
     commands

--- a/examples/ui/box_shadow.rs
+++ b/examples/ui/box_shadow.rs
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands) {
     let args = Args::from_args(&[], &[]).unwrap();
 
     // ui camera
-    commands.spawn((Camera2d, UiBoxShadowSamples(args.samples)));
+    commands.spawn((Camera2d, BoxShadowSamples(args.samples)));
 
     commands
         .spawn((


### PR DESCRIPTION
# Objective

The `UiBoxShadowSamples` resource should be renamed to `BoxShadowSamples` so it matches the `BoxShadow` component.

## Migration Guide

`UiBoxShadowSamples` has been renamed to `BoxShadowSamples`