### PR TITLE
Add `no_std` support to `bevy_hierarchy`

### DIFF
--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -9,23 +9,54 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["bevy_app"]
-trace = []
-bevy_app = ["reflect", "dep:bevy_app"]
-reflect = ["bevy_ecs/bevy_reflect", "bevy_reflect"]
+default = ["std", "bevy_app"]
+
+# Functionality
+
+## Adds integration with the `bevy_app` plugin API.
+bevy_app = ["dep:bevy_app"]
+
+## Adds runtime reflection support using `bevy_reflect`.
+reflect = ["bevy_ecs/bevy_reflect", "bevy_reflect", "bevy_app?/bevy_reflect"]
+
+# Debugging Features
+
+## Enables `tracing` integration, allowing spans and other metrics to be reported
+## through that framework.
+trace = ["dep:tracing"]
+
+# Platform Compatibility
+
+## Allows access to the `std` crate. Enabling this feature will prevent compilation
+## on `no_std` targets, but provides access to certain additional features on
+## supported platforms.
+std = [
+  "bevy_app?/std",
+  "bevy_ecs/std",
+  "bevy_reflect/std",
+  "bevy_utils/std",
+  "disqualified/alloc",
+]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.15.0-dev", optional = true }
+bevy_app = { path = "../bevy_app", version = "0.15.0-dev", default-features = false, optional = true }
 bevy_ecs = { path = "../bevy_ecs", version = "0.15.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.15.0-dev", features = [
-  "bevy",
   "smallvec",
-], optional = true }
-bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev" }
-disqualified = "1.0"
+], default-features = false, optional = true }
+bevy_utils = { path = "../bevy_utils", version = "0.15.0-dev", default-features = false, features = [
+  "alloc",
+] }
+disqualified = { version = "1.0", default-features = false }
 
-smallvec = { version = "1.11", features = ["union", "const_generics"] }
+# other
+smallvec = { version = "1.11", default-features = false, features = [
+  "union",
+  "const_generics",
+] }
+tracing = { version = "0.1", default-features = false, optional = true }
+log = { version = "0.4", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["std", "bevy_app"]
+default = ["std", "bevy_app", "reflect"]
 
 # Functionality
 

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     system::EntityCommands,
     world::{Command, DeferredWorld, EntityWorldMut, World},
 };
-use bevy_utils::tracing::debug;
+use log::debug;
 
 /// Despawns the given entity and all its children recursively
 #[derive(Debug)]
@@ -69,11 +69,11 @@ fn despawn_children_recursive(world: &mut World, entity: Entity, warn: bool) {
 impl Command for DespawnRecursive {
     fn apply(self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!(
+        let _span = tracing::info_span!(
             "command",
             name = "DespawnRecursive",
-            entity = bevy_utils::tracing::field::debug(self.entity),
-            warn = bevy_utils::tracing::field::debug(self.warn)
+            entity = tracing::field::debug(self.entity),
+            warn = tracing::field::debug(self.warn)
         )
         .entered();
         despawn_with_children_recursive(world, self.entity, self.warn);
@@ -83,11 +83,11 @@ impl Command for DespawnRecursive {
 impl Command for DespawnChildrenRecursive {
     fn apply(self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!(
+        let _span = tracing::info_span!(
             "command",
             name = "DespawnChildrenRecursive",
-            entity = bevy_utils::tracing::field::debug(self.entity),
-            warn = bevy_utils::tracing::field::debug(self.warn)
+            entity = tracing::field::debug(self.entity),
+            warn = tracing::field::debug(self.warn)
         )
         .entered();
 
@@ -150,10 +150,10 @@ fn despawn_recursive_inner(world: EntityWorldMut, warn: bool) {
     let entity = world.id();
 
     #[cfg(feature = "trace")]
-    let _span = bevy_utils::tracing::info_span!(
+    let _span = tracing::info_span!(
         "despawn_recursive",
-        entity = bevy_utils::tracing::field::debug(entity),
-        warn = bevy_utils::tracing::field::debug(warn)
+        entity = tracing::field::debug(entity),
+        warn = tracing::field::debug(warn)
     )
     .entered();
 
@@ -167,10 +167,10 @@ fn despawn_descendants_inner<'v, 'w>(
     let entity = world.id();
 
     #[cfg(feature = "trace")]
-    let _span = bevy_utils::tracing::info_span!(
+    let _span = tracing::info_span!(
         "despawn_descendants",
-        entity = bevy_utils::tracing::field::debug(entity),
-        warn = bevy_utils::tracing::field::debug(warn)
+        entity = tracing::field::debug(entity),
+        warn = tracing::field::debug(warn)
     )
     .entered();
 

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -4,6 +4,7 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! Parent-child relationships for Bevy entities.
 //!
@@ -98,8 +99,9 @@ pub struct HierarchyPlugin;
 #[cfg(feature = "bevy_app")]
 impl Plugin for HierarchyPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Children>()
-            .register_type::<Parent>()
-            .add_event::<HierarchyEvent>();
+        #[cfg(feature = "reflect")]
+        app.register_type::<Children>().register_type::<Parent>();
+
+        app.add_event::<HierarchyEvent>();
     }
 }

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use bevy_ecs::prelude::*;
 
 #[cfg(feature = "bevy_app")]
-use {crate::Parent, bevy_utils::HashSet, disqualified::ShortName};
+use {crate::Parent, alloc::format, bevy_utils::HashSet, disqualified::ShortName};
 
 /// When enabled, runs [`check_hierarchy_component_has_valid_parent<T>`].
 ///
@@ -63,7 +63,7 @@ pub fn check_hierarchy_component_has_valid_parent<T: Component>(
         let parent = parent.get();
         if !component_query.contains(parent) && !already_diagnosed.contains(&entity) {
             already_diagnosed.insert(entity);
-            bevy_utils::tracing::warn!(
+            log::warn!(
                 "warning[B0004]: {name} with the {ty_name} component has a parent without {ty_name}.\n\
                 This will cause inconsistent behaviors! See: https://bevyengine.org/learn/errors/b0004",
                 ty_name = ShortName::of::<T>(),

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -4,7 +4,7 @@ use core::any::Any;
 use smallvec::{Array as SmallArray, SmallVec};
 
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec};
+use alloc::{format, vec, vec::Vec};
 
 use crate::{
     self as bevy_reflect, utility::GenericTypeInfoCell, ApplyError, FromReflect, FromType,

--- a/tools/ci/src/commands/compile_check_no_std.rs
+++ b/tools/ci/src/commands/compile_check_no_std.rs
@@ -110,6 +110,14 @@ impl Prepare for CompileCheckNoStdCommand {
             "Please fix compiler errors in output above for bevy_app no_std compatibility.",
         ));
 
+        commands.push(PreparedCommand::new::<Self>(
+            cmd!(
+                sh,
+                "cargo check -p bevy_hierarchy --no-default-features --features bevy_app,reflect --target {target}"
+            ),
+            "Please fix compiler errors in output above for bevy_hierarchy no_std compatibility.",
+        ));
+
         commands
     }
 }


### PR DESCRIPTION
# Objective

- Contributes to #15460

## Solution

- Added the following features:
  - `std` (default)

## Testing

- CI

## Notes

- There was a minor issue with `bevy_reflect`'s `smallvec` feature noticed in this PR which I have also resolved here. I can split this out if desired, but I've left it here for now as it's a very small change and I don't consider this PR itself to be very controversial.