### PR TITLE
use wgpu patch 23.0.1

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -49,7 +49,7 @@ image = { version = "0.25.2", default-features = false }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu = { version = "23", default-features = false }
+wgpu = { version = "23.0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 derive_more = { version = "1", default-features = false, features = [
   "error",

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -24,7 +24,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu = { version = "23", default-features = false }
+wgpu = { version = "23.0.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 hexasphere = "15.0"
 derive_more = { version = "1", default-features = false, features = [

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -68,7 +68,7 @@ codespan-reporting = "0.11.0"
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
 # and Bevy instead wraps `wgpu` types to verify they are not used off their origin thread.
-wgpu = { version = "23", default-features = false, features = [
+wgpu = { version = "23.0.1", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",


### PR DESCRIPTION
# Objective

- Fixes #16363
- Ensure that someone using minimum version doesn't get the bugs that were fixed in the 23.0.1 patch

## Solution

- Use wgpu 23.0.1
