### PR TITLE
Expose bevy_image as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,9 @@ bevy_window = ["bevy_internal/bevy_window"]
 # winit window and input backend
 bevy_winit = ["bevy_internal/bevy_winit"]
 
+# Load and access image data. Usually added by an image format
+bevy_image = ["bevy_internal/bevy_image"]
+
 # Adds support for rendering gizmos
 bevy_gizmos = ["bevy_internal/bevy_gizmos", "bevy_color"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -159,9 +159,13 @@ bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing", "bevy_render?/ci_limits"]
 # Enable animation support, and glTF animation loading
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
-bevy_sprite = ["dep:bevy_sprite", "bevy_gizmos?/bevy_sprite"]
-bevy_pbr = ["dep:bevy_pbr", "bevy_gizmos?/bevy_pbr"]
+bevy_sprite = ["dep:bevy_sprite", "bevy_gizmos?/bevy_sprite", "bevy_image"]
+bevy_pbr = ["dep:bevy_pbr", "bevy_gizmos?/bevy_pbr", "bevy_image"]
 bevy_window = ["dep:bevy_window", "dep:bevy_a11y"]
+bevy_core_pipeline = ["dep:bevy_core_pipeline", "bevy_image"]
+bevy_gizmos = ["dep:bevy_gizmos", "bevy_image"]
+bevy_gltf = ["dep:bevy_gltf", "bevy_image"]
+bevy_ui = ["dep:bevy_ui", "bevy_image"]
 bevy_image = ["dep:bevy_image"]
 
 # Used to disable code that is unsupported when Bevy is dynamically linked
@@ -174,12 +178,13 @@ android_shared_stdcxx = ["bevy_audio/android_shared_stdcxx"]
 # screen readers and forks.)
 accesskit_unix = ["bevy_winit/accesskit_unix"]
 
-bevy_text = ["dep:bevy_text"]
+bevy_text = ["dep:bevy_text", "bevy_image"]
 
 bevy_render = [
   "dep:bevy_render",
   "bevy_scene?/bevy_render",
   "bevy_gizmos?/bevy_render",
+  "bevy_image",
 ]
 
 # Enable assertions to check the validity of parameters passed to glam

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -162,6 +162,7 @@ animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 bevy_sprite = ["dep:bevy_sprite", "bevy_gizmos?/bevy_sprite"]
 bevy_pbr = ["dep:bevy_pbr", "bevy_gizmos?/bevy_pbr"]
 bevy_window = ["dep:bevy_window", "dep:bevy_a11y"]
+bevy_image = ["dep:bevy_image"]
 
 # Used to disable code that is unsupported when Bevy is dynamically linked
 dynamic_linking = ["bevy_diagnostic/dynamic_linking"]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -61,6 +61,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_ci_testing|Enable systems that allow for automated testing on CI|
 |bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
 |bevy_dev_tools|Provides a collection of developer tools|
+|bevy_image|Load and access image data. Usually added by an image format|
 |bevy_remote|Enable the Bevy Remote Protocol|
 |bevy_ui_debug|Provides a debug overlay for bevy UI|
 |bmp|BMP image format support|


### PR DESCRIPTION
# Objective

- Fixes #16563 
- Make sure bevy_image is available when needed

## Solution

- Add a new feature for `bevy_image`
- Also enable the `bevy_image` feature in `bevy_internal` for all features that use `bevy_image` themselves
