### PR TITLE
box shadows comment fix

### DIFF
--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -262,7 +262,7 @@ pub fn extract_shadows(
             continue;
         };
 
-        // Skip invisible images
+        // Skip if no visable shadows
         if !view_visibility.get() || box_shadow.is_empty() || uinode.is_empty() {
             continue;
         }

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -262,7 +262,7 @@ pub fn extract_shadows(
             continue;
         };
 
-        // Skip if no visable shadows
+        // Skip if no visible shadows
         if !view_visibility.get() || box_shadow.is_empty() || uinode.is_empty() {
             continue;
         }


### PR DESCRIPTION
# Objective

Fix this comment in `extract_shadows`:
```
        // Skip invisible images
```
Should be shadows, not images.