### PR TITLE
`prepare_sprite_image_bind_groups` refactor

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -670,8 +670,7 @@ pub fn prepare_sprite_image_bind_groups(
                 continue;
             };
 
-            let batch_image_changed = batch_image_handle != extracted_sprite.image_handle_id;
-            if batch_image_changed {
+            if batch_image_handle != extracted_sprite.image_handle_id {
                 let Some(gpu_image) = gpu_images.get(extracted_sprite.image_handle_id) else {
                     continue;
                 };
@@ -691,6 +690,15 @@ pub fn prepare_sprite_image_bind_groups(
                             )),
                         )
                     });
+
+                batch_item_index = item_index;
+                batches.push((
+                    item.entity(),
+                    SpriteBatch {
+                        image_handle_id: batch_image_handle,
+                        range: index..index,
+                    },
+                ));
             }
 
             // By default, the size of the quad is the size of the texture
@@ -741,18 +749,6 @@ pub fn prepare_sprite_image_bind_groups(
                     &extracted_sprite.color,
                     &uv_offset_scale,
                 ));
-
-            if batch_image_changed {
-                batch_item_index = item_index;
-
-                batches.push((
-                    item.entity(),
-                    SpriteBatch {
-                        image_handle_id: batch_image_handle,
-                        range: index..index,
-                    },
-                ));
-            }
 
             transparent_phase.items[batch_item_index]
                 .batch_range_mut()


### PR DESCRIPTION
# Objective

In `prepare_sprite_image_bind_groups` the `batch_image_changed` condition is checked twice but the second if-block seems unnecessary.

# Solution

Queue new `SpriteBatch`es inside the first if-block and remove the second if-block.