### PR TITLE
Fix stale comment on `LoadContext::finish`.

### DIFF
--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -443,8 +443,7 @@ impl<'a> LoadContext<'a> {
         !self.asset_server.get_handles_untyped(&path).is_empty()
     }
 
-    /// "Finishes" this context by populating the final [`Asset`] value (and the erased [`AssetMeta`] value, if it exists).
-    /// The relevant asset metadata collected in this context will be stored in the returned [`LoadedAsset`].
+    /// "Finishes" this context by populating the final [`Asset`] value.
     pub fn finish<A: Asset>(self, value: A) -> LoadedAsset<A> {
         LoadedAsset {
             value,


### PR DESCRIPTION
# Objective

- The comment is stale after #15487.

## Solution

- Just delete all the references to the meta field.