### PR TITLE
panic on system error

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -605,11 +605,17 @@ impl ExecutorState {
                 // access the world data used by the system.
                 // - `update_archetype_component_access` has been called.
                 unsafe {
-                    // TODO: implement an error-handling API instead of suppressing a possible failure.
-                    let _ = __rust_begin_short_backtrace::run_unsafe(
+                    // TODO: implement an error-handling API instead of panicking.
+                    if let Err(err) = __rust_begin_short_backtrace::run_unsafe(
                         system,
                         context.environment.world_cell,
-                    );
+                    ) {
+                        panic!(
+                            "Encountered an error in system `{}`: {:?}",
+                            &*system.name(),
+                            err
+                        );
+                    };
                 };
             }));
             context.system_completed(system_index, res, system);
@@ -653,8 +659,14 @@ impl ExecutorState {
                 // that no other systems currently have access to the world.
                 let world = unsafe { context.environment.world_cell.world_mut() };
                 let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    // TODO: implement an error-handling API instead of suppressing a possible failure.
-                    let _ = __rust_begin_short_backtrace::run(system, world);
+                    // TODO: implement an error-handling API instead of panicking.
+                    if let Err(err) = __rust_begin_short_backtrace::run(system, world) {
+                        panic!(
+                            "Encountered an error in system `{}`: {:?}",
+                            &*system.name(),
+                            err
+                        );
+                    };
                 }));
                 context.system_completed(system_index, res, system);
             };

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -101,8 +101,14 @@ impl SystemExecutor for SimpleExecutor {
             }
 
             let f = AssertUnwindSafe(|| {
-                // TODO: implement an error-handling API instead of suppressing a possible failure.
-                let _ = __rust_begin_short_backtrace::run(system, world);
+                // TODO: implement an error-handling API instead of panicking.
+                if let Err(err) = __rust_begin_short_backtrace::run(system, world) {
+                    panic!(
+                        "Encountered an error in system `{}`: {:?}",
+                        &*system.name(),
+                        err
+                    );
+                }
             });
 
             #[cfg(feature = "std")]

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -109,8 +109,14 @@ impl SystemExecutor for SingleThreadedExecutor {
 
             let f = AssertUnwindSafe(|| {
                 if system.is_exclusive() {
-                    // TODO: implement an error-handling API instead of suppressing a possible failure.
-                    let _ = __rust_begin_short_backtrace::run(system, world);
+                    // TODO: implement an error-handling API instead of panicking.
+                    if let Err(err) = __rust_begin_short_backtrace::run(system, world) {
+                        panic!(
+                            "Encountered an error in system `{}`: {:?}",
+                            &*system.name(),
+                            err
+                        );
+                    }
                 } else {
                     // Use run_unsafe to avoid immediately applying deferred buffers
                     let world = world.as_unsafe_world_cell();
@@ -118,8 +124,14 @@ impl SystemExecutor for SingleThreadedExecutor {
                     // SAFETY: We have exclusive, single-threaded access to the world and
                     // update_archetype_component_access is being called immediately before this.
                     unsafe {
-                        // TODO: implement an error-handling API instead of suppressing a possible failure.
-                        let _ = __rust_begin_short_backtrace::run_unsafe(system, world);
+                        // TODO: implement an error-handling API instead of panicking.
+                        if let Err(err) = __rust_begin_short_backtrace::run_unsafe(system, world) {
+                            panic!(
+                                "Encountered an error in system `{}`: {:?}",
+                                &*system.name(),
+                                err
+                            );
+                        }
                     };
                 }
             });

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1766,6 +1766,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn simple_fallible_system() {
         fn sys() -> Result {
             Err("error")?;


### PR DESCRIPTION
# Objective

- First step for #16718 
- #16589 introduced an api that can only ignore errors, which is risky

## Solution

- Panic instead of just ignoring the errors

## Testing

- Changed the `fallible_systems` example to return an error
```
Encountered an error in system `fallible_systems::setup`: TooManyVertices { subdivisions: 300, number_of_resulting_points: 906012 }
Encountered a panic in system `fallible_systems::setup`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```
