### PR TITLE
bevy_tasks: Apply `#[deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -50,7 +50,7 @@ macro_rules! impl_sparse_array {
             #[inline]
             pub fn contains(&self, index: I) -> bool {
                 let index = index.sparse_set_index();
-                self.values.get(index).map(|v| v.is_some()).unwrap_or(false)
+                self.values.get(index).is_some_and(Option::is_some)
             }
 
             /// Returns a reference to the value at `index`.
@@ -59,7 +59,7 @@ macro_rules! impl_sparse_array {
             #[inline]
             pub fn get(&self, index: I) -> Option<&V> {
                 let index = index.sparse_set_index();
-                self.values.get(index).map(|v| v.as_ref()).unwrap_or(None)
+                self.values.get(index).and_then(Option::as_ref)
             }
         }
     };
@@ -87,10 +87,7 @@ impl<I: SparseSetIndex, V> SparseArray<I, V> {
     #[inline]
     pub fn get_mut(&mut self, index: I) -> Option<&mut V> {
         let index = index.sparse_set_index();
-        self.values
-            .get_mut(index)
-            .map(|v| v.as_mut())
-            .unwrap_or(None)
+        self.values.get_mut(index).and_then(Option::as_mut)
     }
 
     /// Removes and returns the value stored at `index`.

--- a/crates/bevy_tasks/src/executor.rs
+++ b/crates/bevy_tasks/src/executor.rs
@@ -51,7 +51,7 @@ pub struct LocalExecutor<'a>(LocalExecutorInner<'a>);
 impl Executor<'_> {
     /// Construct a new [`Executor`]
     #[expect(clippy::allow_attributes, reason = "This lint may not always trigger.")]
-    #[allow(dead_code, reason = "not all feature flags require this function.")]
+    #[allow(dead_code, reason = "not all feature flags require this function")]
     pub const fn new() -> Self {
         Self(ExecutorInner::new())
     }
@@ -60,7 +60,7 @@ impl Executor<'_> {
 impl LocalExecutor<'_> {
     /// Construct a new [`LocalExecutor`]
     #[expect(clippy::allow_attributes, reason = "This lint may not always trigger.")]
-    #[allow(dead_code, reason = "not all feature flags require this function.")]
+    #[allow(dead_code, reason = "not all feature flags require this function")]
     pub const fn new() -> Self {
         Self(LocalExecutorInner::new())
     }

--- a/crates/bevy_tasks/src/executor.rs
+++ b/crates/bevy_tasks/src/executor.rs
@@ -50,7 +50,9 @@ pub struct LocalExecutor<'a>(LocalExecutorInner<'a>);
 
 impl Executor<'_> {
     /// Construct a new [`Executor`]
-    #[allow(dead_code, reason = "not all feature flags require this function")]
+    // NOTE: This struct is used under `crate::TaskPool`, and so this is not
+    // technically dead code. However, if that code is changed, then this may
+    // become dead code *depending on what feature flags are enabled.*
     pub const fn new() -> Self {
         Self(ExecutorInner::new())
     }
@@ -58,7 +60,9 @@ impl Executor<'_> {
 
 impl LocalExecutor<'_> {
     /// Construct a new [`LocalExecutor`]
-    #[allow(dead_code, reason = "not all feature flags require this function")]
+    // NOTE: This struct is used under `crate::TaskPool` inside a static, and so
+    // this is not technically dead code. However, if that code is changed, then
+    // this may become dead code *depending on what feature flags are enabled.*
     pub const fn new() -> Self {
         Self(LocalExecutorInner::new())
     }

--- a/crates/bevy_tasks/src/executor.rs
+++ b/crates/bevy_tasks/src/executor.rs
@@ -50,9 +50,8 @@ pub struct LocalExecutor<'a>(LocalExecutorInner<'a>);
 
 impl Executor<'_> {
     /// Construct a new [`Executor`]
-    // NOTE: This struct is used under `crate::TaskPool`, and so this is not
-    // technically dead code. However, if that code is changed, then this may
-    // become dead code *depending on what feature flags are enabled.*
+    #[expect(clippy::allow_attributes, reason = "This lint may not always trigger.")]
+    #[allow(dead_code, reason = "not all feature flags require this function.")]
     pub const fn new() -> Self {
         Self(ExecutorInner::new())
     }
@@ -60,9 +59,8 @@ impl Executor<'_> {
 
 impl LocalExecutor<'_> {
     /// Construct a new [`LocalExecutor`]
-    // NOTE: This struct is used under `crate::TaskPool` inside a static, and so
-    // this is not technically dead code. However, if that code is changed, then
-    // this may become dead code *depending on what feature flags are enabled.*
+    #[expect(clippy::allow_attributes, reason = "This lint may not always trigger.")]
+    #[allow(dead_code, reason = "not all feature flags require this function.")]
     pub const fn new() -> Self {
         Self(LocalExecutorInner::new())
     }

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -5,6 +5,10 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason
+)]
 
 extern crate alloc;
 

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -5,10 +5,7 @@
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![deny(
-    clippy::allow_attributes,
-    clippy::allow_attributes_without_reason
-)]
+#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]
 
 extern crate alloc;
 

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -694,7 +694,6 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_types)]
 mod tests {
     use super::*;
     use core::sync::atomic::{AtomicBool, AtomicI32, Ordering};


### PR DESCRIPTION
# Objective
We want to deny the following lints:
* `clippy::allow_attributes` - Because there's no reason to `#[allow(...)]` an attribute if it wouldn't lint against anything; you should always use `#[expect(...)]`
* `clippy::allow_attributes_without_reason` - Because documenting the reason for allowing/expecting a lint is always good

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_tasks` in line with the new restrictions.

No code changes have been made - except if a lint that was previously `allow(...)`'d could be removed via small code changes. For example, `unused_variables` can be handled by adding a `_` to the beginning of a field's name.

## Testing
I ran `cargo clippy`, and received no errors.