### PR TITLE
Add PhysicsSystems and AiSystems system sets.

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -185,6 +185,18 @@ pub struct Last;
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct Animation;
 
+/// A generic system set for physics. This is unused by Bevy but provides
+/// physics engine with a system set they can insert into, and for other crates
+/// to avoid depending on the particular physics engine.
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+pub struct PhysicsSystems;
+
+/// A generic system set for AI. This is unused by Bevy but provides AI crates
+/// with a system set they can insert into, and for other crates to avoid
+/// depending on the particular AI crate.
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+pub struct AiSystems;
+
 /// Defines the schedules to be run for the [`Main`] schedule, including
 /// their order.
 #[derive(Resource, Debug)]


### PR DESCRIPTION
# Objective

- Allow ordering systems against unknown physics engine / AI crate.

## Solution

- Add an unused generic `PhysicsSystems` and `AiSystems` system set that crates can opt into.

---

## Showcase

The `PhysicsSystems` and `AiSystems` are useful general system sets for ordering systems relative to unknown crates. For example, your crate may care that it manipulates transforms before a physics engine. Physics engines can put their systems in this system set, and your crate can order its systems before this system set. This allows crates to avoid pulling in extra dependencies just for their system sets!
