### PR TITLE
Fix path checking for FileWatcher for virtual workspace projects

### DIFF
--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -30,7 +30,7 @@ impl FileWatcher {
         sender: Sender<AssetSourceEvent>,
         debounce_wait_time: Duration,
     ) -> Result<Self, notify::Error> {
-        let root = normalize_path(super::get_base_path().join(root).as_path());
+        let root = normalize_path(&path);
         let watcher = new_asset_event_debouncer(
             root.clone(),
             debounce_wait_time,

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -26,13 +26,13 @@ pub struct FileWatcher {
 
 impl FileWatcher {
     pub fn new(
-        root: PathBuf,
+        path: PathBuf,
         sender: Sender<AssetSourceEvent>,
         debounce_wait_time: Duration,
     ) -> Result<Self, notify::Error> {
         let root = normalize_path(&path);
         let watcher = new_asset_event_debouncer(
-            root.clone(),
+            path.clone(),
             debounce_wait_time,
             FileEventHandler {
                 root,

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -531,7 +531,7 @@ impl AssetSource {
                 not(target_os = "android")
             ))]
             {
-                let path = std::path::PathBuf::from(path.clone());
+                let path = super::file::get_base_path().join(path.clone());
                 if path.exists() {
                     Some(Box::new(
                         super::file::FileWatcher::new(


### PR DESCRIPTION
# Objective

Fixes #16879

## Solution

Moved the construction of the root path of the assets folder out of `FileWatcher::new()` and into `source.rs`, as the path is checked there with `path.exists()` and fails in certain configurations eg., virtual workspaces.

## Testing

Applied fix to a private fork and tested against both standard project setups and virtual workspaces. Works without issue on both. Have tested under macOS and Arch Linux.
