### PR TITLE
fix visibility propagation during reparenting

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -412,7 +412,7 @@ pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
 fn visibility_propagate_system(
     changed: Query<
         (Entity, &Visibility, Option<&Parent>, Option<&Children>),
-        (With<InheritedVisibility>, Changed<Visibility>),
+        (With<InheritedVisibility>, Or<(Changed<Visibility>, Changed<Parent>)>),
     >,
     mut visibility_query: Query<(&Visibility, &mut InheritedVisibility)>,
     children_query: Query<&Children, (With<Visibility>, With<InheritedVisibility>)>,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -412,7 +412,10 @@ pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
 fn visibility_propagate_system(
     changed: Query<
         (Entity, &Visibility, Option<&Parent>, Option<&Children>),
-        (With<InheritedVisibility>, Or<(Changed<Visibility>, Changed<Parent>)>),
+        (
+            With<InheritedVisibility>,
+            Or<(Changed<Visibility>, Changed<Parent>)>,
+        ),
     >,
     mut visibility_query: Query<(&Visibility, &mut InheritedVisibility)>,
     children_query: Query<&Children, (With<Visibility>, With<InheritedVisibility>)>,
@@ -757,14 +760,12 @@ mod test {
         );
     }
 
-
-
     #[test]
     fn test_visibility_propagation_on_parent_change() {
         // Setup the world and schedule
         let mut app = App::new();
-         
-        app.add_systems(Update,visibility_propagate_system);
+
+        app.add_systems(Update, visibility_propagate_system);
 
         // Create entities with visibility and hierarchy
         let parent1 = app.world_mut().spawn((Visibility::Hidden,)).id();
@@ -773,28 +774,46 @@ mod test {
         let child2 = app.world_mut().spawn((Visibility::Inherited,)).id();
 
         // Build hierarchy
-        app.world_mut().entity_mut(parent1).add_children(&[child1, child2]);
+        app.world_mut()
+            .entity_mut(parent1)
+            .add_children(&[child1, child2]);
 
         // Run the system initially to set up visibility
         app.update();
 
         // Change parent visibility to Hidden
-        app.world_mut().entity_mut(parent2).insert(Visibility::Visible);
+        app.world_mut()
+            .entity_mut(parent2)
+            .insert(Visibility::Visible);
         // Simulate a change in the parent component
-        app.world_mut().entity_mut(child2).set_parent(parent2);  // example of changing parent
+        app.world_mut().entity_mut(child2).set_parent(parent2); // example of changing parent
 
         // Run the system again to propagate changes
         app.update();
 
         // Retrieve and assert visibility
-        let inherited_visibility1 = app.world_mut().entity(child1).get::<InheritedVisibility>().unwrap(); 
-        assert_eq!(inherited_visibility1.get(), false, "Child1 should inherit visibility from parent");
+        let inherited_visibility1 = app
+            .world_mut()
+            .entity(child1)
+            .get::<InheritedVisibility>()
+            .unwrap();
+        assert_eq!(
+            inherited_visibility1.get(),
+            false,
+            "Child1 should inherit visibility from parent"
+        );
 
-        let inherited_visibility2 = app.world_mut().entity(child2).get::<InheritedVisibility>().unwrap();
-        assert_eq!(inherited_visibility2.get(), true, "Child2 should inherit visibility from parent");
+        let inherited_visibility2 = app
+            .world_mut()
+            .entity(child2)
+            .get::<InheritedVisibility>()
+            .unwrap();
+        assert_eq!(
+            inherited_visibility2.get(),
+            true,
+            "Child2 should inherit visibility from parent"
+        );
     }
-
-
 
     #[test]
     fn visibility_propagation_unconditional_visible() {

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -791,26 +791,23 @@ mod test {
         // Run the system again to propagate changes
         app.update();
 
+        let is_visible = |e: Entity| {
+            app.world()
+                .entity(e)
+                .get::<InheritedVisibility>()
+                .unwrap()
+                .get()
+        };
+
         // Retrieve and assert visibility
-        let inherited_visibility1 = app
-            .world_mut()
-            .entity(child1)
-            .get::<InheritedVisibility>()
-            .unwrap();
-        assert_eq!(
-            inherited_visibility1.get(),
-            false,
+
+        assert!(
+            !is_visible(child1),
             "Child1 should inherit visibility from parent"
         );
 
-        let inherited_visibility2 = app
-            .world_mut()
-            .entity(child2)
-            .get::<InheritedVisibility>()
-            .unwrap();
-        assert_eq!(
-            inherited_visibility2.get(),
-            true,
+        assert!(
+            is_visible(child2),
             "Child2 should inherit visibility from parent"
         );
     }


### PR DESCRIPTION
# Objective
Fixes #17024 

## Solution
 

## Testing
 By adding 

```
if let Some(mut cmd) = commands.get_entity( *equipment_link_node ){
                         cmd.insert(Visibility::Inherited); // a hack for now 
                     }

```
in my build after .set_parent() , this fixes the issue.  This is why i think that this change will fix the issue.  Unfortunately i was not able to test the Changed (parent )  , this actual code change, because no matter how i 'patch', it breaks my project.  I got super close but still had 23 errors due to Reflect being angry.  


---
 
 