### PR TITLE
Fix crash when component parameters are invalid

### DIFF
--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -923,7 +923,7 @@ fn deserialize_components(
         let reflected: Box<dyn PartialReflect> =
             TypedReflectDeserializer::new(component_type, type_registry)
                 .deserialize(&component)
-                .unwrap();
+                .map_err(|err| anyhow!("{component_path} is invalid: {err}"))?;
         reflect_components.push(reflected);
     }
 


### PR DESCRIPTION
# Objective

Fix the following crash when using BRP to insert a malformed component:

```
thread 'main' panicked at /home/purplg/workspaces/evtc-replay/bevy/crates/bevy_remote/src/builtin_methods.rs:926:18:
called `Result::unwrap()` on an `Err` value: Error("invalid type: map, expected f32", line: 0, column: 0)
```

## Solution

Return an error instead of unwrapping.

## Testing

Tested by sending this malformed payload before and after implementing the fix:

```json
{
    "jsonrpc": "2.0",
    "id": 0,
    "method": "bevy/insert",
    "params": {
        "entity": 4294967307,
        "components": {
            "bevy_transform::components::transform::Transform": {
                "rotation": [
                    0.0,
                    0.0,
                    0.0,
                    1.0
                ],
                "scale": [
                    1.0,
                    1.0,
                    1.0
                ],
                "translation": [
                    {},
                    0.0,
                    0.0
                ]
            }
        }
    }
}
```

After implementing the fix, I receive the following response instead of a crash:

```json
{
    "jsonrpc": "2.0",
    "id": 0,
    "error": {
        "code": -23402,
        "message": "bevy_transform::components::transform::Transform is invalid: invalid type: map, expected f32"
    }
}
```
