### PR TITLE
Fix non-meshlet shaders for non-bindless mode

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -172,7 +172,7 @@ fn pbr_input_from_standard_material(
             // parallax mapping algorithm easier to understand and reason
             // about.
             -Vt,
-            in.instance_index,
+            slot,
         );
 #else
         uv_b = uv;

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -80,6 +80,7 @@ fn pbr_input_from_standard_material(
     let base_color = pbr_bindings::material[slot].base_color;
     let deferred_lighting_pass_id = pbr_bindings::material[slot].deferred_lighting_pass_id;
 #else   // BINDLESS
+    let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
     let flags = pbr_bindings::material.flags;
     let base_color = pbr_bindings::material.base_color;
     let deferred_lighting_pass_id = pbr_bindings::material.deferred_lighting_pass_id;


### PR DESCRIPTION
# Objective

- Running example `load_gltf` when not using bindless gives this error
```
ERROR bevy_render::render_resource::pipeline_cache: failed to process shader:
error: no definition in scope for identifier: 'slot'
    ┌─ crates/bevy_pbr/src/render/pbr_fragment.wgsl:153:13
    │
153 │             slot,
    │             ^^^^ unknown identifier
    │
    = no definition in scope for identifier: 'slot'
```
- since https://github.com/bevyengine/bevy/pull/16825

## Solution

- Set `slot` to the expected value when not mindless
- Also use it for `uv_b`

## Testing

- Run example `load_gltf` on a Mac or in wasm
