### PR TITLE
picking: disable raycast backface culling for Mesh2d

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -274,9 +274,9 @@ impl<'w, 's> MeshRayCast<'w, 's> {
                     return;
                 };
 
-                let backfaces = match has_backfaces {
-                    true => Backfaces::Include,
-                    false => Backfaces::Cull,
+                let backfaces = match (has_backfaces, mesh2d.is_some()) {
+                    (false, false) => Backfaces::Cull,
+                    _ => Backfaces::Include,
                 };
 
                 // Perform the actual ray cast.

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -274,6 +274,7 @@ impl<'w, 's> MeshRayCast<'w, 's> {
                     return;
                 };
 
+                // Backfaces of 2d meshes are never culled, unlike 3d mehses.
                 let backfaces = match (has_backfaces, mesh2d.is_some()) {
                     (false, false) => Backfaces::Cull,
                     _ => Backfaces::Include,


### PR DESCRIPTION
# Objective

- This fixes raycast picking with lyon
- reverse winding of 2D meshes currently results in them being rendered but not pickable as the raycast passes through the backface and would only hit "from below" 

## Solution

- Disables backface culling for Mesh2d

## Testing

- Tested picking with bevy_prototype_lyon
- Could probably use testing with Mesh3d (should not be affected) and SimplifiedMesh (no experience with that, could have the same issue if used for 2D?)
