### PR TITLE
Enable motion blur on WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -995,7 +995,7 @@ doc-scrape-examples = true
 name = "Motion Blur"
 description = "Demonstrates per-pixel motion blur"
 category = "3D Rendering"
-wasm = false
+wasm = true
 
 [[example]]
 name = "order_independent_transparency"


### PR DESCRIPTION
This feature was tested with WASM, WebGL, and WebGPU. It should work on these targets. I think this was an oversight in the original PR.