### PR TITLE
bevy_reflect: Remove `PartialReflect::serializable`

### DIFF
--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -5,7 +5,6 @@ use crate::{
         args::ArgList, info::FunctionInfo, DynamicFunctionMut, Function, FunctionError,
         FunctionResult, IntoFunction, IntoFunctionMut,
     },
-    serde::Serializable,
     ApplyError, MaybeTyped, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, TypeInfo, TypePath,
 };
@@ -234,10 +233,6 @@ impl PartialReflect for DynamicFunction<'static> {
 
     fn debug(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(self, f)
-    }
-
-    fn serializable(&self) -> Option<Serializable> {
-        None
     }
 
     fn is_dynamic(&self) -> bool {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,6 +1,6 @@
 use crate::{
-    array_debug, enum_debug, list_debug, map_debug, serde::Serializable, set_debug, struct_debug,
-    tuple_debug, tuple_struct_debug, DynamicTypePath, DynamicTyped, OpaqueInfo, ReflectKind,
+    array_debug, enum_debug, list_debug, map_debug, set_debug, struct_debug, tuple_debug,
+    tuple_struct_debug, DynamicTypePath, DynamicTyped, OpaqueInfo, ReflectKind,
     ReflectKindMismatchError, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, Typed,
 };
 use core::{
@@ -267,17 +267,6 @@ where
             ReflectRef::Function(dyn_function) => dyn_function.fmt(f),
             ReflectRef::Opaque(_) => write!(f, "Reflect({})", self.reflect_type_path()),
         }
-    }
-
-    /// Returns a serializable version of the value.
-    ///
-    /// If the underlying type does not support serialization, returns `None`.
-    #[deprecated(
-        since = "0.15.0",
-        note = "No longer used for serialization. Register `ReflectSerialize` instead."
-    )]
-    fn serializable(&self) -> Option<Serializable> {
-        None
     }
 
     /// Indicates whether or not this type is a _dynamic_ type.

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -272,6 +272,10 @@ where
     /// Returns a serializable version of the value.
     ///
     /// If the underlying type does not support serialization, returns `None`.
+    #[deprecated(
+        since = "0.15.0",
+        note = "No longer used for serialization. Register `ReflectSerialize` instead."
+    )]
     fn serializable(&self) -> Option<Serializable> {
         None
     }


### PR DESCRIPTION
# Objective

`PartialReflect::serializable` is unused in the codebase and should be removed.

I believe it originally was used to handle serializing certain types but that's no longer the case.

## Solution

Remove `PartialReflect::serializable`.

## Testing

You can check locally using:

```
cargo check -p bevy_reflect --all-features
```

---

## Migration Guide

`PartialReflect::serializable` has been removed. If you were using this to pass on serialization information, use `ReflectSerialize` instead or create custom type data to generate the `Serializable`.
