### PR TITLE
Fix CAS shader alpha accessor

### DIFF
--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
@@ -65,7 +65,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let b = textureSample(screenTexture, samp, in.uv, vec2<i32>(0, -1)).rgb;
     let d = textureSample(screenTexture, samp, in.uv, vec2<i32>(-1, 0)).rgb;
     // We need the alpha value of the pixel we're working on for the output
-    let e = textureSample(screenTexture, samp, in.uv).rgbw;
+    let e = textureSample(screenTexture, samp, in.uv).rgba;
     let f = textureSample(screenTexture, samp, in.uv, vec2<i32>(1, 0)).rgb;
     let h = textureSample(screenTexture, samp, in.uv, vec2<i32>(0, 1)).rgb;
     // Min and max of ring.


### PR DESCRIPTION
# Objective

Fixes #16528 

## Solution

Use `a` to access alpha instead of `w`
