### PR TITLE
Make animate_targets run before inherit_weights

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1262,7 +1262,7 @@ impl Plugin for AnimationPlugin {
                     // `PostUpdate`. For now, we just disable ambiguity testing
                     // for this system.
                     animate_targets
-                        .after(bevy_render::mesh::inherit_weights)
+                        .before(bevy_render::mesh::inherit_weights)
                         .ambiguous_with_all(),
                     trigger_untargeted_animation_events,
                     expire_completed_transitions,


### PR DESCRIPTION
# Objective

ensure that `animate_targets` runs **before** `bevy_render::mesh::inherit_weights` to address the one-frame delay

Fixes #16554 

## Solution

switch ordering constraints from `after` to `before`

## Testing

ran bevy_animation tests and the animated_fox example on MacOS
