### PR TITLE
fix: scroll list is non-scrollable

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -324,6 +324,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     padding: UiRect::all(Val::Px(10.)),
                     ..default()
                 })
+                .insert(PickingBehavior::IGNORE)
                 .with_children(|parent| {
                     for (flip_x, flip_y) in
                         [(false, false), (false, true), (true, true), (true, false)]


### PR DESCRIPTION
# Objective

Run `testbed_ui` example:

```
cargo run --example testbed_ui
```

The scroll list is non-scrollable because it's blocked by the front four-icon node.

## Solution

Add `PickingBehavior::IGNORE` for the front node

## Testing

- Did you test these changes? If so, how?

Yes.

- Are there any parts that need more testing?

No, I guess.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?
```
cargo run --example testbed_ui
```
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

macOS.
