### PR TITLE
Fix `compile_fail` compile fail

### DIFF
--- a/tools/compile_fail_utils/tests/example.rs
+++ b/tools/compile_fail_utils/tests/example.rs
@@ -1,4 +1,4 @@
-fn main() -> bevy_compile_test_utils::ui_test::Result<()> {
+fn main() -> compile_fail_utils::ui_test::Result<()> {
     // Run all tests in the tests/example_tests folder.
     // If we had more tests we could either call this function
     // on everysingle one or use test_multiple and past it an array
@@ -6,5 +6,5 @@ fn main() -> bevy_compile_test_utils::ui_test::Result<()> {
     //
     // Don't forget that when running tests the working directory
     // is set to the crate root.
-    bevy_compile_test_utils::test("tests/example_tests")
+    compile_fail_utils::test("example_tests", "tests/example_tests")
 }

--- a/tools/compile_fail_utils/tests/example_tests/basic_test.fixed
+++ b/tools/compile_fail_utils/tests/example_tests/basic_test.fixed
@@ -1,0 +1,24 @@
+// Compiler warnings also need to be annotated. We don't
+// want to annotate all the unused variables so let's instruct
+// the compiler to ignore them.
+#![allow(unused_variables)]
+
+fn bad_moves() {
+    let x = String::new();
+    // Help diagnostics need to be annotated
+    let y = x.clone();
+    //~^ HELP: consider cloning
+
+    // We expect a failure on this line
+    println!("{x}"); //~ ERROR: borrow
+
+
+    let x = String::new();
+    // We expect the help message to mention cloning.
+    //~v HELP: consider cloning
+    let y = x.clone();
+
+    // Check error message using a regex
+    println!("{x}");
+    //~^ ERROR: /(move)|(borrow)/
+}

--- a/tools/compile_fail_utils/tests/example_tests/import.stderr
+++ b/tools/compile_fail_utils/tests/example_tests/import.stderr
@@ -7,12 +7,12 @@ error[E0599]: no function or associated item named `this_function_does_not_exist
 note: if you're trying to build a new `Config` consider using one of the following associated functions:
       Config::rustc
       Config::cargo
-   --> $RUSTUP_HOME/.cargo/git/checkouts/ui_test-2b82183a391bb05c/680bb08/src/config.rs:63:5
+   --> $RUSTUP_HOME/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ui_test-0.23.0/src/config.rs:70:5
     |
-63  |     pub fn rustc(root_dir: impl Into<PathBuf>) -> Self {
+70  |     pub fn rustc(root_dir: impl Into<PathBuf>) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-108 |     pub fn cargo(root_dir: impl Into<PathBuf>) -> Self {
+221 |     pub fn cargo(root_dir: impl Into<PathBuf>) -> Self {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
# Objective

- Fixes #16802, part of #16801, extracted from #16770.

## Solution

- Fix `compile_fail_utils`'s example test so that it now compiles.
- Bless the results, which were outdated.

## Testing

- `cd tools/compile_fail_utils && cargo check --all-targets`
- `cd tools/compile_fail_utils && cargo test --test example`
