### PR TITLE
Make `#[bindless]` in `ExtendedMaterial` actually enable bindless mode.

### DIFF
--- a/crates/bevy_pbr/src/material_bind_groups.rs
+++ b/crates/bevy_pbr/src/material_bind_groups.rs
@@ -440,7 +440,7 @@ where
 {
     /// Returns a new bind group.
     fn new() -> MaterialBindlessBindGroup<M> {
-        let count = M::BINDLESS_SLOT_COUNT.unwrap_or(1);
+        let count = M::bindless_slot_count().unwrap_or(1);
 
         MaterialBindlessBindGroup {
             bind_group: None,
@@ -789,7 +789,7 @@ pub fn material_uses_bindless_resources<M>(render_device: &RenderDevice) -> bool
 where
     M: Material,
 {
-    M::BINDLESS_SLOT_COUNT.is_some()
+    M::bindless_slot_count().is_some()
         && render_device
             .features()
             .contains(WgpuFeatures::BUFFER_BINDING_ARRAY | WgpuFeatures::TEXTURE_BINDING_ARRAY)

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -567,7 +567,11 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
     // limitations into account.
     let (bindless_slot_count, actual_bindless_slot_count_declaration) = match attr_bindless_count {
         Some(bindless_count) => (
-            quote! { const BINDLESS_SLOT_COUNT: Option<u32> = Some(#bindless_count); },
+            quote! {
+                fn bindless_slot_count() -> Option<u32> {
+                    Some(#bindless_count)
+                }
+            },
             quote! {
                 let #actual_bindless_slot_count = if render_device.features().contains(
                     #render_path::settings::WgpuFeatures::BUFFER_BINDING_ARRAY |

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -337,7 +337,9 @@ pub trait AsBindGroup {
     /// Note that the *actual* slot count may be different from this value, due
     /// to platform limitations. For example, if bindless resources aren't
     /// supported on this platform, the actual slot count will be 1.
-    const BINDLESS_SLOT_COUNT: Option<u32> = None;
+    fn bindless_slot_count() -> Option<u32> {
+        None
+    }
 
     /// label
     fn label() -> Option<&'static str> {


### PR DESCRIPTION
I forgot to set `BINDLESS_SLOT_COUNT` in `ExtendedMaterial`'s implementation of `AsBindGroup`, so it didn't actually become bindless. In fact, it would usually crash with a shader/bind group layout mismatch, because some parts of Bevy's renderer thought that the resulting material was bindless while other parts didn't. This commit corrects the situation.

I had to make `BINDLESS_SLOT_COUNT` a function instead of a constant because the `ExtendedMaterial` version needs some logic. Unfortunately, trait methods can't be `const fn`s, so it has to be a runtime function.