### PR TITLE
Fix panic in benches caused by missing resources

### DIFF
--- a/benches/benches/bevy_ecs/param/dyn_param.rs
+++ b/benches/benches/bevy_ecs/param/dyn_param.rs
@@ -14,6 +14,8 @@ pub fn dyn_param(criterion: &mut Criterion) {
     #[derive(Resource)]
     struct R;
 
+    world.insert_resource(R);
+
     let mut schedule = Schedule::default();
     let system = (
         DynParamBuilder::new::<Res<R>>(ParamBuilder),

--- a/benches/benches/bevy_ecs/param/param_set.rs
+++ b/benches/benches/bevy_ecs/param/param_set.rs
@@ -11,6 +11,8 @@ pub fn param_set(criterion: &mut Criterion) {
     #[derive(Resource)]
     struct R;
 
+    world.insert_resource(R);
+
     let mut schedule = Schedule::default();
     schedule.add_systems(
         |_: ParamSet<(


### PR DESCRIPTION
# Objective

- To fix the benches panicking on `main`

## Solution

- It appears that systems requiring access to a non-existing `Res` now causes a panic
- Some of the benches run systems that access resources that have not been inserted into the world
- I have made it so that those resources are inserted into the world

## Testing

- I ran all the ecs benches and they all run without panicking
