### PR TITLE
Skip empty spans when updating text buffers

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -107,6 +107,9 @@ impl TextPipeline {
         computed.entities.clear();
 
         for (span_index, (entity, depth, span, text_font, color)) in text_spans.enumerate() {
+            // Save this span entity in the computed text block.
+            computed.entities.push(TextEntity { entity, depth });
+
             if span.is_empty() {
                 continue;
             }
@@ -124,9 +127,6 @@ impl TextPipeline {
 
                 return Err(TextError::NoSuchFont);
             }
-
-            // Save this span entity in the computed text block.
-            computed.entities.push(TextEntity { entity, depth });
 
             // Get max font size for use in cosmic Metrics.
             font_size = font_size.max(text_font.font_size);
@@ -226,7 +226,6 @@ impl TextPipeline {
     ) -> Result<(), TextError> {
         layout_info.glyphs.clear();
         layout_info.size = Default::default();
-        println!("QUEUED");
 
         // Clear this here at the focal point of text rendering to ensure the field's lifecycle has strong boundaries.
         computed.needs_rerender = false;

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -107,6 +107,9 @@ impl TextPipeline {
         computed.entities.clear();
 
         for (span_index, (entity, depth, span, text_font, color)) in text_spans.enumerate() {
+            if span.is_empty() {
+                continue;
+            }
             // Return early if a font is not loaded yet.
             if !fonts.contains(text_font.font.id()) {
                 spans.clear();
@@ -223,6 +226,7 @@ impl TextPipeline {
     ) -> Result<(), TextError> {
         layout_info.glyphs.clear();
         layout_info.size = Default::default();
+        println!("QUEUED");
 
         // Clear this here at the focal point of text rendering to ensure the field's lifecycle has strong boundaries.
         computed.needs_rerender = false;


### PR DESCRIPTION
# Objective

Fixes #16521

## Solution

If an empty span is encountered (such as the default `Text` value), we skip it entirely when updating buffers. This prevents unnecessarily bailing when the font doesn't exist (ex: when the default font is disabled)