### PR TITLE
Generalize bubbling focus input events to other kinds of input

### DIFF
--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -20,16 +20,10 @@ pub mod tab_navigation;
 
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::{
-    component::Component,
-    entity::Entity,
-    event::{Event, EventReader},
-    query::{QueryData, With},
-    system::{Commands, Query, Res, Resource, SystemParam},
-    traversal::Traversal,
-    world::{Command, DeferredWorld, World},
+    prelude::*, query::QueryData, system::SystemParam, traversal::Traversal, world::DeferredWorld,
 };
 use bevy_hierarchy::{HierarchyQueryExt, Parent};
-use bevy_input::keyboard::KeyboardInput;
+use bevy_input::{gamepad::GamepadButtonChangedEvent, keyboard::KeyboardInput};
 use bevy_window::{PrimaryWindow, Window};
 use core::fmt::Debug;
 
@@ -102,17 +96,22 @@ impl SetInputFocus for Commands<'_, '_> {
     }
 }
 
-/// A bubble-able event for keyboard input. This event is normally dispatched to the current
-/// input focus entity, if any. If no entity has input focus, then the event is dispatched to
-/// the main window.
+/// A bubble-able user input event that starts at the currently focused entity.
+///
+/// This event is normally dispatched to the current input focus entity, if any.
+/// If no entity has input focus, then the event is dispatched to the main window.
+///
+/// To set up your own bubbling input event, add the [`dispatch_focused_input::<MyEvent>`](dispatch_focused_input) system to your app,
+/// in the [`InputFocus::Dispatch`] system set during [`PreUpdate`].
 #[derive(Clone, Debug, Component)]
-pub struct FocusKeyboardInput {
-    /// The keyboard input event.
-    pub input: KeyboardInput,
+pub struct FocusedInput<E: Event + Clone> {
+    /// The underlying input event.
+    pub input: E,
+    /// The primary window entity.
     window: Entity,
 }
 
-impl Event for FocusKeyboardInput {
+impl<E: Event + Clone> Event for FocusedInput<E> {
     type Traversal = WindowTraversal;
 
     const AUTO_PROPAGATE: bool = true;
@@ -125,8 +124,8 @@ pub struct WindowTraversal {
     window: Option<&'static Window>,
 }
 
-impl Traversal<FocusKeyboardInput> for WindowTraversal {
-    fn traverse(item: Self::Item<'_>, event: &FocusKeyboardInput) -> Option<Entity> {
+impl<E: Event + Clone> Traversal<FocusedInput<E>> for WindowTraversal {
+    fn traverse(item: Self::Item<'_>, event: &FocusedInput<E>) -> Option<Entity> {
         let WindowTraversalItem { parent, window } = item;
 
         // Send event to parent, if it has one.
@@ -151,14 +150,30 @@ impl Plugin for InputDispatchPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(InputFocus(None))
             .insert_resource(InputFocusVisible(false))
-            .add_systems(PreUpdate, dispatch_keyboard_input);
+            .add_systems(
+                PreUpdate,
+                (
+                    dispatch_focused_input::<KeyboardInput>,
+                    dispatch_focused_input::<GamepadButtonChangedEvent>,
+                )
+                    .in_set(InputFocusSet::Dispatch),
+            );
     }
 }
 
-/// System which dispatches keyboard input events to the focused entity, or to the primary window
+/// System sets for [`bevy_input_focus`](crate).
+///
+/// These systems run in the [`PreUpdate`] schedule.
+#[derive(SystemSet, Debug, PartialEq, Eq, Hash, Clone)]
+pub enum InputFocusSet {
+    /// System which dispatches bubbled input events to the focused entity, or to the primary window.
+    Dispatch,
+}
+
+/// System which dispatches bubbled input events to the focused entity, or to the primary window
 /// if no entity has focus.
-fn dispatch_keyboard_input(
-    mut key_events: EventReader<KeyboardInput>,
+pub fn dispatch_focused_input<E: Event + Clone>(
+    mut key_events: EventReader<E>,
     focus: Res<InputFocus>,
     windows: Query<Entity, With<PrimaryWindow>>,
     mut commands: Commands,
@@ -168,7 +183,7 @@ fn dispatch_keyboard_input(
         if let Some(focus_elt) = focus.0 {
             for ev in key_events.read() {
                 commands.trigger_targets(
-                    FocusKeyboardInput {
+                    FocusedInput {
                         input: ev.clone(),
                         window,
                     },
@@ -180,7 +195,7 @@ fn dispatch_keyboard_input(
             // There should be only one primary window.
             for ev in key_events.read() {
                 commands.trigger_targets(
-                    FocusKeyboardInput {
+                    FocusedInput {
                         input: ev.clone(),
                         window,
                     },
@@ -308,7 +323,7 @@ mod tests {
     struct GatherKeyboardEvents(String);
 
     fn gather_keyboard_events(
-        trigger: Trigger<FocusKeyboardInput>,
+        trigger: Trigger<FocusedInput<KeyboardInput>>,
         mut query: Query<&mut GatherKeyboardEvents>,
     ) {
         if let Ok(mut gather) = query.get_mut(trigger.target()) {

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -23,7 +23,7 @@ use bevy_ecs::{
     prelude::*, query::QueryData, system::SystemParam, traversal::Traversal, world::DeferredWorld,
 };
 use bevy_hierarchy::{HierarchyQueryExt, Parent};
-use bevy_input::{gamepad::GamepadButtonChangedEvent, keyboard::KeyboardInput};
+use bevy_input::{gamepad::GamepadButtonChangedEvent, keyboard::KeyboardInput, mouse::MouseWheel};
 use bevy_window::{PrimaryWindow, Window};
 use core::fmt::Debug;
 
@@ -155,6 +155,7 @@ impl Plugin for InputDispatchPlugin {
                 (
                     dispatch_focused_input::<KeyboardInput>,
                     dispatch_focused_input::<GamepadButtonChangedEvent>,
+                    dispatch_focused_input::<MouseWheel>,
                 )
                     .in_set(InputFocusSet::Dispatch),
             );

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -111,7 +111,7 @@ impl SetInputFocus for Commands<'_, '_> {
 /// If no entity has input focus, then the event is dispatched to the main window.
 ///
 /// To set up your own bubbling input event, add the [`dispatch_focused_input::<MyEvent>`](dispatch_focused_input) system to your app,
-/// in the [`InputFocus::Dispatch`] system set during [`PreUpdate`].
+/// in the [`InputFocusSet::Dispatch`] system set during [`PreUpdate`].
 #[derive(Clone, Debug, Component)]
 pub struct FocusedInput<E: Event + Clone> {
     /// The underlying input event.

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -36,11 +36,14 @@ use bevy_ecs::{
     world::DeferredWorld,
 };
 use bevy_hierarchy::{Children, HierarchyQueryExt, Parent};
-use bevy_input::{keyboard::KeyCode, ButtonInput, ButtonState};
+use bevy_input::{
+    keyboard::{KeyCode, KeyboardInput},
+    ButtonInput, ButtonState,
+};
 use bevy_utils::tracing::warn;
 use bevy_window::PrimaryWindow;
 
-use crate::{FocusKeyboardInput, InputFocus, InputFocusVisible, SetInputFocus};
+use crate::{FocusedInput, InputFocus, InputFocusVisible, SetInputFocus};
 
 /// A component which indicates that an entity wants to participate in tab navigation.
 ///
@@ -264,7 +267,7 @@ fn setup_tab_navigation(mut commands: Commands, window: Query<Entity, With<Prima
 
 /// Observer function which handles tab navigation.
 pub fn handle_tab_navigation(
-    mut trigger: Trigger<FocusKeyboardInput>,
+    mut trigger: Trigger<FocusedInput<KeyboardInput>>,
     nav: TabNavigation,
     mut focus: ResMut<InputFocus>,
     mut visible: ResMut<InputFocusVisible>,

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -266,6 +266,9 @@ fn setup_tab_navigation(mut commands: Commands, window: Query<Entity, With<Prima
 }
 
 /// Observer function which handles tab navigation.
+///
+/// This observer responds to [`KeyCode::Tab`] events and Shift+Tab events,
+/// cycling through focusable entities in the order determined by their tab index.
 pub fn handle_tab_navigation(
     mut trigger: Trigger<FocusedInput<KeyboardInput>>,
     nav: TabNavigation,


### PR DESCRIPTION
# Objective

The new `bevy_input_focus` crates has a tool to bubble input events up the entity hierarchy, ending with the window, based on the currently focused entity. Right now though, this only works for keyboard events!

Both `bevy_ui` buttons and `bevy_egui` should hook into this system (primarily for contextual hotkeys), and we would like to drive `leafwing_input_manager` via these events, to help resolve longstanding pain around "absorbing" / "consuming" inputs based on focus. In order to make that work properly though, we need gamepad support!

## Solution

The logic backing this has been changed to be generic for any cloneable event types, and the machinery to make use of this externally has been made `pub`. 

Within the engine itself, I've added support for gamepad button and scroll events, but nothing else. Mouse button / touch bubbling is handled via bevy_picking, and mouse / gamepad motion doesn't really make sense to bubble.

## Testing

The `tab_navigation` example continues to work, and CI is green.

## Future Work

I would like to add more complex UI examples to stress test this, but not here please.

We should take advantage of the bubbled mouse scrolling when defining scrolled widgets.