### PR TITLE
Clarify that `bevy_app::App.world()` (and mut variant) returns the main `SubApp`'s `World`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1008,12 +1008,18 @@ impl App {
             .try_register_required_components_with::<T, R>(constructor)
     }
 
-    /// Returns a reference to the [`World`].
+    /// Returns a reference to the main [`SubApp`]'s [`World`]. This is the same as calling
+    /// [`app.main().world()`].
+    ///
+    /// [`app.main().world()`]: SubApp::world
     pub fn world(&self) -> &World {
         self.main().world()
     }
 
-    /// Returns a mutable reference to the [`World`].
+    /// Returns a mutable reference to the main [`SubApp`]'s [`World`]. This is the same as calling
+    /// [`app.main_mut().world_mut()`].
+    ///
+    /// [`app.main_mut().world_mut()`]: SubApp::world_mut
     pub fn world_mut(&mut self) -> &mut World {
         self.main_mut().world_mut()
     }


### PR DESCRIPTION
# Objective
The documentation for `bevy_app::App.world()` (and its mut variant) could confuse some into thinking that this is the only World that the App will contain.

## Solution
Clarify the documentation for `bevy_app::App.world()` (and its mut variant), to say that it returns the main subapp's world. This helps imply that Apps can contain more than one world (albeit, only one per SubApp).

## Testing
This is a documentation change, with no changes to doctests. Thus, testing is not necessary beyond ensuring the link syntax is correct.