### PR TITLE
Add missing registration for `TextEntity`

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -118,6 +118,7 @@ impl Plugin for TextPlugin {
             .register_type::<TextBounds>()
             .register_type::<TextLayout>()
             .register_type::<ComputedTextBlock>()
+            .register_type::<TextEntity>()
             .init_asset_loader::<FontLoader>()
             .init_resource::<FontAtlasSets>()
             .init_resource::<TextPipeline>()


### PR DESCRIPTION
# Objective

Fix a [Blenvy](https://github.com/kaosat-dev/Blenvy) crash due to a missing type registration for `TextEntity` (as the type is used by `ComputedTextBlock` but wasn't itself registered.)

## Solution

- Added the missing type registration

## Testing

- N/A