### PR TITLE
Fix 2D Gizmos not always drawn on top

### DIFF
--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -142,8 +142,8 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
             primitive: PrimitiveState::default(),
             depth_stencil: Some(DepthStencilState {
                 format: CORE_2D_DEPTH_FORMAT,
-                depth_write_enabled: true,
-                depth_compare: CompareFunction::GreaterEqual,
+                depth_write_enabled: false,
+                depth_compare: CompareFunction::Always,
                 stencil: StencilState {
                     front: StencilFaceState::IGNORE,
                     back: StencilFaceState::IGNORE,
@@ -243,8 +243,8 @@ impl SpecializedRenderPipeline for LineJointGizmoPipeline {
             primitive: PrimitiveState::default(),
             depth_stencil: Some(DepthStencilState {
                 format: CORE_2D_DEPTH_FORMAT,
-                depth_write_enabled: true,
-                depth_compare: CompareFunction::GreaterEqual,
+                depth_write_enabled: false,
+                depth_compare: CompareFunction::Always,
                 stencil: StencilState {
                     front: StencilFaceState::IGNORE,
                     back: StencilFaceState::IGNORE,


### PR DESCRIPTION
# Objective

- As stated in the linked issue, if a Mesh2D is drawn with elements with a positive Z value, resulting gizmos get drawn behind instead of in front of them. 
- Fixes #17053

## Solution

- Similar to the change done for the `SpritePipeline` in the relevant commit (5abc32ceda1a440271c9f9ef71279bd9f7f9ff5c), this PR changes both line gizmos to avoid writing to the depth buffer and always pass the depth test to ensure they are not filtered out.

## Testing

- Tested with the provided snippet in #17053 
- I looked over the `2d_gizmos` example, but it seemed like adding more elements there to demonstrate this might not be the best idea? Looking for guidance here on if that should be updated or if a new gizmo example needs to be made.