### PR TITLE
Migrate reflection benchmarks to new naming system

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT OR Apache-2.0"
 # Do not automatically discover benchmarks, we specify them manually instead.
 autobenches = false
 
+[dependencies]
+# The primary crate that runs and analyzes our benchmarks. This is a regular dependency because the
+# `bench!` macro refers to it in its documentation.
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
 [dev-dependencies]
 # Bevy crates
 bevy_app = { path = "../crates/bevy_app" }
@@ -22,7 +27,6 @@ bevy_tasks = { path = "../crates/bevy_tasks" }
 bevy_utils = { path = "../crates/bevy_utils" }
 
 # Other crates
-criterion = { version = "0.5.1", features = ["html_reports"] }
 glam = "0.29"
 rand = "0.8"
 rand_chacha = "0.3"

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -1,5 +1,8 @@
+use std::hint::black_box;
+
+use benches::bench;
 use bevy_reflect::func::{ArgList, IntoFunction, IntoFunctionMut, TypedFunction};
-use criterion::{criterion_group, BatchSize, Criterion};
+use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};
 
 criterion_group!(benches, typed, into, call, overload, clone);
 
@@ -8,7 +11,7 @@ fn add(a: i32, b: i32) -> i32 {
 }
 
 fn typed(c: &mut Criterion) {
-    c.benchmark_group("typed")
+    c.benchmark_group(bench!("typed"))
         .bench_function("function", |b| {
             b.iter(|| add.get_function_info());
         })
@@ -25,7 +28,7 @@ fn typed(c: &mut Criterion) {
 }
 
 fn into(c: &mut Criterion) {
-    c.benchmark_group("into")
+    c.benchmark_group(bench!("into"))
         .bench_function("function", |b| {
             b.iter(|| add.into_function());
         })
@@ -42,7 +45,7 @@ fn into(c: &mut Criterion) {
 }
 
 fn call(c: &mut Criterion) {
-    c.benchmark_group("call")
+    c.benchmark_group(bench!("call"))
         .bench_function("trait_object", |b| {
             b.iter_batched(
                 || Box::new(add) as Box<dyn Fn(i32, i32) -> i32>,
@@ -98,15 +101,15 @@ fn overload(c: &mut Criterion) {
     ) {
     }
 
-    c.benchmark_group("with_overload")
-        .bench_function("01_simple_overload", |b| {
+    c.benchmark_group(bench!("with_overload"))
+        .bench_function(BenchmarkId::new("simple_overload", 1), |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| func.with_overload(add::<i16>),
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("01_complex_overload", |b| {
+        .bench_function(BenchmarkId::new("complex_overload", 1), |b| {
             b.iter_batched(
                 || complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>.into_function(),
                 |func| {
@@ -115,7 +118,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("simple_overload", 3), |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -126,7 +129,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_complex_overload", |b| {
+        .bench_function(BenchmarkId::new("complex_overload", 3), |b| {
             b.iter_batched(
                 || complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>.into_function(),
                 |func| {
@@ -137,7 +140,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("simple_overload", 10), |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -154,7 +157,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_complex_overload", |b| {
+        .bench_function(BenchmarkId::new("complex_overload", 10), |b| {
             b.iter_batched(
                 || complex::<i8, i16, i32, i64, i128, u8, u16, u32, u64, u128>.into_function(),
                 |func| {
@@ -171,14 +174,14 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("01_nested_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("nested_simple_overload", 1), |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| func.with_overload(add::<i16>),
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_nested_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("nested_simple_overload", 3), |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -191,7 +194,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_nested_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("nested_simple_overload", 10), |b| {
             b.iter_batched(
                 || add::<i8>.into_function(),
                 |func| {
@@ -219,8 +222,8 @@ fn overload(c: &mut Criterion) {
             );
         });
 
-    c.benchmark_group("call_overload")
-        .bench_function("01_simple_overload", |b| {
+    c.benchmark_group(bench!("call_overload"))
+        .bench_function(BenchmarkId::new("simple_overload", 1), |b| {
             b.iter_batched(
                 || {
                     (
@@ -232,7 +235,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("01_complex_overload", |b| {
+        .bench_function(BenchmarkId::new("complex_overload", 1), |b| {
             b.iter_batched(
                 || {
                     (
@@ -258,7 +261,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("simple_overload", 3), |b| {
             b.iter_batched(
                 || {
                     (
@@ -274,7 +277,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("03_complex_overload", |b| {
+        .bench_function(BenchmarkId::new("complex_overload", 3), |b| {
             b.iter_batched(
                 || {
                     (
@@ -306,7 +309,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_simple_overload", |b| {
+        .bench_function(BenchmarkId::new("simple_overload", 10), |b| {
             b.iter_batched(
                 || {
                     (
@@ -328,7 +331,7 @@ fn overload(c: &mut Criterion) {
                 BatchSize::SmallInput,
             );
         })
-        .bench_function("10_complex_overload", |b| {
+        .bench_function(BenchmarkId::new("complex_overload", 10), |b| {
             b.iter_batched(
                 || {
                     (
@@ -381,8 +384,9 @@ fn overload(c: &mut Criterion) {
 }
 
 fn clone(c: &mut Criterion) {
-    c.benchmark_group("clone").bench_function("function", |b| {
-        let add = add.into_function();
-        b.iter(|| add.clone());
-    });
+    c.benchmark_group(bench!("clone"))
+        .bench_function("function", |b| {
+            let add = add.into_function();
+            b.iter(|| add.clone());
+        });
 }

--- a/benches/benches/bevy_reflect/function.rs
+++ b/benches/benches/bevy_reflect/function.rs
@@ -98,7 +98,6 @@ fn clone(c: &mut Criterion) {
         });
 }
 
-
 fn simple<T: std::ops::Add<Output = T>>(a: T, b: T) -> T {
     a + b
 }

--- a/benches/benches/bevy_reflect/list.rs
+++ b/benches/benches/bevy_reflect/list.rs
@@ -3,8 +3,8 @@ use core::{iter, time::Duration};
 use benches::bench;
 use bevy_reflect::{DynamicList, List};
 use criterion::{
-    black_box, criterion_group, measurement::Measurement, BatchSize, BenchmarkGroup, BenchmarkId,
-    Criterion, Throughput,
+    black_box, criterion_group, measurement::Measurement, AxisScale, BatchSize, BenchmarkGroup,
+    BenchmarkId, Criterion, PlotConfiguration, Throughput,
 };
 
 criterion_group!(
@@ -15,11 +15,29 @@ criterion_group!(
     dynamic_list_push
 );
 
+// Use a shorter warm-up time (from 3 to 0.5 seconds) and measurement time (from 5 to 4) because we
+// have so many combinations (>50) to benchmark.
 const WARM_UP_TIME: Duration = Duration::from_millis(500);
 const MEASUREMENT_TIME: Duration = Duration::from_secs(4);
 
-// log10 scaling
-const SIZES: [usize; 5] = [100_usize, 316, 1000, 3162, 10000];
+/// An array of list sizes used in benchmarks.
+///
+/// This scales logarithmically.
+const SIZES: [usize; 5] = [100, 316, 1000, 3162, 10000];
+
+/// Creates a [`BenchmarkGroup`] with common configuration shared by all benchmarks within this
+/// module.
+fn create_group<'a, M: Measurement>(c: &'a mut Criterion<M>, name: &str) -> BenchmarkGroup<'a, M> {
+    let mut group = c.benchmark_group(name);
+
+    group
+        .warm_up_time(WARM_UP_TIME)
+        .measurement_time(MEASUREMENT_TIME)
+        // Make the plots logarithmic, matching `SIZES`' scale.
+        .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    group
+}
 
 fn list_apply<M, LBase, LPatch, F1, F2, F3>(
     group: &mut BenchmarkGroup<M>,
@@ -54,9 +72,7 @@ fn list_apply<M, LBase, LPatch, F1, F2, F3>(
 }
 
 fn concrete_list_apply(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group(bench!("concrete_list_apply"));
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("concrete_list_apply"));
 
     let empty_base = |_: usize| Vec::<u64>::new;
     let full_base = |size: usize| move || iter::repeat(0).take(size).collect::<Vec<u64>>();
@@ -78,9 +94,7 @@ fn concrete_list_apply(criterion: &mut Criterion) {
 }
 
 fn concrete_list_clone_dynamic(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group(bench!("concrete_list_clone_dynamic"));
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("concrete_list_clone_dynamic"));
 
     for size in SIZES {
         group.throughput(Throughput::Elements(size as u64));
@@ -100,9 +114,7 @@ fn concrete_list_clone_dynamic(criterion: &mut Criterion) {
 }
 
 fn dynamic_list_push(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group(bench!("dynamic_list_push"));
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("dynamic_list_push"));
 
     for size in SIZES {
         group.throughput(Throughput::Elements(size as u64));
@@ -131,9 +143,7 @@ fn dynamic_list_push(criterion: &mut Criterion) {
 }
 
 fn dynamic_list_apply(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group(bench!("dynamic_list_apply"));
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("dynamic_list_apply"));
 
     let empty_base = |_: usize| || Vec::<u64>::new().clone_dynamic();
     let full_base = |size: usize| move || iter::repeat(0).take(size).collect::<Vec<u64>>();

--- a/benches/benches/bevy_reflect/list.rs
+++ b/benches/benches/bevy_reflect/list.rs
@@ -1,5 +1,6 @@
 use core::{iter, time::Duration};
 
+use benches::bench;
 use bevy_reflect::{DynamicList, List};
 use criterion::{
     black_box, criterion_group, measurement::Measurement, BatchSize, BenchmarkGroup, BenchmarkId,
@@ -53,7 +54,7 @@ fn list_apply<M, LBase, LPatch, F1, F2, F3>(
 }
 
 fn concrete_list_apply(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("concrete_list_apply");
+    let mut group = criterion.benchmark_group(bench!("concrete_list_apply"));
     group.warm_up_time(WARM_UP_TIME);
     group.measurement_time(MEASUREMENT_TIME);
 
@@ -77,7 +78,7 @@ fn concrete_list_apply(criterion: &mut Criterion) {
 }
 
 fn concrete_list_clone_dynamic(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("concrete_list_clone_dynamic");
+    let mut group = criterion.benchmark_group(bench!("concrete_list_clone_dynamic"));
     group.warm_up_time(WARM_UP_TIME);
     group.measurement_time(MEASUREMENT_TIME);
 
@@ -99,7 +100,7 @@ fn concrete_list_clone_dynamic(criterion: &mut Criterion) {
 }
 
 fn dynamic_list_push(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("dynamic_list_push");
+    let mut group = criterion.benchmark_group(bench!("dynamic_list_push"));
     group.warm_up_time(WARM_UP_TIME);
     group.measurement_time(MEASUREMENT_TIME);
 
@@ -130,7 +131,7 @@ fn dynamic_list_push(criterion: &mut Criterion) {
 }
 
 fn dynamic_list_apply(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("dynamic_list_apply");
+    let mut group = criterion.benchmark_group(bench!("dynamic_list_apply"));
     group.warm_up_time(WARM_UP_TIME);
     group.measurement_time(MEASUREMENT_TIME);
 

--- a/benches/benches/bevy_reflect/path.rs
+++ b/benches/benches/bevy_reflect/path.rs
@@ -1,5 +1,6 @@
 use core::{fmt::Write, str, time::Duration};
 
+use benches::bench;
 use bevy_reflect::ParsedPath;
 use criterion::{black_box, criterion_group, BatchSize, BenchmarkId, Criterion, Throughput};
 use rand::{distributions::Uniform, Rng, SeedableRng};
@@ -66,7 +67,8 @@ fn mk_paths(size: usize) -> impl FnMut() -> String {
 }
 
 fn parse_reflect_path(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("parse_reflect_path");
+    let mut group = criterion.benchmark_group(bench!("parse_reflect_path"));
+
     group.warm_up_time(WARM_UP_TIME);
     group.measurement_time(MEASUREMENT_TIME);
     group.sample_size(SAMPLE_SIZE);

--- a/benches/benches/bevy_reflect/path.rs
+++ b/benches/benches/bevy_reflect/path.rs
@@ -11,7 +11,7 @@ const WARM_UP_TIME: Duration = Duration::from_millis(500);
 const MEASUREMENT_TIME: Duration = Duration::from_secs(2);
 const SAMPLE_SIZE: usize = 500;
 const NOISE_THRESHOLD: f64 = 0.03;
-const SIZES: [usize; 6] = [100, 3160, 1000, 3_162, 10_000, 24_000];
+const SIZES: [usize; 6] = [100, 316, 1_000, 3_162, 10_000, 24_000];
 
 fn deterministic_rand() -> ChaCha8Rng {
     ChaCha8Rng::seed_from_u64(42)

--- a/benches/benches/bevy_reflect/path.rs
+++ b/benches/benches/bevy_reflect/path.rs
@@ -73,18 +73,26 @@ fn parse_reflect_path(criterion: &mut Criterion) {
     group.measurement_time(MEASUREMENT_TIME);
     group.sample_size(SAMPLE_SIZE);
     group.noise_threshold(NOISE_THRESHOLD);
-    let group = &mut group;
 
     for size in SIZES {
         group.throughput(Throughput::Elements(size as u64));
+
         group.bench_with_input(
-            BenchmarkId::new("parse_reflect_path", size),
+            BenchmarkId::from_parameter(size),
             &size,
             |bencher, &size| {
                 let mk_paths = mk_paths(size);
                 bencher.iter_batched(
                     mk_paths,
-                    |path| assert!(ParsedPath::parse(black_box(&path)).is_ok()),
+                    |path| {
+                        let parsed_path = black_box(ParsedPath::parse(black_box(&path)));
+
+                        // When `cargo test --benches` is run, each benchmark is run once. This
+                        // verifies that we are benchmarking a successful parse without it
+                        // affecting the recorded time.
+                        #[cfg(test)]
+                        assert!(parsed_path.is_ok());
+                    },
                     BatchSize::SmallInput,
                 );
             },

--- a/benches/benches/bevy_reflect/struct.rs
+++ b/benches/benches/bevy_reflect/struct.rs
@@ -60,7 +60,7 @@ fn concrete_struct_field(criterion: &mut Criterion) {
 
                 bencher.iter(|| {
                     for name in &field_names {
-                        s.field(black_box(name));
+                        black_box(s.field(black_box(name)));
                     }
                 });
             },
@@ -157,14 +157,14 @@ fn concrete_struct_type_info(criterion: &mut Criterion) {
             BenchmarkId::new("NonGeneric", field_count),
             &standard,
             |bencher, s| {
-                bencher.iter(|| black_box(s.get_represented_type_info()));
+                bencher.iter(|| s.get_represented_type_info());
             },
         );
         group.bench_with_input(
             BenchmarkId::new("Generic", field_count),
             &generic,
             |bencher, s| {
-                bencher.iter(|| black_box(s.get_represented_type_info()));
+                bencher.iter(|| s.get_represented_type_info());
             },
         );
     }
@@ -203,14 +203,14 @@ fn concrete_struct_clone(criterion: &mut Criterion) {
             BenchmarkId::new("NonGeneric", field_count),
             &standard,
             |bencher, s| {
-                bencher.iter(|| black_box(s.clone_dynamic()));
+                bencher.iter(|| s.clone_dynamic());
             },
         );
         group.bench_with_input(
             BenchmarkId::new("Generic", field_count),
             &generic,
             |bencher, s| {
-                bencher.iter(|| black_box(s.clone_dynamic()));
+                bencher.iter(|| s.clone_dynamic());
             },
         );
     }
@@ -234,7 +234,7 @@ fn dynamic_struct_clone(criterion: &mut Criterion) {
             BenchmarkId::from_parameter(field_count),
             &s,
             |bencher, s| {
-                bencher.iter(|| black_box(s.clone_dynamic()));
+                bencher.iter(|| s.clone_dynamic());
             },
         );
     }
@@ -344,9 +344,7 @@ fn dynamic_struct_get_field(criterion: &mut Criterion) {
                 }
 
                 let field = black_box("field_63");
-                bencher.iter(|| {
-                    black_box(s.get_field::<()>(field));
-                });
+                bencher.iter(|| s.get_field::<()>(field));
             },
         );
     }

--- a/benches/benches/bevy_reflect/struct.rs
+++ b/benches/benches/bevy_reflect/struct.rs
@@ -1,7 +1,11 @@
 use core::time::Duration;
 
+use benches::bench;
 use bevy_reflect::{DynamicStruct, GetField, PartialReflect, Reflect, Struct};
-use criterion::{black_box, criterion_group, BatchSize, BenchmarkId, Criterion, Throughput};
+use criterion::{
+    black_box, criterion_group, measurement::Measurement, AxisScale, BatchSize, BenchmarkGroup,
+    BenchmarkId, Criterion, PlotConfiguration, Throughput,
+};
 
 criterion_group!(
     benches,
@@ -19,10 +23,22 @@ const WARM_UP_TIME: Duration = Duration::from_millis(500);
 const MEASUREMENT_TIME: Duration = Duration::from_secs(4);
 const SIZES: [usize; 4] = [16, 32, 64, 128];
 
+/// Creates a [`BenchmarkGroup`] with common configuration shared by all benchmarks within this
+/// module.
+fn create_group<'a, M: Measurement>(c: &'a mut Criterion<M>, name: &str) -> BenchmarkGroup<'a, M> {
+    let mut group = c.benchmark_group(name);
+
+    group
+        .warm_up_time(WARM_UP_TIME)
+        .measurement_time(MEASUREMENT_TIME)
+        // Make the plots logarithmic, matching `SIZES`' scale.
+        .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    group
+}
+
 fn concrete_struct_field(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("concrete_struct_field");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("concrete_struct_field"));
 
     let structs: [Box<dyn Struct>; 4] = [
         Box::new(Struct16::default()),
@@ -53,9 +69,7 @@ fn concrete_struct_field(criterion: &mut Criterion) {
 }
 
 fn concrete_struct_apply(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("concrete_struct_apply");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("concrete_struct_apply"));
 
     // Use functions that produce trait objects of varying concrete types as the
     // input to the benchmark.
@@ -111,9 +125,7 @@ fn concrete_struct_apply(criterion: &mut Criterion) {
 }
 
 fn concrete_struct_type_info(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("concrete_struct_type_info");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("concrete_struct_type_info"));
 
     let structs: [(Box<dyn Struct>, Box<dyn Struct>); 5] = [
         (
@@ -159,9 +171,7 @@ fn concrete_struct_type_info(criterion: &mut Criterion) {
 }
 
 fn concrete_struct_clone(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("concrete_struct_clone");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("concrete_struct_clone"));
 
     let structs: [(Box<dyn Struct>, Box<dyn Struct>); 5] = [
         (
@@ -207,9 +217,7 @@ fn concrete_struct_clone(criterion: &mut Criterion) {
 }
 
 fn dynamic_struct_clone(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("dynamic_struct_clone");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("dynamic_struct_clone"));
 
     let structs: [Box<dyn Struct>; 5] = [
         Box::new(Struct1::default().clone_dynamic()),
@@ -233,9 +241,7 @@ fn dynamic_struct_clone(criterion: &mut Criterion) {
 }
 
 fn dynamic_struct_apply(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("dynamic_struct_apply");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("dynamic_struct_apply"));
 
     let patches: &[(fn() -> Box<dyn PartialReflect>, usize)] = &[
         (|| Box::new(Struct16::default()), 16),
@@ -293,9 +299,7 @@ fn dynamic_struct_apply(criterion: &mut Criterion) {
 }
 
 fn dynamic_struct_insert(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("dynamic_struct_insert");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("dynamic_struct_insert"));
 
     for field_count in SIZES {
         group.throughput(Throughput::Elements(field_count as u64));
@@ -325,9 +329,7 @@ fn dynamic_struct_insert(criterion: &mut Criterion) {
 }
 
 fn dynamic_struct_get_field(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("dynamic_struct_get");
-    group.warm_up_time(WARM_UP_TIME);
-    group.measurement_time(MEASUREMENT_TIME);
+    let mut group = create_group(criterion, bench!("dynamic_struct_get_field"));
 
     for field_count in SIZES {
         group.throughput(Throughput::Elements(field_count as u64));

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -6,6 +6,20 @@
 /// and are positive [`BenchmarkId`](criterion::BenchmarkId) do not suit your needs, you can use
 /// [`format_bench!`].
 ///
+/// # When to use this
+///
+/// Use this macro to name benchmarks that are not within a group and benchmark groups themselves.
+/// You'll most commonly use this macro with:
+///
+/// - [`Criterion::bench_function()`](criterion::Criterion::bench_function)
+/// - [`Criterion::bench_with_input()`](criterion::Criterion::bench_with_input)
+/// - [`Criterion::benchmark_group()`](criterion::Criterion::benchmark_group)
+///
+/// You do not want to use this macro with
+/// [`BenchmarkGroup::bench_function()`](criterion::BenchmarkGroup::bench_function) or
+/// [`BenchmarkGroup::bench_with_input()`](criterion::BenchmarkGroup::bench_with_input), because
+/// the group they are in already has the qualified path in it.
+///
 /// # Example
 ///
 /// ```

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -29,21 +29,3 @@ macro_rules! bench {
         concat!(module_path!(), "::", $name)
     };
 }
-
-/// Automatically generates the qualified name of a benchmark given string formatting arguments and
-/// its module path.
-///
-/// This macro takes string formatting arguments (see [`std::fmt`]) as input and returns a
-/// [String]. Its results are determined at runtime, so there is a small cost to using this macro.
-///
-/// If you just want to generate variants of the same benchmark name for different inputs (which is
-/// most common), please use [`BenchmarkId`](criterion::BenchmarkId) instead.
-#[macro_export]
-#[deprecated = "Prefer to use `criterion`'s built-in `BenchmarkId` instead."]
-macro_rules! format_bench {
-    ($($arg:tt)*) => {{
-        let mut qualified_name = concat!(module_path!(), "::").to_string();
-        qualified_name.push_str(format!($($arg)*));
-        qualified_name
-    }};
-}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,0 +1,49 @@
+/// Automatically generates the qualified name of a benchmark given its function name and module
+/// path.
+///
+/// This macro takes a single string literal as input and returns a [`&'static str`](str). Its
+/// result is determined at compile-time. If you need to dynamically generate the name at runtime,
+/// and are positive [`BenchmarkId`](criterion::BenchmarkId) do not suit your needs, you can use
+/// [`format_bench!`].
+///
+/// # Example
+///
+/// ```
+/// mod ecs {
+///     mod query {
+///         use criterion::Criterion;
+///         use benches::bench;
+///
+///         fn iter(c: &mut Criterion) {
+///             // Benchmark name ends in `ecs::query::iter`.
+///             c.bench_function(bench!("iter"), |b| {
+///                 // ...
+///             });
+///         }
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! bench {
+    ($name:literal) => {
+        concat!(module_path!(), "::", $name)
+    };
+}
+
+/// Automatically generates the qualified name of a benchmark given string formatting arguments and
+/// its module path.
+///
+/// This macro takes string formatting arguments (see [`std::fmt`]) as input and returns a
+/// [String]. Its results are determined at runtime, so there is a small cost to using this macro.
+///
+/// If you just want to generate variants of the same benchmark name for different inputs (which is
+/// most common), please use [`BenchmarkId`](criterion::BenchmarkId) instead.
+#[macro_export]
+#[deprecated = "Prefer to use `criterion`'s built-in `BenchmarkId` instead."]
+macro_rules! format_bench {
+    ($($arg:tt)*) => {{
+        let mut qualified_name = concat!(module_path!(), "::").to_string();
+        qualified_name.push_str(format!($($arg)*));
+        qualified_name
+    }};
+}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -2,9 +2,8 @@
 /// path.
 ///
 /// This macro takes a single string literal as input and returns a [`&'static str`](str). Its
-/// result is determined at compile-time. If you need to dynamically generate the name at runtime,
-/// and are positive [`BenchmarkId`](criterion::BenchmarkId) do not suit your needs, you can use
-/// [`format_bench!`].
+/// result is determined at compile-time. If you need to create variations of a benchmark name
+/// based on its input, use this in combination with [`BenchmarkId`](criterion::BenchmarkId).
 ///
 /// # When to use this
 ///


### PR DESCRIPTION
# Objective

- Please see #16647 for the full reasoning behind this change.

## Solution

- Create the `bench!` macro, which generates the name of the benchmark at compile time.

  Migrating is a single line change, and it will automatically update if you move the benchmark to a different module:

  ```diff
  + use benches::bench;

  fn my_benchmark(c: &mut Criterion) {
  -   c.bench_function("my_benchmark", |b| {});
  +   c.bench_function(bench!("my_benchmark"), |b| {});
  }
  ```

- Migrate all reflection benchmarks to use `bench!`.
- Fix a few places where `black_box()` or Criterion is misused.

## Testing

```sh
cd benches

# Will take a long time!
cargo bench --bench reflect

# List out the names of all reflection benchmarks, to ensure I didn't miss anything.
cargo bench --bench reflect -- --list

# Check for linter warnings.
cargo clippy --bench reflect

# Run each benchmark once.
cargo test --bench reflect
```
