### PR TITLE
Introduce support for far culling when using `PerspectiveProjection`

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -89,7 +89,7 @@ impl Camera2dBundle {
         // we want 0 to be "closest" and +far to be "farthest" in 2d, so we offset
         // the camera's translation by far and use a right handed coordinate system
         let projection = OrthographicProjection {
-            far,
+            far: Some(far),
             ..OrthographicProjection::default_2d()
         };
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1435,7 +1435,7 @@ fn load_node(
                     let xmag = orthographic.xmag();
                     let orthographic_projection = OrthographicProjection {
                         near: orthographic.znear(),
-                        far: orthographic.zfar(),
+                        far: Some(orthographic.zfar()),
                         scaling_mode: ScalingMode::FixedHorizontal {
                             viewport_width: xmag,
                         },
@@ -1451,7 +1451,7 @@ fn load_node(
                         ..Default::default()
                     };
                     if let Some(zfar) = perspective.zfar() {
-                        perspective_projection.far = zfar;
+                        perspective_projection.far = Some(zfar);
                     }
                     if let Some(aspect_ratio) = perspective.aspect_ratio() {
                         perspective_projection.aspect_ratio = aspect_ratio;

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -618,7 +618,7 @@ pub fn update_point_light_frusta(
                 &clip_from_world,
                 &transform.translation(),
                 &view_backward,
-                point_light.range,
+                Some(point_light.range),
             );
         }
     }
@@ -654,7 +654,7 @@ pub fn update_spot_light_frusta(
             &clip_from_world,
             &transform.translation(),
             &view_backward,
-            spot_light.range,
+            Some(spot_light.range),
         );
     }
 }

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -618,7 +618,7 @@ pub fn update_point_light_frusta(
                 &clip_from_world,
                 &transform.translation(),
                 &view_backward,
-                Some(point_light.range),
+                point_light.range,
             );
         }
     }
@@ -654,7 +654,7 @@ pub fn update_spot_light_frusta(
             &clip_from_world,
             &transform.translation(),
             &view_backward,
-            Some(spot_light.range),
+            spot_light.range,
         );
     }
 }

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -92,7 +92,7 @@ pub trait CameraProjection {
             &clip_from_world,
             &camera_transform.translation(),
             &camera_transform.back(),
-            self.far().unwrap_or_default(),
+            self.far(),
         )
     }
 }
@@ -176,7 +176,7 @@ pub struct PerspectiveProjection {
     ///
     /// Objects farther from the camera than this value will not be visible.
     ///
-    /// Defaults to None (infinite far plane)
+    /// Defaults to `None` (far plane is ignored for visibility checks)
     pub far: Option<f32>,
 }
 
@@ -260,7 +260,7 @@ impl Default for PerspectiveProjection {
         PerspectiveProjection {
             fov: core::f32::consts::PI / 4.0,
             near: 0.1,
-            far: Option::None,
+            far: None,
             aspect_ratio: 1.0,
         }
     }
@@ -354,7 +354,9 @@ pub struct OrthographicProjection {
     ///
     /// Objects further than this will not be rendered.
     ///
-    /// Defaults to None (infinite far plane)
+    /// Defaults to [`OrthographicProjection::DEFAULT_FAR_PLANE`].
+    ///
+    /// ie: `Some(1000.0)`.
     pub far: Option<f32>,
     /// Specifies the origin of the viewport as a normalized position from 0 to 1, where (0, 0) is the bottom left
     /// and (1, 1) is the top right. This determines where the camera's position sits inside the viewport.
@@ -408,7 +410,7 @@ impl CameraProjection for OrthographicProjection {
             self.area.max.y,
             // NOTE: near and far are swapped to invert the depth range from [0,1] to [1,0]
             // This is for interoperability with pipelines using infinite reverse perspective projections.
-            self.far.unwrap_or_default(),
+            self.far.unwrap_or(Self::DEFAULT_FAR_PLANE),
             self.near,
         )
     }
@@ -451,7 +453,7 @@ impl CameraProjection for OrthographicProjection {
             top_prime,
             // NOTE: near and far are swapped to invert the depth range from [0,1] to [1,0]
             // This is for interoperability with pipelines using infinite reverse perspective projections.
-            self.far,
+            self.far.unwrap_or(Self::DEFAULT_FAR_PLANE),
             self.near,
         )
     }
@@ -530,6 +532,8 @@ impl FromWorld for OrthographicProjection {
 }
 
 impl OrthographicProjection {
+    pub const DEFAULT_FAR_PLANE: f32 = 1000.0;
+
     /// Returns the default orthographic projection for a 2D context.
     ///
     /// The near plane is set to a negative value so that the camera can still
@@ -549,7 +553,7 @@ impl OrthographicProjection {
         OrthographicProjection {
             scale: 1.0,
             near: 0.0,
-            far: None,
+            far: Some(Self::DEFAULT_FAR_PLANE),
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize,
             area: Rect::new(-1.0, -1.0, 1.0, 1.0),

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -78,7 +78,7 @@ pub trait CameraProjection {
     fn get_clip_from_view(&self) -> Mat4;
     fn get_clip_from_view_for_sub(&self, sub_view: &super::SubCameraView) -> Mat4;
     fn update(&mut self, width: f32, height: f32);
-    fn far(&self) -> f32;
+    fn far(&self) -> Option<f32>;
     fn get_frustum_corners(&self, z_near: f32, z_far: f32) -> [Vec3A; 8];
 
     /// Compute camera frustum for camera with given projection and transform.
@@ -92,7 +92,7 @@ pub trait CameraProjection {
             &clip_from_world,
             &camera_transform.translation(),
             &camera_transform.back(),
-            self.far(),
+            self.far().unwrap_or_default(),
         )
     }
 }
@@ -127,7 +127,7 @@ impl CameraProjection for Projection {
         }
     }
 
-    fn far(&self) -> f32 {
+    fn far(&self) -> Option<f32> {
         match self {
             Projection::Perspective(projection) => projection.far(),
             Projection::Orthographic(projection) => projection.far(),
@@ -176,8 +176,8 @@ pub struct PerspectiveProjection {
     ///
     /// Objects farther from the camera than this value will not be visible.
     ///
-    /// Defaults to a value of `1000.0`.
-    pub far: f32,
+    /// Defaults to None (infinite far plane)
+    pub far: Option<f32>,
 }
 
 impl CameraProjection for PerspectiveProjection {
@@ -232,7 +232,7 @@ impl CameraProjection for PerspectiveProjection {
             .ratio();
     }
 
-    fn far(&self) -> f32 {
+    fn far(&self) -> Option<f32> {
         self.far
     }
 
@@ -260,7 +260,7 @@ impl Default for PerspectiveProjection {
         PerspectiveProjection {
             fov: core::f32::consts::PI / 4.0,
             near: 0.1,
-            far: 1000.0,
+            far: Option::None,
             aspect_ratio: 1.0,
         }
     }
@@ -354,8 +354,8 @@ pub struct OrthographicProjection {
     ///
     /// Objects further than this will not be rendered.
     ///
-    /// Defaults to `1000.0`
-    pub far: f32,
+    /// Defaults to None (infinite far plane)
+    pub far: Option<f32>,
     /// Specifies the origin of the viewport as a normalized position from 0 to 1, where (0, 0) is the bottom left
     /// and (1, 1) is the top right. This determines where the camera's position sits inside the viewport.
     ///
@@ -408,7 +408,7 @@ impl CameraProjection for OrthographicProjection {
             self.area.max.y,
             // NOTE: near and far are swapped to invert the depth range from [0,1] to [1,0]
             // This is for interoperability with pipelines using infinite reverse perspective projections.
-            self.far,
+            self.far.unwrap_or_default(),
             self.near,
         )
     }
@@ -503,7 +503,7 @@ impl CameraProjection for OrthographicProjection {
         );
     }
 
-    fn far(&self) -> f32 {
+    fn far(&self) -> Option<f32> {
         self.far
     }
 
@@ -549,7 +549,7 @@ impl OrthographicProjection {
         OrthographicProjection {
             scale: 1.0,
             near: 0.0,
-            far: 1000.0,
+            far: None,
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize,
             area: Rect::new(-1.0, -1.0, 1.0, 1.0),

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -88,12 +88,16 @@ pub trait CameraProjection {
     fn compute_frustum(&self, camera_transform: &GlobalTransform) -> Frustum {
         let clip_from_world =
             self.get_clip_from_view() * camera_transform.compute_matrix().inverse();
-        Frustum::from_clip_from_world_custom_far(
-            &clip_from_world,
-            &camera_transform.translation(),
-            &camera_transform.back(),
-            self.far(),
-        )
+
+        match self.far() {
+            None => Frustum::from_clip_from_world(&clip_from_world),
+            Some(far) => Frustum::from_clip_from_world_custom_far(
+                &clip_from_world,
+                &camera_transform.translation(),
+                &camera_transform.back(),
+                far,
+            ),
+        }
     }
 }
 

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -246,10 +246,10 @@ impl Frustum {
         clip_from_world: &Mat4,
         view_translation: &Vec3,
         view_backward: &Vec3,
-        far: f32,
+        far: Option<f32>,
     ) -> Self {
         let mut frustum = Frustum::from_clip_from_world_no_far(clip_from_world);
-        let far_center = *view_translation - far * *view_backward;
+        let far_center = *view_translation - far.unwrap_or_default() * *view_backward;
         frustum.half_spaces[5] =
             HalfSpace::new(view_backward.extend(-view_backward.dot(far_center)));
         frustum

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -241,24 +241,18 @@ impl Frustum {
 
     /// Returns a frustum derived from `clip_from_world`,
     /// but with a custom far plane.
-    /// If `far` is `None` behavior is identical to [`Frustum::from_clip_from_world`]
     #[inline]
     pub fn from_clip_from_world_custom_far(
         clip_from_world: &Mat4,
         view_translation: &Vec3,
         view_backward: &Vec3,
-        far: Option<f32>,
+        far: f32,
     ) -> Self {
-        match far {
-            None => Frustum::from_clip_from_world(clip_from_world),
-            Some(far) => {
-                let mut frustum = Frustum::from_clip_from_world_no_far(clip_from_world);
-                let far_center = *view_translation - far * *view_backward;
-                frustum.half_spaces[5] =
-                    HalfSpace::new(view_backward.extend(-view_backward.dot(far_center)));
-                frustum
-            }
-        }
+        let mut frustum = Frustum::from_clip_from_world_no_far(clip_from_world);
+        let far_center = *view_translation - far * *view_backward;
+        frustum.half_spaces[5] =
+            HalfSpace::new(view_backward.extend(-view_backward.dot(far_center)));
+        frustum
     }
 
     // NOTE: This approach of extracting the frustum half-space from the view

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -114,7 +114,10 @@ fn sprite_picking(
         let Ok(cursor_ray_world) = camera.viewport_to_world(cam_transform, pos_in_viewport) else {
             continue;
         };
-        let cursor_ray_len = cam_ortho.far - cam_ortho.near;
+        let cursor_ray_len = cam_ortho
+            .far
+            .unwrap_or(OrthographicProjection::DEFAULT_FAR_PLANE)
+            - cam_ortho.near;
         let cursor_ray_end = cursor_ray_world.origin + cursor_ray_world.direction * cursor_ray_len;
 
         let picks: Vec<(Entity, HitData)> = sorted_sprites

--- a/examples/math/custom_primitives.rs
+++ b/examples/math/custom_primitives.rs
@@ -35,7 +35,7 @@ const TRANSFORM_2D: Transform = Transform {
 // The projection used for the camera in 2D
 const PROJECTION_2D: Projection = Projection::Orthographic(OrthographicProjection {
     near: -1.0,
-    far: 10.0,
+    far: Some(10.0),
     scale: 1.0,
     viewport_origin: Vec2::new(0.5, 0.5),
     scaling_mode: ScalingMode::AutoMax {
@@ -59,7 +59,7 @@ const TRANSFORM_3D: Transform = Transform {
 const PROJECTION_3D: Projection = Projection::Perspective(PerspectiveProjection {
     fov: PI / 4.0,
     near: 0.1,
-    far: 1000.0,
+    far: Some(1000.0),
     aspect_ratio: 1.0,
 });
 

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -111,8 +111,12 @@ fn setup_scene_after_load(
         let aabb = Aabb::from_min_max(Vec3::from(min), Vec3::from(max));
 
         info!("Spawning a controllable 3D perspective camera");
+        let min_required_far = size * 10.0;
         let mut projection = PerspectiveProjection::default();
-        projection.far = projection.far.max(size * 10.0);
+        projection.far = projection
+            .far
+            .map(|far| far.max(min_required_far))
+            .or(Some(min_required_far));
 
         let walk_speed = size * 3.0;
         let camera_controller = CameraController {


### PR DESCRIPTION
## Note
An update of https://github.com/bevyengine/bevy/pull/8205 for 0.15 and with review suggestions.
All credit to @NotoriousENG

# Objective
* Before this change Frustum Culling on cameras with `PerspectiveProjection` would only account for near, left, right, top, and bottom planes with no trivial user facing overrides
* Fixes:
  * https://github.com/bevyengine/bevy/issues/8173 
  * https://github.com/bevyengine/bevy/issues/16746

## Solution
* Changes return of `CameraProjection::far()` and it's impls from `f32` to `Option<f32>`
* Adds sensible (hopefully non bc breaking) `far` defaults to `OrthographicProjection` and `PerspectiveProjection`
  * `OrthographicProjection` = `Some(OrthographicProjection::DEFAULT_FAR_PLANE)`
     Equivalent to existing behaviour of far clipping at `1000.0`
  * `PerspectiveProjection` = `None`
     Equivalent to existing behaviour of not far clipping at all
* Updates `Frustum::from_clip_from_world_custom_far` to account for `far` becoming optional
* Updates `bevy_render::view::visibility::check_visibility` to perform far culling when appropriate
* Updates users of the above changes as appropriate

## Changelog
* Existing instantiations of  `OrthographicProjection` and `PerspectiveProjection` with an explicit `far` value will need to wrap the value in `Some`
* Custom impls of `CameraProjection` will need updating to account for the changed return type of `far()`
* Usages of `Frustum::from_clip_from_world_custom_far` in downstream code will need updating to account for the changed type of the `far` parameter
