### PR TITLE
Descriptive error message for circular required components recursion

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -87,7 +87,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                     components,
                     storages,
                     required_components,
-                    inheritance_depth + 1
+                    inheritance_depth + 1,
+                    recursion_check_stack
                 );
             });
             match &require.func {
@@ -97,7 +98,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                             storages,
                             required_components,
                             || { let x: #ident = #func().into(); x },
-                            inheritance_depth
+                            inheritance_depth,
+                            recursion_check_stack
                         );
                     });
                 }
@@ -107,7 +109,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                             storages,
                             required_components,
                             || { let x: #ident = (#func)().into(); x },
-                            inheritance_depth
+                            inheritance_depth,
+                            recursion_check_stack
                         );
                     });
                 }
@@ -117,7 +120,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                             storages,
                             required_components,
                             <#ident as Default>::default,
-                            inheritance_depth
+                            inheritance_depth,
+                            recursion_check_stack
                         );
                     });
                 }
@@ -138,9 +142,14 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 storages: &mut #bevy_ecs_path::storage::Storages,
                 required_components: &mut #bevy_ecs_path::component::RequiredComponents,
                 inheritance_depth: u16,
+                recursion_check_stack: &mut Vec<#bevy_ecs_path::component::ComponentId>
             ) {
+                #bevy_ecs_path::component::enforce_no_required_components_recursion(components, recursion_check_stack);
+                let self_id = components.register_component::<Self>(storages);
+                recursion_check_stack.push(self_id);
                 #(#register_required)*
                 #(#register_recursive_requires)*
+                recursion_check_stack.pop();
             }
 
             #[allow(unused_variables)]

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -227,6 +227,7 @@ unsafe impl<C: Component> Bundle for C {
             storages,
             required_components,
             0,
+            &mut Vec::new(),
         );
     }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -422,7 +422,7 @@ pub fn enforce_no_required_components_recursion(
                 "Recursive required components detected: {}\nhelp: {}",
                 recursion_check_stack
                     .iter()
-                    .map(|id| components.get_name(*id).unwrap())
+                    .map(|id| ShortName(components.get_name(*id).unwrap()))
                     .collect::<Vec<_>>()
                     .join(" → "),
                 if direct_recursion {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -414,15 +414,14 @@ pub fn enforce_no_required_components_recursion(
     if let Some((&requiree, check)) = recursion_check_stack.split_last() {
         if let Some(direct_recursion) = check
             .iter()
-            .rev()
-            .enumerate()
-            .find_map(|(index, &id)| (id == requiree).then_some(index == 0))
+            .position(|&id| id == requiree)
+            .map(|index| index == check.len() - 1)
         {
             panic!(
                 "Recursive required components detected: {}\nhelp: {}",
                 recursion_check_stack
                     .iter()
-                    .map(|id| ShortName(components.get_name(*id).unwrap()))
+                    .map(|id| format!("{}", ShortName(components.get_name(*id).unwrap())))
                     .collect::<Vec<_>>()
                     .join(" → "),
                 if direct_recursion {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2056,7 +2056,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_component_and_his_runtime_required_components() {
+    fn remove_component_and_its_runtime_required_components() {
         #[derive(Component)]
         struct X;
 
@@ -2101,7 +2101,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_component_and_his_required_components() {
+    fn remove_component_and_its_required_components() {
         #[derive(Component)]
         #[require(Y)]
         struct X;
@@ -2553,7 +2553,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Recursive required components detected: bevy_ecs::tests::required_components_recursion_errors::A → bevy_ecs::tests::required_components_recursion_errors::B → bevy_ecs::tests::required_components_recursion_errors::A"]
+    #[should_panic = "Recursive required components detected: bevy_ecs::tests::required_components_recursion_errors::A → bevy_ecs::tests::required_components_recursion_errors::B → bevy_ecs::tests::required_components_recursion_errors::A\nhelp: If this is intentional, consider merging the components."]
     fn required_components_recursion_errors() {
         #[derive(Component, Default)]
         #[require(B)]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2553,15 +2553,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Recursive required components detected: bevy_ecs::tests::required_components_recursion_errors::A → bevy_ecs::tests::required_components_recursion_errors::B → bevy_ecs::tests::required_components_recursion_errors::A\nhelp: If this is intentional, consider merging the components."]
+    #[should_panic = "Recursive required components detected: A → B → C → B\nhelp: If this is intentional, consider merging the components."]
     fn required_components_recursion_errors() {
         #[derive(Component, Default)]
         #[require(B)]
         struct A;
 
         #[derive(Component, Default)]
-        #[require(A)]
+        #[require(C)]
         struct B;
+
+        #[derive(Component, Default)]
+        #[require(B)]
+        struct C;
 
         World::new().register_component::<A>();
     }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2552,6 +2552,20 @@ mod tests {
         assert_eq!(to_vec(required_z), vec![(b, 0), (c, 1)]);
     }
 
+    #[test]
+    #[should_panic = "Recursive required components detected: bevy_ecs::tests::required_components_recursion_errors::A → bevy_ecs::tests::required_components_recursion_errors::B → bevy_ecs::tests::required_components_recursion_errors::A"]
+    fn required_components_recursion_errors() {
+        #[derive(Component, Default)]
+        #[require(B)]
+        struct A;
+
+        #[derive(Component, Default)]
+        #[require(A)]
+        struct B;
+
+        World::new().register_component::<A>();
+    }
+
     // These structs are primarily compilation tests to test the derive macros. Because they are
     // never constructed, we have to manually silence the `dead_code` lint.
     #[allow(dead_code)]


### PR DESCRIPTION
# Objective

Fixes #16645

## Solution

Keep track of components in callstack when registering required components.

## Testing

Added a test checking that the error fires.

---

## Showcase

```rust
#[derive(Component, Default)]
#[require(B)]
struct A;

#[derive(Component, Default)]
#[require(A)]
struct B;
World::new().spawn(A);
```

```
thread 'main' panicked at /home/vj/workspace/rust/bevy/crates/bevy_ecs/src/component.rs:415:13:
Recursive required components detected: A → B → A
```