### PR TITLE
Retain `RenderMaterialInstances` and `RenderMeshMaterialIds` from frame to frame.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.28.3
+        uses: crate-ci/typos@v1.28.4
       - name: Typos info
         if: failure()
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,9 @@ bevy_window = ["bevy_internal/bevy_window"]
 # winit window and input backend
 bevy_winit = ["bevy_internal/bevy_winit"]
 
+# Load and access image data. Usually added by an image format
+bevy_image = ["bevy_internal/bevy_image"]
+
 # Adds support for rendering gizmos
 bevy_gizmos = ["bevy_internal/bevy_gizmos", "bevy_color"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ bevy_ui = [
 bevy_window = ["bevy_internal/bevy_window"]
 
 # winit window and input backend
-bevy_winit = ["bevy_internal/bevy_winit"]
+bevy_winit = ["bevy_internal/bevy_winit", "bevy_window"]
 
 # Load and access image data. Usually added by an image format
 bevy_image = ["bevy_internal/bevy_image"]

--- a/benches/benches/bevy_ecs/param/dyn_param.rs
+++ b/benches/benches/bevy_ecs/param/dyn_param.rs
@@ -14,6 +14,8 @@ pub fn dyn_param(criterion: &mut Criterion) {
     #[derive(Resource)]
     struct R;
 
+    world.insert_resource(R);
+
     let mut schedule = Schedule::default();
     let system = (
         DynParamBuilder::new::<Res<R>>(ParamBuilder),

--- a/benches/benches/bevy_ecs/param/param_set.rs
+++ b/benches/benches/bevy_ecs/param/param_set.rs
@@ -11,6 +11,8 @@ pub fn param_set(criterion: &mut Criterion) {
     #[derive(Resource)]
     struct R;
 
+    world.insert_resource(R);
+
     let mut schedule = Schedule::default();
     schedule.add_systems(
         |_: ParamSet<(

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1058,6 +1058,16 @@ impl App {
         &mut self.sub_apps.main
     }
 
+    /// Returns a reference to the [`SubApps`] collection.
+    pub fn sub_apps(&self) -> &SubApps {
+        &self.sub_apps
+    }
+
+    /// Returns a mutable reference to the [`SubApps`] collection.
+    pub fn sub_apps_mut(&mut self) -> &mut SubApps {
+        &mut self.sub_apps
+    }
+
     /// Returns a reference to the [`SubApp`] with the given label.
     ///
     /// # Panics

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -166,6 +166,35 @@ impl SubApp {
         self
     }
 
+    /// Take the function that will be called by [`extract`](Self::extract) out of the app, if any was set,
+    /// and replace it with `None`.
+    ///
+    /// If you use Bevy, `bevy_render` will set a default extract function used to extract data from
+    /// the main world into the render world as part of the Extract phase. In that case, you cannot replace
+    /// it with your own function. Instead, take the Bevy default function with this, and install your own
+    /// instead which calls the Bevy default.
+    ///
+    /// ```
+    /// # use bevy_app::SubApp;
+    /// # let mut app = SubApp::new();
+    /// let default_fn = app.take_extract();
+    /// app.set_extract(move |main, render| {
+    ///     // Do pre-extract custom logic
+    ///     // [...]
+    ///
+    ///     // Call Bevy's default, which executes the Extract phase
+    ///     if let Some(f) = default_fn.as_ref() {
+    ///         f(main, render);
+    ///     }
+    ///
+    ///     // Do post-extract custom logic
+    ///     // [...]
+    /// });
+    /// ```
+    pub fn take_extract(&mut self) -> Option<ExtractFn> {
+        self.extract.take()
+    }
+
     /// See [`App::insert_resource`].
     pub fn insert_resource<R: Resource>(&mut self, resource: R) -> &mut Self {
         self.world.insert_resource(resource);

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -544,7 +544,7 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 /// If you need a unique mutable borrow, use [`ResMut`] instead.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
-/// This will cause systems that use this parameter to be skipped.
+/// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Use [`Option<Res<T>>`] instead if the resource might not always exist.
 pub struct Res<'w, T: ?Sized + Resource> {
@@ -622,7 +622,7 @@ impl_debug!(Res<'w, T>, Resource);
 /// If you need a shared borrow, use [`Res`] instead.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if resource doesn't exist.
-/// This will cause systems that use this parameter to be skipped.
+/// /// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Use [`Option<ResMut<T>>`] instead if the resource might not always exist.
 pub struct ResMut<'w, T: ?Sized + Resource> {
@@ -683,7 +683,7 @@ impl<'w, T: Resource> From<ResMut<'w, T>> for Mut<'w, T> {
 /// over to another thread.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if non-send resource doesn't exist.
-/// This will cause systems that use this parameter to be skipped.
+/// /// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Use [`Option<NonSendMut<T>>`] instead if the resource might not always exist.
 pub struct NonSendMut<'w, T: ?Sized + 'static> {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -58,7 +58,7 @@ pub mod prelude {
         bundle::Bundle,
         change_detection::{DetectChanges, DetectChangesMut, Mut, Ref},
         component::{require, Component},
-        entity::{Entity, EntityMapper},
+        entity::{Entity, EntityBorrow, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         name::{Name, NameOrEntity},
         observer::{CloneEntityWithObserversExt, Observer, Trigger},

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1,11 +1,15 @@
 use super::{QueryData, QueryFilter, ReadOnlyQueryData};
 use crate::{
     archetype::{Archetype, ArchetypeEntity, Archetypes},
+    bundle::Bundle,
     component::Tick,
     entity::{Entities, Entity, EntityBorrow, EntitySet, EntitySetIterator},
     query::{ArchetypeFilter, DebugCheckedUnwrap, QueryState, StorageId},
     storage::{Table, TableRow, Tables},
-    world::unsafe_world_cell::UnsafeWorldCell,
+    world::{
+        unsafe_world_cell::UnsafeWorldCell, EntityMut, EntityMutExcept, EntityRef, EntityRefExcept,
+        FilteredEntityMut, FilteredEntityRef,
+    },
 };
 use alloc::vec::Vec;
 use core::{
@@ -1104,6 +1108,36 @@ impl<'w, 's, D: QueryData, F: QueryFilter> FusedIterator for QueryIter<'w, 's, D
 
 // SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
 unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator for QueryIter<'w, 's, Entity, F> {}
+
+// SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
+unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator for QueryIter<'w, 's, EntityRef<'_>, F> {}
+
+// SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
+unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator for QueryIter<'w, 's, EntityMut<'_>, F> {}
+
+// SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
+unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator
+    for QueryIter<'w, 's, FilteredEntityRef<'_>, F>
+{
+}
+
+// SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
+unsafe impl<'w, 's, F: QueryFilter> EntitySetIterator
+    for QueryIter<'w, 's, FilteredEntityMut<'_>, F>
+{
+}
+
+// SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
+unsafe impl<'w, 's, F: QueryFilter, B: Bundle> EntitySetIterator
+    for QueryIter<'w, 's, EntityRefExcept<'_, B>, F>
+{
+}
+
+// SAFETY: [`QueryIter`] is guaranteed to return every matching entity once and only once.
+unsafe impl<'w, 's, F: QueryFilter, B: Bundle> EntitySetIterator
+    for QueryIter<'w, 's, EntityMutExcept<'_, B>, F>
+{
+}
 
 impl<'w, 's, D: QueryData, F: QueryFilter> Debug for QueryIter<'w, 's, D, F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -80,7 +80,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```should_panic
     /// use bevy_ecs::prelude::*;
     ///
     /// #[derive(Resource, PartialEq)]
@@ -90,7 +90,7 @@ pub trait Condition<Marker, In: SystemInput = ()>: sealed::Condition<Marker, In>
     /// # let mut world = World::new();
     /// # fn my_system() {}
     /// app.add_systems(
-    ///     // The `resource_equals` run condition will fail since we don't initialize `R`,
+    ///     // The `resource_equals` run condition will panic since we don't initialize `R`,
     ///     // just like if we used `Res<R>` in a system.
     ///     my_system.run_if(resource_equals(R(0))),
     /// );

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -308,7 +308,7 @@ mod tests {
         self as bevy_ecs,
         prelude::{IntoSystemConfigs, IntoSystemSetConfigs, Resource, Schedule, SystemSet},
         schedule::ExecutorKind,
-        system::{Commands, In, IntoSystem, Res},
+        system::{Commands, Res, WithParamWarnPolicy},
         world::World,
     };
 
@@ -337,15 +337,11 @@ mod tests {
         schedule.set_executor_kind(executor);
         schedule.add_systems(
             (
-                // Combined systems get skipped together.
-                (|mut commands: Commands| {
-                    commands.insert_resource(R1);
-                })
-                .pipe(|_: In<()>, _: Res<R1>| {}),
                 // This system depends on a system that is always skipped.
-                |mut commands: Commands| {
+                (|mut commands: Commands| {
                     commands.insert_resource(R2);
-                },
+                })
+                .param_warn_once(),
             )
                 .chain(),
         );
@@ -368,18 +364,20 @@ mod tests {
         let mut world = World::new();
         let mut schedule = Schedule::default();
         schedule.set_executor_kind(executor);
-        schedule.configure_sets(S1.run_if(|_: Res<R1>| true));
+        schedule.configure_sets(S1.run_if((|_: Res<R1>| true).param_warn_once()));
         schedule.add_systems((
             // System gets skipped if system set run conditions fail validation.
             (|mut commands: Commands| {
                 commands.insert_resource(R1);
             })
+            .param_warn_once()
             .in_set(S1),
             // System gets skipped if run conditions fail validation.
             (|mut commands: Commands| {
                 commands.insert_resource(R2);
             })
-            .run_if(|_: Res<R2>| true),
+            .param_warn_once()
+            .run_if((|_: Res<R2>| true).param_warn_once()),
         ));
         schedule.run(&mut world);
         assert!(world.get_resource::<R1>().is_none());

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -743,6 +743,10 @@ impl Tables {
         component_ids: &[ComponentId],
         components: &Components,
     ) -> TableId {
+        if component_ids.is_empty() {
+            return TableId::empty();
+        }
+
         let tables = &mut self.tables;
         let (_key, value) = self
             .table_ids
@@ -816,13 +820,25 @@ mod tests {
         component::{Component, Components, Tick},
         entity::Entity,
         ptr::OwningPtr,
-        storage::{Storages, TableBuilder, TableRow},
+        storage::{Storages, TableBuilder, TableId, TableRow, Tables},
     };
     #[cfg(feature = "track_change_detection")]
     use core::panic::Location;
 
     #[derive(Component)]
     struct W<T>(T);
+
+    #[test]
+    fn only_one_empty_table() {
+        let components = Components::default();
+        let mut tables = Tables::default();
+
+        let component_ids = &[];
+        // SAFETY: component_ids is empty, so we know it cannot reference invalid component IDs
+        let table_id = unsafe { tables.get_id_or_insert(component_ids, &components) };
+
+        assert_eq!(table_id, TableId::empty());
+    }
 
     #[test]
     fn table() {

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -214,7 +214,7 @@ where
     #[inline]
     unsafe fn validate_param_unsafe(&mut self, world: UnsafeWorldCell) -> bool {
         // SAFETY: Delegate to other `System` implementations.
-        unsafe { self.a.validate_param_unsafe(world) && self.b.validate_param_unsafe(world) }
+        unsafe { self.a.validate_param_unsafe(world) }
     }
 
     fn initialize(&mut self, world: &mut World) {
@@ -433,7 +433,7 @@ where
 
     unsafe fn validate_param_unsafe(&mut self, world: UnsafeWorldCell) -> bool {
         // SAFETY: Delegate to other `System` implementations.
-        unsafe { self.a.validate_param_unsafe(world) && self.b.validate_param_unsafe(world) }
+        unsafe { self.a.validate_param_unsafe(world) }
     }
 
     fn validate_param(&mut self, world: &World) -> bool {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -60,7 +60,7 @@ impl SystemMeta {
             is_send: true,
             has_deferred: false,
             last_run: Tick::new(0),
-            param_warn_policy: ParamWarnPolicy::Once,
+            param_warn_policy: ParamWarnPolicy::Panic,
             #[cfg(feature = "trace")]
             system_span: info_span!("system", name = name),
             #[cfg(feature = "trace")]
@@ -190,6 +190,8 @@ impl SystemMeta {
 /// State machine for emitting warnings when [system params are invalid](System::validate_param).
 #[derive(Clone, Copy)]
 pub enum ParamWarnPolicy {
+    /// Stop app with a panic.
+    Panic,
     /// No warning should ever be emitted.
     Never,
     /// The warning will be emitted once and status will update to [`Self::Never`].
@@ -200,6 +202,7 @@ impl ParamWarnPolicy {
     /// Advances the warn policy after validation failed.
     #[inline]
     fn advance(&mut self) {
+        // Ignore `Panic` case, because it stops execution before this function gets called.
         *self = Self::Never;
     }
 
@@ -209,15 +212,21 @@ impl ParamWarnPolicy {
     where
         P: SystemParam,
     {
-        if matches!(self, Self::Never) {
-            return;
+        match self {
+            Self::Panic => panic!(
+                "{0} could not access system parameter {1}",
+                name,
+                disqualified::ShortName::of::<P>()
+            ),
+            Self::Once => {
+                log::warn!(
+                    "{0} did not run because it requested inaccessible system parameter {1}",
+                    name,
+                    disqualified::ShortName::of::<P>()
+                );
+            }
+            Self::Never => {}
         }
-
-        log::warn!(
-            "{0} did not run because it requested inaccessible system parameter {1}",
-            name,
-            disqualified::ShortName::of::<P>()
-        );
     }
 }
 
@@ -231,6 +240,11 @@ where
 {
     /// Set warn policy.
     fn with_param_warn_policy(self, warn_policy: ParamWarnPolicy) -> FunctionSystem<M, F>;
+
+    /// Warn only once about invalid system parameters.
+    fn param_warn_once(self) -> FunctionSystem<M, F> {
+        self.with_param_warn_policy(ParamWarnPolicy::Once)
+    }
 
     /// Disable all param warnings.
     fn never_param_warn(self) -> FunctionSystem<M, F> {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1890,7 +1890,7 @@ impl<'w, 'q, Q: QueryData, F: QueryFilter> From<&'q mut Query<'w, '_, Q, F>>
 /// [System parameter] that provides access to single entity's components, much like [`Query::single`]/[`Query::single_mut`].
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if zero or more than one matching entity exists.
-/// This will cause systems that use this parameter to be skipped.
+/// /// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Use [`Option<Single<D, F>>`] instead if zero or one matching entities can exist.
 ///
@@ -1926,7 +1926,7 @@ impl<'w, D: QueryData, F: QueryFilter> Single<'w, D, F> {
 /// [System parameter] that works very much like [`Query`] except it always contains at least one matching entity.
 ///
 /// This [`SystemParam`](crate::system::SystemParam) fails validation if no matching entities exist.
-/// This will cause systems that use this parameter to be skipped.
+/// /// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Much like [`Query::is_empty`] the worst case runtime will be `O(n)` where `n` is the number of *potential* matches.
 /// This can be notably expensive for queries that rely on non-archetypal filters such as [`Added`](crate::query::Added) or [`Changed`](crate::query::Changed)

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -450,7 +450,7 @@ mod tests {
 
         let mut world = World::default();
         // This fails because `T` has not been added to the world yet.
-        let result = world.run_system_once(system);
+        let result = world.run_system_once(system.param_warn_once());
 
         assert!(matches!(result, Err(RunSystemError::InvalidParams(_))));
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1440,7 +1440,7 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
 /// over to another thread.
 ///
 /// This [`SystemParam`] fails validation if non-send resource doesn't exist.
-/// This will cause systems that use this parameter to be skipped.
+/// /// This will cause a panic, but can be configured to do nothing or warn once.
 ///
 /// Use [`Option<NonSend<T>>`] instead if the resource might not always exist.
 pub struct NonSend<'w, T: 'static> {

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -998,7 +998,7 @@ mod tests {
         fn system(_: Res<T>) {}
 
         let mut world = World::new();
-        let id = world.register_system_cached(system);
+        let id = world.register_system(system.param_warn_once());
         // This fails because `T` has not been added to the world yet.
         let result = world.run_system(id);
 

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -8,7 +8,7 @@ use crate::{
     bundle::Bundles,
     change_detection::{MaybeUnsafeCellLocation, MutUntyped, Ticks, TicksMut},
     component::{ComponentId, ComponentTicks, Components, Mutable, StorageType, Tick, TickCells},
-    entity::{Entities, Entity, EntityLocation},
+    entity::{Entities, Entity, EntityBorrow, EntityLocation},
     observer::Observers,
     prelude::Component,
     query::{DebugCheckedUnwrap, ReadOnlyQueryData},
@@ -1181,5 +1181,11 @@ unsafe fn get_ticks(
             table.get_ticks_unchecked(component_id, location.table_row)
         }
         StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get_ticks(entity),
+    }
+}
+
+impl EntityBorrow for UnsafeEntityCell<'_> {
+    fn entity(&self) -> Entity {
+        self.id()
     }
 }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -159,9 +159,14 @@ bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing", "bevy_render?/ci_limits"]
 # Enable animation support, and glTF animation loading
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
-bevy_sprite = ["dep:bevy_sprite", "bevy_gizmos?/bevy_sprite"]
-bevy_pbr = ["dep:bevy_pbr", "bevy_gizmos?/bevy_pbr"]
+bevy_sprite = ["dep:bevy_sprite", "bevy_gizmos?/bevy_sprite", "bevy_image"]
+bevy_pbr = ["dep:bevy_pbr", "bevy_gizmos?/bevy_pbr", "bevy_image"]
 bevy_window = ["dep:bevy_window", "dep:bevy_a11y"]
+bevy_core_pipeline = ["dep:bevy_core_pipeline", "bevy_image"]
+bevy_gizmos = ["dep:bevy_gizmos", "bevy_image"]
+bevy_gltf = ["dep:bevy_gltf", "bevy_image"]
+bevy_ui = ["dep:bevy_ui", "bevy_image"]
+bevy_image = ["dep:bevy_image"]
 
 # Used to disable code that is unsupported when Bevy is dynamically linked
 dynamic_linking = ["bevy_diagnostic/dynamic_linking"]
@@ -173,12 +178,13 @@ android_shared_stdcxx = ["bevy_audio/android_shared_stdcxx"]
 # screen readers and forks.)
 accesskit_unix = ["bevy_winit/accesskit_unix"]
 
-bevy_text = ["dep:bevy_text"]
+bevy_text = ["dep:bevy_text", "bevy_image"]
 
 bevy_render = [
   "dep:bevy_render",
   "bevy_scene?/bevy_render",
   "bevy_gizmos?/bevy_render",
+  "bevy_image",
 ]
 
 # Enable assertions to check the validity of parameters passed to glam

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -271,7 +271,9 @@ bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.15.0-dev" }
 bevy_input_focus = { path = "../bevy_input_focus", version = "0.15.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.15.0-dev" }
-bevy_math = { path = "../bevy_math", version = "0.15.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.15.0-dev", features = [
+  "bevy_reflect",
+] }
 bevy_ptr = { path = "../bevy_ptr", version = "0.15.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "bevy",

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -42,7 +42,7 @@ bevy_math = { path = ".", version = "0.15.0-dev", default-features = false, feat
 glam = { version = "0.29", default-features = false, features = ["approx"] }
 
 [features]
-default = ["std", "rand", "bevy_reflect", "curve"]
+default = ["std", "rand", "curve"]
 std = [
   "alloc",
   "glam/std",

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -28,6 +28,7 @@ smallvec = { version = "1.11" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "glam",
 ], optional = true }
+variadics_please = "1.1"
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -5,6 +5,7 @@ use core::{
     fmt::Debug,
     ops::{Add, Div, Mul, Neg, Sub},
 };
+use variadics_please::all_tuples_enumerated;
 
 /// A type that supports the mathematical operations of a real vector space, irrespective of dimension.
 /// In particular, this means that the implementing type supports:
@@ -393,31 +394,9 @@ impl StableInterpolate for Dir3A {
     }
 }
 
-// If you're confused about how #[doc(fake_variadic)] works,
-// then the `all_tuples` macro is nicely documented (it can be found in the `bevy_utils` crate).
-// tl;dr: `#[doc(fake_variadic)]` goes on the impl of tuple length one.
-// the others have to be hidden using `#[doc(hidden)]`.
 macro_rules! impl_stable_interpolate_tuple {
-    (($T:ident, $n:tt)) => {
-        impl_stable_interpolate_tuple! {
-            @impl
-            #[cfg_attr(any(docsrs, docsrs_dep), doc(fake_variadic))]
-            #[cfg_attr(
-                any(docsrs, docsrs_dep),
-                doc = "This trait is implemented for tuples up to 11 items long."
-            )]
-            ($T, $n)
-        }
-    };
-    ($(($T:ident, $n:tt)),*) => {
-        impl_stable_interpolate_tuple! {
-            @impl
-            #[cfg_attr(any(docsrs, docsrs_dep), doc(hidden))]
-            $(($T, $n)),*
-        }
-    };
-    (@impl $(#[$($meta:meta)*])* $(($T:ident, $n:tt)),*) => {
-        $(#[$($meta)*])*
+    ($(#[$meta:meta])* $(($n:tt, $T:ident)),*) => {
+        $(#[$meta])*
         impl<$($T: StableInterpolate),*> StableInterpolate for ($($T,)*) {
             fn interpolate_stable(&self, other: &Self, t: f32) -> Self {
                 (
@@ -430,68 +409,12 @@ macro_rules! impl_stable_interpolate_tuple {
     };
 }
 
-// (See `macro_metavar_expr`, which might make this better.)
-// This currently implements `StableInterpolate` for tuples of up to 11 elements.
-impl_stable_interpolate_tuple!((T, 0));
-impl_stable_interpolate_tuple!((T0, 0), (T1, 1));
-impl_stable_interpolate_tuple!((T0, 0), (T1, 1), (T2, 2));
-impl_stable_interpolate_tuple!((T0, 0), (T1, 1), (T2, 2), (T3, 3));
-impl_stable_interpolate_tuple!((T0, 0), (T1, 1), (T2, 2), (T3, 3), (T4, 4));
-impl_stable_interpolate_tuple!((T0, 0), (T1, 1), (T2, 2), (T3, 3), (T4, 4), (T5, 5));
-impl_stable_interpolate_tuple!(
-    (T0, 0),
-    (T1, 1),
-    (T2, 2),
-    (T3, 3),
-    (T4, 4),
-    (T5, 5),
-    (T6, 6)
-);
-impl_stable_interpolate_tuple!(
-    (T0, 0),
-    (T1, 1),
-    (T2, 2),
-    (T3, 3),
-    (T4, 4),
-    (T5, 5),
-    (T6, 6),
-    (T7, 7)
-);
-impl_stable_interpolate_tuple!(
-    (T0, 0),
-    (T1, 1),
-    (T2, 2),
-    (T3, 3),
-    (T4, 4),
-    (T5, 5),
-    (T6, 6),
-    (T7, 7),
-    (T8, 8)
-);
-impl_stable_interpolate_tuple!(
-    (T0, 0),
-    (T1, 1),
-    (T2, 2),
-    (T3, 3),
-    (T4, 4),
-    (T5, 5),
-    (T6, 6),
-    (T7, 7),
-    (T8, 8),
-    (T9, 9)
-);
-impl_stable_interpolate_tuple!(
-    (T0, 0),
-    (T1, 1),
-    (T2, 2),
-    (T3, 3),
-    (T4, 4),
-    (T5, 5),
-    (T6, 6),
-    (T7, 7),
-    (T8, 8),
-    (T9, 9),
-    (T10, 10)
+all_tuples_enumerated!(
+    #[doc(fake_variadic)]
+    impl_stable_interpolate_tuple,
+    1,
+    11,
+    T
 );
 
 /// A type that has tangents.

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -163,8 +163,8 @@ pub const RGB9E5_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(26590
 const MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE: Handle<Shader> =
     Handle::weak_from_u128(2325134235233421);
 
-const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 23;
-const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 24;
+pub const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 23;
+pub const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 24;
 
 /// Sets up the entire PBR infrastructure of bevy.
 pub struct PbrPlugin {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -675,7 +675,10 @@ fn extract_mesh_materials<M: Material>(
     ) where
         M: Material,
     {
-        if material_instances.remove(&MainEntity::from(entity)).is_none() {
+        if material_instances
+            .remove(&MainEntity::from(entity))
+            .is_none()
+        {
             return;
         }
 

--- a/crates/bevy_pbr/src/meshlet/instance_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/instance_manager.rs
@@ -123,7 +123,7 @@ impl InstanceManager {
         let mesh_uniform = MeshUniform::new(
             &transforms,
             0,
-            mesh_material_binding_id.slot,
+            mesh_material_binding_id.id.slot,
             None,
             None,
             None,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wgsl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wgsl
@@ -94,6 +94,7 @@ struct VertexOutput {
     world_tangent: vec4<f32>,
     mesh_flags: u32,
     cluster_id: u32,
+    material_bind_group_slot: u32,
 #ifdef PREPASS_FRAGMENT
 #ifdef MOTION_VECTOR_PREPASS
     motion_vector: vec2<f32>,
@@ -173,6 +174,7 @@ fn resolve_vertex_output(frag_coord: vec4<f32>) -> VertexOutput {
         world_tangent,
         instance_uniform.flags,
         instance_id ^ meshlet_id,
+        instance_uniform.material_and_lightmap_bind_group_slot & 0xffffu,
 #ifdef PREPASS_FRAGMENT
 #ifdef MOTION_VECTOR_PREPASS
         motion_vector,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -137,6 +137,10 @@ impl Plugin for MeshRenderPlugin {
         load_internal_asset!(app, SKINNING_HANDLE, "skinning.wgsl", Shader::from_wgsl);
         load_internal_asset!(app, MORPH_HANDLE, "morph.wgsl", Shader::from_wgsl);
 
+        if app.get_sub_app(RenderApp).is_none() {
+            return;
+        }
+
         app.add_systems(
             PostUpdate,
             (no_automatic_skin_batching, no_automatic_morph_batching),

--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -2,8 +2,10 @@
 
 #import bevy_pbr::mesh_types::Mesh
 
+#ifndef MESHLET_MESH_MATERIAL_PASS
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
 @group(1) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
 @group(1) @binding(0) var<storage> mesh: array<Mesh>;
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
+#endif  // MESHLET_MESH_MATERIAL_PASS

--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -12,6 +12,7 @@
 }
 #import bevy_render::maths::{affine3_to_square, mat2x4_f32_to_mat3x3_unpack}
 
+#ifndef MESHLET_MESH_MATERIAL_PASS
 
 fn get_world_from_local(instance_index: u32) -> mat4x4<f32> {
     return affine3_to_square(mesh[instance_index].world_from_local);
@@ -20,6 +21,8 @@ fn get_world_from_local(instance_index: u32) -> mat4x4<f32> {
 fn get_previous_world_from_local(instance_index: u32) -> mat4x4<f32> {
     return affine3_to_square(mesh[instance_index].previous_world_from_local);
 }
+
+#endif  // MESHLET_MESH_MATERIAL_PASS
 
 fn mesh_position_local_to_world(world_from_local: mat4x4<f32>, vertex_position: vec4<f32>) -> vec4<f32> {
     return world_from_local * vertex_position;
@@ -32,6 +35,8 @@ fn mesh_position_local_to_clip(world_from_local: mat4x4<f32>, vertex_position: v
     let world_position = mesh_position_local_to_world(world_from_local, vertex_position);
     return position_world_to_clip(world_position.xyz);
 }
+
+#ifndef MESHLET_MESH_MATERIAL_PASS
 
 fn mesh_normal_local_to_world(vertex_normal: vec3<f32>, instance_index: u32) -> vec3<f32> {
     // NOTE: The mikktspace method of normal mapping requires that the world normal is
@@ -53,6 +58,8 @@ fn mesh_normal_local_to_world(vertex_normal: vec3<f32>, instance_index: u32) -> 
     }
 }
 
+#endif  // MESHLET_MESH_MATERIAL_PASS
+
 // Calculates the sign of the determinant of the 3x3 model matrix based on a
 // mesh flag
 fn sign_determinant_model_3x3m(mesh_flags: u32) -> f32 {
@@ -61,6 +68,8 @@ fn sign_determinant_model_3x3m(mesh_flags: u32) -> f32 {
     // * 2.0 - 1.0 remaps 0.0 or 1.0 to -1.0 or 1.0 respectively
     return f32(bool(mesh_flags & MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT)) * 2.0 - 1.0;
 }
+
+#ifndef MESHLET_MESH_MATERIAL_PASS
 
 fn mesh_tangent_local_to_world(world_from_local: mat4x4<f32>, vertex_tangent: vec4<f32>, instance_index: u32) -> vec4<f32> {
     // NOTE: The mikktspace method of normal mapping requires that the world tangent is
@@ -87,6 +96,8 @@ fn mesh_tangent_local_to_world(world_from_local: mat4x4<f32>, vertex_tangent: ve
         return vertex_tangent;
     }
 }
+
+#endif  // MESHLET_MESH_MATERIAL_PASS
 
 // Returns an appropriate dither level for the current mesh instance.
 //

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -71,7 +71,11 @@ fn pbr_input_from_standard_material(
     is_front: bool,
 ) -> pbr_types::PbrInput {
 #ifdef BINDLESS
+#ifdef MESHLET_MESH_MATERIAL_PASS
+    let slot = in.material_bind_group_slot;
+#else   // MESHLET_MESH_MATERIAL_PASS
     let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
+#endif  // MESHLET_MESH_MATERIAL_PASS
     let flags = pbr_bindings::material[slot].flags;
     let base_color = pbr_bindings::material[slot].base_color;
     let deferred_lighting_pass_id = pbr_bindings::material[slot].deferred_lighting_pass_id;
@@ -146,7 +150,7 @@ fn pbr_input_from_standard_material(
             // parallax mapping algorithm easier to understand and reason
             // about.
             -Vt,
-            in.instance_index,
+            slot,
         );
 #endif
 

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -25,6 +25,7 @@ use bevy_ecs::{
 };
 use bevy_image::BevyDefault as _;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::render_graph::RenderGraph;
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin},
     render_graph::{NodeRunError, RenderGraphApp, RenderGraphContext, ViewNode, ViewNodeRunner},
@@ -233,8 +234,19 @@ impl Plugin for ScreenSpaceReflectionsPlugin {
 
         render_app
             .init_resource::<ScreenSpaceReflectionsPipeline>()
-            .init_resource::<SpecializedRenderPipelines<ScreenSpaceReflectionsPipeline>>()
-            .add_render_graph_edges(
+            .init_resource::<SpecializedRenderPipelines<ScreenSpaceReflectionsPipeline>>();
+
+        // only reference the default deferred lighting pass
+        // if it has been added
+        let has_default_deferred_lighting_pass = render_app
+            .world_mut()
+            .resource_mut::<RenderGraph>()
+            .sub_graph(Core3d)
+            .get_node_state(NodePbr::DeferredLightingPass)
+            .is_ok();
+
+        if has_default_deferred_lighting_pass {
+            render_app.add_render_graph_edges(
                 Core3d,
                 (
                     NodePbr::DeferredLightingPass,
@@ -242,6 +254,12 @@ impl Plugin for ScreenSpaceReflectionsPlugin {
                     Node3d::MainOpaquePass,
                 ),
             );
+        } else {
+            render_app.add_render_graph_edges(
+                Core3d,
+                (NodePbr::ScreenSpaceReflections, Node3d::MainOpaquePass),
+            );
+        }
     }
 }
 

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -23,9 +23,9 @@
 //!
 //! The order in which interaction events are received is extremely important, and you can read more
 //! about it on the docs for the dispatcher system: [`pointer_events`]. This system runs in
-//! [`PreUpdate`](bevy_app::PreUpdate) in [`PickSet::Focus`](crate::PickSet::Focus). All pointer-event
+//! [`PreUpdate`](bevy_app::PreUpdate) in [`PickSet::Hover`](crate::PickSet::Hover). All pointer-event
 //! observers resolve during the sync point between [`pointer_events`] and
-//! [`update_interactions`](crate::focus::update_interactions).
+//! [`update_interactions`](crate::hover::update_interactions).
 //!
 //! # Events Types
 //!
@@ -49,7 +49,7 @@ use bevy_window::Window;
 
 use crate::{
     backend::{prelude::PointerLocation, HitData},
-    focus::{HoverMap, PreviousHoverMap},
+    hover::{HoverMap, PreviousHoverMap},
     pointer::{
         Location, PointerAction, PointerButton, PointerId, PointerInput, PointerMap, PressDirection,
     },
@@ -385,7 +385,7 @@ pub struct PickingEventWriters<'w> {
 /// receive [`Out`] and then entity B will receive [`Over`]. No entity will ever
 /// receive both an [`Over`] and and a [`Out`] event during the same frame.
 ///
-/// When we account for event bubbling, this is no longer true. When focus shifts
+/// When we account for event bubbling, this is no longer true. When the hovering focus shifts
 /// between children, parent entities may receive redundant [`Out`] → [`Over`] pairs.
 /// In the context of UI, this is especially problematic. Additional hierarchy-aware
 /// events will be added in a future release.

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -692,6 +692,10 @@ pub fn pointer_events(
 
                     // Emit Drag events to the entities we are dragging
                     for (drag_target, drag) in state.dragging.iter_mut() {
+                        let delta = location.position - drag.latest_pos;
+                        if delta == Vec2::ZERO {
+                            continue; // No need to emit a Drag event if there is no movement
+                        }
                         let drag_event = Pointer::new(
                             pointer_id,
                             location.clone(),
@@ -699,7 +703,7 @@ pub fn pointer_events(
                             Drag {
                                 button,
                                 distance: location.position - drag.start_pos,
-                                delta: location.position - drag.latest_pos,
+                                delta,
                             },
                         );
                         commands.trigger_targets(drag_event.clone(), *drag_target);

--- a/crates/bevy_picking/src/hover.rs
+++ b/crates/bevy_picking/src/hover.rs
@@ -62,7 +62,7 @@ pub struct PreviousHoverMap(pub HashMap<PointerId, HashMap<Entity, HitData>>);
 
 /// Coalesces all data from inputs and backends to generate a map of the currently hovered entities.
 /// This is the final focusing step to determine which entity the pointer is hovering over.
-pub fn update_focus(
+pub fn generate_hovermap(
     // Inputs
     picking_behavior: Query<&PickingBehavior>,
     pointers: Query<&PointerId>,

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -121,11 +121,11 @@
 //!
 //! You will eventually need to choose which picking backend(s) you want to use. This crate does not
 //! supply any backends, and expects you to select some from the other bevy crates or the third-party
-//! ecosystem. You can find all the provided backends in the [`backend`] module.
+//! ecosystem.
 //!
 //! It's important to understand that you can mix and match backends! For example, you might have a
 //! backend for your UI, and one for the 3d scene, with each being specialized for their purpose.
-//! This crate provides some backends out of the box, but you can even write your own. It's been
+//! Bevy provides some backends out of the box, but you can even write your own. It's been
 //! made as easy as possible intentionally; the `bevy_mod_raycast` backend is 50 lines of code.
 //!
 //! #### Focus ([`focus`])

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -489,11 +489,11 @@ pub fn clear_batched_gpu_instance_buffers<GFBD>(
 }
 
 /// A system that removes GPU preprocessing work item buffers that correspond to
-/// deleted [`ViewTarget`]s.
+/// deleted [`crate::view::ViewTarget`]s.
 ///
 /// This is a separate system from [`clear_batched_gpu_instance_buffers`]
-/// because [`ViewTarget`]s aren't created until after the extraction phase is
-/// completed.
+/// because [`crate::view::ViewTarget`]s aren't created until after the
+/// extraction phase is completed.
 pub fn delete_old_work_item_buffers<GFBD>(
     mut gpu_batched_instance_buffers: ResMut<
         BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -19,7 +19,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     change_detection::DetectChanges,
     component::{Component, ComponentId, Mutable},
-    entity::Entity,
+    entity::{Entity, EntityBorrow},
     event::EventReader,
     prelude::{require, With},
     query::Has,

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -4,7 +4,7 @@ use crate::{
     renderer::RenderContext,
     view::ExtractedWindows,
 };
-use bevy_ecs::{prelude::QueryState, world::World};
+use bevy_ecs::{entity::EntityBorrow, prelude::QueryState, world::World};
 use bevy_utils::HashSet;
 use wgpu::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor, StoreOp};
 

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -3,7 +3,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::entity::EntityHash;
 use bevy_ecs::{
     component::Component,
-    entity::Entity,
+    entity::{Entity, EntityBorrow, TrustedEntityBorrow},
     observer::Trigger,
     query::With,
     reflect::ReflectComponent,
@@ -140,6 +140,15 @@ impl From<Entity> for RenderEntity {
     }
 }
 
+impl EntityBorrow for RenderEntity {
+    fn entity(&self) -> Entity {
+        self.id()
+    }
+}
+
+// SAFETY: RenderEntity is a newtype around Entity that derives its comparison traits.
+unsafe impl TrustedEntityBorrow for RenderEntity {}
+
 /// Component added on the render world entities to keep track of the corresponding main world entity.
 ///
 /// Can also be used as a newtype wrapper for main world entities.
@@ -157,6 +166,15 @@ impl From<Entity> for MainEntity {
         MainEntity(entity)
     }
 }
+
+impl EntityBorrow for MainEntity {
+    fn entity(&self) -> Entity {
+        self.id()
+    }
+}
+
+// SAFETY: RenderEntity is a newtype around Entity that derives its comparison traits.
+unsafe impl TrustedEntityBorrow for MainEntity {}
 
 /// A [`HashMap`](hashbrown::HashMap) pre-configured to use [`EntityHash`] hashing with a [`MainEntity`].
 pub type MainEntityHashMap<V> = hashbrown::HashMap<MainEntity, V, EntityHash>;

--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -1,10 +1,7 @@
 use crate::TextureAtlasLayout;
 use bevy_image::{Image, TextureFormatPixelInfo};
 use bevy_math::{URect, UVec2};
-use bevy_render::{
-    render_asset::{RenderAsset, RenderAssetUsages},
-    texture::GpuImage,
-};
+use bevy_render::render_asset::RenderAssetUsages;
 use guillotiere::{size2, Allocation, AtlasAllocator};
 
 /// Helper utility to update [`TextureAtlasLayout`] on the fly.
@@ -53,9 +50,8 @@ impl DynamicTextureAtlasBuilder {
         ));
         if let Some(allocation) = allocation {
             assert!(
-                <GpuImage as RenderAsset>::asset_usage(atlas_texture)
-                    .contains(RenderAssetUsages::MAIN_WORLD),
-                "The asset at atlas_texture_handle must have the RenderAssetUsages::MAIN_WORLD usage flag set"
+                atlas_texture.asset_usage.contains(RenderAssetUsages::MAIN_WORLD),
+                "The atlas_texture image must have the RenderAssetUsages::MAIN_WORLD usage flag set"
             );
 
             self.place_texture(atlas_texture, allocation, texture);

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -17,7 +17,6 @@ use bevy_ecs::{
 };
 use bevy_math::FloatOrd;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_render::view::RenderVisibleEntities;
 use bevy_render::{
     mesh::{MeshVertexBufferLayoutRef, RenderMesh},
     render_asset::{
@@ -38,6 +37,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_render::{render_resource::BindingResources, sync_world::MainEntityHashMap};
+use bevy_render::{sync_world::MainEntity, view::RenderVisibleEntities};
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::tracing::error;
 use core::{hash::Hash, marker::PhantomData};
@@ -280,14 +280,55 @@ impl<M: Material2d> Default for RenderMaterial2dInstances<M> {
 
 fn extract_mesh_materials_2d<M: Material2d>(
     mut material_instances: ResMut<RenderMaterial2dInstances<M>>,
-    query: Extract<Query<(Entity, &ViewVisibility, &MeshMaterial2d<M>), With<Mesh2d>>>,
+    changed_meshes_query: Extract<
+        Query<
+            (Entity, &ViewVisibility, &MeshMaterial2d<M>),
+            Or<(Changed<ViewVisibility>, Changed<MeshMaterial2d<M>>)>,
+        >,
+    >,
+    mut removed_visibilities_query: Extract<RemovedComponents<ViewVisibility>>,
+    mut removed_materials_query: Extract<RemovedComponents<MeshMaterial2d<M>>>,
 ) {
-    material_instances.clear();
-
-    for (entity, view_visibility, material) in &query {
+    for (entity, view_visibility, material) in &changed_meshes_query {
         if view_visibility.get() {
-            material_instances.insert(entity.into(), material.id());
+            add_mesh_instance(entity, material, &mut material_instances);
+        } else {
+            remove_mesh_instance(entity, &mut material_instances);
         }
+    }
+
+    for entity in removed_visibilities_query
+        .read()
+        .chain(removed_materials_query.read())
+    {
+        // Only queue a mesh for removal if we didn't pick it up above.
+        // It's possible that a necessary component was removed and re-added in
+        // the same frame.
+        if !changed_meshes_query.contains(entity) {
+            remove_mesh_instance(entity, &mut material_instances);
+        }
+    }
+
+    // Adds or updates a mesh instance in the [`RenderMaterial2dInstances`]
+    // array.
+    fn add_mesh_instance<M>(
+        entity: Entity,
+        material: &MeshMaterial2d<M>,
+        material_instances: &mut RenderMaterial2dInstances<M>,
+    ) where
+        M: Material2d,
+    {
+        material_instances.insert(entity.into(), material.id());
+    }
+
+    // Removes a mesh instance from the [`RenderMaterial2dInstances`] array.
+    fn remove_mesh_instance<M>(
+        entity: Entity,
+        material_instances: &mut RenderMaterial2dInstances<M>,
+    ) where
+        M: Material2d,
+    {
+        material_instances.remove(&MainEntity::from(entity));
     }
 }
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -232,7 +232,8 @@ impl From<String> for TextSpan {
 /// This only affects the internal positioning of the lines of text within a text entity and
 /// does not affect the text entity's position.
 ///
-/// _Has no affect on a single line text entity._
+/// _Has no affect on a single line text entity_, unless used together with a
+/// [`TextBounds`](super::bounds::TextBounds) component with an explicit `width` value.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
 pub enum JustifyText {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use bevy_ecs::{
     change_detection::DetectChangesMut,
-    entity::Entity,
+    entity::{Entity, EntityBorrow},
     prelude::{Component, With},
     query::QueryData,
     reflect::ReflectComponent,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
-    BorderRadius, ComputedNode, ContentSize, DefaultUiCamera, Display, Node, Outline, OverflowAxis,
-    ScrollPosition, TargetCamera, UiScale, Val,
+    BorderRadius, ComputedNode, ContentSize, DefaultUiCamera, Display, LayoutConfig, Node, Outline,
+    OverflowAxis, ScrollPosition, TargetCamera, UiScale, Val,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
@@ -120,10 +120,12 @@ pub fn ui_layout_system(
         &mut ComputedNode,
         &mut Transform,
         &Node,
+        Option<&LayoutConfig>,
         Option<&BorderRadius>,
         Option<&Outline>,
         Option<&ScrollPosition>,
     )>,
+
     mut buffer_query: Query<&mut ComputedTextBlock>,
     mut font_system: ResMut<CosmicFontSystem>,
 ) {
@@ -294,6 +296,7 @@ with UI components as a child of an entity without UI components, your UI layout
                 &mut commands,
                 *root,
                 &mut ui_surface,
+                true,
                 None,
                 &mut node_transform_query,
                 &ui_children,
@@ -312,11 +315,13 @@ with UI components as a child of an entity without UI components, your UI layout
         commands: &mut Commands,
         entity: Entity,
         ui_surface: &mut UiSurface,
+        inherited_use_rounding: bool,
         root_size: Option<Vec2>,
         node_transform_query: &mut Query<(
             &mut ComputedNode,
             &mut Transform,
             &Node,
+            Option<&LayoutConfig>,
             Option<&BorderRadius>,
             Option<&Outline>,
             Option<&ScrollPosition>,
@@ -330,12 +335,17 @@ with UI components as a child of an entity without UI components, your UI layout
             mut node,
             mut transform,
             style,
+            maybe_layout_config,
             maybe_border_radius,
             maybe_outline,
             maybe_scroll_position,
         )) = node_transform_query.get_mut(entity)
         {
-            let Ok((layout, unrounded_size)) = ui_surface.get_layout(entity) else {
+            let use_rounding = maybe_layout_config
+                .map(|layout_config| layout_config.use_rounding)
+                .unwrap_or(inherited_use_rounding);
+
+            let Ok((layout, unrounded_size)) = ui_surface.get_layout(entity, use_rounding) else {
                 return;
             };
 
@@ -446,6 +456,7 @@ with UI components as a child of an entity without UI components, your UI layout
                     commands,
                     child_uinode,
                     ui_surface,
+                    use_rounding,
                     Some(viewport_size),
                     node_transform_query,
                     ui_children,
@@ -573,7 +584,7 @@ mod tests {
         let mut ui_surface = world.resource_mut::<UiSurface>();
 
         for ui_entity in [ui_root, ui_child] {
-            let layout = ui_surface.get_layout(ui_entity).unwrap().0;
+            let layout = ui_surface.get_layout(ui_entity, true).unwrap().0;
             assert_eq!(layout.size.width, WINDOW_WIDTH);
             assert_eq!(layout.size.height, WINDOW_HEIGHT);
         }
@@ -962,7 +973,7 @@ mod tests {
             let mut ui_surface = world.resource_mut::<UiSurface>();
 
             let layout = ui_surface
-                .get_layout(ui_node_entity)
+                .get_layout(ui_node_entity, true)
                 .expect("failed to get layout")
                 .0;
 
@@ -1049,7 +1060,7 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let mut ui_surface = world.resource_mut::<UiSurface>();
-        let layout = ui_surface.get_layout(ui_entity).unwrap().0;
+        let layout = ui_surface.get_layout(ui_entity, true).unwrap().0;
 
         // the node should takes its size from the fixed size measure func
         assert_eq!(layout.size.width, content_size.x);
@@ -1078,7 +1089,7 @@ mod tests {
 
         // a node with a content size should have taffy context
         assert!(ui_surface.taffy.get_node_context(ui_node).is_some());
-        let layout = ui_surface.get_layout(ui_entity).unwrap().0;
+        let layout = ui_surface.get_layout(ui_entity, true).unwrap().0;
         assert_eq!(layout.size.width, content_size.x);
         assert_eq!(layout.size.height, content_size.y);
 
@@ -1091,7 +1102,7 @@ mod tests {
         assert!(ui_surface.taffy.get_node_context(ui_node).is_none());
 
         // Without a content size, the node has no width or height constraints so the length of both dimensions is 0.
-        let layout = ui_surface.get_layout(ui_entity).unwrap().0;
+        let layout = ui_surface.get_layout(ui_entity, true).unwrap().0;
         assert_eq!(layout.size.width, 0.);
         assert_eq!(layout.size.height, 0.);
     }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
-    entity::{Entity, EntityHashMap, EntityHashSet},
+    entity::{Entity, EntityBorrow, EntityHashMap, EntityHashSet},
     event::EventReader,
     query::With,
     removal_detection::RemovedComponents,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2550,6 +2550,28 @@ impl Default for ShadowStyle {
     }
 }
 
+#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
+#[reflect(Component, Debug, PartialEq, Default)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+/// This component can be added to any UI node to modify its layout behavior.
+pub struct LayoutConfig {
+    /// If set to true the coordinates for this node and its descendents will be rounded to the nearest physical pixel.
+    /// This can help prevent visual artifacts like blurry images or semi-transparent edges that can occur with sub-pixel positioning.
+    ///
+    /// Defaults to true.
+    pub use_rounding: bool,
+}
+
+impl Default for LayoutConfig {
+    fn default() -> Self {
+        Self { use_rounding: true }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::GridPlacement;

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,7 +1,7 @@
 use core::num::NonZero;
 
 use bevy_ecs::{
-    entity::{Entity, VisitEntities, VisitEntitiesMut},
+    entity::{Entity, EntityBorrow, VisitEntities, VisitEntitiesMut},
     prelude::{Component, ReflectComponent},
 };
 use bevy_math::{CompassOctant, DVec2, IVec2, UVec2, Vec2};
@@ -88,9 +88,8 @@ impl VisitEntitiesMut for WindowRef {
 )]
 pub struct NormalizedWindowRef(Entity);
 
-impl NormalizedWindowRef {
-    /// Fetch the entity of this window reference
-    pub fn entity(&self) -> Entity {
+impl EntityBorrow for NormalizedWindowRef {
+    fn entity(&self) -> Entity {
         self.0
     }
 }

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -61,6 +61,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_ci_testing|Enable systems that allow for automated testing on CI|
 |bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
 |bevy_dev_tools|Provides a collection of developer tools|
+|bevy_image|Load and access image data. Usually added by an image format|
 |bevy_remote|Enable the Bevy Remote Protocol|
 |bevy_ui_debug|Provides a debug overlay for bevy UI|
 |bmp|BMP image format support|

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -20,22 +20,20 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        // Systems that fail parameter validation will emit warnings.
-        // The default policy is to emit a warning once per system.
-        // This is good for catching unexpected behavior, but can
-        // lead to spam. You can disable invalid param warnings
-        // per system using the `.never_param_warn()` method.
+        // Default system policy is to panic if parameters fail to be fetched.
+        // We overwrite that configuration, to either warn us once or never.
+        // This is good for catching unexpected behavior without crashing the app,
+        // but can lead to spam.
         .add_systems(
             Update,
             (
-                user_input,
+                user_input.param_warn_once(),
                 move_targets.never_param_warn(),
                 move_pointer.never_param_warn(),
             )
                 .chain(),
         )
-        // We will leave this systems with default warning policy.
-        .add_systems(Update, do_nothing_fail_validation)
+        .add_systems(Update, do_nothing_fail_validation.param_warn_once())
         .run();
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -7,7 +7,7 @@ use bevy::{
     a11y::AccessibilityNode,
     color::palettes::{basic::LIME, css::DARK_GRAY},
     input::mouse::{MouseScrollUnit, MouseWheel},
-    picking::focus::HoverMap,
+    picking::hover::HoverMap,
     prelude::*,
     ui::widget::NodeImageMode,
 };

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -4,7 +4,7 @@ use accesskit::{Node as Accessible, Role};
 use bevy::{
     a11y::AccessibilityNode,
     input::mouse::{MouseScrollUnit, MouseWheel},
-    picking::focus::HoverMap,
+    picking::hover::HoverMap,
     prelude::*,
     winit::WinitSettings,
 };


### PR DESCRIPTION
This commit makes Bevy use change detection to only update `RenderMaterialInstances` and `RenderMeshMaterialIds` when meshes have been added, changed, or removed. `extract_mesh_materials`, the system that extracts these, now follows the pattern that
`extract_meshes_for_gpu_building` established.

This improves frame time of `many_cubes` from 3.9ms to approximately 3.1ms, which slightly surpasses the performance of Bevy 0.14.

![Screenshot 2024-12-17 182109](https://github.com/user-attachments/assets/dfb26e20-b314-4c67-a59a-dc9623fabb62)
