### PR TITLE
Experiment to mitigate StorageId union access patterns

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1,4 +1,6 @@
 use super::{QueryData, QueryFilter, ReadOnlyQueryData, StorageIds};
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+use crate::query::StorageId;
 use crate::{
     archetype::{Archetype, ArchetypeEntity, ArchetypeId, Archetypes},
     bundle::Bundle,
@@ -11,8 +13,6 @@ use crate::{
         FilteredEntityMut, FilteredEntityRef,
     },
 };
-#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-use crate::query::StorageId;
 use alloc::vec::Vec;
 use core::{
     cmp::Ordering,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -150,19 +150,15 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
                 // - The caller has ensured a valid `storage_id` and `range`
                 // - The caller has ensured we provided the original `storage_id`, and so we can
                 //   trust it that table iteration is valid.
-                unsafe {
-                    self.fold_over_table_range_by_id(accum, func, table_id, range)
-                }
-            },
+                unsafe { self.fold_over_table_range_by_id(accum, func, table_id, range) }
+            }
             StorageId::Archetype(archetype_id) => {
                 // SAFETY:
                 // - The caller has ensured a valid `storage_id` and `range`
                 // - The caller has ensured we provided the original `storage_id`, and so we can
                 //   trust it that archetype iteration is valid.
-                unsafe {
-                    self.fold_over_archetype_range_by_id(accum, func, archetype_id, range)
-                }
-            },
+                unsafe { self.fold_over_archetype_range_by_id(accum, func, archetype_id, range) }
+            }
         }
     }
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2654,6 +2654,22 @@ enum QueryIterationEntitySource<'w, 's> {
     },
 }
 
+#[cfg(test)]
+impl<'w, 's> QueryIterationEntitySource<'w, 's> {
+    fn is_archetypes(&self) -> bool {
+        matches!(self, Self::Archetypes { .. })
+    }
+
+    fn entities_len(&self) -> usize {
+        match self {
+            Self::Tables { table_entities, .. } => table_entities.len(),
+            Self::Archetypes {
+                archetype_entities, ..
+            } => archetype_entities.len(),
+        }
+    }
+}
+
 impl<'w, 's> QueryIterationEntitySource<'w, 's> {
     fn new_from_storage_ids_empty(storage_ids: &'s StorageIds) -> Self {
         match storage_ids {
@@ -2678,23 +2694,6 @@ impl<'w, 's> QueryIterationEntitySource<'w, 's> {
                 archetype_entities: &[],
                 archetype_ids: archetype_ids.iter(),
             },
-        }
-    }
-
-    fn is_archetypes(&self) -> bool {
-        matches!(self, Self::Archetypes { .. })
-    }
-
-    fn is_tables(&self) -> bool {
-        matches!(self, Self::Tables { .. })
-    }
-
-    fn entities_len(&self) -> usize {
-        match self {
-            Self::Tables { table_entities, .. } => table_entities.len(),
-            Self::Archetypes {
-                archetype_entities, ..
-            } => archetype_entities.len(),
         }
     }
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -134,6 +134,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///  - `storage_id` must have been retrieved from `cursor.entity_source` to ensure
     ///    that the variant of `StorageId` matches the variant of `QueryIterationEntitySource`.
     #[inline]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     pub(super) unsafe fn fold_over_storage_range_by_id<B, Func>(
         &mut self,
         accum: B,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2654,23 +2654,6 @@ enum QueryIterationEntitySource<'w, 's> {
     },
 }
 
-// These impls are only used in tests
-#[cfg(test)]
-impl<'w, 's> QueryIterationEntitySource<'w, 's> {
-    fn is_archetypes(&self) -> bool {
-        matches!(self, Self::Archetypes { .. })
-    }
-
-    fn entities_len(&self) -> usize {
-        match self {
-            Self::Tables { table_entities, .. } => table_entities.len(),
-            Self::Archetypes {
-                archetype_entities, ..
-            } => archetype_entities.len(),
-        }
-    }
-}
-
 impl<'w, 's> QueryIterationEntitySource<'w, 's> {
     /// Creates the appropriate variant of `QueryIterationEntitySource` based on the variant
     /// of `StorageIds` provided from the `QueryState` associated with this iteration, but
@@ -3018,6 +3001,7 @@ mod tests {
     use crate::entity::Entity;
     #[allow(unused_imports)]
     use crate::prelude::World;
+    use crate::query::iter::QueryIterationEntitySource;
     #[allow(unused_imports)]
     use crate::{self as bevy_ecs};
 
@@ -3026,6 +3010,21 @@ mod tests {
     #[derive(Component, Debug, Eq, PartialEq, Clone, Copy)]
     #[component(storage = "SparseSet")]
     struct Sparse(usize);
+
+    impl<'w, 's> QueryIterationEntitySource<'w, 's> {
+        fn is_archetypes(&self) -> bool {
+            matches!(self, Self::Archetypes { .. })
+        }
+
+        fn entities_len(&self) -> usize {
+            match self {
+                Self::Tables { table_entities, .. } => table_entities.len(),
+                Self::Archetypes {
+                    archetype_entities, ..
+                } => archetype_entities.len(),
+            }
+        }
+    }
 
     #[allow(clippy::unnecessary_sort_by)]
     #[test]

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2693,7 +2693,7 @@ impl<'w, 's> QueryIterationEntitySource<'w, 's> {
 
     /// Creates the appropriate variant of `QueryIterationEntitySource` based on the variant
     /// of `StorageIds` provided from the `QueryState` associated with this iteration. This
-    /// also initialises the storage ID iterators as appropriate.
+    /// also initializes the storage ID iterators as appropriate.
     fn new_from_storage_ids(storage_ids: &'s StorageIds) -> Self {
         match storage_ids {
             StorageIds::Tables(table_ids) => Self::Tables {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -4,13 +4,15 @@ use crate::{
     bundle::Bundle,
     component::Tick,
     entity::{Entities, Entity, EntityBorrow, EntitySet, EntitySetIterator},
-    query::{ArchetypeFilter, DebugCheckedUnwrap, QueryState, StorageId},
+    query::{ArchetypeFilter, DebugCheckedUnwrap, QueryState},
     storage::{Table, TableId, TableRow, Tables},
     world::{
         unsafe_world_cell::UnsafeWorldCell, EntityMut, EntityMutExcept, EntityRef, EntityRefExcept,
         FilteredEntityMut, FilteredEntityRef,
     },
 };
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+use crate::query::StorageId;
 use alloc::vec::Vec;
 use core::{
     cmp::Ordering,

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1116,7 +1116,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Iterator for QueryIter<'w, 's, D, F> 
         // it with an empty one.
         let empty_iterator =
             QueryIterationEntitySource::new_from_storage_ids_empty(&self.query_state.storage_ids);
-        match std::mem::replace(&mut self.cursor.entity_source, empty_iterator) {
+        match core::mem::replace(&mut self.cursor.entity_source, empty_iterator) {
             QueryIterationEntitySource::Tables { table_ids, .. } => {
                 table_ids.fold(accum, |accum, id| {
                     // SAFETY:

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -1,7 +1,7 @@
 use crate::{
     batching::BatchingStrategy,
     component::Tick,
-    query::{QueryData, QueryFilter, QueryItem, QueryState, StorageIds},
+    query::{QueryData, QueryFilter, QueryItem, QueryState},
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 
@@ -125,6 +125,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     fn get_batch_size(&self, thread_count: usize) -> usize {
+        use crate::query::StorageIds;
+
         let max_items = || {
             match &self.state.storage_ids {
                 StorageIds::Tables(table_ids) => {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -146,9 +146,9 @@ impl StorageIds {
     #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     fn iter(&self) -> StorageIdIter<'_> {
         match self {
-            Self::Tables(table_ids) => StorageIdIter::Tables(table_ids.iter().clone()),
+            Self::Tables(table_ids) => StorageIdIter::Tables(table_ids.iter()),
             Self::Archetypes(archetype_ids) => {
-                StorageIdIter::Archetypes(archetype_ids.iter().clone())
+                StorageIdIter::Archetypes(archetype_ids.iter())
             }
         }
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -38,6 +38,9 @@ impl StorageId {
         }
     }
 
+    /// # Safety
+    ///
+    /// Needs a safety comment before merging!
     pub(super) unsafe fn debug_checked_as_archetype_id(&self) -> ArchetypeId {
         self.as_archetype_id().debug_checked_unwrap()
     }
@@ -49,6 +52,9 @@ impl StorageId {
         }
     }
 
+    /// # Safety
+    ///
+    /// Needs a safety comment before merging!
     pub(super) unsafe fn debug_checked_as_table_id(&self) -> TableId {
         self.as_table_id().debug_checked_unwrap()
     }
@@ -76,8 +82,8 @@ impl Iterator for StorageIdIter<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            Self::Tables(table_ids) => table_ids.next().copied().map(|id| id.into()),
-            Self::Archetypes(archetype_ids) => archetype_ids.next().copied().map(|id| id.into()),
+            Self::Tables(table_ids) => table_ids.next().copied().map(Into::into),
+            Self::Archetypes(archetype_ids) => archetype_ids.next().copied().map(Into::into),
         }
     }
 }
@@ -95,8 +101,8 @@ impl StorageIds {
 
     fn new_from_dense_flag(dense: bool) -> Self {
         match dense {
-            true => Self::Tables(vec![]),
-            false => Self::Archetypes(vec![]),
+            true => Self::Tables(Vec::new()),
+            false => Self::Archetypes(Vec::new()),
         }
     }
 
@@ -808,19 +814,9 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         matched_tables.intersect_with(&other.matched_tables);
         matched_archetypes.intersect_with(&other.matched_archetypes);
         let storage_ids = if is_iterating_tables {
-            StorageIds::Tables(
-                matched_tables
-                    .ones()
-                    .map(|id| TableId::from_usize(id))
-                    .collect(),
-            )
+            StorageIds::Tables(matched_tables.ones().map(TableId::from_usize).collect())
         } else {
-            StorageIds::Archetypes(
-                matched_archetypes
-                    .ones()
-                    .map(|id| ArchetypeId::new(id))
-                    .collect(),
-            )
+            StorageIds::Archetypes(matched_archetypes.ones().map(ArchetypeId::new).collect())
         };
 
         QueryState {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -73,11 +73,13 @@ impl From<ArchetypeId> for StorageId {
     }
 }
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
 pub(super) enum StorageIdIter<'s> {
     Archetypes(core::slice::Iter<'s, ArchetypeId>),
     Tables(core::slice::Iter<'s, TableId>),
 }
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
 impl Iterator for StorageIdIter<'_> {
     type Item = StorageId;
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -110,6 +110,7 @@ impl StorageIds {
         matches!(self, Self::Tables(_))
     }
 
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     fn iter(&self) -> StorageIdIter<'_> {
         match self {
             Self::Tables(table_ids) => StorageIdIter::Tables(table_ids.iter().clone()),

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1750,7 +1750,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                     let mut iter = self.iter_unchecked_manual(world, last_run, this_run);
                     let mut accum = init_accum();
                     for storage_id in queue {
-                        accum = iter.fold_over_storage_range(accum, &mut func, storage_id, None);
+                        accum = iter.fold_over_storage_range_by_id(accum, &mut func, storage_id, None);
                     }
                 });
             };
@@ -1767,7 +1767,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                         let _span = self.par_iter_span.enter();
                         let accum = init_accum();
                         self.iter_unchecked_manual(world, last_run, this_run)
-                            .fold_over_storage_range(accum, &mut func, storage_id, Some(batch));
+                            .fold_over_storage_range_by_id(accum, &mut func, storage_id, Some(batch));
                     });
                 }
             };

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1750,7 +1750,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                     let mut iter = self.iter_unchecked_manual(world, last_run, this_run);
                     let mut accum = init_accum();
                     for storage_id in queue {
-                        accum = iter.fold_over_storage_range_by_id(accum, &mut func, storage_id, None);
+                        accum =
+                            iter.fold_over_storage_range_by_id(accum, &mut func, storage_id, None);
                     }
                 });
             };
@@ -1767,7 +1768,12 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                         let _span = self.par_iter_span.enter();
                         let accum = init_accum();
                         self.iter_unchecked_manual(world, last_run, this_run)
-                            .fold_over_storage_range_by_id(accum, &mut func, storage_id, Some(batch));
+                            .fold_over_storage_range_by_id(
+                                accum,
+                                &mut func,
+                                storage_id,
+                                Some(batch),
+                            );
                     });
                 }
             };


### PR DESCRIPTION
# Objective

- In the query iteration code there are some types which rely on comments & programmer discipline to ensure correct access of fields:
  - `StorageId` - a union of `ArchetypeId` and `TableId`
  - `QueryIterationCursor` - multiple fields are only valid, and some types vary, depending on a boolean value:
    ```rust
    is_dense: bool,
    storage_id_iter: core::slice::Iter<'s, StorageId>,
    table_entities: &'w [Entity],
    archetype_entities: &'w [ArchetypeEntity],
    ```
  - `QueryState` - similar to above:
    ```rust
    // NOTE: we maintain both a bitset and a vec because iterating the vec is faster
    pub(super) matched_storage_ids: Vec<StorageId>,
    // Represents whether this query iteration is dense or not. When this is true
    // `matched_storage_ids` stores `TableId`s, otherwise it stores `ArchetypeId`s.
    pub(super) is_dense: bool,
    ```
- I asked why this wasn't achieved with an `enum` of some kind [on Discord](https://discord.com/channels/691052431525675048/749335865876021248/1320499282113069117).
- [Somebody replied](https://discord.com/channels/691052431525675048/749335865876021248/1320501000192266332) saying the reasoning for this is historical (`is_dense` used to be derived from a const generic or similar), and my proposed enum refactoring was worth considering.
  
## Solution

- The fields whose access patterns must be managed are now largely moved into enums, making it broadly impossible to access the wrong fields at the wrong times.
- I have tried, where possible, to make the number of checks no more than before - aka where we only checked `is_dense` before, we now do a single match on the enum.
- However, I have left in the concept of a `StorageId` type and made it a normal `enum` rather than `union`. I have then tried to only use this in places where the downsides are hopefully minimal, such as:
  - Where I think the discriminator being stored won't be significant (e.g. it's just transient as part of an iterator)
  - Where I think the cost of accessing the variant is minimal (we would've had to check `is_dense` anyway)
- This is largely because I didn't want it to be too drastic a refactor in the fairly scary code around `fold_over_storage_range`, but I'm open to people giving advice on how to proceed there, whether I should be braver (or not).
- I have put in the concept of accessing the `ArchetypeId` or `TableId` via `debug_checked_as_x()` unsafely, to still preserve the idea that when the `QueryIter` knows whether the iteration is dense or not, it doesn't want to pay the cost of checking that again when being asked to iterate storage by a `StorageId`. The old code didn't pay that cost, so I was wary of doing so. If people feel that this is overly cautious perf-wise, then I can make it safe and have it fail in some way (or whatever you suggest).

## Testing

- I've run the `bevy_ecs` unit tests, but don't know what else to do. Please advise! I'm also asking in #bevy_ecs on discord.
- I've now also run the full CI pipeline locally which passed, and the checks GitHub has run on this PR so far have passed.
- I've also run `cargo miri test -p bevy_ecs` and found no issues that weren't already present on `main` (there are ~7 memory leaks reported on both main and my branch!).
- I haven't added any new tests as it is a refactor that should have no external effects 🤞 