### PR TITLE
Add `compile_fail_utils`, compile fail tests, and benchmarks to Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,19 @@ documentation = "https://docs.rs/bevy"
 rust-version = "1.82.0"
 
 [workspace]
-exclude = [
-  "benches",
-  "crates/bevy_derive/compile_fail",
-  "crates/bevy_ecs/compile_fail",
-  "crates/bevy_reflect/compile_fail",
-  "tools/compile_fail_utils",
-]
 members = [
+  # All of Bevy's official crates are within the `crates` folder!
   "crates/*",
+  # Several crates with macros have "compile fail" tests nested inside them, also known as UI
+  # tests, that verify diagnostic output does not accidentally change.
+  "crates/*/compile_fail",
+  # Examples of compiling Bevy for mobile platforms.
   "examples/mobile",
-  "tools/ci",
-  "tools/build-templated-pages",
-  "tools/build-wasm-example",
-  "tools/example-showcase",
+  # Benchmarks
+  "benches",
+  # Internal tools that are not published.
+  "tools/*",
+  # Bevy's error codes. This is a crate so we can automatically check all of the code blocks.
   "errors",
 ]
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -32,6 +32,9 @@ rand_chacha = "0.3"
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 bevy_winit = { path = "../crates/bevy_winit", features = ["x11"] }
 
+[lints.clippy]
+needless_lifetimes = "allow"
+
 [[bench]]
 name = "ecs"
 path = "benches/bevy_ecs/main.rs"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -32,10 +32,6 @@ rand_chacha = "0.3"
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 bevy_winit = { path = "../crates/bevy_winit", features = ["x11"] }
 
-[profile.release]
-opt-level = 3
-lto = true
-
 [[bench]]
 name = "ecs"
 path = "benches/bevy_ecs/main.rs"

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -83,6 +83,7 @@ fn overload(c: &mut Criterion) {
         a + b
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn complex<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         _: T0,
         _: T1,

--- a/benches/benches/bevy_reflect/map.rs
+++ b/benches/benches/bevy_reflect/map.rs
@@ -217,7 +217,7 @@ fn dynamic_map_get(criterion: &mut Criterion) {
                 bencher.iter(|| {
                     for i in 0..size as u64 {
                         let key = black_box(i);
-                        black_box(assert!(map.get(&key).is_some()));
+                        assert!(map.get(&key).is_some());
                     }
                 });
             },

--- a/crates/bevy_derive/compile_fail/tests/derive.rs
+++ b/crates/bevy_derive/compile_fail/tests/derive.rs
@@ -1,4 +1,6 @@
 fn main() -> compile_fail_utils::ui_test::Result<()> {
-    compile_fail_utils::test_multiple("derive_deref", ["tests/deref_derive", "tests/deref_mut_derive"])
+    compile_fail_utils::test_multiple(
+        "derive_deref",
+        ["tests/deref_derive", "tests/deref_mut_derive"],
+    )
 }
-

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -17,7 +17,9 @@ impl Prepare for TestCommand {
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo test --workspace --lib --bins --tests --benches {no_fail_fast}"
+                // Test most targets except for doc-tests, examples, and benchmarks. This is based
+                // of of the list at <https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection>.
+                "cargo test --workspace --lib --bins --tests {no_fail_fast}"
             ),
             "Please fix failing tests in output above.",
         )]

--- a/tools/compile_fail_utils/src/lib.rs
+++ b/tools/compile_fail_utils/src/lib.rs
@@ -109,10 +109,17 @@ pub fn test_with_multiple_configs(
     test_name: impl Into<String>,
     configs: impl IntoIterator<Item = ui_test::Result<Config>>,
 ) -> ui_test::Result<()> {
-    let configs = configs.into_iter().collect::<ui_test::Result<Vec<Config>>>()?;
+    let configs = configs
+        .into_iter()
+        .collect::<ui_test::Result<Vec<Config>>>()?;
 
     let emitter: Box<dyn StatusEmitter + Send> = if env::var_os("CI").is_some() {
-        Box::new((Text::verbose(), Gha::<true> { name: test_name.into() }))
+        Box::new((
+            Text::verbose(),
+            Gha::<true> {
+                name: test_name.into(),
+            },
+        ))
     } else {
         Box::new(Text::quiet())
     };

--- a/tools/compile_fail_utils/tests/example.rs
+++ b/tools/compile_fail_utils/tests/example.rs
@@ -1,4 +1,4 @@
-fn main() -> bevy_compile_test_utils::ui_test::Result<()> {
+fn main() -> compile_fail_utils::ui_test::Result<()> {
     // Run all tests in the tests/example_tests folder.
     // If we had more tests we could either call this function
     // on everysingle one or use test_multiple and past it an array
@@ -6,5 +6,5 @@ fn main() -> bevy_compile_test_utils::ui_test::Result<()> {
     //
     // Don't forget that when running tests the working directory
     // is set to the crate root.
-    bevy_compile_test_utils::test("tests/example_tests")
+    compile_fail_utils::test("example_tests", "tests/example_tests")
 }

--- a/tools/compile_fail_utils/tests/example_tests/basic_test.fixed
+++ b/tools/compile_fail_utils/tests/example_tests/basic_test.fixed
@@ -1,0 +1,24 @@
+// Compiler warnings also need to be annotated. We don't
+// want to annotate all the unused variables so let's instruct
+// the compiler to ignore them.
+#![allow(unused_variables)]
+
+fn bad_moves() {
+    let x = String::new();
+    // Help diagnostics need to be annotated
+    let y = x.clone();
+    //~^ HELP: consider cloning
+
+    // We expect a failure on this line
+    println!("{x}"); //~ ERROR: borrow
+
+
+    let x = String::new();
+    // We expect the help message to mention cloning.
+    //~v HELP: consider cloning
+    let y = x.clone();
+
+    // Check error message using a regex
+    println!("{x}");
+    //~^ ERROR: /(move)|(borrow)/
+}

--- a/tools/compile_fail_utils/tests/example_tests/import.stderr
+++ b/tools/compile_fail_utils/tests/example_tests/import.stderr
@@ -7,12 +7,12 @@ error[E0599]: no function or associated item named `this_function_does_not_exist
 note: if you're trying to build a new `Config` consider using one of the following associated functions:
       Config::rustc
       Config::cargo
-   --> $RUSTUP_HOME/.cargo/git/checkouts/ui_test-2b82183a391bb05c/680bb08/src/config.rs:63:5
+   --> $RUSTUP_HOME/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ui_test-0.23.0/src/config.rs:70:5
     |
-63  |     pub fn rustc(root_dir: impl Into<PathBuf>) -> Self {
+70  |     pub fn rustc(root_dir: impl Into<PathBuf>) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-108 |     pub fn cargo(root_dir: impl Into<PathBuf>) -> Self {
+221 |     pub fn cargo(root_dir: impl Into<PathBuf>) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
# Objective

- `compile_fail_utils`, `benches`, and all of our `compile_fail` sub-crates are outside of the Cargo workspace, so they are not checked by default nor caught by CI. As a result, these crates have several compile errors and warnings that were never discovered.

## Solution

- Add `compile_fail_utils`, `benches`, and all `compile_fail` crates to the Cargo workspace.
- Fix several compile errors and warnings, and run `rustfmt`.
- Remove custom `release` profile from benchmarks.
  - This may cause a regression in benchmark statistics, since we no longer set `lto = true`.
  - I can re-add this back as a custom profile available to all crates within the workspace, but I'm unsure its worth the hassle.
- Do not run `cargo test --benches` in CI.
  - This would have caused all of the benchmarks to be run for every pull request, which doesn't seem desired.

## Testing

- `cargo check --workspace --all-targets`
- `cd tools/compile_fail_utils && cargo test --test example`
