### PR TITLE
Link to required components docs in component type docs

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -174,11 +174,11 @@ pub fn document_required_components(attr: TokenStream, item: TokenStream) -> Tok
         .collect::<Vec<_>>()
         .join(", ");
 
-    let bevy_ecs_path: Path = crate::bevy_ecs_path();
-    let required_components_path = format!(
-        "{}::component::Component#required-components",
-        bevy_ecs_path.to_token_stream()
-    );
+    let bevy_ecs_path = crate::bevy_ecs_path()
+        .to_token_stream()
+        .to_string()
+        .replace(' ', "");
+    let required_components_path = bevy_ecs_path + "::component::Component#required-components";
 
     // Insert information about required components after any existing doc comments
     let mut out = TokenStream::new();

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -174,13 +174,19 @@ pub fn document_required_components(attr: TokenStream, item: TokenStream) -> Tok
         .collect::<Vec<_>>()
         .join(", ");
 
+    let bevy_ecs_path: Path = crate::bevy_ecs_path();
+    let required_components_path = format!(
+        "{}::component::Component#required-components",
+        bevy_ecs_path.to_token_stream()
+    );
+
     // Insert information about required components after any existing doc comments
     let mut out = TokenStream::new();
     let mut end_of_attributes_reached = false;
     for tt in item {
         if !end_of_attributes_reached & matches!(tt, TokenTree::Ident(_)) {
             end_of_attributes_reached = true;
-            let doc: TokenStream = format!("#[doc = \"\n\n# Required Components\n{paths} \n\n A component's required components are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively, in depth-first order.\"]").parse().unwrap();
+            let doc: TokenStream = format!("#[doc = \"\n\n# Required Components\n{paths} \n\n A component's [required components]({required_components_path}) are inserted whenever it is inserted. Note that this will also insert the required components _of_ the required components, recursively, in depth-first order.\"]").parse().unwrap();
             out.extend(doc);
         }
         out.extend(Some(tt));


### PR DESCRIPTION
# Objective

#16575 moved required component docs from the `Component` impl to type docs.

However, it doesn't actually link to what [required components](https://docs.rs/bevy/0.15.0/bevy/ecs/component/trait.Component.html#required-components) are and how they work.

## Solution

Link to [required components](https://docs.rs/bevy/0.15.0/bevy/ecs/component/trait.Component.html#required-components)!

## Testing

I tested the link for some components in different Bevy crates. I did not test in external third party crates, but I would assume that it should work there too.

---

## Showcase

![Link to required components](https://github.com/user-attachments/assets/888837dd-29a1-4092-be20-c7c6f0910174)

Note: The tooltip doesn't show the `#required-components` anchor for some reason, but it is there.