### PR TITLE
switch bevy_mesh to use wgpu-types instead of wgpu

### DIFF
--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -24,7 +24,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
 # misc
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
-wgpu = { version = "23.0.1", default-features = false }
+wgpu-types = { version = "23", default-features = false }
 serde = { version = "1", features = ["derive"] }
 hexasphere = "15.0"
 derive_more = { version = "1", default-features = false, features = [

--- a/crates/bevy_mesh/src/index.rs
+++ b/crates/bevy_mesh/src/index.rs
@@ -2,7 +2,7 @@ use bevy_reflect::Reflect;
 use core::iter;
 use core::iter::FusedIterator;
 use derive_more::derive::{Display, Error};
-use wgpu::IndexFormat;
+use wgpu_types::IndexFormat;
 
 /// A disjunction of four iterators. This is necessary to have a well-formed type for the output
 /// of [`Mesh::triangles`](super::Mesh::triangles), which produces iterators of four different types depending on the
@@ -176,7 +176,7 @@ impl From<&Indices> for IndexFormat {
 #[cfg(test)]
 mod tests {
     use crate::Indices;
-    use wgpu::IndexFormat;
+    use wgpu_types::IndexFormat;
 
     #[test]
     fn test_indices_push() {

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -1,5 +1,5 @@
 use bevy_transform::components::Transform;
-pub use wgpu::PrimitiveTopology;
+pub use wgpu_types::PrimitiveTopology;
 
 use super::{
     face_normal, generate_tangents_for_mesh, scale_normal, FourIterators, GenerateTangentsError,
@@ -14,7 +14,7 @@ use bevy_math::{primitives::Triangle3d, *};
 use bevy_reflect::Reflect;
 use bevy_utils::tracing::warn;
 use bytemuck::cast_slice;
-use wgpu::{VertexAttribute, VertexFormat, VertexStepMode};
+use wgpu_types::{VertexAttribute, VertexFormat, VertexStepMode};
 
 pub const INDEX_BUFFER_ASSET_INDEX: u64 = 0;
 pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
@@ -1210,11 +1210,11 @@ impl core::ops::Mul<Mesh> for Transform {
 mod tests {
     use super::Mesh;
     use crate::mesh::{Indices, MeshWindingInvertError, VertexAttributeValues};
+    use crate::PrimitiveTopology;
     use bevy_asset::RenderAssetUsages;
     use bevy_math::primitives::Triangle3d;
     use bevy_math::Vec3;
     use bevy_transform::components::Transform;
-    use wgpu::PrimitiveTopology;
 
     #[test]
     #[should_panic]

--- a/crates/bevy_mesh/src/mikktspace.rs
+++ b/crates/bevy_mesh/src/mikktspace.rs
@@ -1,7 +1,7 @@
 use super::{Indices, Mesh, VertexAttributeValues};
 use bevy_math::Vec3;
 use derive_more::derive::{Display, Error};
-use wgpu::{PrimitiveTopology, VertexFormat};
+use wgpu_types::{PrimitiveTopology, VertexFormat};
 
 struct MikktspaceGeometryHelper<'a> {
     indices: Option<&'a Indices>,

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -7,7 +7,7 @@ use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
 use core::iter;
 use derive_more::derive::{Display, Error};
-use wgpu::{Extent3d, TextureDimension, TextureFormat};
+use wgpu_types::{Extent3d, TextureDimension, TextureFormat};
 
 const MAX_TEXTURE_WIDTH: u32 = 2048;
 // NOTE: "component" refers to the element count of math objects,

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -12,7 +12,7 @@ use bevy_math::{
     },
     FloatExt, Vec2,
 };
-use wgpu::PrimitiveTopology;
+use wgpu_types::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`Circle`] shape.
 #[derive(Clone, Copy, Debug)]

--- a/crates/bevy_mesh/src/primitives/dim3/capsule.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/capsule.rs
@@ -1,7 +1,7 @@
+use crate::PrimitiveTopology;
 use crate::{Indices, Mesh, MeshBuilder, Meshable};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Capsule3d, Vec2, Vec3};
-use wgpu::PrimitiveTopology;
 
 /// Manner in which UV coordinates are distributed vertically.
 #[derive(Clone, Copy, Debug, Default)]

--- a/crates/bevy_mesh/src/primitives/dim3/capsule.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/capsule.rs
@@ -1,5 +1,4 @@
-use crate::PrimitiveTopology;
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Capsule3d, Vec2, Vec3};
 

--- a/crates/bevy_mesh/src/primitives/dim3/cone.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cone.rs
@@ -1,5 +1,4 @@
-use crate::PrimitiveTopology;
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Cone, Vec3};
 

--- a/crates/bevy_mesh/src/primitives/dim3/cone.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cone.rs
@@ -1,7 +1,7 @@
+use crate::PrimitiveTopology;
 use crate::{Indices, Mesh, MeshBuilder, Meshable};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Cone, Vec3};
-use wgpu::PrimitiveTopology;
 
 /// Anchoring options for [`ConeMeshBuilder`]
 #[derive(Debug, Copy, Clone, Default)]

--- a/crates/bevy_mesh/src/primitives/dim3/conical_frustum.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/conical_frustum.rs
@@ -1,7 +1,6 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::ConicalFrustum, Vec3};
-use wgpu::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`ConicalFrustum`] shape.
 #[derive(Clone, Copy, Debug)]

--- a/crates/bevy_mesh/src/primitives/dim3/cuboid.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cuboid.rs
@@ -1,7 +1,6 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{primitives::Cuboid, Vec3};
-use wgpu::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`Cuboid`] shape.
 pub struct CuboidMeshBuilder {

--- a/crates/bevy_mesh/src/primitives/dim3/cylinder.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/cylinder.rs
@@ -1,7 +1,6 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Cylinder};
-use wgpu::PrimitiveTopology;
 
 /// Anchoring options for [`CylinderMeshBuilder`]
 #[derive(Debug, Copy, Clone, Default)]

--- a/crates/bevy_mesh/src/primitives/dim3/plane.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/plane.rs
@@ -1,7 +1,6 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{primitives::Plane3d, Dir3, Quat, Vec2, Vec3};
-use wgpu::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`Plane3d`] shape.
 #[derive(Clone, Copy, Debug, Default)]

--- a/crates/bevy_mesh/src/primitives/dim3/sphere.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/sphere.rs
@@ -1,10 +1,9 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Sphere};
 use core::f32::consts::PI;
 use derive_more::derive::{Display, Error};
 use hexasphere::shapes::IcoSphere;
-use wgpu::PrimitiveTopology;
 
 /// An error when creating an icosphere [`Mesh`] from a [`SphereMeshBuilder`].
 #[derive(Clone, Copy, Debug, Error, Display)]

--- a/crates/bevy_mesh/src/primitives/dim3/tetrahedron.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/tetrahedron.rs
@@ -1,8 +1,7 @@
 use super::triangle3d;
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::primitives::{Tetrahedron, Triangle3d};
-use wgpu::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`Tetrahedron`] shape.
 pub struct TetrahedronMeshBuilder {

--- a/crates/bevy_mesh/src/primitives/dim3/torus.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/torus.rs
@@ -1,8 +1,7 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{ops, primitives::Torus, Vec3};
 use core::ops::RangeInclusive;
-use wgpu::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`Torus`] shape.
 #[derive(Clone, Debug)]

--- a/crates/bevy_mesh/src/primitives/dim3/triangle3d.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/triangle3d.rs
@@ -1,7 +1,6 @@
-use crate::{Indices, Mesh, MeshBuilder, Meshable};
+use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{primitives::Triangle3d, Vec3};
-use wgpu::PrimitiveTopology;
 
 /// A builder used for creating a [`Mesh`] with a [`Triangle3d`] shape.
 pub struct Triangle3dMeshBuilder {

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -72,7 +72,7 @@ impl PerimeterSegment {
 /// ## Warning
 ///
 /// By implementing this trait you guarantee that the `primitive_topology` of the mesh returned by
-/// this builder is [`PrimitiveTopology::TriangleList`](wgpu::PrimitiveTopology::TriangleList)
+/// this builder is [`PrimitiveTopology::TriangleList`](crate::PrimitiveTopology::TriangleList)
 /// and that your mesh has a [`Mesh::ATTRIBUTE_POSITION`] attribute.
 pub trait Extrudable: MeshBuilder {
     /// A list of the indices each representing a part of the perimeter of the mesh.

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -72,7 +72,7 @@ impl PerimeterSegment {
 /// ## Warning
 ///
 /// By implementing this trait you guarantee that the `primitive_topology` of the mesh returned by
-/// this builder is [`PrimitiveTopology::TriangleList`](PrimitiveTopology::TriangleList)
+/// this builder is [`PrimitiveTopology::TriangleList`]
 /// and that your mesh has a [`Mesh::ATTRIBUTE_POSITION`] attribute.
 pub trait Extrudable: MeshBuilder {
     /// A list of the indices each representing a part of the perimeter of the mesh.

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -72,7 +72,7 @@ impl PerimeterSegment {
 /// ## Warning
 ///
 /// By implementing this trait you guarantee that the `primitive_topology` of the mesh returned by
-/// this builder is [`PrimitiveTopology::TriangleList`](crate::PrimitiveTopology::TriangleList)
+/// this builder is [`PrimitiveTopology::TriangleList`](PrimitiveTopology::TriangleList)
 /// and that your mesh has a [`Mesh::ATTRIBUTE_POSITION`] attribute.
 pub trait Extrudable: MeshBuilder {
     /// A list of the indices each representing a part of the perimeter of the mesh.

--- a/crates/bevy_mesh/src/primitives/extrusion.rs
+++ b/crates/bevy_mesh/src/primitives/extrusion.rs
@@ -4,7 +4,7 @@ use bevy_math::{
 };
 
 use super::{MeshBuilder, Meshable};
-use crate::{Indices, Mesh, VertexAttributeValues};
+use crate::{Indices, Mesh, PrimitiveTopology, VertexAttributeValues};
 
 /// A type representing a segment of the perimeter of an extrudable mesh.
 pub enum PerimeterSegment {
@@ -198,7 +198,7 @@ where
             // By swapping the first and second indices of each triangle we invert the winding order thus making the mesh visible from the other side
             if let Some(indices) = back_face.indices_mut() {
                 match topology {
-                    wgpu::PrimitiveTopology::TriangleList => match indices {
+                    PrimitiveTopology::TriangleList => match indices {
                         Indices::U16(indices) => {
                             indices.chunks_exact_mut(3).for_each(|arr| arr.swap(1, 0));
                         }
@@ -401,14 +401,11 @@ where
                 }
             }
 
-            Mesh::new(
-                wgpu::PrimitiveTopology::TriangleList,
-                front_face.asset_usage,
-            )
-            .with_inserted_indices(Indices::U32(indices))
-            .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
-            .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
-            .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
+            Mesh::new(PrimitiveTopology::TriangleList, front_face.asset_usage)
+                .with_inserted_indices(Indices::U32(indices))
+                .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
+                .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
+                .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
         };
 
         front_face.merge(&back_face);

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -6,7 +6,7 @@ use bevy_utils::HashSet;
 use bytemuck::cast_slice;
 use core::hash::{Hash, Hasher};
 use derive_more::derive::{Display, Error};
-use wgpu::{BufferAddress, VertexAttribute, VertexFormat, VertexStepMode};
+use wgpu_types::{BufferAddress, VertexAttribute, VertexFormat, VertexStepMode};
 
 #[derive(Debug, Clone, Copy)]
 pub struct MeshVertexAttribute {


### PR DESCRIPTION
# Objective

- dont depend on wgpu if we dont have to

## Solution

- works towards this, but doesnt fully accomplish it. bevy_mesh depends on bevy_image

## Testing

- 3d_scene runs
