### PR TITLE
reduce nesting in the `sparse_set` module

### DIFF
--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -50,7 +50,7 @@ macro_rules! impl_sparse_array {
             #[inline]
             pub fn contains(&self, index: I) -> bool {
                 let index = index.sparse_set_index();
-                self.values.get(index).and_then(Option::as_ref).is_some()
+                self.values.get(index).is_some_and(|v| v.is_some())
             }
 
             /// Returns a reference to the value at `index`.

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -50,7 +50,7 @@ macro_rules! impl_sparse_array {
             #[inline]
             pub fn contains(&self, index: I) -> bool {
                 let index = index.sparse_set_index();
-                self.values.get(index).is_some_and(|v| v.is_some())
+                self.values.get(index).is_some_and(Option::is_some)
             }
 
             /// Returns a reference to the value at `index`.

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -50,7 +50,7 @@ macro_rules! impl_sparse_array {
             #[inline]
             pub fn contains(&self, index: I) -> bool {
                 let index = index.sparse_set_index();
-                self.values.get(index).map(|v| v.is_some()).unwrap_or(false)
+                self.values.get(index).and_then(Option::as_ref).is_some()
             }
 
             /// Returns a reference to the value at `index`.
@@ -59,7 +59,7 @@ macro_rules! impl_sparse_array {
             #[inline]
             pub fn get(&self, index: I) -> Option<&V> {
                 let index = index.sparse_set_index();
-                self.values.get(index).map(|v| v.as_ref()).unwrap_or(None)
+                self.values.get(index).and_then(Option::as_ref)
             }
         }
     };
@@ -87,10 +87,7 @@ impl<I: SparseSetIndex, V> SparseArray<I, V> {
     #[inline]
     pub fn get_mut(&mut self, index: I) -> Option<&mut V> {
         let index = index.sparse_set_index();
-        self.values
-            .get_mut(index)
-            .map(|v| v.as_mut())
-            .unwrap_or(None)
+        self.values.get_mut(index).and_then(Option::as_mut)
     }
 
     /// Removes and returns the value stored at `index`.


### PR DESCRIPTION
# Objective

Just being fussy but I hate this `.map(|v| v.is_some()).unwrap_or(false)` stuff.

## Solution
Reduce it using `and_then`.