### PR TITLE
Do not lowercase asset file extensions

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -454,7 +454,7 @@ impl<'a> AssetPath<'a> {
     pub fn get_full_extension(&self) -> Option<String> {
         let file_name = self.path().file_name()?.to_str()?;
         let index = file_name.find('.')?;
-        let mut extension = file_name[index + 1..].to_lowercase();
+        let mut extension = file_name[index + 1..].to_owned();
 
         // Strip off any query parameters
         let query = extension.find('?');
@@ -972,5 +972,8 @@ mod tests {
 
         let result = AssetPath::from("http://a.tar.bz2?foo=bar#Baz");
         assert_eq!(result.get_full_extension(), Some("tar.bz2".to_string()));
+
+        let result = AssetPath::from("asset.Custom");
+        assert_eq!(result.get_full_extension(), Some("Custom".to_string()));
     }
 }


### PR DESCRIPTION
# Objective

Resolves #17064

## Solution

- Bevy no longer converts asset file extensions to lowercase before trying to resolve an asset loader

## Testing

- I adapted the `custom_asset` example (see comment in #17064)
- The changes were tested on Linux

As far as I know, Windows has a case-insensitive file system by default, so case-sensitive asset file extensions are probably bad practice in a game. But we should be case-sensitive everywhere or handle asset paths completely case-insensitive. 

Before this PR:
* asset loader extensions are case-sensitive
* asset file names are case-sensitive
* asset file extensions are converted to lowercase :zap: 

Now everything should be case-sensitive
