### PR TITLE
Fix Docs // incorrect default value for ChromaticAberration intensity

### DIFF
--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -112,7 +112,7 @@ pub struct ChromaticAberration {
     /// The size of the streaks around the edges of objects, as a fraction of
     /// the window size.
     ///
-    /// The default value is 0.2.
+    /// The default value is 0.02.
     pub intensity: f32,
 
     /// A cap on the number of texture samples that will be performed.


### PR DESCRIPTION
# Objective

Incorrect default value for ChromatticAberration intensity, missing a zero. Bevy 0.15
