### PR TITLE
Fix Clippy lints in benchmarks

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -36,6 +36,30 @@ bevy_winit = { path = "../crates/bevy_winit", features = ["x11"] }
 opt-level = 3
 lto = true
 
+[lints.clippy]
+doc_markdown = "warn"
+manual_let_else = "warn"
+match_same_arms = "warn"
+redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+semicolon_if_nothing_returned = "warn"
+type_complexity = "allow"
+undocumented_unsafe_blocks = "warn"
+unwrap_or_default = "warn"
+needless_lifetimes = "allow"
+
+ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
+ref_as_ptr = "warn"
+
+# see: https://github.com/bevyengine/bevy/pull/15375#issuecomment-2366966219
+too_long_first_doc_paragraph = "allow"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
+unsafe_op_in_unsafe_fn = "warn"
+unused_qualifications = "warn"
+
 [[bench]]
 name = "ecs"
 path = "benches/bevy_ecs/main.rs"

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -350,7 +350,7 @@ fn multiple_archetype_none_changed_detection_generic<
                     assert_eq!(0, count);
                 },
                 criterion::BatchSize::LargeInput,
-            )
+            );
         },
     );
 }

--- a/benches/benches/bevy_ecs/empty_archetypes.rs
+++ b/benches/benches/bevy_ecs/empty_archetypes.rs
@@ -180,7 +180,7 @@ fn empty_archetypes(criterion: &mut Criterion) {
             |bencher, &_| {
                 bencher.iter(|| {
                     schedule.run(&mut world);
-                })
+                });
             },
         );
     }
@@ -211,7 +211,7 @@ fn empty_archetypes(criterion: &mut Criterion) {
             |bencher, &_| {
                 bencher.iter(|| {
                     schedule.run(&mut world);
-                })
+                });
             },
         );
     }
@@ -242,7 +242,7 @@ fn empty_archetypes(criterion: &mut Criterion) {
             |bencher, &_| {
                 bencher.iter(|| {
                     schedule.run(&mut world);
-                })
+                });
             },
         );
     }

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_hybrid.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_hybrid.rs
@@ -38,6 +38,6 @@ impl<'w> Benchmark<'w> {
     pub fn run(&mut self) {
         self.1
             .iter_mut(&mut self.0)
-            .for_each(|(mut v1, v2)| v1.0 += v2.0)
+            .for_each(|(mut v1, v2)| v1.0 += v2.0);
     }
 }

--- a/benches/benches/bevy_ecs/iteration/par_iter_simple_foreach_hybrid.rs
+++ b/benches/benches/bevy_ecs/iteration/par_iter_simple_foreach_hybrid.rs
@@ -40,6 +40,6 @@ impl<'w> Benchmark<'w> {
     pub fn run(&mut self) {
         self.1
             .par_iter_mut(&mut self.0)
-            .for_each(|(mut v1, v2)| v1.0 += v2.0)
+            .for_each(|(mut v1, v2)| v1.0 += v2.0);
     }
 }

--- a/benches/benches/bevy_ecs/observers/simple.rs
+++ b/benches/benches/bevy_ecs/observers/simple.rs
@@ -20,7 +20,7 @@ pub fn observe_simple(criterion: &mut Criterion) {
         world.add_observer(empty_listener_base);
         bencher.iter(|| {
             for _ in 0..10000 {
-                world.trigger(EventBase)
+                world.trigger(EventBase);
             }
         });
     });

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -120,7 +120,7 @@ pub fn build_schedule(criterion: &mut Criterion) {
 }
 
 pub fn empty_schedule_run(criterion: &mut Criterion) {
-    let mut app = bevy_app::App::default();
+    let mut app = App::default();
 
     let mut group = criterion.benchmark_group("run_empty_schedule");
 

--- a/benches/benches/bevy_math/bezier.rs
+++ b/benches/benches/bevy_math/bezier.rs
@@ -8,7 +8,7 @@ fn easing(c: &mut Criterion) {
         b.iter(|| {
             (0..1000).map(|i| i as f32 / 1000.0).for_each(|t| {
                 black_box(cubic_bezier.ease(black_box(t)));
-            })
+            });
         });
     });
 }

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -83,6 +83,7 @@ fn overload(c: &mut Criterion) {
         a + b
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn complex<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         _: T0,
         _: T1,


### PR DESCRIPTION
# Objective

- Closes #16804.
- This copies over our lint configuration to our benchmarks and fixes any lints.

## Solution

- Copied over our Clippy configuration from the root `Cargo.toml` to `benches/Cargo.toml`.
- Fixed any warnings that Clippy emitted.

## Testing

- `cd benches && cargo clippy --benches`