### PR TITLE
Improve msrv CI

### DIFF
--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -149,7 +149,7 @@ jobs:
                run_id: ${{ github.event.workflow_run.id }},
             });
             var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "msrv-failures"
+              return artifact.name == "msrv"
             });
             if (matchArtifacts.length == 0) { return "false" }
             var matchArtifact = matchArtifacts[0];
@@ -160,9 +160,9 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/msrv-failures.zip', Buffer.from(download.data));
+            fs.writeFileSync('${{github.workspace}}/msrv.zip', Buffer.from(download.data));
             return "true"
-      - run: unzip msrv-failures.zip
+      - run: unzip msrv.zip
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
       - name: 'Comment on PR'
         if: ${{ steps.find-artifact.outputs.result == 'true' }}

--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -176,7 +176,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: 'Your PR increases Bevy Minimum Supported Rust Version. Please update the `rust-version` field in the root Cargo.toml file.'
+              body: 'Your PR increases Bevy Minimum Supported Rust Version. Please update the `rust-version` field in the appropriate Cargo.toml file.'
             });
 
   make-macos-screenshots-available:

--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -149,7 +149,7 @@ jobs:
                run_id: ${{ github.event.workflow_run.id }},
             });
             var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "msrv"
+              return artifact.name == "msrv-failures"
             });
             if (matchArtifacts.length == 0) { return "false" }
             var matchArtifact = matchArtifacts[0];
@@ -160,9 +160,9 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/msrv.zip', Buffer.from(download.data));
+            fs.writeFileSync('${{github.workspace}}/msrv-failures.zip', Buffer.from(download.data));
             return "true"
-      - run: unzip msrv.zip
+      - run: unzip msrv-failures.zip
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
       - name: 'Comment on PR'
         if: ${{ steps.find-artifact.outputs.result == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,13 +491,13 @@ jobs:
       - name: Save PR number
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
         run: |
-          mkdir -p ./msrv-failures
-          echo ${{ github.event.number }} > ./msrv-failures/NR
+          mkdir -p ./msrv
+          echo ${{ github.event.number }} > ./msrv/NR
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
         with:
-          name: msrv-failures
-          path: msrv-failures/
+          name: msrv
+          path: msrv/
 
   check-bevy-internal-imports:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,54 +439,62 @@ jobs:
             echo "One or more crates are missing an MSRV. Please address the issues and try again."
             exit 1
           fi
+      - name: Install Linux dependencies
+        uses: ./.github/actions/install-linux-deps
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy }}
-      - name: Install Linux dependencies
-        uses: ./.github/actions/install-linux-deps
       - name: Run cargo check for Bevy
+        continue-on-error: true
         run: cargo check --manifest-path Cargo.toml
       - name: Check Bevy Color
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_color }}
       - name: Run cargo check for Bevy Color
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_color/Cargo.toml
       - name: Check Bevy ECS
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ecs }}
       - name: Run cargo check for Bevy ECS
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_ecs/Cargo.toml
       - name: Check Bevy Input Focus
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_input_focus }}
       - name: Run cargo check for Bevy Input Focus
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_input_focus/Cargo.toml
       - name: Check Bevy Math
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_math }}
       - name: Run cargo check for Bevy Math
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_math/Cargo.toml
       - name: Check Bevy Mikktspace
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_mikktspace }}
       - name: Run cargo check for Bevy Mikktspace
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_mikktspace/Cargo.toml
       - name: Check Bevy Ptr
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ptr }}
       - name: Run cargo check for Bevy Ptr
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_ptr/Cargo.toml
       - name: Check Bevy Reflect
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_reflect }}
       - name: Run cargo check for Bevy Reflect
+        continue-on-error: true
         run: cargo check --manifest-path crates/bevy_reflect/Cargo.toml
       - name: Save PR number
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,13 +490,13 @@ jobs:
       - name: Save PR number
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
         run: |
-          mkdir -p ./msrv
-          echo ${{ github.event.number }} > ./msrv/NR
+          mkdir -p ./msrv-failures
+          echo ${{ github.event.number }} > ./msrv-failures/NR
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
         with:
-          name: msrv
-          path: msrv/
+          name: msrv-failures
+          path: msrv-failures/
 
   check-bevy-internal-imports:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,22 +409,22 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.toml') }}
-      - name: get MSRVs
+      - name: Get MSRVs
         id: msrv
         run: |
-          # bevy
-          msrv_bevy=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
-          if [ -z "$msrv" ]; then
+          echo "Fetching MSRVs for crates..."
+          # Base crate
+          msrv_bevy=$(cargo metadata --manifest-path "Cargo.toml" --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version')
+          if [ -z "$msrv_bevy" ]; then
             echo "No MSRV found for bevy. Please add \`rust-version\` to Cargo.toml."
             missing_msrv=true
           else
-            echo "msrv_$crate=$msrv" >> $GITHUB_OUTPUT
+            echo "msrv_bevy=$msrv_bevy" >> $GITHUB_OUTPUT
           fi
 
-          # crates
+          # Additional crates
           crates=("bevy_color" "bevy_ecs" "bevy_input_focus" "bevy_math" "bevy_mikktspace" "bevy_ptr" "bevy_reflect")
           for crate in "${crates[@]}"; do
-            echo "Checking MSRV for $crate"
             msrv=$(cargo metadata --manifest-path "crates/$crate/Cargo.toml" --no-deps --format-version 1 | jq --raw-output ".packages[] | select(.name==\"$crate\") | .rust_version")
             if [ -z "$msrv" ]; then
               echo "No MSRV found for $crate. Please add \`rust-version\` to $crate/Cargo.toml."
@@ -443,9 +443,50 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy }}
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
-      - name: Run cargo check
-        id: check
-        run: cargo check
+      - name: Run cargo check for Bevy
+        run: cargo check --manifest-path Cargo.toml
+      - name: Check Bevy Color
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_color }}
+      - name: Run cargo check for Bevy Color
+        run: cargo check --manifest-path crates/bevy_color/Cargo.toml
+      - name: Check Bevy ECS
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_ecs }}
+      - name: Run cargo check for Bevy ECS
+        run: cargo check --manifest-path crates/bevy_ecs/Cargo.toml
+      - name: Check Bevy Input Focus
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_input_focus }}
+      - name: Run cargo check for Bevy Input Focus
+        run: cargo check --manifest-path crates/bevy_input_focus/Cargo.toml
+      - name: Check Bevy Math
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_math }}
+      - name: Run cargo check for Bevy Math
+        run: cargo check --manifest-path crates/bevy_math/Cargo.toml
+      - name: Check Bevy Mikktspace
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_mikktspace }}
+      - name: Run cargo check for Bevy Mikktspace
+        run: cargo check --manifest-path crates/bevy_mikktspace/Cargo.toml
+      - name: Check Bevy Ptr
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_ptr }}
+      - name: Run cargo check for Bevy Ptr
+        run: cargo check --manifest-path crates/bevy_ptr/Cargo.toml
+      - name: Check Bevy Reflect
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy_reflect }}
+      - name: Run cargo check for Bevy Reflect
+        run: cargo check --manifest-path crates/bevy_reflect/Cargo.toml
       - name: Save PR number
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,12 +504,12 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_reflect/Cargo.toml
       - name: Save PR number
-        if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         run: |
           mkdir -p ./msrv
           echo ${{ github.event.number }} > ./msrv/NR
       - uses: actions/upload-artifact@v4
-        if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         with:
           name: msrv
           path: msrv/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,56 +445,56 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy }}
       - name: Run cargo check for Bevy
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path Cargo.toml
       - name: Check Bevy Color
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_color }}
       - name: Run cargo check for Bevy Color
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_color/Cargo.toml
       - name: Check Bevy ECS
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ecs }}
       - name: Run cargo check for Bevy ECS
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_ecs/Cargo.toml
       - name: Check Bevy Input Focus
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_input_focus }}
       - name: Run cargo check for Bevy Input Focus
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_input_focus/Cargo.toml
       - name: Check Bevy Math
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_math }}
       - name: Run cargo check for Bevy Math
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_math/Cargo.toml
       - name: Check Bevy Mikktspace
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_mikktspace }}
       - name: Run cargo check for Bevy Mikktspace
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_mikktspace/Cargo.toml
       - name: Check Bevy Ptr
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ptr }}
       - name: Run cargo check for Bevy Ptr
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_ptr/Cargo.toml
       - name: Check Bevy Reflect
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_reflect }}
       - name: Run cargo check for Bevy Reflect
-        continue-on-error: true
+        if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_reflect/Cargo.toml
       - name: Save PR number
         if: ${{ failure() && github.event_name == 'pull_request' && steps.check.conclusion == 'failure' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path Cargo.toml
       - name: Check Bevy Color
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_color }}
@@ -454,6 +455,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_color/Cargo.toml
       - name: Check Bevy ECS
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ecs }}
@@ -461,6 +463,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_ecs/Cargo.toml
       - name: Check Bevy Input Focus
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_input_focus }}
@@ -468,6 +471,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_input_focus/Cargo.toml
       - name: Check Bevy Math
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_math }}
@@ -475,6 +479,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_math/Cargo.toml
       - name: Check Bevy Mikktspace
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_mikktspace }}
@@ -482,6 +487,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_mikktspace/Cargo.toml
       - name: Check Bevy Ptr
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ptr }}
@@ -489,6 +495,7 @@ jobs:
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_ptr/Cargo.toml
       - name: Check Bevy Reflect
+        if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_reflect }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,6 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -410,14 +409,38 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.toml') }}
-      - name: get MSRV
+      - name: get MSRVs
         id: msrv
         run: |
-          msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
-          echo "msrv=$msrv" >> $GITHUB_OUTPUT
+          # bevy
+          msrv_bevy=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
+          if [ -z "$msrv" ]; then
+            echo "No MSRV found for bevy. Please add \`rust-version\` to Cargo.toml."
+            missing_msrv=true
+          else
+            echo "msrv_$crate=$msrv" >> $GITHUB_OUTPUT
+          fi
+
+          # crates
+          crates=("bevy_color" "bevy_ecs" "bevy_input_focus" "bevy_math" "bevy_mikktspace" "bevy_ptr" "bevy_reflect")
+          for crate in "${crates[@]}"; do
+            echo "Checking MSRV for $crate"
+            msrv=$(cargo metadata --manifest-path "crates/$crate/Cargo.toml" --no-deps --format-version 1 | jq --raw-output ".packages[] | select(.name==\"$crate\") | .rust_version")
+            if [ -z "$msrv" ]; then
+              echo "No MSRV found for $crate. Please add \`rust-version\` to $crate/Cargo.toml."
+              missing_msrv=true
+            else
+              echo "msrv_$crate=$msrv" >> $GITHUB_OUTPUT
+            fi
+          done
+
+          if [ "$missing_msrv" = true ]; then
+            echo "One or more crates are missing an MSRV. Please address the issues and try again."
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+          toolchain: ${{ steps.msrv.outputs.msrv_bevy }}
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Run cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,66 +440,67 @@ jobs:
           fi
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
-      - uses: dtolnay/rust-toolchain@master
+      - name: Use bevy's minimum toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy }}
-      - name: Run cargo check for Bevy
+      - name: Run cargo check for bevy
         if: '!cancelled()'
         run: cargo check --manifest-path Cargo.toml
-      - name: Check Bevy Color
+      - name: Use bevy_color's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_color }}
-      - name: Run cargo check for Bevy Color
+      - name: Run cargo check for bevy_color
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_color/Cargo.toml
-      - name: Check Bevy ECS
+      - name: Use bevy_ecs's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ecs }}
-      - name: Run cargo check for Bevy ECS
+      - name: Run cargo check for bevy_ecs
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_ecs/Cargo.toml
-      - name: Check Bevy Input Focus
+      - name: Use bevy_input_focus's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_input_focus }}
-      - name: Run cargo check for Bevy Input Focus
+      - name: Run cargo check for msrv_bevy_input_focus
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_input_focus/Cargo.toml
-      - name: Check Bevy Math
+      - name: Use bevy_math's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_math }}
-      - name: Run cargo check for Bevy Math
+      - name: Run cargo check for msrv_bevy_math
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_math/Cargo.toml
-      - name: Check Bevy Mikktspace
+      - name: Use bevy_mikktspace's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_mikktspace }}
-      - name: Run cargo check for Bevy Mikktspace
+      - name: Run cargo check for bevy_mikktspace
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_mikktspace/Cargo.toml
-      - name: Check Bevy Ptr
+      - name: Use bevy_ptr's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_ptr }}
-      - name: Run cargo check for Bevy Ptr
+      - name: Run cargo check for bevy_ptr
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_ptr/Cargo.toml
-      - name: Check Bevy Reflect
+      - name: Use bevy_reflect's minimum toolchain
         if: '!cancelled()'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_reflect }}
-      - name: Run cargo check for Bevy Reflect
+      - name: Run cargo check for bevy_reflect
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_reflect/Cargo.toml
       - name: Save PR number

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,6 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_input_focus }}
-      - name: Run cargo check for msrv_bevy_input_focus
+      - name: Run cargo check for bevy_input_focus
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_input_focus/Cargo.toml
       - name: Use bevy_math's minimum toolchain
@@ -476,7 +476,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv_bevy_math }}
-      - name: Run cargo check for msrv_bevy_math
+      - name: Run cargo check for bevy_math
         if: '!cancelled()'
         run: cargo check --manifest-path crates/bevy_math/Cargo.toml
       - name: Use bevy_mikktspace's minimum toolchain

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "color"]
-rust-version = "1.82.0"
+rust-version = "1.83.0"
 
 [dependencies]
 bevy_math = { path = "../bevy_math", version = "0.15.0-dev", default-features = false, features = [

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["ecs", "game", "bevy"]
 categories = ["game-engines", "data-structures"]
-rust-version = "1.81.0"
+rust-version = "1.83.0"
 
 [features]
 default = ["std", "bevy_reflect", "async_executor"]
@@ -84,7 +84,7 @@ critical-section = [
 ]
 
 ## `portable-atomic` provides additional platform support for atomic types and
-## operations, even on targets without native support. 
+## operations, even on targets without native support.
 portable-atomic = [
   "dep:portable-atomic",
   "dep:portable-atomic-util",

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -147,10 +147,10 @@ impl<'a, 'b> ComponentCloneCtx<'a, 'b> {
         if self.target_component_written {
             panic!("Trying to write component '{short_name}' multiple times")
         }
-        if !self
+        if self
             .component_info
             .type_id()
-            .is_some_and(|id| id == TypeId::of::<T>())
+            .is_none_or(|id| id != TypeId::of::<T>())
         {
             panic!("TypeId of component '{short_name}' does not match source component TypeId")
         };

--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.76.0"
+rust-version = "1.83.0"
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.15.0-dev", default-features = false }

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
-rust-version = "1.81.0"
+rust-version = "1.83.0"
 
 [dependencies]
 glam = { version = "0.29", default-features = false, features = ["bytemuck"] }

--- a/tools/ci/src/ci.rs
+++ b/tools/ci/src/ci.rs
@@ -81,6 +81,7 @@ impl CI {
                 cmds.append(&mut commands::CompileFailCommand::default().prepare(sh, flags));
                 cmds.append(&mut commands::BenchCheckCommand::default().prepare(sh, flags));
                 cmds.append(&mut commands::ExampleCheckCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::MsrvCommand::default().prepare(sh, flags));
                 cmds
             }
         }
@@ -107,6 +108,7 @@ enum Commands {
     CompileFail(commands::CompileFailCommand),
     BenchCheck(commands::BenchCheckCommand),
     ExampleCheck(commands::ExampleCheckCommand),
+    Msrv(commands::MsrvCommand),
 }
 
 impl Prepare for Commands {
@@ -127,6 +129,7 @@ impl Prepare for Commands {
             Commands::CompileFail(subcommand) => subcommand.prepare(sh, flags),
             Commands::BenchCheck(subcommand) => subcommand.prepare(sh, flags),
             Commands::ExampleCheck(subcommand) => subcommand.prepare(sh, flags),
+            Commands::Msrv(subcommand) => subcommand.prepare(sh, flags),
         }
     }
 }

--- a/tools/ci/src/commands/mod.rs
+++ b/tools/ci/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub use doc_test::*;
 pub use example_check::*;
 pub use format::*;
 pub use lints::*;
+pub use msrv::*;
 pub use test::*;
 pub use test_check::*;
 
@@ -25,5 +26,6 @@ mod doc_test;
 mod example_check;
 mod format;
 mod lints;
+mod msrv;
 mod test;
 mod test_check;

--- a/tools/ci/src/commands/msrv.rs
+++ b/tools/ci/src/commands/msrv.rs
@@ -1,0 +1,47 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Check for clippy warnings and errors.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "msrv")]
+pub struct MsrvCommand {}
+
+impl Prepare for MsrvCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        vec![
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --verify"),
+                "Please fix update 'rust-version' in `Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_color --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_color/Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_ecs --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_ecs/Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_input_focus --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_input_focus/Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_math --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_math/Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_mikktspace --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_mikktspace/Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_ptr --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_ptr/Cargo.toml`.",
+            ),
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo msrv --path ./crates/bevy_reflect --verify"),
+                "Please fix update 'rust-version' in `crates/bevy_reflect/Cargo.toml`.",
+            ),
+        ]
+    }
+}


### PR DESCRIPTION
# Objective

Fixes #16330
Fixes #17008

## Solution

Have the CI check the msrv for a select list of crates which are intended to be used apart from bevy.
I added a tool to make checking MSRVs easier.
I also removed the `needs: build` from msrv because it often uses a different toolchain, so the cache probably isn't helpful. Unblocking this makes it complete quicker.

## Testing

bevy_ecs's rust-version is already incorrect, so see the showcase for a demonstration of the failure.

https://github.com/bevyengine/bevy/actions/runs/12529512145/job/34945194232

## Showcase

![image](https://github.com/user-attachments/assets/1ad59596-97bb-4f08-8ce1-94df8dc32e82)

![image](https://github.com/user-attachments/assets/638b2b1e-44e3-4422-9ea1-78224bf4ee9f)


