### PR TITLE
Anamorphic Bloom

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
+++ b/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
@@ -53,6 +53,7 @@ fn karis_average(color: vec3<f32>) -> f32 {
 // [COD] slide 153
 fn sample_input_13_tap(uv: vec2<f32>) -> vec3<f32> {
 #ifdef FIRST_DOWNSAMPLE
+    // Prevents noticeable sampling/ghosting artifacts when using large scales.
     let scale = vec2<f32>(1.0, 1.0);
 #else
     let scale = uniforms.scale;

--- a/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
+++ b/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
@@ -9,6 +9,7 @@
 struct BloomUniforms {
     threshold_precomputations: vec4<f32>,
     viewport: vec4<f32>,
+    scale: vec2<f32>,
     aspect: f32,
     uv_offset: f32
 };
@@ -51,19 +52,32 @@ fn karis_average(color: vec3<f32>) -> f32 {
 
 // [COD] slide 153
 fn sample_input_13_tap(uv: vec2<f32>) -> vec3<f32> {
-    let a = textureSample(input_texture, s, uv, vec2<i32>(-2, 2)).rgb;
-    let b = textureSample(input_texture, s, uv, vec2<i32>(0, 2)).rgb;
-    let c = textureSample(input_texture, s, uv, vec2<i32>(2, 2)).rgb;
-    let d = textureSample(input_texture, s, uv, vec2<i32>(-2, 0)).rgb;
+#ifdef FIRST_DOWNSAMPLE
+    let scale = vec2<f32>(1.0, 1.0);
+#else
+    let scale = uniforms.scale;
+#endif
+    let x_s = scale.x / f32(textureDimensions(input_texture).x);
+    let y_s = scale.y / f32(textureDimensions(input_texture).y);
+    let x_l = 2.0 * x_s;
+    let y_l = 2.0 * y_s;
+    let x_ns = -1.0 * x_s;
+    let y_ns = -1.0 * y_s;
+    let x_nl = -2.0 * x_s;
+    let y_nl = -2.0 * y_s;
+    let a = textureSample(input_texture, s, uv + vec2<f32>(x_nl, y_l)).rgb;
+    let b = textureSample(input_texture, s, uv + vec2<f32>(0.0, y_l)).rgb;
+    let c = textureSample(input_texture, s, uv + vec2<f32>(x_l, y_l)).rgb;
+    let d = textureSample(input_texture, s, uv + vec2<f32>(x_nl, 0.0)).rgb;
     let e = textureSample(input_texture, s, uv).rgb;
-    let f = textureSample(input_texture, s, uv, vec2<i32>(2, 0)).rgb;
-    let g = textureSample(input_texture, s, uv, vec2<i32>(-2, -2)).rgb;
-    let h = textureSample(input_texture, s, uv, vec2<i32>(0, -2)).rgb;
-    let i = textureSample(input_texture, s, uv, vec2<i32>(2, -2)).rgb;
-    let j = textureSample(input_texture, s, uv, vec2<i32>(-1, 1)).rgb;
-    let k = textureSample(input_texture, s, uv, vec2<i32>(1, 1)).rgb;
-    let l = textureSample(input_texture, s, uv, vec2<i32>(-1, -1)).rgb;
-    let m = textureSample(input_texture, s, uv, vec2<i32>(1, -1)).rgb;
+    let f = textureSample(input_texture, s, uv + vec2<f32>(x_l, 0.0)).rgb;
+    let g = textureSample(input_texture, s, uv + vec2<f32>(x_nl, y_nl)).rgb;
+    let h = textureSample(input_texture, s, uv + vec2<f32>(0.0, y_nl)).rgb;
+    let i = textureSample(input_texture, s, uv + vec2<f32>(x_l, y_nl)).rgb;
+    let j = textureSample(input_texture, s, uv + vec2<f32>(x_ns, y_s)).rgb;
+    let k = textureSample(input_texture, s, uv + vec2<f32>(x_s, y_s)).rgb;
+    let l = textureSample(input_texture, s, uv + vec2<f32>(x_ns, y_ns)).rgb;
+    let m = textureSample(input_texture, s, uv + vec2<f32>(x_s, y_ns)).rgb;
 
 #ifdef FIRST_DOWNSAMPLE
     // [COD] slide 168

--- a/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
 };
-use bevy_math::Vec4;
+use bevy_math::{Vec2, Vec4};
 use bevy_render::{
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
@@ -40,6 +40,7 @@ pub struct BloomUniforms {
     // Precomputed values used when thresholding, see https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4
     pub threshold_precomputations: Vec4,
     pub viewport: Vec4,
+    pub scale: Vec2,
     pub aspect: f32,
     pub uv_offset: f32,
 }

--- a/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
@@ -43,7 +43,6 @@ pub struct BloomUniforms {
     pub viewport: Vec4,
     pub scale: Vec2,
     pub aspect: f32,
-    pub uv_offset: f32,
 }
 
 impl FromWorld for BloomDownsamplingPipeline {

--- a/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
@@ -31,6 +31,7 @@ pub struct BloomDownsamplingPipeline {
 pub struct BloomDownsamplingPipelineKeys {
     prefilter: bool,
     first_downsample: bool,
+    uniform_scale: bool,
 }
 
 /// The uniform struct extracted from [`Bloom`] attached to a Camera.
@@ -103,6 +104,10 @@ impl SpecializedRenderPipeline for BloomDownsamplingPipeline {
             shader_defs.push("USE_THRESHOLD".into());
         }
 
+        if key.uniform_scale {
+            shader_defs.push("UNIFORM_SCALE".into());
+        }
+
         RenderPipelineDescriptor {
             label: Some(
                 if key.first_downsample {
@@ -149,6 +154,7 @@ pub fn prepare_downsampling_pipeline(
             BloomDownsamplingPipelineKeys {
                 prefilter,
                 first_downsample: false,
+                uniform_scale: bloom.scale == Vec2::ONE,
             },
         );
 
@@ -158,6 +164,7 @@ pub fn prepare_downsampling_pipeline(
             BloomDownsamplingPipelineKeys {
                 prefilter,
                 first_downsample: true,
+                uniform_scale: bloom.scale == Vec2::ONE,
             },
         );
 

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -146,7 +146,7 @@ impl Bloom {
     pub const ANAMORPHIC: Self = Self {
         // The larger scale necessitates a larger resolution to reduce artifacts:
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION * 2,
-        scale: Vec2::new(6.0, 0.8),
+        scale: Vec2::new(4.0, 1.0),
         ..Self::NATURAL
     };
 

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -118,7 +118,7 @@ pub struct Bloom {
     pub uv_offset: f32,
 
     /// Amount to stretch the bloom on each axis. Artistic control, can be used to emulate
-    /// anamorphic blur by using a large x-value. For large stretch values, you may need to increase
+    /// anamorphic blur by using a large x-value. For large values, you may need to increase
     /// [`Bloom::max_mip_dimension`] to reduce sampling artifacts.
     pub scale: Vec2,
 }
@@ -151,6 +151,7 @@ impl Bloom {
     /// Emulates the look of stylized anamorphic bloom, stretched horizontally.
     pub const ANAMORPHIC: Self = Self {
         uv_offset: Self::DEFAULT_UV_OFFSET / 2.0,
+        // The larger scale necessitates a larger resolution to reduce artifacts:
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION * 2,
         scale: Vec2::new(8.0, 1.0),
         ..Self::NATURAL

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -113,10 +113,6 @@ pub struct Bloom {
     /// Only tweak if you are seeing visual artifacts.
     pub max_mip_dimension: u32,
 
-    /// UV offset for bloom shader. Ideally close to 2.0 / `max_mip_dimension`.
-    /// Only tweak if you are seeing visual artifacts.
-    pub uv_offset: f32,
-
     /// Amount to stretch the bloom on each axis. Artistic control, can be used to emulate
     /// anamorphic blur by using a large x-value. For large values, you may need to increase
     /// [`Bloom::max_mip_dimension`] to reduce sampling artifacts.
@@ -128,7 +124,6 @@ pub type BloomSettings = Bloom;
 
 impl Bloom {
     const DEFAULT_MAX_MIP_DIMENSION: u32 = 512;
-    const DEFAULT_UV_OFFSET: f32 = 0.004;
 
     /// The default bloom preset.
     ///
@@ -144,16 +139,14 @@ impl Bloom {
         },
         composite_mode: BloomCompositeMode::EnergyConserving,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
-        uv_offset: Self::DEFAULT_UV_OFFSET,
         scale: Vec2::ONE,
     };
 
     /// Emulates the look of stylized anamorphic bloom, stretched horizontally.
     pub const ANAMORPHIC: Self = Self {
-        uv_offset: Self::DEFAULT_UV_OFFSET / 2.0,
         // The larger scale necessitates a larger resolution to reduce artifacts:
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION * 2,
-        scale: Vec2::new(8.0, 1.0),
+        scale: Vec2::new(6.0, 0.8),
         ..Self::NATURAL
     };
 
@@ -169,7 +162,6 @@ impl Bloom {
         },
         composite_mode: BloomCompositeMode::Additive,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
-        uv_offset: Self::DEFAULT_UV_OFFSET,
         scale: Vec2::ONE,
     };
 
@@ -185,7 +177,6 @@ impl Bloom {
         },
         composite_mode: BloomCompositeMode::EnergyConserving,
         max_mip_dimension: Self::DEFAULT_MAX_MIP_DIMENSION,
-        uv_offset: Self::DEFAULT_UV_OFFSET,
         scale: Vec2::ONE,
     };
 }
@@ -263,7 +254,6 @@ impl ExtractComponent for Bloom {
                     aspect: AspectRatio::try_from_pixels(size.x, size.y)
                         .expect("Valid screen size values for Bloom settings")
                         .ratio(),
-                    uv_offset: bloom.uv_offset,
                     scale: bloom.scale,
                 };
 

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -107,6 +107,7 @@ fn update_bloom_settings(
                 "(U/J) Threshold softness: {}\n",
                 bloom.prefilter.threshold_softness
             ));
+            text.push_str(&format!("(I/K) Horizontal Scale: {}\n", bloom.scale.x));
 
             if keycode.just_pressed(KeyCode::Space) {
                 commands.entity(entity).remove::<Bloom>();
@@ -169,6 +170,14 @@ fn update_bloom_settings(
                 bloom.prefilter.threshold_softness += dt / 10.0;
             }
             bloom.prefilter.threshold_softness = bloom.prefilter.threshold_softness.clamp(0.0, 1.0);
+
+            if keycode.pressed(KeyCode::KeyK) {
+                bloom.scale.x -= dt * 2.0;
+            }
+            if keycode.pressed(KeyCode::KeyI) {
+                bloom.scale.x += dt * 2.0;
+            }
+            bloom.scale.x = bloom.scale.x.clamp(0.0, 16.0);
         }
 
         (entity, None) => {

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -3,7 +3,7 @@
 use bevy::{
     core_pipeline::{
         bloom::{Bloom, BloomCompositeMode},
-        tonemapping::Tonemapping,
+        tonemapping::{DebandDither, Tonemapping},
     },
     prelude::*,
 };
@@ -30,6 +30,7 @@ fn setup(
         },
         Tonemapping::TonyMcMapface, // 2. Using a tonemapper that desaturates to white is recommended
         Bloom::default(),           // 3. Enable bloom for the camera
+        DebandDither::Enabled,      // Optional: bloom causes gradients which cause banding
     ));
 
     // Sprite

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -26,6 +26,7 @@ fn setup(
         Camera2d,
         Camera {
             hdr: true, // 1. HDR is required for bloom
+            clear_color: ClearColorConfig::Custom(Color::BLACK),
             ..default()
         },
         Tonemapping::TonyMcMapface, // 2. Using a tonemapper that desaturates to white is recommended

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -1,7 +1,6 @@
 //! Illustrates bloom post-processing using HDR and emissive materials.
 
 use bevy::{
-    color::palettes::basic::GRAY,
     core_pipeline::{
         bloom::{Bloom, BloomCompositeMode},
         tonemapping::Tonemapping,
@@ -40,19 +39,19 @@ fn setup_scene(
     ));
 
     let material_emissive1 = materials.add(StandardMaterial {
-        emissive: LinearRgba::rgb(0.0, 0.0, 25.0), // 4. Put something bright in a dark environment to see the effect
+        emissive: LinearRgba::rgb(0.0, 0.0, 150.0), // 4. Put something bright in a dark environment to see the effect
         ..default()
     });
     let material_emissive2 = materials.add(StandardMaterial {
-        emissive: LinearRgba::rgb(8.0, 100.0, 0.0),
+        emissive: LinearRgba::rgb(1000.0, 1000.0, 1000.0),
         ..default()
     });
     let material_emissive3 = materials.add(StandardMaterial {
-        emissive: LinearRgba::rgb(25.0, 0.0, 0.0),
+        emissive: LinearRgba::rgb(50.0, 0.0, 0.0),
         ..default()
     });
     let material_non_emissive = materials.add(StandardMaterial {
-        base_color: GRAY.into(),
+        base_color: Color::BLACK,
         ..default()
     });
 
@@ -67,8 +66,8 @@ fn setup_scene(
             let rand = (hasher.finish() + 3) % 6;
 
             let (material, scale) = match rand {
-                0 => (material_emissive1.clone(), 1.0),
-                1 => (material_emissive2.clone(), 0.2),
+                0 => (material_emissive1.clone(), 0.5),
+                1 => (material_emissive2.clone(), 0.1),
                 2 => (material_emissive3.clone(), 1.0),
                 3..=5 => (material_non_emissive.clone(), 1.5),
                 _ => unreachable!(),

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -36,8 +36,7 @@ fn setup_scene(
         },
         Tonemapping::TonyMcMapface, // 2. Using a tonemapper that desaturates to white is recommended
         Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        // 3. Enable bloom for the camera
-        Bloom::NATURAL,
+        Bloom::NATURAL, // 3. Enable bloom for the camera
     ));
 
     let material_emissive1 = materials.add(StandardMaterial {
@@ -206,7 +205,7 @@ fn update_bloom_settings(
             if keycode.pressed(KeyCode::KeyI) {
                 bloom.scale.x += dt * 2.0;
             }
-            bloom.scale.x = bloom.scale.x.clamp(0.0, 16.0);
+            bloom.scale.x = bloom.scale.x.clamp(0.0, 8.0);
         }
 
         (entity, None) => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/e2de3d20-4246-4eba-a0a7-8469a468dddb

The _JJ Abrahams_

https://github.com/user-attachments/assets/2dce3df9-665b-46ff-b687-e7cb54364f30

The _Cyberfunk 2025_

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/0179df38-ea2e-4f34-bbd3-d3240f0d0a4f" />

# Objective

- Add the ability to scale bloom for artistic control, and to mimic anamorphic blurs.

## Solution

- Add a scale factor in bloom settings, and plumb this to the shader.

## Testing

- Added runtime-tweak-able setting to the `bloom_3d`/`bloom_2d ` example

---

## Showcase

![image](https://github.com/user-attachments/assets/bb44dae4-52bb-4981-a77f-aaa1ec83f5d6)

- Added `scale` parameter to `Bloom` to improve artistic control and enable anamorphic bloom.
