### PR TITLE
Make 8 methods public and updated input parameter generics for SystemState::build_system_with_input

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1272,28 +1272,28 @@ impl<T: SparseSetIndex> FilteredAccessSet<T> {
     }
 
     /// Adds a read access to a resource to the set.
-    pub(crate) fn add_unfiltered_resource_read(&mut self, index: T) {
+    pub fn add_unfiltered_resource_read(&mut self, index: T) {
         let mut filter = FilteredAccess::default();
         filter.add_resource_read(index);
         self.add(filter);
     }
 
     /// Adds a write access to a resource to the set.
-    pub(crate) fn add_unfiltered_resource_write(&mut self, index: T) {
+    pub fn add_unfiltered_resource_write(&mut self, index: T) {
         let mut filter = FilteredAccess::default();
         filter.add_resource_write(index);
         self.add(filter);
     }
 
     /// Adds read access to all resources to the set.
-    pub(crate) fn add_unfiltered_read_all_resources(&mut self) {
+    pub fn add_unfiltered_read_all_resources(&mut self) {
         let mut filter = FilteredAccess::default();
         filter.access.read_all_resources();
         self.add(filter);
     }
 
     /// Adds write access to all resources to the set.
-    pub(crate) fn add_unfiltered_write_all_resources(&mut self) {
+    pub fn add_unfiltered_write_all_resources(&mut self) {
         let mut filter = FilteredAccess::default();
         filter.access.write_all_resources();
         self.add(filter);

--- a/crates/bevy_ecs/src/schedule/graph/graph_map.rs
+++ b/crates/bevy_ecs/src/schedule/graph/graph_map.rs
@@ -125,7 +125,7 @@ where
     /// For a directed graph, the edge is directed from `a` to `b`.
     ///
     /// Inserts nodes `a` and/or `b` if they aren't already part of the graph.
-    pub(crate) fn add_edge(&mut self, a: NodeId, b: NodeId) {
+    pub fn add_edge(&mut self, a: NodeId, b: NodeId) {
         if self.edges.insert(Self::edge_key(a, b)) {
             // insert in the adjacency list if it's a new edge
             self.nodes

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -476,7 +476,7 @@ impl<Param: SystemParam> SystemState<Param> {
 
     /// Gets the metadata for this instance.
     #[inline]
-    pub unsafe fn meta_mut(&mut self) -> &mut SystemMeta {
+    pub fn meta_mut(&mut self) -> &mut SystemMeta {
         &mut self.meta
     }
 
@@ -659,6 +659,10 @@ impl<Param: SystemParam> SystemState<Param> {
     /// Returns a mutable reference to the current system param states.
     /// Marked as unsafe because modifying the system states may result in violation to certain
     /// assumptions made by the [`SystemParam`]. Use with care.
+    /// 
+    /// Safety: Modifying the system param states may have unintented consequences.
+    /// the param state is generally considered to be owned by the [`SystemParam`]. Modifications
+    /// should respect any invariants as required by the [`SystemParam`].
     pub unsafe fn param_state_mut(&mut self) -> &mut Param::State {
         &mut self.param_state
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -474,6 +474,13 @@ impl<Param: SystemParam> SystemState<Param> {
         &self.meta
     }
 
+
+    /// Gets the metadata for this instance.
+    #[inline]
+    pub unsafe fn meta_mut(&mut self) -> &mut SystemMeta {
+        &mut self.meta
+    }
+
     /// Retrieve the [`SystemParam`] values. This can only be called when all parameters are read-only.
     #[inline]
     pub fn get<'w, 's>(&'s mut self, world: &'w World) -> SystemParamItem<'w, 's, Param>

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -396,7 +396,7 @@ macro_rules! impl_build_system {
                 Input: SystemInput,
                 Out: 'static,
                 Marker,
-                F: FnMut(In<Input>, $(SystemParamItem<$param>),*) -> Out
+                F: FnMut(Input, $(SystemParamItem<$param>),*) -> Out
                     + SystemParamFunction<Marker, Param = ($($param,)*), In = Input, Out = Out>,
             >(
                 self,
@@ -643,6 +643,18 @@ impl<Param: SystemParam> SystemState<Param> {
             unsafe { Param::get_param(&mut self.param_state, &self.meta, world, change_tick) };
         self.meta.last_run = change_tick;
         param
+    }
+
+    /// Returns a reference to the current system param states.
+    pub fn param_state(&self) -> &Param::State {
+        &self.param_state
+    }
+    
+    /// Returns a mutable reference to the current system param states.
+    /// Marked as unsafe because modifying the system states may result in violation to certain
+    /// assumptions made by the [`SystemParam`]. Use with care.
+    pub unsafe fn param_state_mut(&mut self) -> &mut Param::State {
+        &mut self.param_state
     }
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -660,8 +660,9 @@ impl<Param: SystemParam> SystemState<Param> {
     /// Marked as unsafe because modifying the system states may result in violation to certain
     /// assumptions made by the [`SystemParam`]. Use with care.
     ///
-    /// Safety: Modifying the system param states may have unintended consequences.
-    /// the param state is generally considered to be owned by the [`SystemParam`]. Modifications
+    /// # Safety
+    /// Modifying the system param states may have unintended consequences.
+    /// The param state is generally considered to be owned by the [`SystemParam`]. Modifications
     /// should respect any invariants as required by the [`SystemParam`].
     pub unsafe fn param_state_mut(&mut self) -> &mut Param::State {
         &mut self.param_state

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -664,6 +664,8 @@ impl<Param: SystemParam> SystemState<Param> {
     /// Modifying the system param states may have unintended consequences.
     /// The param state is generally considered to be owned by the [`SystemParam`]. Modifications
     /// should respect any invariants as required by the [`SystemParam`].
+    /// For example, modifying the system state of [`ResMut`](crate::system::ResMut) without also
+    /// updating [`SystemMeta::component_access_set`] will obviously create issues.
     pub unsafe fn param_state_mut(&mut self) -> &mut Param::State {
         &mut self.param_state
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -474,7 +474,6 @@ impl<Param: SystemParam> SystemState<Param> {
         &self.meta
     }
 
-
     /// Gets the metadata for this instance.
     #[inline]
     pub unsafe fn meta_mut(&mut self) -> &mut SystemMeta {
@@ -656,7 +655,7 @@ impl<Param: SystemParam> SystemState<Param> {
     pub fn param_state(&self) -> &Param::State {
         &self.param_state
     }
-    
+
     /// Returns a mutable reference to the current system param states.
     /// Marked as unsafe because modifying the system states may result in violation to certain
     /// assumptions made by the [`SystemParam`]. Use with care.

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -659,8 +659,8 @@ impl<Param: SystemParam> SystemState<Param> {
     /// Returns a mutable reference to the current system param states.
     /// Marked as unsafe because modifying the system states may result in violation to certain
     /// assumptions made by the [`SystemParam`]. Use with care.
-    /// 
-    /// Safety: Modifying the system param states may have unintented consequences.
+    ///
+    /// Safety: Modifying the system param states may have unintended consequences.
     /// the param state is generally considered to be owned by the [`SystemParam`]. Modifications
     /// should respect any invariants as required by the [`SystemParam`].
     pub unsafe fn param_state_mut(&mut self) -> &mut Param::State {
@@ -678,7 +678,7 @@ impl<Param: SystemParam> FromWorld for SystemState<Param> {
 ///
 /// You get this by calling [`IntoSystem::into_system`]  on a function that only accepts
 /// [`SystemParam`]s. The output of the system becomes the functions return type, while the input
-/// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
+/// becomes the functions first parameter or `()` if no such parameter exists.
 ///
 /// [`FunctionSystem`] must be `.initialized` before they can be run.
 ///

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -18,7 +18,7 @@ use variadics_please::all_tuples;
 #[cfg(feature = "trace")]
 use tracing::{info_span, Span};
 
-use super::{In, IntoSystem, ReadOnlySystem, SystemParamBuilder};
+use super::{IntoSystem, ReadOnlySystem, SystemParamBuilder};
 
 /// The metadata of a [`System`].
 #[derive(Clone)]


### PR DESCRIPTION
# Objective

- Made certain methods public for advanced use cases. Methods that returns mutable references are marked as unsafe due to the possibility of violating internal lifetime constraint assumptions.
- Fixes an issue introduced by #15184
