### PR TITLE
Refactor non-core Curve methods into extension traits

### DIFF
--- a/crates/bevy_color/src/color_gradient.rs
+++ b/crates/bevy_color/src/color_gradient.rs
@@ -76,6 +76,7 @@ where
 mod tests {
     use super::*;
     use crate::{palettes::basic, Srgba};
+    use bevy_math::curve::{Curve, CurveExt};
 
     #[test]
     fn test_color_curve() {

--- a/crates/bevy_gizmos/src/curves.rs
+++ b/crates/bevy_gizmos/src/curves.rs
@@ -4,7 +4,10 @@
 //! [`GizmoBuffer::curve_3d`] and assorted support items.
 
 use bevy_color::Color;
-use bevy_math::{curve::Curve, Vec2, Vec3};
+use bevy_math::{
+    curve::{Curve, CurveExt},
+    Vec2, Vec3,
+};
 
 use crate::{gizmos::GizmoBuffer, prelude::GizmoConfigGroup};
 

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -18,6 +18,10 @@ mod paths {
     pub(super) const THIS_CRATE: &str = "bevy_math";
 }
 
+// Import `CurveExt` just for doc links.
+#[expect(unused)]
+use super::CurveExt;
+
 // NOTE ON REFLECTION:
 //
 // Function members of structs pose an obstacle for reflection, because they don't implement
@@ -173,7 +177,7 @@ where
 }
 
 /// A curve whose samples are defined by mapping samples from another curve through a
-/// given function. Curves of this type are produced by [`Curve::map`].
+/// given function. Curves of this type are produced by [`CurveExt::map`].
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -269,7 +273,7 @@ where
 }
 
 /// A curve whose sample space is mapped onto that of some base curve's before sampling.
-/// Curves of this type are produced by [`Curve::reparametrize`].
+/// Curves of this type are produced by [`CurveExt::reparametrize`].
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -364,7 +368,7 @@ where
 }
 
 /// A curve that has had its domain changed by a linear reparameterization (stretching and scaling).
-/// Curves of this type are produced by [`Curve::reparametrize_linear`].
+/// Curves of this type are produced by [`CurveExt::reparametrize_linear`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -399,7 +403,7 @@ where
 }
 
 /// A curve that has been reparametrized by another curve, using that curve to transform the
-/// sample times before sampling. Curves of this type are produced by [`Curve::reparametrize_by_curve`].
+/// sample times before sampling. Curves of this type are produced by [`CurveExt::reparametrize_by_curve`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -432,7 +436,7 @@ where
 }
 
 /// A curve that is the graph of another curve over its parameter space. Curves of this type are
-/// produced by [`Curve::graph`].
+/// produced by [`CurveExt::graph`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -462,7 +466,7 @@ where
 }
 
 /// A curve that combines the output data from two constituent curves into a tuple output. Curves
-/// of this type are produced by [`Curve::zip`].
+/// of this type are produced by [`CurveExt::zip`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -503,7 +507,7 @@ where
 /// For this to be well-formed, the first curve's domain must be right-finite and the second's
 /// must be left-finite.
 ///
-/// Curves of this type are produced by [`Curve::chain`].
+/// Curves of this type are produced by [`CurveExt::chain`].
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
@@ -549,7 +553,7 @@ where
 
 /// The curve that results from reversing another.
 ///
-/// Curves of this type are produced by [`Curve::reverse`].
+/// Curves of this type are produced by [`CurveExt::reverse`].
 ///
 /// # Domain
 ///
@@ -590,7 +594,7 @@ where
 /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
 ///   value at `domain.end()` in the original curve
 ///
-/// Curves of this type are produced by [`Curve::repeat`].
+/// Curves of this type are produced by [`CurveExt::repeat`].
 ///
 /// # Domain
 ///
@@ -649,7 +653,7 @@ where
 /// - the value at the transitioning points (`domain.end() * n` for `n >= 1`) in the results is the
 ///   value at `domain.end()` in the original curve
 ///
-/// Curves of this type are produced by [`Curve::forever`].
+/// Curves of this type are produced by [`CurveExt::forever`].
 ///
 /// # Domain
 ///
@@ -703,7 +707,7 @@ where
 /// The curve that results from chaining a curve with its reversed version. The transition point
 /// is guaranteed to make no jump.
 ///
-/// Curves of this type are produced by [`Curve::ping_pong`].
+/// Curves of this type are produced by [`CurveExt::ping_pong`].
 ///
 /// # Domain
 ///
@@ -756,7 +760,7 @@ where
 /// realized by translating the second curve so that its start sample point coincides with the
 /// first curves' end sample point.
 ///
-/// Curves of this type are produced by [`Curve::chain_continue`].
+/// Curves of this type are produced by [`CurveExt::chain_continue`].
 ///
 /// # Domain
 ///

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -18,8 +18,7 @@ mod paths {
     pub(super) const THIS_CRATE: &str = "bevy_math";
 }
 
-// Import `CurveExt` just for doc links.
-#[expect(unused)]
+#[expect(unused, reason = "imported just for doc links")]
 use super::CurveExt;
 
 // NOTE ON REFLECTION:

--- a/crates/bevy_math/src/curve/cores.rs
+++ b/crates/bevy_math/src/curve/cores.rs
@@ -432,14 +432,14 @@ impl<T> UnevenCore<T> {
     }
 
     /// This core, but with the sample times moved by the map `f`.
-    /// In principle, when `f` is monotone, this is equivalent to [`Curve::reparametrize`],
+    /// In principle, when `f` is monotone, this is equivalent to [`CurveExt::reparametrize`],
     /// but the function inputs to each are inverses of one another.
     ///
     /// The samples are re-sorted by time after mapping and deduplicated by output time, so
     /// the function `f` should generally be injective over the set of sample times, otherwise
     /// data will be deleted.
     ///
-    /// [`Curve::reparametrize`]: crate::curve::Curve::reparametrize
+    /// [`CurveExt::reparametrize`]: crate::curve::CurveExt::reparametrize
     #[must_use]
     pub fn map_sample_times(mut self, f: impl Fn(f32) -> f32) -> UnevenCore<T> {
         let mut timed_samples = self

--- a/crates/bevy_math/src/curve/derivatives/adaptor_impls.rs
+++ b/crates/bevy_math/src/curve/derivatives/adaptor_impls.rs
@@ -453,7 +453,7 @@ mod tests {
 
     use super::*;
     use crate::cubic_splines::{CubicBezier, CubicCardinalSpline, CubicCurve, CubicGenerator};
-    use crate::curve::{Curve, Interval};
+    use crate::curve::{Curve, CurveExt, Interval};
     use crate::{vec2, Vec2, Vec3};
 
     fn test_curve() -> CubicCurve<Vec2> {

--- a/crates/bevy_math/src/curve/derivatives/mod.rs
+++ b/crates/bevy_math/src/curve/derivatives/mod.rs
@@ -20,7 +20,7 @@
 //! counterpart.
 //!
 //! [`with_derivative`]: CurveWithDerivative::with_derivative
-//! [`by_ref`]: Curve::by_ref
+//! [`by_ref`]: crate::curve::CurveExt::by_ref
 
 pub mod adaptor_impls;
 

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -4,8 +4,8 @@
 //! [easing functions]: EaseFunction
 
 use crate::{
-    curve::{FunctionCurve, Interval},
-    Curve, Dir2, Dir3, Dir3A, Quat, Rot2, VectorSpace,
+    curve::{Curve, CurveExt, FunctionCurve, Interval},
+    Dir2, Dir3, Dir3A, Quat, Rot2, VectorSpace,
 };
 
 // TODO: Think about merging `Ease` with `StableInterpolate`

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -366,6 +366,17 @@ where
     }
 }
 
+/// Extension trait implemented by [curves], allowing access to a number of adaptors and
+/// convenience methods.
+///
+/// This trait is automatically implemented for all curves that are `Sized`. In particular,
+/// it is implemented for types like `Box<dyn Curve<T>>`. `CurveExt` is not dyn-compatible
+/// itself.
+///
+/// For more information, see the [module-level documentation].
+///
+/// [curves]: Curve
+/// [module-level documentation]: self
 pub trait CurveExt<T>: Curve<T> + Sized {
     /// Sample a collection of `n >= 0` points on this curve at the parameter values `t_n`,
     /// returning `None` if the point is outside of the curve's domain.
@@ -752,6 +763,16 @@ pub trait CurveExt<T>: Curve<T> + Sized {
 
 impl<C, T> CurveExt<T> for C where C: Curve<T> {}
 
+/// Extension trait implemented by [curves], allowing access to generic resampling methods as
+/// well as those based on [stable interpolation].
+///
+/// This trait is automatically implemented for all curves.
+///
+/// For more information, see the [module-level documentation].
+///
+/// [curves]: Curve
+/// [stable interpolation]: crate::StableInterpolate
+/// [module-level documentation]: self
 #[cfg(feature = "alloc")]
 pub trait CurveResampleExt<T>: Curve<T> {
     /// Resample this [`Curve`] to produce a new one that is defined by interpolation over equally
@@ -863,6 +884,7 @@ pub trait CurveResampleExt<T>: Curve<T> {
             interpolation,
         })
     }
+
     /// Resample this [`Curve`] to produce a new one that is defined by [automatic interpolation] over
     /// samples taken at the given set of times. The given `sample_times` are expected to contain at least
     /// two valid times within the curve's domain interval.

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -926,6 +926,7 @@ pub trait CurveResampleExt<T>: Curve<T> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<C, T> CurveResampleExt<T> for C where C: Curve<T> + ?Sized {}
 
 /// An error indicating that a linear reparameterization couldn't be performed because of

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -269,18 +269,18 @@
 //!
 //! [domain]: Curve::domain
 //! [sampled]: Curve::sample
-//! [changing parametrizations]: Curve::reparametrize
-//! [mapping output]: Curve::map
-//! [rasterization]: Curve::resample
+//! [changing parametrizations]: CurveExt::reparametrize
+//! [mapping output]: CurveExt::map
+//! [rasterization]: CurveResampleExt::resample
 //! [functions]: FunctionCurve
 //! [sample interpolation]: SampleCurve
 //! [splines]: crate::cubic_splines
 //! [easings]: easing
 //! [spline curves]: crate::cubic_splines
 //! [easing curves]: easing
-//! [`chain`]: Curve::chain
-//! [`zip`]: Curve::zip
-//! [`resample`]: Curve::resample
+//! [`chain`]: CurveExt::chain
+//! [`zip`]: CurveExt::zip
+//! [`resample`]: CurveResampleExt::resample
 //!
 //! [^footnote]: In fact, universal as well, in some sense: if `curve` is any curve, then `FunctionCurve::new
 //! (curve.domain(), |t| curve.sample_unchecked(t))` is an equivalent function curve.
@@ -446,7 +446,7 @@ pub trait CurveExt<T>: Curve<T> + Sized {
     /// let scaled_curve = my_curve.reparametrize(interval(0.0, 2.0).unwrap(), |t| t / 2.0);
     /// ```
     /// This kind of linear remapping is provided by the convenience method
-    /// [`Curve::reparametrize_linear`], which requires only the desired domain for the new curve.
+    /// [`CurveExt::reparametrize_linear`], which requires only the desired domain for the new curve.
     ///
     /// # Examples
     /// ```

--- a/crates/bevy_math/src/curve/sample_curves.rs
+++ b/crates/bevy_math/src/curve/sample_curves.rs
@@ -285,11 +285,13 @@ impl<T, I> UnevenSampleCurve<T, I> {
     }
 
     /// This [`UnevenSampleAutoCurve`], but with the sample times moved by the map `f`.
-    /// In principle, when `f` is monotone, this is equivalent to [`Curve::reparametrize`],
+    /// In principle, when `f` is monotone, this is equivalent to [`CurveExt::reparametrize`],
     /// but the function inputs to each are inverses of one another.
     ///
     /// The samples are re-sorted by time after mapping and deduplicated by output time, so
     /// the function `f` should generally be injective over the sample times of the curve.
+    ///
+    /// [`CurveExt::reparametrize`]: super::CurveExt::reparametrize
     pub fn map_sample_times(self, f: impl Fn(f32) -> f32) -> UnevenSampleCurve<T, I> {
         Self {
             core: self.core.map_sample_times(f),
@@ -343,11 +345,13 @@ impl<T> UnevenSampleAutoCurve<T> {
     }
 
     /// This [`UnevenSampleAutoCurve`], but with the sample times moved by the map `f`.
-    /// In principle, when `f` is monotone, this is equivalent to [`Curve::reparametrize`],
+    /// In principle, when `f` is monotone, this is equivalent to [`CurveExt::reparametrize`],
     /// but the function inputs to each are inverses of one another.
     ///
     /// The samples are re-sorted by time after mapping and deduplicated by output time, so
     /// the function `f` should generally be injective over the sample times of the curve.
+    ///
+    /// [`CurveExt::reparametrize`]: super::CurveExt::reparametrize
     pub fn map_sample_times(self, f: impl Fn(f32) -> f32) -> UnevenSampleAutoCurve<T> {
         Self {
             core: self.core.map_sample_times(f),


### PR DESCRIPTION
# Objective

The way `Curve` presently achieves dyn-compatibility involves shoving `Self: Sized` bounds on a bunch of methods to forbid them from appearing in vtables. (This is called *explicit non-dispatchability*.) The `Curve` trait probably also just has way too many methods on its own. 

In the past, using extension traits instead to achieve similar functionality has been discussed. The upshot is that this would allow the "core" of the curve trait, on which all the automatic methods rely, to live in a very simple dyn-compatible trait, while other functionality is implemented by extensions. For instance, `dyn Curve<T>` cannot use the `Sized` methods, but `Box<dyn Curve<T>>` is `Sized`, hence would automatically implement the extension trait, containing the methods which are currently non-dispatchable.

Other motivations for this include modularity and code organization: the `Curve` trait itself has grown quite large with the addition of numerous adaptors, and refactoring it to demonstrate the separation of functionality that is already present makes a lot of sense. Furthermore, resampling behavior in particular is dependent on special traits that may be mimicked or analogized in user-space, and creating extension traits to achieve similar behavior in user-space is something we ought to encourage by example.

## Solution

`Curve` now contains only `domain` and the `sample` methods. 

`CurveExt` has been created, and it contains all adaptors, along with the other sampling convenience methods (`samples`, `sample_iter`, etc.). It is implemented for all `C` where `C: Curve<T> + Sized`.

`CurveResampleExt` has been created, and it contains all resampling methods. It is implemented for all `C` where `C: Curve<T> + ?Sized`. 

## Testing

It compiles and `cargo doc` succeeds.

---

## Future work

- Consider writing extension traits for resampling curves in related domains (e.g. resampling for `Curve<T>` where `T: Animatable` into an `AnimatableKeyframeCurve`). 
- `CurveExt` might be further broken down to separate the adaptor and sampling methods.

---

## Migration Guide

`Curve` has been refactored so that much of its functionality is now in extension traits. Adaptors such as `map`, `reparametrize`, `reverse`, and so on now require importing `CurveExt`, while the resampling methods `resample_*` require importing `CurveResampleExt`. Both of these new traits are exported through `bevy::math::curve` and through `bevy::math::prelude`.

