### PR TITLE
Move Volume and GlobalVolume to own file

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -1,36 +1,10 @@
 #![expect(deprecated)]
 
-use crate::{AudioSource, Decodable};
+use crate::{AudioSource, Decodable, Volume};
 use bevy_asset::{Asset, Handle};
-use bevy_derive::Deref;
 use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
 use bevy_reflect::prelude::*;
-
-/// A volume level equivalent to a non-negative float.
-#[derive(Clone, Copy, Deref, Debug, Reflect)]
-pub struct Volume(pub(crate) f32);
-
-impl Default for Volume {
-    fn default() -> Self {
-        Self(1.0)
-    }
-}
-
-impl Volume {
-    /// Create a new volume level.
-    pub fn new(volume: f32) -> Self {
-        debug_assert!(volume >= 0.0);
-        Self(f32::max(volume, 0.))
-    }
-    /// Get the value of the volume level.
-    pub fn get(&self) -> f32 {
-        self.0
-    }
-
-    /// Zero (silent) volume level
-    pub const ZERO: Self = Volume(0.0);
-}
 
 /// The way Bevy manages the sound playback.
 #[derive(Debug, Clone, Copy, Reflect)]
@@ -193,25 +167,6 @@ impl SpatialListener {
         SpatialListener {
             left_ear_offset: Vec3::X * gap / -2.0,
             right_ear_offset: Vec3::X * gap / 2.0,
-        }
-    }
-}
-
-/// Use this [`Resource`] to control the global volume of all audio.
-///
-/// Note: changing this value will not affect already playing audio.
-#[derive(Resource, Default, Clone, Copy, Reflect)]
-#[reflect(Resource, Default)]
-pub struct GlobalVolume {
-    /// The global volume of all audio.
-    pub volume: Volume,
-}
-
-impl GlobalVolume {
-    /// Create a new [`GlobalVolume`] with the given volume.
-    pub fn new(volume: f32) -> Self {
-        Self {
-            volume: Volume::new(volume),
         }
     }
 }

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -34,6 +34,7 @@ mod audio_output;
 mod audio_source;
 mod pitch;
 mod sinks;
+mod volume;
 
 /// The audio prelude.
 ///
@@ -51,6 +52,7 @@ pub mod prelude {
 pub use audio::*;
 pub use audio_source::*;
 pub use pitch::*;
+pub use volume::*;
 
 pub use rodio::{cpal::Sample as CpalSample, source::Source, Sample};
 pub use sinks::*;

--- a/crates/bevy_audio/src/volume.rs
+++ b/crates/bevy_audio/src/volume.rs
@@ -1,0 +1,48 @@
+use bevy_derive::Deref;
+use bevy_ecs::prelude::*;
+use bevy_reflect::prelude::*;
+
+/// Use this [`Resource`] to control the global volume of all audio.
+///
+/// Note: changing this value will not affect already playing audio.
+#[derive(Resource, Default, Clone, Copy, Reflect)]
+#[reflect(Resource, Default)]
+pub struct GlobalVolume {
+    /// The global volume of all audio.
+    pub volume: Volume,
+}
+
+impl GlobalVolume {
+    /// Create a new [`GlobalVolume`] with the given volume.
+    pub fn new(volume: f32) -> Self {
+        Self {
+            volume: Volume::new(volume),
+        }
+    }
+}
+
+/// A volume level equivalent to a non-negative float.
+#[derive(Clone, Copy, Deref, Debug, Reflect)]
+#[reflect(Debug)]
+pub struct Volume(pub(crate) f32);
+
+impl Default for Volume {
+    fn default() -> Self {
+        Self(1.0)
+    }
+}
+
+impl Volume {
+    /// Create a new volume level.
+    pub fn new(volume: f32) -> Self {
+        debug_assert!(volume >= 0.0);
+        Self(f32::max(volume, 0.))
+    }
+    /// Get the value of the volume level.
+    pub fn get(&self) -> f32 {
+        self.0
+    }
+
+    /// Zero (silent) volume level
+    pub const ZERO: Self = Volume(0.0);
+}


### PR DESCRIPTION
# Objective

- Prework for reviving #9582.

## Solution

- Move the two types to volume.rs and made it compile.
- Also `#[reflect(Debug)]` on `Volume` while I'm here. 

## Testing

- Ran example locally.
- Rely on CI.
