### PR TITLE
Fix CAS toggle broken by retained render world

### DIFF
--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -249,6 +249,10 @@ fn prepare_cas_pipelines(
     >,
     mut removals: RemovedComponents<CasUniform>,
 ) {
+    for entity in removals.read() {
+        commands.entity(entity).remove::<ViewCasPipeline>();
+    }
+
     for (entity, view, denoise_cas) in &views {
         let pipeline_id = pipelines.specialize(
             &pipeline_cache,
@@ -264,10 +268,6 @@ fn prepare_cas_pipelines(
         );
 
         commands.entity(entity).insert(ViewCasPipeline(pipeline_id));
-    }
-
-    for entity in removals.read() {
-        commands.entity(entity).remove::<ViewCasPipeline>();
     }
 }
 

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -243,14 +243,18 @@ fn prepare_cas_pipelines(
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<CasPipeline>>,
     sharpening_pipeline: Res<CasPipeline>,
-    views: Query<(Entity, &ExtractedView, &DenoiseCas), With<CasUniform>>,
+    views: Query<
+        (Entity, &ExtractedView, &DenoiseCas),
+        Or<(Added<CasUniform>, Changed<DenoiseCas>)>,
+    >,
+    mut removals: RemovedComponents<CasUniform>,
 ) {
-    for (entity, view, cas) in &views {
+    for (entity, view, denoise_cas) in &views {
         let pipeline_id = pipelines.specialize(
             &pipeline_cache,
             &sharpening_pipeline,
             CasPipelineKey {
-                denoise: cas.0,
+                denoise: denoise_cas.0,
                 texture_format: if view.hdr {
                     ViewTarget::TEXTURE_FORMAT_HDR
                 } else {
@@ -260,6 +264,10 @@ fn prepare_cas_pipelines(
         );
 
         commands.entity(entity).insert(ViewCasPipeline(pipeline_id));
+    }
+
+    for entity in removals.read() {
+        commands.entity(entity).remove::<ViewCasPipeline>();
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #16531

I also added change detection when creating the pipeline, which technically isn't needed but it felt weird leaving it as is.

## Solution

Remove the pipeline if CAS is disabled. The uniform was already being removed, which caused flickering / weirdness.

## Testing

Tested the anti_alias example by toggling CAS a bunch on/off.
