### PR TITLE
Making sure each plugin indicates its default group and feature when …

### DIFF
--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -108,7 +108,8 @@ pub enum AccessibilitySystem {
     /// Update the accessibility tree
     Update,
 }
-
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_window` feature is enabled.
+///
 /// Plugin managing non-GUI aspects of integrating with accessibility APIs.
 #[derive(Default)]
 pub struct AccessibilityPlugin;

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1233,6 +1233,8 @@ pub fn animate_targets(
         });
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_animation` feature is enabled.
+///
 /// Adds animation support to an app
 #[derive(Default)]
 pub struct AnimationPlugin;

--- a/crates/bevy_app/src/panic_handler.rs
+++ b/crates/bevy_app/src/panic_handler.rs
@@ -8,7 +8,9 @@
 
 use crate::{App, Plugin};
 
-/// Adds sensible panic handlers to Apps. This plugin is part of the `DefaultPlugins`. Adding
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
+/// Adds sensible panic handlers to Apps. Adding
 /// this plugin will setup a panic hook appropriate to your target platform:
 /// * On Wasm, uses [`console_error_panic_hook`](https://crates.io/crates/console_error_panic_hook), logging
 ///     to the browser console.

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -135,11 +135,20 @@ macro_rules! plugin_group {
         $(#[doc = concat!(
             " - [`", stringify!($plugin_name), "`](" $(, stringify!($plugin_path), "::")*, stringify!($plugin_name), ")"
             $(, " - with feature `", $plugin_feature, "`")?
+            $(, " - `", stringify!($plugin_meta), "`")*
         )])*
        $($(#[doc = concat!(
             " - [`", stringify!($plugin_group_name), "`](" $(, stringify!($plugin_group_path), "::")*, stringify!($plugin_group_name), ")"
             $(, " - with feature `", $plugin_group_feature, "`")?
-        )]),+)?
+            $(, " - `", stringify!($plugin_group_meta), "`")*
+        )])+)?
+        $($(
+            #[doc = concat!(
+                " - [`", stringify!($hidden_plugin_name), "`](" $(, stringify!($hidden_plugin_path), "::")*, stringify!($hidden_plugin_name), ")"
+                $(, " - with feature `", $hidden_plugin_feature, "`")?
+                $(, " - ", stringify!($hidden_plugin_meta))*
+            )]
+        )+)?
         $(
             ///
             $(#[doc = $post_doc])+

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -32,12 +32,11 @@ impl Default for RunMode {
         RunMode::Loop { wait: None }
     }
 }
-
+/// - Is part of the [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_window` feature is **not** enabled.
+///
 /// Configures an [`App`] to run its [`Schedule`](bevy_ecs::schedule::Schedule) according to a given
 /// [`RunMode`].
-///
-/// [`ScheduleRunnerPlugin`] is included in the
-/// [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
 ///
 /// [`ScheduleRunnerPlugin`] is *not* included in the
 /// [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group

--- a/crates/bevy_app/src/terminal_ctrl_c_handler.rs
+++ b/crates/bevy_app/src/terminal_ctrl_c_handler.rs
@@ -9,6 +9,8 @@ pub use ctrlc;
 /// Indicates that all [`App`]'s should exit.
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `wasm32` is not the target.
+///
 /// Gracefully handles `Ctrl+C` by emitting a [`AppExit`] event. This plugin is part of the `DefaultPlugins`.
 ///
 /// ```no_run

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -221,6 +221,8 @@ compile_error!(
     Consider either disabling the \"file_watcher\" feature or enabling \"multi_threaded\""
 );
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_asset` feature is enabled.
+///
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],
 /// which can be something like a filesystem, a network, etc.
 ///

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -66,6 +66,8 @@ use audio_output::*;
 #[derive(SystemSet, Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 struct AudioPlaySet;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_audio` feature is enabled.
+///
 /// Adds support for audio playback to a Bevy Application
 ///
 /// Insert an [`AudioPlayer`] onto your entities to play audio.

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -35,7 +35,9 @@ use core::marker::PhantomData;
 
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
-
+/// - Is part of the [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Registration of default types to the [`TypeRegistry`](bevy_reflect::TypeRegistry) resource.
 #[derive(Default)]
 pub struct TypeRegistrationPlugin;
@@ -47,7 +49,9 @@ impl Plugin for TypeRegistrationPlugin {
         app.register_type::<Name>();
     }
 }
-
+/// - Is part of the [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Setup of default task pools: [`AsyncComputeTaskPool`](bevy_tasks::AsyncComputeTaskPool),
 /// [`ComputeTaskPool`](bevy_tasks::ComputeTaskPool), [`IoTaskPool`](bevy_tasks::IoTaskPool).
 #[derive(Default)]
@@ -90,6 +94,9 @@ fn tick_global_task_pools(_main_thread_marker: Option<NonSend<NonSendMarker>>) {
 #[derive(Debug, Default, Resource, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FrameCount(pub u32);
 
+/// - Is part of the [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Adds frame counting functionality to Apps.
 #[derive(Default)]
 pub struct FrameCountPlugin;

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -43,6 +43,8 @@ pub mod experimental {
     }
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_core_pipeline` feature is enabled.
+///
 /// The core pipeline prelude.
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.

--- a/crates/bevy_dev_tools/src/ci_testing/mod.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/mod.rs
@@ -11,14 +11,16 @@ use bevy_render::view::screenshot::trigger_screenshots;
 use bevy_time::TimeUpdateStrategy;
 use core::time::Duration;
 
+/// When the `bevy_ci_testing` feature is enabled:
+/// - Is part of the [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// A plugin that instruments continuous integration testing by automatically executing user-defined actions.
 ///
 /// This plugin reads a [`ron`] file specified with the `CI_TESTING_CONFIG` environmental variable
 /// (`ci_testing_config.ron` by default) and executes its specified actions. For a reference of the
 /// allowed configuration, see [`CiTestingConfig`].
 ///
-/// This plugin is included within `DefaultPlugins` and `MinimalPlugins`
-/// when the `bevy_ci_testing` feature is enabled.
 /// It is recommended to only used this plugin during testing (manual or
 /// automatic), and disable it during regular development and for production builds.
 #[derive(Default)]

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -20,6 +20,8 @@ pub mod ui_debug_overlay;
 
 pub mod states;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_dev_tools` feature is enabled.
+///
 /// Enables developer tools in an [`App`]. This plugin is added automatically with `bevy_dev_tools`
 /// feature.
 ///

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -30,6 +30,8 @@ pub use system_information_diagnostics_plugin::{SystemInfo, SystemInformationDia
 
 use bevy_app::prelude::*;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Adds core diagnostics resources to an App.
 #[derive(Default)]
 pub struct DiagnosticsPlugin;

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -47,6 +47,8 @@ impl GilrsGamepads {
     }
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_gilrs` feature is enabled.
+///
 /// Plugin that provides gamepad handling to an [`App`].
 #[derive(Default)]
 pub struct GilrsPlugin;

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -141,6 +141,8 @@ const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(74148126892380
 #[cfg(feature = "bevy_render")]
 const LINE_JOINT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(1162780797909187908);
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_gizmo` feature is enabled.
+///
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
 ///
 /// Requires to be loaded after [`PbrPlugin`](bevy_pbr::PbrPlugin) or [`SpritePlugin`](bevy_sprite::SpritePlugin).

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -120,6 +120,8 @@ pub mod prelude {
     pub use crate::{Gltf, GltfAssetLabel, GltfExtras};
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_gltf` feature is enabled.
+///
 /// Adds support for glTF file loading to the app.
 #[derive(Default)]
 pub struct GltfPlugin {

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -86,6 +86,8 @@ pub mod prelude {
 #[cfg(feature = "bevy_app")]
 use bevy_app::prelude::*;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Provides hierarchy functionality to a Bevy app.
 ///
 /// Check the [crate-level documentation] for all the features.

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -64,6 +64,8 @@ use gamepad::{
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Adds keyboard and mouse input to an App
 #[derive(Default)]
 pub struct InputPlugin;

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -76,7 +76,9 @@ use {
 #[derive(Resource)]
 pub(crate) struct FlushGuard(SyncCell<tracing_chrome::FlushGuard>);
 
-/// Adds logging to Apps. This plugin is part of the `DefaultPlugins`. Adding
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
+/// Adds logging to Apps. Adding
 /// this plugin will setup a collector appropriate to your target platform:
 /// * Using [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber) by default,
 ///     logging to `stdout`.

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -167,6 +167,8 @@ const MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE: Handle<Shader> =
 const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 23;
 const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 24;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_pbr` feature is enabled.
+///
 /// Sets up the entire PBR infrastructure of bevy.
 pub struct PbrPlugin {
     /// Controls if the prepass is enabled for the [`StandardMaterial`].

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -267,6 +267,8 @@ pub enum PickSet {
     Last,
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_picking` feature is enabled.
+///
 /// One plugin that contains the [`PointerInputPlugin`](input::PointerInputPlugin), [`PickingPlugin`]
 /// and the [`InteractionPlugin`], this is probably the plugin that will be most used.
 ///

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -101,6 +101,8 @@ use bevy_utils::tracing::debug;
 use core::ops::{Deref, DerefMut};
 use std::sync::Mutex;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_render` feature is enabled.
+///
 /// Contains the default Bevy rendering backend based on wgpu.
 ///
 /// Rendering is done in a [`SubApp`], which exchanges data with the main app

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -65,6 +65,8 @@ impl Drop for RenderAppChannels {
     }
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_render` & `multi_threaded` features are enabled and target is not `wasm32`.
+///
 /// The [`PipelinedRenderingPlugin`] can be added to your application to enable pipelined rendering.
 ///
 /// This moves rendering into a different thread, so that the Nth frame's rendering can

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -21,6 +21,8 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{AssetApp, Assets, Handle};
 use bevy_ecs::prelude::*;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_render` feature is enabled.
+///
 /// A handle to a 1 x 1 transparent white image.
 ///
 /// Like [`Handle<Image>::default`], this is a handle to a fallback image asset.

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -53,6 +53,8 @@ pub mod prelude {
 use bevy_app::prelude::*;
 use bevy_asset::AssetApp;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_scene` feature is enabled.
+///
 /// Plugin that provides scene functionality to an [`App`].
 #[derive(Default)]
 pub struct ScenePlugin;

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -64,6 +64,8 @@ use bevy_render::{
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_sprite` feature is enabled.
+///
 /// Adds support for 2D sprite rendering.
 pub struct SpritePlugin {
     /// Whether to add the sprite picking backend to the app.

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -297,6 +297,8 @@ impl AppExtStates for App {
     }
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_state` feature is enabled.
+///
 /// Registers the [`StateTransition`] schedule in the [`MainScheduleOrder`] to enable state processing.
 #[derive(Default)]
 pub struct StatesPlugin;

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -85,6 +85,8 @@ use bevy_sprite::SpriteSystem;
 #[cfg(feature = "default_font")]
 pub const DEFAULT_FONT_DATA: &[u8] = include_bytes!("FiraMono-subset.ttf");
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_text` feature is enabled.
+///
 /// Adds text rendering support to an app.
 ///
 /// When the `bevy_text` feature is enabled with the `bevy` crate, this

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -39,6 +39,9 @@ use bevy_utils::{tracing::warn, Duration, Instant};
 pub use crossbeam_channel::TrySendError;
 use crossbeam_channel::{Receiver, Sender};
 
+/// - Is part of the [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// Adds time functionality to Apps.
 #[derive(Default)]
 pub struct TimePlugin;

--- a/crates/bevy_transform/src/plugins.rs
+++ b/crates/bevy_transform/src/plugins.rs
@@ -13,7 +13,8 @@ pub enum TransformSystem {
     /// Propagates changes in transform to children's [`GlobalTransform`]
     TransformPropagate,
 }
-
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group.
+///
 /// The base plugin for handling [`Transform`] components
 #[derive(Default)]
 pub struct TransformPlugin;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -80,6 +80,8 @@ use stack::ui_stack_system;
 pub use stack::UiStack;
 use update::{update_clipping_system, update_target_camera_system};
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_ui` feature is enabled.
+///
 /// The basic plugin for Bevy UI
 pub struct UiPlugin {
     /// If set to false, the UI's rendering systems won't be added to the `RenderApp` and no UI elements will be drawn.

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -59,6 +59,8 @@ impl Default for WindowPlugin {
     }
 }
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_window` feature is enabled.
+///
 /// A [`Plugin`] that defines an interface for windowing support in Bevy.
 pub struct WindowPlugin {
     /// Settings for the primary window.

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -51,6 +51,8 @@ mod winit_config;
 mod winit_monitors;
 mod winit_windows;
 
+/// - Is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group when `bevy_winit` feature is enabled.
+///
 /// A [`Plugin`] that uses `winit` to create and manage windows, and receive window and input
 /// events.
 ///


### PR DESCRIPTION


# Objective

- Updating `plugin_group!` macro to include the plugin's meta information.
- Making sure each plugin indicates its default group and feature when applicable.

## Solution

- Output additional `cfg` flags when using `plugin_group!`
- For each plugin, add links to the plugin groups associated and necessary conditions. 

## Testing

- Checked that the docs updated accordingly. 
---

