### PR TITLE
Add `SubApp::take_extract()`

### DIFF
--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -182,8 +182,8 @@ impl SubApp {
     ///     // [...]
     ///
     ///     // Call Bevy's default, which executes the Extract phase
-    ///     if let Some(fn) = default_fn.as_mut() {
-    ///         fn(main, render);
+    ///     if let Some(f) = default_fn.as_mut() {
+    ///         f(main, render);
     ///     }
     ///
     ///     // Do post-extract custom logic

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -165,6 +165,32 @@ impl SubApp {
         self
     }
 
+    /// Take the function that will be called by [`extract`](Self::extract) out of the app, if any was set,
+    /// and replace it with `None`.
+    ///
+    /// If you use Bevy, `bevy_render` will set a default extract function used to extract data from
+    /// the main world into the render world as part of the Extract phase. In that case, you cannot replace
+    /// it with your own function. Instead, take the Bevy default function with this, and install your own
+    /// instead which calls the Bevy default.
+    ///
+    /// ```
+    /// # let mut app = SubApp::new();
+    /// let default_fn = app.take_extract();
+    /// app.set_extract(move |(main, render)| {
+    ///     // Do pre-extract custom logic
+    ///     // [...]
+    ///
+    ///     // Call Bevy's default, which executes the Extract phase
+    ///     default_fn(main, render);
+    ///
+    ///     // Do post-extract custom logic
+    ///     // [...]
+    /// });
+    /// ```
+    pub fn take_extract(&mut self) -> Option<ExtractFn> {
+        self.extract.take()
+    }
+
     /// See [`App::insert_resource`].
     pub fn insert_resource<R: Resource>(&mut self, resource: R) -> &mut Self {
         self.world.insert_resource(resource);

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -174,6 +174,7 @@ impl SubApp {
     /// instead which calls the Bevy default.
     ///
     /// ```
+    /// # use bevy_app::SubApp;
     /// # let mut app = SubApp::new();
     /// let default_fn = app.take_extract();
     /// app.set_extract(move |(main, render)| {

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -176,7 +176,7 @@ impl SubApp {
     /// ```
     /// # use bevy_app::SubApp;
     /// # let mut app = SubApp::new();
-    /// let default_fn = app.take_extract();
+    /// let mut default_fn = app.take_extract();
     /// app.set_extract(move |main, render| {
     ///     // Do pre-extract custom logic
     ///     // [...]

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -177,12 +177,14 @@ impl SubApp {
     /// # use bevy_app::SubApp;
     /// # let mut app = SubApp::new();
     /// let default_fn = app.take_extract();
-    /// app.set_extract(move |(main, render)| {
+    /// app.set_extract(move |main, render| {
     ///     // Do pre-extract custom logic
     ///     // [...]
     ///
     ///     // Call Bevy's default, which executes the Extract phase
-    ///     default_fn(main, render);
+    ///     if let Some(fn) = default_fn.as_mut() {
+    ///         fn(main, render);
+    ///     }
     ///
     ///     // Do post-extract custom logic
     ///     // [...]

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -176,13 +176,13 @@ impl SubApp {
     /// ```
     /// # use bevy_app::SubApp;
     /// # let mut app = SubApp::new();
-    /// let mut default_fn = app.take_extract();
+    /// let default_fn = app.take_extract();
     /// app.set_extract(move |main, render| {
     ///     // Do pre-extract custom logic
     ///     // [...]
     ///
     ///     // Call Bevy's default, which executes the Extract phase
-    ///     if let Some(f) = default_fn.as_mut() {
+    ///     if let Some(f) = default_fn.as_ref() {
     ///         f(main, render);
     ///     }
     ///


### PR DESCRIPTION
# Objective

Fixes #16850

## Solution

Add a new function `SubApp::take_extract()`, similar to `Option::take()`, which allows stealing the currently installed extract function of a sub-app, with the intent to replace it with a custom one calling the original one via `set_extract()`.

This pattern enables registering a custom "world sync" function similar to the existing one `entity_sync_system()`, to run custom world sync logic with mutable access to both the main and render worlds.

## Testing

`cargo r -p ci` currently doesn't build locally, event after upgrading rustc to latest and doing a `cargo update`.
