### PR TITLE
Overhaul picking benchmarks

### DIFF
--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -64,8 +64,13 @@ fn create_mesh(vertices_per_side: u32) -> SimpleMesh {
 /// An enum that represents the configuration for all variations of the ray mesh intersection
 /// benchmarks.
 enum Benchmarks {
+    /// The ray intersects the mesh, and culling is enabled.
     CullIntersect,
+
+    /// The ray intersects the mesh, and culling is disabled.
     NoCullIntersect,
+
+    /// The ray does not intersect the mesh, and culling is enabled.
     CullNoIntersect,
 }
 
@@ -75,7 +80,12 @@ impl Benchmarks {
 
     /// Returns an iterator over every variant in this enum.
     fn iter() -> impl Iterator<Item = Self> {
-        [Self::CullIntersect, Self::NoCullIntersect, Self::CullNoIntersect].into_iter()
+        [
+            Self::CullIntersect,
+            Self::NoCullIntersect,
+            Self::CullNoIntersect,
+        ]
+        .into_iter()
     }
 
     /// Returns the benchmark group name.

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use benches::bench;
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};
 use bevy_picking::mesh_picking::ray_cast;
-use criterion::{criterion_group, BenchmarkId, Criterion};
+use criterion::{criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
 
 criterion_group!(benches, bench);
 
@@ -98,7 +98,10 @@ fn bench(c: &mut Criterion) {
     for benchmark in Benchmarks::iter() {
         let mut group = c.benchmark_group(benchmark.name());
 
-        group.warm_up_time(Benchmarks::WARM_UP_TIME);
+        group
+            .warm_up_time(Benchmarks::WARM_UP_TIME)
+            // Make the scale logarithmic, to match `VERTICES_PER_SIDE`.
+            .plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
         for vertices_per_side in Benchmarks::VERTICES_PER_SIDE {
             group.bench_with_input(

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -1,5 +1,6 @@
 use core::hint::black_box;
 
+use benches::bench;
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};
 use bevy_picking::mesh_picking::ray_cast;
 use criterion::{criterion_group, Criterion};
@@ -42,7 +43,7 @@ fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
 }
 
 fn ray_mesh_intersection(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ray_mesh_intersection");
+    let mut group = c.benchmark_group(bench!("ray_mesh_intersection"));
     group.warm_up_time(std::time::Duration::from_millis(500));
 
     for vertices_per_side in [10_u32, 100, 1000] {
@@ -66,7 +67,7 @@ fn ray_mesh_intersection(c: &mut Criterion) {
 }
 
 fn ray_mesh_intersection_no_cull(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ray_mesh_intersection_no_cull");
+    let mut group = c.benchmark_group(bench!("ray_mesh_intersection_no_cull"));
     group.warm_up_time(std::time::Duration::from_millis(500));
 
     for vertices_per_side in [10_u32, 100, 1000] {
@@ -90,7 +91,7 @@ fn ray_mesh_intersection_no_cull(c: &mut Criterion) {
 }
 
 fn ray_mesh_intersection_no_intersection(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ray_mesh_intersection_no_intersection");
+    let mut group = c.benchmark_group(bench!("ray_mesh_intersection_no_intersection"));
     group.warm_up_time(std::time::Duration::from_millis(500));
 
     for vertices_per_side in [10_u32, 100, 1000] {

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use benches::bench;
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};
-use bevy_picking::mesh_picking::ray_cast;
+use bevy_picking::mesh_picking::ray_cast::{self, Backfaces};
 use criterion::{criterion_group, AxisScale, BenchmarkId, Criterion, PlotConfiguration};
 
 criterion_group!(benches, bench);
@@ -102,10 +102,10 @@ impl Benchmarks {
         Mat4::IDENTITY
     }
 
-    fn backface_culling(&self) -> ray_cast::Backfaces {
+    fn backface_culling(&self) -> Backfaces {
         match *self {
-            Self::CullIntersect | Self::CullNoIntersect => ray_cast::Backfaces::Cull,
-            Self::NoCullIntersect => ray_cast::Backfaces::Include,
+            Self::CullIntersect | Self::CullNoIntersect => Backfaces::Cull,
+            Self::NoCullIntersect => Backfaces::Include,
         }
     }
 }

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -3,7 +3,7 @@ use core::hint::black_box;
 use benches::bench;
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};
 use bevy_picking::mesh_picking::ray_cast;
-use criterion::{criterion_group, Criterion};
+use criterion::{criterion_group, BenchmarkId, Criterion};
 
 fn ptoxznorm(p: u32, size: u32) -> (f32, f32) {
     let ij = (p / (size), p % (size));
@@ -43,74 +43,86 @@ fn mesh_creation(vertices_per_side: u32) -> SimpleMesh {
 }
 
 fn ray_mesh_intersection(c: &mut Criterion) {
-    let mut group = c.benchmark_group(bench!("ray_mesh_intersection"));
+    let mut group = c.benchmark_group(bench!("normal"));
     group.warm_up_time(std::time::Duration::from_millis(500));
 
     for vertices_per_side in [10_u32, 100, 1000] {
-        group.bench_function(format!("{}_vertices", vertices_per_side.pow(2)), |b| {
-            let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Dir3::NEG_Y);
-            let mesh_to_world = Mat4::IDENTITY;
-            let mesh = mesh_creation(vertices_per_side);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{}_vertices", vertices_per_side.pow(2))),
+            &vertices_per_side,
+            |b, &vertices_per_side| {
+                let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Dir3::NEG_Y);
+                let mesh_to_world = Mat4::IDENTITY;
+                let mesh = mesh_creation(vertices_per_side);
 
-            b.iter(|| {
-                black_box(ray_cast::ray_mesh_intersection(
-                    ray,
-                    &mesh_to_world,
-                    &mesh.positions,
-                    Some(&mesh.normals),
-                    Some(&mesh.indices),
-                    ray_cast::Backfaces::Cull,
-                ));
-            });
-        });
+                b.iter(|| {
+                    black_box(ray_cast::ray_mesh_intersection(
+                        ray,
+                        &mesh_to_world,
+                        &mesh.positions,
+                        Some(&mesh.normals),
+                        Some(&mesh.indices),
+                        ray_cast::Backfaces::Cull,
+                    ));
+                });
+            },
+        );
     }
 }
 
 fn ray_mesh_intersection_no_cull(c: &mut Criterion) {
-    let mut group = c.benchmark_group(bench!("ray_mesh_intersection_no_cull"));
+    let mut group = c.benchmark_group(bench!("no_cull"));
     group.warm_up_time(std::time::Duration::from_millis(500));
 
     for vertices_per_side in [10_u32, 100, 1000] {
-        group.bench_function(format!("{}_vertices", vertices_per_side.pow(2)), |b| {
-            let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Dir3::NEG_Y);
-            let mesh_to_world = Mat4::IDENTITY;
-            let mesh = mesh_creation(vertices_per_side);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{}_vertices", vertices_per_side.pow(2))),
+            &vertices_per_side,
+            |b, &vertices_per_side| {
+                let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Dir3::NEG_Y);
+                let mesh_to_world = Mat4::IDENTITY;
+                let mesh = mesh_creation(vertices_per_side);
 
-            b.iter(|| {
-                black_box(ray_cast::ray_mesh_intersection(
-                    ray,
-                    &mesh_to_world,
-                    &mesh.positions,
-                    Some(&mesh.normals),
-                    Some(&mesh.indices),
-                    ray_cast::Backfaces::Include,
-                ));
-            });
-        });
+                b.iter(|| {
+                    black_box(ray_cast::ray_mesh_intersection(
+                        ray,
+                        &mesh_to_world,
+                        &mesh.positions,
+                        Some(&mesh.normals),
+                        Some(&mesh.indices),
+                        ray_cast::Backfaces::Include,
+                    ));
+                });
+            },
+        );
     }
 }
 
 fn ray_mesh_intersection_no_intersection(c: &mut Criterion) {
-    let mut group = c.benchmark_group(bench!("ray_mesh_intersection_no_intersection"));
+    let mut group = c.benchmark_group(bench!("no_intersection"));
     group.warm_up_time(std::time::Duration::from_millis(500));
 
     for vertices_per_side in [10_u32, 100, 1000] {
-        group.bench_function(format!("{}_vertices", (vertices_per_side).pow(2)), |b| {
-            let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Dir3::X);
-            let mesh_to_world = Mat4::IDENTITY;
-            let mesh = mesh_creation(vertices_per_side);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{}_vertices", (vertices_per_side).pow(2))),
+            &vertices_per_side,
+            |b, &vertices_per_side| {
+                let ray = Ray3d::new(Vec3::new(0.0, 1.0, 0.0), Dir3::X);
+                let mesh_to_world = Mat4::IDENTITY;
+                let mesh = mesh_creation(vertices_per_side);
 
-            b.iter(|| {
-                black_box(ray_cast::ray_mesh_intersection(
-                    ray,
-                    &mesh_to_world,
-                    &mesh.positions,
-                    Some(&mesh.normals),
-                    Some(&mesh.indices),
-                    ray_cast::Backfaces::Cull,
-                ));
-            });
-        });
+                b.iter(|| {
+                    black_box(ray_cast::ray_mesh_intersection(
+                        ray,
+                        &mesh_to_world,
+                        &mesh.positions,
+                        Some(&mesh.normals),
+                        Some(&mesh.indices),
+                        ray_cast::Backfaces::Cull,
+                    ));
+                });
+            },
+        );
     }
 }
 

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -65,13 +65,13 @@ fn create_mesh(vertices_per_side: u32) -> SimpleMesh {
 /// benchmarks.
 enum Benchmarks {
     /// The ray intersects the mesh, and culling is enabled.
-    CullIntersect,
+    CullHit,
 
     /// The ray intersects the mesh, and culling is disabled.
-    NoCullIntersect,
+    NoCullHit,
 
     /// The ray does not intersect the mesh, and culling is enabled.
-    CullNoIntersect,
+    CullMiss,
 }
 
 impl Benchmarks {
@@ -81,9 +81,9 @@ impl Benchmarks {
     /// Returns an iterator over every variant in this enum.
     fn iter() -> impl Iterator<Item = Self> {
         [
-            Self::CullIntersect,
-            Self::NoCullIntersect,
-            Self::CullNoIntersect,
+            Self::CullHit,
+            Self::NoCullHit,
+            Self::CullMiss,
         ]
         .into_iter()
     }
@@ -91,9 +91,9 @@ impl Benchmarks {
     /// Returns the benchmark group name.
     fn name(&self) -> &'static str {
         match *self {
-            Self::CullIntersect => bench!("cull_intersect"),
-            Self::NoCullIntersect => bench!("no_cull_intersect"),
-            Self::CullNoIntersect => bench!("cull_no_intersect"),
+            Self::CullHit => bench!("cull_intersect"),
+            Self::NoCullHit => bench!("no_cull_intersect"),
+            Self::CullMiss => bench!("cull_no_intersect"),
         }
     }
 
@@ -101,9 +101,9 @@ impl Benchmarks {
         Ray3d::new(
             Vec3::new(0.0, 1.0, 0.0),
             match *self {
-                Self::CullIntersect | Self::NoCullIntersect => Dir3::NEG_Y,
+                Self::CullHit | Self::NoCullHit => Dir3::NEG_Y,
                 // `NoIntersection` should not hit the mesh, so it goes an orthogonal direction.
-                Self::CullNoIntersect => Dir3::X,
+                Self::CullMiss => Dir3::X,
             },
         )
     }
@@ -114,8 +114,8 @@ impl Benchmarks {
 
     fn backface_culling(&self) -> Backfaces {
         match *self {
-            Self::CullIntersect | Self::CullNoIntersect => Backfaces::Cull,
-            Self::NoCullIntersect => Backfaces::Include,
+            Self::CullHit | Self::CullMiss => Backfaces::Cull,
+            Self::NoCullHit => Backfaces::Include,
         }
     }
 }

--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -64,9 +64,9 @@ fn create_mesh(vertices_per_side: u32) -> SimpleMesh {
 /// An enum that represents the configuration for all variations of the ray mesh intersection
 /// benchmarks.
 enum Benchmarks {
-    Normal,
-    NoCull,
-    NoIntersection,
+    CullIntersect,
+    NoCullIntersect,
+    CullNoIntersect,
 }
 
 impl Benchmarks {
@@ -75,15 +75,15 @@ impl Benchmarks {
 
     /// Returns an iterator over every variant in this enum.
     fn iter() -> impl Iterator<Item = Self> {
-        [Self::Normal, Self::NoCull, Self::NoIntersection].into_iter()
+        [Self::CullIntersect, Self::NoCullIntersect, Self::CullNoIntersect].into_iter()
     }
 
     /// Returns the benchmark group name.
     fn name(&self) -> &'static str {
         match *self {
-            Self::Normal => bench!("normal"),
-            Self::NoCull => bench!("no_cull"),
-            Self::NoIntersection => bench!("no_intersection"),
+            Self::CullIntersect => bench!("cull_intersect"),
+            Self::NoCullIntersect => bench!("no_cull_intersect"),
+            Self::CullNoIntersect => bench!("cull_no_intersect"),
         }
     }
 
@@ -91,9 +91,9 @@ impl Benchmarks {
         Ray3d::new(
             Vec3::new(0.0, 1.0, 0.0),
             match *self {
-                Self::Normal | Self::NoCull => Dir3::NEG_Y,
+                Self::CullIntersect | Self::NoCullIntersect => Dir3::NEG_Y,
                 // `NoIntersection` should not hit the mesh, so it goes an orthogonal direction.
-                Self::NoIntersection => Dir3::X,
+                Self::CullNoIntersect => Dir3::X,
             },
         )
     }
@@ -104,8 +104,8 @@ impl Benchmarks {
 
     fn backface_culling(&self) -> ray_cast::Backfaces {
         match *self {
-            Self::Normal | Self::NoIntersection => ray_cast::Backfaces::Cull,
-            Self::NoCull => ray_cast::Backfaces::Include,
+            Self::CullIntersect | Self::CullNoIntersect => ray_cast::Backfaces::Cull,
+            Self::NoCullIntersect => ray_cast::Backfaces::Include,
         }
     }
 }


### PR DESCRIPTION
# Objective

- Part of #16647.
- This PR goes through our `ray_cast::ray_mesh_intersection()` benchmarks and overhauls them with more comments and better extensibility. The code is also a lot less duplicated!

## Solution

- Create a `Benchmarks` enum that describes all of the different kind of scenarios we want to benchmark.
- Merge all of our existing benchmark functions into a single one, `bench()`, which sets up the scenarios all at once.
- Add comments to `mesh_creation()` and `ptoxznorm()`, and move some lines around to be a bit clearer.
- Make the benchmarks use the new `bench!` macro, as part of #16647.
- Rename many functions and benchmarks to be clearer.

## For reviewers

I split this PR up into several, easier to digest commits. You might find it easier to review by looking through each commit, instead of the complete file changes.

None of my changes actually modifies the behavior of the benchmarks; they still track the exact same test cases. There shouldn't be significant changes in benchmark performance before and after this PR.

## Testing

List all picking benchmarks: `cargo bench -p benches --bench picking -- --list`

Run the benchmarks once in debug mode: `cargo test -p benches --bench picking`

Run the benchmarks and analyze their performance: `cargo bench -p benches --bench picking`

- Check out the generated HTML report in `./target/criterion/report/index.html` once you're done!

---

## Showcase

List of all picking benchmarks, after having been renamed:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/a1b53daf-4a8b-4c45-a25a-c6306c7175d1" />

Example report for `picking::ray_mesh_intersection::cull_intersect/100_vertices`:

<img width="992" alt="image" src="https://github.com/user-attachments/assets/a1aaf53f-ce21-4bef-89c4-b982bb158f5d" />
