### PR TITLE
`get_glyph_atlas_info` refactor

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -179,22 +179,15 @@ impl FontAtlasSet {
         self.font_atlases
             .get(&FontAtlasKey(cache_key.font_size_bits, font_smoothing))
             .and_then(|font_atlases| {
-                font_atlases
-                    .iter()
-                    .find_map(|atlas| {
-                        atlas.get_glyph_index(cache_key).map(|location| {
-                            (
-                                location,
-                                atlas.texture_atlas.clone_weak(),
-                                atlas.texture.clone_weak(),
-                            )
+                font_atlases.iter().find_map(|atlas| {
+                    atlas
+                        .get_glyph_index(cache_key)
+                        .map(|location| GlyphAtlasInfo {
+                            location,
+                            texture_atlas: atlas.texture_atlas.clone_weak(),
+                            texture: atlas.texture.clone_weak(),
                         })
-                    })
-                    .map(|(location, texture_atlas, texture)| GlyphAtlasInfo {
-                        texture_atlas,
-                        location,
-                        texture,
-                    })
+                })
             })
     }
 


### PR DESCRIPTION
# Objective

Return a `GlyphAtlasInfo` instead of a tuple from the inner block so we can remove the outer mapping.