### PR TITLE
Fixed panic in pbr example

### DIFF
--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, environment_map_load_finish)
+        .add_systems(Update, environment_map_load_finish.never_param_warn())
         .run();
 }
 

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -7,6 +7,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
+        // This system relies on system parameters that are not available at start
+        // Ignore parameter failures so that it will run when possible
         .add_systems(Update, environment_map_load_finish.never_param_warn())
         .run();
 }


### PR DESCRIPTION
# Objective

- Fixes #16959
- The `pbr.rs` example in the 3d section panicked because of the changes in #16638, that was not supposed to happen

## Solution

- For now it's sufficient to introduce a `never_param_warn` call when adding the fallible system into the app 

## Testing

- Tested on my machine via `cargo r --example pbr`, it built and ran successfully

