### PR TITLE
Resource Params as references. `fn system(_res: &Res){}`

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -60,7 +60,7 @@ mod tests {
         world.resource_mut::<SystemOrder>().0.push(u32::MAX);
     }
 
-    fn counting_system(counter: Res<Counter>) {
+    fn counting_system(counter: &Counter) {
         counter.0.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -741,6 +741,7 @@ mod tests {
 
         fn empty_system() {}
         fn res_system(_res: Res<R>) {}
+        fn res_ref_system(_res: &R) {}
         fn resmut_system(_res: ResMut<R>) {}
         fn nonsend_system(_ns: NonSend<R>) {}
         fn nonsendmut_system(_ns: NonSendMut<R>) {}
@@ -788,6 +789,7 @@ mod tests {
                 empty_system,
                 res_system,
                 res_system,
+                res_ref_system,
                 nonsend_system,
                 nonsend_system,
                 read_component_system,

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -396,7 +396,7 @@ mod tests {
 
         fn query_system(
             mut ran: ResMut<SystemRan>,
-            entities_array: Res<EntitiesArray>,
+            entities_array: &EntitiesArray,
             q: Query<&W<usize>>,
         ) {
             let entities_array: [Entity; ENTITIES_COUNT] =
@@ -1063,9 +1063,9 @@ mod tests {
 
     #[test]
     fn get_system_conflicts() {
-        fn sys_x(_: Res<A>, _: Res<B>, _: Query<(&C, &D)>) {}
+        fn sys_x(_: &A, _: &B, _: Query<(&C, &D)>) {}
 
-        fn sys_y(_: Res<A>, _: ResMut<B>, _: Query<(&C, &mut D)>) {}
+        fn sys_y(_: &A, _: ResMut<B>, _: Query<(&C, &mut D)>) {}
 
         let mut world = World::default();
         let mut x = IntoSystem::into_system(sys_x);


### PR DESCRIPTION
# Objective

- In the same way that queries can be written like `Query<&Component>`, one would expect to refer to resources as `&Resource` while writing systems.
 - I couldn't find any issue or pull request talking about this in the past, but if this is not align with the API that Bevy wants to provide, I can  close this pull request. I understand this would be a controversial change, but it would be a big quality of life improvement for many systems

## Solution

- This PR allows resources to be use just by reference by implementing `SystemParam` for `&T where T: Resource `.
- The behaviour should be exactly the same one as `Res<T>` without the access to track changes.
- `Res<T>` will continue to exist and it can be used when it makes sense, like `Ref` exists for components.
- Honestly I'm not sure if this was not possible in the past, and I was not expecting this change to even compile, but it seem to work just fine without any disadvantages


## Testing

-. 
- `cargo run -p ci`: OK
- `MIRIFLAGS="-Zmiri-ignore-leaks -Zmiri-disable-isolation" cargo +nightly miri test -p bevy_ecs`: OK

---

## Showcase

With this PR, some systems that don't need the methods provided by `Res` can be simplified, common examples are `ButtonInput<T>`, `AssetServer` or `Time`.

Now you can write systems like this:

```rust
fn my_system(keyboard: &ButtonInput<KeyCode>, asset_server: &AssetServer, time: &Time) {
    // Do stuff
}

```



