### PR TITLE
use scale factor for touches in UI focus

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -197,16 +197,19 @@ pub fn ui_focus_system(
             else {
                 return None;
             };
+            let window = windows.get(window_ref.entity()).ok()?;
 
             let viewport_position = camera
                 .physical_viewport_rect()
                 .map(|rect| rect.min.as_vec2())
                 .unwrap_or_default();
-            windows
-                .get(window_ref.entity())
-                .ok()
-                .and_then(Window::physical_cursor_position)
-                .or_else(|| touches_input.first_pressed_position())
+            window
+                .physical_cursor_position()
+                .or_else(|| {
+                    touches_input
+                        .first_pressed_position()
+                        .map(|pos| pos * window.scale_factor())
+                })
                 .map(|cursor_position| (entity, cursor_position - viewport_position))
         })
         .collect();


### PR DESCRIPTION
# Objective

- Fix the issue mentioned on iOS in https://github.com/bevyengine/bevy/issues/16363#issuecomment-2499766031
- touch on the button in the mobile example are not detected

## Solution

- UI focus now uses the window scale factor for touches
