### PR TITLE
Fix rounding bug in camera projection

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -492,8 +492,8 @@ impl CameraProjection for OrthographicProjection {
             ScalingMode::Fixed { width, height } => (width, height),
         };
 
-        let origin_x = projection_width * self.viewport_origin.x;
-        let origin_y = projection_height * self.viewport_origin.y;
+        let origin_x = (projection_width * self.viewport_origin.x).round();
+        let origin_y = (projection_height * self.viewport_origin.y).round();
 
         self.area = Rect::new(
             self.scale * -origin_x,


### PR DESCRIPTION
# Objective

Fixes #16773

## Solution

https://github.com/bevyengine/bevy/pull/15969 introduces a regression that causes image tearing when `ImageFilterMode::Nearest` is used as the sampler. Rounding the origin fixes the issue.

Credits to @sophrosyne97 for bisecting and finding the commit that broke it.

## Testing

You can test it with this repository: https://github.com/musjj/nearest_filter_bug

```bash
git clone https://github.com/musjj/nearest_filter_bug
cd nearest_filter_bug
echo '[patch.crates-io]\nbevy = { git = "https://github.com/musjj/bevy.git", branch = "rounding-bug" }' >>Cargo.toml
sed -i -e 's/0.15.0/0.15.0-dev/' Cargo.toml
cargo update && cargo run
```
Gradually resize the window to various sizes, while paying attention to the sprite and font. No tearing should occur on any window resolution, even on odd numbers.

Tested on Linux with Gnome. Tests on other platforms would be appreciated.

---

## Showcase

Before:

![image](https://github.com/user-attachments/assets/785edeae-7b28-4735-bb8e-d7f79eb09ac2)


After:

![image](https://github.com/user-attachments/assets/9288bc45-a3cf-4e4e-b941-85a00844c627)