### PR TITLE
many_components stress test improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ trace_tracy_memory = [
 ]
 
 # Tracing support
-trace = ["bevy_internal/trace"]
+trace = ["bevy_internal/trace", "dep:tracing"]
 
 # Basis Universal compressed texture support
 basis-universal = ["bevy_internal/basis-universal"]
@@ -477,6 +477,7 @@ ghost_nodes = ["bevy_internal/ghost_nodes"]
 
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.16.0-dev", default-features = false }
+tracing = { version = "0.1", default-features = false, optional = true }
 
 # Wasm does not support dynamic linking.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -162,7 +162,10 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
         }
     }
 
-    println!("Number of Archetype-Components: {}", world.archetypes().archetype_components_len());
+    println!(
+        "Number of Archetype-Components: {}",
+        world.archetypes().archetype_components_len()
+    );
 
     // overwrite Update schedule in the app
     app.add_schedule(schedule);

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -140,7 +140,7 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
 
         let mut entity = world.spawn_empty();
         // We use `ManuallyDrop` here as we need to avoid dropping the u8's when `values` is dropped
-        // since ownership of the values is passed to the world in `insert_by_ids`. 
+        // since ownership of the values is passed to the world in `insert_by_ids`.
         // But we do want to deallocate the memory when values is dropped.
         let mut values: Vec<ManuallyDrop<u8>> = components
             .iter()

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -143,10 +143,13 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
             .iter()
             .map(|_id| {
                 let mut value: u8 = rng.gen_range(0..255);
-                let value = &mut value;
+                let value = &mut value as *mut u8;
                 // SAFETY: value is non null since it was initialized from an &mut above
                 #[allow(unsafe_code)]
-                let ptr = unsafe { NonNull::new_unchecked(value as *mut u8) };
+                let ptr = unsafe { NonNull::new_unchecked(value) };
+                // SAFETY:
+                // * ptr was created from a u8, so is valid, aligned, and has correct provenance.
+                // * ptr was created from an exclusive reference, so nothing else can read or write the value
                 #[allow(unsafe_code)]
                 unsafe {
                     OwningPtr::new(ptr)

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -93,8 +93,8 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
             world.register_component_with_descriptor(
                 #[expect(unsafe_code, reason = "Used to register a bunch of fake components")]
                 // SAFETY:
-                // we don't implement a drop function
-                // u8 is Sync and Send
+                // * We don't implement a drop function
+                // * u8 is Sync and Send
                 unsafe {
                     ComponentDescriptor::new_with_layout(
                         format!("Component{}", i).to_string(),
@@ -144,7 +144,7 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
             .map(|_id| {
                 let mut value: u8 = rng.gen_range(0..255);
                 let value = &mut value;
-                // SAFETY: value is initialized above
+                // SAFETY: value is non null since it was initialized from an &mut above
                 #[allow(unsafe_code)]
                 let ptr = unsafe { NonNull::new_unchecked(value as *mut u8) };
                 #[allow(unsafe_code)]
@@ -155,7 +155,7 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
             .collect();
         // SAFETY:
         // * component_id is from the same world
-        // * value is u8, so ptr is a valid reference for component_id
+        // * values was initialized above, so references are valid
         #[allow(unsafe_code)]
         unsafe {
             entity.insert_by_ids(&components, values.into_iter());

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -113,6 +113,11 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
             .choose_multiple(&mut rng, num_access_components)
             .copied()
             .collect();
+        let without_components: Vec<ComponentId> = component_ids
+            .iter()
+            .filter(|component_id| !access_components.contains(component_id))
+            .copied()
+            .collect();
         let system = (QueryParamBuilder::new(|builder| {
             for &access_component in &access_components {
                 if rand::random::<bool>() {
@@ -120,6 +125,10 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
                 } else {
                     builder.ref_id(access_component);
                 }
+            }
+
+            for &without_component in &without_components {
+                builder.without_id(without_component);
             }
         }),)
             .build_state(world)

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -21,7 +21,7 @@ use bevy::{
         system::QueryParamBuilder,
         world::FilteredEntityMut,
     },
-    log::LogPlugin,
+    log::{info_span, LogPlugin},
     prelude::{App, In, IntoSystem, Query, Schedule, SystemParamBuilder, Update},
     ptr::OwningPtr,
     MinimalPlugins,
@@ -34,6 +34,7 @@ use std::{alloc::Layout, num::Wrapping};
 // A simple system that matches against several components and does some menial calculation to create
 // some non-trivial load.
 fn base_system(access_components: In<Vec<ComponentId>>, mut query: Query<FilteredEntityMut>) {
+    let _span = info_span!("base_system", components = ?access_components.0).entered();
     for mut filtered_entity in &mut query {
         // We calculate Faulhaber's formula mod 256 with n = value and p = exponent.
         // See https://en.wikipedia.org/wiki/Faulhaber%27s_formula

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -114,11 +114,6 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
             .choose_multiple(&mut rng, num_access_components)
             .copied()
             .collect();
-        // let without_components: Vec<ComponentId> = component_ids
-        //     .iter()
-        //     .filter(|component_id| !access_components.contains(component_id))
-        //     .copied()
-        //     .collect();
         let system = (QueryParamBuilder::new(|builder| {
             for &access_component in &access_components {
                 if rand::random::<bool>() {
@@ -127,10 +122,6 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
                     builder.ref_id(access_component);
                 }
             }
-
-            // for &without_component in &without_components {
-            //     builder.without_id(without_component);
-            // }
         }),)
             .build_state(world)
             .build_any_system(base_system);

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -36,7 +36,7 @@ use std::{alloc::Layout, mem::ManuallyDrop, num::Wrapping};
 // some non-trivial load.
 fn base_system(access_components: In<Vec<ComponentId>>, mut query: Query<FilteredEntityMut>) {
     #[cfg(feature = "trace")]
-    let _span = bevy::utils::tracing::info_span!("base_system", components = ?access_components.0, count = query.iter().len()).entered();
+    let _span = tracing::info_span!("base_system", components = ?access_components.0, count = query.iter().len()).entered();
 
     for mut filtered_entity in &mut query {
         // We calculate Faulhaber's formula mod 256 with n = value and p = exponent.

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -162,6 +162,8 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
         }
     }
 
+    println!("Number of Archetype-Components: {}", world.archetypes().archetype_components_len());
+
     // overwrite Update schedule in the app
     app.add_schedule(schedule);
     app.add_plugins(MinimalPlugins)

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -21,7 +21,7 @@ use bevy::{
         system::QueryParamBuilder,
         world::FilteredEntityMut,
     },
-    log::{info_span, LogPlugin},
+    log::LogPlugin,
     prelude::{App, In, IntoSystem, Query, Schedule, SystemParamBuilder, Update},
     ptr::OwningPtr,
     MinimalPlugins,
@@ -34,7 +34,9 @@ use std::{alloc::Layout, num::Wrapping, ptr::NonNull};
 // A simple system that matches against several components and does some menial calculation to create
 // some non-trivial load.
 fn base_system(access_components: In<Vec<ComponentId>>, mut query: Query<FilteredEntityMut>) {
-    let _span = info_span!("base_system", components = ?access_components.0, count = query.iter().len()).entered();
+    #[cfg(feature = "trace")]
+    let _span = bevy::utils::tracing::info_span!("base_system", components = ?access_components.0, count = query.iter().len()).entered();
+
     for mut filtered_entity in &mut query {
         // We calculate Faulhaber's formula mod 256 with n = value and p = exponent.
         // See https://en.wikipedia.org/wiki/Faulhaber%27s_formula


### PR DESCRIPTION
# Objective

- I was getting familiar with the many_components example to test some recent pr's for executor changes and saw some things to improve.

## Solution

- Use `insert_by_ids` instead of `insert_by_id`. This reduces the number of archetype moves and improves startup times substantially.
- Add a tracing span to `base_system`. I'm not sure why, but tracing spans weren't showing for this system. I think it's something to do with how pipe system works, but need to investigate more. The approach in this pr is a little better than the default span too, since it allows adding the number of entities queried to the span which is not possible with the default system span.
- println the number of archetype component id's that are created. This is useful since part of the purpose of this stress test is to test how well the use of FixedBitSet scales in the executor.

## Testing

- Ran the example with `cargo run --example many_components -F trace_tracy 1000000` and connected with tracy
- Timed the time it took to spawn 1 million entities on main (240 s) vs this pr (15 s)

---

## Showcase

![image](https://github.com/user-attachments/assets/69da4db0-4ecc-4acb-aebb-2e47d1a35f3b)

## Future Work

- Currently systems are created with a random set of components and entities are created with a random set of components without any correlation between the randomness. This means that some systems won't match any entities and some entities could not match any systems. It might be better to spawn the entities from the pool of components that match the queries that the systems are using.