### PR TITLE
Support tuple structs in AnimatedField

### DIFF
--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -992,3 +992,21 @@ macro_rules! animated_field {
         })
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_animated_field_tuple_struct_simple_uses() {
+        #[derive(Clone, Debug, Component, Reflect)]
+        struct A(f32);
+        let _ = AnimatedField::new_unchecked("0", |a: &mut A| &mut a.0);
+
+        #[derive(Clone, Debug, Component, Reflect)]
+        struct B(f32, f64, f32);
+        let _ = AnimatedField::new_unchecked("0", |b: &mut B| &mut b.0);
+        let _ = AnimatedField::new_unchecked("1", |b: &mut B| &mut b.1);
+        let _ = AnimatedField::new_unchecked("2", |b: &mut B| &mut b.2);
+    }
+}


### PR DESCRIPTION
# Objective

Partially fixes #16736.

## Solution

`AnimatedField::new_unchecked` now supports tuple struct fields. `animated_field!` is unchanged.

## Testing

Added a test to make sure common and simple uses of `AnimatedField::new_unchecked` with tuple structs don't panic.
