### PR TITLE
Added `bevy/components` method to BRP, which lists all world components

### DIFF
--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -797,11 +797,7 @@ pub fn process_remote_list_watching_request(
 }
 
 /// Handles a `bevy/components` request (list all world components) coming from a client.
-pub fn process_remote_components_request(
-    In(_): In<Option<Value>>,
-    world: &World,
-) -> BrpResult {
-
+pub fn process_remote_components_request(In(_): In<Option<Value>>, world: &World) -> BrpResult {
     let components = world.components();
     let mut response = BrpListResponse::default();
 

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -48,6 +48,9 @@ pub const BRP_REPARENT_METHOD: &str = "bevy/reparent";
 /// The method path for a `bevy/list` request.
 pub const BRP_LIST_METHOD: &str = "bevy/list";
 
+/// The method path for a `bevy/components` request.
+pub const BRP_COMPONENTS_METHOD: &str = "bevy/components";
+
 /// The method path for a `bevy/get+watch` request.
 pub const BRP_GET_AND_WATCH_METHOD: &str = "bevy/get+watch";
 
@@ -791,6 +794,23 @@ pub fn process_remote_list_watching_request(
             serde_json::to_value(response).map_err(BrpError::internal)?,
         ))
     }
+}
+
+/// Handles a `bevy/components` request (list all world components) coming from a client.
+pub fn process_remote_components_request(
+    In(_): In<Option<Value>>,
+    world: &World,
+) -> BrpResult {
+
+    let components = world.components();
+    let mut response = BrpListResponse::default();
+
+    for component in components.iter() {
+        response.push(component.name().to_owned());
+    }
+
+    response.sort();
+    serde_json::to_value(response).map_err(BrpError::internal)
 }
 
 /// Immutably retrieves an entity from the [`World`], returning an error if the

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -257,6 +257,14 @@
 //!   in the last tick.
 //!
 //!
+//! ### bevy/components
+//!
+//! list all components present on the world.
+//!
+//! `params`: None
+//!
+//! `result`: An array of fully-qualified type names of all world components
+//!
 //! ## Custom methods
 //!
 //! In addition to the provided methods, the Bevy Remote Protocol can be extended to include custom
@@ -403,6 +411,10 @@ impl Default for RemotePlugin {
             .with_method(
                 builtin_methods::BRP_LIST_METHOD,
                 builtin_methods::process_remote_list_request,
+            )
+            .with_method(
+                builtin_methods::BRP_COMPONENTS_METHOD,
+                builtin_methods::process_remote_components_request,
             )
             .with_watching_method(
                 builtin_methods::BRP_GET_AND_WATCH_METHOD,


### PR DESCRIPTION
# New BRP method to list all available fully qualified components in the active world.

After using the newly added BRP feature and trying to build tools around it, I encountered a common issue. There is no way to get all available fully qualified component names from bevy and user space without accumulating them over each entity. Which has an insane cost attached to it.

This is a Problem If you want to provided auto complete for a query API or just want to know what is available without looking into the source code.

This should not be part of the user space, rather be a common method in bevy_remote itself.

## Solution

-  Added a new method that returns a list of all fully qualified component names, active on the current world.
- `method`: `bevy/components`
- `params`: None
- `result`: An array of fully-qualified type names of all world components


## Testing

- Tested on the new `server` example with curl and JSON-RPC.

---

## Showcase

start the server example

```bash
cargo run --example server --features="bevy_remote"
```

get the list result from the new  `bevy/components` method

```bash
curl --silent --no-buffer -X POST -H 'Content-Type: application/json' -d '{"id": 0 ,"jsonrpc":"2.0", "method": "bevy/components", "params": {}}' http://127.0.0.1:15702
```

### Result
[remote_component_list_response.json](https://github.com/user-attachments/files/17992832/remote_component_list_response.json)
