### PR TITLE
Improve child_builder add_child documentation slightly

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -386,7 +386,7 @@ pub trait BuildChildren {
     /// Adds a single child.
     ///
     /// If the child was previously the child of another parent, that parent's [`Children`] component
-    /// will have that child removed from its list. Removing all children from a parent causes its
+    /// will have the child removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
     ///
     /// # Panics

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -385,8 +385,8 @@ pub trait BuildChildren {
 
     /// Adds a single child.
     ///
-    /// If the children were previously children of another parent, that parent's [`Children`] component
-    /// will have those children removed from its list. Removing all children from a parent causes its
+    /// If the child was previously the child of another parent, that parent's [`Children`] component
+    /// will have that child removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
     ///
     /// # Panics


### PR DESCRIPTION
A small documentation improvement. The description was copied from insert_children. I changed the documentation to be singular instead of plural when referring to the child in add_child.

# Objective

- The description was copied from insert_children and still refers to the child being added as plural children

## Solution

- Description now has child in singular form.

## Testing

- N/A