### PR TITLE
Feature flag testbed_3d code correctly

### DIFF
--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -138,6 +138,7 @@ mod light {
     }
 }
 
+#[cfg(not(all(feature = "bevy_ci_testing", target_os = "windows")))]
 mod bloom {
     use bevy::{
         core_pipeline::{bloom::Bloom, tonemapping::Tonemapping},
@@ -191,6 +192,7 @@ mod bloom {
     }
 }
 
+#[cfg(not(all(feature = "bevy_ci_testing", target_os = "windows")))]
 mod gltf {
     use bevy::prelude::*;
 


### PR DESCRIPTION
# Objective

Rust-Analyzer was reporting problems with dead code in the 3d testbed scene.

## Solution

These scenes don't work in CI on the Windows runner (because they're too weak).

Mirror the feature flags from above onto the offending modules.

## Testing

RA no longer complains.