### PR TITLE
`many_buttons` `display-none` commandline argument

### DIFF
--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -46,6 +46,10 @@ struct Args {
     /// at the start of each frame despawn any existing UI nodes and spawn a new UI tree
     #[argh(switch)]
     respawn: bool,
+
+    /// set the root node to display none, removing all nodes from the layout.
+    #[argh(switch)]
+    display_none: bool,
 }
 
 /// This example shows what happens when there is a lot of buttons on screen.
@@ -153,6 +157,11 @@ fn setup_flex(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
     let as_rainbow = |i: usize| Color::hsl((i as f32 / buttons_f) * 360.0, 0.9, 0.8);
     commands
         .spawn(Node {
+            display: if args.display_none {
+                Display::None
+            } else {
+                Display::Flex
+            },
             flex_direction: FlexDirection::Column,
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
@@ -203,7 +212,11 @@ fn setup_grid(mut commands: Commands, asset_server: Res<AssetServer>, args: Res<
     let as_rainbow = |i: usize| Color::hsl((i as f32 / buttons_f) * 360.0, 0.9, 0.8);
     commands
         .spawn(Node {
-            display: Display::Grid,
+            display: if args.display_none {
+                Display::None
+            } else {
+                Display::Grid
+            },
             width: Val::Percent(100.),
             height: Val::Percent(100.0),
             grid_template_columns: RepeatedGridTrack::flex(args.buttons as u16, 1.0),


### PR DESCRIPTION
# Objective

Add a benchmark that captures performance with a removed UI layout where the root node is set to `Display::None`.

# Solution

Added a `display-none` commandline argument to the `many_buttons` example. When used `display-none` sets the `display` field of the root node to `Display::None`.

# Testing
```
cargo run --example many_buttons -- --display-none
```
Which displays nothing, as desired.