### PR TITLE
Add missing `#[reflect(Component, Default)]` to `SceneRoot` and `DynamicSceneRoot`.

### DIFF
--- a/crates/bevy_scene/src/components.rs
+++ b/crates/bevy_scene/src/components.rs
@@ -16,7 +16,7 @@ use crate::{DynamicScene, Scene};
 /// Adding this component will spawn the scene as a child of that entity.
 /// Once it's spawned, the entity will have a [`SceneInstance`](crate::SceneInstance) component.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(Component, Default, Debug, PartialEq)]
 #[require(Transform)]
 #[cfg_attr(feature = "bevy_render", require(Visibility))]
 pub struct SceneRoot(pub Handle<Scene>);
@@ -24,7 +24,7 @@ pub struct SceneRoot(pub Handle<Scene>);
 /// Adding this component will spawn the scene as a child of that entity.
 /// Once it's spawned, the entity will have a [`SceneInstance`](crate::SceneInstance) component.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
-#[reflect(Component, Default)]
+#[reflect(Component, Default, Debug, PartialEq)]
 #[require(Transform)]
 #[cfg_attr(feature = "bevy_render", require(Visibility))]
 pub struct DynamicSceneRoot(pub Handle<DynamicScene>);

--- a/crates/bevy_scene/src/components.rs
+++ b/crates/bevy_scene/src/components.rs
@@ -1,7 +1,10 @@
 use bevy_asset::Handle;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::component::{require, Component};
-use bevy_reflect::Reflect;
+use bevy_ecs::{
+    component::{require, Component},
+    prelude::ReflectComponent,
+};
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 use derive_more::derive::From;
 
@@ -13,6 +16,7 @@ use crate::{DynamicScene, Scene};
 /// Adding this component will spawn the scene as a child of that entity.
 /// Once it's spawned, the entity will have a [`SceneInstance`](crate::SceneInstance) component.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
+#[reflect(Component, Default)]
 #[require(Transform)]
 #[cfg_attr(feature = "bevy_render", require(Visibility))]
 pub struct SceneRoot(pub Handle<Scene>);
@@ -20,6 +24,7 @@ pub struct SceneRoot(pub Handle<Scene>);
 /// Adding this component will spawn the scene as a child of that entity.
 /// Once it's spawned, the entity will have a [`SceneInstance`](crate::SceneInstance) component.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
+#[reflect(Component, Default)]
 #[require(Transform)]
 #[cfg_attr(feature = "bevy_render", require(Visibility))]
 pub struct DynamicSceneRoot(pub Handle<DynamicScene>);


### PR DESCRIPTION
Someone forgot to add these, and I need them since I spawn these components in my [glXF] files.

[glXF]: https://github.com/pcwalton/bevy-glxf-loader/