### PR TITLE
add `.include_entity()` helper on query iterators

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -305,12 +305,18 @@ pub unsafe trait QueryData: WorldQuery {
     ) -> Self::Item<'w>;
 }
 
+unsafe impl<D: QueryData> QueryData for crate::query::IncludeEntity<D> {
+    type ReadOnly = crate::query::IncludeEntity<D::ReadOnly>;
+}
+
 /// A [`QueryData`] that is read only.
 ///
 /// # Safety
 ///
 /// This must only be implemented for read-only [`QueryData`]'s.
 pub unsafe trait ReadOnlyQueryData: QueryData<ReadOnly = Self> {}
+
+unsafe impl<D: ReadOnlyQueryData> ReadOnlyQueryData for crate::query::IncludeEntity<D> {}
 
 /// The item type returned when a [`WorldQuery`] is iterated over
 pub type QueryItem<'w, Q> = <Q as QueryData>::Item<'w>;

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -305,6 +305,12 @@ pub unsafe trait QueryData: WorldQuery {
     ) -> Self::Item<'w>;
 }
 
+/// SAFETY:
+///
+/// The `IncludeEntity<D>` wrapper type has no additional state over the
+/// underlying query type `D`. Its access is identical to the access of
+/// `D`, except that the `Entity` being queried is also included in the
+/// output.
 unsafe impl<D: QueryData> QueryData for crate::query::IncludeEntity<D> {
     type ReadOnly = crate::query::IncludeEntity<D::ReadOnly>;
 }
@@ -316,6 +322,13 @@ unsafe impl<D: QueryData> QueryData for crate::query::IncludeEntity<D> {
 /// This must only be implemented for read-only [`QueryData`]'s.
 pub unsafe trait ReadOnlyQueryData: QueryData<ReadOnly = Self> {}
 
+/// SAFETY:
+///
+/// The underlying state and access of `IncludeEntity<D>` is identical to `D` itself,
+/// except that the iterated `Entity` is also included in the output.
+///
+/// Including the `Entity` in the output does not make any additional kind of mutation
+/// possible.
 unsafe impl<D: ReadOnlyQueryData> ReadOnlyQueryData for crate::query::IncludeEntity<D> {}
 
 /// The item type returned when a [`WorldQuery`] is iterated over

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -322,7 +322,7 @@ unsafe impl<D: QueryData> QueryData for crate::query::IncludeEntity<D> {
         (item.0, D::shrink(item.1))
     }
 
-    /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
+    /// Fetch [`Self::Item`](`QueryData::Item`) for either the given `entity` in the current [`Table`],
     /// or for the given `entity` in the current [`Archetype`]. This must always be called after
     /// [`WorldQuery::set_table`] with a `table_row` in the range of the current [`Table`] or after
     /// [`WorldQuery::set_archetype`]  with a `entity` in the current archetype.

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2635,7 +2635,7 @@ mod tests {
     use std::println;
 
     use crate::component::Component;
-    use crate::entity::{self, Entity};
+    use crate::entity::Entity;
     use crate::prelude::World;
 
     #[derive(Component, Debug, PartialEq, PartialOrd, Clone, Copy)]

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -888,11 +888,16 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// #[derive(Component)]
     /// struct Damage(f32);
     ///
-    /// fn example_system(mut query: Query<(&mut Health, &Damage)>) {
-    ///     for (entity, (mut health, damage)) in query.iter_mut().include_entity() {
-    ///         if damage.0 > 0.0 {
-    ///             health.0 -= damage.0;
-    ///             println!("entity {:?} took damage", entity);
+    /// fn apply_damage_system(mut query: Query<(&mut Health, &Damage)>) {
+    ///     // Iterate over the input query:
+    ///     for (mut health, damage) in query.iter_mut() {
+    ///        health.0 -= damage.0;
+    ///     }
+    ///
+    ///     // Iterate again, this time including the entity:
+    ///     for (entity, (health, damage)) in query.iter().include_entity() {
+    ///         if health.0 <= 0.0 {
+    ///             println!("entity {:?} has been reduce to 0 health by {} damage", entity, damage.0);
     ///         }
     ///     }
     /// }

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -888,8 +888,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// #[derive(Component)]
     /// struct Damage(f32);
     ///
-    /// fn example_system(query: Query<(&mut Health, &Damage)>) {
-    ///     for (entity, (health, damage)) in query.iter().include_entity() {
+    /// fn example_system(mut query: Query<(&mut Health, &Damage)>) {
+    ///     for (entity, (mut health, damage)) in query.iter_mut().include_entity() {
     ///         if damage.0 > 0.0 {
     ///             health.0 -= damage.0;
     ///             println!("entity {:?} took damage", entity);

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -893,11 +893,18 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// ```
     ///
     pub fn include_entity(self) -> QueryIter<'w, 's, crate::query::IncludeEntity<D>, F> {
+        let query_state: &QueryState<super::IncludeEntity<D>, F> = 
+        // SAFETY: `IncludeEntity<D>` and `D` have identical access and query the same archetypes,
+        // since the internal state is not affected in any way by the `IncludeEntity` wrapper.
+        unsafe {
+            self.query_state.as_transmuted_state()
+        };
         QueryIter {
             world: self.world,
             tables: self.tables,
             archetypes: self.archetypes,
-            query_state: unsafe { self.query_state.as_transmuted_state() },
+
+            query_state,
             cursor: QueryIterationCursor {
                 is_dense: self.cursor.is_dense,
                 storage_id_iter: self.cursor.storage_id_iter,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -893,12 +893,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     /// ```
     ///
     pub fn include_entity(self) -> QueryIter<'w, 's, crate::query::IncludeEntity<D>, F> {
-        let query_state: &QueryState<super::IncludeEntity<D>, F> = 
         // SAFETY: `IncludeEntity<D>` and `D` have identical access and query the same archetypes,
         // since the internal state is not affected in any way by the `IncludeEntity` wrapper.
-        unsafe {
-            self.query_state.as_transmuted_state()
-        };
+        let query_state = unsafe { self.query_state.as_transmuted_state() };
         QueryIter {
             world: self.world,
             tables: self.tables,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -875,6 +875,41 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
             )
         }
     }
+
+    /// Transforms the iterator output to include the `Entity` which is being iterated over.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// #[derive(Component)]
+    /// struct ExampleComponent;
+    ///
+    /// fn example_system(query: Query<&ExampleComponent>) {
+    ///     for (entity, component) in query.iter().include_entity() {
+    ///         println!("entity {:?}", entity);
+    ///     }
+    /// }
+    /// ```
+    ///
+    pub fn include_entity(self) -> QueryIter<'w, 's, crate::query::IncludeEntity<D>, F> {
+        QueryIter {
+            world: self.world,
+            tables: self.tables,
+            archetypes: self.archetypes,
+            query_state: unsafe { self.query_state.as_transmuted_state() },
+            cursor: QueryIterationCursor {
+                is_dense: self.cursor.is_dense,
+                storage_id_iter: self.cursor.storage_id_iter,
+                table_entities: self.cursor.table_entities,
+                archetype_entities: self.cursor.archetype_entities,
+                fetch: self.cursor.fetch,
+                filter: self.cursor.filter,
+                current_len: self.cursor.current_len,
+                current_row: self.cursor.current_row,
+            },
+        }
+    }
 }
 
 impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for QueryIter<'w, 's, D, F> {

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -135,7 +135,7 @@ pub unsafe trait WorldQuery {
 /// A wrapper type around a data query `D` which will return the queried [`Entity`]
 /// alongside the results from `D`.
 ///
-/// This convenience wrapper can be used by calling [`QueryIter::include_entity`] on
+/// This convenience wrapper can be used by calling [`super::iter::QueryIter::include_entity`] on
 /// an iterator returned from `[Query::iter()]` or `[Query::iter_mut()]`.
 ///
 /// Unlike `(Entity, D)`, the type `IncludeEntity<D>` is guaranteed to have identical

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -150,20 +150,11 @@ pub struct IncludeEntity<D>(pub D);
 /// The only difference is that the `Entity` (which is tracked by all queries internally) is
 /// also included in the output `Item`.
 unsafe impl<D: WorldQuery> WorldQuery for IncludeEntity<D> {
-    /// The item is the same as `D`, but also includes the entity.
-    type Item<'a> = (Entity, D::Item<'a>);
-
     /// The same underlying state is used for `IncludeEntity<D>` as `D` itself.
     type Fetch<'a> = D::Fetch<'a>;
 
     /// The same underlying state is used for `IncludeEntity<D>` as `D` itself.
     type State = D::State;
-
-    /// This function manually implements subtyping for the query items.
-    /// The non-`Entity` part of the query is shrunk exactly how `D` specifies.
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        (item.0, D::shrink(item.1))
-    }
 
     /// This function manually implements subtyping for the query items.
     /// The query is shrunk exactly how `D` specifies.
@@ -213,23 +204,6 @@ unsafe impl<D: WorldQuery> WorldQuery for IncludeEntity<D> {
     /// Called when constructing a [`QueryLens`](crate::system::QueryLens) or calling [`QueryState::from_builder`](super::QueryState::from_builder)
     fn set_access(state: &mut Self::State, access: &FilteredAccess<ComponentId>) {
         D::set_access(state, access);
-    }
-
-    /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
-    /// or for the given `entity` in the current [`Archetype`]. This must always be called after
-    /// [`WorldQuery::set_table`] with a `table_row` in the range of the current [`Table`] or after
-    /// [`WorldQuery::set_archetype`]  with a `entity` in the current archetype.
-    ///
-    /// # Safety
-    ///
-    /// Must always be called _after_ [`WorldQuery::set_table`] or [`WorldQuery::set_archetype`]. `entity` and
-    /// `table_row` must be in the range of the current table and archetype.
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        table_row: TableRow,
-    ) -> Self::Item<'w> {
-        (entity, D::fetch(fetch, entity, table_row))
     }
 
     /// Adds any component accesses used by this [`WorldQuery`] to `access`.

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -132,7 +132,7 @@ pub unsafe trait WorldQuery {
     ) -> bool;
 }
 
-/// A wrapper type around a data query `D` which will return the queried [`Entity`]
+/// A wrapper type around a data query `D` which will return the queried [`crate::entity::Entity`]
 /// alongside the results from `D`.
 ///
 /// This convenience wrapper can be used by calling [`super::iter::QueryIter::include_entity`] on

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -132,6 +132,129 @@ pub unsafe trait WorldQuery {
     ) -> bool;
 }
 
+/// A wrapper type which includes the entity in the selected query data,
+/// but which has the same underlying state as `D`.
+///
+/// Most applications should use `(Entity, D)` instead; but unlike `(Entity, D)`,
+/// it is guaranteed that `IncludeEntity<D>` has the same `WorldQuery::State as `D`.
+pub struct IncludeEntity<D>(pub D);
+
+unsafe impl<D: WorldQuery> WorldQuery for IncludeEntity<D> {
+    /// The item is the same as `D`, but also includes the entity.
+    type Item<'a> = (Entity, D::Item<'a>);
+
+    /// The same underlying state is used for `IncludeEntity<D>` as `D` itself.
+    type Fetch<'a> = D::Fetch<'a>;
+
+    /// The same underlying state is used for `IncludeEntity<D>` as `D` itself.
+    type State = D::State;
+
+    /// This function manually implements subtyping for the query items.
+    /// The non-`Entity` query is shrunk exactly how `D` specifies.
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        (item.0, D::shrink(item.1))
+    }
+
+    /// This function manually implements subtyping for the query items.
+    /// The query is shrunk exactly how `D` specifies.
+    fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
+        D::shrink_fetch(fetch)
+    }
+
+    /// Creates a new instance of this fetch.
+    unsafe fn init_fetch<'w>(
+        world: UnsafeWorldCell<'w>,
+        state: &Self::State,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Self::Fetch<'w> {
+        D::init_fetch(world, state, last_run, this_run)
+    }
+
+    const IS_DENSE: bool = D::IS_DENSE;
+
+    /// # Safety
+    ///
+    /// - `archetype` and `tables` must be from the same [`World`] that [`WorldQuery::init_state`] was called on.
+    /// - `table` must correspond to `archetype`.
+    /// - `state` must be the [`State`](Self::State) that `fetch` was initialized with.
+    unsafe fn set_archetype<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        state: &Self::State,
+        archetype: &'w Archetype,
+        table: &'w Table,
+    ) {
+        D::set_archetype(fetch, state, archetype, table);
+    }
+
+    /// Adjusts internal state to account for the next [`Table`]. This will always be called on tables
+    /// that match this [`WorldQuery`].
+    ///
+    /// # Safety
+    ///
+    /// - `table` must be from the same [`World`] that [`WorldQuery::init_state`] was called on.
+    /// - `state` must be the [`State`](Self::State) that `fetch` was initialized with.
+    unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table) {
+        D::set_table(fetch, state, table);
+    }
+
+    /// Sets available accesses for implementors with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
+    /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).
+    ///
+    /// Called when constructing a [`QueryLens`](crate::system::QueryLens) or calling [`QueryState::from_builder`](super::QueryState::from_builder)
+    fn set_access(state: &mut Self::State, access: &FilteredAccess<ComponentId>) {
+        D::set_access(state, access);
+    }
+
+    /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
+    /// or for the given `entity` in the current [`Archetype`]. This must always be called after
+    /// [`WorldQuery::set_table`] with a `table_row` in the range of the current [`Table`] or after
+    /// [`WorldQuery::set_archetype`]  with a `entity` in the current archetype.
+    ///
+    /// # Safety
+    ///
+    /// Must always be called _after_ [`WorldQuery::set_table`] or [`WorldQuery::set_archetype`]. `entity` and
+    /// `table_row` must be in the range of the current table and archetype.
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w> {
+        (entity, D::fetch(fetch, entity, table_row))
+    }
+
+    /// Adds any component accesses used by this [`WorldQuery`] to `access`.
+    ///
+    /// Used to check which queries are disjoint and can run in parallel
+    // This does not have a default body of `{}` because 99% of cases need to add accesses
+    // and forgetting to do so would be unsound.
+    fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+        D::update_component_access(state, access);
+    }
+
+    /// Creates and initializes a [`State`](WorldQuery::State) for this [`WorldQuery`] type.
+    fn init_state(world: &mut World) -> Self::State {
+        D::init_state(world)
+    }
+
+    /// Attempts to initialize a [`State`](WorldQuery::State) for this [`WorldQuery`] type using read-only
+    /// access to [`Components`].
+    fn get_state(components: &Components) -> Option<Self::State> {
+        D::get_state(components)
+    }
+
+    /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
+    ///
+    /// Used to check which [`Archetype`]s can be skipped by the query
+    /// (if none of the [`Component`](crate::component::Component)s match)
+    fn matches_component_set(
+        state: &Self::State,
+        set_contains_id: &impl Fn(ComponentId) -> bool,
+    ) -> bool {
+        D::matches_component_set(state, set_contains_id)
+    }
+}
+
 macro_rules! impl_tuple_world_query {
     ($(#[$meta:meta])* $(($name: ident, $state: ident)),*) => {
 


### PR DESCRIPTION
# Objective

Adds a helper method to the  `QueryIter` struct called `.include_entity()`, which automatically adds `(Entity, _)` around whatever is currently being iterated. Since the underlying `Entity` is always tracked anyway, this can be done "for free" at zero additional runtime cost.

This helper makes it more ergonomic to evolve systems over time. For example, as we write a complex system, we encounter a case where we need the `Entity` that we're iterating over:

```rs
fn example(q_data: Query<(&mut Player, &Transform, &Health)>) {
   for (player, transform, _health) in q_data.iter() {
       do_thing1(player, transform);
    }

   for (mut player, transform, health) in q_data.iter_mut() {
       do_thing2(player, transform, health);
    }

   for (mut player, transform, _health) in q_data.iter() {
       do_thing3(todo!() /* need entity! */, player, transform);
    }
}
```

Despite the `Entity` already being tracked at runtime, we then need to go back and update multiple lines of code to request it:

```rs
fn example(q_data: Query<(Entity, &mut Player, &Transform, &Health)>) {   // changed
   for (_entity, player, transform, _health) in q_data.iter() {           // changed
       do_thing1(player, transform);
    }

   for (_entity, mut player, transform, _health) in q_data.iter_mut() {   // changed
       do_thing2(player, transform, health);
    }

   for (entity, mut player, transform, _health) in q_data.iter_mut() {    // changed
       do_thing3(entity, player, transform);                              // changed
    }
}
```

Of the 5 changed lines, only the last 2 are essential to the change we actually want to make. If we use `include_entity()` instead, then we get the much-more-explicit delta:


```rs
fn example(q_data: Query<(&mut Player, &Transform, &Health)>) {
   for (player, transform, _health) in q_data.iter() {
       do_thing1(player, transform);
    }

   for (mut player, transform, _health) in q_data.iter_mut() {
       do_thing2(player, transform, health);
    }

   for (entity, (mut player, transform, _health)) in q_data.iter_mut().include_entity() { // changed
       do_thing3(entity, player, transform);                                              // changed
    }
}
```


## Why not `(Entity, D)`? Why a new `IncludeEntity<D>` type?

The underlying query state for the query `(A, B)` is `(A::State, B::State)`. This means that for `(Entity, D)` the underlying state type is `((), D::State))`, not `D::State`. Despite looking very similar, these types aren't guaranteed to have the same layout, and so we cannot transmute between them.

The `IncludeEntity<_>` query type is not intended for typical use by game developers, but is made public so that other utilities/libraries can also rely on it for transmute safety.

## Testing

- [ ] Needs tests before merging


