### PR TITLE
Fix inaccurate comment in custom_ui_material.wgsl shader

### DIFF
--- a/assets/shaders/custom_ui_material.wgsl
+++ b/assets/shaders/custom_ui_material.wgsl
@@ -1,4 +1,5 @@
-// This shader draws a circle with a given input color
+// This shader draws a progress bar that changes its color based on time elapsed
+// and cycles between 0% full and 100% full
 #import bevy_ui::ui_vertex_output::UiVertexOutput
 
 @group(1) @binding(0) var<uniform> color: vec4<f32>;

--- a/assets/shaders/custom_ui_material.wgsl
+++ b/assets/shaders/custom_ui_material.wgsl
@@ -1,5 +1,4 @@
-// This shader draws a progress bar that changes its color based on time elapsed
-// and cycles between 0% full and 100% full
+// Draws a progress bar with properties defined in CustomUiMaterial
 #import bevy_ui::ui_vertex_output::UiVertexOutput
 
 @group(1) @binding(0) var<uniform> color: vec4<f32>;


### PR DESCRIPTION
# Objective

- Modify a comment in the shader file to describe what the shader actually does
- Fixes #16830

## Solution

- Changed the comment.

## Testing

- Testing is not relevant to fixing comments (as long as the comment is accurate)
