### PR TITLE
Remove TODO and add docs about limitations of `PlaybackMode::Once`

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -36,6 +36,12 @@ impl Volume {
 #[derive(Debug, Clone, Copy, Reflect)]
 pub enum PlaybackMode {
     /// Play the sound once. Do nothing when it ends.
+    ///
+    /// NOTE: It is not possible to reuse an `AudioPlayer` after it has finished playing and
+    /// the underlying `AudioSink` or `SpatialAudioSink` has been drained.
+    ///
+    /// To replay a sound, the audio components provided by `AudioPlayer` must be removed and
+    /// added again.
     Once,
     /// Repeat the sound forever.
     Loop,
@@ -77,7 +83,6 @@ pub struct PlaybackSettings {
 
 impl Default for PlaybackSettings {
     fn default() -> Self {
-        // TODO: what should the default be: ONCE/DESPAWN/REMOVE?
         Self::ONCE
     }
 }

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -37,7 +37,7 @@ impl Volume {
 pub enum PlaybackMode {
     /// Play the sound once. Do nothing when it ends.
     ///
-    /// NOTE: It is not possible to reuse an `AudioPlayer` after it has finished playing and
+    /// Note: It is not possible to reuse an `AudioPlayer` after it has finished playing and
     /// the underlying `AudioSink` or `SpatialAudioSink` has been drained.
     ///
     /// To replay a sound, the audio components provided by `AudioPlayer` must be removed and
@@ -89,6 +89,12 @@ impl Default for PlaybackSettings {
 
 impl PlaybackSettings {
     /// Will play the associated audio source once.
+    ///
+    /// Note: It is not possible to reuse an `AudioPlayer` after it has finished playing and
+    /// the underlying `AudioSink` or `SpatialAudioSink` has been drained.
+    ///
+    /// To replay a sound, the audio components provided by `AudioPlayer` must be removed and
+    /// added again.
     pub const ONCE: PlaybackSettings = PlaybackSettings {
         mode: PlaybackMode::Once,
         volume: Volume(1.0),


### PR DESCRIPTION
# Objective

Fixes #12359

## Solution

Implement alternative number 4.

https://github.com/bevyengine/bevy/issues/12359#issuecomment-2536422301
> I don't think that I agree with the premise of this issue anymore. I am not sure that entities "magically" despawning themselves or components removing themselves make for great defaults in an "ECS-based API". This behavior is likely to be just as surprising to people.
>
> I think that the lack of sink re-usability should be treated as a bug and possibly the documentation improved to reflect the current limitations if it doesn't seem like a fix is forthcoming.
> -- me