### PR TITLE
Don't overalign aligned values in `gpu_readback::align_byte_size`

### DIFF
--- a/crates/bevy_render/src/gpu_readback.rs
+++ b/crates/bevy_render/src/gpu_readback.rs
@@ -27,7 +27,7 @@ use bevy_utils::{tracing::warn, HashMap};
 use encase::internal::ReadFrom;
 use encase::private::Reader;
 use encase::ShaderType;
-use wgpu::{CommandEncoder, COPY_BYTES_PER_ROW_ALIGNMENT};
+use wgpu::CommandEncoder;
 
 /// A plugin that enables reading back gpu buffers and textures to the cpu.
 pub struct GpuReadbackPlugin {
@@ -348,14 +348,17 @@ fn map_buffers(mut readbacks: ResMut<GpuReadbacks>) {
 
 // Utils
 
-pub(crate) fn align_byte_size(value: u32) -> u32 {
-    value + (COPY_BYTES_PER_ROW_ALIGNMENT - (value % COPY_BYTES_PER_ROW_ALIGNMENT))
+/// Round up a given value to be a multiple of [`wgpu::COPY_BYTES_PER_ROW_ALIGNMENT`].
+pub(crate) const fn align_byte_size(value: u32) -> u32 {
+    RenderDevice::align_copy_bytes_per_row(value as usize) as u32
 }
 
-pub(crate) fn get_aligned_size(width: u32, height: u32, pixel_size: u32) -> u32 {
+/// Get the size of a image when the size of each row has been rounded up to [`wgpu::COPY_BYTES_PER_ROW_ALIGNMENT`].
+pub(crate) const fn get_aligned_size(width: u32, height: u32, pixel_size: u32) -> u32 {
     height * align_byte_size(width * pixel_size)
 }
 
+/// Get a [`ImageDataLayout`] aligned such that the image can be copied into a buffer.
 pub(crate) fn layout_data(width: u32, height: u32, format: TextureFormat) -> ImageDataLayout {
     ImageDataLayout {
         bytes_per_row: if height > 1 {


### PR DESCRIPTION
# Objective

Fix alignment calculations in our rendering code.
Fixes #16992 

The `gpu_readback::align_byte_size` function incorrectly rounds aligned values to the next alignment.
If we assume the alignment to be 256 (because that's what wgpu says it its) the function would align 0 to 256, 256 to 512, etc...

## Solution

Forward the `gpu_readback::align_byte_size` to `RenderDevice::align_copy_bytes_per_row` so we don't implement the same method twice.
Simplify `RenderDevice::align_copy_bytes_per_row`.

## Testing

Ran the code provided in #16992 to see if the issue has been solved + added a test to check if `align_copy_bytes_per_row` returns the correct values.
