### PR TITLE
System Yielding

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -386,4 +386,92 @@ mod tests {
         assert!(world.get_resource::<R1>().is_none());
         assert!(world.get_resource::<R2>().is_none());
     }
+
+    #[test]
+    fn system_yielding() {
+        for executor in [
+            ExecutorKind::Simple,
+            ExecutorKind::SingleThreaded,
+            ExecutorKind::MultiThreaded,
+        ] {
+            system_yielding_core(executor);
+        }
+    }
+
+    fn system_yielding_core(executor: ExecutorKind) {
+        use crate::system::{System, SystemMeta};
+        use core::sync::atomic::{AtomicU32, Ordering};
+        use alloc::sync::Arc;
+        let mut world = World::new();
+        let mut schedule = Schedule::default();
+        schedule.set_executor_kind(executor);
+        struct MySystem {
+            count: Arc<AtomicU32>,
+            system_meta: SystemMeta,
+        }
+        impl System for MySystem {
+            type In = ();
+            type Out = ();
+            fn name(&self) -> alloc::borrow::Cow<'static, str> {
+                core::any::type_name::<Self>().into()
+            }
+            fn component_access(&self) -> &crate::query::Access<crate::component::ComponentId> {
+                self.system_meta.component_access_set.combined_access()
+            }
+            fn archetype_component_access(
+                &self,
+            ) -> &crate::query::Access<crate::archetype::ArchetypeComponentId> {
+                &self.system_meta.archetype_component_access
+            }
+            fn is_send(&self) -> bool {
+                true
+            }
+            fn is_exclusive(&self) -> bool {
+                false
+            }
+            fn has_deferred(&self) -> bool {
+                false
+            }
+            unsafe fn run_unsafe(
+                &mut self,
+                _input: crate::prelude::SystemIn<'_, Self>,
+                _world: crate::world::unsafe_world_cell::UnsafeWorldCell,
+            ) -> Self::Out {
+                self.count.fetch_add(1, Ordering::Relaxed);
+            }
+            fn apply_deferred(&mut self, _world: &mut World) {}
+            fn queue_deferred(&mut self, _world: crate::world::DeferredWorld) {}
+            unsafe fn validate_param_unsafe(
+                &mut self,
+                _world: crate::world::unsafe_world_cell::UnsafeWorldCell,
+            ) -> bool {
+                true
+            }
+            fn initialize(&mut self, _world: &mut World) {}
+            fn update_archetype_component_access(
+                &mut self,
+                _world: crate::world::unsafe_world_cell::UnsafeWorldCell,
+            ) {
+            }
+            fn check_change_tick(&mut self, _change_tick: crate::component::Tick) {}
+            fn get_last_run(&self) -> crate::component::Tick {
+                self.system_meta.last_run
+            }
+
+            fn set_last_run(&mut self, last_run: crate::component::Tick) {
+                self.system_meta.last_run = last_run;
+            }
+            fn yielded(&self) -> bool {
+                self.count.load(Ordering::Relaxed) < 3
+            }
+        }
+        schedule.configure_sets(S1.run_if((|_: Res<R1>| true).param_warn_once()));
+        let count = Arc::new(AtomicU32::new(0));
+        schedule.add_systems(MySystem {
+            count: count.clone(),
+            system_meta: SystemMeta::new::<MySystem>(),
+        });
+        schedule.run(&mut world);
+        assert_eq!(count.load(Ordering::Relaxed), 3);
+    }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -79,6 +79,7 @@ struct SystemTaskMetadata {
 /// The result of running a system that is sent across a channel.
 struct SystemResult {
     system_index: usize,
+    yielded: bool,
 }
 
 /// Runs the schedule using a thread pool. Non-conflicting systems can run in parallel.
@@ -277,7 +278,10 @@ impl<'scope, 'env: 'scope, 'sys> Context<'scope, 'env, 'sys> {
         self.environment
             .executor
             .system_completion
-            .push(SystemResult { system_index })
+            .push(SystemResult {
+                system_index,
+                yielded: system.yielded(),
+            })
             .unwrap_or_else(|error| unreachable!("{}", error));
         if let Err(payload) = res {
             eprintln!("Encountered a panic in system `{}`!", &*system.name());
@@ -679,7 +683,10 @@ impl ExecutorState {
     }
 
     fn finish_system_and_handle_dependents(&mut self, result: SystemResult) {
-        let SystemResult { system_index, .. } = result;
+        let SystemResult {
+            system_index,
+            yielded,
+        } = result;
 
         if self.system_task_metadata[system_index].is_exclusive {
             self.exclusive_running = false;
@@ -692,10 +699,15 @@ impl ExecutorState {
         debug_assert!(self.num_running_systems >= 1);
         self.num_running_systems -= 1;
         self.running_systems.remove(system_index);
-        self.completed_systems.insert(system_index);
-        self.unapplied_systems.insert(system_index);
 
-        self.signal_dependents(system_index);
+        if yielded {
+            self.ready_systems.insert(system_index);
+        } else {
+            self.completed_systems.insert(system_index);
+            self.unapplied_systems.insert(system_index);
+
+            self.signal_dependents(system_index);
+        }
     }
 
     fn skip_system_and_signal_dependents(&mut self, system_index: usize) {

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -48,7 +48,8 @@ impl SystemExecutor for SimpleExecutor {
             self.completed_systems |= skipped_systems;
         }
 
-        for system_index in 0..schedule.systems.len() {
+        let mut system_index: usize = 0;
+        while system_index < schedule.systems.len() {
             #[cfg(feature = "trace")]
             let name = schedule.systems[system_index].name();
             #[cfg(feature = "trace")]
@@ -92,10 +93,12 @@ impl SystemExecutor for SimpleExecutor {
             self.completed_systems.insert(system_index);
 
             if !should_run {
+                system_index += 1;
                 continue;
             }
 
             if is_apply_deferred(system) {
+                system_index += 1;
                 continue;
             }
 
@@ -121,6 +124,12 @@ impl SystemExecutor for SimpleExecutor {
             #[cfg(not(feature = "std"))]
             {
                 (f)();
+            }
+
+            if system.yielded() {
+                self.completed_systems.remove(system_index);
+            } else {
+                system_index += 1;
             }
         }
 

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -54,7 +54,8 @@ impl SystemExecutor for SingleThreadedExecutor {
             self.completed_systems |= skipped_systems;
         }
 
-        for system_index in 0..schedule.systems.len() {
+        let mut system_index: usize = 0;
+        while system_index < schedule.systems.len() {
             #[cfg(feature = "trace")]
             let name = schedule.systems[system_index].name();
             #[cfg(feature = "trace")]
@@ -98,11 +99,13 @@ impl SystemExecutor for SingleThreadedExecutor {
             self.completed_systems.insert(system_index);
 
             if !should_run {
+                system_index += 1;
                 continue;
             }
 
             if is_apply_deferred(system) {
                 self.apply_deferred(schedule, world);
+                system_index += 1;
                 continue;
             }
 
@@ -148,7 +151,12 @@ impl SystemExecutor for SingleThreadedExecutor {
                 (f)();
             }
 
-            self.unapplied_systems.insert(system_index);
+            if system.yielded() {
+                self.completed_systems.remove(system_index);
+            } else {
+                self.unapplied_systems.insert(system_index);
+                system_index += 1;
+            }
         }
 
         if self.apply_final_deferred {

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -208,6 +208,10 @@ where
     fn set_last_run(&mut self, last_run: crate::component::Tick) {
         self.system.set_last_run(last_run);
     }
+
+    fn yielded(&self) -> bool {
+        self.system.yielded()
+    }
 }
 
 // SAFETY: The inner system is read-only.

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -253,6 +253,14 @@ where
         self.a.set_last_run(last_run);
         self.b.set_last_run(last_run);
     }
+
+    fn yielded(&self) -> bool {
+        assert!(
+            !self.a.yielded() && !self.b.yielded(),
+            "Combined systems cannot yield"
+        );
+        false
+    }
 }
 
 /// SAFETY: Both systems are read-only, so any system created by combining them will only read from the world.
@@ -475,6 +483,14 @@ where
     fn set_last_run(&mut self, last_run: Tick) {
         self.a.set_last_run(last_run);
         self.b.set_last_run(last_run);
+    }
+
+    fn yielded(&self) -> bool {
+        assert!(
+            !self.a.yielded() && !self.b.yielded(),
+            "Piped systems cannot yield"
+        );
+        false
     }
 }
 

--- a/crates/bevy_ecs/src/system/schedule_system.rs
+++ b/crates/bevy_ecs/src/system/schedule_system.rs
@@ -114,6 +114,11 @@ impl<S: System<In = (), Out = ()>> System for InfallibleSystemWrapper<S> {
     fn default_system_sets(&self) -> Vec<crate::schedule::InternedSystemSet> {
         self.0.default_system_sets()
     }
+
+    #[inline(always)]
+    fn yielded(&self) -> bool {
+        self.0.yielded()
+    }
 }
 
 /// Type alias for a `BoxedSystem` that a `Schedule` can store.

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -163,6 +163,27 @@ pub trait System: Send + Sync + 'static {
     /// However, it can be an essential escape hatch when, for example,
     /// you are trying to synchronize representations using change detection and need to avoid infinite recursion.
     fn set_last_run(&mut self, last_run: Tick);
+
+    /// This method is designed to be called by the ECS scheduler to determine if a system should continue to be executed
+    /// repeatedly.
+    ///
+    /// - `yielded()` will be called by the scheduler immediately after [`System::run_unsafe`] has been executed.
+    /// - If `yielded()` returns true, the scheduler will schedule this system for execution again
+    ///   after all other systems currently scheduled for execution have been completed
+    /// - While `yielded()` returns true, the system will be executed continuously until it returns false. Dependent systems
+    ///   will not be scheduled for execution.
+    /// - If `yielded()` returns false, the scheduler will stop scheduling this system and proceed to
+    ///   schedule any dependent systems.
+    ///
+    /// This allows for custom implementations of the [`System`] trait to control their own execution flow and
+    /// block dependent systems when the conditions for execution have not been met, or where the same system need
+    /// to be scheduled for execution multiple times per frame.
+    ///
+    /// Careful consideration should be given to the potential for deadlocks when using this mechanism to ensure that
+    /// systems that yield do not indefinitely block other systems from executing.
+    fn yielded(&self) -> bool {
+        false
+    }
 }
 
 /// [`System`] types that do not modify the [`World`] when run.


### PR DESCRIPTION
# Objective

- In some cases, systems may not be immediately ready for execution due to unmet constraints. For example, the execution of a certain system may be dependent upon the completion of an asynchronous GPU submission. 
- In those cases, we may not want to skip the execution of this system for the current frame altogether. Instead, we would like to **defer** the execution of this system without violating system dependencies. We schedule all other systems first, and once we're done, we come back and pick up where we left off.
- This is also particularly useful for the scheduling of **async systems**. We can create a system wrapper that wraps an async system. Each time the system gets scheduled, we call `poll` on the future. And we don't mark the system as completed until the future returns `Poll::Ready`.

## Solution

- Added a new method, `yielded`, on the `System` trait. If `yielded` returns true, the scheduler defer the execution of the system until all other currently ready systems have completed execution.
- Maybe `pending` is a better name for this method?

## Testing

Added new unit tests. Also tested as a part of a custom implementation of a Vulkan-based rendering backend that returns GPUFutures.

## Draft Release Notes


System Deferral: Introduced a new mechanism in the ECS scheduler to defer the execution of systems. This allows systems to temporarily defer their execution by allowing the scheduler to execute other systems first. This is useful in cases where the execution of a system is dependent upon the completion of an asynchronous operation. It is also useful for implementing asynchronous systems.