### PR TITLE
Replace `map` + `unwrap_or(false)` with `is_some_and`

### DIFF
--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -126,8 +126,7 @@ impl Animatable for bool {
     fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
         inputs
             .max_by_key(|x| FloatOrd(x.weight))
-            .map(|input| input.value)
-            .unwrap_or(false)
+            .is_some_and(|input| input.value)
     }
 }
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -254,8 +254,7 @@ impl PluginGroupBuilder {
     pub fn enabled<T: Plugin>(&self) -> bool {
         self.plugins
             .get(&TypeId::of::<T>())
-            .map(|e| e.enabled)
-            .unwrap_or(false)
+            .is_some_and(|e| e.enabled)
     }
 
     /// Finds the index of a target [`Plugin`].

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -54,10 +54,7 @@ pub(crate) fn get_asset_path(root: &Path, absolute_path: &Path) -> (PathBuf, boo
             root.display()
         )
     });
-    let is_meta = relative_path
-        .extension()
-        .map(|e| e == "meta")
-        .unwrap_or(false);
+    let is_meta = relative_path.extension().is_some_and(|e| e == "meta");
     let asset_path = if is_meta {
         relative_path.with_extension("")
     } else {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1877,12 +1877,11 @@ impl World {
         self.storages
             .resources
             .get(component_id)
-            .and_then(|resource| {
-                resource
-                    .get_ticks()
-                    .map(|ticks| ticks.is_added(self.last_change_tick(), self.read_change_tick()))
+            .is_some_and(|resource| {
+                resource.get_ticks().is_some_and(|ticks| {
+                    ticks.is_added(self.last_change_tick(), self.read_change_tick())
+                })
             })
-            .unwrap_or(false)
     }
 
     /// Returns `true` if a resource of type `R` exists and was modified since the world's
@@ -1895,8 +1894,7 @@ impl World {
     pub fn is_resource_changed<R: Resource>(&self) -> bool {
         self.components
             .get_resource_id(TypeId::of::<R>())
-            .map(|component_id| self.is_resource_changed_by_id(component_id))
-            .unwrap_or(false)
+            .is_some_and(|component_id| self.is_resource_changed_by_id(component_id))
     }
 
     /// Returns `true` if a resource with id `component_id` exists and was modified since the world's
@@ -1910,12 +1908,11 @@ impl World {
         self.storages
             .resources
             .get(component_id)
-            .and_then(|resource| {
-                resource
-                    .get_ticks()
-                    .map(|ticks| ticks.is_changed(self.last_change_tick(), self.read_change_tick()))
+            .is_some_and(|resource| {
+                resource.get_ticks().is_some_and(|ticks| {
+                    ticks.is_changed(self.last_change_tick(), self.read_change_tick())
+                })
             })
-            .unwrap_or(false)
     }
 
     /// Retrieves the change ticks for the given resource.

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -235,8 +235,7 @@ impl Location {
 
         camera
             .logical_viewport_rect()
-            .map(|rect| rect.contains(self.position))
-            .unwrap_or(false)
+            .is_some_and(|rect| rect.contains(self.position))
     }
 }
 

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -352,8 +352,7 @@ impl dyn PartialReflect {
     #[inline]
     pub fn represents<T: Reflect + TypePath>(&self) -> bool {
         self.get_represented_type_info()
-            .map(|t| t.type_path() == T::type_path())
-            .unwrap_or(false)
+            .is_some_and(|t| t.type_path() == T::type_path())
     }
 
     /// Downcasts the value to type `T`, consuming the trait object.

--- a/crates/bevy_reflect/src/serde/ser/structs.rs
+++ b/crates/bevy_reflect/src/serde/ser/structs.rs
@@ -48,10 +48,7 @@ impl<P: ReflectSerializerProcessor> Serialize for StructSerializer<'_, P> {
         )?;
 
         for (index, value) in self.struct_value.iter_fields().enumerate() {
-            if serialization_data
-                .map(|data| data.is_field_skipped(index))
-                .unwrap_or(false)
-            {
+            if serialization_data.is_some_and(|data| data.is_field_skipped(index)) {
                 continue;
             }
             let key = struct_info.field_at(index).unwrap().name();

--- a/crates/bevy_reflect/src/serde/ser/tuple_structs.rs
+++ b/crates/bevy_reflect/src/serde/ser/tuple_structs.rs
@@ -57,10 +57,7 @@ impl<P: ReflectSerializerProcessor> Serialize for TupleStructSerializer<'_, P> {
         )?;
 
         for (index, value) in self.tuple_struct.iter_fields().enumerate() {
-            if serialization_data
-                .map(|data| data.is_field_skipped(index))
-                .unwrap_or(false)
-            {
+            if serialization_data.is_some_and(|data| data.is_field_skipped(index)) {
                 continue;
             }
             state.serialize_field(&TypedReflectSerializer::new_internal(

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -98,8 +98,7 @@ fn sprite_picking(
                 camera
                     .target
                     .normalize(primary_window)
-                    .map(|x| x == location.target)
-                    .unwrap_or(false)
+                    .is_some_and(|x| x == location.target)
             })
         else {
             continue;

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -94,8 +94,7 @@ impl RelativeCursorPosition {
     /// A helper function to check if the mouse is over the node
     pub fn mouse_over(&self) -> bool {
         self.normalized
-            .map(|position| self.normalized_visible_node_rect.contains(position))
-            .unwrap_or(false)
+            .is_some_and(|position| self.normalized_visible_node_rect.contains(position))
     }
 }
 
@@ -274,15 +273,13 @@ pub fn ui_focus_system(
             };
 
             let contains_cursor = relative_cursor_position_component.mouse_over()
-                && cursor_position
-                    .map(|point| {
-                        pick_rounded_rect(
-                            *point - node_rect.center(),
-                            node_rect.size(),
-                            node.node.border_radius,
-                        )
-                    })
-                    .unwrap_or(false);
+                && cursor_position.is_some_and(|point| {
+                    pick_rounded_rect(
+                        *point - node_rect.center(),
+                        node_rect.size(),
+                        node.node.border_radius,
+                    )
+                });
 
             // Save the relative cursor position to the correct component
             if let Some(mut node_relative_cursor_position_component) = node.relative_cursor_position

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -215,8 +215,7 @@ pub fn ui_layout_system(
                     || node.is_changed()
                     || content_size
                         .as_ref()
-                        .map(|c| c.is_changed() || c.measure.is_some())
-                        .unwrap_or(false)
+                        .is_some_and(|c| c.is_changed() || c.measure.is_some())
                 {
                     let layout_context = LayoutContext::new(
                         camera.scale_factor,


### PR DESCRIPTION
# Objective

The `my_option.map(|inner| inner.is_whatever).unwrap_or(false)` pattern is fragile and ugly. 

Replace it with `is_some_and` everywhere.

