### PR TITLE
Fix newline in AnimationEvaluationState docs

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -711,7 +711,7 @@ pub struct AnimationEvaluationState {
     ///
     /// This is a mapping from the id of an animation curve evaluator to
     /// the animation curve evaluator itself.
-
+    ///
     /// For efficiency's sake, the [`AnimationCurveEvaluator`]s are cached from
     /// frame to frame and animation target to animation target. Therefore,
     /// there may be entries in this list corresponding to properties that the


### PR DESCRIPTION
# Objective

CI [is broken](https://github.com/bevyengine/bevy/actions/runs/12070933255/job/33661528875) by the new Rust version.

## Solution

Appease the crab gods by fixing our doc comments.

## Testing

CI has my back!