### PR TITLE
Lint against `clippy::allow_attributes` and `clippy::allow_attributes_without_reason`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ members = [
 ]
 
 [workspace.lints.clippy]
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+
 doc_markdown = "warn"
 manual_let_else = "warn"
 match_same_arms = "warn"

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -142,7 +142,14 @@ pub use srgba::*;
 pub use xyza::*;
 
 /// Describes the traits that a color should implement for consistency.
-#[allow(dead_code)] // This is an internal marker trait used to ensure that our color types impl the required traits
+#[expect(
+    clippy::allow_attributes,
+    reason = "If the below attribute on `dead_code` is removed, then rustc complains that `StandardColor` is dead code. However, if we `expect` the `dead_code` lint, then rustc complains of an unfulfilled expectation."
+)]
+#[allow(
+    dead_code,
+    reason = "This is an internal marker trait used to ensure that our color types impl the required traits"
+)]
 pub(crate) trait StandardColor
 where
     Self: core::fmt::Debug,

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -216,7 +216,10 @@ impl ColorToComponents for Oklaba {
     }
 }
 
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "The code with excessive precision was copied from another codebase."
+)]
 impl From<LinearRgba> for Oklaba {
     fn from(value: LinearRgba) -> Self {
         let LinearRgba {
@@ -239,7 +242,10 @@ impl From<LinearRgba> for Oklaba {
     }
 }
 
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "The code with excessive precision was copied from another codebase."
+)]
 impl From<Oklaba> for LinearRgba {
     fn from(value: Oklaba) -> Self {
         let Oklaba {

--- a/crates/bevy_color/src/palettes/css.rs
+++ b/crates/bevy_color/src/palettes/css.rs
@@ -4,7 +4,6 @@
 use crate::Srgba;
 
 // The CSS4 colors are a superset of the CSS1 colors, so we can just re-export the CSS1 colors.
-#[allow(unused_imports)]
 pub use crate::palettes::basic::*;
 
 /// <div style="background-color:rgb(94.1%, 97.3%, 100.0%); width: 10px; padding: 10px; border: 1px solid;"></div>

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -409,7 +409,7 @@ impl Archetype {
             component_index
                 .entry(component_id)
                 .or_default()
-                .insert(id, ArchetypeRecord { column: Some(idx) });
+                .insert(id, ArchetypeRecord { _column: Some(idx) });
         }
 
         for (component_id, archetype_component_id) in sparse_set_components {
@@ -427,7 +427,7 @@ impl Archetype {
             component_index
                 .entry(component_id)
                 .or_default()
-                .insert(id, ArchetypeRecord { column: None });
+                .insert(id, ArchetypeRecord { _column: None });
         }
         Self {
             id,
@@ -789,8 +789,7 @@ pub struct Archetypes {
 pub struct ArchetypeRecord {
     /// Index of the component in the archetype's [`Table`](crate::storage::Table),
     /// or None if the component is a sparse set component.
-    #[allow(dead_code)]
-    pub(crate) column: Option<usize>,
+    pub(crate) _column: Option<usize>,
 }
 
 impl Archetypes {
@@ -827,7 +826,10 @@ impl Archetypes {
 
     /// Fetches the total number of [`Archetype`]s within the world.
     #[inline]
-    #[allow(clippy::len_without_is_empty)] // the internal vec is never empty.
+    #[expect(
+        clippy::len_without_is_empty,
+        reason = "The internal vec is never empty"
+    )]
     pub fn len(&self) -> usize {
         self.archetypes.len()
     }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -322,7 +322,7 @@ macro_rules! tuple_impl {
             fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) {
                 #[allow(
                     non_snake_case,
-                    reason = "The name of these variables is determined at the invocation location, not by this macro."
+                    reason = "Variable names use parameters provided by the macro invocation."
                 )]
                 let ($(mut $name,)*) = self;
                 $(

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -254,23 +254,45 @@ macro_rules! tuple_impl {
         // - `Bundle::get_components` is called exactly once for each member. Relies on the above implementation to pass the correct
         //   `StorageType` into the callback.
         unsafe impl<$($name: Bundle),*> Bundle for ($($name,)*) {
-            #[allow(unused_variables)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "This is within a macro, and as such won't always be linted."
+            )]
+            #[allow(
+                unused_variables,
+                reason = "Zero-length tuples won't have any components to get IDs for."
+            )]
             fn component_ids(components: &mut Components, storages: &mut Storages, ids: &mut impl FnMut(ComponentId)){
                 $(<$name as Bundle>::component_ids(components, storages, ids);)*
             }
 
-            #[allow(unused_variables)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "This is within a macro, and as such won't always be linted."
+            )]
+            #[allow(
+                unused_variables,
+                reason = "Zero-length tuples won't have any components to get IDs for."
+            )]
             fn get_component_ids(components: &Components, ids: &mut impl FnMut(Option<ComponentId>)){
                 $(<$name as Bundle>::get_component_ids(components, ids);)*
             }
 
-            #[allow(unused_variables, unused_mut)]
-            #[allow(clippy::unused_unit)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "This is within a macro, and as such the lints may not apply."
+            )]
+            #[allow(
+                unused_mut,
+                unused_unsafe,
+                unused_variables,
+                clippy::unused_unit,
+                reason = "Zero-length tuples won't return any component data."
+            )]
             unsafe fn from_components<T, F>(ctx: &mut T, func: &mut F) -> Self
             where
                 F: FnMut(&mut T) -> OwningPtr<'_>
             {
-                #[allow(unused_unsafe)]
                 // SAFETY: Rust guarantees that tuple calls are evaluated 'left to right'.
                 // https://doc.rust-lang.org/reference/expressions.html#evaluation-order-of-operands
                 unsafe { ($(<$name as Bundle>::from_components(ctx, func),)*) }
@@ -287,10 +309,21 @@ macro_rules! tuple_impl {
 
         $(#[$meta])*
         impl<$($name: Bundle),*> DynamicBundle for ($($name,)*) {
-            #[allow(unused_variables, unused_mut)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "This is within a macro, and as such the lints may not apply."
+            )]
+            #[allow(
+                unused_mut,
+                unused_variables,
+                reason = "Zero-length tuples won't have any components to get."
+            )]
             #[inline(always)]
             fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) {
-                #[allow(non_snake_case)]
+                #[allow(
+                    non_snake_case,
+                    reason = "The name of these variables is determined at the invocation location, not by this macro."
+                )]
                 let ($(mut $name,)*) = self;
                 $(
                     $name.get_components(&mut *func);
@@ -504,7 +537,10 @@ impl BundleInfo {
     /// `table` must be the "new" table for `entity`. `table_row` must have space allocated for the
     /// `entity`, `bundle` must match this [`BundleInfo`]'s type
     #[inline]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Can't be rewritten with less arguments."
+    )]
     unsafe fn write_components<'a, T: DynamicBundle, S: BundleComponentStatus>(
         &self,
         table: &mut Table,
@@ -594,7 +630,10 @@ impl BundleInfo {
     /// This method _should not_ be called outside of [`BundleInfo::write_components`].
     /// For more information, read the [`BundleInfo::write_components`] safety docs.
     /// This function inherits the safety requirements defined there.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Can't be rewritten with less arguments."
+    )]
     pub(crate) unsafe fn initialize_required_component(
         table: &mut Table,
         sparse_sets: &mut SparseSets,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -609,7 +609,10 @@ impl<'w, T: Resource> Res<'w, T> {
     ///
     /// Note that unless you actually need an instance of `Res<T>`, you should
     /// prefer to just convert it to `&T` which can be freely copied.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "A `Clone` implementation would interfere with the common case of cloning the inner content. A similar case of this happening can be found at `std::cell::Ref::clone()`."
+    )]
     pub fn clone(this: &Self) -> Self {
         Self {
             value: this.value,

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -382,11 +382,11 @@ mod tests {
     use crate::prelude::{Schedule, World};
 
     use crate::component::Component;
+    use crate::entity::Entity;
     use crate::query::{QueryState, With};
     use crate::system::Query;
     use crate::world::Mut;
     use crate::{self as bevy_ecs};
-    use crate::entity::Entity;
 
     use super::UniqueEntityIter;
 

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -379,26 +379,25 @@ impl<I: Iterator<Item: TrustedEntityBorrow> + Debug> Debug for UniqueEntityIter<
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
     use crate::prelude::{Schedule, World};
 
-    #[allow(unused_imports)]
     use crate::component::Component;
     use crate::query::{QueryState, With};
     use crate::system::Query;
     use crate::world::Mut;
-    #[allow(unused_imports)]
     use crate::{self as bevy_ecs};
-    #[allow(unused_imports)]
-    use crate::{entity::Entity, world::unsafe_world_cell};
+    use crate::entity::Entity;
 
     use super::UniqueEntityIter;
 
     #[derive(Component, Clone)]
     pub struct Thing;
 
-    #[allow(clippy::iter_skip_zero)]
     #[test]
+    #[expect(
+        clippy::iter_skip_zero,
+        reason = "Uniqueness of entities should be preserved, even when skipping zero entities."
+    )]
     fn preserving_uniqueness() {
         let mut world = World::new();
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -592,7 +592,14 @@ impl Entities {
     /// Reserve entity IDs concurrently.
     ///
     /// Storage for entity generation and location is lazily allocated by calling [`flush`](Entities::flush).
-    #[allow(clippy::unnecessary_fallible_conversions)] // Because `IdCursor::try_from` may fail on 32-bit platforms.
+    #[expect(
+        clippy::allow_attributes,
+        reason = "The lints are only sometimes applicable."
+    )]
+    #[allow(
+        clippy::unnecessary_fallible_conversions,
+        reason = "`IdCursor::try_from` may fail on 32-bit platforms."
+    )]
     pub fn reserve_entities(&self, count: u32) -> ReserveEntitiesIterator {
         // Use one atomic subtract to grab a range of new IDs. The range might be
         // entirely nonnegative, meaning all IDs come from the freelist, or entirely
@@ -786,7 +793,14 @@ impl Entities {
     }
 
     /// Ensure at least `n` allocations can succeed without reallocating.
-    #[allow(clippy::unnecessary_fallible_conversions)] // Because `IdCursor::try_from` may fail on 32-bit platforms.
+    #[expect(
+        clippy::allow_attributes,
+        reason = "The lints are only sometimes applicable."
+    )]
+    #[allow(
+        clippy::unnecessary_fallible_conversions,
+        reason = "`IdCursor::try_from` may fail on 32-bit platforms."
+    )]
     pub fn reserve(&mut self, additional: u32) {
         self.verify_flushed();
 
@@ -1149,7 +1163,10 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::nonminimal_bool)] // This is intentionally testing `lt` and `ge` as separate functions.
+    #[expect(
+        clippy::nonminimal_bool,
+        reason = "We are intentionally testing `lt` and `ge` as separate functions."
+    )]
     fn entity_comparison() {
         assert_eq!(
             Entity::from_raw_and_generation(123, NonZero::<u32>::new(456).unwrap()),

--- a/crates/bevy_ecs/src/entity/visit_entities.rs
+++ b/crates/bevy_ecs/src/entity/visit_entities.rs
@@ -70,7 +70,6 @@ mod tests {
         ordered: Vec<Entity>,
         unordered: HashSet<Entity>,
         single: Entity,
-        #[allow(dead_code)]
         #[visit_entities(ignore)]
         not_an_entity: String,
     }

--- a/crates/bevy_ecs/src/event/event_cursor.rs
+++ b/crates/bevy_ecs/src/event/event_cursor.rs
@@ -74,7 +74,6 @@ impl<E: Event> Clone for EventCursor<E> {
     }
 }
 
-#[allow(clippy::len_without_is_empty)] // Check fails since the is_empty implementation has a signature other than `(&self) -> bool`
 impl<E: Event> EventCursor<E> {
     /// See [`EventReader::read`](super::EventReader::read)
     pub fn read<'a>(&'a mut self, events: &'a Events<E>) -> EventIterator<'a, E> {

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -567,7 +567,6 @@ mod tests {
         assert!(last.is_none(), "EventMutator should be empty");
     }
 
-    #[allow(clippy::iter_nth_zero)]
     #[test]
     fn test_event_reader_iter_nth() {
         use bevy_ecs::prelude::*;
@@ -594,7 +593,6 @@ mod tests {
         schedule.run(&mut world);
     }
 
-    #[allow(clippy::iter_nth_zero)]
     #[test]
     fn test_event_mutator_iter_nth() {
         use bevy_ecs::prelude::*;

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -216,7 +216,10 @@ mod tests {
 
     #[rustfmt::skip]
     #[test]
-    #[allow(clippy::nonminimal_bool)] // This is intentionally testing `lt` and `ge` as separate functions.
+    #[expect(
+        clippy::nonminimal_bool,
+        reason = "We are intentionally testing `lt` and `ge` as separate functions."
+    )]
     fn id_comparison() {
         assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() == Identifier::new(123, 456, IdKind::Entity).unwrap());
         assert!(Identifier::new(123, 456, IdKind::Placeholder).unwrap() == Identifier::new(123, 456, IdKind::Placeholder).unwrap());

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,7 +1,8 @@
 // FIXME(11590): remove this once the lint is fixed
-#![allow(unsafe_op_in_unsafe_fn)]
-// TODO: remove once Edition 2024 is released
-#![allow(dependency_on_unit_never_type_fallback)]
+#![expect(
+    unsafe_op_in_unsafe_fn,
+    reason = "See <https://github.com/bevyengine/bevy/issues/11590>. To be removed once the lint is fixed."
+)]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(
     any(docsrs, docsrs_dep),
@@ -11,7 +12,7 @@
     )
 )]
 #![cfg_attr(any(docsrs, docsrs_dep), feature(doc_auto_cfg, rustdoc_internals))]
-#![allow(unsafe_code)]
+#![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -52,7 +53,10 @@ pub use bevy_ptr as ptr;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[expect(deprecated)]
+    #[expect(
+        deprecated,
+        reason = "Items here are part of a prelude meant for consumer crates, not for us."
+    )]
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,
@@ -139,8 +143,11 @@ mod tests {
     #[derive(Component, Debug, PartialEq, Eq, Clone, Copy)]
     struct C;
 
-    #[allow(dead_code)]
     #[derive(Default)]
+    #[expect(
+        dead_code,
+        reason = "We don't care about the specific values contained within this struct, so long as we can use it for testing."
+    )]
     struct NonSendA(usize, PhantomData<*mut ()>);
 
     #[derive(Component, Clone, Debug)]
@@ -158,10 +165,12 @@ mod tests {
         }
     }
 
-    // TODO: The compiler says the Debug and Clone are removed during dead code analysis. Investigate.
-    #[allow(dead_code)]
     #[derive(Component, Clone, Debug)]
     #[component(storage = "SparseSet")]
+    #[expect(
+        dead_code,
+        reason = "We don't care about the specific values contained within this struct, so long as we can use it for testing."
+    )]
     struct DropCkSparse(DropCk);
 
     #[derive(Component, Copy, Clone, PartialEq, Eq, Debug)]
@@ -2635,31 +2644,37 @@ mod tests {
 
     // These structs are primarily compilation tests to test the derive macros. Because they are
     // never constructed, we have to manually silence the `dead_code` lint.
-    #[allow(dead_code)]
     #[derive(Component)]
+    #[expect(
+        dead_code,
+        reason = "This struct is primarily a compilation test to test the derive macros, and so is intentionally never constructed."
+    )]
     struct ComponentA(u32);
 
-    #[allow(dead_code)]
     #[derive(Component)]
+    #[expect(
+        dead_code,
+        reason = "This struct is primarily a compilation test to test the derive macros, and so is intentionally never constructed."
+    )]
     struct ComponentB(u32);
 
-    #[allow(dead_code)]
     #[derive(Bundle)]
     struct Simple(ComponentA);
 
-    #[allow(dead_code)]
     #[derive(Bundle)]
     struct Tuple(Simple, ComponentB);
 
-    #[allow(dead_code)]
     #[derive(Bundle)]
     struct Record {
         field0: Simple,
         field1: ComponentB,
     }
 
-    #[allow(dead_code)]
     #[derive(Component, VisitEntities, VisitEntitiesMut)]
+    #[expect(
+        dead_code,
+        reason = "This struct is primarily a compilation test to test the derive macros, and so is intentionally never constructed."
+    )]
     struct MyEntities {
         entities: Vec<Entity>,
         another_one: Entity,
@@ -2668,7 +2683,10 @@ mod tests {
         something_else: String,
     }
 
-    #[allow(dead_code)]
     #[derive(Component, VisitEntities, VisitEntitiesMut)]
+    #[expect(
+        dead_code,
+        reason = "This struct is primarily a compilation test to test the derive macros, and so is intentionally never constructed."
+    )]
     struct MyEntitiesTuple(Vec<Entity>, Entity, #[visit_entities(ignore)] usize);
 }

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -81,7 +81,6 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
                 .is_some_and(|info| info.storage_type() == StorageType::Table)
         };
 
-        #[allow(deprecated)]
         let (mut component_reads_and_writes, component_reads_and_writes_inverted) =
             self.access.access().component_reads_and_writes();
         if component_reads_and_writes_inverted {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2015,8 +2015,6 @@ pub struct AnyOf<T>(PhantomData<T>);
 
 macro_rules! impl_tuple_query_data {
     ($(#[$meta:meta])* $(($name: ident, $state: ident)),*) => {
-        #[allow(non_snake_case)]
-        #[allow(clippy::unused_unit)]
         $(#[$meta])*
         // SAFETY: defers to soundness `$name: WorldQuery` impl
         unsafe impl<$($name: QueryData),*> QueryData for ($($name,)*) {
@@ -2033,8 +2031,18 @@ macro_rules! impl_tuple_query_data {
 macro_rules! impl_anytuple_fetch {
     ($(#[$meta:meta])* $(($name: ident, $state: ident)),*) => {
         $(#[$meta])*
-        #[allow(non_snake_case)]
-        #[allow(clippy::unused_unit)]
+        #[expect(
+            clippy::allow_attributes,
+            reason = "This is within a macro, and as such won't always lint."
+        )]
+        #[allow(
+            non_snake_case,
+            reason = "The `name` macro parameter is provided by the invocation, not by us."
+        )]
+        #[allow(
+            clippy::unused_unit,
+            reason = "Zero-length tuples will often return no data."
+        )]
         /// SAFETY:
         /// `fetch` accesses are a subset of the subqueries' accesses
         /// This is sound because `update_component_access` and `update_archetype_component_access` adds accesses according to the implementations of all the subqueries.
@@ -2059,7 +2067,6 @@ macro_rules! impl_anytuple_fetch {
             }
 
             #[inline]
-            #[allow(clippy::unused_unit)]
             unsafe fn init_fetch<'w>(_world: UnsafeWorldCell<'w>, state: &Self::State, _last_run: Tick, _this_run: Tick) -> Self::Fetch<'w> {
                 let ($($name,)*) = state;
                  // SAFETY: The invariants are uphold by the caller.
@@ -2100,7 +2107,6 @@ macro_rules! impl_anytuple_fetch {
             }
 
             #[inline(always)]
-            #[allow(clippy::unused_unit)]
             unsafe fn fetch<'w>(
                 _fetch: &mut Self::Fetch<'w>,
                 _entity: Entity,
@@ -2139,11 +2145,18 @@ macro_rules! impl_anytuple_fetch {
                 <($(Option<$name>,)*)>::update_component_access(state, access);
 
             }
-            #[allow(unused_variables)]
+            
+            #[allow(
+                unused_variables,
+                reason = "Zero-length tuples won't use the world variable."
+            )]
             fn init_state(world: &mut World) -> Self::State {
                 ($($name::init_state(world),)*)
             }
-            #[allow(unused_variables)]
+            #[allow(
+                unused_variables,
+                reason = "Zero-length tuples won't get the state of any components."
+            )]
             fn get_state(components: &Components) -> Option<Self::State> {
                 Some(($($name::get_state(components)?,)*))
             }
@@ -2155,8 +2168,14 @@ macro_rules! impl_anytuple_fetch {
         }
 
         $(#[$meta])*
-        #[allow(non_snake_case)]
-        #[allow(clippy::unused_unit)]
+        #[expect(
+            clippy::allow_attributes,
+            reason = "This is within a macro, and as such won't always lint."
+        )]
+        #[allow(
+            non_snake_case,
+            reason = "The `name` macro parameter is provided by the invocation, not by us."
+        )]
         // SAFETY: defers to soundness of `$name: WorldQuery` impl
         unsafe impl<$($name: QueryData),*> QueryData for AnyOf<($($name,)*)> {
             type ReadOnly = AnyOf<($($name::ReadOnly,)*)>;

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2145,7 +2145,7 @@ macro_rules! impl_anytuple_fetch {
                 <($(Option<$name>,)*)>::update_component_access(state, access);
 
             }
-            
+
             #[allow(
                 unused_variables,
                 reason = "Zero-length tuples won't use the world variable."

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -98,7 +98,6 @@ pub unsafe trait QueryFilter: WorldQuery {
     ///
     /// Must always be called _after_ [`WorldQuery::set_table`] or [`WorldQuery::set_archetype`]. `entity` and
     /// `table_row` must be in the range of the current table and archetype.
-    #[allow(unused_variables)]
     unsafe fn filter_fetch(
         fetch: &mut Self::Fetch<'_>,
         entity: Entity,

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -122,7 +122,10 @@ impl SystemSchedule {
     since = "0.16.0",
     note = "Use `ApplyDeferred` instead. This was previously a function but is now a marker struct System."
 )]
-#[expect(non_upper_case_globals)]
+#[expect(
+    non_upper_case_globals,
+    reason = "This used to be a function, but is now an alias to a struct for the purposes of deprecation."
+)]
 pub const apply_deferred: ApplyDeferred = ApplyDeferred;
 
 /// A special [`System`] that instructs the executor to call

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2073,6 +2073,11 @@ mod tests {
 
     // regression test for https://github.com/bevyengine/bevy/issues/9114
     #[test]
+    // TODO: remove this expect once Edition 2024 is released
+    #[expect(
+        dependency_on_unit_never_type_fallback,
+        reason = "The panic here will never run, and thus the never type is not actually the return type."
+    )]
     fn ambiguous_with_not_breaking_run_conditions() {
         #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
         struct Set;

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -414,7 +414,10 @@ impl Stepping {
                     // transitions, and add debugging messages for permitted
                     // transitions.  Any action transition that falls through
                     // this match block will be performed.
-                    #[expect(clippy::match_same_arms)]
+                    #[expect(
+                        clippy::match_same_arms,
+                        reason = "Readability would be negatively impacted by combining the `(Waiting, Runall)` and `(Continue, RunAll) match arms."
+                    )]
                     match (self.action, action) {
                         // ignore non-transition updates, and prevent a call to
                         // enable() from overwriting a step or continue call

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1609,6 +1609,11 @@ mod tests {
 
     #[test]
     #[should_panic]
+    // TODO: remove this expect once Edition 2024 is released
+    #[expect(
+        dependency_on_unit_never_type_fallback,
+        reason = "`#[should_panic]` cannot be used unless the return type is `()`. Additionally, the return type here doesn't actually matter."
+    )]
     fn panic_inside_system() {
         let mut world = World::new();
         run_system(&mut world, || panic!("this system panics"));

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -385,12 +385,11 @@ impl PartialEq for EntityRef<'_> {
 
 impl Eq for EntityRef<'_> {}
 
-#[expect(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for EntityRef<'_> {
     /// [`EntityRef`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.entity().partial_cmp(&other.entity())
+        Some(self.cmp(other))
     }
 }
 
@@ -923,12 +922,11 @@ impl PartialEq for EntityMut<'_> {
 
 impl Eq for EntityMut<'_> {}
 
-#[expect(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for EntityMut<'_> {
     /// [`EntityMut`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.entity().partial_cmp(&other.entity())
+        Some(self.cmp(other))
     }
 }
 
@@ -3114,12 +3112,11 @@ impl PartialEq for FilteredEntityRef<'_> {
 
 impl Eq for FilteredEntityRef<'_> {}
 
-#[expect(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for FilteredEntityRef<'_> {
     /// [`FilteredEntityRef`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.entity().partial_cmp(&other.entity())
+        Some(self.cmp(other))
     }
 }
 
@@ -3441,12 +3438,11 @@ impl PartialEq for FilteredEntityMut<'_> {
 
 impl Eq for FilteredEntityMut<'_> {}
 
-#[expect(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for FilteredEntityMut<'_> {
     /// [`FilteredEntityMut`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.entity().partial_cmp(&other.entity())
+        Some(self.cmp(other))
     }
 }
 
@@ -3589,12 +3585,11 @@ impl<B: Bundle> PartialEq for EntityRefExcept<'_, B> {
 
 impl<B: Bundle> Eq for EntityRefExcept<'_, B> {}
 
-#[expect(clippy::non_canonical_partial_ord_impl)]
 impl<B: Bundle> PartialOrd for EntityRefExcept<'_, B> {
     /// [`EntityRefExcept`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.entity().partial_cmp(&other.entity())
+        Some(self.cmp(other))
     }
 }
 
@@ -3729,12 +3724,11 @@ impl<B: Bundle> PartialEq for EntityMutExcept<'_, B> {
 
 impl<B: Bundle> Eq for EntityMutExcept<'_, B> {}
 
-#[expect(clippy::non_canonical_partial_ord_impl)]
 impl<B: Bundle> PartialOrd for EntityMutExcept<'_, B> {
     /// [`EntityMutExcept`]'s comparison trait implementations match the underlying [`Entity`],
     /// and cannot discern between different worlds.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.entity().partial_cmp(&other.entity())
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1688,6 +1688,8 @@ impl<'w> EntityWorldMut<'w> {
             })
         };
 
+        // SAFETY: `new_archetype_id` is a subset of the components in `old_location.archetype_id`
+        // because it is created by removing a bundle from these components.
         unsafe {
             Self::move_entity_from_remove::<false>(
                 entity,
@@ -1861,19 +1863,21 @@ impl<'w> EntityWorldMut<'w> {
             }
         }
 
+        let mut new_location = location;
         // SAFETY: `new_archetype_id` is a subset of the components in `old_location.archetype_id`
         // because it is created by removing a bundle from these components.
-        let mut new_location = location;
-        Self::move_entity_from_remove::<true>(
-            entity,
-            &mut new_location,
-            location.archetype_id,
-            location,
-            &mut world.entities,
-            &mut world.archetypes,
-            &mut world.storages,
-            new_archetype_id,
-        );
+        unsafe {
+            Self::move_entity_from_remove::<true>(
+                entity,
+                &mut new_location,
+                location.archetype_id,
+                location,
+                &mut world.entities,
+                &mut world.archetypes,
+                &mut world.storages,
+                new_archetype_id,
+            );
+        }
 
         new_location
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1688,7 +1688,6 @@ impl<'w> EntityWorldMut<'w> {
             })
         };
 
-        #[allow(clippy::undocumented_unsafe_blocks)] // TODO: document why this is safe
         unsafe {
             Self::move_entity_from_remove::<false>(
                 entity,
@@ -1715,7 +1714,10 @@ impl<'w> EntityWorldMut<'w> {
     /// when DROP is true removed components will be dropped otherwise they will be forgotten
     // We use a const generic here so that we are less reliant on
     // inlining for rustc to optimize out the `match DROP`
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Can't be rewritten with less arguments."
+    )]
     unsafe fn move_entity_from_remove<const DROP: bool>(
         entity: Entity,
         self_location: &mut EntityLocation,
@@ -1795,7 +1797,6 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// # Safety
     /// - A `BundleInfo` with the corresponding `BundleId` must have been initialized.
-    #[allow(clippy::too_many_arguments)]
     unsafe fn remove_bundle(&mut self, bundle: BundleId) -> EntityLocation {
         let entity = self.entity;
         let world = &mut self.world;

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1095,7 +1095,10 @@ impl<'w> UnsafeWorldCell<'w> {
 /// - `storage_type` must accurately reflect where the components for `component_id` are stored.
 /// - the caller must ensure that no aliasing rules are violated
 #[inline]
-#[allow(unsafe_op_in_unsafe_fn)]
+#[expect(
+    unsafe_op_in_unsafe_fn,
+    reason = "See <https://github.com/bevyengine/bevy/issues/11590>. To be removed once the lint is fixed."
+)]
 unsafe fn get_component(
     world: UnsafeWorldCell<'_>,
     component_id: ComponentId,
@@ -1122,7 +1125,10 @@ unsafe fn get_component(
 /// - `storage_type` must accurately reflect where the components for `component_id` are stored.
 /// - the caller must ensure that no aliasing rules are violated
 #[inline]
-#[allow(unsafe_op_in_unsafe_fn)]
+#[expect(
+    unsafe_op_in_unsafe_fn,
+    reason = "See <https://github.com/bevyengine/bevy/issues/11590>. To be removed once the lint is fixed."
+)]
 unsafe fn get_component_and_ticks(
     world: UnsafeWorldCell<'_>,
     component_id: ComponentId,
@@ -1166,7 +1172,10 @@ unsafe fn get_component_and_ticks(
 /// - `storage_type` must accurately reflect where the components for `component_id` are stored.
 /// - the caller must ensure that no aliasing rules are violated
 #[inline]
-#[allow(unsafe_op_in_unsafe_fn)]
+#[expect(
+    unsafe_op_in_unsafe_fn,
+    reason = "See <https://github.com/bevyengine/bevy/issues/11590>. To be removed once the lint is fixed."
+)]
 unsafe fn get_ticks(
     world: UnsafeWorldCell<'_>,
     component_id: ComponentId,

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -51,10 +51,12 @@ fn arc_bounding_points(arc: Arc2d, rotation: impl Into<Rot2>) -> SmallVec<[Vec2;
         // If inverted = true, then right_angle > left_angle, so we are looking for an angle that is not between them.
         // There's a chance that this condition fails due to rounding error, if the endpoint angle is juuuust shy of the axis.
         // But in that case, the endpoint itself is within rounding error of the axis and will define the bounds just fine.
-        #[allow(clippy::nonminimal_bool)]
-        if !inverted && angle >= right_angle && angle <= left_angle
-            || inverted && (angle >= right_angle || angle <= left_angle)
-        {
+        let angle_within_parameters = if inverted {
+            angle >= right_angle || angle <= left_angle
+        } else {
+            angle >= right_angle && angle <= left_angle
+        };
+        if angle_within_parameters {
             bounds.push(extremum * arc.radius);
         }
     }
@@ -475,7 +477,6 @@ mod tests {
     // Arcs and circular segments have the same bounding shapes so they share test cases.
     fn arc_and_segment() {
         struct TestCase {
-            #[allow(unused)]
             name: &'static str,
             arc: Arc2d,
             translation: Vec2,
@@ -629,7 +630,6 @@ mod tests {
     #[test]
     fn circular_sector() {
         struct TestCase {
-            #[allow(unused)]
             name: &'static str,
             arc: Arc2d,
             translation: Vec2,

--- a/crates/bevy_math/src/cubic_splines/mod.rs
+++ b/crates/bevy_math/src/cubic_splines/mod.rs
@@ -995,7 +995,6 @@ impl<P: VectorSpace> CubicSegment<P> {
     }
 
     /// Calculate polynomial coefficients for the cubic curve using a characteristic matrix.
-    #[allow(unused)]
     #[inline]
     fn coefficients(p: [P; 4], char_matrix: [[f32; 4]; 4]) -> Self {
         let [c0, c1, c2, c3] = char_matrix;
@@ -1376,7 +1375,6 @@ impl<P: VectorSpace> RationalSegment<P> {
     }
 
     /// Calculate polynomial coefficients for the cubic polynomials using a characteristic matrix.
-    #[allow(unused)]
     #[inline]
     fn coefficients(
         control_points: [P; 4],

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -471,9 +471,15 @@ mod easing_functions {
     // with blatantly more digits than needed (since rust will round them to the
     // nearest representable value anyway) rather than make it seem like the
     // truncated value is somehow carefully chosen.
-    #[allow(clippy::excessive_precision)]
+    #[expect(
+        clippy::excessive_precision,
+        reason = "This is deliberately more precise than an f32 will allow, as truncating the value might imply that the value is carefully chosen."
+    )]
     const LOG2_1023: f32 = 9.998590429745328646459226;
-    #[allow(clippy::excessive_precision)]
+    #[expect(
+        clippy::excessive_precision,
+        reason = "This is deliberately more precise than an f32 will allow, as truncating the value might imply that the value is carefully chosen."
+    )]
     const FRAC_1_1023: f32 = 0.00097751710654936461388074291;
     #[inline]
     pub(crate) fn exponential_in(t: f32) -> f32 {

--- a/crates/bevy_math/src/float_ord.rs
+++ b/crates/bevy_math/src/float_ord.rs
@@ -47,7 +47,10 @@ impl PartialOrd for FloatOrd {
 }
 
 impl Ord for FloatOrd {
-    #[allow(clippy::comparison_chain)]
+    #[expect(
+        clippy::comparison_chain,
+        reason = "This can't be rewritten with `match` and `cmp`, as this is `cmp` itself."
+    )]
     fn cmp(&self, other: &Self) -> Ordering {
         if self > other {
             Ordering::Greater
@@ -124,7 +127,10 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::nonminimal_bool)]
+    #[expect(
+        clippy::nonminimal_bool,
+        reason = "This tests that all operators work as they should, and in the process requires some non-simplified boolean expressions."
+    )]
     fn float_ord_cmp_operators() {
         assert!(!(NAN < NAN));
         assert!(NAN < ZERO);

--- a/crates/bevy_math/src/ops.rs
+++ b/crates/bevy_math/src/ops.rs
@@ -8,9 +8,6 @@
 //! It also provides `no_std` compatible alternatives to certain floating-point
 //! operations which are not provided in the [`core`] library.
 
-#![allow(dead_code)]
-#![allow(clippy::disallowed_methods)]
-
 // Note: There are some Rust methods with unspecified precision without a `libm`
 // equivalent:
 // - `f32::powi` (integer powers)
@@ -23,6 +20,10 @@
 // - `f32::ln_gamma`
 
 #[cfg(not(feature = "libm"))]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Many of the disallowed methods point to methods which are ultimately defined here."
+)]
 mod std_ops {
 
     /// Raises a number to a floating point power.
@@ -519,6 +520,10 @@ mod libm_ops_for_no_std {
 }
 
 #[cfg(feature = "std")]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Many of the disallowed methods point to methods which are ultimately defined here."
+)]
 mod std_ops_for_no_std {
     //! Provides standardized names for [`f32`] operations which may not be
     //! supported on `no_std` platforms.

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -152,7 +152,6 @@ macro_rules! impl_custom_attribute_methods {
             $self.custom_attributes().get::<T>()
         }
 
-        #[allow(rustdoc::redundant_explicit_links)]
         /// Gets a custom attribute by its [`TypeId`](core::any::TypeId).
         ///
         /// This is the dynamic equivalent of [`get_attribute`](Self::get_attribute).

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -112,7 +112,6 @@ impl ReflectFromReflect {
     ///
     /// This will convert the object to a concrete type if it wasn't already, and return
     /// the value as `Box<dyn Reflect>`.
-    #[allow(clippy::wrong_self_convention)]
     pub fn from_reflect(&self, reflect_value: &dyn PartialReflect) -> Option<Box<dyn Reflect>> {
         (self.from_reflect)(reflect_value)
     }

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -615,7 +615,6 @@ macro_rules! impl_typed_function {
                 FunctionInfo::new(
                     create_info::<Function>()
                         .with_args({
-                            #[allow(unused_mut)]
                             let mut _index = 0;
                             vec![
                                 $(ArgInfo::new::<$Arg>({
@@ -641,7 +640,6 @@ macro_rules! impl_typed_function {
                 FunctionInfo::new(
                     create_info::<Function>()
                         .with_args({
-                            #[allow(unused_mut)]
                             let mut _index = 1;
                             vec![
                                 ArgInfo::new::<&Receiver>(0),
@@ -668,7 +666,6 @@ macro_rules! impl_typed_function {
                 FunctionInfo::new(
                     create_info::<Function>()
                         .with_args({
-                            #[allow(unused_mut)]
                             let mut _index = 1;
                             vec![
                                 ArgInfo::new::<&mut Receiver>(0),
@@ -695,7 +692,6 @@ macro_rules! impl_typed_function {
                 FunctionInfo::new(
                     create_info::<Function>()
                         .with_args({
-                            #[allow(unused_mut)]
                             let mut _index = 1;
                             vec![
                                 ArgInfo::new::<&mut Receiver>(0),

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -91,7 +91,14 @@ macro_rules! impl_reflect_fn {
             // This clause essentially asserts that `Arg::This` is the same type as `Arg`
             Function: for<'a> Fn($($Arg::This<'a>),*) -> ReturnType + 'env,
         {
-            #[allow(unused_mut)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "This lint is part of a macro, which may not always trigger the `unused_mut` lint."
+            )]
+            #[allow(
+                unused_mut,
+                reason = "Some invocations of this macro may trigger the `unused_mut` lint, where others won't."
+            )]
             fn reflect_call<'a>(&self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!($($Arg)*);
 

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -98,7 +98,14 @@ macro_rules! impl_reflect_fn_mut {
             // This clause essentially asserts that `Arg::This` is the same type as `Arg`
             Function: for<'a> FnMut($($Arg::This<'a>),*) -> ReturnType + 'env,
         {
-            #[allow(unused_mut)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "This lint is part of a macro, which may not always trigger the `unused_mut` lint."
+            )]
+            #[allow(
+                unused_mut,
+                reason = "Some invocations of this macro may trigger the `unused_mut` lint, where others won't."
+            )]
             fn reflect_call_mut<'a>(&mut self, mut args: ArgList<'a>) -> FunctionResult<'a> {
                 const COUNT: usize = count_tokens!($($Arg)*);
 

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -10,7 +10,10 @@ macro_rules! reflect_enum {
         impl_reflect!($(#[$meta])* enum $ident { $($ty)* });
 
         #[assert_type_match($ident, test_only)]
-        #[allow(clippy::upper_case_acronyms)]
+        #[expect(
+            clippy::upper_case_acronyms,
+            reason = "The variants used are not acronyms."
+        )]
         enum $ident { $($ty)* }
     };
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,5 +1,7 @@
-// Temporary workaround for impl_reflect!(Option/Result false-positive
-#![allow(unused_qualifications)]
+#![expect(
+    unused_qualifications,
+    reason = "Temporary workaround for impl_reflect!(Option/Result false-positive"
+)]
 
 use crate::{
     self as bevy_reflect, impl_type_path, map_apply, map_partial_eq, map_try_apply,
@@ -236,7 +238,6 @@ macro_rules! impl_reflect_for_atomic {
             #[cfg(feature = "functions")]
             crate::func::macros::impl_function_traits!($ty);
 
-            #[allow(unused_mut)]
             impl GetTypeRegistration for $ty
             where
                 $ty: Any + Send + Sync,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -683,8 +683,7 @@ pub mod __macro_exports {
         note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
     )]
     pub trait RegisterForReflection {
-        #[allow(unused_variables)]
-        fn __register(registry: &mut TypeRegistry) {}
+        fn __register(_registry: &mut TypeRegistry) {}
     }
 
     impl<T: GetTypeRegistration> RegisterForReflection for T {
@@ -709,7 +708,10 @@ pub mod __macro_exports {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_types, clippy::approx_constant)]
+#[expect(
+    clippy::approx_constant,
+    reason = "We don't need the exact value of Pi here."
+)]
 mod tests {
     use ::serde::{de::DeserializeSeed, Deserialize, Serialize};
     use alloc::borrow::Cow;
@@ -866,7 +868,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::disallowed_types)]
     fn reflect_unit_struct() {
         #[derive(Reflect)]
         struct Foo(u32, u64);
@@ -2138,7 +2139,7 @@ mod tests {
             enum_struct: SomeEnum,
             custom: CustomDebug,
             #[reflect(ignore)]
-            #[allow(dead_code)]
+            #[expect(dead_code, reason = "This value is intended to not be reflected.")]
             ignored: isize,
         }
 

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -502,7 +502,10 @@ impl core::ops::IndexMut<usize> for ParsedPath {
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp, clippy::approx_constant)]
+#[expect(
+    clippy::approx_constant,
+    reason = "We don't need the exact value of Pi here."
+)]
 mod tests {
     use super::*;
     use crate as bevy_reflect;

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -64,7 +64,10 @@ impl<'a> PathParser<'a> {
         //   the last byte before an ASCII utf-8 character (ie: it is a char
         //   boundary).
         // - The slice always starts after a symbol ie: an ASCII character's boundary.
-        #[allow(unsafe_code)]
+        #[expect(
+            unsafe_code,
+            reason = "We have fulfilled the Safety requirements for `from_utf8_unchecked`."
+        )]
         let ident = unsafe { from_utf8_unchecked(ident) };
 
         self.remaining = remaining;

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -199,7 +199,7 @@ mod tests {
 
         #[reflect_trait]
         trait Enemy: Reflect + Debug {
-            #[allow(dead_code, reason = "this method is purely for testing purposes")]
+            #[expect(dead_code, reason = "this method is purely for testing purposes")]
             fn hp(&self) -> u8;
         }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -79,8 +79,7 @@ pub trait GetTypeRegistration: 'static {
     ///
     /// This method is called by [`TypeRegistry::register`] to register any other required types.
     /// Often, this is done for fields of structs and enum variants to ensure all types are properly registered.
-    #[allow(unused_variables)]
-    fn register_type_dependencies(registry: &mut TypeRegistry) {}
+    fn register_type_dependencies(_registry: &mut TypeRegistry) {}
 }
 
 impl Default for TypeRegistry {
@@ -785,7 +784,10 @@ pub struct ReflectFromPtr {
     from_ptr_mut: unsafe fn(PtrMut) -> &mut dyn Reflect,
 }
 
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "We must interact with pointers here, which are inherently unsafe."
+)]
 impl ReflectFromPtr {
     /// Returns the [`TypeId`] that the [`ReflectFromPtr`] was constructed for.
     pub fn type_id(&self) -> TypeId {
@@ -837,7 +839,10 @@ impl ReflectFromPtr {
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "We must interact with pointers here, which are inherently unsafe."
+)]
 impl<T: Reflect> FromType<T> for ReflectFromPtr {
     fn from_type() -> Self {
         ReflectFromPtr {
@@ -857,7 +862,10 @@ impl<T: Reflect> FromType<T> for ReflectFromPtr {
 }
 
 #[cfg(test)]
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "We must interact with pointers here, which are inherently unsafe."
+)]
 mod test {
     use super::*;
     use crate as bevy_reflect;

--- a/crates/bevy_tasks/src/executor.rs
+++ b/crates/bevy_tasks/src/executor.rs
@@ -50,7 +50,9 @@ pub struct LocalExecutor<'a>(LocalExecutorInner<'a>);
 
 impl Executor<'_> {
     /// Construct a new [`Executor`]
-    #[allow(dead_code, reason = "not all feature flags require this function")]
+    // NOTE: This struct is used under `crate::TaskPool`, and so this is not
+    // technically dead code. However, if that code is changed, then this may
+    // become dead code *depending on what feature flags are enabled.*
     pub const fn new() -> Self {
         Self(ExecutorInner::new())
     }
@@ -58,7 +60,9 @@ impl Executor<'_> {
 
 impl LocalExecutor<'_> {
     /// Construct a new [`LocalExecutor`]
-    #[allow(dead_code, reason = "not all feature flags require this function")]
+    // NOTE: This struct is used under `crate::TaskPool` inside a static, and so
+    // this is not technically dead code. However, if that code is changed, then
+    // this may become dead code *depending on what feature flags are enabled.*
     pub const fn new() -> Self {
         Self(LocalExecutorInner::new())
     }

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -694,7 +694,6 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_types)]
 mod tests {
     use super::*;
     use core::sync::atomic::{AtomicBool, AtomicI32, Ordering};


### PR DESCRIPTION
This PR is a WIP - but please feel free to comment anything that comes to mind.

# Objective
We want to deny the following lints:
* `clippy::allow_attributes` - Because there's no reason to `#[allow(...)]` an attribute if it wouldn't lint against anything; you should always use `#[expect(...)]`
* `clippy::allow_attributes_without_reason` - Because documenting the reason for allowing/expecting a lint is always good

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring Bevy's code base in line with the new restrictions.

This PR **does not** modify any code other than lint attributes, as I consider that out-of-scope - except in cases such as the `unused_variables` lint, where the lint attribute can be removed entirely via a very simple change.

## Testing
Uhh... I ran `cargo clippy`? lol