### PR TITLE
Rename `RayCastSettings` to `MeshRayCastSettings`

### DIFF
--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -172,7 +172,7 @@ pub mod prelude {
     #[cfg(feature = "bevy_mesh_picking_backend")]
     #[doc(hidden)]
     pub use crate::mesh_picking::{
-        ray_cast::{MeshRayCast, RayCastBackfaces, RayCastSettings, RayCastVisibility},
+        ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastBackfaces, RayCastVisibility},
         MeshPickingPlugin, MeshPickingSettings, RayCastPickable,
     };
     #[doc(hidden)]

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -19,7 +19,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
 use bevy_render::{prelude::*, view::RenderLayers};
-use ray_cast::{MeshRayCast, RayCastSettings, RayCastVisibility, SimplifiedMesh};
+use ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastVisibility, SimplifiedMesh};
 
 /// Runtime settings for the [`MeshPickingPlugin`].
 #[derive(Resource, Reflect)]
@@ -89,7 +89,7 @@ pub fn update_hits(
 
         let cam_layers = cam_layers.to_owned().unwrap_or_default();
 
-        let settings = RayCastSettings {
+        let settings = MeshRayCastSettings {
             visibility: backend_settings.ray_cast_visibility,
             filter: &|entity| {
                 let marker_requirement =

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -34,7 +34,7 @@ pub enum RayCastVisibility {
 
 /// Settings for a ray cast.
 #[derive(Clone)]
-pub struct RayCastSettings<'a> {
+pub struct MeshRayCastSettings<'a> {
     /// Determines how ray casting should consider [`Visibility`].
     pub visibility: RayCastVisibility,
     /// A predicate that is applied for every entity that ray casts are performed against.
@@ -45,7 +45,7 @@ pub struct RayCastSettings<'a> {
     pub early_exit_test: &'a dyn Fn(Entity) -> bool,
 }
 
-impl<'a> RayCastSettings<'a> {
+impl<'a> MeshRayCastSettings<'a> {
     /// Set the filter to apply to the ray cast.
     pub fn with_filter(mut self, filter: &'a impl Fn(Entity) -> bool) -> Self {
         self.filter = filter;
@@ -75,7 +75,7 @@ impl<'a> RayCastSettings<'a> {
     }
 }
 
-impl<'a> Default for RayCastSettings<'a> {
+impl<'a> Default for MeshRayCastSettings<'a> {
     fn default() -> Self {
         Self {
             visibility: RayCastVisibility::VisibleInView,
@@ -128,13 +128,13 @@ type MeshFilter = Or<(With<Mesh3d>, With<Mesh2d>, With<SimplifiedMesh>)>;
 /// # use bevy_picking::prelude::*;
 /// fn ray_cast_system(mut ray_cast: MeshRayCast) {
 ///     let ray = Ray3d::new(Vec3::ZERO, Dir3::X);
-///     let hits = ray_cast.cast_ray(ray, &RayCastSettings::default());
+///     let hits = ray_cast.cast_ray(ray, &MeshRayCastSettings::default());
 /// }
 /// ```
 ///
 /// ## Configuration
 ///
-/// You can specify the behavior of the ray cast using [`RayCastSettings`]. This allows you to filter out
+/// You can specify the behavior of the ray cast using [`MeshRayCastSettings`]. This allows you to filter out
 /// entities, configure early-out behavior, and set whether the [`Visibility`] of an entity should be
 /// considered.
 ///
@@ -156,7 +156,7 @@ type MeshFilter = Or<(With<Mesh3d>, With<Mesh2d>, With<SimplifiedMesh>)>;
 ///     // Ignore the visibility of entities. This allows ray casting hidden entities.
 ///     let visibility = RayCastVisibility::Any;
 ///
-///     let settings = RayCastSettings::default()
+///     let settings = MeshRayCastSettings::default()
 ///         .with_filter(&filter)
 ///         .with_early_exit_test(&early_exit_test)
 ///         .with_visibility(visibility);
@@ -205,7 +205,11 @@ pub struct MeshRayCast<'w, 's> {
 
 impl<'w, 's> MeshRayCast<'w, 's> {
     /// Casts the `ray` into the world and returns a sorted list of intersections, nearest first.
-    pub fn cast_ray(&mut self, ray: Ray3d, settings: &RayCastSettings) -> &[(Entity, RayMeshHit)] {
+    pub fn cast_ray(
+        &mut self,
+        ray: Ray3d,
+        settings: &MeshRayCastSettings,
+    ) -> &[(Entity, RayMeshHit)] {
         let ray_cull = info_span!("ray culling");
         let ray_cull_guard = ray_cull.enter();
 

--- a/examples/3d/mesh_ray_cast.rs
+++ b/examples/3d/mesh_ray_cast.rs
@@ -51,7 +51,10 @@ fn bounce_ray(mut ray: Ray3d, ray_cast: &mut MeshRayCast, gizmos: &mut Gizmos, c
 
     for i in 0..MAX_BOUNCES {
         // Cast the ray and get the first hit
-        let Some((_, hit)) = ray_cast.cast_ray(ray, &MeshRayCastSettings::default()).first() else {
+        let Some((_, hit)) = ray_cast
+            .cast_ray(ray, &MeshRayCastSettings::default())
+            .first()
+        else {
             break;
         };
 

--- a/examples/3d/mesh_ray_cast.rs
+++ b/examples/3d/mesh_ray_cast.rs
@@ -51,7 +51,7 @@ fn bounce_ray(mut ray: Ray3d, ray_cast: &mut MeshRayCast, gizmos: &mut Gizmos, c
 
     for i in 0..MAX_BOUNCES {
         // Cast the ray and get the first hit
-        let Some((_, hit)) = ray_cast.cast_ray(ray, &RayCastSettings::default()).first() else {
+        let Some((_, hit)) = ray_cast.cast_ray(ray, &MeshRayCastSettings::default()).first() else {
             break;
         };
 


### PR DESCRIPTION
# Objective

The `RayCastSettings` type is only used in the context of ray casts with the `MeshRayCast` system parameter. The current name is somewhat inconsistent with other existing types, like `MeshRayCast` and `MeshPickingSettings`, but more importantly, it easily conflicts with physics, and forces those crates to opt for some other name like `RayCastConfig` or `RayCastOptions`.

We should rename `RayCastSettings` to `MeshRayCastSettings` to avoid naming conflicts and improve consistency.

## Solution

Rename `RayCastSettings` to `MeshRayCastSettings`.

---

## Migration Guide

`RayCastSettings` has been renamed to `MeshRayCastSettings` to avoid naming conflicts with other ray casting backends and types.