### PR TITLE
bevy_color: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -1,6 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
-#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
-#![deny(
-    clippy::allow_attributes,
-    clippy::allow_attributes_without_reason
-)]
+#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -1,5 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -142,7 +146,14 @@ pub use srgba::*;
 pub use xyza::*;
 
 /// Describes the traits that a color should implement for consistency.
-#[allow(dead_code)] // This is an internal marker trait used to ensure that our color types impl the required traits
+#[expect(
+    clippy::allow_attributes,
+    reason = "If the below attribute on `dead_code` is removed, then rustc complains that `StandardColor` is dead code. However, if we `expect` the `dead_code` lint, then rustc complains of an unfulfilled expectation."
+)]
+#[allow(
+    dead_code,
+    reason = "This is an internal marker trait used to ensure that our color types impl the required traits"
+)]
 pub(crate) trait StandardColor
 where
     Self: core::fmt::Debug,

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -216,7 +216,10 @@ impl ColorToComponents for Oklaba {
     }
 }
 
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "The code with excessive precision was copied from another codebase."
+)]
 impl From<LinearRgba> for Oklaba {
     fn from(value: LinearRgba) -> Self {
         let LinearRgba {
@@ -239,7 +242,10 @@ impl From<LinearRgba> for Oklaba {
     }
 }
 
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "The code with excessive precision was copied from another codebase."
+)]
 impl From<Oklaba> for LinearRgba {
     fn from(value: Oklaba) -> Self {
         let Oklaba {

--- a/crates/bevy_color/src/palettes/css.rs
+++ b/crates/bevy_color/src/palettes/css.rs
@@ -4,7 +4,6 @@
 use crate::Srgba;
 
 // The CSS4 colors are a superset of the CSS1 colors, so we can just re-export the CSS1 colors.
-#[allow(unused_imports)]
 pub use crate::palettes::basic::*;
 
 /// <div style="background-color:rgb(94.1%, 97.3%, 100.0%); width: 10px; padding: 10px; border: 1px solid;"></div>


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_audio` in line with the new restrictions.

No code changes have been made - except if a lint that was previously `allow(...)`'d could be removed via small code changes. For example, `unused_variables` can be handled by adding a `_` to the beginning of a field's name.

## Testing
I ran `cargo clippy`, and received no errors.