### PR TITLE
fix tiny copy-paste mistake in `bevy_text::font_atlas_set`

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -200,11 +200,12 @@ impl FontAtlasSet {
             })
     }
 
-    /// Returns the number of font atlases in this set
+    /// Returns the number of font atlases in this set.
     pub fn len(&self) -> usize {
         self.font_atlases.len()
     }
-    /// Returns the number of font atlases in this set
+
+    /// Returns `true` if the set has no font atlases.
     pub fn is_empty(&self) -> bool {
         self.font_atlases.len() == 0
     }


### PR DESCRIPTION
This fixes a minor copy-paste mistake in the `FontAtlasSet::is_empty` method's documentation.

# Objective

- Correct the documentation for that method.

## Solution

- Remove the copy + paste'd docs from `FontAtlasSet::is_empty` and add something similar to `alloc::collections::btree_set::BTreeSet::is_empty`.

## Testing

- No testable changes were made. However, the two tests in the `bevy_text` module still pass.