### PR TITLE
`many_glyphs` `no-ui` and `no-text2d` commandline arguments

### DIFF
--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -5,6 +5,7 @@
 //!
 //! To recompute all text each frame run
 //! `cargo run --example many_glyphs --release recompute-text`
+use argh::FromArgs;
 use bevy::{
     color::palettes::basic::RED,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -14,7 +15,29 @@ use bevy::{
     winit::{UpdateMode, WinitSettings},
 };
 
+#[derive(FromArgs, Resource)]
+/// `many_glyphs` stress test
+struct Args {
+    /// don't draw the UI text.
+    #[argh(switch)]
+    no_ui: bool,
+
+    /// don't draw the Text2d text.
+    #[argh(switch)]
+    no_text2d: bool,
+
+    /// whether to force the text to recompute every frame by triggering change detection.
+    #[argh(switch)]
+    recompute_text: bool,
+}
+
 fn main() {
+    // `from_env` panics on the web
+    #[cfg(not(target_arch = "wasm32"))]
+    let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
     let mut app = App::new();
     app.add_plugins((
         DefaultPlugins.set(WindowPlugin {
@@ -34,14 +57,14 @@ fn main() {
     })
     .add_systems(Startup, setup);
 
-    if std::env::args().any(|arg| arg == "recompute-text") {
+    if args.recompute_text {
         app.add_systems(Update, force_text_recomputation);
     }
 
-    app.run();
+    app.insert_resource(args).run();
 }
 
-fn setup(mut commands: Commands) {
+fn setup(mut commands: Commands, args: Res<Args>) {
     warn!(include_str!("warning_string.txt"));
 
     commands.spawn(Camera2d);
@@ -55,29 +78,34 @@ fn setup(mut commands: Commands) {
         linebreak: LineBreak::AnyCharacter,
     };
 
-    commands
-        .spawn(Node {
-            width: Val::Percent(100.),
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
-            ..default()
-        })
-        .with_children(|commands| {
-            commands
-                .spawn(Node {
-                    width: Val::Px(1000.),
-                    ..Default::default()
-                })
-                .with_child((Text(text_string.clone()), text_font.clone(), text_block));
-        });
+    if !args.no_ui {
+        commands
+            .spawn(Node {
+                width: Val::Percent(100.),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            })
+            .with_children(|commands| {
+                commands
+                    .spawn(Node {
+                        width: Val::Px(1000.),
+                        ..Default::default()
+                    })
+                    .with_child((Text(text_string.clone()), text_font.clone(), text_block));
+            });
+    }
 
-    commands.spawn((
-        Text2d::new(text_string),
-        TextColor(RED.into()),
-        bevy::sprite::Anchor::Center,
-        TextBounds::new_horizontal(1000.),
-        text_block,
-    ));
+    if !args.no_text2d {
+        commands.spawn((
+            Text2d::new(text_string),
+            text_font.clone(),
+            TextColor(RED.into()),
+            bevy::sprite::Anchor::Center,
+            TextBounds::new_horizontal(1000.),
+            text_block,
+        ));
+    }
 }
 
 fn force_text_recomputation(mut text_query: Query<&mut TextLayout>) {


### PR DESCRIPTION
# Objective

Add commandline options to `many_glyphs` to disable the `Text2d` or `UI` text for more targeted benching.

## Solution
* Use `Argh` to manage the commandline options for `many_glyphs`.
* Added `no-ui` and `no-text2d` commandline options.