### PR TITLE
Register type `BoxShadow`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -166,6 +166,7 @@ impl Plugin for UiPlugin {
             .register_type::<UiScale>()
             .register_type::<BorderColor>()
             .register_type::<BorderRadius>()
+            .register_type::<BoxShadow>()
             .register_type::<widget::Button>()
             .register_type::<widget::Label>()
             .register_type::<ZIndex>()


### PR DESCRIPTION
# Objective

- Register `BoxShadow` type for reflection

## Testing

- Tested that box shadow example compiles and runs

## Additional

- It would be nice to have this in 0.15.1