### PR TITLE
Hide `SubApps` from the documentation

### DIFF
--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -445,7 +445,7 @@ impl SubApp {
 
 /// The collection of sub-apps that belong to an [`App`].
 #[derive(Default)]
-pub struct SubApps {
+pub(crate) struct SubApps {
     /// The primary sub-app that contains the "main" world.
     pub main: SubApp,
     /// Other, labeled sub-apps.


### PR DESCRIPTION
# Objective
`SubApps` is visible within the documentation for `bevy_app`. However, no way of accessing the `SubApps` field in `App` is currently available.

## Solution
Hides `SubApps` from the documentation.

The other solution is to expose access to `SubApps` in `Apps`, which I  submitted as a PR at <https://github.com/bevyengine/bevy/pull/16952>.

## Testing
Because of the simplicity of the changes, I only tested by compiling `bevy_app` - which compiled successfully.