### PR TITLE
Skip all jobs on the `Weekly beta compile test` workflow when running on a fork

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,12 +10,29 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# The jobs listed here are intentionally skipped when running on forks, for a number of reasons:
+#
+# * Scheduled workflows run on the base/default branch, with no way (currently) to change this. On
+#   forks, the base/default branch is usually kept in sync with the main Bevy repository, meaning
+#   that running this workflow on forks would just be a waste of resources.
+#
+# * Even if there was a way to change the branch that a scheduled workflow runs on, forks default
+#   to not having an issue tracker.
+#
+# * Even in the event that a fork's issue tracker is enabled, most users probably don't want to
+#   receive automated issues in the event of a compilation failure.
+#
+# Because of these reasons, this workflow is irrelevant for 99% of forks. Thus, the jobs here will
+# be skipped when running on any repository that isn't the main Bevy repository.
+
 jobs:
   test:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Disable this job when running on a fork.
+    if: github.repository == 'bevyengine/bevy'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +48,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'bevyengine/bevy'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +67,8 @@ jobs:
 
   check-compiles:
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'bevyengine/bevy'
     timeout-minutes: 30
     needs: test
     steps:
@@ -65,8 +86,9 @@ jobs:
     needs: [test, lint, check-compiles]
     permissions:
       issues: write
+    # We disable this job on forks, because 
     # Use always() so the job doesn't get canceled if any other jobs fail
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ github.repository == 'bevyengine/bevy' && always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Create issue
         run: |


### PR DESCRIPTION
# Objective
The weekly beta compile test workflow can be useful to people who have forked the repository.

However, there are a few small issues with how this workflow is currently set up:
* Scheduled workflows run on the base/default branch, with no way (currently) to change this. On forks, the base/default branch is usually kept in sync with the main Bevy repository, meaning that running this workflow on forks would just be a waste of resources. (See [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule) - "Scheduled workflows will only run on the default branch.")
* Even if there was a way to change the branch that a scheduled workflow runs on, forks default to not having an issue tracker.
* Even in the event that a fork's issue tracker is enabled, most users probably don't want to receive automated issues in the event of a compilation failure.

Because of these reasons, this workflow is irrelevant for 99% of forks.

## Solution
We now skip all jobs on the `Weekly beta compile test` workflow, if we detect we're running this workflow on a fork.

## Testing
Testing? Who needs testing? (Seriously though, I made sure the syntax is correct.)