### PR TITLE
Remove duplicated default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ unused_qualifications = "warn"
 [features]
 default = [
   "android-game-activity",
-  "android-game-activity",
   "android_shared_stdcxx",
   "animation",
   "bevy_asset",


### PR DESCRIPTION
# Objective

- The feature `android-game-activity` was in the default feature list twice

## Solution

- Remove one of the features