### PR TITLE
ensure all Material2d rendering happen in order

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -236,6 +236,12 @@ impl<M: Material2d> Default for Material2dPlugin<M> {
     }
 }
 
+#[derive(Resource, Debug)]
+struct MaterialCounts(usize);
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+struct MaterialSet(usize);
+
 impl<M: Material2d> Plugin for Material2dPlugin<M>
 where
     M::Data: PartialEq + Eq + Hash + Clone,
@@ -245,6 +251,13 @@ where
             .register_type::<MeshMaterial2d<M>>()
             .add_plugins(RenderAssetPlugin::<PreparedMaterial2d<M>>::default());
 
+        let current_material = app
+            .world_mut()
+            .remove_resource::<MaterialCounts>()
+            .map(|mc| mc.0 + 1)
+            .unwrap_or_default();
+        app.insert_resource(MaterialCounts(current_material));
+
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .add_render_command::<Opaque2d, DrawMaterial2d<M>>()
@@ -252,17 +265,30 @@ where
                 .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
                 .init_resource::<RenderMaterial2dInstances<M>>()
                 .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
-                .add_systems(ExtractSchedule, extract_mesh_materials_2d::<M>)
-                .add_systems(
+                .add_systems(ExtractSchedule, extract_mesh_materials_2d::<M>);
+            if current_material == 0 {
+                render_app.add_systems(
                     Render,
                     queue_material2d_meshes::<M>
                         .in_set(RenderSet::QueueMeshes)
+                        .in_set(MaterialSet(current_material))
                         .after(prepare_assets::<PreparedMaterial2d<M>>),
                 );
+            } else {
+                render_app.add_systems(
+                    Render,
+                    queue_material2d_meshes::<M>
+                        .in_set(RenderSet::QueueMeshes)
+                        .in_set(MaterialSet(current_material))
+                        .after(MaterialSet(current_material - 1))
+                        .after(prepare_assets::<PreparedMaterial2d<M>>),
+                );
+            }
         }
     }
 
     fn finish(&self, app: &mut App) {
+        app.world_mut().remove_resource::<MaterialCounts>();
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.init_resource::<Material2dPipeline<M>>();
         }


### PR DESCRIPTION
# Objective

- `Material2d` rendering order is random
- This can be seen in example `wireframe_2d`, wireframe is randomly visible 50% of the time

## Solution

- Add a temp resource counting the materials added
- Add sets to materials with a unique value
- Order each material to be after those added before
- *This means rendering order is dependent on plugin addition order*

## Testing

```sh
steps=10; git restore .;
echo "wireframe_2d" > test
cargo run -p example-showcase -- run --stop-frame 250 --screenshot-frame 100 --fixed-frame-time 0.05 --example-list test --in-ci;
mv screenshots base;
for prefix in `seq 0 $steps`;
do
  echo step $prefix;
  cargo run -p example-showcase -- run --stop-frame 250 --screenshot-frame 100 --fixed-frame-time 0.05 --example-list test;
  mv screenshots $prefix-screenshots;
done;
mv base screenshots
for prefix in `seq 0 $steps`;
do
  echo check $prefix
  for file in screenshots/*/*;
  do
    echo $file;
    diff $file $prefix-$file;
  done;
done;
```