### PR TITLE
Use a read-only depth buffer for transparent/transmissive passes

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -5,7 +5,7 @@ use bevy_render::{
     diagnostic::RecordDiagnostics,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::ViewSortedRenderPhases,
-    render_resource::{RenderPassDescriptor, StoreOp},
+    render_resource::RenderPassDescriptor,
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget},
 };
@@ -51,13 +51,7 @@ impl ViewNode for MainTransparentPass2dNode {
             let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
                 label: Some("main_transparent_pass_2d"),
                 color_attachments: &[Some(target.get_color_attachment())],
-                // NOTE: For the transparent pass we load the depth buffer. There should be no
-                // need to write to it, but store is set to `true` as a workaround for issue #3776,
-                // https://github.com/bevyengine/bevy/issues/3776
-                // so that wgpu does not clear the depth buffer.
-                // As the opaque and alpha mask passes run first, opaque meshes can occlude
-                // transparent ones.
-                depth_stencil_attachment: Some(depth.get_attachment(StoreOp::Store)),
+                depth_stencil_attachment: Some(depth.get_read_only_attachment()),
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });

--- a/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
@@ -5,7 +5,7 @@ use bevy_render::{
     camera::ExtractedCamera,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::ViewSortedRenderPhases,
-    render_resource::{Extent3d, RenderPassDescriptor, StoreOp},
+    render_resource::{Extent3d, RenderPassDescriptor},
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget},
 };
@@ -52,7 +52,7 @@ impl ViewNode for MainTransmissivePass3dNode {
         let render_pass_descriptor = RenderPassDescriptor {
             label: Some("main_transmissive_pass_3d"),
             color_attachments: &[Some(target.get_color_attachment())],
-            depth_stencil_attachment: Some(depth.get_attachment(StoreOp::Store)),
+            depth_stencil_attachment: Some(depth.get_read_only_attachment()),
             timestamp_writes: None,
             occlusion_query_set: None,
         };

--- a/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
@@ -5,7 +5,7 @@ use bevy_render::{
     diagnostic::RecordDiagnostics,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::ViewSortedRenderPhases,
-    render_resource::{RenderPassDescriptor, StoreOp},
+    render_resource::RenderPassDescriptor,
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget},
 };
@@ -54,13 +54,7 @@ impl ViewNode for MainTransparentPass3dNode {
             let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
                 label: Some("main_transparent_pass_3d"),
                 color_attachments: &[Some(target.get_color_attachment())],
-                // NOTE: For the transparent pass we load the depth buffer. There should be no
-                // need to write to it, but store is set to `true` as a workaround for issue #3776,
-                // https://github.com/bevyengine/bevy/issues/3776
-                // so that wgpu does not clear the depth buffer.
-                // As the opaque and alpha mask passes run first, opaque meshes can occlude
-                // transparent ones.
-                depth_stencil_attachment: Some(depth.get_attachment(StoreOp::Store)),
+                depth_stencil_attachment: Some(depth.get_read_only_attachment()),
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });

--- a/crates/bevy_render/src/texture/texture_attachment.rs
+++ b/crates/bevy_render/src/texture/texture_attachment.rs
@@ -118,6 +118,15 @@ impl DepthAttachment {
             stencil_ops: None,
         }
     }
+
+    /// Get this texture view as a read-only attachment.
+    pub fn get_read_only_attachment(&self) -> RenderPassDepthStencilAttachment {
+        RenderPassDepthStencilAttachment {
+            view: &self.view,
+            depth_ops: None,
+            stencil_ops: None,
+        }
+    }
 }
 
 /// A wrapper for a [`TextureView`] that is used as a [`RenderPassColorAttachment`] for a view

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -785,6 +785,10 @@ impl ViewDepthTexture {
         self.attachment.get_attachment(store)
     }
 
+    pub fn get_read_only_attachment(&self) -> RenderPassDepthStencilAttachment {
+        self.attachment.get_read_only_attachment()
+    }
+
     pub fn view(&self) -> &TextureView {
         &self.attachment.view
     }


### PR DESCRIPTION
# Objective
- Fix https://github.com/bevyengine/bevy/issues/3776 properly

## Solution
- Bind the depth attachment as read-only (depth_ops: None) during the transparent/transmissive pass

---

## Changelog
- Added ViewDepthTexture::get_read_only_attachment()
- Added DepthAttachment::get_read_only_attachment()