### PR TITLE
Changed GLTF Asset Label to use Strings instead of indexes

### DIFF
--- a/assets/animation_graphs/Fox.animgraph.ron
+++ b/assets/animation_graphs/Fox.animgraph.ron
@@ -12,17 +12,17 @@
                 weight: 1.0,
             ),
             (
-                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation0")),
+                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation:Survey")),
                 mask: 0,
                 weight: 1.0,
             ),
             (
-                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation1")),
+                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation:Walk")),
                 mask: 0,
                 weight: 1.0,
             ),
             (
-                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation2")),
+                node_type: Clip(AssetPath("models/animated/Fox.glb#Animation:Run")),
                 mask: 0,
                 weight: 1.0,
             ),

--- a/examples/2d/custom_gltf_vertex_attribute.rs
+++ b/examples/2d/custom_gltf_vertex_attribute.rs
@@ -46,13 +46,8 @@ fn setup(
     mut materials: ResMut<Assets<CustomMaterial>>,
 ) {
     // Add a mesh loaded from a glTF file. This mesh has data for `ATTRIBUTE_BARYCENTRIC`.
-    let mesh = asset_server.load(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            primitive: 0,
-        }
-        .from_asset("models/barycentric/barycentric.gltf"),
-    );
+    let mesh = asset_server
+        .load(GltfAssetLabel::primitive("0", 0).from_asset("models/barycentric/barycentric.gltf"));
     commands.spawn((
         Mesh2d(mesh),
         MeshMaterial2d(materials.add(CustomMaterial {})),

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -72,7 +72,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
     spawn_directional_light(&mut commands);
 
     commands.spawn((
-        SceneRoot(asset_server.load("models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene0")),
+        SceneRoot(asset_server.load("models/AnisotropyBarnLamp/AnisotropyBarnLamp.gltf#Scene:0")),
         Transform::from_xyz(0.0, 0.07, -0.13),
     ));
 

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -278,7 +278,7 @@ fn setup(
 
     // Flight Helmet
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+        GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
     )));
 
     // Light

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -67,7 +67,7 @@ fn setup_terrain_scene(
 
     // Terrain
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/terrain/Mountains.gltf"),
+        GltfAssetLabel::scene("Scene").from_asset("models/terrain/Mountains.gltf"),
     )));
 
     // Sky

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -146,7 +146,8 @@ fn spawn_coated_glass_bubble_sphere(
 fn spawn_golf_ball(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/GolfBall/GolfBall.glb")),
+            asset_server
+                .load(GltfAssetLabel::scene("Scene").from_asset("models/GolfBall/GolfBall.glb")),
         ),
         Transform::from_xyz(1.0, 1.0, 0.0).with_scale(Vec3::splat(SPHERE_SCALE)),
         ExampleSphere,

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -360,14 +360,15 @@ fn add_camera(commands: &mut Commands, asset_server: &AssetServer, color_grading
 fn add_basic_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+        GltfAssetLabel::scene("Scene").from_asset("models/TonemappingTest/TonemappingTest.gltf"),
     )));
 
     // Spawn the flight helmet.
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_xyz(0.5, 0.0, -0.5).with_rotation(Quat::from_rotation_y(-0.15 * PI)),
     ));

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -80,7 +80,7 @@ fn setup(
 
     // FlightHelmet
     let helmet_scene = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+        .load(GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"));
 
     commands.spawn(SceneRoot(helmet_scene.clone()));
     commands.spawn((

--- a/examples/3d/depth_of_field.rs
+++ b/examples/3d/depth_of_field.rs
@@ -87,9 +87,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: R
     }
 
     // Spawn the scene.
-    commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
-    )));
+    commands.spawn(SceneRoot(
+        asset_server.load(
+            GltfAssetLabel::scene("Scene")
+                .from_asset("models/DepthOfFieldExample/DepthOfFieldExample.glb"),
+        ),
+    ));
 
     // Spawn the help text.
     commands.spawn((

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -481,17 +481,17 @@ fn handle_mouse_clicks(
 
 impl FromWorld for ExampleAssets {
     fn from_world(world: &mut World) -> Self {
-        let fox_animation =
-            world.load_asset(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb"));
+        let fox_animation = world
+            .load_asset(GltfAssetLabel::animation("Survey").from_asset("models/animated/Fox.glb"));
         let (fox_animation_graph, fox_animation_node) =
             AnimationGraph::from_clip(fox_animation.clone());
 
         ExampleAssets {
             main_sphere: world.add_asset(Sphere::default().mesh().uv(32, 18)),
-            fox: world.load_asset(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            fox: world.load_asset(GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb")),
             main_sphere_material: world.add_asset(Color::from(SILVER)),
             main_scene: world.load_asset(
-                GltfAssetLabel::Scene(0)
+                GltfAssetLabel::scene("Scene")
                     .from_asset("models/IrradianceVolumeExample/IrradianceVolumeExample.glb"),
             ),
             irradiance_volume: world.load_asset("irradiance_volumes/Example.vxgi.ktx2"),

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -13,7 +13,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/CornellBox/CornellBox.glb"),
+        GltfAssetLabel::scene("Scene").from_asset("models/CornellBox/CornellBox.glb"),
     )));
 
     commands.spawn((

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .build(),
     ));
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+        GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
     )));
 }
 

--- a/examples/3d/load_gltf_extras.rs
+++ b/examples/3d/load_gltf_extras.rs
@@ -29,7 +29,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // a barebones scene containing one of each gltf_extra type
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/extras/gltf_extras.glb"),
+        GltfAssetLabel::scene("Scene").from_asset("models/extras/gltf_extras.glb"),
     )));
 
     // a place to display the extras on screen

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -202,7 +202,7 @@ fn spawn_light(commands: &mut Commands, app_status: &AppStatus) {
 /// Loads and spawns the glTF palm tree scene.
 fn spawn_gltf_scene(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn(SceneRoot(
-        asset_server.load("models/PalmTree/PalmTree.gltf#Scene0"),
+        asset_server.load("models/PalmTree/PalmTree.gltf#Scene:Scene"),
     ));
 }
 

--- a/examples/3d/post_processing.rs
+++ b/examples/3d/post_processing.rs
@@ -91,14 +91,15 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
     // Spawn the main scene.
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+        GltfAssetLabel::scene("Scene").from_asset("models/TonemappingTest/TonemappingTest.gltf"),
     )));
 
     // Spawn the flight helmet.
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_xyz(0.5, 0.0, -0.5).with_rotation(Quat::from_rotation_y(-0.15 * PI)),
     ));

--- a/examples/3d/query_gltf_primitives.rs
+++ b/examples/3d/query_gltf_primitives.rs
@@ -64,6 +64,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/GltfPrimitives/gltf_primitives.glb"),
+        GltfAssetLabel::scene("Scene").from_asset("models/GltfPrimitives/gltf_primitives.glb"),
     )));
 }

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -96,9 +96,9 @@ fn setup(
 
 // Spawns the cubes, light, and camera.
 fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
-    commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/cubes/Cubes.glb")),
-    ));
+    commands.spawn(SceneRoot(asset_server.load(
+        GltfAssetLabel::scene("Scene").from_asset("models/cubes/Cubes.glb"),
+    )));
 }
 
 // Spawns the camera.

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -27,9 +27,9 @@ fn setup(
         MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
     ));
 
-    commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
-    ));
+    commands.spawn(SceneRoot(asset_server.load(
+        GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb"),
+    )));
 
     // Light
     commands.spawn((

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -162,8 +162,9 @@ fn spawn_cube(
 fn spawn_flight_helmet(commands: &mut Commands, asset_server: &AssetServer) {
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_scale(Vec3::splat(2.5)),
         FlightHelmetModel,

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -95,17 +95,21 @@ fn setup(
 fn setup_basic_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Main scene
     commands.spawn((
-        SceneRoot(asset_server.load(
-            GltfAssetLabel::Scene(0).from_asset("models/TonemappingTest/TonemappingTest.gltf"),
-        )),
+        SceneRoot(
+            asset_server.load(
+                GltfAssetLabel::scene("Scene")
+                    .from_asset("models/TonemappingTest/TonemappingTest.gltf"),
+            ),
+        ),
         SceneNumber(1),
     ));
 
     // Flight Helmet
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         Transform::from_xyz(0.5, 0.0, -0.5).with_rotation(Quat::from_rotation_y(-0.15 * PI)),
         SceneNumber(1),

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -38,16 +38,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Transform::from_xyz(-1.0, 0.0, 0.0),
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
     ));
 
     // Spawn a second scene, and add a tag component to be able to target it later
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         MovedScene,
     ));

--- a/examples/3d/visibility_range.rs
+++ b/examples/3d/visibility_range.rs
@@ -107,8 +107,9 @@ fn setup(
 
     commands.spawn((
         SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+            asset_server.load(
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+            ),
         ),
         MainModel::HighPoly,
     ));
@@ -116,7 +117,7 @@ fn setup(
     commands.spawn((
         SceneRoot(
             asset_server.load(
-                GltfAssetLabel::Scene(0)
+                GltfAssetLabel::scene("Scene")
                     .from_asset("models/FlightHelmetLowPoly/FlightHelmetLowPoly.gltf"),
             ),
         ),

--- a/examples/3d/volumetric_fog.rs
+++ b/examples/3d/volumetric_fog.rs
@@ -57,9 +57,12 @@ fn main() {
 /// Initializes the scene.
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_settings: Res<AppSettings>) {
     // Spawn the glTF scene.
-    commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
-    )));
+    commands.spawn(SceneRoot(
+        asset_server.load(
+            GltfAssetLabel::scene("Scene")
+                .from_asset("models/VolumetricFogExample/VolumetricFogExample.glb"),
+        ),
+    ));
 
     // Spawn the camera.
     commands

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -74,9 +74,9 @@ fn setup(
 ) {
     // Build the animation graph
     let (graph, node_indices) = AnimationGraph::from_clips([
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset(FOX_PATH)),
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset(FOX_PATH)),
+        asset_server.load(GltfAssetLabel::animation("Walk").from_asset(FOX_PATH)),
+        asset_server.load(GltfAssetLabel::animation("Survey").from_asset(FOX_PATH)),
+        asset_server.load(GltfAssetLabel::animation("Run").from_asset(FOX_PATH)),
     ]);
 
     // Insert a resource with the current scene information
@@ -115,7 +115,7 @@ fn setup(
 
     // Fox
     commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH)),
+        asset_server.load(GltfAssetLabel::scene("0").from_asset(FOX_PATH)),
     ));
 
     println!("Animation controls:");

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -157,17 +157,18 @@ fn setup_assets_programmatically(
     let mut animation_graph = AnimationGraph::new();
     let blend_node = animation_graph.add_blend(0.5, animation_graph.root);
     animation_graph.add_clip(
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
+        asset_server
+            .load(GltfAssetLabel::animation("Survey").from_asset("models/animated/Fox.glb")),
         1.0,
         animation_graph.root,
     );
     animation_graph.add_clip(
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfAssetLabel::animation("Walk").from_asset("models/animated/Fox.glb")),
         1.0,
         blend_node,
     );
     animation_graph.add_clip(
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfAssetLabel::animation("Run").from_asset("models/animated/Fox.glb")),
         1.0,
         blend_node,
     );
@@ -233,7 +234,7 @@ fn setup_scene(
 
     commands.spawn((
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            asset_server.load(GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb")),
         ),
         Transform::from_scale(Vec3::splat(0.07)),
     ));

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -140,7 +140,7 @@ fn setup_scene(
     // Spawn the fox.
     commands.spawn((
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            asset_server.load(GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb")),
         ),
         Transform::from_scale(Vec3::splat(0.07)),
     ));
@@ -357,8 +357,15 @@ fn setup_animation_graph_once_loaded(
         let animation_graph_nodes: [AnimationNodeIndex; 3] =
             std::array::from_fn(|animation_index| {
                 let handle = asset_server.load(
-                    GltfAssetLabel::Animation(animation_index)
-                        .from_asset("models/animated/Fox.glb"),
+                    GltfAssetLabel::Animation(
+                        match animation_index {
+                            0 => "Survey",
+                            1 => "Walk",
+                            _ => "Run",
+                        }
+                        .into(),
+                    )
+                    .from_asset("models/animated/Fox.glb"),
                 );
                 let mask = if animation_index == 0 { 0 } else { 0x3f };
                 animation_graph.add_clip_with_mask(handle, mask, 1.0, blend_node)

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -26,7 +26,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Spawn the first scene in `models/SimpleSkin/SimpleSkin.gltf`
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/SimpleSkin/SimpleSkin.gltf"),
+        GltfAssetLabel::scene("0").from_asset("models/SimpleSkin/SimpleSkin.gltf"),
     )));
 }
 

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -36,18 +36,16 @@ struct MorphData {
 
 fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
     commands.insert_resource(MorphData {
-        the_wave: asset_server
-            .load(GltfAssetLabel::Animation(2).from_asset("models/animated/MorphStressTest.gltf")),
+        the_wave: asset_server.load(
+            GltfAssetLabel::animation("TheWave").from_asset("models/animated/MorphStressTest.gltf"),
+        ),
         mesh: asset_server.load(
-            GltfAssetLabel::Primitive {
-                mesh: 0,
-                primitive: 0,
-            }
-            .from_asset("models/animated/MorphStressTest.gltf"),
+            GltfAssetLabel::primitive("Cube.001", 0)
+                .from_asset("models/animated/MorphStressTest.gltf"),
         ),
     });
     commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/animated/MorphStressTest.gltf"),
+        GltfAssetLabel::scene("Scene").from_asset("models/animated/MorphStressTest.gltf"),
     )));
     commands.spawn((
         DirectionalLight::default(),

--- a/examples/asset/alter_mesh.rs
+++ b/examples/asset/alter_mesh.rs
@@ -42,6 +42,13 @@ impl Shape {
             Shape::Sphere => Shape::Cube,
         }
     }
+
+    fn get_mesh_name(&self) -> &'static str {
+        match self {
+            Shape::Cube => "Cube",
+            Shape::Sphere => "Sphere",
+        }
+    }
 }
 
 #[derive(Component, Debug)]
@@ -58,17 +65,8 @@ fn setup(
     // In normal use, you can call `asset_server.load`, however see below for an explanation of
     // `RenderAssetUsages`.
     let left_shape_model = asset_server.load_with_settings(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            // This field stores an index to this primitive in its parent mesh. In this case, we
-            // want the first one. You might also have seen the syntax:
-            //
-            //     models/cube/cube.gltf#Scene0
-            //
-            // which accomplishes the same thing.
-            primitive: 0,
-        }
-        .from_asset(left_shape.get_model_path()),
+        GltfAssetLabel::primitive(left_shape.get_mesh_name(), 0)
+            .from_asset(left_shape.get_model_path()),
         // `RenderAssetUsages::all()` is already the default, so the line below could be omitted.
         // It's helpful to know it exists, however.
         //
@@ -88,11 +86,8 @@ fn setup(
 
     // Here, we rely on the default loader settings to achieve a similar result to the above.
     let right_shape_model = asset_server.load(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            primitive: 0,
-        }
-        .from_asset(right_shape.get_model_path()),
+        GltfAssetLabel::primitive(right_shape.get_mesh_name(), 0)
+            .from_asset(right_shape.get_model_path()),
     );
 
     // Add a material asset directly to the materials storage
@@ -162,11 +157,7 @@ fn alter_handle(
     // have to load the same path from storage media once: repeated attempts will re-use the
     // asset.
     mesh.0 = asset_server.load(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            primitive: 0,
-        }
-        .from_asset(shape.get_model_path()),
+        GltfAssetLabel::primitive(shape.get_mesh_name(), 0).from_asset(shape.get_model_path()),
     );
 }
 

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -20,20 +20,10 @@ fn setup(
     // where "ROOT" is the directory of the Application.
     //
     // This can be overridden by setting [`AssetPlugin.file_path`].
-    let cube_handle = asset_server.load(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            primitive: 0,
-        }
-        .from_asset("models/cube/cube.gltf"),
-    );
-    let sphere_handle = asset_server.load(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            primitive: 0,
-        }
-        .from_asset("models/sphere/sphere.gltf"),
-    );
+    let cube_handle =
+        asset_server.load(GltfAssetLabel::primitive("Cube", 0).from_asset("models/cube/cube.gltf"));
+    let sphere_handle = asset_server
+        .load(GltfAssetLabel::primitive("Sphere", 0).from_asset("models/sphere/sphere.gltf"));
 
     // All assets end up in their Assets<T> collection once they are done loading:
     if let Some(sphere) = meshes.get(&sphere_handle) {
@@ -58,13 +48,8 @@ fn setup(
     // It will _not_ be loaded a second time.
     // The LoadedFolder asset will ultimately also hold handles to the assets, but waiting for it to load
     // and finding the right handle is more work!
-    let torus_handle = asset_server.load(
-        GltfAssetLabel::Primitive {
-            mesh: 0,
-            primitive: 0,
-        }
-        .from_asset("models/torus/torus.gltf"),
-    );
+    let torus_handle = asset_server
+        .load(GltfAssetLabel::primitive("Torus.005", 0).from_asset("models/torus/torus.gltf"));
 
     // You can also add assets directly to their Assets<T> storage:
     let material_handle = materials.add(StandardMaterial {

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -17,7 +17,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Load our mesh:
     let scene_handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf"));
+        asset_server.load(GltfAssetLabel::scene("Scene").from_asset("models/torus/torus.gltf"));
 
     // Any changes to the mesh will be reloaded automatically! Try making a change to torus.gltf.
     // You should see the changes immediately show up in your app.

--- a/examples/camera/projection_zoom.rs
+++ b/examples/camera/projection_zoom.rs
@@ -78,7 +78,7 @@ fn setup(
     commands.spawn((
         Name::new("Fox"),
         SceneRoot(
-            asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
+            asset_server.load(GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb")),
         ),
         // Note: the scale adjustment is purely an accident of our fox model, which renders
         // HUGE unless mitigated!

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -133,7 +133,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
 
     // spawn the game board
     let cell_scene =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/tile.glb"));
+        asset_server.load(GltfAssetLabel::scene("0").from_asset("models/AlienCake/tile.glb"));
     game.board = (0..BOARD_SIZE_J)
         .map(|j| {
             (0..BOARD_SIZE_I)
@@ -151,30 +151,30 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
         .collect();
 
     // spawn the game character
-    game.player.entity = Some(
-        commands
-            .spawn((
-                StateScoped(GameState::Playing),
-                Transform {
-                    translation: Vec3::new(
-                        game.player.i as f32,
-                        game.board[game.player.j][game.player.i].height,
-                        game.player.j as f32,
-                    ),
-                    rotation: Quat::from_rotation_y(-PI / 2.),
-                    ..default()
-                },
-                SceneRoot(
-                    asset_server
-                        .load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/alien.glb")),
-                ),
-            ))
-            .id(),
-    );
+    game.player.entity =
+        Some(
+            commands
+                .spawn((
+                    StateScoped(GameState::Playing),
+                    Transform {
+                        translation: Vec3::new(
+                            game.player.i as f32,
+                            game.board[game.player.j][game.player.i].height,
+                            game.player.j as f32,
+                        ),
+                        rotation: Quat::from_rotation_y(-PI / 2.),
+                        ..default()
+                    },
+                    SceneRoot(asset_server.load(
+                        GltfAssetLabel::scene("Scene").from_asset("models/AlienCake/alien.glb"),
+                    )),
+                ))
+                .id(),
+        );
 
     // load the scene for the cake
-    game.bonus.handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/AlienCake/cakeBirthday.glb"));
+    game.bonus.handle = asset_server
+        .load(GltfAssetLabel::scene("0").from_asset("models/AlienCake/cakeBirthday.glb"));
 
     // scoreboard
     commands.spawn((

--- a/examples/games/loading_screen.rs
+++ b/examples/games/loading_screen.rs
@@ -141,7 +141,7 @@ fn load_level_1(
     ));
 
     // Save the asset into the `loading_assets` vector.
-    let fox = asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"));
+    let fox = asset_server.load(GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb"));
     loading_data.loading_assets.push(fox.clone().into());
     // Spawn the fox.
     commands.spawn((
@@ -175,7 +175,7 @@ fn load_level_2(
 
     // Spawn the helmet.
     let helmet_scene = asset_server
-        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
+        .load(GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"));
     loading_data
         .loading_assets
         .push(helmet_scene.clone().into());

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -117,9 +117,10 @@ fn setup(
 
     // Insert a resource with the current scene information
     let animation_clips = [
-        asset_server.load(GltfAssetLabel::Animation(2).from_asset("models/animated/Fox.glb")),
-        asset_server.load(GltfAssetLabel::Animation(1).from_asset("models/animated/Fox.glb")),
-        asset_server.load(GltfAssetLabel::Animation(0).from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfAssetLabel::animation("Walk").from_asset("models/animated/Fox.glb")),
+        asset_server
+            .load(GltfAssetLabel::animation("Survey").from_asset("models/animated/Fox.glb")),
+        asset_server.load(GltfAssetLabel::animation("Run").from_asset("models/animated/Fox.glb")),
     ];
     let mut animation_graph = AnimationGraph::new();
     let node_indices = animation_graph
@@ -136,7 +137,7 @@ fn setup(
 
     // NOTE: This fox model faces +z
     let fox_handle =
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb"));
+        asset_server.load(GltfAssetLabel::scene("0").from_asset("models/animated/Fox.glb"));
 
     let ring_directions = [
         (

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -218,7 +218,7 @@ mod gltf {
         ));
         commands.spawn((
             SceneRoot(asset_server.load(
-                GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+                GltfAssetLabel::scene("0").from_asset("models/FlightHelmet/FlightHelmet.gltf"),
             )),
             StateScoped(CURRENT_SCENE),
         ));
@@ -245,7 +245,7 @@ mod animation {
         mut graphs: ResMut<Assets<AnimationGraph>>,
     ) {
         let (graph, node) = AnimationGraph::from_clip(
-            asset_server.load(GltfAssetLabel::Animation(2).from_asset(FOX_PATH)),
+            asset_server.load(GltfAssetLabel::animation("2").from_asset(FOX_PATH)),
         );
 
         let graph_handle = graphs.add(graph);
@@ -271,7 +271,7 @@ mod animation {
 
         commands
             .spawn((
-                SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(FOX_PATH))),
+                SceneRoot(asset_server.load(GltfAssetLabel::scene("0").from_asset(FOX_PATH))),
                 StateScoped(CURRENT_SCENE),
             ))
             .observe(pause_animation_frame);

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -83,7 +83,7 @@ fn setup(
     commands.spawn((
         SceneRoot(
             asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/ship/craft_speederD.gltf")),
+                .load(GltfAssetLabel::scene("0").from_asset("models/ship/craft_speederD.gltf")),
         ),
         Ship {
             target_transform: random_axes_target_alignment(&RandomAxes(first, second)),

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -12,9 +12,9 @@ fn main() {
 
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // add entities to the world
-    commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/torus/torus.gltf")),
-    ));
+    commands.spawn(SceneRoot(asset_server.load(
+        GltfAssetLabel::scene("Scene").from_asset("models/torus/torus.gltf"),
+    )));
     // light
     commands.spawn((
         DirectionalLight::default(),


### PR DESCRIPTION
* Changed GLTF Asset Label to use Strings instead of indexes
* Removed Primitive name field as GLTF Spec does not allow Primitive names
* Changed all examples to use new asset label format.

# Objective

It's hard to find out GLTF scene/meshes/materials/animation indexes from gltf, which can also change on every export from Blender. Let's introduce `String` labels instead.

## Solution

Replace compatible `GltfAssetLabel` variants from `usize` to `Cow<'static, str>` instead.

## Testing

I ran gltf unit tests, and each example that this pull request touches. 
---

## Showcase

You can now load, e.g. animations with `assets.load("models.glb#Animation:Walk");`

## Migration Guide

GLTF Assets are now keyed by their names, not indexes. Assets that don't have a name, still use their index. For example

```rust
assets.load("fox.glb#Animation:Walk"); // load by name
assets.load("fox.glb#Scene:0"); // load by index
```

It is theoretically possible to have a gltf that has names only for some objects, but not all. Properly developed tools that output GLTF should be consistent in naming, however if they are not - the indexes will NOT be continuous. A good fix for this is to load your GLTF in blender first and assign proper names to items you're interested in.

If an object has  a name it is now also impossible to load it by index. 