### PR TITLE
Rename `NodeImageMode` to `ImageNodeMode`

### DIFF
--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -275,10 +275,10 @@ pub fn extract_ui_texture_slices(
         };
 
         let image_scale_mode = match image.image_mode.clone() {
-            widget::NodeImageMode::Sliced(texture_slicer) => {
+            widget::ImageNodeMode::Sliced(texture_slicer) => {
                 SpriteImageMode::Sliced(texture_slicer)
             }
-            widget::NodeImageMode::Tiled {
+            widget::ImageNodeMode::Tiled {
                 tile_x,
                 tile_y,
                 stretch_value,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -37,7 +37,7 @@ pub struct ImageNode {
     /// is offset by the atlas's minimal (top-left) corner position.
     pub rect: Option<Rect>,
     /// Controls how the image is altered to fit within the layout and how the layout algorithm determines the space to allocate for the image.
-    pub image_mode: NodeImageMode,
+    pub image_mode: ImageNodeMode,
 }
 
 impl Default for ImageNode {
@@ -59,7 +59,7 @@ impl Default for ImageNode {
             flip_x: false,
             flip_y: false,
             rect: None,
-            image_mode: NodeImageMode::Auto,
+            image_mode: ImageNodeMode::Auto,
         }
     }
 }
@@ -85,7 +85,7 @@ impl ImageNode {
             flip_y: false,
             texture_atlas: None,
             rect: None,
-            image_mode: NodeImageMode::Auto,
+            image_mode: ImageNodeMode::Auto,
         }
     }
 
@@ -126,7 +126,7 @@ impl ImageNode {
     }
 
     #[must_use]
-    pub const fn with_mode(mut self, mode: NodeImageMode) -> Self {
+    pub const fn with_mode(mut self, mode: ImageNodeMode) -> Self {
         self.image_mode = mode;
         self
     }
@@ -140,7 +140,7 @@ impl From<Handle<Image>> for ImageNode {
 
 /// Controls how the image is altered to fit within the layout and how the layout algorithm determines the space in the layout for the image
 #[derive(Default, Debug, Clone, Reflect)]
-pub enum NodeImageMode {
+pub enum ImageNodeMode {
     /// The image will be sized automatically by taking the size of the source image and applying any layout constraints.
     #[default]
     Auto,
@@ -160,13 +160,13 @@ pub enum NodeImageMode {
     },
 }
 
-impl NodeImageMode {
-    /// Returns true if this mode uses slices internally ([`NodeImageMode::Sliced`] or [`NodeImageMode::Tiled`])
+impl ImageNodeMode {
+    /// Returns true if this mode uses slices internally ([`ImageNodeMode::Sliced`] or [`ImageNodeMode::Tiled`])
     #[inline]
     pub fn uses_slices(&self) -> bool {
         matches!(
             self,
-            NodeImageMode::Sliced(..) | NodeImageMode::Tiled { .. }
+            ImageNodeMode::Sliced(..) | ImageNodeMode::Tiled { .. }
         )
     }
 }
@@ -269,7 +269,7 @@ pub fn update_image_content_size_system(
         * ui_scale.0;
 
     for (mut content_size, image, mut image_size) in &mut query {
-        if !matches!(image.image_mode, NodeImageMode::Auto)
+        if !matches!(image.image_mode, ImageNodeMode::Auto)
             || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
         {
             if image.is_changed() {

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -9,7 +9,7 @@ use bevy::{
     input::mouse::{MouseScrollUnit, MouseWheel},
     picking::hover::HoverMap,
     prelude::*,
-    ui::widget::NodeImageMode,
+    ui::widget::ImageNodeMode,
 };
 
 fn main() {
@@ -287,7 +287,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     parent
                         .spawn((
                             ImageNode::new(asset_server.load("branding/bevy_logo_dark_big.png"))
-                                .with_mode(NodeImageMode::Stretch),
+                                .with_mode(ImageNodeMode::Stretch),
                             Node {
                                 width: Val::Px(500.0),
                                 height: Val::Px(125.0),

--- a/examples/ui/ui_texture_atlas_slice.rs
+++ b/examples/ui/ui_texture_atlas_slice.rs
@@ -4,7 +4,7 @@
 use bevy::{
     color::palettes::css::{GOLD, ORANGE},
     prelude::*,
-    ui::widget::NodeImageMode,
+    ui::widget::ImageNodeMode,
     winit::WinitSettings,
 };
 
@@ -89,7 +89,7 @@ fn setup(
                                 layout: atlas_layout_handle.clone(),
                             },
                         )
-                        .with_mode(NodeImageMode::Sliced(slicer.clone())),
+                        .with_mode(ImageNodeMode::Sliced(slicer.clone())),
                         Node {
                             width: Val::Px(w),
                             height: Val::Px(h),

--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -4,7 +4,7 @@
 use bevy::{
     color::palettes::css::{GOLD, ORANGE},
     prelude::*,
-    ui::widget::NodeImageMode,
+    ui::widget::ImageNodeMode,
     winit::WinitSettings,
 };
 
@@ -70,7 +70,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         Button,
                         ImageNode {
                             image: image.clone(),
-                            image_mode: NodeImageMode::Sliced(slicer.clone()),
+                            image_mode: ImageNodeMode::Sliced(slicer.clone()),
                             ..default()
                         },
                         Node {

--- a/examples/ui/ui_texture_slice_flip_and_tile.rs
+++ b/examples/ui/ui_texture_slice_flip_and_tile.rs
@@ -3,7 +3,7 @@
 use bevy::{
     image::{ImageLoaderSettings, ImageSampler},
     prelude::*,
-    ui::widget::NodeImageMode,
+    ui::widget::ImageNodeMode,
     winit::WinitSettings,
 };
 
@@ -59,7 +59,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             image: image.clone(),
                             flip_x,
                             flip_y,
-                            image_mode: NodeImageMode::Sliced(slicer.clone()),
+                            image_mode: ImageNodeMode::Sliced(slicer.clone()),
                             ..default()
                         },
                         Node {


### PR DESCRIPTION
# Objective

Fixes #16909 

## Solution

Rename the type

## Migration Guide

`widget::image::NodeImageMode` is now `widget::image::ImageNodeMode`