### PR TITLE
Support `SystemInput` tuples up to 8 elements

### DIFF
--- a/crates/bevy_ecs/src/system/input.rs
+++ b/crates/bevy_ecs/src/system/input.rs
@@ -265,8 +265,8 @@ mod tests {
         fn by_ref((InRef(a), InRef(b)): (InRef<usize>, InRef<usize>)) -> usize {
             *a + *b
         }
-        fn by_mut((InMut(a), InMut(b)): (InMut<usize>, InMut<usize>)) {
-            *a += *b;
+        fn by_mut((InMut(a), In(b)): (InMut<usize>, In<usize>)) {
+            *a += b;
         }
 
         let mut world = World::new();
@@ -279,11 +279,11 @@ mod tests {
         by_mut.initialize(&mut world);
 
         let mut a = 12;
-        let mut b = 24;
+        let b = 24;
 
         assert_eq!(by_value.run((a, b), &mut world), 36);
         assert_eq!(by_ref.run((&a, &b), &mut world), 36);
-        by_mut.run((&mut a, &mut b), &mut world);
+        by_mut.run((&mut a, b), &mut world);
         assert_eq!(a, 36);
     }
 }

--- a/crates/bevy_ecs/src/system/input.rs
+++ b/crates/bevy_ecs/src/system/input.rs
@@ -17,6 +17,25 @@ use crate::{bundle::Bundle, prelude::Trigger, system::System};
 ///
 /// For advanced usecases, you can implement this trait for your own types.
 ///
+/// # Examples
+///
+/// ## Tuples of [`SystemInput`]s
+///
+/// ```
+/// use bevy_ecs::prelude::*;
+///
+/// fn add((InMut(a), In(b)): (InMut<usize>, In<usize>)) {
+///     *a += b;
+/// }
+/// # let mut world = World::new();
+/// # let mut add = IntoSystem::into_system(add);
+/// # add.initialize(&mut world);
+/// # let mut a = 12;
+/// # let b = 24;
+/// # add.run((&mut a, b), &mut world);
+/// # assert_eq!(a, 36);
+/// ```
+///
 /// [`ObserverSystem`]: crate::system::ObserverSystem
 pub trait SystemInput: Sized {
     /// The wrapper input type that is defined as the first argument to [`FunctionSystem`]s.
@@ -43,6 +62,8 @@ pub type SystemIn<'a, S> = <<S as System>::In as SystemInput>::Inner<'a>;
 /// are being [`run`](System::run). For [`FunctionSystem`]s the input may be marked
 /// with this `In` type, but only the first param of a function may be tagged as an input. This also
 /// means a system can only have one or zero input parameters.
+///
+/// See [`SystemInput`] to learn more about system inputs in general.
 ///
 /// # Examples
 ///
@@ -96,6 +117,8 @@ impl<T> DerefMut for In<T> {
 /// This is similar to [`In`] but takes a reference to a value instead of the value itself.
 /// See [`InMut`] for the mutable version.
 ///
+/// See [`SystemInput`] to learn more about system inputs in general.
+///
 /// # Examples
 ///
 /// Here is a simple example of a system that logs the passed in message.
@@ -146,6 +169,8 @@ impl<'i, T: ?Sized> Deref for InRef<'i, T> {
 ///
 /// This is similar to [`In`] but takes a mutable reference to a value instead of the value itself.
 /// See [`InRef`] for the read-only version.
+///
+/// See [`SystemInput`] to learn more about system inputs in general.
 ///
 /// # Examples
 ///
@@ -214,6 +239,8 @@ impl<E: 'static, B: Bundle> SystemInput for Trigger<'_, E, B> {
 ///
 /// This makes it useful for having arbitrary [`SystemInput`]s in
 /// function systems.
+///
+/// See [`SystemInput`] to learn more about system inputs in general.
 pub struct StaticSystemInput<'a, I: SystemInput>(pub I::Inner<'a>);
 
 impl<'a, I: SystemInput> SystemInput for StaticSystemInput<'a, I> {


### PR DESCRIPTION
# Objective

- Writing an API, and I want to allow users to pass in extra data alongside the API provided input, and tuples are the most natural extension in this case.
- Bring `SystemInput` up to par with `SystemParam` for tuple support.

## Solution

- Added impls for tuples up to 8 elements. If you need a 9-arity tuple or more, write your own `SystemInput` type (it's incredibly simple to do).

## Testing

- Added a test demonstrating this.

---

## Showcase

Tuples of arbitrary`SystemInput`s are now supported:
```rust
fn by_value((In(a), In(b)): (In<usize>, In<usize>)) -> usize {
    a + b
}
fn by_mut((InMut(a), In(b)): (InMut<usize>, In<usize>)) {
    *a += b;
}

let mut world = World::new();
let mut by_value = IntoSystem::into_system(by_value);
let mut by_mut = IntoSystem::into_system(by_mut);

by_value.initialize(&mut world);
by_mut.initialize(&mut world);

assert_eq!(by_value.run((12, 24), &mut world), 36);

let mut a = 10;
let b = 5;
by_mut.run((&mut a, b), &mut world);
assert_eq!(*a, 15);
```