### PR TITLE
Remove deprecated ECS items

### DIFF
--- a/crates/bevy_ecs/src/event/collections.rs
+++ b/crates/bevy_ecs/src/event/collections.rs
@@ -192,28 +192,6 @@ impl<E: Event> Events<E> {
         }
     }
 
-    #[deprecated(
-        since = "0.14.0",
-        note = "`get_reader` has been deprecated. Please use `get_cursor` instead."
-    )]
-    /// Gets a new [`EventCursor`]. This will include all events already in the event buffers.
-    pub fn get_reader(&self) -> EventCursor<E> {
-        EventCursor::default()
-    }
-
-    #[deprecated(
-        since = "0.14.0",
-        note = "`get_reader_current` has been replaced. Please use `get_cursor_current` instead."
-    )]
-    /// Gets a new [`EventCursor`]. This will ignore all events already in the event buffers.
-    /// It will read all future events.
-    pub fn get_reader_current(&self) -> EventCursor<E> {
-        EventCursor {
-            last_event_count: self.event_count,
-            ..Default::default()
-        }
-    }
-
     /// Swaps the event buffers and clears the oldest event buffer. In general, this should be
     /// called once per frame/update.
     ///

--- a/crates/bevy_ecs/src/event/event_cursor.rs
+++ b/crates/bevy_ecs/src/event/event_cursor.rs
@@ -6,17 +6,6 @@ use bevy_ecs::event::{
 use bevy_ecs::event::{EventMutParIter, EventParIter};
 use core::marker::PhantomData;
 
-// Deprecated in favor of `EventCursor`, there is no nice way to deprecate this
-// because generic constraints are not allowed in type aliases, so this will always
-// 'dead code'. Hence the `#[allow(dead_code)]`.
-#[deprecated(
-    since = "0.14.0",
-    note = "`ManualEventReader` has been replaced. Please use `EventCursor` instead."
-)]
-#[doc(alias = "EventCursor")]
-#[allow(dead_code)]
-pub type ManualEventReader<E> = EventCursor<E>;
-
 /// Stores the state for an [`EventReader`] or [`EventMutator`].
 ///
 /// Access to the [`Events<E>`] resource is required to read any incoming events.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -50,7 +50,7 @@ pub use bevy_ptr as ptr;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -1328,9 +1328,9 @@ mod tests {
         );
 
         schedule.run(&mut world);
-        assert_eq!(world.resource::<Counter>().0, 7);
+        assert_eq!(world.resource::<Counter>().0, 5);
         schedule.run(&mut world);
-        assert_eq!(world.resource::<Counter>().0, 72);
+        assert_eq!(world.resource::<Counter>().0, 52);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -123,57 +123,6 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
         CombinatorSystem::new(a, b, Cow::Owned(name))
     }
 
-    /// Returns a new run condition that only returns `true`
-    /// if both this one and the passed `and_then` return `true`.
-    ///
-    /// The returned run condition is short-circuiting, meaning
-    /// `and_then` will only be invoked if `self` returns `true`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bevy_ecs::prelude::*;
-    ///
-    /// #[derive(Resource, PartialEq)]
-    /// struct R(u32);
-    ///
-    /// # let mut app = Schedule::default();
-    /// # let mut world = World::new();
-    /// # fn my_system() {}
-    /// app.add_systems(
-    ///     // The `resource_equals` run condition will fail since we don't initialize `R`,
-    ///     // just like if we used `Res<R>` in a system.
-    ///     my_system.run_if(resource_equals(R(0))),
-    /// );
-    /// # app.run(&mut world);
-    /// ```
-    ///
-    /// Use `.and_then()` to avoid checking the condition.
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # #[derive(Resource, PartialEq)]
-    /// # struct R(u32);
-    /// # let mut app = Schedule::default();
-    /// # let mut world = World::new();
-    /// # fn my_system() {}
-    /// app.add_systems(
-    ///     // `resource_equals` will only get run if the resource `R` exists.
-    ///     my_system.run_if(resource_exists::<R>.and_then(resource_equals(R(0)))),
-    /// );
-    /// # app.run(&mut world);
-    /// ```
-    ///
-    /// Note that in this case, it's better to just use the run condition [`resource_exists_and_equals`].
-    ///
-    /// [`resource_exists_and_equals`]: common_conditions::resource_exists_and_equals
-    #[deprecated(
-        note = "Users should use the `.and(condition)` method in lieu of `.and_then(condition)`"
-    )]
-    fn and_then<M, C: Condition<M, In>>(self, and_then: C) -> And<Self::System, C::System> {
-        self.and(and_then)
-    }
-
     /// Returns a new run condition that only returns `false`
     /// if both this one and the passed `nand` return `true`.
     ///
@@ -323,53 +272,6 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
         let b = IntoSystem::into_system(or);
         let name = format!("{} || {}", a.name(), b.name());
         CombinatorSystem::new(a, b, Cow::Owned(name))
-    }
-
-    /// Returns a new run condition that returns `true`
-    /// if either this one or the passed `or` return `true`.
-    ///
-    /// The returned run condition is short-circuiting, meaning
-    /// `or` will only be invoked if `self` returns `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bevy_ecs::prelude::*;
-    ///
-    /// #[derive(Resource, PartialEq)]
-    /// struct A(u32);
-    ///
-    /// #[derive(Resource, PartialEq)]
-    /// struct B(u32);
-    ///
-    /// # let mut app = Schedule::default();
-    /// # let mut world = World::new();
-    /// # #[derive(Resource)] struct C(bool);
-    /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
-    /// app.add_systems(
-    ///     // Only run the system if either `A` or `B` exist.
-    ///     my_system.run_if(resource_exists::<A>.or(resource_exists::<B>)),
-    /// );
-    /// #
-    /// # world.insert_resource(C(false));
-    /// # app.run(&mut world);
-    /// # assert!(!world.resource::<C>().0);
-    /// #
-    /// # world.insert_resource(A(0));
-    /// # app.run(&mut world);
-    /// # assert!(world.resource::<C>().0);
-    /// #
-    /// # world.remove_resource::<A>();
-    /// # world.insert_resource(B(0));
-    /// # world.insert_resource(C(false));
-    /// # app.run(&mut world);
-    /// # assert!(world.resource::<C>().0);
-    /// ```
-    #[deprecated(
-        note = "Users should use the `.or(condition)` method in lieu of `.or_else(condition)`"
-    )]
-    fn or_else<M, C: Condition<M, In>>(self, or_else: C) -> Or<Self::System, C::System> {
-        self.or(or_else)
     }
 
     /// Returns a new run condition that only returns `true`
@@ -1406,7 +1308,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn run_condition_combinators() {
         let mut world = World::new();
         world.init_resource::<Counter>();
@@ -1415,15 +1316,13 @@ mod tests {
         schedule.add_systems(
             (
                 increment_counter.run_if(every_other_time.and(|| true)), // Run every odd cycle.
-                increment_counter.run_if(every_other_time.and_then(|| true)), // Run every odd cycle.
-                increment_counter.run_if(every_other_time.nand(|| false)),    // Always run.
-                double_counter.run_if(every_other_time.nor(|| false)), // Run every even cycle.
-                increment_counter.run_if(every_other_time.or(|| true)), // Always run.
-                increment_counter.run_if(every_other_time.or_else(|| true)), // Always run.
+                increment_counter.run_if(every_other_time.nand(|| false)), // Always run.
+                double_counter.run_if(every_other_time.nor(|| false)),   // Run every even cycle.
+                increment_counter.run_if(every_other_time.or(|| true)),  // Always run.
                 increment_counter.run_if(every_other_time.xnor(|| true)), // Run every odd cycle.
-                double_counter.run_if(every_other_time.xnor(|| false)), // Run every even cycle.
+                double_counter.run_if(every_other_time.xnor(|| false)),  // Run every even cycle.
                 increment_counter.run_if(every_other_time.xor(|| false)), // Run every odd cycle.
-                double_counter.run_if(every_other_time.xor(|| true)),  // Run every even cycle.
+                double_counter.run_if(every_other_time.xor(|| true)),    // Run every even cycle.
             )
                 .chain(),
         );

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -109,7 +109,7 @@ impl SystemSchedule {
 
 /// See [`ApplyDeferred`].
 #[deprecated(
-    since = "0.15.0",
+    since = "0.16.0",
     note = "Use `ApplyDeferred` instead. This was previously a function but is now a marker struct System."
 )]
 #[expect(non_upper_case_globals)]

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -108,7 +108,10 @@ impl SystemSchedule {
 }
 
 /// See [`ApplyDeferred`].
-#[deprecated = "Use `ApplyDeferred` instead. This was previously a function but is now a marker struct System."]
+#[deprecated(
+    since = "0.15.0",
+    note = "Use `ApplyDeferred` instead. This was previously a function but is now a marker struct System."
+)]
 #[expect(non_upper_case_globals)]
 pub const apply_deferred: ApplyDeferred = ApplyDeferred;
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -38,10 +38,10 @@ use crate::{
         ComponentInfo, ComponentTicks, Components, Mutable, RequiredComponents,
         RequiredComponentsError, Tick,
     },
-    entity::{AllocAtWithoutReplacement, Entities, Entity, EntityHashSet, EntityLocation},
+    entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
     event::{Event, EventId, Events, SendBatchIds},
     observer::Observers,
-    query::{DebugCheckedUnwrap, QueryData, QueryEntityError, QueryFilter, QueryState},
+    query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     removal_detection::RemovedComponentEvents,
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
@@ -849,76 +849,6 @@ impl World {
         }
     }
 
-    /// Gets an [`EntityRef`] for multiple entities at once.
-    ///
-    /// # Panics
-    ///
-    /// If any entity does not exist in the world.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Getting multiple entities.
-    /// let [entity1, entity2] = world.many_entities([id1, id2]);
-    /// ```
-    ///
-    /// ```should_panic
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Trying to get a despawned entity will fail.
-    /// world.despawn(id2);
-    /// world.many_entities([id1, id2]);
-    /// ```
-    #[deprecated(since = "0.15.0", note = "Use `World::entity::<[Entity; N]>` instead")]
-    pub fn many_entities<const N: usize>(&mut self, entities: [Entity; N]) -> [EntityRef<'_>; N] {
-        self.entity(entities)
-    }
-
-    /// Gets mutable access to multiple entities at once.
-    ///
-    /// # Panics
-    ///
-    /// If any entities do not exist in the world,
-    /// or if the same entity is specified multiple times.
-    ///
-    /// # Examples
-    ///
-    /// Disjoint mutable access.
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Disjoint mutable access.
-    /// let [entity1, entity2] = world.many_entities_mut([id1, id2]);
-    /// ```
-    ///
-    /// Trying to access the same entity multiple times will fail.
-    ///
-    /// ```should_panic
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id = world.spawn_empty().id();
-    /// world.many_entities_mut([id, id]);
-    /// ```
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use `World::entity_mut::<[Entity; N]>` instead"
-    )]
-    pub fn many_entities_mut<const N: usize>(
-        &mut self,
-        entities: [Entity; N],
-    ) -> [EntityMut<'_>; N] {
-        self.entity_mut(entities)
-    }
-
     /// Returns the components of an [`Entity`] through [`ComponentInfo`].
     #[inline]
     pub fn inspect_entity(&self, entity: Entity) -> impl Iterator<Item = &ComponentInfo> {
@@ -1010,70 +940,6 @@ impl World {
         let cell = self.as_unsafe_world_cell_readonly();
         // SAFETY: `&self` gives read access to the entire world, and prevents mutable access.
         unsafe { entities.fetch_ref(cell) }
-    }
-
-    /// Gets an [`EntityRef`] for multiple entities at once.
-    ///
-    /// # Errors
-    ///
-    /// If any entity does not exist in the world.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Getting multiple entities.
-    /// let [entity1, entity2] = world.get_many_entities([id1, id2]).unwrap();
-    ///
-    /// // Trying to get a despawned entity will fail.
-    /// world.despawn(id2);
-    /// assert!(world.get_many_entities([id1, id2]).is_err());
-    /// ```
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use `World::get_entity::<[Entity; N]>` instead"
-    )]
-    pub fn get_many_entities<const N: usize>(
-        &self,
-        entities: [Entity; N],
-    ) -> Result<[EntityRef<'_>; N], Entity> {
-        self.get_entity(entities)
-    }
-
-    /// Gets an [`EntityRef`] for multiple entities at once, whose number is determined at runtime.
-    ///
-    /// # Errors
-    ///
-    /// If any entity does not exist in the world.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Getting multiple entities.
-    /// let entities = world.get_many_entities_dynamic(&[id1, id2]).unwrap();
-    /// let entity1 = entities.get(0).unwrap();
-    /// let entity2 = entities.get(1).unwrap();
-    ///
-    /// // Trying to get a despawned entity will fail.
-    /// world.despawn(id2);
-    /// assert!(world.get_many_entities_dynamic(&[id1, id2]).is_err());
-    /// ```
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use `World::get_entity::<&[Entity]>` instead"
-    )]
-    pub fn get_many_entities_dynamic<'w>(
-        &'w self,
-        entities: &[Entity],
-    ) -> Result<Vec<EntityRef<'w>>, Entity> {
-        self.get_entity(entities)
     }
 
     /// Returns [`EntityMut`]s that expose read and write operations for the
@@ -1171,129 +1037,6 @@ impl World {
                     unsafe { EntityMut::new(cell) }
                 })
         })
-    }
-
-    /// Gets mutable access to multiple entities.
-    ///
-    /// # Errors
-    ///
-    /// If any entities do not exist in the world,
-    /// or if the same entity is specified multiple times.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Disjoint mutable access.
-    /// let [entity1, entity2] = world.get_many_entities_mut([id1, id2]).unwrap();
-    ///
-    /// // Trying to access the same entity multiple times will fail.
-    /// assert!(world.get_many_entities_mut([id1, id1]).is_err());
-    /// ```
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use `World::get_entity_mut::<[Entity; N]>` instead"
-    )]
-    pub fn get_many_entities_mut<const N: usize>(
-        &mut self,
-        entities: [Entity; N],
-    ) -> Result<[EntityMut<'_>; N], QueryEntityError<'_>> {
-        self.get_entity_mut(entities).map_err(|e| match e {
-            EntityFetchError::NoSuchEntity(entity, world) => {
-                QueryEntityError::NoSuchEntity(entity, world)
-            }
-            EntityFetchError::AliasedMutability(entity) => {
-                QueryEntityError::AliasedMutability(entity)
-            }
-        })
-    }
-
-    /// Gets mutable access to multiple entities, whose number is determined at runtime.
-    ///
-    /// # Errors
-    ///
-    /// If any entities do not exist in the world,
-    /// or if the same entity is specified multiple times.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// // Disjoint mutable access.
-    /// let mut entities = world.get_many_entities_dynamic_mut(&[id1, id2]).unwrap();
-    /// let entity1 = entities.get_mut(0).unwrap();
-    ///
-    /// // Trying to access the same entity multiple times will fail.
-    /// assert!(world.get_many_entities_dynamic_mut(&[id1, id1]).is_err());
-    /// ```
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use `World::get_entity_mut::<&[Entity]>` instead"
-    )]
-    pub fn get_many_entities_dynamic_mut<'w>(
-        &'w mut self,
-        entities: &[Entity],
-    ) -> Result<Vec<EntityMut<'w>>, QueryEntityError<'w>> {
-        self.get_entity_mut(entities).map_err(|e| match e {
-            EntityFetchError::NoSuchEntity(entity, world) => {
-                QueryEntityError::NoSuchEntity(entity, world)
-            }
-            EntityFetchError::AliasedMutability(entity) => {
-                QueryEntityError::AliasedMutability(entity)
-            }
-        })
-    }
-
-    /// Gets mutable access to multiple entities, contained in a [`EntityHashSet`].
-    /// The uniqueness of items in a [`EntityHashSet`] allows us to avoid checking for duplicates.
-    ///
-    /// # Errors
-    ///
-    /// If any entities do not exist in the world.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::entity::EntityHash;
-    /// # use bevy_ecs::entity::EntityHashSet;
-    /// # use bevy_utils::HashSet;
-    /// # let mut world = World::new();
-    /// # let id1 = world.spawn_empty().id();
-    /// # let id2 = world.spawn_empty().id();
-    /// let s = EntityHash::default();
-    /// let mut set = EntityHashSet::with_hasher(s);
-    /// set.insert(id1);
-    /// set.insert(id2);
-    ///
-    /// // Disjoint mutable access.
-    /// let mut entities = world.get_many_entities_from_set_mut(&set).unwrap();
-    /// let entity1 = entities.get_mut(0).unwrap();
-    /// ```
-    #[deprecated(
-        since = "0.15.0",
-        note = "Use `World::get_entity_mut::<&EntityHashSet>` instead."
-    )]
-    pub fn get_many_entities_from_set_mut<'w>(
-        &'w mut self,
-        entities: &EntityHashSet,
-    ) -> Result<Vec<EntityMut<'w>>, QueryEntityError<'w>> {
-        self.get_entity_mut(entities)
-            .map(|fetched| fetched.into_values().collect())
-            .map_err(|e| match e {
-                EntityFetchError::NoSuchEntity(entity, world) => {
-                    QueryEntityError::NoSuchEntity(entity, world)
-                }
-                EntityFetchError::AliasedMutability(entity) => {
-                    QueryEntityError::AliasedMutability(entity)
-                }
-            })
     }
 
     /// Spawns a new [`Entity`] and returns a corresponding [`EntityWorldMut`], which can be used

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -697,6 +697,8 @@ impl World {
     ///     assert_eq!(eref.get::<Position>().unwrap().y, 1.0);
     /// }
     /// ```
+    ///
+    /// [`EntityHashSet`]: crate::entity::EntityHashSet
     #[inline]
     #[track_caller]
     pub fn entity<F: WorldEntityFetch>(&self, entities: F) -> F::Ref<'_> {
@@ -833,6 +835,8 @@ impl World {
     ///     assert_eq!(pos.y, 2.0);
     /// }
     /// ```
+    ///
+    /// [`EntityHashSet`]: crate::entity::EntityHashSet
     #[inline]
     #[track_caller]
     pub fn entity_mut<F: WorldEntityFetch>(&mut self, entities: F) -> F::Mut<'_> {
@@ -935,6 +939,8 @@ impl World {
     /// # Examples
     ///
     /// For examples, see [`World::entity`].
+    ///
+    /// [`EntityHashSet`]: crate::entity::EntityHashSet
     #[inline]
     pub fn get_entity<F: WorldEntityFetch>(&self, entities: F) -> Result<F::Ref<'_>, Entity> {
         let cell = self.as_unsafe_world_cell_readonly();
@@ -971,6 +977,8 @@ impl World {
     /// # Examples
     ///
     /// For examples, see [`World::entity_mut`].
+    ///
+    /// [`EntityHashSet`]: crate::entity::EntityHashSet
     #[inline]
     pub fn get_entity_mut<F: WorldEntityFetch>(
         &mut self,


### PR DESCRIPTION
# Objective

- Cleanup deprecated code

## Solution

- Removed `#[deprecated]` items which were marked as such in 0.15 or prior versions.

## Migration Guide

- The following deprecated items were removed: `Events::get_reader`, `Events::get_reader_current`, `ManualEventReader`, `Condition::and_then`, `Condition::or_else`, `World::,many_entities`, `World::many_entities_mut`, `World::get_many_entities`, `World::get_many_entities_dynamic`, `World::get_many_entities_mut`, `World::get_many_entities_dynamic_mut`, `World::get_many_entities_from_set_mut`