### PR TITLE
Implement FromStr for Val

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -86,7 +86,7 @@ impl core::str::FromStr for Val {
 
         let Some(end_of_number) = s
             .bytes()
-            .position(|c| !(b'0'..=b'9').contains(&c) && c != b'.' && c != b'-')
+            .position(|c| !(c.is_ascii_digit() || c == b'.' || c == b'-' || c == b'+'))
         else {
             return Err(ValParseError::UnitMissing);
         };

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -813,6 +813,8 @@ mod tests {
         assert_eq!("3.5".parse::<Val>(), Err(ValParseError::UnitMissing));
         assert_eq!("3pxx".parse::<Val>(), Err(ValParseError::InvalidUnit));
         assert_eq!("3.5pxx".parse::<Val>(), Err(ValParseError::InvalidUnit));
+        assert_eq!("3-3px".parse::<Val>(), Err(ValParseError::InvalidValue));
+        assert_eq!("3.5-3px".parse::<Val>(), Err(ValParseError::InvalidValue));
     }
 
     #[test]

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -11,7 +11,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// This enum allows specifying values for various [`Node`](crate::Node) properties in different units,
 /// such as logical pixels, percentages, or automatically determined values.
 ///
-/// `Val` also implements [`std::str::FromStr`] to allow parsing values from strings in the format `#.#px`. Whitespaces between the value and unit is allowed. The following units are supported:
+/// `Val` also implements [`core::str::FromStr`] to allow parsing values from strings in the format `#.#px`. Whitespaces between the value and unit is allowed. The following units are supported:
 /// * `px`: logical pixels
 /// * `%`: percentage
 /// * `vw`: percentage of the viewport width
@@ -63,8 +63,8 @@ pub enum ValParseError {
     InvalidUnit,
 }
 
-impl std::fmt::Display for ValParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ValParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ValParseError::UnitMissing => write!(f, "unit missing"),
             ValParseError::ValueMissing => write!(f, "value missing"),
@@ -74,7 +74,7 @@ impl std::fmt::Display for ValParseError {
     }
 }
 
-impl std::str::FromStr for Val {
+impl core::str::FromStr for Val {
     type Err = ValParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -86,7 +86,7 @@ impl std::str::FromStr for Val {
 
         let Some(end_of_number) = s
             .bytes()
-            .position(|c| (c < b'0' || c > b'9') && c != b'.' && c != b'-')
+            .position(|c| !(b'0'..=b'9').contains(&c) && c != b'.' && c != b'-')
         else {
             return Err(ValParseError::UnitMissing);
         };


### PR DESCRIPTION
# Objective

This PR implements `FromStr` for `Val`, so developers can parse values like `10px` and `50%`

## Testing

Added tests for this. I think they cover pretty much everything, and it's a fairly simple unit test.

## Limitations

Currently the following float values are not parsed:
- `inf`, `-inf`, `+infinity`, `NaN`
- `2.5E10`, `2.5e10`, `2.5E-10`

For my use case this is perfectly fine but other developers might want to support these values