### PR TITLE
Moving `PlaybackMode` to `AudioPlayer` and defaulting to `PlaybackMode::Remove`

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -164,7 +164,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
                 sink.pause();
             }
 
-            match settings.mode {
+            match source_handle.1 {
                 PlaybackMode::Loop => {
                     sink.append(audio_source.decoder().repeat_infinite());
                     commands.entity(entity).insert(SpatialAudioSink { sink });
@@ -204,7 +204,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
                 sink.pause();
             }
 
-            match settings.mode {
+            match source_handle.1 {
                 PlaybackMode::Loop => {
                     sink.append(audio_source.decoder().repeat_infinite());
                     commands.entity(entity).insert(AudioSink { sink });

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ```no_run
 //! # use bevy_ecs::prelude::*;
-//! # use bevy_audio::{AudioPlayer, AudioPlugin, AudioSource, PlaybackSettings};
+//! # use bevy_audio::{AudioPlayer, AudioPlugin, AudioSource};
 //! # use bevy_asset::{AssetPlugin, AssetServer};
 //! # use bevy_app::{App, AppExit, NoopPluginGroup as MinimalPlugins, Startup};
 //! fn main() {
@@ -20,10 +20,9 @@
 //! }
 //!
 //! fn play_background_audio(asset_server: Res<AssetServer>, mut commands: Commands) {
-//!     commands.spawn((
-//!         AudioPlayer::new(asset_server.load("background_audio.ogg")),
-//!         PlaybackSettings::LOOP,
-//!     ));
+//!     commands.spawn(
+//!         AudioPlayer::with_loop(asset_server.load("background_audio.ogg"))
+//!     );
 //! }
 //! ```
 

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -11,7 +11,7 @@ fn main() {
 }
 
 fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
-    commands.spawn(AudioPlayer::new(
+    commands.spawn(AudioPlayer::with_once(
         asset_server.load("sounds/Windless Slopes.ogg"),
     ));
 }

--- a/examples/audio/decodable.rs
+++ b/examples/audio/decodable.rs
@@ -1,7 +1,7 @@
 //! Shows how to create a custom [`Decodable`] type by implementing a Sine wave.
 
 use bevy::{
-    audio::{AddAudioSource, AudioPlugin, Source},
+    audio::{AddAudioSource, AudioPlugin, PlaybackMode, Source},
     math::ops,
     prelude::*,
     reflect::TypePath,
@@ -99,5 +99,5 @@ fn setup(mut assets: ResMut<Assets<SineAudio>>, mut commands: Commands) {
     let audio_handle = assets.add(SineAudio {
         frequency: 440., // this is the frequency of A4
     });
-    commands.spawn(AudioPlayer(audio_handle));
+    commands.spawn(AudioPlayer(audio_handle, PlaybackMode::Once));
 }

--- a/examples/audio/pitch.rs
+++ b/examples/audio/pitch.rs
@@ -1,6 +1,6 @@
 //! This example illustrates how to play a single-frequency sound (aka a pitch)
 
-use bevy::prelude::*;
+use bevy::{audio::PlaybackMode, prelude::*};
 use std::time::Duration;
 
 fn main() {
@@ -30,9 +30,9 @@ fn play_pitch(
 ) {
     for _ in events.read() {
         info!("playing pitch with frequency: {}", frequency.0);
-        commands.spawn((
-            AudioPlayer(pitch_assets.add(Pitch::new(frequency.0, Duration::new(1, 0)))),
-            PlaybackSettings::DESPAWN,
+        commands.spawn(AudioPlayer(
+            pitch_assets.add(Pitch::new(frequency.0, Duration::new(1, 0))),
+            PlaybackMode::Despawn,
         ));
         info!("number of pitch assets: {}", pitch_assets.len());
     }

--- a/examples/audio/soundtrack.rs
+++ b/examples/audio/soundtrack.rs
@@ -79,9 +79,8 @@ fn change_track(
         match game_state.as_ref() {
             GameState::Peaceful => {
                 commands.spawn((
-                    AudioPlayer(soundtrack_player.track_list.first().unwrap().clone()),
+                    AudioPlayer::with_loop(soundtrack_player.track_list.first().unwrap().clone()),
                     PlaybackSettings {
-                        mode: bevy::audio::PlaybackMode::Loop,
                         volume: bevy::audio::Volume::ZERO,
                         ..default()
                     },
@@ -90,9 +89,8 @@ fn change_track(
             }
             GameState::Battle => {
                 commands.spawn((
-                    AudioPlayer(soundtrack_player.track_list.get(1).unwrap().clone()),
+                    AudioPlayer::with_loop(soundtrack_player.track_list.get(1).unwrap().clone()),
                     PlaybackSettings {
-                        mode: bevy::audio::PlaybackMode::Loop,
                         volume: bevy::audio::Volume::ZERO,
                         ..default()
                     },

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -38,8 +38,8 @@ fn setup(
         MeshMaterial2d(materials.add(Color::from(BLUE))),
         Transform::from_translation(Vec3::new(0.0, 50.0, 0.0)),
         Emitter::default(),
-        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
-        PlaybackSettings::LOOP.with_spatial(true),
+        AudioPlayer::with_loop(asset_server.load("sounds/Windless Slopes.ogg")),
+        PlaybackSettings::default().with_spatial(true),
     ));
 
     let listener = SpatialListener::new(gap);

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -29,8 +29,8 @@ fn setup(
         MeshMaterial3d(materials.add(Color::from(BLUE))),
         Transform::from_xyz(0.0, 0.0, 0.0),
         Emitter::default(),
-        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
-        PlaybackSettings::LOOP.with_spatial(true),
+        AudioPlayer::with_loop(asset_server.load("sounds/Windless Slopes.ogg")),
+        PlaybackSettings::default().with_spatial(true),
     ));
 
     let listener = SpatialListener::new(gap);

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -404,7 +404,7 @@ fn play_collision_sound(
     if !collision_events.is_empty() {
         // This prevents events staying active on the next frame.
         collision_events.clear();
-        commands.spawn((AudioPlayer(sound.clone()), PlaybackSettings::DESPAWN));
+        commands.spawn(AudioPlayer::with_despawn(sound.clone()));
     }
 }
 

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -165,9 +165,8 @@ fn button_handler(
 }
 
 fn setup_music(asset_server: Res<AssetServer>, mut commands: Commands) {
-    commands.spawn((
-        AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
-        PlaybackSettings::LOOP,
+    commands.spawn(AudioPlayer::with_loop(
+        asset_server.load("sounds/Windless Slopes.ogg"),
     ));
 }
 


### PR DESCRIPTION
# Objective
Fix: https://github.com/bevyengine/bevy/issues/12359

Wanted to make it clear what happens when audio is being played, and the source is related to the `PlaybackMode`.
You're either playing sound effects that are temporary in lifetime, or constant repeated music.
Some sound effects related to existing entity while others are children of said entities. 
I wanted the API to actually reflect that, instead of being split over two components. 
It requires explicit input about `PlaybackMode `

This break existing code in two places: 
* When `AudioPlayer::new()` is used it changes default mode to `Remove`, current default is `Once`.
* Tuple struct syntax requires as second argument. 


## Solution

* Changing the default `PlaybackMode` to `PlaybackMode::Remove`
* Adding `PlaybackMode` to `AudioPlayer`
* Adding convenience methods to `AudioPlayer` to create with different `PlaybackMode`s


## Testing

> - Did you test these changes? If so, how?

* Ran each audio example. 
* Ran tests

> - Are there any parts that need more testing?

Performance? Since `AudioPlayer` now holds `PlaybackMode` there can have been a difference in internal optimizations that I might have missed. 

> - How can other people (reviewers) test your changes? Is there anything specific they need to know?

Run audio examples. 

> - If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

Tested only on `macOS`, I don't think it's relevant for other platforms unless there are performance implications with the new default `remove` for `PlaybackMode`. 

---

## Migration Guide

### Changed the default behaviour to be `remove`

```rust
    pub fn new(source: Handle<AudioSource>) -> Self {
        Self(source, PlaybackMode::default())
    }
```

### Introducing new functions to create `AudioPlayer`

```rust
    /// Creates a new [`AudioPlayer`] that plays the sound once.
    pub fn with_once(source: Handle<AudioSource>) -> Self {
        Self(source, PlaybackMode::Once)
    }

    /// Creates a new [`AudioPlayer`] that loops the sound forever.
    pub fn with_loop(source: Handle<AudioSource>) -> Self {
        Self(source, PlaybackMode::Loop)
    }

    /// Creates a new [`AudioPlayer`] that despawns the entity when the sound finishes playing.
    pub fn with_despawn(source: Handle<AudioSource>) -> Self {
        Self(source, PlaybackMode::Despawn)
    }

    /// Creates a new [`AudioPlayer`] that removes the audio component from the entity when the sound finishes playing.
    pub fn with_remove(source: Handle<AudioSource>) -> Self {
        Self(source, PlaybackMode::Remove)
    }
```

#### Examples: 

Old
```rust
    commands.spawn(AudioPlayer(
        asset_server.load("sounds/Windless Slopes.ogg"),
    ));
```
New
```rust
    commands.spawn(AudioPlayer::with_once(
        asset_server.load("sounds/Windless Slopes.ogg"),
    ));
```

Old
```rust
        commands.spawn((
            AudioPlayer(pitch_assets.add(Pitch::new(frequency.0, Duration::new(1, 0)))),
            PlaybackSettings::DESPAWN,
        ));
```
New
```rust
        commands.spawn(AudioPlayer(
            pitch_assets.add(Pitch::new(frequency.0, Duration::new(1, 0))),
            PlaybackMode::Despawn,
        ));
```
