### PR TITLE
add index_range for TextureAtlas

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -171,7 +171,7 @@ pub struct TextureAtlas {
     pub layout: Handle<TextureAtlasLayout>,
     /// Texture atlas section index
     pub index: usize,
-    /// Texture atlas default index range (first, last)
+    /// The index of the first and last images in the atlas
     pub index_range: (usize, usize),
 }
 

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -32,6 +32,7 @@ impl TextureAtlasSources {
         Some(TextureAtlas {
             layout,
             index: self.texture_index(texture)?,
+            index_range: (0, 0),
         })
     }
 
@@ -170,6 +171,8 @@ pub struct TextureAtlas {
     pub layout: Handle<TextureAtlasLayout>,
     /// Texture atlas section index
     pub index: usize,
+    /// Texture atlas default index range (first, last)
+    pub index_range: (usize, usize),
 }
 
 impl TextureAtlas {
@@ -178,6 +181,14 @@ impl TextureAtlas {
         let atlas = texture_atlases.get(&self.layout)?;
         atlas.textures.get(self.index).copied()
     }
+
+    pub fn advance_index(&mut self) -> &mut Self {
+        self.index += 1;
+        if self.index > self.index_range.1 {
+            self.index = self.index_range.0;
+        }
+        self
+    }
 }
 
 impl From<Handle<TextureAtlasLayout>> for TextureAtlas {
@@ -185,6 +196,7 @@ impl From<Handle<TextureAtlasLayout>> for TextureAtlas {
         Self {
             layout: texture_atlas,
             index: 0,
+            index_range: (0, 0),
         }
     }
 }

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -64,10 +64,10 @@ fn execute_animations(time: Res<Time>, mut query: Query<(&mut AnimationConfig, &
             if let Some(atlas) = &mut sprite.texture_atlas {
                 if atlas.index == config.last_sprite_index {
                     // ...and it IS the last frame, then we move back to the first frame and stop.
-                    atlas.index = config.first_sprite_index;
+                    atlas.advance_index();
                 } else {
                     // ...and it is NOT the last frame, then we move to the next frame...
-                    atlas.index += 1;
+                    atlas.advance_index();
                     // ...and reset the frame timer to start counting all over again
                     config.frame_timer = AnimationConfig::timer_from_fps(config.fps);
                 }
@@ -106,6 +106,7 @@ fn setup(
             texture_atlas: Some(TextureAtlas {
                 layout: texture_atlas_layout.clone(),
                 index: animation_config_1.first_sprite_index,
+                index_range: (animation_config_1.first_sprite_index, animation_config_1.last_sprite_index),
             }),
             ..default()
         },
@@ -124,6 +125,7 @@ fn setup(
             texture_atlas: Some(TextureAtlas {
                 layout: texture_atlas_layout.clone(),
                 index: animation_config_2.first_sprite_index,
+                index_range: (animation_config_2.first_sprite_index, animation_config_2.last_sprite_index),
             }),
             ..Default::default()
         },

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -11,29 +11,19 @@ fn main() {
         .run();
 }
 
-#[derive(Component)]
-struct AnimationIndices {
-    first: usize,
-    last: usize,
-}
-
 #[derive(Component, Deref, DerefMut)]
 struct AnimationTimer(Timer);
 
 fn animate_sprite(
     time: Res<Time>,
-    mut query: Query<(&AnimationIndices, &mut AnimationTimer, &mut Sprite)>,
+    mut query: Query<(&mut AnimationTimer, &mut Sprite)>,
 ) {
-    for (indices, mut timer, mut sprite) in &mut query {
+    for (mut timer, mut sprite) in &mut query {
         timer.tick(time.delta());
 
         if timer.just_finished() {
             if let Some(atlas) = &mut sprite.texture_atlas {
-                atlas.index = if atlas.index == indices.last {
-                    indices.first
-                } else {
-                    atlas.index + 1
-                };
+                atlas.advance_index();
             }
         }
     }
@@ -47,19 +37,18 @@ fn setup(
     let texture = asset_server.load("textures/rpg/chars/gabe/gabe-idle-run.png");
     let layout = TextureAtlasLayout::from_grid(UVec2::splat(24), 7, 1, None, None);
     let texture_atlas_layout = texture_atlas_layouts.add(layout);
-    // Use only the subset of sprites in the sheet that make up the run animation
-    let animation_indices = AnimationIndices { first: 1, last: 6 };
+
     commands.spawn(Camera2d);
     commands.spawn((
         Sprite::from_atlas_image(
             texture,
             TextureAtlas {
                 layout: texture_atlas_layout,
-                index: animation_indices.first,
+                index: 1,
+                index_range: (1, 6)
             },
         ),
         Transform::from_scale(Vec3::splat(6.0)),
-        animation_indices,
         AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
     ));
 }

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -31,7 +31,7 @@ fn button_system(
             Interaction::Pressed => {
                 **text = "Press".to_string();
                 if let Some(atlas) = &mut image.texture_atlas {
-                    atlas.index = (atlas.index + 1) % 30;
+                    atlas.advance_index();
                 }
                 image.color = GOLD.into();
             }
@@ -87,6 +87,7 @@ fn setup(
                             TextureAtlas {
                                 index: idx,
                                 layout: atlas_layout_handle.clone(),
+                                index_range: (idx, 30)
                             },
                         )
                         .with_mode(NodeImageMode::Sliced(slicer.clone())),


### PR DESCRIPTION
# Objective

To simplify index updating for TextureAtlas when playing animation.  

## Solution

Add index_range and advance_index() for TextureAtlas.  

So  

```rust
// init
let animation_indices = AnimationIndices { first: 1, last: 6 };

TextureAtlas {
    layout: texture_atlas_layout,
    index: animation_indices.first,
},

// update
atlas.index = if atlas.index == indices.last {
    indices.first
} else {
    atlas.index + 1
};
```

will become

```rust
// init
TextureAtlas {
    layout: texture_atlas_layout,
    index: 1,
    index_range: (1, 6)
},

// update
atlas.advance_index();
```

## Migration Guide

1. Provide `index_range: (my_first_index, my_last_index)` for all your `TextureAtlas` initializations.   
```rust
TextureAtlas {
    layout: texture_atlas_layout,
    index: 1,
    index_range: (1, 6), // add this as defualt index range
},
```
2. Instead of manually updating index like 
```rust
atlas.index = if atlas.index == indices.last {
    indices.first
} else {
    atlas.index + 1
};
```
just call  
```rust
atlas.advance_index(); // index += 1
```

3. Remove unnecessary code like

```rust
let animation_indices = AnimationIndices { first: 1, last: 6 }; // delete this
```

## Testing

Tested all examples related to TextureAtlas. 
