### PR TITLE
Use GitHub markdown alerts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@
 
 Bevy is a refreshingly simple data-driven game engine built in Rust. It is free and open-source forever!
 
-## WARNING
-
-Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. A new version of Bevy containing breaking changes to the API is released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). We provide [migration guides](https://bevyengine.org/learn/migration-guides/), but we can't guarantee migrations will always be easy. Use only if you are willing to work in this environment.
+> [!CAUTION]  
+> Bevy is still in the early stages of development.
+> Important features are missing.
+> Documentation is sparse.
+> A new version of Bevy containing breaking changes to the API is released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule).
+> We provide [migration guides](https://bevyengine.org/learn/migration-guides/), but we can't guarantee migrations will always be easy. Use only if you are willing to work in this environment.
 
 **MSRV:** Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is generally close to "the latest stable release" of Rust.


### PR DESCRIPTION
# Objective

Use [GitHub's markdown alert](https://github.com/orgs/community/discussions/16925) in README, which looks like this:

> <img width="600" alt="image" src="https://github.com/user-attachments/assets/a2f3e747-2480-4799-ae55-c87139a2219f">

## Solution

Use `[!CAUTION]` alert type. I've considered also the `[!WARNING]` one but it's not very _bold_:

> <img width="600" alt="image" src="https://github.com/user-attachments/assets/97b8ec78-a1e4-4a84-bfbd-eca76e25a6a1">

## Testing

Checked in the GitHub markdown preview.