### PR TITLE
Remove benchmarks from CI test

### DIFF
--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -17,7 +17,7 @@ impl Prepare for TestCommand {
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo test --workspace --lib --bins --tests --benches {no_fail_fast}"
+                "cargo test --workspace --lib --bins --tests {no_fail_fast}"
             ),
             "Please fix failing tests in output above.",
         )]


### PR DESCRIPTION
# Objective

Fixes [Do not test benchmarks in CI #16803](https://github.com/bevyengine/bevy/issues/16803), part of [Add benchmarks and compile fail tests back to workspace #16801](https://github.com/bevyengine/bevy/issues/16801)

## Solution

Removes the `--benches` flag from the CI tool test.

## Testing

`cargo run -p ci --quiet -- test`