### PR TITLE
Use new get_unchecked methods in QuerySortedIter

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -868,6 +868,17 @@ impl Archetypes {
         self.archetypes.get(id.index())
     }
 
+    // Fetches an immutable reference to an Archetype using its
+    // ID, without checking whether it exists.
+    //
+    // # Safety
+    //
+    // A corresponding archetype must exist.
+    #[inline]
+    pub(crate) unsafe fn get_unchecked(&self, id: ArchetypeId) -> &Archetype {
+        self.archetypes.get_unchecked(id.index())
+    }
+
     /// # Panics
     ///
     /// Panics if `a` and `b` are equal.

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -868,7 +868,7 @@ impl Archetypes {
         self.archetypes.get(id.index())
     }
 
-    /// Fetches an immutable reference to an Archetype using its
+    /// Fetches an immutable reference to an [`Archetype`] using its
     /// ID, without checking whether it exists.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -868,12 +868,12 @@ impl Archetypes {
         self.archetypes.get(id.index())
     }
 
-    // Fetches an immutable reference to an Archetype using its
-    // ID, without checking whether it exists.
-    //
-    // # Safety
-    //
-    // A corresponding archetype must exist.
+    /// Fetches an immutable reference to an Archetype using its
+    /// ID, without checking whether it exists.
+    ///
+    /// # Safety
+    ///
+    /// A corresponding archetype must exist.
     #[inline]
     pub(crate) unsafe fn get_unchecked(&self, id: ArchetypeId) -> &Archetype {
         self.archetypes.get_unchecked(id.index())

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -808,7 +808,7 @@ impl Entities {
     ///
     /// # Safety
     ///
-    /// Must be an entity that currently exists, and that has an EntityLocation with a valid ArchetypeId.
+    /// Must be an entity that currently exists, and that has an [`EntityLocation`] with a valid [`ArchetypeId`].
     #[inline]
     pub(crate) unsafe fn get_unchecked(&self, entity: Entity) -> EntityLocation {
         self.meta.get_unchecked(entity.index() as usize).location

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -804,7 +804,7 @@ impl Entities {
         }
     }
 
-    /// Returns the location of an Entity without checking its generation or archetype.
+    /// Returns the location of an [`Entity`] without checking its generation or archetype.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -804,6 +804,16 @@ impl Entities {
         }
     }
 
+    // Returns the location of an Entity without checking its generation or archetype.
+    //
+    // # Safety
+    //
+    // Must be an entity that currently exists, and that has an EntityLocation with a valid ArchetypeId.
+    #[inline]
+    pub(crate) unsafe fn get_unchecked(&self, entity: Entity) -> EntityLocation {
+        self.meta.get_unchecked(entity.index() as usize)
+    }
+
     /// Updates the location of an [`Entity`]. This must be called when moving the components of
     /// the entity around in storage.
     ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -804,11 +804,11 @@ impl Entities {
         }
     }
 
-    // Returns the location of an Entity without checking its generation or archetype.
-    //
-    // # Safety
-    //
-    // Must be an entity that currently exists, and that has an EntityLocation with a valid ArchetypeId.
+    /// Returns the location of an Entity without checking its generation or archetype.
+    ///
+    /// # Safety
+    ///
+    /// Must be an entity that currently exists, and that has an EntityLocation with a valid ArchetypeId.
     #[inline]
     pub(crate) unsafe fn get_unchecked(&self, entity: Entity) -> EntityLocation {
         self.meta.get_unchecked(entity.index() as usize).location

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -811,7 +811,7 @@ impl Entities {
     // Must be an entity that currently exists, and that has an EntityLocation with a valid ArchetypeId.
     #[inline]
     pub(crate) unsafe fn get_unchecked(&self, entity: Entity) -> EntityLocation {
-        self.meta.get_unchecked(entity.index() as usize)
+        self.meta.get_unchecked(entity.index() as usize).location
     }
 
     /// Updates the location of an [`Entity`]. This must be called when moving the components of

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1163,13 +1163,11 @@ where
         // SAFETY:
         // `tables` and `archetypes` belong to the same world that the [`QueryIter`]
         // was initialized for.
+        // Any invalid locations, archetypes and tables were skipped by the initial [`QueryIter`].
         unsafe {
-            location = self.entities.get(entity).debug_checked_unwrap();
-            archetype = self
-                .archetypes
-                .get(location.archetype_id)
-                .debug_checked_unwrap();
-            table = self.tables.get(location.table_id).debug_checked_unwrap();
+            location = self.entities.get_unchecked(entity);
+            archetype = self.archetypes.get_unchecked(location.archetype_id);
+            table = self.tables.get_unchecked(location.table_id);
         }
 
         // SAFETY: `archetype` is from the world that `fetch` was created for,

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -716,7 +716,7 @@ impl Tables {
         self.tables.get(id.as_usize())
     }
 
-    /// Fetches a Table by its TableId, without checking validity.
+    /// Fetches a Table by its [`TableId`], without checking validity.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -716,6 +716,16 @@ impl Tables {
         self.tables.get(id.as_usize())
     }
 
+    // Fetches a Table by its TableId, without checking validity.
+    //
+    // # Safety
+    //
+    // This id must be valid.
+    #[inline]
+    pub(crate) unsafe fn get_unchecked(&self, id: TableId) -> &Table {
+        self.tables.get_unchecked(id.as_usize())
+    }
+
     /// Fetches mutable references to two different [`Table`]s.
     ///
     /// # Panics

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -716,11 +716,11 @@ impl Tables {
         self.tables.get(id.as_usize())
     }
 
-    // Fetches a Table by its TableId, without checking validity.
-    //
-    // # Safety
-    //
-    // This id must be valid.
+    /// Fetches a Table by its TableId, without checking validity.
+    ///
+    /// # Safety
+    ///
+    /// This id must be valid.
     #[inline]
     pub(crate) unsafe fn get_unchecked(&self, id: TableId) -> &Table {
         self.tables.get_unchecked(id.as_usize())


### PR DESCRIPTION
# Objective

In `QuerySortedIter::fetch_next`, `Entites::get`. `Archetypes::get`, `Tables::get` are all guaranteed to return correctly, but still do bounds checks/further checks.

## Solution

Introduce `get_unchecked` methods on `Entities`, `Archetypes`, and `Tables`, and use those.