### PR TITLE
Make `extract_mesh_materials` and `MaterialBindGroupAllocator` public

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -582,7 +582,7 @@ pub const fn screen_space_specular_transmission_pipeline_key(
     }
 }
 
-fn extract_mesh_materials<M: Material>(
+pub fn extract_mesh_materials<M: Material>(
     mut material_instances: ResMut<RenderMaterialInstances<M>>,
     mut material_ids: ResMut<RenderMeshMaterialIds>,
     mut material_bind_group_allocator: ResMut<MaterialBindGroupAllocator<M>>,

--- a/crates/bevy_pbr/src/material_bind_groups.rs
+++ b/crates/bevy_pbr/src/material_bind_groups.rs
@@ -202,7 +202,7 @@ where
     M: Material,
 {
     /// Creates or recreates any bind groups that were modified this frame.
-    pub(crate) fn prepare_bind_groups(
+    pub fn prepare_bind_groups(
         &mut self,
         render_device: &RenderDevice,
         fallback_image: &FallbackImage,
@@ -221,12 +221,12 @@ where
 
     /// Returns the bind group with the given index, if it exists.
     #[inline]
-    pub(crate) fn get(&self, index: MaterialBindGroupIndex) -> Option<&MaterialBindGroup<M>> {
+    pub fn get(&self, index: MaterialBindGroupIndex) -> Option<&MaterialBindGroup<M>> {
         self.bind_groups.get(index.0 as usize)
     }
 
     /// Allocates a new binding slot and returns its ID.
-    pub(crate) fn allocate(&mut self) -> MaterialBindingId {
+    pub fn allocate(&mut self) -> MaterialBindingId {
         let group_index = self.free_bind_groups.pop().unwrap_or_else(|| {
             let group_index = self.bind_groups.len() as u32;
             self.bind_groups
@@ -249,7 +249,7 @@ where
 
     /// Assigns an unprepared bind group to the group and slot specified in the
     /// [`MaterialBindingId`].
-    pub(crate) fn init(
+    pub fn init(
         &mut self,
         render_device: &RenderDevice,
         material_binding_id: MaterialBindingId,
@@ -268,7 +268,7 @@ where
     /// This is only a meaningful operation for non-bindless bind groups. It's
     /// rarely used, but see the `texture_binding_array` example for an example
     /// demonstrating how this feature might see use in practice.
-    pub(crate) fn init_custom(
+    pub fn init_custom(
         &mut self,
         material_binding_id: MaterialBindingId,
         bind_group: BindGroup,
@@ -279,7 +279,7 @@ where
     }
 
     /// Marks the slot corresponding to the given [`MaterialBindingId`] as free.
-    pub(crate) fn free(&mut self, material_binding_id: MaterialBindingId) {
+    pub fn free(&mut self, material_binding_id: MaterialBindingId) {
         let bind_group = &mut self.bind_groups[material_binding_id.group.0 as usize];
         let was_full = bind_group.is_full();
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -278,7 +278,7 @@ impl<M: Material2d> Default for RenderMaterial2dInstances<M> {
     }
 }
 
-fn extract_mesh_materials_2d<M: Material2d>(
+pub fn extract_mesh_materials_2d<M: Material2d>(
     mut material_instances: ResMut<RenderMaterial2dInstances<M>>,
     query: Extract<Query<(Entity, &ViewVisibility, &MeshMaterial2d<M>), With<Mesh2d>>>,
 ) {


### PR DESCRIPTION
# Objective

Fixes #16730

## Solution

Make the relevant functions public. (`MaterialBindGroupAllocator` itself was already `pub`)
