### PR TITLE
Add `Commands::run_schedule`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1017,7 +1017,7 @@ impl<'w, 's> Commands<'w, 's> {
     pub fn run_schedule(&mut self, label: impl ScheduleLabel) {
         self.queue(|world: &mut World| {
             if let Err(error) = world.try_run_schedule(label) {
-                error!("Failed to run schedule: {error}");
+                panic!("Failed to run schedule: {error}");
             }
         });
     }


### PR DESCRIPTION
# Objective

- Fixes #16495

## Solution

- Added `Commands::run_schedule`, which internally calls `World::try_run_schedule`, panicking on any issues.

## Testing

- Added doctest
- Ran CI

## Showcase

Instead of writing:

```rust
commands.queue(|world: &mut World| world.run_schedule(FooSchedule));
```

You can now write:

```rust
commands.run_schedule(FooSchedule);
```