### PR TITLE
Easing curves for tuples

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -28,6 +28,7 @@ smallvec = { version = "1.11" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
   "glam",
 ], optional = true }
+variadics_please = "1.1"
 
 [dev-dependencies]
 approx = "0.5"


### PR DESCRIPTION
# Objective

Make it so that users can ease between tuples of easeable values. 

## Solution

Use `variadics_please`'s `all_tuples_enumerated` macro to generate code that creates these trait implementations. For two elements, the result looks like this:
```rust
impl<T0: Ease, T1: Ease> Ease for (T0, T1) {
    fn interpolating_curve_unbounded(start: Self, end: Self) -> impl Curve<Self> {
        let curve_tuple = (
            <T0 as Ease>::interpolating_curve_unbounded(start.0, end.0),
            <T1 as Ease>::interpolating_curve_unbounded(start.1, end.1),
        );
        FunctionCurve::new(Interval::EVERYWHERE, move |t| {
            (
                curve_tuple.0.sample_unchecked(t),
                curve_tuple.1.sample_unchecked(t),
            )
        })
    }
}
```

## Testing

It compiles, and I futzed about with some manual examples, which seem to work as expected. 

---

## Showcase

Easing curves now support easing tuples of values that can themselves be eased. For example:
```rust
// Easing between two `(Vec3, Quat)` values:
let easing_curve = EasingCurve::new(
    (vec3(0.0, 0.0, 0.0), Quat::from_rotation_z(-FRAC_PI_2)),
    (vec3(1.0, 1.0, 1.0), Quat::from_rotation_z(FRAC_PI_2)),
    EaseFunction::ExponentialInOut
);
```