### PR TITLE
Fix `clippy::precedence`

### DIFF
--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -141,17 +141,17 @@ impl Srgba {
             3 => {
                 let [l, b] = u16::from_str_radix(hex, 16)?.to_be_bytes();
                 let (r, g, b) = (l & 0x0F, (b & 0xF0) >> 4, b & 0x0F);
-                Ok(Self::rgb_u8(r << 4 | r, g << 4 | g, b << 4 | b))
+                Ok(Self::rgb_u8((r << 4) | r, (g << 4) | g, (b << 4) | b))
             }
             // RGBA
             4 => {
                 let [l, b] = u16::from_str_radix(hex, 16)?.to_be_bytes();
                 let (r, g, b, a) = ((l & 0xF0) >> 4, l & 0xF, (b & 0xF0) >> 4, b & 0x0F);
                 Ok(Self::rgba_u8(
-                    r << 4 | r,
-                    g << 4 | g,
-                    b << 4 | b,
-                    a << 4 | a,
+                    (r << 4) | r,
+                    (g << 4) | g,
+                    (b << 4) | b,
+                    (a << 4) | a,
                 ))
             }
             // RRGGBB

--- a/crates/bevy_pbr/src/cluster/mod.rs
+++ b/crates/bevy_pbr/src/cluster/mod.rs
@@ -824,7 +824,7 @@ impl ViewClusterBuffers {
 // the number of light probes is irrelevant.
 fn pack_offset_and_counts(offset: usize, point_count: u32, spot_count: u32) -> u32 {
     ((offset as u32 & CLUSTER_OFFSET_MASK) << (CLUSTER_COUNT_SIZE * 2))
-        | (point_count & CLUSTER_COUNT_MASK) << CLUSTER_COUNT_SIZE
+        | ((point_count & CLUSTER_COUNT_MASK) << CLUSTER_COUNT_SIZE)
         | (spot_count & CLUSTER_COUNT_MASK)
 }
 


### PR DESCRIPTION
# Objective

Nightly clippy warnings

## Solution

Add parens

## Testing

```
PS C:\Users\BenjaminBrienen\source\bevy> cargo +nightly clippy
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s
```