### PR TITLE
Fix `Text2d` performance regression

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -36,7 +36,6 @@ pub mod prelude {
     };
 }
 
-use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 pub use bundle::*;
 pub use dynamic_texture_atlas_builder::*;
 pub use mesh2d::*;
@@ -58,7 +57,7 @@ use bevy_render::{
     primitives::Aabb,
     render_phase::AddRenderCommand,
     render_resource::{Shader, SpecializedRenderPipelines},
-    view::{self, NoFrustumCulling, VisibilityClass, VisibilitySystems},
+    view::{NoFrustumCulling, VisibilitySystems},
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
 
@@ -88,16 +87,6 @@ pub enum SpriteSystem {
     ExtractSprites,
     ComputeSlices,
 }
-
-/// A component that marks entities that aren't themselves sprites but become
-/// sprites during rendering.
-///
-/// Right now, this is used for `Text`.
-#[derive(Component, Reflect, Clone, Copy, Debug, Default)]
-#[reflect(Component, Default, Debug)]
-#[require(VisibilityClass)]
-#[component(on_add = view::add_visibility_class::<Sprite>)]
-pub struct SpriteSource;
 
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -51,10 +51,9 @@ pub use texture_slice::*;
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetApp, Assets, Handle};
 use bevy_core_pipeline::core_2d::Transparent2d;
-use bevy_ecs::{prelude::*, query::QueryItem};
+use bevy_ecs::prelude::*;
 use bevy_image::Image;
 use bevy_render::{
-    extract_component::{ExtractComponent, ExtractComponentPlugin},
     mesh::{Mesh, Mesh2d, MeshAabb},
     primitives::Aabb,
     render_phase::AddRenderCommand,
@@ -122,12 +121,7 @@ impl Plugin for SpritePlugin {
             .register_type::<Anchor>()
             .register_type::<TextureAtlas>()
             .register_type::<Mesh2d>()
-            .register_type::<SpriteSource>()
-            .add_plugins((
-                Mesh2dRenderPlugin,
-                ColorMaterialPlugin,
-                ExtractComponentPlugin::<SpriteSource>::default(),
-            ))
+            .add_plugins((Mesh2dRenderPlugin, ColorMaterialPlugin))
             .add_systems(
                 PostUpdate,
                 (
@@ -226,18 +220,6 @@ pub fn calculate_bounds_2d(
             };
             commands.entity(entity).try_insert(aabb);
         }
-    }
-}
-
-impl ExtractComponent for SpriteSource {
-    type QueryData = ();
-
-    type QueryFilter = With<SpriteSource>;
-
-    type Out = SpriteSource;
-
-    fn extract_component(_: QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
-        Some(SpriteSource)
     }
 }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -7,6 +7,7 @@ use crate::{
 use bevy_asset::Assets;
 use bevy_color::LinearRgba;
 use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::entity::EntityHashSet;
 use bevy_ecs::{
     change_detection::{DetectChanges, Ref},
     component::{require, Component},
@@ -28,7 +29,6 @@ use bevy_render::{
 use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, Sprite, TextureAtlasLayout};
 use bevy_transform::components::Transform;
 use bevy_transform::prelude::GlobalTransform;
-use bevy_utils::HashSet;
 use bevy_window::{PrimaryWindow, Window};
 
 /// [`Text2dBundle`] was removed in favor of required components.
@@ -237,7 +237,7 @@ pub fn extract_text2d_sprite(
 pub fn update_text2d_layout(
     mut last_scale_factor: Local<f32>,
     // Text items which should be reprocessed again, generally when the font hasn't loaded yet.
-    mut queue: Local<HashSet<Entity>>,
+    mut queue: Local<EntityHashSet>,
     mut textures: ResMut<Assets<Image>>,
     fonts: Res<Assets<Font>>,
     windows: Query<&Window, With<PrimaryWindow>>,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -270,7 +270,7 @@ pub fn update_text2d_layout(
         if factor_changed
             || computed.needs_rerender()
             || bounds.is_changed()
-            || queue.remove(&entity)
+            || (!queue.is_empty() && queue.remove(&entity))
         {
             let text_bounds = TextBounds {
                 width: if block.linebreak == LineBreak::NoWrap {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -19,13 +19,13 @@ use bevy_image::Image;
 use bevy_math::Vec2;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::sync_world::TemporaryRenderEntity;
-use bevy_render::view::Visibility;
+use bevy_render::view::{self, Visibility, VisibilityClass};
 use bevy_render::{
     primitives::Aabb,
     view::{NoFrustumCulling, ViewVisibility},
     Extract,
 };
-use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, SpriteSource, TextureAtlasLayout};
+use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, Sprite, TextureAtlasLayout};
 use bevy_transform::components::Transform;
 use bevy_transform::prelude::GlobalTransform;
 use bevy_utils::HashSet;
@@ -94,10 +94,11 @@ pub struct Text2dBundle {}
     TextColor,
     TextBounds,
     Anchor,
-    SpriteSource,
     Visibility,
+    VisibilityClass,
     Transform
 )]
+#[component(on_add = view::add_visibility_class::<Sprite>)]
 pub struct Text2d(pub String);
 
 impl Text2d {


### PR DESCRIPTION
# Objective

Probably fixes #16972

## Solution

With 100k text2d, tracy was showing most time being spent in `extract_components<bevy_sprite::SpriteSource>`.

![image](https://github.com/user-attachments/assets/e82d5d4e-bb39-4d7e-ab7f-47a5466cb74f)

Browsing Bevy's code, this `SpriteSource` component is seemingly not even used in the render world. So I just ~~deleted the code that was extracting it~~ it.

## Testing

`cargo run --example text2d` still seems to work.

The example from [my comment](https://github.com/bevyengine/bevy/issues/16972#issuecomment-2562680876) in the linked issue shows a ~50x speedup.
