### PR TITLE
Add alpha mode implementation to shader_material_2d 

### DIFF
--- a/examples/shader/shader_material_2d.rs
+++ b/examples/shader/shader_material_2d.rs
@@ -4,7 +4,7 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::render_resource::{AsBindGroup, ShaderRef},
-    sprite::{Material2d, Material2dPlugin},
+    sprite::{AlphaMode2d, Material2d, Material2dPlugin},
 };
 
 /// This example uses a shader source file from the assets subdirectory
@@ -56,5 +56,9 @@ struct CustomMaterial {
 impl Material2d for CustomMaterial {
     fn fragment_shader() -> ShaderRef {
         SHADER_ASSET_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
     }
 }

--- a/examples/shader/shader_material_2d.rs
+++ b/examples/shader/shader_material_2d.rs
@@ -59,6 +59,6 @@ impl Material2d for CustomMaterial {
     }
 
     fn alpha_mode(&self) -> AlphaMode2d {
-        AlphaMode2d::Blend
+        AlphaMode2d::Mask(0.5)
     }
 }


### PR DESCRIPTION
## Objective 

Bevy 0.15 introduced new method in `Material2d` trait- `alpha_mode`. Before that when new material was created it had alpha blending, now it does not. 

## Solution 

While I am okay with it, it could be useful to add the new trait method implementation to one of the samples so users are more aware of it.