### PR TITLE
Remove `SetInputFocus` helper trait

### DIFF
--- a/crates/bevy_input_focus/src/autofocus.rs
+++ b/crates/bevy_input_focus/src/autofocus.rs
@@ -2,7 +2,7 @@
 
 use bevy_ecs::{component::ComponentId, prelude::*, world::DeferredWorld};
 
-use crate::SetInputFocus;
+use crate::InputFocus;
 
 /// Indicates that this widget should automatically receive [`InputFocus`](crate::InputFocus).
 ///
@@ -16,5 +16,7 @@ use crate::SetInputFocus;
 pub struct AutoFocus;
 
 fn on_auto_focus_added(mut world: DeferredWorld, entity: Entity, _: ComponentId) {
-    world.set_input_focus(entity);
+    if let Some(mut input_focus) = world.get_resource_mut::<InputFocus>() {
+        input_focus.set(entity);
+    }
 }

--- a/crates/bevy_input_focus/src/autofocus.rs
+++ b/crates/bevy_input_focus/src/autofocus.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{component::ComponentId, prelude::*, world::DeferredWorld};
 
 use crate::InputFocus;
 
-/// Indicates that this widget should automatically receive [`InputFocus`](crate::InputFocus).
+/// Indicates that this widget should automatically receive [`InputFocus`].
 ///
 /// This can be useful for things like dialog boxes, the first text input in a form,
 /// or the first button in a game menu.

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -31,6 +31,41 @@ use core::fmt::Debug;
 
 /// Resource representing which entity has input focus, if any. Keyboard events will be
 /// dispatched to the current focus entity, or to the primary window if no entity has focus.
+///
+/// Changing the input focus is as easy as modifying this resource.
+///
+/// # Examples
+///
+/// From within a system:
+///
+/// ```rust
+/// use bevy_ecs::prelude::*;
+/// use bevy_input_focus::InputFocus;
+///
+/// fn clear_focus(mut input_focus: ResMut<InputFocus>) {
+///   input_focus.clear();
+/// }
+/// ```
+///
+/// With exclusive (or deferred) world access:
+///
+/// ```rust
+/// use bevy_ecs::prelude::*;
+/// use bevy_input_focus::InputFocus;
+///
+/// fn set_focus_from_world(world: &mut World) {
+///     let entity = world.spawn().id();
+///
+///     // Fetch the resource from the world
+///     let mut input_focus = world.resource_mut::<InputFocus>();
+///     // Then mutate it!
+///     input_focus.set(entity);
+///
+///     // Or you can just insert a fresh copy of the resource
+///     // which will overwrite the existing one.
+///     world.insert_resource(InputFocus::from_entity(entity));
+/// }
+/// ```
 #[derive(Clone, Debug, Default, Resource)]
 pub struct InputFocus(pub Option<Entity>);
 

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -54,7 +54,7 @@ use core::fmt::Debug;
 /// use bevy_input_focus::InputFocus;
 ///
 /// fn set_focus_from_world(world: &mut World) {
-///     let entity = world.spawn().id();
+///     let entity = world.spawn_empty().id();
 ///
 ///     // Fetch the resource from the world
 ///     let mut input_focus = world.resource_mut::<InputFocus>();

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! This crate provides a system for managing input focus in Bevy applications, including:
 //! * [`InputFocus`], a resource for tracking which entity has input focus.
-//! * Methods for getting and setting input focus via [`SetInputFocus`], [`InputFocus`] and [`IsFocusedHelper`].
+//! * Methods for getting and setting input focus via [`InputFocus`] and [`IsFocusedHelper`].
 //! * A generic [`FocusedInput`] event for input events which bubble up from the focused entity.
 //!
 //! This crate does *not* provide any integration with UI widgets: this is the responsibility of the widget crate,

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -372,13 +372,11 @@ mod tests {
     };
 
     #[test]
-    fn test_without_plugin() {
+    fn test_no_panics_if_resource_missing() {
         let mut app = App::new();
+        // Note that we do not insert InputFocus here!
 
         let entity = app.world_mut().spawn_empty().id();
-
-        app.world_mut()
-            .insert_resource(InputFocus::from_entity(entity));
 
         assert!(!app.world().is_focused(entity));
 

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -475,7 +475,7 @@ mod tests {
 
         app.world_mut()
             .run_system_once(move |mut input_focus: ResMut<InputFocus>| {
-                input_focus.set(entity_b);
+                input_focus.set(child_of_b);
             })
             .unwrap();
         assert!(app.world().is_focus_within(entity_b));


### PR DESCRIPTION
# Objective

The `SetInputFocus` trait is not very useful: we're just setting a resource's value.

This is a very common and simple pattern, so we should expose it directly to users rather than creating confusing indirection.

## Solution

Remove the `SetInputFocus` trait and migrate existing uses to just modify the `InputFocus` resource. The helper methods on that type make this nicer than before :)

P.S. This is non-breaking as bevy_input_focus has not yet shipped.

## Testing

Code compiles! CI will check the existing unit tests.
