### PR TITLE
Add `Text2d` picking backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ default = [
   "bevy_sprite_picking_backend",
   "bevy_state",
   "bevy_text",
+  "bevy_text2d_picking_backend",
   "bevy_ui",
   "bevy_ui_picking_backend",
   "bevy_window",
@@ -154,6 +155,12 @@ bevy_sprite_picking_backend = [
 bevy_ui_picking_backend = [
   "bevy_picking",
   "bevy_internal/bevy_ui_picking_backend",
+]
+
+# Provides an implementation for picking Text2d
+bevy_text2d_picking_backend = [
+  "bevy_picking",
+  "bevy_internal/bevy_text2d_picking_backend",
 ]
 
 # Provides a debug overlay for bevy UI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3834,6 +3834,19 @@ wasm = true
 required-features = ["bevy_sprite_picking_backend"]
 
 [[example]]
+name = "text2d_picking"
+path = "examples/picking/text2d_picking.rs"
+doc-scrape-examples = true
+required-features = ["bevy_text2d_picking_backend"]
+
+[package.metadata.example.text2d_picking]
+name = "Text2d Picking"
+description = "Demonstrates picking 2d text"
+category = "Picking"
+wasm = true
+required-features = ["bevy_text2d_picking_backend"]
+
+[[example]]
 name = "animation_masks"
 path = "examples/animation/animation_masks.rs"
 doc-scrape-examples = true

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -235,6 +235,12 @@ bevy_sprite_picking_backend = [
 # Provides a UI picking backend
 bevy_ui_picking_backend = ["bevy_picking", "bevy_ui/bevy_ui_picking_backend"]
 
+# Provides a Text2d picking backend
+bevy_text2d_picking_backend = [
+  "bevy_picking",
+  "bevy_text/bevy_text2d_picking_backend",
+]
+
 # Provides a UI debug overlay
 bevy_ui_debug = ["bevy_ui?/bevy_ui_debug"]
 

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+bevy_text2d_picking_backend = ["bevy_picking"]
 default_font = []
 
 [dependencies]
@@ -21,6 +22,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.15.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.15.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev" }
+bevy_picking = { path = "../bevy_picking", version = "0.15.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "bevy",
 ] }

--- a/crates/bevy_text/src/text2d_picking_backend.rs
+++ b/crates/bevy_text/src/text2d_picking_backend.rs
@@ -3,7 +3,7 @@
 //! 2d text is pickable even in its transparent areas.
 //!
 //! **Note:** This backend is pretty much a 1:1 port of the [`bevy_sprite`] picking backend,
-//! and *is not reposible for handling the picking of UI Text*. For that, please refer to the
+//! and *is not responsible for handling the picking of UI Text*. For that, please refer to the
 //! picking backend implementation under the `bevy_ui` crate.
 
 use core::cmp::Reverse;

--- a/crates/bevy_text/src/text2d_picking_backend.rs
+++ b/crates/bevy_text/src/text2d_picking_backend.rs
@@ -1,0 +1,176 @@
+//! A [`bevy_picking`] backend for [`Text2d`]. Works for 2d text with arbitrary transforms.
+//! Picking is done based on [`TextLayoutInfo`] bounds, not visible pixels. This means that
+//! 2d text is pickable even in its transparent areas.
+//!
+//! **Note:** This backend is pretty much a 1:1 port of the [`bevy_sprite`] picking backend,
+//! and *is not reposible for handling the picking of UI Text*. For that, please refer to the
+//! picking backend implementation under the `bevy_ui` crate.
+
+use core::cmp::Reverse;
+
+use crate::{Text2d, TextLayoutInfo};
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_math::{prelude::*, FloatExt, FloatOrd};
+use bevy_picking::backend::prelude::*;
+use bevy_render::prelude::*;
+use bevy_sprite::Anchor;
+use bevy_transform::prelude::*;
+use bevy_window::PrimaryWindow;
+
+#[derive(Clone)]
+pub struct Text2dPickingPlugin;
+
+impl Plugin for Text2dPickingPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(PreUpdate, text2d_picking.in_set(PickSet::Backend));
+    }
+}
+
+pub fn text2d_picking(
+    pointers: Query<(&PointerId, &PointerLocation)>,
+    cameras: Query<(Entity, &Camera, &GlobalTransform, &OrthographicProjection)>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    text2d_query: Query<
+        (
+            Entity,
+            &TextLayoutInfo,
+            &Anchor,
+            &GlobalTransform,
+            Option<&PickingBehavior>,
+            &ViewVisibility,
+        ),
+        With<Text2d>,
+    >,
+    mut output: EventWriter<PointerHits>,
+) {
+    let mut sorted_text2d: Vec<_> = text2d_query
+        .iter()
+        .filter_map(
+            |(entity, text_layout_info, anchor, transform, picking_behavior, vis)| {
+                if !transform.affine().is_nan() && vis.get() {
+                    Some((
+                        entity,
+                        text_layout_info,
+                        anchor,
+                        transform,
+                        picking_behavior,
+                    ))
+                } else {
+                    None
+                }
+            },
+        )
+        .collect();
+
+    sorted_text2d.sort_by_key(|x| Reverse(FloatOrd(x.3.translation().z)));
+
+    let primary_window = primary_window.get_single().ok();
+
+    for (pointer, location) in pointers.iter().filter_map(|(pointer, pointer_location)| {
+        pointer_location.location().map(|loc| (pointer, loc))
+    }) {
+        let mut blocked = false;
+        let Some((cam_entity, camera, cam_transform, cam_ortho)) = cameras
+            .iter()
+            .filter(|(_, camera, _, _)| camera.is_active)
+            .find(|(_, camera, _, _)| {
+                camera
+                    .target
+                    .normalize(primary_window)
+                    .map(|x| x == location.target)
+                    .unwrap_or(false)
+            })
+        else {
+            continue;
+        };
+
+        let viewport_pos = camera
+            .logical_viewport_rect()
+            .map(|v| v.min)
+            .unwrap_or_default();
+        let pos_in_viewport = location.position - viewport_pos;
+
+        let Ok(cursor_ray_world) = camera.viewport_to_world(cam_transform, pos_in_viewport) else {
+            continue;
+        };
+        let cursor_ray_len = cam_ortho.far - cam_ortho.near;
+        let cursor_ray_end = cursor_ray_world.origin + cursor_ray_world.direction * cursor_ray_len;
+
+        let picks: Vec<(Entity, HitData)> = sorted_text2d
+            .iter()
+            .copied()
+            .filter_map(
+                |(entity, text_layout_info, anchor, text2d_transform, picking_behavior)| {
+                    if blocked {
+                        return None;
+                    }
+
+                    // Hit box in text2d coordinate system
+                    let extents = text_layout_info.size;
+                    let anchor = anchor.as_vec();
+                    let center = -anchor * extents;
+                    let rect = Rect::from_center_half_size(center, extents / 2.0);
+
+                    // Transform cursor line segment to text2d coordinate system
+                    let world_to_text2d = text2d_transform.affine().inverse();
+                    let cursor_start_text2d =
+                        world_to_text2d.transform_point3(cursor_ray_world.origin);
+                    let cursor_end_text2d = world_to_text2d.transform_point3(cursor_ray_end);
+
+                    // Find where the cursor segment intersects the plane Z=0 (which is the text2d's
+                    // plane in text2d-local space). It may not intersect if, for example, we're
+                    // viewing the text2d side-on
+                    if cursor_start_text2d.z == cursor_end_text2d.z {
+                        // Cursor ray is parallel to the text2d and misses it
+                        return None;
+                    }
+                    let lerp_factor =
+                        f32::inverse_lerp(cursor_start_text2d.z, cursor_end_text2d.z, 0.0);
+                    if !(0.0..=1.0).contains(&lerp_factor) {
+                        // Lerp factor is out of range, meaning that while an infinite line cast by
+                        // the cursor would intersect the text2d, the text2d is not between the
+                        // camera's near and far planes
+                        return None;
+                    }
+                    // Otherwise we can interpolate the xy of the start and end positions by the
+                    // lerp factor to get the cursor position in text2d space!
+                    let cursor_pos_text2d = cursor_start_text2d
+                        .lerp(cursor_end_text2d, lerp_factor)
+                        .xy();
+
+                    let is_cursor_in_text2d = rect.contains(cursor_pos_text2d);
+
+                    blocked = is_cursor_in_text2d
+                        && picking_behavior
+                            .map(|p| p.should_block_lower)
+                            .unwrap_or(true);
+
+                    is_cursor_in_text2d.then(|| {
+                        let hit_pos_world =
+                            text2d_transform.transform_point(cursor_pos_text2d.extend(0.0));
+                        // Transform point from world to camera space to get the Z distance
+                        let hit_pos_cam = cam_transform
+                            .affine()
+                            .inverse()
+                            .transform_point3(hit_pos_world);
+                        // HitData requires a depth as calculated from the camera's near clipping plane
+                        let depth = -cam_ortho.near - hit_pos_cam.z;
+                        (
+                            entity,
+                            HitData::new(
+                                cam_entity,
+                                depth,
+                                Some(hit_pos_world),
+                                Some(*text2d_transform.back()),
+                            ),
+                        )
+                    })
+                },
+            )
+            .collect();
+
+        let order = camera.order as f32;
+        output.send(PointerHits::new(*pointer, picks, order));
+    }
+}

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -31,6 +31,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_sprite_picking_backend|Provides an implementation for picking sprites|
 |bevy_state|Enable built in global state machines|
 |bevy_text|Provides text functionality|
+|bevy_text2d_picking_backend|Provides an implementation for picking Text2d|
 |bevy_ui|A custom ECS-driven UI framework|
 |bevy_ui_picking_backend|Provides an implementation for picking UI|
 |bevy_window|Windowing layer|

--- a/examples/README.md
+++ b/examples/README.md
@@ -382,6 +382,7 @@ Example | Description
 [Mesh Picking](../examples/picking/mesh_picking.rs) | Demonstrates picking meshes
 [Showcases simple picking events and usage](../examples/picking/simple_picking.rs) | Demonstrates how to use picking events to spawn simple objects
 [Sprite Picking](../examples/picking/sprite_picking.rs) | Demonstrates picking sprites and sprite atlases
+[Text2d Picking](../examples/picking/text2d_picking.rs) | Demonstrates picking 2d text
 
 ## Reflection
 

--- a/examples/picking/text2d_picking.rs
+++ b/examples/picking/text2d_picking.rs
@@ -1,0 +1,92 @@
+//! Demonstrates picking for text2d. The picking backend only tests against the
+//! text2d bounds, so the 2d text can be picked by clicking on its transparent areas.
+
+use bevy::{prelude::*, sprite::Anchor};
+use std::fmt::Debug;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_text2d)
+        .run();
+}
+
+fn move_text2d(
+    time: Res<Time>,
+    mut sprite: Query<&mut Transform, (Without<Sprite>, Without<Text2d>, With<Children>)>,
+) {
+    let t = time.elapsed_secs() * 0.1;
+    for mut transform in &mut sprite {
+        let new = Vec2 {
+            x: 50.0 * ops::sin(t),
+            y: 50.0 * ops::sin(t * 2.0),
+        };
+        transform.translation.x = new.x;
+        transform.translation.y = new.y;
+    }
+}
+
+/// Set up a scene that tests all anchor types.
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    let w = 256.0;
+    let h = 128.0;
+
+    commands
+        .spawn((Transform::default(), Visibility::default()))
+        .with_children(|commands| {
+            for (anchor_index, anchor) in [
+                Anchor::TopLeft,
+                Anchor::TopCenter,
+                Anchor::TopRight,
+                Anchor::CenterLeft,
+                Anchor::Center,
+                Anchor::CenterRight,
+                Anchor::BottomLeft,
+                Anchor::BottomCenter,
+                Anchor::BottomRight,
+                Anchor::Custom(Vec2::new(0.5, 0.5)),
+            ]
+            .iter()
+            .enumerate()
+            {
+                let i = (anchor_index % 3) as f32;
+                let j = (anchor_index / 3) as f32;
+
+                // spawn black square behind text to show anchor point
+                commands.spawn((
+                    Sprite::from_color(Color::BLACK, Vec2::splat(15.0)),
+                    Transform::from_xyz(i * w - w, -1.0 * (j * h - h), -1.0),
+                ));
+
+                commands
+                    .spawn((
+                        Text2d(format!("{:?}", anchor)),
+                        TextColor(Color::WHITE),
+                        *anchor,
+                        // 3x3 grid of anchor examples by changing transform
+                        Transform::from_xyz(i * w - w, -1.0 * (j * h - h), 0.0)
+                            .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2))
+                            .with_rotation(Quat::from_rotation_z((j - 1.0) * 0.2)),
+                    ))
+                    .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 0.0)))
+                    .observe(recolor_on::<Pointer<Out>>(Color::srgb(1.0, 0.0, 0.0)))
+                    .observe(recolor_on::<Pointer<Pressed>>(Color::srgb(0.0, 0.0, 1.0)))
+                    .observe(recolor_on::<Pointer<Released>>(Color::srgb(0.0, 1.0, 0.0)));
+            }
+        });
+}
+
+// An observer listener that changes the target entity's color.
+fn recolor_on<E: Debug + Clone + Reflect>(
+    color: Color,
+) -> impl Fn(Trigger<E>, Query<&mut TextColor>) {
+    move |ev, mut text_colors| {
+        let Ok(mut text_color) = text_colors.get_mut(ev.target()) else {
+            return;
+        };
+        text_color.0 = color;
+    }
+}


### PR DESCRIPTION
# Objective

- This PR adds support for picking `Text2d`.

## Solution

- Introduce a new feature flag, `bevy_text2d_picking_backend`, and add all the required plumbing;
- Extend the `TextPlugin` struct to include a `add_picking` setting;
- Port over the existing sprite picking backend to `bevy_text`, using `TextLayoutInfo` for the bounds;
- Add a `text2d_picking` example.

Note: I'm deliberately not calling the feature `bevy_text_picking_backend`, to avoid misleading people into thinking this might be used for UI Text.

## Testing

- Did you test these changes? If so, how? Yes, by running the `text2d_picking` example.
- Are there any parts that need more testing? Not that I'm aware of
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Run the `text2d_picking` example.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? macOS

