### PR TITLE
Revert "Make doc CI use nightly (#16147)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,6 @@ jobs:
       - name: Check Compile
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
-  
   check-compiles-no-std:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -295,7 +294,6 @@ jobs:
         with:
           name: example-run-macos
           path: example-run/
-        
   check-doc:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Check Compile
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
-
+  
   check-compiles-no-std:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -295,7 +295,7 @@ jobs:
         with:
           name: example-run-macos
           path: example-run/
-
+        
   check-doc:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -310,9 +310,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -323,7 +321,7 @@ jobs:
         run: cargo run -p ci -- doc
         env:
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0 --cfg docsrs_dep"
+          RUSTFLAGS: "-C debuginfo=0"
       # This currently report a lot of false positives
       # Enable it again once it's fixed - https://github.com/bevyengine/bevy/issues/1983
       # - name: Installs cargo-deadlinks

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -80,24 +80,6 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
 
-  check-doc:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@beta
-      - name: Install Linux dependencies
-        uses: ./.github/actions/install-linux-deps
-        with:
-          wayland: true
-          xkb: true
-      - name: Build and check docs
-        # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doc
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C debuginfo=0"
-
   open-issue:
     name: Warn that weekly CI fails
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -116,7 +116,7 @@ jobs:
             --jq '.[0].number')
           if [[ -n $previous_issue_number ]]; then
             gh issue comment $previous_issue_number \
-              --body "Weekly pipeline still fails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" 
+              --body "Weekly pipeline still fails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             gh issue create \
               --title "$TITLE" \
@@ -128,6 +128,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: Main branch fails to compile on Rust beta.
           LABELS: C-Bug,S-Needs-Triage
-          BODY: | 
+          BODY: |
             ## Weekly CI run has failed.
             [The offending run.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -80,6 +80,24 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
 
+  check-doc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@beta
+      - name: Install Linux dependencies
+        uses: ./.github/actions/install-linux-deps
+        with:
+          wayland: true
+          xkb: true
+      - name: Build and check docs
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- doc
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0"
+
   open-issue:
     name: Warn that weekly CI fails
     runs-on: ubuntu-latest
@@ -98,7 +116,7 @@ jobs:
             --jq '.[0].number')
           if [[ -n $previous_issue_number ]]; then
             gh issue comment $previous_issue_number \
-              --body "Weekly pipeline still fails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              --body "Weekly pipeline still fails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" 
           else
             gh issue create \
               --title "$TITLE" \
@@ -110,6 +128,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: Main branch fails to compile on Rust beta.
           LABELS: C-Bug,S-Needs-Triage
-          BODY: |
+          BODY: | 
             ## Weekly CI run has failed.
             [The offending run.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/tools/ci/src/commands/doc_check.rs
+++ b/tools/ci/src/commands/doc_check.rs
@@ -16,6 +16,6 @@ impl Prepare for DocCheckCommand {
             ),
             "Please fix doc warnings in output above.",
         )
-        .with_env_var("RUSTDOCFLAGS", "-D warnings --cfg=docsrs")]
+        .with_env_var("RUSTDOCFLAGS", "-D warnings")]
     }
 }


### PR DESCRIPTION
This reverts commit 58a73924ebf4b8afadaa48a9f0bbf2f057292a43.

# Objective

This is causing local `cargo run -p ci` runs to fail on `stable` Rust when used locally. Fixes #16871.

## Solution

Revert #16147. We shouldn't have merged this until we had a full solution (I missed a Controversial tag, sorry!).

## Testing

`cargo run -p ci` fails for me before this change in the reported fashion. After this reversion, it passes.