### PR TITLE
Ignore the 'instant is unmaintained' advisory.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,10 @@ all-features = true
 
 [advisories]
 version = 2
-ignore = []
+ignore = [
+  # TODO: #16477 - Delete this once notify-types has been bumped.
+  "RUSTSEC-2024-0384",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
# Objective

- Hides #16477.

## Solution

Add the advisory ID to the list of ignored advisories.

The notify-types crate has already been switched to web-time upstream, but it's up to the maintainer to publish the crate. There is nothing for us to do, so better to just ignore it so we don't ignore this CI check anymore (and mistakenly miss new advisories).

## Testing

- Tested locally.
