### PR TITLE
Do not attempt to send screenshots to Pixel Eagle without a token

### DIFF
--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -24,7 +24,7 @@ jobs:
     name: Send screenshots to Pixel Eagle
     runs-on: ubuntu-24.04
     steps:
-      - name: Notify user on non-existant token
+      - name: Notify user on non-existent token
         if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'false' }}
         run: |
           echo "The PIXELEAGLE_TOKEN secret does not exist, so uploading screenshots to Pixel Eagle was skipped." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -25,6 +25,10 @@ jobs:
   send-to-pixel-eagle:
     name: Send screenshots to Pixel Eagle
     runs-on: ubuntu-24.04
+    # Pixel Eagle is irrelevant for most forks, even of those that allow workflows to run. Thus, we
+    # disable this job for any forks. Any forks where Pixel Eagle is relevant can comment out the
+    # `if:` conditional below.
+    if: ${{ github.repository == 'bevyengine/bevy' }}
     steps:
       - name: Notify user on non-existent token
         if: ${{ ! fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}

--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -16,18 +16,27 @@ on:
         required: true
         type: string
 
+env:
+  PIXELEAGLE_TOKEN_EXISTS: ${{ secrets.PIXELEAGLE_TOKEN != '' }}
+
 jobs:
   send-to-pixel-eagle:
     name: Send screenshots to Pixel Eagle
     runs-on: ubuntu-24.04
     steps:
+      - name: Notify user on non-existant token
+        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'false' }}
+        run: |
+          echo "The PIXELEAGLE_TOKEN secret does not exist, so uploading screenshots to Pixel Eagle was skipped." >> $GITHUB_STEP_SUMMARY
       
       - name: Download artifact
+        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS != 'false' }}
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ inputs.artifact }}
       
       - name: Send to Pixel Eagle
+        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS != 'false' }}
         env:
           project: B04F67C0-C054-4A6F-92EC-F599FEC2FD1D
         run: |

--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -27,18 +27,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Notify user on non-existent token
-        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'false' }}
+        if: ${{ ! fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}
         run: |
           echo "The PIXELEAGLE_TOKEN secret does not exist, so uploading screenshots to Pixel Eagle was skipped." >> $GITHUB_STEP_SUMMARY
       
       - name: Download artifact
-        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'true' }}
+        if: ${{ fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ inputs.artifact }}
       
       - name: Send to Pixel Eagle
-        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'true' }}
+        if: ${{ fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}
         env:
           project: B04F67C0-C054-4A6F-92EC-F599FEC2FD1D
         run: |

--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -32,13 +32,13 @@ jobs:
           echo "The PIXELEAGLE_TOKEN secret does not exist, so uploading screenshots to Pixel Eagle was skipped." >> $GITHUB_STEP_SUMMARY
       
       - name: Download artifact
-        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS != 'false' }}
+        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'true' }}
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ inputs.artifact }}
       
       - name: Send to Pixel Eagle
-        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS != 'false' }}
+        if: ${{ env.PIXELEAGLE_TOKEN_EXISTS == 'true' }}
         env:
           project: B04F67C0-C054-4A6F-92EC-F599FEC2FD1D
         run: |

--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -17,6 +17,8 @@ on:
         type: string
 
 env:
+  # Unfortunately, we can't check secrets in `if:` conditionals. However, Github's own documentation
+  # suggests a workaround: Putting the secret in an environment variable, and checking that instead.
   PIXELEAGLE_TOKEN_EXISTS: ${{ secrets.PIXELEAGLE_TOKEN != '' }}
 
 jobs:


### PR DESCRIPTION
# Objective
Running Github Actions on forks helps users to reduce the amount of CI errors they get before submitting a PR. However, due to how workflows are set up on the Bevy repository, this can result in errors occurring for jobs that may not be related to their PR - in this case, uploading screenshots to Pixel Eagle.

## Solution
The Pixel Eagle workflow is skipped if we aren't running on the Bevy repository.

If we are on the Bevy repository, or the user has set it to run elsewhere, we check if the `PIXELEAGLE_TOKEN` secret is set. If it isn't, we skip uploading screenshots to Pixel Eagle.

* Artifacts still continue to generate, in case the user needs them.
* In the event that the Pixel Eagle workflow runs, but the `PIXELEAGLE_TOKEN` secret isn't set, we generate a step summary that notifies the user of why it was skipped. https://github.com/LikeLakers2/bevy/actions/runs/12173329006/attempts/1#summary-33953502068 for an example.

## Testing
Lots. And lots. Of trying to get Github Actions to work with me.