### PR TITLE
Move UI `Transform` to a field on `Node`

### DIFF
--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -436,6 +436,8 @@ impl RepeatedGridTrack {
 
 #[cfg(test)]
 mod tests {
+    use bevy_transform::components::Transform;
+
     use super::*;
 
     #[test]
@@ -509,6 +511,7 @@ mod tests {
             ],
             grid_column: GridPlacement::start(4),
             grid_row: GridPlacement::span(3),
+            transform: Transform::IDENTITY,
         };
         let viewport_values = LayoutContext::new(1.0, bevy_math::Vec2::new(800., 600.));
         let taffy_style = from_node(&node, &viewport_values, false);

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -374,15 +374,16 @@ with UI components as a child of an entity without UI components, your UI layout
                 bottom: rect.bottom,
             };
 
-            transform *=
-                style.transform.compute_matrix() * Mat4::from_translation(node_center.extend(0.));
-
             node.bypass_change_detection().border = taffy_rect_to_border_rect(layout.border);
             node.bypass_change_detection().padding = taffy_rect_to_border_rect(layout.padding);
 
-            let new_transform = GlobalTransform::from(transform);
-            if new_transform != *global_transform {
-                *global_transform = new_transform;
+            let mut node_transform = style.transform;
+            node_transform.translation /= inverse_target_scale_factor;
+            transform *=
+                node_transform.compute_matrix() * Mat4::from_translation(node_center.extend(0.));
+            let new_global_transform = GlobalTransform::from(transform);
+            if new_global_transform != *global_transform {
+                *global_transform = new_global_transform;
             }
 
             let viewport_size = root_size.unwrap_or(node.size);

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -189,7 +189,7 @@ impl Plugin for UiPlugin {
 
         let ui_layout_system_config = ui_layout_system
             .in_set(UiSystem::Layout)
-            .before(TransformSystem::TransformPropagate);
+            .in_set(TransformSystem::TransformPropagate);
 
         let ui_layout_system_config = ui_layout_system_config
             // Text and Text2D operate on disjoint sets of entities

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     view::Visibility,
 };
 use bevy_sprite::BorderRect;
-use bevy_transform::components::Transform;
+use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::warn_once;
 use bevy_window::{PrimaryWindow, WindowRef};
 use core::num::NonZero;
@@ -305,9 +305,9 @@ impl From<&Vec2> for ScrollPosition {
     BorderRadius,
     FocusPolicy,
     ScrollPosition,
-    Transform,
     Visibility,
-    ZIndex
+    ZIndex,
+    GlobalTransform
 )]
 #[reflect(Component, Default, PartialEq, Debug)]
 #[cfg_attr(
@@ -586,6 +586,9 @@ pub struct Node {
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column>
     pub grid_column: GridPlacement,
+
+    /// Rotate, scale, skew, or translate an element.
+    pub transform: Transform,
 }
 
 impl Node {
@@ -628,6 +631,7 @@ impl Node {
         grid_auto_columns: Vec::new(),
         grid_column: GridPlacement::DEFAULT,
         grid_row: GridPlacement::DEFAULT,
+        transform: Transform::IDENTITY,
     };
 }
 

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -41,16 +41,16 @@ struct AnimationState {
 struct Container(u8);
 
 trait UpdateTransform {
-    fn update(&self, t: f32, transform: &mut Transform);
+    fn update(&self, t: f32, transform: &mut Node);
 }
 
 #[derive(Component)]
 struct Move;
 
 impl UpdateTransform for Move {
-    fn update(&self, t: f32, transform: &mut Transform) {
-        transform.translation.x = ops::sin(t * TAU - FRAC_PI_2) * HALF_CONTAINER_SIZE;
-        transform.translation.y = -ops::cos(t * TAU - FRAC_PI_2) * HALF_CONTAINER_SIZE;
+    fn update(&self, t: f32, node: &mut Node) {
+        node.transform.translation.x = ops::sin(t * TAU - FRAC_PI_2) * HALF_CONTAINER_SIZE;
+        node.transform.translation.y = -ops::cos(t * TAU - FRAC_PI_2) * HALF_CONTAINER_SIZE;
     }
 }
 
@@ -58,9 +58,9 @@ impl UpdateTransform for Move {
 struct Scale;
 
 impl UpdateTransform for Scale {
-    fn update(&self, t: f32, transform: &mut Transform) {
-        transform.scale.x = 1.0 + 0.5 * ops::cos(t * TAU).max(0.0);
-        transform.scale.y = 1.0 + 0.5 * ops::cos(t * TAU + PI).max(0.0);
+    fn update(&self, t: f32, node: &mut Node) {
+        node.transform.scale.x = 1.0 + 0.5 * ops::cos(t * TAU).max(0.0);
+        node.transform.scale.y = 1.0 + 0.5 * ops::cos(t * TAU + PI).max(0.0);
     }
 }
 
@@ -68,8 +68,8 @@ impl UpdateTransform for Scale {
 struct Rotate;
 
 impl UpdateTransform for Rotate {
-    fn update(&self, t: f32, transform: &mut Transform) {
-        transform.rotation =
+    fn update(&self, t: f32, node: &mut Node) {
+        node.transform.rotation =
             Quat::from_axis_angle(Vec3::Z, (ops::cos(t * TAU) * 45.0).to_radians());
     }
 }
@@ -175,10 +175,6 @@ fn spawn_container(
     update_transform: impl UpdateTransform + Component,
     spawn_children: impl FnOnce(&mut ChildBuilder),
 ) {
-    let mut transform = Transform::default();
-
-    update_transform.update(0.0, &mut transform);
-
     parent
         .spawn((
             Node {
@@ -198,11 +194,8 @@ fn spawn_container(
                     Node {
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        top: Val::Px(transform.translation.x),
-                        left: Val::Px(transform.translation.y),
                         ..default()
                     },
-                    transform,
                     update_transform,
                 ))
                 .with_children(spawn_children);
@@ -233,13 +226,10 @@ fn update_animation(
 
 fn update_transform<T: UpdateTransform + Component>(
     animation: Res<AnimationState>,
-    mut containers: Query<(&mut Transform, &mut Node, &ComputedNode, &T)>,
+    mut containers: Query<(&mut Node, &T)>,
 ) {
-    for (mut transform, mut node, computed_node, update_transform) in &mut containers {
-        update_transform.update(animation.t, &mut transform);
-
-        node.left = Val::Px(transform.translation.x * computed_node.inverse_scale_factor());
-        node.top = Val::Px(transform.translation.y * computed_node.inverse_scale_factor());
+    for (mut node, update_transform) in &mut containers {
+        update_transform.update(animation.t, &mut node);
     }
 }
 


### PR DESCRIPTION
# Objective

Animating UI elements by modifying the `Transform` component of UI nodes doesn't work very well because `ui_layout_system` overwrites the translations each frame. The `overflow_debug` example uses a horrible hack where it copies the transform into the position that'll likely cause a panic if any users naively copy it.

## Solution
There have been a couple of other attempts to fix this with `UiTransform` components etc but they were quite complicated and controversial and got bogged down in review. So I thought about it again and came up with this simpler alternative: 
* Opt-out of the builtin transform propagation by requiring `GlobalTransform` instead of `Transform` on `Node`.
* Add a `transform: Transform` field to `Node`.
* Update UI node global transforms during layout updates.