### PR TITLE
Test benchmarks in CI

### DIFF
--- a/benches/benches/bevy_tasks/iter.rs
+++ b/benches/benches/bevy_tasks/iter.rs
@@ -61,7 +61,7 @@ fn bench_for_each(c: &mut Criterion) {
         b.iter(|| {
             v.iter_mut().for_each(|x| {
                 busy_work(10000);
-                *x *= *x;
+                *x = x.wrapping_mul(*x);
             });
         });
     });
@@ -77,7 +77,7 @@ fn bench_for_each(c: &mut Criterion) {
                 b.iter(|| {
                     ParChunksMut(v.chunks_mut(100)).for_each(&pool, |x| {
                         busy_work(10000);
-                        *x *= *x;
+                        *x = x.wrapping_mul(*x);
                     });
                 });
             },

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -17,7 +17,8 @@ impl Prepare for TestCommand {
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                // `--benches` runs each benchmark once, to verify that they behave correctly.
+                // `--benches` runs each benchmark once in order to verify that they behave
+                // correctly and do not panic.
                 "cargo test --workspace --lib --bins --tests --benches {no_fail_fast}"
             ),
             "Please fix failing tests in output above.",

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -17,7 +17,8 @@ impl Prepare for TestCommand {
         vec![PreparedCommand::new::<Self>(
             cmd!(
                 sh,
-                "cargo test --workspace --lib --bins --tests {no_fail_fast}"
+                // `--benches` runs each benchmark once, to verify that they behave correctly.
+                "cargo test --workspace --lib --bins --tests --benches {no_fail_fast}"
             ),
             "Please fix failing tests in output above.",
         )]


### PR DESCRIPTION
# Objective

- This reverts #16833, and completely goes against #16803.
- Turns out running `cargo test --benches` runs each benchmark once, without timing it, just to ensure nothing panics. This is actually desired because we can use it to verify benchmarks are working correctly without all the time constraints of actual benchmarks.

## Solution

- Add the `--benches` flag to the CI test command.

## Testing

- `cargo run -p ci -- test`