### PR TITLE
Update entity cloning benchmarks

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -61,11 +61,6 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [[bench]]
-name = "entity_cloning"
-path = "benches/bevy_ecs/entity_cloning.rs"
-harness = false
-
-[[bench]]
 name = "ecs"
 path = "benches/bevy_ecs/main.rs"
 harness = false

--- a/benches/benches/bevy_ecs/entity_cloning.rs
+++ b/benches/benches/bevy_ecs/entity_cloning.rs
@@ -4,7 +4,7 @@ use benches::bench;
 use bevy_ecs::bundle::Bundle;
 use bevy_ecs::component::ComponentCloneHandler;
 use bevy_ecs::reflect::AppTypeRegistry;
-use bevy_ecs::{component::Component, reflect::ReflectComponent, world::World};
+use bevy_ecs::{component::Component, world::World};
 use bevy_hierarchy::{BuildChildren, CloneEntityHierarchyExt};
 use bevy_math::Mat4;
 use bevy_reflect::{GetTypeRegistration, Reflect};
@@ -19,8 +19,36 @@ criterion_group!(
 );
 
 #[derive(Component, Reflect, Default, Clone)]
-#[reflect(Component)]
-struct Foo(Mat4);
+struct C1(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C2(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C3(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C4(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C5(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C6(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C7(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C8(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C9(Mat4);
+
+#[derive(Component, Reflect, Default, Clone)]
+struct C10(Mat4);
+
+type ComplexBundle = (C1, C2, C3, C4, C5, C6, C7, C8, C9, C10);
 
 /// Sets the [`ComponentCloneHandler`] for all explicit and required components in a bundle `B` to
 /// use the [`Reflect`] trait instead of [`Clone`].
@@ -141,6 +169,7 @@ fn bench_clone_hierarchy<B: Bundle + Default + GetTypeRegistration>(
 // constant represents this as an easy array that can be used in a `for` loop.
 const SCENARIOS: [(&'static str, bool); 2] = [("clone", false), ("reflect", true)];
 
+/// Benchmarks cloning a single entity with 10 components and no children.
 fn single(c: &mut Criterion) {
     let mut group = c.benchmark_group(bench!("single"));
 
@@ -149,13 +178,14 @@ fn single(c: &mut Criterion) {
 
     for (id, clone_via_reflect) in SCENARIOS {
         group.bench_function(id, |b| {
-            bench_clone::<Foo>(b, clone_via_reflect);
+            bench_clone::<ComplexBundle>(b, clone_via_reflect);
         });
     }
 
     group.finish();
 }
 
+/// Benchmarks cloning an an entity and its 50 descendents, each with only 1 component.
 fn hierarchy_tall(c: &mut Criterion) {
     let mut group = c.benchmark_group(bench!("hierarchy_tall"));
 
@@ -164,13 +194,14 @@ fn hierarchy_tall(c: &mut Criterion) {
 
     for (id, clone_via_reflect) in SCENARIOS {
         group.bench_function(id, |b| {
-            bench_clone_hierarchy::<Foo>(b, 50, 1, clone_via_reflect);
+            bench_clone_hierarchy::<C1>(b, 50, 1, clone_via_reflect);
         });
     }
 
     group.finish();
 }
 
+/// Benchmarks cloning an an entity and its 50 direct children, each with only 1 component.
 fn hierarchy_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group(bench!("hierarchy_wide"));
 
@@ -179,26 +210,25 @@ fn hierarchy_wide(c: &mut Criterion) {
 
     for (id, clone_via_reflect) in SCENARIOS {
         group.bench_function(id, |b| {
-            bench_clone_hierarchy::<Foo>(b, 1, 50, clone_via_reflect);
+            bench_clone_hierarchy::<C1>(b, 1, 50, clone_via_reflect);
         });
     }
 
     group.finish();
 }
 
+/// Benchmarks cloning a large hierarchy of entities with several children each. Each entity has 10
+/// components.
 fn hierarchy_many(c: &mut Criterion) {
     let mut group = c.benchmark_group(bench!("hierarchy_many"));
 
-    // We're cloning 3,906 entities total. This number was calculated by manually counting the
-    // number of entities spawned in `bench_clone_hierarchy()` with a `println!()` statement. :)
-    group.throughput(Throughput::Elements(3906));
-
-    // The default 5 seconds are not enough here.
-    group.measurement_time(std::time::Duration::from_secs(8));
+    // We're cloning 364 entities total. This number was calculated by manually counting the number
+    // of entities spawned in `bench_clone_hierarchy()` with a `println!()` statement. :)
+    group.throughput(Throughput::Elements(364));
 
     for (id, clone_via_reflect) in SCENARIOS {
         group.bench_function(id, |b| {
-            bench_clone_hierarchy::<Foo>(b, 5, 5, clone_via_reflect);
+            bench_clone_hierarchy::<ComplexBundle>(b, 5, 3, clone_via_reflect);
         });
     }
 

--- a/benches/benches/bevy_ecs/entity_cloning.rs
+++ b/benches/benches/bevy_ecs/entity_cloning.rs
@@ -6,10 +6,9 @@ use bevy_ecs::{component::Component, reflect::ReflectComponent, world::World};
 use bevy_hierarchy::{BuildChildren, CloneEntityHierarchyExt};
 use bevy_math::Mat4;
 use bevy_reflect::{GetTypeRegistration, Reflect};
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{criterion_group, Bencher, Criterion};
 
 criterion_group!(benches, reflect_benches, clone_benches);
-criterion_main!(benches);
 
 #[derive(Component, Reflect, Default, Clone)]
 #[reflect(Component)]

--- a/benches/benches/bevy_ecs/entity_cloning.rs
+++ b/benches/benches/bevy_ecs/entity_cloning.rs
@@ -1,5 +1,6 @@
 use core::hint::black_box;
 
+use benches::bench;
 use bevy_ecs::bundle::Bundle;
 use bevy_ecs::reflect::AppTypeRegistry;
 use bevy_ecs::{component::Component, reflect::ReflectComponent, world::World};
@@ -8,7 +9,7 @@ use bevy_math::Mat4;
 use bevy_reflect::{GetTypeRegistration, Reflect};
 use criterion::{criterion_group, Bencher, Criterion};
 
-criterion_group!(benches, reflect_benches, clone_benches);
+criterion_group!(benches, with_reflect, with_clone);
 
 #[derive(Component, Reflect, Default, Clone)]
 #[reflect(Component)]
@@ -135,38 +136,46 @@ fn simple<C: Bundle + Default + GetTypeRegistration>(b: &mut Bencher, clone_via_
     });
 }
 
-fn reflect_benches(c: &mut Criterion) {
-    c.bench_function("many components reflect", |b| {
+fn with_reflect(c: &mut Criterion) {
+    let mut group = c.benchmark_group(bench!("with_reflect"));
+
+    group.bench_function("simple", |b| {
         simple::<ComplexBundle>(b, true);
     });
 
-    c.bench_function("hierarchy wide reflect", |b| {
+    group.bench_function("hierarchy_wide", |b| {
         hierarchy::<C1>(b, 10, 4, true);
     });
 
-    c.bench_function("hierarchy tall reflect", |b| {
+    group.bench_function("hierarchy_tall", |b| {
         hierarchy::<C1>(b, 1, 50, true);
     });
 
-    c.bench_function("hierarchy many reflect", |b| {
+    group.bench_function("hierarchy_many", |b| {
         hierarchy::<ComplexBundle>(b, 5, 5, true);
     });
+
+    group.finish();
 }
 
-fn clone_benches(c: &mut Criterion) {
-    c.bench_function("many components clone", |b| {
+fn with_clone(c: &mut Criterion) {
+    let mut group = c.benchmark_group(bench!("with_clone"));
+
+    group.bench_function("simple", |b| {
         simple::<ComplexBundle>(b, false);
     });
 
-    c.bench_function("hierarchy wide clone", |b| {
+    group.bench_function("hierarchy_wide", |b| {
         hierarchy::<C1>(b, 10, 4, false);
     });
 
-    c.bench_function("hierarchy tall clone", |b| {
+    group.bench_function("hierarchy_tall", |b| {
         hierarchy::<C1>(b, 1, 50, false);
     });
 
-    c.bench_function("hierarchy many clone", |b| {
+    group.bench_function("hierarchy_many", |b| {
         hierarchy::<ComplexBundle>(b, 5, 5, false);
     });
+
+    group.finish();
 }

--- a/benches/benches/bevy_ecs/entity_cloning.rs
+++ b/benches/benches/bevy_ecs/entity_cloning.rs
@@ -167,7 +167,7 @@ fn bench_clone_hierarchy<B: Bundle + Default + GetTypeRegistration>(
 
 // Each benchmark runs twice: using either the `Clone` or `Reflect` traits to clone entities. This
 // constant represents this as an easy array that can be used in a `for` loop.
-const SCENARIOS: [(&'static str, bool); 2] = [("clone", false), ("reflect", true)];
+const SCENARIOS: [(&str, bool); 2] = [("clone", false), ("reflect", true)];
 
 /// Benchmarks cloning a single entity with 10 components and no children.
 fn single(c: &mut Criterion) {

--- a/benches/benches/bevy_ecs/main.rs
+++ b/benches/benches/bevy_ecs/main.rs
@@ -9,6 +9,7 @@ use criterion::criterion_main;
 mod change_detection;
 mod components;
 mod empty_archetypes;
+mod entity_cloning;
 mod events;
 mod fragmentation;
 mod iteration;
@@ -21,6 +22,7 @@ criterion_main!(
     change_detection::benches,
     components::benches,
     empty_archetypes::benches,
+    entity_cloning::benches,
     events::benches,
     iteration::benches,
     fragmentation::benches,


### PR DESCRIPTION
# Objective

- `entity_cloning` was separated from the rest of the ECS benchmarks.
- There was some room for improvement in the benchmarks themselves.
- Part of #16647.

## Solution

- Merge `entity_cloning` into the rest of the ECS benchmarks.
- Apply the `bench!` macro to all benchmark names.\
- Reorganize benchmarks and their helper functions, with more comments than before.
- Remove all the extra component definitions (`C2`, `C3`, etc.), and just leave one. Now all entities have exactly one component.

## Testing

```sh
# List all entity cloning benchmarks, to verify their names have updated.
cargo bench -p benches --bench ecs entity_cloning -- --list

# Test benchmarks by running them once.
cargo test -p benches --bench ecs entity_cloning

# Run all benchmarks (takes about a minute).
cargo bench -p benches --bench ecs entity_cloning
```

---

## Showcase

![image](https://github.com/user-attachments/assets/4e3d7d98-015a-4974-ae16-363cf1b9423c)

Interestingly, using `Clone` instead of `Reflect` appears to be 2-2.5 times faster. Furthermore, there were noticeable jumps in time when running the benchmarks:

![image](https://github.com/user-attachments/assets/bd8513de-3922-432f-b3dd-1b1b7750bdb5)


I theorize this is because the `World` is allocating more space for all the entities, but I don't know for certain. Neat!