### PR TITLE
add missing type registration for `Monitor`

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -164,7 +164,8 @@ impl Plugin for WindowPlugin {
             .register_type::<FileDragAndDrop>()
             .register_type::<WindowMoved>()
             .register_type::<WindowThemeChanged>()
-            .register_type::<AppLifecycle>();
+            .register_type::<AppLifecycle>()
+            .register_type::<Monitor>();
 
         // Register window descriptor and related types
         app.register_type::<Window>()


### PR DESCRIPTION
# Objective

![image](https://github.com/user-attachments/assets/4b8d6a2c-86ed-4353-8133-0e0efdb3a697)
make `Monitor` reflectable by default

## Solution

- register type
