### PR TITLE
bevy_input_focus improvements (follow-up PR)

### DIFF
--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["bevy", "color"]
 rust-version = "1.76.0"
 
 [dependencies]
-bevy_a11y = { path = "../bevy_a11y", version = "0.15.0-dev", default-features = false }
 bevy_app = { path = "../bevy_app", version = "0.15.0-dev", default-features = false }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev", default-features = false }
 bevy_input = { path = "../bevy_input", version = "0.15.0-dev", default-features = false }

--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bevy", "color"]
 rust-version = "1.76.0"
 
 [dependencies]
+bevy_a11y = { path = "../bevy_a11y", version = "0.15.0-dev", default-features = false }
 bevy_app = { path = "../bevy_app", version = "0.15.0-dev", default-features = false }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev", default-features = false }
 bevy_input = { path = "../bevy_input", version = "0.15.0-dev", default-features = false }

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -16,14 +16,13 @@
 //! This crate does *not* provide any integration with UI widgets, or provide functions for
 //! tab navigation or gamepad-based focus navigation, as those are typically application-specific.
 
-use bevy_a11y::Focus;
-use bevy_app::{App, Plugin, PostUpdate, Update};
+use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
     event::{Event, EventReader},
     query::With,
-    system::{Commands, Query, Res, ResMut, Resource},
+    system::{Commands, Query, Res, Resource},
     world::{Command, DeferredWorld, World},
 };
 use bevy_hierarchy::Parent;
@@ -109,8 +108,7 @@ impl Plugin for InputDispatchPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(InputFocus(None))
             .insert_resource(InputFocusVisible(false))
-            .add_systems(Update, dispatch_keyboard_input)
-            .add_systems(PostUpdate, sync_a11y_focus);
+            .add_systems(Update, dispatch_keyboard_input);
     }
 }
 
@@ -135,13 +133,6 @@ fn dispatch_keyboard_input(
                 commands.trigger_targets(FocusKeyboardInput(ev.clone()), window);
             }
         }
-    }
-}
-
-/// System which synchronizes the a11y focus state with the input focus state.
-fn sync_a11y_focus(focus: Res<InputFocus>, mut a11y_focus: ResMut<Focus>) {
-    if a11y_focus.0 != focus.0 {
-        a11y_focus.0 = focus.0;
     }
 }
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -268,6 +268,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev" }
 bevy_state = { path = "../bevy_state", optional = true, version = "0.15.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.15.0-dev" }
+bevy_input_focus = { path = "../bevy_input_focus", version = "0.15.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.15.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.15.0-dev" }

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -41,6 +41,7 @@ pub use bevy_hierarchy as hierarchy;
 #[cfg(feature = "bevy_image")]
 pub use bevy_image as image;
 pub use bevy_input as input;
+pub use bevy_input_focus as input_focus;
 pub use bevy_log as log;
 pub use bevy_math as math;
 #[cfg(feature = "bevy_pbr")]


### PR DESCRIPTION
This adds a few minor items which were left out of the previous PR:

- Added synchronization from bevy_input_focus to bevy_a11y.
- Initialize InputFocusVisible resource.
- Make `input_focus` available from `bevy` module.

I've tested this using VoiceOver on Mac OS. It works, but it needs considerable polish.