### PR TITLE
Add `RayMap::map_mut`

### DIFF
--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -191,6 +191,11 @@ pub mod ray {
             &self.map
         }
 
+        /// The mutable hash map of all rays cast in the current frame.
+        pub fn map_mut(&mut self) -> &mut HashMap<RayId, Ray3d> {
+            &mut self.map
+        }
+
         /// Clears the [`RayMap`] and re-populates it with one ray for each
         /// combination of pointer entity and camera entity where the pointer
         /// intersects the camera's viewport.


### PR DESCRIPTION
# Objective

- Manually generate rays used for picking (partially resolves #16664).
- My use case is portals. I would like portal `PointerHits` to be propagated "through" the portal. This is of course doable by having manual backend implementations live locally, but having a mutable `RayMap::map` accessor can let these rays be processed next frame and handled by backends as usual.

## Solution

- Add `RayMap::map_mut`. 

## Testing

- Ran CI.

## Open Questions

- Can this make it into `0.15.1` (if uncontroversial)? I'm not overly familiar with Bevy's versioning :)
- Perhaps `RayMap::push` would be better, so that existing rays cannot be modified?
- Should we also have `RayMap::iter_mut`?
