### PR TITLE
Add BRP method to mutate a component

### DIFF
--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -736,8 +736,7 @@ pub fn process_remote_mutate_component_request(
     let app_type_registry = world.resource::<AppTypeRegistry>().clone();
     let type_registry = app_type_registry.read();
 
-    // Get the type of the component to be mutated.
-    // E.g. `bevy_transform::components::transform::Transform`
+    // Get the fully-qualified type names of the component to be mutated.
     let component_type: &TypeRegistration = type_registry
         .get_with_type_path(&component)
         .ok_or_else(|| {

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -205,13 +205,20 @@ pub struct BrpListParams {
 /// The server responds with a null.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct BrpMutateParams {
-    /// TODO
+    /// The entity of the component to mutate.
     pub entity: Entity,
-    /// TODO
+
+    /// The [full path] of component to mutate.
+    ///
+    /// [full path]: bevy_reflect::TypePath::type_path
     pub component: String,
-    /// TODO
+
+    /// The [path] of the field within the component.
+    ///
+    /// [path]: bevy_reflect::GetPath
     pub path: String,
-    /// TODO
+
+    /// The value to insert at `path`.
     pub value: Value,
 }
 
@@ -712,7 +719,10 @@ pub fn process_remote_insert_request(
     Ok(Value::Null)
 }
 
-/// TODO Handles a `bevy/mutate_component`
+/// Handles a `bevy/mutate_component` request coming from a client.
+///
+/// This method allows you to mutate a single field inside an Entity's
+/// component.
 pub fn process_remote_mutate_component_request(
     In(params): In<Option<Value>>,
     world: &mut World,

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -751,7 +751,7 @@ pub fn process_remote_mutate_component_request(
         .get_with_type_path(
             reflected
                 .reflect_path(path.as_str())
-                .unwrap()
+                .map_err(BrpError::component_error)?
                 .reflect_type_path(),
         )
         .ok_or_else(|| {

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -194,7 +194,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/mutate_component
+//! ### `bevy/mutate_component`
 //!
 //! Mutate a field in a component.
 //!
@@ -202,7 +202,7 @@
 //! - `entity`: The ID of the entity to with the component to mutate.
 //! - `component`: The component's [fully-qualified type name].
 //! - `path`: The path of the field within the component. See
-//!   [GetPath](bevy_reflect::GetPath#syntax) for more information on formatting this string.
+//!   [`GetPath`](bevy_reflect::GetPath#syntax) for more information on formatting this string.
 //! - `value`: The value to insert at `path`.
 //!
 //! `result`: null.

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -414,8 +414,8 @@ impl Default for RemotePlugin {
                 builtin_methods::export_registry_types,
             )
             .with_method(
-                builtin_methods::BRP_MUTATE_METHOD,
-                builtin_methods::process_remote_mutate_request,
+                builtin_methods::BRP_MUTATE_COMPONENT_METHOD,
+                builtin_methods::process_remote_mutate_component_request,
             )
             .with_watching_method(
                 builtin_methods::BRP_GET_AND_WATCH_METHOD,

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -194,6 +194,18 @@
 //!
 //! `result`: null.
 //!
+//! ### bevy/mutate_component
+//!
+//! Mutate a field in a component.
+//!
+//! `params`:
+//! - `entity`: The ID of the entity to with the component to mutate.
+//! - `component`: The component's [fully-qualified type name].
+//! - `path`: The path of the field within the component.
+//! - `value`: The value to insert at `path`.
+//!
+//! `result`: null.
+//!
 //! ### bevy/reparent
 //!
 //! Assign a new parent to one or more entities.

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -201,7 +201,8 @@
 //! `params`:
 //! - `entity`: The ID of the entity to with the component to mutate.
 //! - `component`: The component's [fully-qualified type name].
-//! - `path`: The path of the field within the component.
+//! - `path`: The path of the field within the component. See
+//!   [GetPath](bevy_reflect::GetPath#syntax) for more infomation on formatting this string.
 //! - `value`: The value to insert at `path`.
 //!
 //! `result`: null.

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -413,6 +413,10 @@ impl Default for RemotePlugin {
                 builtin_methods::BRP_REGISTRY_SCHEMA_METHOD,
                 builtin_methods::export_registry_types,
             )
+            .with_method(
+                builtin_methods::BRP_MUTATE_METHOD,
+                builtin_methods::process_remote_mutate_request,
+            )
             .with_watching_method(
                 builtin_methods::BRP_GET_AND_WATCH_METHOD,
                 builtin_methods::process_remote_get_watching_request,

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -202,7 +202,7 @@
 //! - `entity`: The ID of the entity to with the component to mutate.
 //! - `component`: The component's [fully-qualified type name].
 //! - `path`: The path of the field within the component. See
-//!   [GetPath](bevy_reflect::GetPath#syntax) for more infomation on formatting this string.
+//!   [GetPath](bevy_reflect::GetPath#syntax) for more information on formatting this string.
 //! - `value`: The value to insert at `path`.
 //!
 //! `result`: null.


### PR DESCRIPTION
# Objective

Add a method to mutate components with BRP.

Currently the only way to modify a component on an entity with BRP is to insert a new one with the new values. This isn't ideal for several reasons, one reason being that the client has to know what all the fields are of the component and stay in sync with the server.

## Solution

Add a new BRP method called `bevy/mutate_component` to mutate a single field in a component on an entity.

## Testing

Tested on a simple scene on all `Transform`, `Name`, and a custom component.

---

## Showcase

Example JSON-RPC request to change the `Name` of an entity to "New name!"

```json
{
    "jsonrpc": "2.0",
    "id": 0,
    "method": "bevy/mutate_component",
    "params": {
        "entity": 4294967308,
        "component": "bevy_ecs::name::Name",
        "path": ".name",
        "value": "New name!"
    }
}
```

Or setting the X translation to 10.0 on a Transform:

```json
{
    "jsonrpc": "2.0",
    "id": 0,
    "method": "bevy/mutate_component",
    "params": {
        "entity": 4294967308,
        "component": "bevy_transform::components::transform::Transform",
        "path": ".translation.x",
        "value": 10.0
    }
}
```

Clip of my Emacs BRP package using this method:

https://github.com/user-attachments/assets/a786b245-5c20-4189-859f-2261c5086a68


