### PR TITLE
Remove unnecessary cast in DynamicTextureAtlasBuilder

### DIFF
--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -1,10 +1,7 @@
 use crate::TextureAtlasLayout;
 use bevy_image::{Image, TextureFormatPixelInfo};
 use bevy_math::{URect, UVec2};
-use bevy_render::{
-    render_asset::{RenderAsset, RenderAssetUsages},
-    texture::GpuImage,
-};
+use bevy_render::render_asset::RenderAssetUsages;
 use guillotiere::{size2, Allocation, AtlasAllocator};
 
 /// Helper utility to update [`TextureAtlasLayout`] on the fly.
@@ -53,9 +50,8 @@ impl DynamicTextureAtlasBuilder {
         ));
         if let Some(allocation) = allocation {
             assert!(
-                <GpuImage as RenderAsset>::asset_usage(atlas_texture)
-                    .contains(RenderAssetUsages::MAIN_WORLD),
-                "The asset at atlas_texture_handle must have the RenderAssetUsages::MAIN_WORLD usage flag set"
+                atlas_texture.asset_usage.contains(RenderAssetUsages::MAIN_WORLD),
+                "The atlas_texture image must have the RenderAssetUsages::MAIN_WORLD usage flag set"
             );
 
             self.place_texture(atlas_texture, allocation, texture);


### PR DESCRIPTION
# Summary 

- I started experimenting if `TextureAtlas` and friends can be moved to `bevy_image`. See [Discord](https://discord.com/channels/691052431525675048/692572690833473578/1320176054911897642) thread.
- While doing that, and moving `DynamicTextureAtlasBuilder` to `bevy_image`, it revealed that `DynamicTextureAtlasBuilder` depends on `bevy_render::GpuImage`, but we can't have `bevy_image` depend on `bevy_render`.
- The reason for the dependency is an assertion introduced in [this PR](https://github.com/bevyengine/bevy/pull/12827/files?show-viewed-files=true&file-filters%5B%5D=#diff-d9afd2170466f4aae340b244bdaa2a80aef58e979268c003878ca6c95860eb37R59).
- [It doesn't seem like there was a specific reason for that change](https://discord.com/channels/691052431525675048/743663924229963868/1320506862067650580), so should be safe to change it.
- So instead of the cast, just look up `asset_usage` directly on the concrete `Image` type.
- Also update the message which referred to a non-existent variable `atlas_texture_handle` (it was renamed during a subsequent refactor PR).

# Testing

- Checked on Discord if there was any known reason this had to stay like this.
- CI builds it.