### PR TITLE
Reorder PickSet::Focus systems

### DIFF
--- a/crates/bevy_picking/src/focus.rs
+++ b/crates/bevy_picking/src/focus.rs
@@ -200,7 +200,7 @@ pub enum PickingInteraction {
     None = 0,
 }
 
-/// Uses pointer events to update [`PointerInteraction`] and [`PickingInteraction`] components.
+/// Uses [`HoverMap`] changes to update [`PointerInteraction`] and [`PickingInteraction`] components.
 pub fn update_interactions(
     // Input
     hover_map: Res<HoverMap>,

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -414,7 +414,7 @@ impl Plugin for InteractionPlugin {
             .add_event::<Pointer<Released>>()
             .add_systems(
                 PreUpdate,
-                (update_focus, pointer_events, update_interactions)
+                (update_focus, update_interactions, pointer_events)
                     .chain()
                     .in_set(PickSet::Focus),
             );


### PR DESCRIPTION
# Objective

- `PointerInteraction` components should be updated before sending picking events. Otherwise they will be stale when event observers run.
- Allow inserting logic before picking events but after `PointerInteraction` components have been updated.

## Solution

- Reorder systems in `PickSet::Focus`.
