### PR TITLE
Fix panics in `scene_viewer` and `audio_control`

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -172,7 +172,7 @@ fn pbr_input_from_standard_material(
             // parallax mapping algorithm easier to understand and reason
             // about.
             -Vt,
-            in.instance_index,
+            slot,
         );
 #else
         uv_b = uv;

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -80,6 +80,7 @@ fn pbr_input_from_standard_material(
     let base_color = pbr_bindings::material[slot].base_color;
     let deferred_lighting_pass_id = pbr_bindings::material[slot].deferred_lighting_pass_id;
 #else   // BINDLESS
+    let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
     let flags = pbr_bindings::material.flags;
     let base_color = pbr_bindings::material.base_color;
     let deferred_lighting_pass_id = pbr_bindings::material.deferred_lighting_pass_id;

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -34,11 +34,22 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 #[derive(Component)]
 struct MyMusic;
 
-fn update_speed(sink: Single<&AudioSink, With<MyMusic>>, time: Res<Time>) {
+fn update_speed(music_controller: Query<&AudioSink, With<MyMusic>>, time: Res<Time>) {
+    let Ok(sink) = music_controller.get_single() else {
+        return;
+    };
+
     sink.set_speed((ops::sin(time.elapsed_secs() / 5.0) + 1.0).max(0.1));
 }
 
-fn pause(keyboard_input: Res<ButtonInput<KeyCode>>, sink: Single<&AudioSink, With<MyMusic>>) {
+fn pause(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    music_controller: Query<&AudioSink, With<MyMusic>>,
+) {
+    let Ok(sink) = music_controller.get_single() else {
+        return;
+    };
+
     if keyboard_input.just_pressed(KeyCode::Space) {
         sink.toggle_playback();
     }
@@ -46,8 +57,12 @@ fn pause(keyboard_input: Res<ButtonInput<KeyCode>>, sink: Single<&AudioSink, Wit
 
 fn mute(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut sink: Single<&mut AudioSink, With<MyMusic>>,
+    mut music_controller: Query<&mut AudioSink, With<MyMusic>>,
 ) {
+    let Ok(mut sink) = music_controller.get_single_mut() else {
+        return;
+    };
+
     if keyboard_input.just_pressed(KeyCode::KeyM) {
         sink.toggle_mute();
     }
@@ -55,8 +70,12 @@ fn mute(
 
 fn volume(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut sink: Single<&mut AudioSink, With<MyMusic>>,
+    mut music_controller: Query<&mut AudioSink, With<MyMusic>>,
 ) {
+    let Ok(mut sink) = music_controller.get_single_mut() else {
+        return;
+    };
+
     if keyboard_input.just_pressed(KeyCode::Equal) {
         let current_volume = sink.volume();
         sink.set_volume(current_volume + 0.1);

--- a/examples/helpers/camera_controller.rs
+++ b/examples/helpers/camera_controller.rs
@@ -109,11 +109,13 @@ fn run_camera_controller(
     key_input: Res<ButtonInput<KeyCode>>,
     mut toggle_cursor_grab: Local<bool>,
     mut mouse_cursor_grab: Local<bool>,
-    query: Single<(&mut Transform, &mut CameraController), With<Camera>>,
+    mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,
 ) {
     let dt = time.delta_secs();
 
-    let (mut transform, mut controller) = query.into_inner();
+    let Ok((mut transform, mut controller)) = query.get_single_mut() else {
+        return;
+    };
 
     if !controller.initialized {
         let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -124,8 +124,8 @@ impl fmt::Display for Target {
     }
 }
 impl Target {
-    fn text_span(&self, key: &str, style: TextFont) -> (String, TextFont) {
-        (format!("[{key}] {self}\n"), style)
+    fn text_span(&self, key: &str, style: TextFont) -> (TextSpan, TextFont) {
+        (TextSpan::new(format!("[{key}] {self}\n")), style)
     }
     fn new(
         entity_name: Option<&Name>,
@@ -179,7 +179,6 @@ impl MorphKey {
     }
 }
 fn update_text(
-    mut commands: Commands,
     controls: Option<ResMut<WeightsControl>>,
     texts: Query<Entity, With<Text>>,
     morphs: Query<&MorphWeights>,
@@ -205,20 +204,7 @@ fn update_text(
         }
         let key_name = &AVAILABLE_KEYS[i].name;
 
-        if let Some(mut val) = writer.get_text(text, i + 3) {
-            *val = format!("[{key_name}] {target}\n");
-        } else {
-            let new_span = commands
-                .spawn((
-                    TextSpan::new(format!("[{key_name}] {target}\n")),
-                    TextFont {
-                        font_size: FONT_SIZE,
-                        ..default()
-                    },
-                ))
-                .id();
-            commands.entity(text).add_child(new_span);
-        }
+        *writer.text(text, i + 3) = format!("[{key_name}] {target}\n");
     }
 }
 fn update_morphs(
@@ -280,8 +266,8 @@ fn detect_morphs(
         ..default()
     };
     let mut spans = vec![
-        ("Morph Target Controls\n".into(), style.clone()),
-        ("---------------\n".into(), style.clone()),
+        (TextSpan::new("Morph Target Controls\n"), style.clone()),
+        (TextSpan::new("---------------\n"), style.clone()),
     ];
     let target_to_text =
         |(i, target): (usize, &Target)| target.text_span(AVAILABLE_KEYS[i].name, style.clone());
@@ -298,8 +284,9 @@ fn detect_morphs(
             },
         ))
         .with_children(|p| {
-            p.spawn((TextSpan::new("Morph Target Controls\n"), style.clone()));
-            p.spawn((TextSpan::new("---------------\n"), style));
+            for span in spans {
+                p.spawn(span);
+            }
         });
 }
 


### PR DESCRIPTION
# Objective

Fixes #16978

While testing, discovered that the morph weight interface in `scene_viewer` has been broken for a while (panics when loaded model has morph weights), probably since #15591. Fixed that too.

While testing, saw example text in morph interface with [wrong padding](https://bevyengine.org/learn/contribute/helping-out/creating-examples/#visual-guidelines). Fixed that too. Left the small font size because there may be a lot of morphs to display, so that seems intentional.

## Solution

Use normal queries and bail early

## Testing

Morph interface can be tested with
```
cargo run --example scene_viewer assets/models/animated/MorphStressTest.gltf
```

## Discussion

I noticed that this fix is different than what is happening in #16976. Feel free to discard this for an alternative fix. I opened this anyway to document the issue with morph weight display.

This is on top of #16966 which is required to test.