### PR TITLE
Make `bevy_gltf` compile without `bevy_animation` feature

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 use alloc::collections::VecDeque;
-use bevy_animation::animated_field;
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, Handle, LoadContext, ReadAssetBytesError,
 };
@@ -275,7 +274,7 @@ async fn load_gltf<'a, 'b, 'c>(
 
     #[cfg(feature = "bevy_animation")]
     let (animations, named_animations, animation_roots) = {
-        use bevy_animation::{animation_curves::*, gltf_curves::*, VariableCurve};
+        use bevy_animation::{animated_field, animation_curves::*, gltf_curves::*, VariableCurve};
         use bevy_math::curve::{ConstantCurve, Interval, UnevenSampleAutoCurve};
         use bevy_math::{Quat, Vec4};
         use gltf::animation::util::ReadOutputs;


### PR DESCRIPTION
# Objective

See title.

## Solution

Move `bevy_animation` import to where it is used.

## Testing

Compiled with and without `bevy_animation` feature enabled.