### PR TITLE
Fix example build for wasm

### DIFF
--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -20,12 +20,6 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, example_control_system);
 
-    // Unfortunately, MSAA and HDR are not supported simultaneously under WebGL.
-    // Since this example uses HDR, we must disable MSAA for Wasm builds, at least
-    // until WebGPU is ready and no longer behind a feature flag in Web browsers.
-    #[cfg(target_arch = "wasm32")]
-    app.insert_resource(Msaa::Off);
-
     app.run();
 }
 
@@ -155,6 +149,11 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0.0, 2.5, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        // Unfortunately, MSAA and HDR are not supported simultaneously under WebGL.
+        // Since this example uses HDR, we must disable MSAA for Wasm builds, at least
+        // until WebGPU is ready and no longer behind a feature flag in Web browsers.
+        #[cfg(target_arch = "wasm32")]
+        Msaa::Off,
     ));
 
     // Controls Text

--- a/examples/3d/motion_blur.rs
+++ b/examples/3d/motion_blur.rs
@@ -11,10 +11,6 @@ use bevy::{
 fn main() {
     let mut app = App::new();
 
-    // MSAA and Motion Blur together are not compatible on WebGL
-    #[cfg(all(feature = "webgl2", target_arch = "wasm32", not(feature = "webgpu")))]
-    app.insert_resource(Msaa::Off);
-
     app.add_plugins(DefaultPlugins)
         .add_systems(Startup, (setup_camera, setup_scene, setup_ui))
         .add_systems(Update, (keyboard_inputs, move_cars, move_camera).chain())
@@ -33,6 +29,9 @@ fn setup_camera(mut commands: Commands) {
             #[cfg(all(feature = "webgl2", target_arch = "wasm32", not(feature = "webgpu")))]
             _webgl2_padding: Default::default(),
         },
+        // MSAA and Motion Blur together are not compatible on WebGL
+        #[cfg(all(feature = "webgl2", target_arch = "wasm32", not(feature = "webgpu")))]
+        Msaa::Off,
     ));
 }
 


### PR DESCRIPTION
# Objective

- Some examples failed to build for wasm on the website

## Solution

- Fix them
  - `Msaa` is now a component instead of a resource