### PR TITLE
Expose access to `SubApps` within `App`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1058,6 +1058,16 @@ impl App {
         &mut self.sub_apps.main
     }
 
+    /// Returns a reference to the [`SubApps`] collection.
+    pub fn sub_apps(&self) -> &SubApps {
+        &self.sub_apps
+    }
+
+    /// Returns a mutable reference to the [`SubApps`] collection.
+    pub fn sub_apps_mut(&mut self) -> &mut SubApps {
+        &mut self.sub_apps
+    }
+
     /// Returns a reference to the [`SubApp`] with the given label.
     ///
     /// # Panics


### PR DESCRIPTION
# Objective
`SubApps` is visible within the documentation for `bevy_app`. However, no way of accessing the `SubApps` field in `App` is currently available.

## Solution
Expose two new functions, `App::sub_apps()` and `App::sub_apps_mut()`, which give immutable and mutable access to `SubApps` respectively.

The other solution is to hide `SubApps`, which I submitted as a PR at <https://github.com/bevyengine/bevy/pull/16953>.

## Testing
Because of the simplicity of the changes, I only tested by compiling `bevy_app` - which compiled successfully.

Note: `SubApps`, and its corresponding field on `App`, are not used outside of `bevy_app` - which means that compiling the other crates is not necessary.