### PR TITLE
don't trigger drag events if there's no movement

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -692,6 +692,10 @@ pub fn pointer_events(
 
                     // Emit Drag events to the entities we are dragging
                     for (drag_target, drag) in state.dragging.iter_mut() {
+                        let delta = location.position - drag.latest_pos;
+                        if delta == Vec2::ZERO {
+                            continue; // No need to emit a Drag event if there is no movement
+                        }
                         let drag_event = Pointer::new(
                             pointer_id,
                             location.clone(),
@@ -699,7 +703,7 @@ pub fn pointer_events(
                             Drag {
                                 button,
                                 distance: location.position - drag.start_pos,
-                                delta: location.position - drag.latest_pos,
+                                delta,
                             },
                         );
                         commands.trigger_targets(drag_event.clone(), *drag_target);


### PR DESCRIPTION
# Objective

- Fixes #16571

## Solution

- When position delta is zero, don't trigger `Drag` or `DragOver` events

## Testing

- tested with the code from the issue