### PR TITLE
`unique_handle!` macro.

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -670,7 +670,7 @@ mod tests {
 
         let handle1: Handle<TestAsset> = unique_handle!();
         let handle2: Handle<TestAsset> = unique_handle!();
-        panic!("{:?}, {:?}", handle1, handle2);
+        assert_ne!(handle1, handle2);
     }
 
     /// `Reflect::clone_value` should increase the strong count of a strong handle

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -530,7 +530,6 @@ pub enum UntypedAssetConversionError {
 ///
 /// * Different instances of this macro will always generate a different id.
 /// * The same instance of this macro will always generate the same id.
-/// * The result is `const`.
 /// * The result's id is not constant across executions and not safe for serialization.
 ///
 /// ```
@@ -542,7 +541,7 @@ pub enum UntypedAssetConversionError {
 /// let handle2 = unique_handle!(Shader);
 /// assert_ne!(handle1, handle2);
 ///
-/// const fn get_handle() -> Handle<Shader> {
+/// fn get_handle() -> Handle<Shader> {
 ///     unique_handle!()
 /// }
 /// let handle1 = get_handle();

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -215,6 +215,8 @@ use bevy_ecs::{
     world::FromWorld,
 };
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
+#[doc(hidden)]
+pub use bevy_utils::syncunsafecell::SyncUnsafeCell;
 use bevy_utils::{tracing::error, HashSet};
 use core::any::TypeId;
 


### PR DESCRIPTION
# Objective

Added a straightforward way to create a unique `Handle` for shaders and other types of assets without worrying about collision.

## Solution

Added the `unique_handle!` macro.

## Testing

Added a few tests and doc tests.
