### PR TITLE
Revert "Update `sysinfo` version to 0.32.1 (#16517)"

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -27,7 +27,7 @@ const-fnv1a-hash = "1.1.0"
 # macOS
 [target.'cfg(all(target_os="macos"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
-sysinfo = { version = "0.32.1", optional = true, default-features = false, features = [
+sysinfo = { version = "0.32.0", optional = true, default-features = false, features = [
   "apple-app-store",
   "system",
 ] }


### PR DESCRIPTION
This reverts commit 3476a9f3a658fe7c8326ca0e618ad543914ca7f4.

# Objective

#16517 makes it impossible to select a libc version, now that the "breaking" libc release was yanked

## Solution

Revert the version bump so we can select a version of sysinfo that builds (the previous version)
