### PR TITLE
Remove `OnceLock` usage from `bevy_ecs`

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -130,7 +130,6 @@ portable-atomic-util = { version = "0.2.4", features = [
 spin = { version = "0.9.8", default-features = false, features = [
   "spin_mutex",
   "rwlock",
-  "once",
 ] }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -338,13 +338,13 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Sets this as having access to all resources (i.e. `&World`).
     #[inline]
-    pub fn read_all_resources(&mut self) {
+    pub const fn read_all_resources(&mut self) {
         self.reads_all_resources = true;
     }
 
     /// Sets this as having mutable access to all resources (i.e. `&mut World`).
     #[inline]
-    pub fn write_all_resources(&mut self) {
+    pub const fn write_all_resources(&mut self) {
         self.reads_all_resources = true;
         self.writes_all_resources = true;
     }

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -214,7 +214,7 @@ impl<'w, 's> From<&'w FilteredResourcesMut<'_, 's>> for FilteredResources<'w, 's
 
 impl<'w> From<&'w World> for FilteredResources<'w, 'static> {
     fn from(value: &'w World) -> Self {
-        const READ_ALL_RESOURCES: &'static Access<ComponentId> = {
+        const READ_ALL_RESOURCES: &Access<ComponentId> = {
             const ACCESS: Access<ComponentId> = {
                 let mut access = Access::new();
                 access.read_all_resources();
@@ -493,7 +493,7 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
 
 impl<'w> From<&'w mut World> for FilteredResourcesMut<'w, 'static> {
     fn from(value: &'w mut World) -> Self {
-        const WRITE_ALL_RESOURCES: &'static Access<ComponentId> = {
+        const WRITE_ALL_RESOURCES: &Access<ComponentId> = {
             const ACCESS: Access<ComponentId> = {
                 let mut access = Access::new();
                 access.write_all_resources();

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -1,9 +1,3 @@
-#[cfg(feature = "std")]
-use std::sync::OnceLock;
-
-#[cfg(not(feature = "std"))]
-use spin::once::Once as OnceLock;
-
 use crate::{
     change_detection::{Mut, MutUntyped, Ref, Ticks, TicksMut},
     component::{ComponentId, Tick},
@@ -220,21 +214,13 @@ impl<'w, 's> From<&'w FilteredResourcesMut<'_, 's>> for FilteredResources<'w, 's
 
 impl<'w> From<&'w World> for FilteredResources<'w, 'static> {
     fn from(value: &'w World) -> Self {
-        static READ_ALL_RESOURCES: OnceLock<Access<ComponentId>> = OnceLock::new();
-        let access = {
-            let init = || {
+        const READ_ALL_RESOURCES: &'static Access<ComponentId> = {
+            const ACCESS: Access<ComponentId> = {
                 let mut access = Access::new();
                 access.read_all_resources();
                 access
             };
-
-            #[cfg(feature = "std")]
-            let access = READ_ALL_RESOURCES.get_or_init(init);
-
-            #[cfg(not(feature = "std"))]
-            let access = READ_ALL_RESOURCES.call_once(init);
-
-            access
+            &ACCESS
         };
 
         let last_run = value.last_change_tick();
@@ -243,7 +229,7 @@ impl<'w> From<&'w World> for FilteredResources<'w, 'static> {
         unsafe {
             Self::new(
                 value.as_unsafe_world_cell_readonly(),
-                access,
+                READ_ALL_RESOURCES,
                 last_run,
                 this_run,
             )
@@ -507,22 +493,13 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
 
 impl<'w> From<&'w mut World> for FilteredResourcesMut<'w, 'static> {
     fn from(value: &'w mut World) -> Self {
-        static WRITE_ALL_RESOURCES: OnceLock<Access<ComponentId>> = OnceLock::new();
-
-        let access = {
-            let init = || {
+        const WRITE_ALL_RESOURCES: &'static Access<ComponentId> = {
+            const ACCESS: Access<ComponentId> = {
                 let mut access = Access::new();
                 access.write_all_resources();
                 access
             };
-
-            #[cfg(feature = "std")]
-            let access = WRITE_ALL_RESOURCES.get_or_init(init);
-
-            #[cfg(not(feature = "std"))]
-            let access = WRITE_ALL_RESOURCES.call_once(init);
-
-            access
+            &ACCESS
         };
 
         let last_run = value.last_change_tick();
@@ -531,7 +508,7 @@ impl<'w> From<&'w mut World> for FilteredResourcesMut<'w, 'static> {
         unsafe {
             Self::new(
                 value.as_unsafe_world_cell_readonly(),
-                access,
+                WRITE_ALL_RESOURCES,
                 last_run,
                 this_run,
             )


### PR DESCRIPTION
# Objective

- Fixes #16868

## Solution

- Replaced several usages of `OnceLock` within `bevy_ecs` with `const`s

## Testing

- CI
