### PR TITLE
Updated comment: ZIndex::Local(0) -> ZIndex(0).

### DIFF
--- a/examples/ui/z_index.rs
+++ b/examples/ui/z_index.rs
@@ -20,7 +20,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
     // spawn the container with default z-index.
-    // the default z-index value is `ZIndex::Local(0)`.
+    // the default z-index value is `ZIndex(0)`.
     // because this is a root UI node, using local or global values will do the same thing.
     commands
         .spawn(Node {


### PR DESCRIPTION
# Objective

In c5742ff43e13b942a5f7a5faecc3b9bf108709e1 ZIndex::Local() and ZIndex::Global() were replaced with ZIndex() and GlobalZIndex().

A comment was likely forgotten.

## Solution

- Remove the deprecated "::Local" in the comment.