### PR TITLE
Expose Tonemapping LUT binding indices

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -163,8 +163,8 @@ pub const RGB9E5_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(26590
 const MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE: Handle<Shader> =
     Handle::weak_from_u128(2325134235233421);
 
-const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 23;
-const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 24;
+pub const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 23;
+pub const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 24;
 
 /// Sets up the entire PBR infrastructure of bevy.
 pub struct PbrPlugin {


### PR DESCRIPTION
This PR simply exposes Bevy PBR's `TONEMAPPING_LUT_TEXTURE_BINDING_INDEX` and `TONEMAPPING_LUT_SAMPLER_BINDING_INDEX`. 

# Objective 
Alongside #16932, this is the last required change to be able to replace Bevy's built-in deferred lighting pass with a custom one based on the original logic.
