### PR TITLE
Fix depth_bias and build errors on less capable platforms

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -93,7 +93,7 @@ portable-atomic-util = { version = "0.2.4", features = [
   "alloc",
 ], optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(any(unix, windows))'.dependencies]
 ctrlc = { version = "3.4.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -30,7 +30,7 @@ mod schedule_runner;
 mod sub_app;
 #[cfg(feature = "bevy_tasks")]
 mod task_pool_plugin;
-#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+#[cfg(all(any(unix, windows), feature = "std"))]
 mod terminal_ctrl_c_handler;
 
 pub use app::*;
@@ -42,7 +42,7 @@ pub use schedule_runner::*;
 pub use sub_app::*;
 #[cfg(feature = "bevy_tasks")]
 pub use task_pool_plugin::*;
-#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+#[cfg(all(any(unix, windows), feature = "std"))]
 pub use terminal_ctrl_c_handler::*;
 
 /// The app prelude.

--- a/crates/bevy_dev_tools/src/ci_testing/mod.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/mod.rs
@@ -62,7 +62,7 @@ impl Plugin for CiTestingPlugin {
 
         // The offending system does not exist in the wasm32 target.
         // As a result, we must conditionally order the two systems using a system set.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(any(unix, windows))]
         app.configure_sets(
             Update,
             SendEvents.before(bevy_app::TerminalCtrlCHandlerPlugin::exit_on_flag),

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -18,7 +18,7 @@ plugin_group! {
         bevy_window:::WindowPlugin,
         #[cfg(feature = "bevy_window")]
         bevy_a11y:::AccessibilityPlugin,
-        #[custom(cfg(not(target_arch = "wasm32")))]
+        #[custom(cfg(any(unix, windows)))]
         bevy_app:::TerminalCtrlCHandlerPlugin,
         #[cfg(feature = "bevy_asset")]
         bevy_asset:::AssetPlugin,

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -1238,7 +1238,9 @@ impl From<&StandardMaterial> for StandardMaterialKey {
         }
 
         key.insert(StandardMaterialKey::from_bits_retain(
-            (material.depth_bias as u64) << STANDARD_MATERIAL_KEY_DEPTH_BIAS_SHIFT,
+            // Casting to i32 first to ensure the full i32 range is preserved.
+            // (wgpu expects the depth_bias as an i32 when this is extracted in a later step)
+            (material.depth_bias as i32 as u64) << STANDARD_MATERIAL_KEY_DEPTH_BIAS_SHIFT,
         ));
         key
     }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -367,10 +367,12 @@ impl_reflect_for_atomic!(
     ::core::sync::atomic::AtomicUsize,
     ::core::sync::atomic::Ordering::SeqCst
 );
+#[cfg(target_has_atomic = "64")]
 impl_reflect_for_atomic!(
     ::core::sync::atomic::AtomicI64,
     ::core::sync::atomic::Ordering::SeqCst
 );
+#[cfg(target_has_atomic = "64")]
 impl_reflect_for_atomic!(
     ::core::sync::atomic::AtomicU64,
     ::core::sync::atomic::Ordering::SeqCst


### PR DESCRIPTION
# Objective

- I'm compiling (parts of) bevy for an embedded platform with no 64bit atomic and ctrlc handler support. Some compilation errors came up. This PR contains the fixes for those.
- Fix depth_bias casting in PBR material (Fixes #14169)
  - Negative depth_bias values were casted to 0 before this PR
  - f32::INFINITY depth_bias value was casted to -1 before this PR

## Solutions

- Restrict 64bit atomic reflection to supported platforms
- Restrict ctrlc handler to supported platforms (linux, windows or macos instead of "not wasm")
- The depth bias value (f32) is first casted to i32 then u64 in order to preserve negative values

## Testing
- This version compiles on a platform with no 64bit atomic support, and no ctrlc support
- CtrlC handler still works on Linux and Windows (I can't test on Macos)
- depth_bias:
```rust
println!("{}",f32::INFINITY as u64 as i32); // Prints: -1 (old implementation)
println!("{}",f32::INFINITY as i32 as u64 as i32); // Prints: 2147483647 (expected, new implementation)
```
Also ran a modified version of 3d_scene example with the following results:

RED cube depth_bias: -1000.0
BLUE cube depth_bias: 0.0
![image](https://github.com/user-attachments/assets/d5a96759-dd3c-4a0a-97ff-821163873a0d)

RED cube depth_bias: -INF
BLUE cube depth_bias: 0.0
![image](https://github.com/user-attachments/assets/e4de22b4-0c31-4dea-8be1-12b700e440b9)

RED cube depth_bias: INF (case reported in #14169)
BLUE cube depth_bias: 0.0
(Im not completely sure whats going on with the shadows here, it seems like depth_bias has some affect to those aswell, if this is unintentional this issue was not introduced by this PR)
![image](https://github.com/user-attachments/assets/52d9348f-df27-468f-a001-2d3d3ff6b553)
