### PR TITLE
Refactor `FunctionSystem` to use a single `Option`

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -611,7 +611,7 @@ where
     marker: PhantomData<fn() -> Marker>,
 }
 
-/// Stores the state of a [`FunctionSystem`], which must be initialized with
+/// The state of a [`FunctionSystem`], which must be initialized with
 /// [`System::initialize`] before the system can be run. A panic will occur if
 /// the system is run without being initialized.
 struct FunctionSystemState<Marker, F>
@@ -683,7 +683,8 @@ where
     /// Message shown when a system isn't initialized
     // When lines get too long, rustfmt can sometimes refuse to format them.
     // Work around this by storing the message separately.
-    const ERROR_UNINITIALIZED: &'static str = "System's param_state was not found. Did you forget to initialize this system before running it?";
+    const ERROR_UNINITIALIZED: &'static str =
+        "System's state was not found. Did you forget to initialize this system before running it?";
 }
 
 impl<Marker, F> System for FunctionSystem<Marker, F>
@@ -735,11 +736,7 @@ where
 
         let change_tick = world.increment_change_tick();
 
-        let param_state = self
-            .state
-            .as_mut()
-            .map(|state| &mut state.param)
-            .expect(Self::ERROR_UNINITIALIZED);
+        let param_state = &mut self.state.as_mut().expect(Self::ERROR_UNINITIALIZED).param;
         // SAFETY:
         // - The caller has invoked `update_archetype_component_access`, which will panic
         //   if the world does not match.
@@ -754,31 +751,19 @@ where
 
     #[inline]
     fn apply_deferred(&mut self, world: &mut World) {
-        let param_state = self
-            .state
-            .as_mut()
-            .map(|state| &mut state.param)
-            .expect(Self::ERROR_UNINITIALIZED);
+        let param_state = &mut self.state.as_mut().expect(Self::ERROR_UNINITIALIZED).param;
         F::Param::apply(param_state, &self.system_meta, world);
     }
 
     #[inline]
     fn queue_deferred(&mut self, world: DeferredWorld) {
-        let param_state = self
-            .state
-            .as_mut()
-            .map(|state| &mut state.param)
-            .expect(Self::ERROR_UNINITIALIZED);
+        let param_state = &mut self.state.as_mut().expect(Self::ERROR_UNINITIALIZED).param;
         F::Param::queue(param_state, &self.system_meta, world);
     }
 
     #[inline]
     unsafe fn validate_param_unsafe(&mut self, world: UnsafeWorldCell) -> bool {
-        let param_state = self
-            .state
-            .as_ref()
-            .map(|state| &state.param)
-            .expect(Self::ERROR_UNINITIALIZED);
+        let param_state = &self.state.as_ref().expect(Self::ERROR_UNINITIALIZED).param;
         // SAFETY:
         // - The caller has invoked `update_archetype_component_access`, which will panic
         //   if the world does not match.

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -604,7 +604,7 @@ where
     F: SystemParamFunction<Marker>,
 {
     func: F,
-    state: Option<FunctionSystemState<Marker, F>>,
+    state: Option<FunctionSystemState<F::Param>>,
     system_meta: SystemMeta,
     archetype_generation: ArchetypeGeneration,
     // NOTE: PhantomData<fn()-> T> gives this safe Send/Sync impls
@@ -614,12 +614,9 @@ where
 /// The state of a [`FunctionSystem`], which must be initialized with
 /// [`System::initialize`] before the system can be run. A panic will occur if
 /// the system is run without being initialized.
-struct FunctionSystemState<Marker, F>
-where
-    F: SystemParamFunction<Marker>,
-{
-    /// Stores the cached state of the system's [`SystemParam`]s.
-    param: <F::Param as SystemParam>::State,
+struct FunctionSystemState<P: SystemParam> {
+    /// The cached state of the system's [`SystemParam`]s.
+    param: P::State,
     /// The id of the [`World`] this system was initialized with. If the world
     /// passed to [`System::update_archetype_component_access`] does not match
     /// this id, a panic will occur.

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -621,7 +621,8 @@ where
     /// Stores the cached state of the system's [`SystemParam`]s.
     param: <F::Param as SystemParam>::State,
     /// The id of the [`World`] this system was initialized with. If the world
-    /// passed to [`System::run`] does not match this id, a panic will occur.
+    /// passed to [`System::update_archetype_component_access`] does not match
+    /// this id, a panic will occur.
     world_id: WorldId,
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -682,7 +682,7 @@ where
     /// Message shown when a system isn't initialized
     // When lines get too long, rustfmt can sometimes refuse to format them.
     // Work around this by storing the message separately.
-    const ERROR_UNITIALIZED: &'static str = "System's param_state was not found. Did you forget to initialize this system before running it?";
+    const ERROR_UNINITIALIZED: &'static str = "System's param_state was not found. Did you forget to initialize this system before running it?";
 }
 
 impl<Marker, F> System for FunctionSystem<Marker, F>
@@ -738,7 +738,7 @@ where
             .state
             .as_mut()
             .map(|state| &mut state.param)
-            .expect(Self::ERROR_UNITIALIZED);
+            .expect(Self::ERROR_UNINITIALIZED);
         // SAFETY:
         // - The caller has invoked `update_archetype_component_access`, which will panic
         //   if the world does not match.
@@ -757,7 +757,7 @@ where
             .state
             .as_mut()
             .map(|state| &mut state.param)
-            .expect(Self::ERROR_UNITIALIZED);
+            .expect(Self::ERROR_UNINITIALIZED);
         F::Param::apply(param_state, &self.system_meta, world);
     }
 
@@ -767,7 +767,7 @@ where
             .state
             .as_mut()
             .map(|state| &mut state.param)
-            .expect(Self::ERROR_UNITIALIZED);
+            .expect(Self::ERROR_UNINITIALIZED);
         F::Param::queue(param_state, &self.system_meta, world);
     }
 
@@ -777,7 +777,7 @@ where
             .state
             .as_ref()
             .map(|state| &state.param)
-            .expect(Self::ERROR_UNITIALIZED);
+            .expect(Self::ERROR_UNINITIALIZED);
         // SAFETY:
         // - The caller has invoked `update_archetype_component_access`, which will panic
         //   if the world does not match.
@@ -808,7 +808,7 @@ where
     }
 
     fn update_archetype_component_access(&mut self, world: UnsafeWorldCell) {
-        let state = self.state.as_mut().expect(Self::ERROR_UNITIALIZED);
+        let state = self.state.as_mut().expect(Self::ERROR_UNINITIALIZED);
         assert_eq!(state.world_id, world.id(), "Encountered a mismatched World. A System cannot be used with Worlds other than the one it was initialized with.");
 
         let archetypes = world.archetypes();


### PR DESCRIPTION
# Objective

Combine the `Option<_>` state in `FunctionSystem` into a single `Option` to provide clarity and save space.

## Solution

Simplifies `FunctionSystem`'s layout by using a single `Option<FunctionSystemState>` for state that must be initialized before running, and saves a byte by removing the need to store an enum tag. Additionally, calling `System::run` on an uninitialized `System` will now give a more descriptive message prior to verifying the `WorldId`.

## Testing

Ran CI checks locally.