### PR TITLE
`OverflowClipBox::MarginBox`

### DIFF
--- a/crates/bevy_sprite/src/texture_slice/border_rect.rs
+++ b/crates/bevy_sprite/src/texture_slice/border_rect.rs
@@ -1,3 +1,5 @@
+use std::ops::Neg;
+
 use bevy_reflect::Reflect;
 
 /// Struct defining a [`Sprite`](crate::Sprite) border with padding values
@@ -40,6 +42,20 @@ impl BorderRect {
             right: horizontal,
             top: vertical,
             bottom: vertical,
+        }
+    }
+}
+
+impl Neg for BorderRect {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        Self {
+            left: -self.left,
+            right: -self.right,
+            top: -self.top,
+            bottom: -self.bottom,
         }
     }
 }

--- a/crates/bevy_sprite/src/texture_slice/border_rect.rs
+++ b/crates/bevy_sprite/src/texture_slice/border_rect.rs
@@ -1,5 +1,3 @@
-use std::ops::Neg;
-
 use bevy_reflect::Reflect;
 
 /// Struct defining a [`Sprite`](crate::Sprite) border with padding values
@@ -46,7 +44,7 @@ impl BorderRect {
     }
 }
 
-impl Neg for BorderRect {
+impl core::ops::Neg for BorderRect {
     type Output = Self;
 
     #[inline]

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -366,6 +366,7 @@ with UI components as a child of an entity without UI components, your UI layout
 
             node.bypass_change_detection().border = taffy_rect_to_border_rect(layout.border);
             node.bypass_change_detection().padding = taffy_rect_to_border_rect(layout.padding);
+            node.bypass_change_detection().margin = taffy_rect_to_border_rect(layout.margin);
 
             let viewport_size = root_size.unwrap_or(node.size);
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1171,6 +1171,14 @@ impl OverflowClipMargin {
         }
     }
 
+    /// Clip any content that overflows outside the border box
+    pub const fn margin_box() -> Self {
+        Self {
+            visual_box: OverflowClipBox::MarginBox,
+            ..Self::DEFAULT
+        }
+    }
+
     /// Add a margin on each edge of the visual box in logical pixels.
     /// The width of the margin will be zero if a negative value is set.
     pub const fn with_margin(mut self, margin: f32) -> Self {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -57,6 +57,11 @@ pub struct ComputedNode {
     ///
     /// Automatically calculated by [`super::layout::ui_layout_system`].
     pub(crate) padding: BorderRect,
+    /// Resolved margin values in physical pixels.
+    /// Margin updates bypass change detection.
+    ///
+    /// Automatically calculated by [`super::layout::ui_layout_system`].
+    pub(crate) margin: BorderRect,
     /// Inverse scale factor for this Node.
     /// Multiply physical coordinates by the inverse scale factor to give logical coordinates.
     ///
@@ -191,6 +196,14 @@ impl ComputedNode {
         self.padding
     }
 
+    /// Returns the thickness of the node's margin on each edge in physical pixels.
+    ///
+    /// Automatically calculated by [`super::layout::ui_layout_system`].
+    #[inline]
+    pub const fn margin(&self) -> BorderRect {
+        self.margin
+    }
+
     /// Returns the combined inset on each edge including both padding and border thickness in physical pixels.
     #[inline]
     pub const fn content_inset(&self) -> BorderRect {
@@ -220,6 +233,7 @@ impl ComputedNode {
         border_radius: ResolvedBorderRadius::ZERO,
         border: BorderRect::ZERO,
         padding: BorderRect::ZERO,
+        margin: BorderRect::ZERO,
         inverse_scale_factor: 1.,
     };
 }
@@ -1181,6 +1195,8 @@ pub enum OverflowClipBox {
     PaddingBox,
     /// Clip any content that overflows outside the border box
     BorderBox,
+    /// Clip any content that overflows outside the margin box
+    MarginBox,
 }
 
 /// The strategy used to position this node

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     experimental::{UiChildren, UiRootNodes},
-    CalculatedClip, Display, Node, OverflowAxis, TargetCamera,
+    CalculatedClip, Display, Node, OverflowAxis, OverflowClipBox, TargetCamera,
 };
 
 use super::ComputedNode;
@@ -105,9 +105,10 @@ fn update_clipping(
         // `clip_inset` should always fit inside `node_rect`.
         // Even if `clip_inset` were to overflow, we won't return a degenerate result as `Rect::intersect` will clamp the intersection, leaving it empty.
         let clip_inset = match node.overflow_clip_margin.visual_box {
-            crate::OverflowClipBox::BorderBox => BorderRect::ZERO,
-            crate::OverflowClipBox::ContentBox => computed_node.content_inset(),
-            crate::OverflowClipBox::PaddingBox => computed_node.border(),
+            OverflowClipBox::MarginBox => -computed_node.margin(),
+            OverflowClipBox::BorderBox => BorderRect::ZERO,
+            OverflowClipBox::ContentBox => computed_node.content_inset(),
+            OverflowClipBox::PaddingBox => computed_node.border(),
         };
 
         clip_rect.min.x += clip_inset.left;

--- a/examples/ui/overflow_clip_margin.rs
+++ b/examples/ui/overflow_clip_margin.rs
@@ -23,72 +23,85 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 height: Val::Percent(100.),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
-                row_gap: Val::Px(40.),
-                flex_direction: FlexDirection::Column,
-                ..default()
+                ..Default::default()
             },
             BackgroundColor(ANTIQUE_WHITE.into()),
         ))
         .with_children(|parent| {
-            for overflow_clip_margin in [
-                OverflowClipMargin::border_box().with_margin(25.),
-                OverflowClipMargin::border_box(),
-                OverflowClipMargin::padding_box(),
-                OverflowClipMargin::content_box(),
-            ] {
-                parent
-                    .spawn(Node {
-                        flex_direction: FlexDirection::Row,
-                        column_gap: Val::Px(20.),
-                        ..default()
-                    })
-                    .with_children(|parent| {
+            parent
+                .spawn((Node {
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    row_gap: Val::Px(25.),
+                    flex_direction: FlexDirection::Column,
+                    ..default()
+                },))
+                .with_children(|parent| {
+                    for overflow_clip_margin in [
+                        OverflowClipMargin::margin_box(),
+                        OverflowClipMargin::border_box().with_margin(20.),
+                        OverflowClipMargin::border_box(),
+                        OverflowClipMargin::padding_box(),
+                        OverflowClipMargin::content_box(),
+                    ] {
                         parent
-                            .spawn((
-                                Node {
-                                    padding: UiRect::all(Val::Px(10.)),
-                                    margin: UiRect::bottom(Val::Px(25.)),
-                                    ..default()
-                                },
-                                BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
-                            ))
-                            .with_child(Text(format!("{overflow_clip_margin:#?}")));
-
-                        parent
-                            .spawn((
-                                Node {
-                                    margin: UiRect::top(Val::Px(10.)),
-                                    width: Val::Px(100.),
-                                    height: Val::Px(100.),
-                                    padding: UiRect::all(Val::Px(20.)),
-                                    border: UiRect::all(Val::Px(5.)),
-                                    overflow: Overflow::clip(),
-                                    overflow_clip_margin,
-                                    ..default()
-                                },
-                                BackgroundColor(GRAY.into()),
-                                BorderColor(Color::BLACK),
-                            ))
+                            .spawn(Node {
+                                flex_direction: FlexDirection::Row,
+                                column_gap: Val::Px(20.),
+                                align_items: AlignItems::Center,
+                                ..default()
+                            })
                             .with_children(|parent| {
                                 parent
                                     .spawn((
                                         Node {
-                                            min_width: Val::Px(50.),
-                                            min_height: Val::Px(50.),
+                                            padding: UiRect::all(Val::Px(10.)),
                                             ..default()
                                         },
-                                        BackgroundColor(LIGHT_CYAN.into()),
+                                        BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
                                     ))
-                                    .with_child((
-                                        ImageNode::new(image.clone()),
-                                        Node {
-                                            min_width: Val::Px(100.),
-                                            min_height: Val::Px(100.),
-                                            ..default()
-                                        },
-                                    ));
+                                    .with_child(Text(format!("{overflow_clip_margin:#?}")));
+
+                                parent
+                                    .spawn((Node::default(), BackgroundColor(BURLYWOOD.into())))
+                                    .with_children(|parent| {
+                                        parent
+                                            .spawn((
+                                                Node {
+                                                    margin: UiRect::all(Val::Px(10.)),
+                                                    width: Val::Px(100.),
+                                                    height: Val::Px(100.),
+                                                    padding: UiRect::all(Val::Px(20.)),
+                                                    border: UiRect::all(Val::Px(5.)),
+                                                    overflow: Overflow::clip(),
+                                                    overflow_clip_margin,
+                                                    ..default()
+                                                },
+                                                BackgroundColor(GRAY.into()),
+                                                BorderColor(Color::BLACK),
+                                            ))
+                                            .with_children(|parent| {
+                                                parent
+                                                    .spawn((
+                                                        Node {
+                                                            min_width: Val::Px(50.),
+                                                            min_height: Val::Px(50.),
+                                                            ..default()
+                                                        },
+                                                        BackgroundColor(LIGHT_CYAN.into()),
+                                                    ))
+                                                    .with_child((
+                                                        ImageNode::new(image.clone()),
+                                                        Node {
+                                                            min_width: Val::Px(100.),
+                                                            min_height: Val::Px(100.),
+                                                            ..default()
+                                                        },
+                                                    ));
+                                            });
+                                    });
                             });
-                    });
-            }
+                    }
+                });
         });
 }


### PR DESCRIPTION
# Objective

Add support for clipping content overflowing a UI node's margin box.

## Solution

* Add a new field `margin` to `ComputedNode` which is updated in `ui_layout_system` from the margins computed by Taffy.
* Add a `MarginBox` variant to the `OverflowClipBox` enum.
* In `update_clipping` clip to the margin box when a node with `OverflowClipBox::MarginBox` is found.

## Testing
I added an item demonstrating `OverflowClipBox::MarginBox` to the `overflow_clip_margin` example:
```
cargo run --example overflow_clip_margin
```

<img width="376" alt="margin-box" src="https://github.com/user-attachments/assets/14cb8967-2628-47d1-99d2-2b7d05c3778e">