### PR TITLE
Remove COPY_DST from AsBindGroup uniform buffers

### DIFF
--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -482,7 +482,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                         #render_path::render_resource::OwnedBindingResource::Buffer(render_device.create_buffer_with_data(
                             &#render_path::render_resource::BufferInitDescriptor {
                                 label: None,
-                                usage: #render_path::render_resource::BufferUsages::COPY_DST | #uniform_buffer_usages,
+                                usage: #uniform_buffer_usages,
                                 contents: buffer.as_ref(),
                             },
                         ))
@@ -528,7 +528,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                         #render_path::render_resource::OwnedBindingResource::Buffer(render_device.create_buffer_with_data(
                             &#render_path::render_resource::BufferInitDescriptor {
                                 label: None,
-                                usage: #render_path::render_resource::BufferUsages::COPY_DST | #uniform_buffer_usages,
+                                usage: #uniform_buffer_usages,
                                 contents: buffer.as_ref(),
                             },
                         ))


### PR DESCRIPTION
# Objective
- Wgpu barrier tracking is expensive. Making buffers read-only makes ideally lets wgpu skip worrying about barriers, although in wgpu 23 it apparently won't yet.

## Solution
- Remove COPY_DST usage from AsBindGroup uniform buffers to allow future wgpu versions to make this cheaper.
- AsBindGroup never updates buffers, so there's no need for COPY_DST. We always recreate all buffers and the bind group every time data changes, which yeah is also expensive.

## Testing
- Ran the animated materials example with/without bindless enabled. No crashes.