### PR TITLE
Rename `EntityCommands::clone` to `clone_and_spawn`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1720,9 +1720,11 @@ impl<'a> EntityCommands<'a> {
 
     /// Clones an entity and returns the [`EntityCommands`] of the clone.
     ///
-    /// The clone will have all the components of the original entity that
-    /// can be cloned. A component must implement either `Clone` or `Reflect`
-    /// to be cloned.
+    /// The clone will receive all the components of the original that implement
+    /// [`Clone`] or [`Reflect`](bevy_reflect::Reflect).
+    ///
+    /// To configure cloning behavior (such as only cloning certain components),
+    /// use [`EntityCommands::clone_and_spawn_with`].
     ///
     /// # Panics
     ///
@@ -1739,23 +1741,26 @@ impl<'a> EntityCommands<'a> {
     /// struct ComponentB(u32);
     ///
     /// fn example_system(mut commands: Commands) {
-    ///     // Create a new entity and keep its EntityCommands.
+    ///     // Create a new entity and keep its EntityCommands
     ///     let mut entity = commands.spawn((ComponentA(10), ComponentB(20)));
     ///
     ///     // Create a clone of the first entity
-    ///     let mut entity_clone = entity.spawn_clone();
+    ///     let mut entity_clone = entity.clone_and_spawn();
     /// }
     /// # bevy_ecs::system::assert_is_system(example_system);
-    pub fn spawn_clone(&mut self) -> EntityCommands<'_> {
-        self.spawn_clone_with(|_| {})
+    pub fn clone_and_spawn(&mut self) -> EntityCommands<'_> {
+        self.clone_and_spawn_with(|_| {})
     }
 
     /// Clones an entity and allows configuring cloning behavior using [`EntityCloneBuilder`],
     /// returning the [`EntityCommands`] of the clone.
     ///
-    /// The clone will have all the components of the original entity that
-    /// can be cloned. A component must implement either `Clone` or `Reflect`
-    /// to be cloned.
+    /// By default, the clone will receive all the components of the original that implement
+    /// [`Clone`] or [`Reflect`](bevy_reflect::Reflect).
+    ///
+    /// To exclude specific components, use [`EntityCloneBuilder::deny`].
+    /// To only include specific components, use [`EntityCloneBuilder::deny_all`]
+    /// followed by [`EntityCloneBuilder::allow`].
     ///
     /// # Panics
     ///
@@ -1772,21 +1777,21 @@ impl<'a> EntityCommands<'a> {
     /// struct ComponentB(u32);
     ///
     /// fn example_system(mut commands: Commands) {
-    ///     // Create a new entity and keep its EntityCommands.
+    ///     // Create a new entity and keep its EntityCommands
     ///     let mut entity = commands.spawn((ComponentA(10), ComponentB(20)));
     ///
     ///     // Create a clone of the first entity, but without ComponentB
-    ///     let mut entity_clone = entity.spawn_clone_with(|builder| {
+    ///     let mut entity_clone = entity.clone_and_spawn_with(|builder| {
     ///         builder.deny::<ComponentB>();
     ///     });
     /// }
     /// # bevy_ecs::system::assert_is_system(example_system);
-    pub fn spawn_clone_with(
+    pub fn clone_and_spawn_with(
         &mut self,
         f: impl FnOnce(&mut EntityCloneBuilder) + Send + Sync + 'static,
     ) -> EntityCommands<'_> {
         let entity_clone = self.commands().spawn_empty().id();
-        self.queue(spawn_clone_with(entity_clone, f));
+        self.queue(clone_and_spawn_with(entity_clone, f));
         EntityCommands {
             commands: self.commands_mut().reborrow(),
             entity: entity_clone,
@@ -2266,7 +2271,7 @@ fn observe<E: Event, B: Bundle, M>(
     }
 }
 
-fn spawn_clone_with(
+fn clone_and_spawn_with(
     entity_clone: Entity,
     f: impl FnOnce(&mut EntityCloneBuilder) + Send + Sync + 'static,
 ) -> impl EntityCommand {

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -444,7 +444,7 @@ mod tests {
                 .id();
             let e_clone = commands
                 .entity(e)
-                .clone_with(|builder| {
+                .spawn_clone_with(|builder| {
                     builder.recursive(true);
                 })
                 .id();
@@ -483,7 +483,7 @@ mod tests {
 
         let child_clone = commands
             .entity(child)
-            .clone_with(|builder| {
+            .spawn_clone_with(|builder| {
                 builder.as_child(true);
             })
             .id();

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -444,7 +444,7 @@ mod tests {
                 .id();
             let e_clone = commands
                 .entity(e)
-                .spawn_clone_with(|builder| {
+                .clone_and_spawn_with(|builder| {
                     builder.recursive(true);
                 })
                 .id();
@@ -483,7 +483,7 @@ mod tests {
 
         let child_clone = commands
             .entity(child)
-            .spawn_clone_with(|builder| {
+            .clone_and_spawn_with(|builder| {
                 builder.as_child(true);
             })
             .id();


### PR DESCRIPTION
## Objective

Follow-up to #16672.

`EntityCommands::clone` looks the same as the `Clone` trait, which could be confusing. A discord discussion has made me realize that's probably a bigger problem than I thought. Oops :P

## Solution

Renamed `EntityCommands::clone` to `EntityCommands::clone_and_spawn`, renamed `EntityCommands::clone_with` to `EntityCommands::clone_and_spawn_with`. Also added some docs explaining the commands' relation to `Clone` (components need to implement it (or `Reflect`)).

## Showcase

```
// Create a new entity and keep its EntityCommands
let mut entity = commands.spawn((ComponentA(10), ComponentB(20)));

// Create a clone of the first entity
let mut entity_clone = entity.clone_and_spawn();
```

## The Bikeshed

- `clone_and_spawn` (Alice's suggestion)
- `spawn_clone` (benfrankel's suggestion)
- `spawn_cloned` (rparrett's suggestion)