### PR TITLE
Remove Implicit `std` Prelude from `no_std` Crates

### DIFF
--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! This crate is about everything concerning the highest-level, application layer of a Bevy app.
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -11,9 +11,12 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! This crate is about everything concerning the highest-level, application layer of a Bevy app.
+
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -554,6 +554,7 @@ impl PluginGroup for NoopPluginGroup {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use core::{any::TypeId, fmt::Debug};
 
     use super::PluginGroupBuilder;

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! Representations of colors in various color spaces.
 //!
@@ -89,6 +89,9 @@
 //! println!("Srgba: {:?}", srgba);
 //! println!("Hsla: {:?}", hsla);
 //! ```
+
+#![cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -90,7 +90,7 @@
 //! println!("Hsla: {:?}", hsla);
 //! ```
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(feature = "alloc")]

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1643,6 +1643,7 @@ fn sorted_remove<T: Eq + Ord + Copy>(source: &mut Vec<T>, remove: &[T]) {
 mod tests {
     use crate as bevy_ecs;
     use crate::{component::ComponentId, prelude::*, world::DeferredWorld};
+    use alloc::vec;
 
     #[derive(Component)]
     struct A;

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -671,6 +671,7 @@ mod tests {
         entity::EntityCloneBuilder,
         world::{DeferredWorld, World},
     };
+    use alloc::vec::Vec;
     use bevy_ecs_macros::require;
     use bevy_ptr::OwningPtr;
     use core::alloc::Layout;
@@ -679,6 +680,7 @@ mod tests {
     mod reflect {
         use super::*;
         use crate::reflect::{AppTypeRegistry, ReflectComponent, ReflectFromWorld};
+        use alloc::vec;
         use bevy_reflect::{std_traits::ReflectDefault, FromType, Reflect, ReflectFromPtr};
 
         #[test]

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -379,6 +379,8 @@ impl<I: Iterator<Item: TrustedEntityBorrow> + Debug> Debug for UniqueEntityIter<
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
+
     #[allow(unused_imports)]
     use crate::prelude::{Schedule, World};
 

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -135,6 +135,7 @@ unsafe impl<T: TrustedEntityBorrow> TrustedEntityBorrow for Arc<T> {}
 /// [`into_iter()`]: IntoIterator::into_iter
 /// [`iter_many_unique`]: crate::system::Query::iter_many_unique
 /// [`iter_many_unique_mut`]: crate::system::Query::iter_many_unique_mut
+/// [`Vec`]: alloc::vec::Vec
 pub trait EntitySet: IntoIterator<IntoIter: EntitySetIterator> {}
 
 impl<T: IntoIterator<IntoIter: EntitySetIterator>> EntitySet for T {}

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -69,12 +69,15 @@ use crate::{
     },
     storage::{SparseSetIndex, TableId, TableRow},
 };
-use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
 use core::{fmt, hash::Hash, mem, num::NonZero};
 use log::warn;
 
 #[cfg(feature = "track_location")]
-use core::panic::Location;
+use {
+    core::panic::Location,
+    alloc::format,
+};
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
@@ -1064,6 +1067,7 @@ impl EntityLocation {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
     use super::*;
 
     #[test]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -74,10 +74,7 @@ use core::{fmt, hash::Hash, mem, num::NonZero};
 use log::warn;
 
 #[cfg(feature = "track_location")]
-use {
-    core::panic::Location,
-    alloc::format,
-};
+use {alloc::format, core::panic::Location};
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
@@ -1067,8 +1064,8 @@ impl EntityLocation {
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
     use super::*;
+    use alloc::format;
 
     #[test]
     fn entity_niche_optimization() {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -69,7 +69,7 @@ use crate::{
     },
     storage::{SparseSetIndex, TableId, TableRow},
 };
-use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use alloc::{borrow::ToOwned, format, string::String, vec::Vec};
 use core::{fmt, hash::Hash, mem, num::NonZero};
 use log::warn;
 

--- a/crates/bevy_ecs/src/entity/visit_entities.rs
+++ b/crates/bevy_ecs/src/entity/visit_entities.rs
@@ -61,6 +61,7 @@ mod tests {
         entity::{EntityHashMap, MapEntities, SceneEntityMapper},
         world::World,
     };
+    use alloc::{string::String, vec, vec::Vec};
     use bevy_utils::HashSet;
 
     use super::*;

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -32,6 +32,7 @@ pub use writer::EventWriter;
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;
+    use alloc::{vec, vec::Vec};
     use bevy_ecs::{event::*, system::assert_is_read_only_system};
     use bevy_ecs_macros::Event;
 

--- a/crates/bevy_ecs/src/intern.rs
+++ b/crates/bevy_ecs/src/intern.rs
@@ -180,6 +180,7 @@ impl<T: ?Sized> Default for Interner<T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{boxed::Box, string::ToString};
     use bevy_utils::FixedHasher;
     use core::hash::{BuildHasher, Hash, Hasher};
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -16,7 +16,9 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#![cfg(feature = "std")]
+extern crate std;
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");
@@ -120,7 +122,12 @@ mod tests {
         system::Resource,
         world::{EntityMut, EntityRef, Mut, World},
     };
-    use alloc::{sync::Arc, vec};
+    use alloc::{
+        string::{String, ToString},
+        sync::Arc,
+        vec,
+        vec::Vec,
+    };
     use bevy_ecs_macros::{VisitEntities, VisitEntitiesMut};
     use bevy_tasks::{ComputeTaskPool, TaskPool};
     use bevy_utils::HashSet;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -17,7 +17,8 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 #![no_std]
-#![cfg(feature = "std")]
+
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(target_pointer_width = "16")]

--- a/crates/bevy_ecs/src/name.rs
+++ b/crates/bevy_ecs/src/name.rs
@@ -264,6 +264,7 @@ impl<'de> Visitor<'de> for NameVisitor {
 mod tests {
     use super::*;
     use crate::world::World;
+    use alloc::string::ToString;
 
     #[test]
     fn test_display_of_debug_name() {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -744,7 +744,7 @@ impl World {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use alloc::{vec, vec::Vec};
 
     use bevy_ptr::OwningPtr;
     use bevy_utils::HashMap;

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1338,6 +1338,7 @@ mod tests {
     use crate::query::{
         access::AccessFilters, Access, AccessConflicts, FilteredAccess, FilteredAccessSet,
     };
+    use alloc::vec;
     use core::marker::PhantomData;
     use fixedbitset::FixedBitSet;
 

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -278,6 +278,7 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
 mod tests {
     use crate as bevy_ecs;
     use crate::{prelude::*, world::FilteredEntityRef};
+    use std::dbg;
 
     #[derive(Component, PartialEq, Debug)]
     struct A(usize);

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -119,6 +119,7 @@ pub enum QuerySingleError {
 mod test {
     use crate as bevy_ecs;
     use crate::prelude::World;
+    use alloc::format;
     use bevy_ecs_macros::Component;
 
     #[test]

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2950,6 +2950,9 @@ impl<T> Ord for NeutralOrd<T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+    use std::println;
+
     #[allow(unused_imports)]
     use crate::component::Component;
     #[allow(unused_imports)]

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -117,9 +117,10 @@ mod tests {
         system::{assert_is_system, IntoSystem, Query, System, SystemState},
         world::{unsafe_world_cell::UnsafeWorldCell, World},
     };
+    use alloc::{vec, vec::Vec};
     use bevy_ecs_macros::QueryFilter;
     use core::{any::type_name, fmt::Debug, hash::Hash};
-    use std::collections::HashSet;
+    use std::{collections::HashSet, println};
 
     #[derive(Component, Debug, Hash, Eq, PartialEq, Clone, Copy, PartialOrd, Ord)]
     struct A(usize);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1883,6 +1883,7 @@ mod tests {
     use crate::{
         component::Component, prelude::*, query::QueryEntityError, world::FilteredEntityRef,
     };
+    use alloc::vec::Vec;
 
     #[test]
     fn get_many_unchecked_manual_uniqueness() {

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -403,6 +403,7 @@ mod tests {
         system::{Commands, SystemState},
         world::World,
     };
+    use alloc::{borrow::ToOwned, boxed::Box};
     use bevy_ecs_macros::Resource;
     use bevy_reflect::{PartialReflect, Reflect, TypeRegistry};
 

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -4,7 +4,10 @@ use bevy_utils::{default, syncunsafecell::SyncUnsafeCell};
 use concurrent_queue::ConcurrentQueue;
 use core::{any::Any, panic::AssertUnwindSafe};
 use fixedbitset::FixedBitSet;
-use std::sync::{Mutex, MutexGuard};
+use std::{
+    eprintln,
+    sync::{Mutex, MutexGuard},
+};
 
 #[cfg(feature = "trace")]
 use tracing::{info_span, Span};

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -1,7 +1,11 @@
 use core::panic::AssertUnwindSafe;
 use fixedbitset::FixedBitSet;
+
 #[cfg(feature = "trace")]
 use tracing::info_span;
+
+#[cfg(feature = "std")]
+use std::eprintln;
 
 use crate::{
     schedule::{

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -1,7 +1,11 @@
 use core::panic::AssertUnwindSafe;
 use fixedbitset::FixedBitSet;
+
 #[cfg(feature = "trace")]
 use tracing::info_span;
+
+#[cfg(feature = "std")]
+use std::eprintln;
 
 use crate::{
     schedule::{is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule},

--- a/crates/bevy_ecs/src/schedule/graph/graph_map.rs
+++ b/crates/bevy_ecs/src/schedule/graph/graph_map.rs
@@ -393,6 +393,7 @@ impl CompactNodeIdPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     /// The `Graph` type _must_ preserve the order that nodes are inserted in if
     /// no removals occur. Removals are permitted to swap the latest node into the

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -17,6 +17,7 @@ pub use self::graph::NodeId;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{string::ToString, vec, vec::Vec};
     use core::sync::atomic::{AtomicU32, Ordering};
 
     pub use crate as bevy_ecs;

--- a/crates/bevy_ecs/src/schedule/stepping.rs
+++ b/crates/bevy_ecs/src/schedule/stepping.rs
@@ -823,6 +823,8 @@ impl ScheduleState {
 mod tests {
     use super::*;
     use crate::{prelude::*, schedule::ScheduleLabel};
+    use alloc::{format, vec};
+    use std::println;
 
     pub use crate as bevy_ecs;
 

--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -77,6 +77,8 @@ impl BlobArray {
     /// # Safety
     /// - The element at index `index` is safe to access.
     ///     (If the safety requirements of every method that has been used on `Self` have been fulfilled, the caller just needs to ensure that `index` < `len`)
+    ///
+    /// [`Vec::len`]: alloc::vec::Vec::len
     #[inline]
     pub unsafe fn get_unchecked(&self, index: usize) -> Ptr<'_> {
         #[cfg(debug_assertions)]
@@ -98,6 +100,8 @@ impl BlobArray {
     /// # Safety
     /// - The element with at index `index` is safe to access.
     ///     (If the safety requirements of every method that has been used on `Self` have been fulfilled, the caller just needs to ensure that `index` < `len`)
+    ///
+    /// [`Vec::len`]: alloc::vec::Vec::len
     #[inline]
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> PtrMut<'_> {
         #[cfg(debug_assertions)]
@@ -134,6 +138,8 @@ impl BlobArray {
     /// # Safety
     /// - The type `T` must be the type of the items in this [`BlobArray`].
     /// - `slice_len` <= `len`
+    ///
+    /// [`Vec::len`]: alloc::vec::Vec::len
     pub unsafe fn get_sub_slice<T>(&self, slice_len: usize) -> &[UnsafeCell<T>] {
         #[cfg(debug_assertions)]
         debug_assert!(slice_len <= self.capacity);
@@ -151,6 +157,8 @@ impl BlobArray {
     /// # Safety
     /// - For every element with index `i`, if `i` < `len`: It must be safe to call [`Self::get_unchecked_mut`] with `i`.
     ///     (If the safety requirements of every method that has been used on `Self` have been fulfilled, the caller just needs to ensure that `len` is correct.)
+    ///
+    /// [`Vec::clear`]: alloc::vec::Vec::clear
     pub unsafe fn clear(&mut self, len: usize) {
         #[cfg(debug_assertions)]
         debug_assert!(self.capacity >= len);

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -497,11 +497,13 @@ const fn padding_needed_for(layout: &Layout, align: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use super::BlobVec;
     use crate as bevy_ecs; // required for derive macros
     use crate::{component::Component, ptr::OwningPtr, world::World};
-
-    use super::BlobVec;
-    use alloc::rc::Rc;
+    use alloc::{
+        rc::Rc,
+        string::{String, ToString},
+    };
     use core::{alloc::Layout, cell::RefCell};
 
     /// # Safety

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -666,6 +666,7 @@ mod tests {
         entity::Entity,
         storage::SparseSet,
     };
+    use alloc::{vec, vec::Vec};
 
     #[derive(Debug, Eq, PartialEq)]
     struct Foo(usize);

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -822,6 +822,8 @@ mod tests {
         ptr::OwningPtr,
         storage::{Storages, TableBuilder, TableId, TableRow, Tables},
     };
+    use alloc::vec::Vec;
+
     #[cfg(feature = "track_location")]
     use core::panic::Location;
 

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -14,6 +14,8 @@ use core::{
 ///
 /// This type can be treated as a `ManuallyDrop<Box<[T]>>` without a built in length. To avoid
 /// memory leaks, [`drop`](Self::drop) must be called when no longer in use.
+///
+/// [`Vec<T>`]: alloc::vec::Vec
 pub struct ThinArrayPtr<T> {
     data: NonNull<T>,
     #[cfg(debug_assertions)]

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -684,6 +684,7 @@ mod tests {
         prelude::{Component, Query},
         system::{Local, RunSystemOnce},
     };
+    use alloc::vec;
 
     use super::*;
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2284,7 +2284,7 @@ mod tests {
         system::{Commands, Resource},
         world::{CommandQueue, FromWorld, World},
     };
-    use alloc::sync::Arc;
+    use alloc::{string::String, sync::Arc, vec, vec::Vec};
     use core::{
         any::TypeId,
         sync::atomic::{AtomicUsize, Ordering},

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -126,6 +126,7 @@ all_tuples!(
 mod tests {
     use crate as bevy_ecs;
     use crate::{schedule::Schedule, system::Local, world::World};
+    use alloc::vec::Vec;
     use bevy_ecs_macros::Resource;
     use core::marker::PhantomData;
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -116,6 +116,8 @@
 //! - [`DynSystemParam`]
 //! - [`Vec<P>`] where `P: SystemParam`
 //! - [`ParamSet<Vec<P>>`] where `P: SystemParam`
+//!
+//! [`Vec<P>`]: alloc::vec::Vec
 
 mod adapter_system;
 mod builder;

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -317,8 +317,10 @@ pub fn assert_system_does_not_conflict<Out, Params, S: IntoSystem<(), Out, Param
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use bevy_utils::default;
     use core::any::TypeId;
+    use std::println;
 
     use crate::{
         self as bevy_ecs,

--- a/crates/bevy_ecs/src/system/system_name.rs
+++ b/crates/bevy_ecs/src/system/system_name.rs
@@ -94,6 +94,7 @@ mod tests {
         system::{IntoSystem, RunSystemOnce, SystemName},
         world::World,
     };
+    use alloc::{borrow::ToOwned, string::String};
 
     #[test]
     fn test_system_name_regular_param() {

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -346,7 +346,7 @@ mod test {
     use super::*;
     use crate as bevy_ecs;
     use crate::system::Resource;
-    use alloc::sync::Arc;
+    use alloc::{borrow::ToOwned, string::String, sync::Arc};
     use core::{
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicU32, Ordering},

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -352,6 +352,9 @@ mod test {
         sync::atomic::{AtomicU32, Ordering},
     };
 
+    #[cfg(miri)]
+    use alloc::format;
+
     struct DropCheck(Arc<AtomicU32>);
 
     impl DropCheck {

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -192,6 +192,7 @@ impl<'w> DeferredWorld<'w> {
     /// [`EntityMut`]: crate::world::EntityMut
     /// [`&EntityHashSet`]: crate::entity::EntityHashSet
     /// [`EntityHashMap<EntityMut>`]: crate::entity::EntityHashMap
+    /// [`Vec<EntityMut>`]: alloc::vec::Vec
     #[inline]
     pub fn get_entity_mut<F: WorldEntityFetch>(
         &mut self,
@@ -323,6 +324,7 @@ impl<'w> DeferredWorld<'w> {
     /// [`EntityMut`]: crate::world::EntityMut
     /// [`&EntityHashSet`]: crate::entity::EntityHashSet
     /// [`EntityHashMap<EntityMut>`]: crate::entity::EntityHashMap
+    /// [`Vec<EntityMut>`]: alloc::vec::Vec
     #[inline]
     pub fn entity_mut<F: WorldEntityFetch>(&mut self, entities: F) -> F::DeferredMut<'_> {
         self.get_entity_mut(entities).unwrap()

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -4115,8 +4115,10 @@ unsafe impl DynamicComponentFetch for &'_ HashSet<ComponentId> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use bevy_ptr::{OwningPtr, Ptr};
     use core::panic::AssertUnwindSafe;
+
     #[cfg(feature = "track_location")]
     use core::panic::Location;
     #[cfg(feature = "track_location")]

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -99,6 +99,7 @@ impl SparseSetIndex for WorldId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn world_ids_unique() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3766,7 +3766,13 @@ mod tests {
         system::Resource,
         world::error::EntityFetchError,
     };
-    use alloc::sync::Arc;
+    use alloc::{
+        borrow::ToOwned,
+        string::{String, ToString},
+        sync::Arc,
+        vec,
+        vec::Vec,
+    };
     use bevy_ecs_macros::Component;
     use bevy_utils::{HashMap, HashSet};
     use core::{
@@ -3774,7 +3780,7 @@ mod tests {
         panic,
         sync::atomic::{AtomicBool, AtomicU32, Ordering},
     };
-    use std::sync::Mutex;
+    use std::{println, sync::Mutex};
 
     // For bevy_ecs_macros
     use crate as bevy_ecs;

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -597,7 +597,7 @@ mod tests {
         components::{Children, Parent},
         HierarchyEvent::{self, ChildAdded, ChildMoved, ChildRemoved},
     };
-    use alloc::vec::Vec;
+    use alloc::{vec, vec::Vec};
     use smallvec::{smallvec, SmallVec};
 
     use bevy_ecs::{

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -597,6 +597,7 @@ mod tests {
         components::{Children, Parent},
         HierarchyEvent::{self, ChildAdded, ChildMoved, ChildRemoved},
     };
+    use alloc::vec::Vec;
     use smallvec::{smallvec, SmallVec};
 
     use bevy_ecs::{

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -247,6 +247,7 @@ fn component_clone_parent(world: &mut DeferredWorld, ctx: &mut ComponentCloneCtx
 
 #[cfg(test)]
 mod tests {
+    use alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
     use bevy_ecs::{
         component::Component,
         system::Commands,

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! Parent-child relationships for Bevy entities.
 //!
@@ -51,6 +51,9 @@
 //! [hierarchical despawn extension methods]: DespawnRecursiveExt
 //! [plugin]: HierarchyPlugin
 //! [query extension methods]: HierarchyQueryExt
+
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -52,7 +52,7 @@
 //! [plugin]: HierarchyPlugin
 //! [query extension methods]: HierarchyQueryExt
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_hierarchy/src/query_extension.rs
+++ b/crates/bevy_hierarchy/src/query_extension.rs
@@ -312,6 +312,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
     use bevy_ecs::{
         prelude::Component,
         system::{Query, SystemState},

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1641,6 +1641,7 @@ mod tests {
         RawGamepadButtonChangedEvent, RawGamepadEvent,
     };
     use crate::ButtonState;
+    use alloc::string::ToString;
     use bevy_app::{App, PreUpdate};
     use bevy_ecs::entity::Entity;
     use bevy_ecs::event::Events;

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! `bevy` currently supports keyboard, mouse, gamepad, and touch inputs.
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -4,13 +4,16 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! Input functionality for the [Bevy game engine](https://bevyengine.org/).
 //!
 //! # Supported input devices
 //!
 //! `bevy` currently supports keyboard, mouse, gamepad, and touch inputs.
+
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -441,6 +441,7 @@ impl Bounded2d for Capsule2d {
 #[cfg(test)]
 mod tests {
     use core::f32::consts::{FRAC_PI_2, FRAC_PI_3, FRAC_PI_4, FRAC_PI_6, TAU};
+    use std::println;
 
     use approx::assert_abs_diff_eq;
     use glam::Vec2;

--- a/crates/bevy_math/src/cubic_splines/mod.rs
+++ b/crates/bevy_math/src/cubic_splines/mod.rs
@@ -995,6 +995,13 @@ impl<P: VectorSpace> CubicSegment<P> {
     }
 
     /// Calculate polynomial coefficients for the cubic curve using a characteristic matrix.
+    #[cfg_attr(
+        not(feature = "alloc"),
+        expect(
+            dead_code,
+            reason = "Method only used when `alloc` feature is enabled."
+        )
+    )]
     #[inline]
     fn coefficients(p: [P; 4], char_matrix: [[f32; 4]; 4]) -> Self {
         let [c0, c1, c2, c3] = char_matrix;
@@ -1375,6 +1382,13 @@ impl<P: VectorSpace> RationalSegment<P> {
     }
 
     /// Calculate polynomial coefficients for the cubic polynomials using a characteristic matrix.
+    #[cfg_attr(
+        not(feature = "alloc"),
+        expect(
+            dead_code,
+            reason = "Method only used when `alloc` feature is enabled."
+        )
+    )]
     #[inline]
     fn coefficients(
         control_points: [P; 4],

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -5,13 +5,15 @@ use super::Curve;
 
 use crate::ops;
 use crate::VectorSpace;
-use alloc::format;
 use core::any::type_name;
 use core::fmt::{self, Debug};
 use core::marker::PhantomData;
 
 #[cfg(feature = "bevy_reflect")]
-use bevy_reflect::{utility::GenericTypePathCell, FromReflect, Reflect, TypePath};
+use {
+    alloc::format,
+    bevy_reflect::{utility::GenericTypePathCell, FromReflect, Reflect, TypePath},
+};
 
 #[cfg(feature = "bevy_reflect")]
 mod paths {

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -5,6 +5,7 @@ use super::Curve;
 
 use crate::ops;
 use crate::VectorSpace;
+use alloc::format;
 use core::any::type_name;
 use core::fmt::{self, Debug};
 use core::marker::PhantomData;

--- a/crates/bevy_math/src/curve/cores.rs
+++ b/crates/bevy_math/src/curve/cores.rs
@@ -697,6 +697,7 @@ pub fn uneven_interp(times: &[f32], t: f32) -> InterpolationDatum<usize> {
 mod tests {
     use super::{ChunkedUnevenCore, EvenCore, UnevenCore};
     use crate::curve::{cores::InterpolationDatum, interval};
+    use alloc::vec;
     use approx::{assert_abs_diff_eq, AbsDiffEq};
 
     fn approx_between<T>(datum: InterpolationDatum<T>, start: T, end: T, p: f32) -> bool

--- a/crates/bevy_math/src/curve/interval.rs
+++ b/crates/bevy_math/src/curve/interval.rs
@@ -201,6 +201,7 @@ mod tests {
     use crate::ops;
 
     use super::*;
+    use alloc::vec::Vec;
     use approx::{assert_abs_diff_eq, AbsDiffEq};
 
     #[test]

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -1005,6 +1005,7 @@ pub enum ResamplingError {
 mod tests {
     use super::*;
     use crate::{ops, Quat};
+    use alloc::vec::Vec;
     use approx::{assert_abs_diff_eq, AbsDiffEq};
     use core::f32::consts::TAU;
     use glam::*;

--- a/crates/bevy_math/src/curve/sample_curves.rs
+++ b/crates/bevy_math/src/curve/sample_curves.rs
@@ -4,6 +4,7 @@ use super::cores::{EvenCore, EvenCoreError, UnevenCore, UnevenCoreError};
 use super::{Curve, Interval};
 
 use crate::StableInterpolate;
+use alloc::format;
 use core::any::type_name;
 use core::fmt::{self, Debug};
 
@@ -369,6 +370,7 @@ mod tests {
     //! - function pointers
     use super::{SampleCurve, UnevenSampleCurve};
     use crate::{curve::Interval, VectorSpace};
+    use alloc::boxed::Box;
     use bevy_reflect::Reflect;
 
     #[test]

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -12,7 +12,7 @@ use bevy_reflect::Reflect;
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
-#[cfg(all(feature = "debug_assertions", feature = "std"))]
+#[cfg(all(debug_assertions, feature = "std"))]
 use std::eprintln;
 
 /// An error indicating that a direction is invalid.

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -8,8 +8,12 @@ use derive_more::derive::Into;
 
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
+
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+
+#[cfg(feature = "std")]
+use std::eprintln;
 
 /// An error indicating that a direction is invalid.
 #[derive(Debug, PartialEq)]

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -12,7 +12,7 @@ use bevy_reflect::Reflect;
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "debug_assertions", feature = "std"))]
 use std::eprintln;
 
 /// An error indicating that a direction is invalid.

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -21,7 +21,7 @@
 //! matrices like [`Mat2`], [`Mat3`] and [`Mat4`] and orientation representations
 //! like [`Quat`].
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(feature = "alloc")]

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -12,13 +12,16 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! Provides math types and functionality for the Bevy game engine.
 //!
 //! The commonly used types are vectors like [`Vec2`] and [`Vec3`],
 //! matrices like [`Mat2`], [`Mat3`] and [`Mat4`] and orientation representations
 //! like [`Quat`].
+
+#![cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -12,7 +12,8 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 #![no_std]
-#![cfg(feature = "std")]
+
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -11,7 +11,9 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_reflect/derive/src/impls/func/into_return.rs
+++ b/crates/bevy_reflect/derive/src/impls/func/into_return.rs
@@ -14,7 +14,7 @@ pub(crate) fn impl_into_return(
     quote! {
         impl #impl_generics #bevy_reflect::func::IntoReturn for #type_path #ty_generics #where_reflect_clause {
             fn into_return<'into_return>(self) -> #bevy_reflect::func::Return<'into_return> where Self: 'into_return {
-                #bevy_reflect::func::Return::Owned(Box::new(self))
+                #bevy_reflect::func::Return::Owned(#bevy_reflect::__macro_exports::alloc_utils::Box::new(self))
             }
         }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -513,6 +513,8 @@ pub fn array_debug(dyn_array: &dyn Array, f: &mut Formatter<'_>) -> core::fmt::R
 #[cfg(test)]
 mod tests {
     use crate::Reflect;
+    use alloc::boxed::Box;
+
     #[test]
     fn next_index_increment() {
         const SIZE: usize = if cfg!(debug_assertions) {

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -181,6 +181,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::{type_info::Typed, TypeInfo, VariantInfo};
+    use alloc::{format, string::String};
     use core::ops::RangeInclusive;
 
     #[derive(Reflect, PartialEq, Debug)]

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -12,6 +12,7 @@ pub use variants::*;
 mod tests {
     use crate as bevy_reflect;
     use crate::*;
+    use alloc::boxed::Box;
 
     #[derive(Reflect, Debug, PartialEq)]
     enum MyEnum {

--- a/crates/bevy_reflect/src/func/args/arg.rs
+++ b/crates/bevy_reflect/src/func/args/arg.rs
@@ -2,11 +2,8 @@ use crate::{
     func::args::{ArgError, FromArg, Ownership},
     PartialReflect, Reflect, TypePath,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, string::ToString};
 use core::ops::Deref;
-
-#[cfg(not(feature = "std"))]
-use alloc::{format, vec};
 
 /// Represents an argument that can be passed to a [`DynamicFunction`] or [`DynamicFunctionMut`].
 ///

--- a/crates/bevy_reflect/src/func/args/error.rs
+++ b/crates/bevy_reflect/src/func/args/error.rs
@@ -4,9 +4,6 @@ use thiserror::Error;
 
 use crate::func::args::Ownership;
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// An error that occurs when converting an [argument].
 ///
 /// [argument]: crate::func::args::Arg

--- a/crates/bevy_reflect/src/func/args/from_arg.rs
+++ b/crates/bevy_reflect/src/func/args/from_arg.rs
@@ -1,8 +1,5 @@
 use crate::func::args::{Arg, ArgError};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// A trait for types that can be created from an [`Arg`].
 ///
 /// This trait exists so that types can be automatically converted into an [`Arg`]

--- a/crates/bevy_reflect/src/func/args/info.rs
+++ b/crates/bevy_reflect/src/func/args/info.rs
@@ -6,9 +6,6 @@ use crate::{
     Type, TypePath,
 };
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// Type information for an [`Arg`] used in a [`DynamicFunction`] or [`DynamicFunctionMut`].
 ///
 /// [`Arg`]: crate::func::args::Arg

--- a/crates/bevy_reflect/src/func/args/list.rs
+++ b/crates/bevy_reflect/src/func/args/list.rs
@@ -10,9 +10,6 @@ use alloc::{
     collections::vec_deque::{Iter, VecDeque},
 };
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// A list of arguments that can be passed to a [`DynamicFunction`] or [`DynamicFunctionMut`].
 ///
 /// # Example
@@ -308,6 +305,7 @@ impl<'a> ArgList<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::String;
 
     #[test]
     fn should_push_arguments_in_order() {

--- a/crates/bevy_reflect/src/func/args/ownership.rs
+++ b/crates/bevy_reflect/src/func/args/ownership.rs
@@ -1,8 +1,5 @@
 use core::fmt::{Display, Formatter};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// A trait for getting the ownership of a type.
 ///
 /// This trait exists so that [`TypedFunction`] can automatically generate

--- a/crates/bevy_reflect/src/func/dynamic_function.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function.rs
@@ -15,9 +15,6 @@ use alloc::{borrow::Cow, boxed::Box, sync::Arc};
 use bevy_reflect_derive::impl_type_path;
 use core::fmt::{Debug, Formatter};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// An [`Arc`] containing a callback to a reflected function.
 ///
 /// The `Arc` is used to both ensure that it is `Send + Sync`
@@ -473,6 +470,7 @@ mod tests {
     use crate::func::signature::ArgumentSignature;
     use crate::func::{FunctionError, IntoReturn, SignatureInfo};
     use crate::Type;
+    use alloc::{format, string::String, vec, vec::Vec};
     use bevy_utils::HashSet;
     use core::ops::Add;
 

--- a/crates/bevy_reflect/src/func/dynamic_function_internal.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_internal.rs
@@ -1,7 +1,7 @@
 use crate::func::args::ArgCount;
 use crate::func::signature::{ArgListSignature, ArgumentSignature};
 use crate::func::{ArgList, FunctionError, FunctionInfo, FunctionOverloadError};
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, vec, vec::Vec};
 use bevy_utils::HashMap;
 use core::fmt::{Debug, Formatter};
 

--- a/crates/bevy_reflect/src/func/dynamic_function_mut.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_mut.rs
@@ -1,9 +1,6 @@
 use alloc::{borrow::Cow, boxed::Box, sync::Arc};
 use core::fmt::{Debug, Formatter};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 use crate::func::{
     args::{ArgCount, ArgList},
     dynamic_function_internal::DynamicFunctionInternal,
@@ -381,6 +378,7 @@ impl<'env> IntoFunctionMut<'env, ()> for DynamicFunctionMut<'env> {
 mod tests {
     use super::*;
     use crate::func::{FunctionError, IntoReturn, SignatureInfo};
+    use alloc::vec;
     use core::ops::Add;
 
     #[test]

--- a/crates/bevy_reflect/src/func/error.rs
+++ b/crates/bevy_reflect/src/func/error.rs
@@ -7,9 +7,6 @@ use alloc::borrow::Cow;
 use bevy_utils::HashSet;
 use thiserror::Error;
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// An error that occurs when calling a [`DynamicFunction`] or [`DynamicFunctionMut`].
 ///
 /// [`DynamicFunction`]: crate::func::DynamicFunction

--- a/crates/bevy_reflect/src/func/function.rs
+++ b/crates/bevy_reflect/src/func/function.rs
@@ -8,9 +8,6 @@ use crate::{
 use alloc::borrow::Cow;
 use core::fmt::Debug;
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// A trait used to power [function-like] operations via [reflection].
 ///
 /// This trait allows types to be called like regular functions
@@ -74,6 +71,7 @@ pub trait Function: PartialReflect + Debug {
 mod tests {
     use super::*;
     use crate::func::IntoFunction;
+    use alloc::boxed::Box;
 
     #[test]
     fn should_call_dyn_function() {

--- a/crates/bevy_reflect/src/func/info.rs
+++ b/crates/bevy_reflect/src/func/info.rs
@@ -1,8 +1,5 @@
-use alloc::{borrow::Cow, vec};
+use alloc::{borrow::Cow, boxed::Box, vec, vec::Vec};
 use core::fmt::{Debug, Formatter};
-
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
 
 use crate::{
     func::args::{ArgCount, ArgCountOutOfBoundsError, ArgInfo, GetOwnership, Ownership},

--- a/crates/bevy_reflect/src/func/into_function.rs
+++ b/crates/bevy_reflect/src/func/into_function.rs
@@ -1,8 +1,5 @@
 use crate::func::{DynamicFunction, ReflectFn, TypedFunction};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// A trait for types that can be converted into a [`DynamicFunction`].
 ///
 /// This trait is automatically implemented for any type that implements

--- a/crates/bevy_reflect/src/func/into_function_mut.rs
+++ b/crates/bevy_reflect/src/func/into_function_mut.rs
@@ -1,8 +1,5 @@
 use crate::func::{DynamicFunctionMut, ReflectFnMut, TypedFunction};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// A trait for types that can be converted into a [`DynamicFunctionMut`].
 ///
 /// This trait is automatically implemented for any type that implements

--- a/crates/bevy_reflect/src/func/macros.rs
+++ b/crates/bevy_reflect/src/func/macros.rs
@@ -1,6 +1,3 @@
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 /// Helper macro to implement the necessary traits for function reflection.
 ///
 /// This macro calls the following macros:

--- a/crates/bevy_reflect/src/func/reflect_fn.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn.rs
@@ -1,8 +1,5 @@
 use variadics_please::all_tuples;
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 use crate::{
     func::{
         args::{ArgCount, FromArg},

--- a/crates/bevy_reflect/src/func/reflect_fn_mut.rs
+++ b/crates/bevy_reflect/src/func/reflect_fn_mut.rs
@@ -1,8 +1,5 @@
 use variadics_please::all_tuples;
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 use crate::{
     func::{
         args::{ArgCount, FromArg},

--- a/crates/bevy_reflect/src/func/registry.rs
+++ b/crates/bevy_reflect/src/func/registry.rs
@@ -2,9 +2,6 @@ use alloc::{borrow::Cow, sync::Arc};
 use core::fmt::Debug;
 use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
-
 use bevy_utils::HashMap;
 
 use crate::func::{
@@ -359,6 +356,7 @@ impl FunctionRegistryArc {
 mod tests {
     use super::*;
     use crate::func::{ArgList, IntoFunction};
+    use alloc::format;
 
     #[test]
     fn should_register_function() {

--- a/crates/bevy_reflect/src/func/return_type.rs
+++ b/crates/bevy_reflect/src/func/return_type.rs
@@ -1,9 +1,6 @@
 use crate::PartialReflect;
 use alloc::boxed::Box;
 
-#[cfg(not(feature = "std"))]
-use alloc::{format, vec};
-
 /// The return type of a [`DynamicFunction`] or [`DynamicFunctionMut`].
 ///
 /// [`DynamicFunction`]: crate::func::DynamicFunction

--- a/crates/bevy_reflect/src/func/signature.rs
+++ b/crates/bevy_reflect/src/func/signature.rs
@@ -14,6 +14,7 @@
 use crate::func::args::ArgInfo;
 use crate::func::{ArgList, SignatureInfo};
 use crate::Type;
+use alloc::boxed::Box;
 use bevy_utils::hashbrown::Equivalent;
 use core::borrow::Borrow;
 use core::fmt::{Debug, Formatter};
@@ -203,6 +204,7 @@ impl From<&ArgList<'_>> for ArgumentSignature {
 mod tests {
     use super::*;
     use crate::func::TypedFunction;
+    use alloc::{format, string::String, vec};
 
     #[test]
     fn should_generate_signature_from_function_info() {

--- a/crates/bevy_reflect/src/generics.rs
+++ b/crates/bevy_reflect/src/generics.rs
@@ -241,6 +241,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::{Reflect, Typed};
+    use alloc::string::String;
     use core::fmt::Debug;
 
     #[test]

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -378,7 +378,7 @@ impl_reflect_opaque!(::glam::BVec4A(Debug, Default, Deserialize, Serialize));
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
+    use alloc::{format, string::String};
     use ron::{
         ser::{to_string_pretty, PrettyConfig},
         Deserializer,

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -2428,7 +2428,7 @@ mod tests {
         self as bevy_reflect, Enum, FromReflect, PartialReflect, Reflect, ReflectSerialize,
         TypeInfo, TypeRegistry, Typed, VariantInfo, VariantType,
     };
-    use alloc::collections::BTreeMap;
+    use alloc::{collections::BTreeMap, string::String, vec};
     use bevy_utils::{Duration, HashMap, Instant};
     use core::f32::consts::{PI, TAU};
     use static_assertions::assert_impl_all;

--- a/crates/bevy_reflect/src/kind.rs
+++ b/crates/bevy_reflect/src/kind.rs
@@ -274,6 +274,7 @@ impl ReflectOwned {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use std::collections::HashSet;
 
     use super::*;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -557,7 +557,9 @@
 //! [`ArgList`]: crate::func::ArgList
 //! [derive `Reflect`]: derive@crate::Reflect
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 
@@ -712,7 +714,14 @@ pub mod __macro_exports {
 #[allow(clippy::disallowed_types, clippy::approx_constant)]
 mod tests {
     use ::serde::{de::DeserializeSeed, Deserialize, Serialize};
-    use alloc::borrow::Cow;
+    use alloc::{
+        borrow::Cow,
+        boxed::Box,
+        format,
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
     use bevy_utils::HashMap;
     use core::{
         any::TypeId,
@@ -2556,6 +2565,8 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_reflect_remote_type() {
         mod external_crate {
+            use alloc::string::String;
+
             #[derive(Debug, Default)]
             pub struct TheirType {
                 pub value: String,
@@ -2631,6 +2642,8 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_reflect_remote_value_type() {
         mod external_crate {
+            use alloc::string::String;
+
             #[derive(Clone, Debug, Default)]
             pub struct TheirType {
                 pub value: String,
@@ -2714,6 +2727,8 @@ bevy_reflect::tests::Test {
             // error[E0433]: failed to resolve: use of undeclared crate or module `external_crate`
             // ```
             pub mod external_crate {
+                use alloc::string::String;
+
                 pub struct TheirType {
                     pub value: String,
                 }
@@ -2735,6 +2750,8 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_reflect_remote_enum() {
         mod external_crate {
+            use alloc::string::String;
+
             #[derive(Debug, PartialEq, Eq)]
             pub enum TheirType {
                 Unit,
@@ -2899,6 +2916,8 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_take_remote_type() {
         mod external_crate {
+            use alloc::string::String;
+
             #[derive(Debug, Default, PartialEq, Eq)]
             pub struct TheirType {
                 pub value: String,
@@ -2931,6 +2950,8 @@ bevy_reflect::tests::Test {
     #[test]
     fn should_try_take_remote_type() {
         mod external_crate {
+            use alloc::string::String;
+
             #[derive(Debug, Default, PartialEq, Eq)]
             pub struct TheirType {
                 pub value: String,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -558,7 +558,8 @@
 //! [derive `Reflect`]: derive@crate::Reflect
 
 #![no_std]
-#![cfg(feature = "std")]
+
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -535,6 +535,7 @@ pub fn list_debug(dyn_list: &dyn List, f: &mut Formatter<'_>) -> core::fmt::Resu
 mod tests {
     use super::DynamicList;
     use crate::Reflect;
+    use alloc::{boxed::Box, vec};
     use core::assert_eq;
 
     #[test]

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -631,6 +631,10 @@ pub fn map_try_apply<M: Map>(a: &mut M, b: &dyn PartialReflect) -> Result<(), Ap
 #[cfg(test)]
 mod tests {
     use super::{DynamicMap, Map};
+    use alloc::{
+        borrow::ToOwned,
+        string::{String, ToString},
+    };
 
     #[test]
     fn test_into_iter() {

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -507,6 +507,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::*;
+    use alloc::vec;
 
     #[derive(Reflect)]
     struct A {

--- a/crates/bevy_reflect/src/serde/de/error_utils.rs
+++ b/crates/bevy_reflect/src/serde/de/error_utils.rs
@@ -1,5 +1,7 @@
 use core::fmt::Display;
 use serde::de::Error;
+
+#[cfg(feature = "debug_stack")]
 use std::thread_local;
 
 #[cfg(feature = "debug_stack")]

--- a/crates/bevy_reflect/src/serde/de/error_utils.rs
+++ b/crates/bevy_reflect/src/serde/de/error_utils.rs
@@ -1,5 +1,6 @@
 use core::fmt::Display;
 use serde::de::Error;
+use std::thread_local;
 
 #[cfg(feature = "debug_stack")]
 thread_local! {

--- a/crates/bevy_reflect/src/serde/de/mod.rs
+++ b/crates/bevy_reflect/src/serde/de/mod.rs
@@ -24,11 +24,16 @@ mod tuples;
 
 #[cfg(test)]
 mod tests {
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
     use bincode::Options;
     use core::{any::TypeId, f32::consts::PI, ops::RangeInclusive};
-    use serde::{de::IgnoredAny, Deserializer};
-
     use serde::{de::DeserializeSeed, Deserialize};
+    use serde::{de::IgnoredAny, Deserializer};
 
     use bevy_utils::{HashMap, HashSet};
 

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -189,7 +189,7 @@ mod tests {
         use crate::serde::{DeserializeWithRegistry, ReflectDeserializeWithRegistry};
         use crate::serde::{ReflectSerializeWithRegistry, SerializeWithRegistry};
         use crate::{ReflectFromReflect, TypePath};
-        use alloc::sync::Arc;
+        use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
         use bevy_reflect_derive::reflect_trait;
         use core::any::TypeId;
         use core::fmt::{Debug, Formatter};

--- a/crates/bevy_reflect/src/serde/ser/error_utils.rs
+++ b/crates/bevy_reflect/src/serde/ser/error_utils.rs
@@ -1,5 +1,7 @@
 use core::fmt::Display;
 use serde::ser::Error;
+
+#[cfg(feature = "debug_stack")]
 use std::thread_local;
 
 #[cfg(feature = "debug_stack")]

--- a/crates/bevy_reflect/src/serde/ser/error_utils.rs
+++ b/crates/bevy_reflect/src/serde/ser/error_utils.rs
@@ -1,5 +1,6 @@
 use core::fmt::Display;
 use serde::ser::Error;
+use std::thread_local;
 
 #[cfg(feature = "debug_stack")]
 thread_local! {

--- a/crates/bevy_reflect/src/serde/ser/mod.rs
+++ b/crates/bevy_reflect/src/serde/ser/mod.rs
@@ -25,6 +25,12 @@ mod tests {
         serde::{ReflectSerializer, ReflectSerializerProcessor},
         PartialReflect, Reflect, ReflectSerialize, Struct, TypeRegistry,
     };
+    use alloc::{
+        boxed::Box,
+        string::{String, ToString},
+        vec,
+        vec::Vec,
+    };
     use bevy_utils::{HashMap, HashSet};
     use core::{any::TypeId, f32::consts::PI, ops::RangeInclusive};
     use ron::{extensions::Extensions, ser::PrettyConfig};
@@ -647,6 +653,7 @@ mod tests {
     mod functions {
         use super::*;
         use crate::func::{DynamicFunction, IntoFunction};
+        use alloc::string::ToString;
 
         #[test]
         fn should_not_serialize_function() {

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -498,6 +498,7 @@ pub fn set_try_apply<S: Set>(a: &mut S, b: &dyn PartialReflect) -> Result<(), Ap
 #[cfg(test)]
 mod tests {
     use super::DynamicSet;
+    use alloc::string::{String, ToString};
 
     #[test]
     fn test_into_iter() {

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -585,6 +585,7 @@ impl OpaqueInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn should_return_error_on_invalid_cast() {

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -547,6 +547,8 @@ pub(crate) use impl_type_methods;
 /// For example, [`i32`] cannot be broken down any further, so it is represented by an [`OpaqueInfo`].
 /// And while [`String`] itself is a struct, its fields are private, so we don't really treat
 /// it _as_ a struct. It therefore makes more sense to represent it as an [`OpaqueInfo`].
+///
+/// [`String`]: alloc::string::String
 #[derive(Debug, Clone)]
 pub struct OpaqueInfo {
     ty: Type,

--- a/crates/bevy_reflect/src/type_info_stack.rs
+++ b/crates/bevy_reflect/src/type_info_stack.rs
@@ -1,11 +1,9 @@
 use crate::TypeInfo;
+use alloc::vec::Vec;
 use core::{
     fmt::{Debug, Formatter},
     slice::Iter,
 };
-
-#[cfg(not(feature = "std"))]
-use alloc::{boxed::Box, format, vec};
 
 /// Helper struct for managing a stack of [`TypeInfo`] instances.
 ///

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -24,6 +24,7 @@ pub trait TypedProperty: sealed::Sealed {
 /// Used to store a [`String`] in a [`GenericTypePathCell`] as part of a [`TypePath`] implementation.
 ///
 /// [`TypePath`]: crate::TypePath
+/// [`String`]: alloc::string::String
 pub struct TypePathComponent;
 
 mod sealed {

--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! In Bevy, states are app-wide interdependent, finite state machines that are generally used to model the large scale structure of your program: whether a game is paused, if the player is in combat, if assets are loaded and so on.
 //!
@@ -37,6 +37,8 @@
     )
 )]
 #![cfg_attr(any(docsrs, docsrs_dep), feature(rustdoc_internals))]
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_state/src/lib.rs
+++ b/crates/bevy_state/src/lib.rs
@@ -37,7 +37,8 @@
     )
 )]
 #![cfg_attr(any(docsrs, docsrs_dep), feature(rustdoc_internals))]
-#![cfg(feature = "std")]
+
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_state/src/state/mod.rs
+++ b/crates/bevy_state/src/state/mod.rs
@@ -17,6 +17,7 @@ pub use transitions::*;
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
     use bevy_ecs::{event::EventRegistry, prelude::*};
     use bevy_state_macros::{States, SubStates};
 

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]
 #![no_std]
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -4,7 +4,9 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -3,6 +3,9 @@ use core::{cell::RefCell, future::Future, marker::PhantomData, mem};
 
 use crate::Task;
 
+#[cfg(feature = "std")]
+use std::thread_local;
+
 #[cfg(feature = "portable-atomic")]
 use portable_atomic_util::Arc;
 

--- a/crates/bevy_tasks/src/slice.rs
+++ b/crates/bevy_tasks/src/slice.rs
@@ -215,6 +215,7 @@ impl<S, T: Send> ParallelSliceMut<T> for S where S: AsMut<[T]> {}
 #[cfg(test)]
 mod tests {
     use crate::*;
+    use alloc::vec;
 
     #[test]
     fn test_par_chunks_map() {

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -1,4 +1,4 @@
-use alloc::{format, string::String, vec::Vec};
+use alloc::{boxed::Box, format, string::String, vec::Vec};
 use core::{future::Future, marker::PhantomData, mem, panic::AssertUnwindSafe};
 use std::{
     thread::{self, JoinHandle},
@@ -10,7 +10,7 @@ use concurrent_queue::ConcurrentQueue;
 use futures_lite::FutureExt;
 
 #[cfg(feature = "portable-atomic")]
-use {alloc::boxed::Box, portable_atomic_util::Arc};
+use portable_atomic_util::Arc;
 
 #[cfg(not(feature = "portable-atomic"))]
 use alloc::sync::Arc;

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -1,5 +1,9 @@
+use alloc::{format, string::String, vec::Vec};
 use core::{future::Future, marker::PhantomData, mem, panic::AssertUnwindSafe};
-use std::thread::{self, JoinHandle};
+use std::{
+    thread::{self, JoinHandle},
+    thread_local,
+};
 
 use crate::executor::FallibleTask;
 use concurrent_queue::ConcurrentQueue;

--- a/crates/bevy_transform/src/helper.rs
+++ b/crates/bevy_transform/src/helper.rs
@@ -80,6 +80,7 @@ pub enum ComputeGlobalTransformError {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{vec, vec::Vec};
     use core::f32::consts::TAU;
 
     use bevy_app::App;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -5,7 +5,8 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 #![no_std]
-#![cfg(feature = "std")]
+
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(feature = "alloc")]

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -4,7 +4,9 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#![cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -186,6 +186,7 @@ unsafe fn propagate_recursive(
 
 #[cfg(test)]
 mod test {
+    use alloc::vec;
     use bevy_app::prelude::*;
     use bevy_ecs::{prelude::*, world::CommandQueue};
     use bevy_math::{vec3, Vec3};

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,8 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![expect(
-    unsafe_code,
-    reason = "Some utilities, such as cells, require unsafe code."
-)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -370,6 +366,10 @@ impl<F: FnOnce()> OnDrop<F> {
 
 impl<F: FnOnce()> Drop for OnDrop<F> {
     fn drop(&mut self) {
+        #![expect(
+            unsafe_code,
+            reason = "Taking from a ManuallyDrop requires unsafe code."
+        )]
         // SAFETY: We may move out of `self`, since this instance can never be observed after it's dropped.
         let callback = unsafe { ManuallyDrop::take(&mut self.callback) };
         callback();

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -7,11 +7,14 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! General utilities for first-party [Bevy] engine crates.
 //!
 //! [Bevy]: https://bevyengine.org/
+
+#![cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! [Bevy]: https://bevyengine.org/
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(feature = "alloc")]

--- a/crates/bevy_utils/src/parallel_queue.rs
+++ b/crates/bevy_utils/src/parallel_queue.rs
@@ -1,6 +1,4 @@
-#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::vec::Vec;
-
 use core::{cell::RefCell, ops::DerefMut};
 use thread_local::ThreadLocal;
 

--- a/crates/bevy_utils/src/synccell.rs
+++ b/crates/bevy_utils/src/synccell.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_code, reason = "SyncCell requires unsafe code.")]
+
 //! A reimplementation of the currently unstable [`std::sync::Exclusive`]
 //!
 //! [`std::sync::Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html

--- a/crates/bevy_utils/src/syncunsafecell.rs
+++ b/crates/bevy_utils/src/syncunsafecell.rs
@@ -1,3 +1,5 @@
+#![expect(unsafe_code, reason = "SyncUnsafeCell requires unsafe code.")]
+
 //! A reimplementation of the currently unstable [`std::cell::SyncUnsafeCell`]
 //!
 //! [`std::cell::SyncUnsafeCell`]: https://doc.rust-lang.org/nightly/std/cell/struct.SyncUnsafeCell.html

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -12,7 +12,7 @@
 //! The [`WindowPlugin`] sets up some global window-related parameters and
 //! is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
 
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 extern crate alloc;

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -3,7 +3,7 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! `bevy_window` provides a platform-agnostic interface for windowing in Bevy.
 //!
@@ -11,6 +11,9 @@
 //! used by windowing implementors such as `bevy_winit`.
 //! The [`WindowPlugin`] sets up some global window-related parameters and
 //! is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
+
+#![cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/tools/example-showcase/window-settings-wasm.patch
+++ b/tools/example-showcase/window-settings-wasm.patch
@@ -10,7 +10,7 @@ index ccc861a78..0cae580cd 100644
 +            fit_canvas_to_parent: true,
              prevent_default_event_handling: true,
 -            canvas: None,
-+            canvas: Some("#bevy".to_string()),
++            canvas: Some("#bevy".to_owned()),
              window_theme: None,
              visible: true,
              skip_taskbar: false,


### PR DESCRIPTION
# Background

In `no_std` compatible crates, there is often an `std` feature which will allow access to the standard library. Currently, with the `std` feature _enabled_, the [`std::prelude`](https://doc.rust-lang.org/std/prelude/index.html) is implicitly imported in all modules. With the feature _disabled_, instead the [`core::prelude`](https://doc.rust-lang.org/core/prelude/index.html) is implicitly imported. This creates a subtle and pervasive issue where `alloc` items _may_ be implicitly included (if `std` is enabled), or must be explicitly included (if `std` is not enabled).

# Objective

- Make the implicit imports for `no_std` crates consistent regardless of what features are/not enabled.

## Solution

- Replace the `cfg_attr` "double negative" `no_std` attribute with conditional compilation to _include_ `std` as an external crate.
```rust
// Before
#![cfg_attr(not(feature = "std"), no_std)]

// After
#![no_std]

#[cfg(feature = "std")]
extern crate std;
```
- Fix imports that are currently broken but are only now visible with the above fix.

## Testing

- CI

## Notes

I had previously used the "double negative" version of `no_std` based on general consensus that it was "cleaner" within the Rust embedded community. However, this implicit prelude issue likely was considered when forming this consensus. I believe the reason why is the items most affected by this issue are provided by the `alloc` crate, which is rarely used within embedded but extensively used within Bevy.