### PR TITLE
Add ability to mute audio sinks

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -69,6 +69,11 @@ pub struct PlaybackSettings {
     /// Useful for "deferred playback", if you want to prepare
     /// the entity, but hear the sound later.
     pub paused: bool,
+    /// Whether to create the sink in muted state or not.
+    ///
+    /// This is useful for audio that should be initially muted. You can still
+    /// set the initial volume and it is applied when the audio is unmuted.
+    pub muted: bool,
     /// Enables spatial audio for this source.
     ///
     /// See also: [`SpatialListener`].
@@ -100,6 +105,7 @@ impl PlaybackSettings {
         volume: Volume(1.0),
         speed: 1.0,
         paused: false,
+        muted: false,
         spatial: false,
         spatial_scale: None,
     };
@@ -125,6 +131,12 @@ impl PlaybackSettings {
     /// Helper to start in a paused state.
     pub const fn paused(mut self) -> Self {
         self.paused = true;
+        self
+    }
+
+    /// Helper to start muted.
+    pub const fn muted(mut self) -> Self {
+        self.muted = true;
         self
     }
 

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -160,7 +160,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             match settings.mode {
                 PlaybackMode::Loop => sink.append(audio_source.decoder().repeat_infinite()),
                 PlaybackMode::Once | PlaybackMode::Despawn | PlaybackMode::Remove => {
-                    sink.append(audio_source.decoder())
+                    sink.append(audio_source.decoder());
                 }
             };
 
@@ -200,7 +200,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             match settings.mode {
                 PlaybackMode::Loop => sink.append(audio_source.decoder().repeat_infinite()),
                 PlaybackMode::Once | PlaybackMode::Despawn | PlaybackMode::Remove => {
-                    sink.append(audio_source.decoder())
+                    sink.append(audio_source.decoder());
                 }
             };
 

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -159,9 +159,9 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
 
             match settings.mode {
                 PlaybackMode::Loop => sink.append(audio_source.decoder().repeat_infinite()),
-                PlaybackMode::Once => sink.append(audio_source.decoder()),
-                PlaybackMode::Despawn => sink.append(audio_source.decoder()),
-                PlaybackMode::Remove => sink.append(audio_source.decoder()),
+                PlaybackMode::Once | PlaybackMode::Despawn | PlaybackMode::Remove => {
+                    sink.append(audio_source.decoder())
+                }
             };
 
             let mut sink = SpatialAudioSink::new(sink);
@@ -178,8 +178,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             }
 
             match settings.mode {
-                PlaybackMode::Loop => commands.entity(entity).insert(sink),
-                PlaybackMode::Once => commands.entity(entity).insert(sink),
+                PlaybackMode::Loop | PlaybackMode::Once => commands.entity(entity).insert(sink),
                 PlaybackMode::Despawn => commands
                     .entity(entity)
                     // PERF: insert as bundle to reduce archetype moves
@@ -200,9 +199,9 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
 
             match settings.mode {
                 PlaybackMode::Loop => sink.append(audio_source.decoder().repeat_infinite()),
-                PlaybackMode::Once => sink.append(audio_source.decoder()),
-                PlaybackMode::Despawn => sink.append(audio_source.decoder()),
-                PlaybackMode::Remove => sink.append(audio_source.decoder()),
+                PlaybackMode::Once | PlaybackMode::Despawn | PlaybackMode::Remove => {
+                    sink.append(audio_source.decoder())
+                }
             };
 
             let mut sink = AudioSink::new(sink);
@@ -219,8 +218,7 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             }
 
             match settings.mode {
-                PlaybackMode::Loop => commands.entity(entity).insert(sink),
-                PlaybackMode::Once => commands.entity(entity).insert(sink),
+                PlaybackMode::Loop | PlaybackMode::Once => commands.entity(entity).insert(sink),
                 PlaybackMode::Despawn => commands
                     .entity(entity)
                     // PERF: insert as bundle to reduce archetype moves

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -167,25 +167,25 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             match settings.mode {
                 PlaybackMode::Loop => {
                     sink.append(audio_source.decoder().repeat_infinite());
-                    commands.entity(entity).insert(SpatialAudioSink { sink });
+                    commands.entity(entity).insert(SpatialAudioSink::new(sink));
                 }
                 PlaybackMode::Once => {
                     sink.append(audio_source.decoder());
-                    commands.entity(entity).insert(SpatialAudioSink { sink });
+                    commands.entity(entity).insert(SpatialAudioSink::new(sink));
                 }
                 PlaybackMode::Despawn => {
                     sink.append(audio_source.decoder());
                     commands
                         .entity(entity)
                         // PERF: insert as bundle to reduce archetype moves
-                        .insert((SpatialAudioSink { sink }, PlaybackDespawnMarker));
+                        .insert((SpatialAudioSink::new(sink), PlaybackDespawnMarker));
                 }
                 PlaybackMode::Remove => {
                     sink.append(audio_source.decoder());
                     commands
                         .entity(entity)
                         // PERF: insert as bundle to reduce archetype moves
-                        .insert((SpatialAudioSink { sink }, PlaybackRemoveMarker));
+                        .insert((SpatialAudioSink::new(sink), PlaybackRemoveMarker));
                 }
             };
         } else {
@@ -207,25 +207,25 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
             match settings.mode {
                 PlaybackMode::Loop => {
                     sink.append(audio_source.decoder().repeat_infinite());
-                    commands.entity(entity).insert(AudioSink { sink });
+                    commands.entity(entity).insert(AudioSink::new(sink));
                 }
                 PlaybackMode::Once => {
                     sink.append(audio_source.decoder());
-                    commands.entity(entity).insert(AudioSink { sink });
+                    commands.entity(entity).insert(AudioSink::new(sink));
                 }
                 PlaybackMode::Despawn => {
                     sink.append(audio_source.decoder());
                     commands
                         .entity(entity)
                         // PERF: insert as bundle to reduce archetype moves
-                        .insert((AudioSink { sink }, PlaybackDespawnMarker));
+                        .insert((AudioSink::new(sink), PlaybackDespawnMarker));
                 }
                 PlaybackMode::Remove => {
                     sink.append(audio_source.decoder());
                     commands
                         .entity(entity)
                         // PERF: insert as bundle to reduce archetype moves
-                        .insert((AudioSink { sink }, PlaybackRemoveMarker));
+                        .insert((AudioSink::new(sink), PlaybackRemoveMarker));
                 }
             };
         }

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -235,7 +235,7 @@ impl SpatialAudioSink {
 
 impl AudioSinkPlayback for SpatialAudioSink {
     fn volume(&self) -> f32 {
-        self.sink.volume()
+        self.managed_volume.unwrap_or_else(|| self.sink.volume())
     }
 
     fn set_volume(&mut self, volume: f32) {

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -366,18 +366,4 @@ mod tests {
         let audio_sink = AudioSink::new(sink);
         test_audio_sink_playback(audio_sink);
     }
-
-    #[test]
-    fn test_spatial_audio_sink() {
-        let (_stream, stream_handle) = OutputStream::try_default().unwrap();
-        let sink = SpatialSink::try_new(
-            &stream_handle,
-            [0.0, 0.0, 0.0],
-            [10.0, 0.0, 0.0],
-            [-10.0, 0.0, 0.0],
-        )
-        .unwrap();
-        let spatial_audio_sink = SpatialAudioSink::new(sink);
-        test_audio_sink_playback(spatial_audio_sink);
-    }
 }

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -313,7 +313,7 @@ impl SpatialAudioSink {
 
 #[cfg(test)]
 mod tests {
-    use rodio::{OutputStream, Sink, SpatialSink};
+    use rodio::Sink;
 
     use super::*;
 

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -20,10 +20,11 @@ pub trait AudioSinkPlayback {
     /// The value `1.0` is the "normal" volume (unfiltered input). Any value other than `1.0`
     /// will multiply each sample by this value.
     ///
-    /// If the sink is muted, this sets the managed volume rather than the
-    /// sink's actual volume. This allows you to control the volume even when
-    /// the sink is muted, so that when it is unmuted, the volume is restored
-    /// and all calls to this function are respected.
+    /// If the sink is muted, changing the volume won't unmute it, i.e. the
+    /// sink's volume will remain at `0.0`. However, the sink will remember the
+    /// volume change and it will be used when [`unmute`](Self::unmute) is
+    /// called. This allows you to control the volume even when the sink is
+    /// muted.
     ///
     /// # Note on Audio Volume
     ///
@@ -85,9 +86,14 @@ pub trait AudioSinkPlayback {
     fn is_muted(&self) -> bool;
 
     /// Mutes the sink.
+    ///
+    /// Muting a sink sets the volume to 0. Use [`unmute`](Self::unmute) to
+    /// unmute the sink and restore the original volume.
     fn mute(&mut self);
 
     /// Unmutes the sink.
+    ///
+    /// Restores the volume to the value it was before it was muted.
     fn unmute(&mut self);
 
     /// Toggles whether the sink is muted or not.

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -140,11 +140,7 @@ impl AudioSink {
 
 impl AudioSinkPlayback for AudioSink {
     fn volume(&self) -> f32 {
-        if let Some(volume) = self.managed_volume {
-            volume
-        } else {
-            self.sink.volume()
-        }
+        self.managed_volume.unwrap_or_else(|| self.sink.volume())
     }
 
     fn set_volume(&mut self, volume: f32) {
@@ -193,9 +189,8 @@ impl AudioSinkPlayback for AudioSink {
     }
 
     fn unmute(&mut self) {
-        if let Some(volume) = self.managed_volume {
+        if let Some(volume) = self.managed_volume.take() {
             self.sink.set_volume(volume);
-            self.managed_volume = None;
         }
     }
 }
@@ -289,9 +284,8 @@ impl AudioSinkPlayback for SpatialAudioSink {
     }
 
     fn unmute(&mut self) {
-        if let Some(volume) = self.managed_volume {
+        if let Some(volume) = self.managed_volume.take() {
             self.sink.set_volume(volume);
-            self.managed_volume = None;
         }
     }
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_speed, pause, volume))
+        .add_systems(Update, (update_speed, pause, mute, volume))
         .run();
 }
 
@@ -30,10 +30,24 @@ fn pause(keyboard_input: Res<ButtonInput<KeyCode>>, sink: Single<&AudioSink, Wit
     }
 }
 
-fn volume(keyboard_input: Res<ButtonInput<KeyCode>>, sink: Single<&AudioSink, With<MyMusic>>) {
+fn mute(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut sink: Single<&mut AudioSink, With<MyMusic>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::KeyM) {
+        sink.toggle_mute();
+    }
+}
+
+fn volume(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut sink: Single<&mut AudioSink, With<MyMusic>>,
+) {
     if keyboard_input.just_pressed(KeyCode::Equal) {
-        sink.set_volume(sink.volume() + 0.1);
+        let current_volume = sink.volume();
+        sink.set_volume(current_volume + 0.1);
     } else if keyboard_input.just_pressed(KeyCode::Minus) {
-        sink.set_volume(sink.volume() - 0.1);
+        let current_volume = sink.volume();
+        sink.set_volume(current_volume - 0.1);
     }
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -15,6 +15,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
         MyMusic,
     ));
+
+    // example instructions
+    commands.spawn((
+        Text::new("-/=: Volume Down/Up\nSpace: Pause Playback\nM: Toggle Mute"),
+        Node {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+    ));
+
+    // camera
+    commands.spawn(Camera3d::default());
 }
 
 #[derive(Component)]

--- a/examples/audio/soundtrack.rs
+++ b/examples/audio/soundtrack.rs
@@ -113,8 +113,9 @@ fn fade_in(
     mut audio_sink: Query<(&mut AudioSink, Entity), With<FadeIn>>,
     time: Res<Time>,
 ) {
-    for (audio, entity) in audio_sink.iter_mut() {
-        audio.set_volume(audio.volume() + time.delta_secs() / FADE_TIME);
+    for (mut audio, entity) in audio_sink.iter_mut() {
+        let current_volume = audio.volume();
+        audio.set_volume(current_volume + time.delta_secs() / FADE_TIME);
         if audio.volume() >= 1.0 {
             audio.set_volume(1.0);
             commands.entity(entity).remove::<FadeIn>();
@@ -129,8 +130,9 @@ fn fade_out(
     mut audio_sink: Query<(&mut AudioSink, Entity), With<FadeOut>>,
     time: Res<Time>,
 ) {
-    for (audio, entity) in audio_sink.iter_mut() {
-        audio.set_volume(audio.volume() - time.delta_secs() / FADE_TIME);
+    for (mut audio, entity) in audio_sink.iter_mut() {
+        let current_volume = audio.volume();
+        audio.set_volume(current_volume - time.delta_secs() / FADE_TIME);
         if audio.volume() <= 0.0 {
             commands.entity(entity).despawn_recursive();
         }

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -11,6 +11,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, update_positions)
         .add_systems(Update, update_listener)
+        .add_systems(Update, mute)
         .run();
 }
 
@@ -126,5 +127,13 @@ fn update_listener(
     }
     if keyboard.pressed(KeyCode::ArrowUp) {
         listeners.translation.z -= speed * time.delta_secs();
+    }
+}
+
+fn mute(keyboard_input: Res<ButtonInput<KeyCode>>, mut sinks: Query<&mut SpatialAudioSink>) {
+    if keyboard_input.just_pressed(KeyCode::KeyM) {
+        for mut sink in sinks.iter_mut() {
+            sink.toggle_mute();
+        }
     }
 }

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -65,7 +65,9 @@ fn setup(
 
     // example instructions
     commands.spawn((
-        Text::new("Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement"),
+        Text::new(
+            "Up/Down/Left/Right: Move Listener\nSpace: Toggle Emitter Movement\nM: Toggle Mute",
+        ),
         Node {
             position_type: PositionType::Absolute,
             bottom: Val::Px(12.0),

--- a/tools/example-showcase/disable-audio.patch
+++ b/tools/example-showcase/disable-audio.patch
@@ -9,7 +9,7 @@ index 3e8082e23..624769443 100644
 -use rodio::{OutputStream, OutputStreamHandle, Sink, Source, SpatialSink};
 +use rodio::{OutputStreamHandle, Sink, Source, SpatialSink};
  
- use crate::AudioSink;
+ use crate::{AudioSink, AudioSinkPlayback};
  
 @@ -30,18 +30,10 @@ pub(crate) struct AudioOutput {
  


### PR DESCRIPTION
# Objective

- Allow users to mute audio.

```rust
fn mute(
    keyboard_input: Res<ButtonInput<KeyCode>>,
    mut sink: Single<&mut AudioSink, With<MyMusic>>,
) {
    if keyboard_input.just_pressed(KeyCode::KeyM) {
        sink.toggle_mute();
    }
}
```

- I want to be able to press, say, `M` and mute all my audio. I want this for dev, but I'm sure it's a useful player setting as well.
- Muting is different to pausing—I don't want to pause my sounds, I want them to keep playing but with no volume. For example if I have background music playing which is made up of 5 tracks, I want to be able to temporarily mute my background music, and if I unmute at, say, track 4, I want to play track 4 rather than have had everything paused and still be on the first track.
- I want to be able to continue to control the volume of my audio even when muted. Like in the example, if I have muted my audio but I use the volume up/down controls, I want Bevy to remember those volume changes so that when I unmute, the volume corresponds to that.

## Solution

- Add methods to audio to allow muting, unmuting and toggling muting.
- To preserve the user's intended volume, each sink needs to keep track of a "managed volume".
- I checked `rodio` and I don't see any built in support for doing this, so I added it to `bevy_audio`.
- I'm interested to hear if this is a good idea or a bad idea. To me, this API looks nice and looks usable, but I'm aware it involves some changes to the existing API and now also requires mutable access in some places compared to before.
- I'm also aware of work on *Better Audio*, but I'm hoping that if this change isn't too wild it might be a useful addition considering we don't really know when we'll eventually get better audio.

## Testing

- Update and run the example:  `cargo run --example audio_control`
- Run the example:  `cargo run --example soundtrack`
- Update and run the example:  `cargo run --example spatial_audio_3d`
- Add unit tests.

---

## Showcase

See 2 changed examples that show how you can mute an audio sink and a spatial audio sink.

## Migration Guide

- The `AudioSinkPlayback` trait now has 4 new methods to allow you to mute audio sinks: `is_muted`, `mute`, `unmute` and `toggle_mute`. You can use these methods on `bevy_audio`'s `AudioSink` and `SpatialAudioSink` components to manage the sink's mute state.
- `AudioSinkPlayback`'s `set_volume` method now takes a mutable reference instead of an immutable one. Update your code which calls `set_volume` on `AudioSink` and `SpatialAudioSink` components to take a mutable reference. E.g.:

Before:

```rust
fn increase_volume(sink: Single<&AudioSink>) {
    sink.set_volume(sink.volume() + 0.1);
}
```

After:

```rust
fn increase_volume(mut sink: Single<&mut AudioSink>) {
    let current_volume = sink.volume();
    sink.set_volume(current_volume + 0.1);
}
```

- The `PlaybackSettings` component now has a `muted` field which you can use to spawn your audio in a muted state. `PlaybackSettings` also now has a helper method `muted` which you can use when building the component. E.g.: 

```rust
commands.spawn((
    // ...
    AudioPlayer::new(asset_server.load("sounds/Windless Slopes.ogg")),
    PlaybackSettings::LOOP.with_spatial(true).muted(),
));
```
