### PR TITLE
Remove unused generic in `DeferredWorld::trigger`

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -562,7 +562,7 @@ impl<'w> DeferredWorld<'w> {
     }
 
     /// Sends a "global" [`Trigger`](crate::observer::Trigger) without any targets.
-    pub fn trigger<T: Event>(&mut self, trigger: impl Event) {
+    pub fn trigger(&mut self, trigger: impl Event) {
         self.commands().trigger(trigger);
     }
 


### PR DESCRIPTION
Fixing what I just noticed.

## Migration Guide

- Remove the generic parameter when calling this method