### PR TITLE
UI Debug Overlay `show_hidden` and `show_clipped` options

### DIFF
--- a/crates/bevy_ui/src/render/debug_overlay.rs
+++ b/crates/bevy_ui/src/render/debug_overlay.rs
@@ -1,3 +1,7 @@
+use crate::CalculatedClip;
+use crate::ComputedNode;
+use crate::DefaultUiCamera;
+use crate::TargetCamera;
 use bevy_asset::AssetId;
 use bevy_color::Hsla;
 use bevy_ecs::entity::Entity;
@@ -10,13 +14,10 @@ use bevy_math::Rect;
 use bevy_math::Vec2;
 use bevy_render::sync_world::RenderEntity;
 use bevy_render::sync_world::TemporaryRenderEntity;
+use bevy_render::view::ViewVisibility;
 use bevy_render::Extract;
 use bevy_sprite::BorderRect;
 use bevy_transform::components::GlobalTransform;
-
-use crate::ComputedNode;
-use crate::DefaultUiCamera;
-use crate::TargetCamera;
 
 use super::ExtractedUiItem;
 use super::ExtractedUiNode;
@@ -75,8 +76,8 @@ pub fn extract_debug_overlay(
         return;
     }
 
-    for (entity, uinode, transform, camera) in &uinode_query {
-        if !debug_overlay.show_hidden && !visibility.get() {
+    for (entity, uinode, visibility, maybe_clip, transform, camera) in &uinode_query {
+        if !debug_options.show_hidden && !visibility.get() {
             continue;
         }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -60,6 +60,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ..default()
                             },
                             BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
+                            Visibility::Visible,
                         ))
                         .with_children(|parent| {
                             // text
@@ -77,16 +78,46 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             ));
 
                             #[cfg(feature = "bevy_ui_debug")]
-                            // Debug overlay text
-                            parent.spawn((
-                                Text::new("Press Space to toggle debug outlines."),
-                                TextFont {
-                                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                    ..default()
-                                },
-                                Label,
-                            ));
+                            {
+                                // Debug overlay text
+                                parent.spawn((
+                                    Text::new("Press Space to toggle debug outlines."),
+                                    TextFont {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        ..default()
+                                    },
+                                    Label,
+                                ));
 
+                                parent.spawn((
+                                    Text::new("V: toggle UI visibility"),
+                                    TextFont {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font_size: 12.,
+                                        ..default()
+                                    },
+                                    Label,
+                                ));
+
+                                parent.spawn((
+                                    Text::new("S: toggle outlines for hidden nodes"),
+                                    TextFont {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font_size: 12.,
+                                        ..default()
+                                    },
+                                    Label,
+                                ));
+                                parent.spawn((
+                                    Text::new("C: toggle outlines for clipped nodes"),
+                                    TextFont {
+                                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                        font_size: 12.,
+                                        ..default()
+                                    },
+                                    Label,
+                                ));
+                            }
                             #[cfg(not(feature = "bevy_ui_debug"))]
                             parent.spawn((
                                 Text::new("Try enabling feature \"bevy_ui_debug\"."),
@@ -346,11 +377,32 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 #[cfg(feature = "bevy_ui_debug")]
 // The system that will enable/disable the debug outlines around the nodes
-fn toggle_debug_overlay(input: Res<ButtonInput<KeyCode>>, mut options: ResMut<UiDebugOptions>) {
+fn toggle_debug_overlay(
+    input: Res<ButtonInput<KeyCode>>,
+    mut debug_options: ResMut<UiDebugOptions>,
+    mut root_node_query: Query<&mut Visibility, (With<Node>, Without<Parent>)>,
+) {
     info_once!("The debug outlines are enabled, press Space to turn them on/off");
     if input.just_pressed(KeyCode::Space) {
-        // The toggle method will enable the debug_overlay if disabled and disable if enabled
-        options.toggle();
+        // The toggle method will enable the debug overlay if disabled and disable if enabled
+        debug_options.toggle();
+    }
+
+    if input.just_pressed(KeyCode::KeyS) {
+        // Toggle debug outlines for nodes with `ViewVisibility` set to false.
+        debug_options.show_hidden = !debug_options.show_hidden;
+    }
+
+    if input.just_pressed(KeyCode::KeyC) {
+        // Toggle outlines for clipped UI nodes.
+        debug_options.show_clipped = !debug_options.show_clipped;
+    }
+
+    if input.just_pressed(KeyCode::KeyV) {
+        for mut visibility in root_node_query.iter_mut() {
+            // Toggle the UI root node's visibility
+            visibility.toggle_inherited_hidden();
+        }
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -90,7 +90,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ));
 
                                 parent.spawn((
-                                    Text::new("V: toggle UI visibility"),
+                                    Text::new("V: toggle UI root's visibility"),
                                     TextFont {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                         font_size: 12.,


### PR DESCRIPTION
# Objective

The UI debug overlay draws an outline for every UI node even if it is invisible or clipped. 
Disable debug outlines for hidden and clipped nodes by default and add options to renable them if needed.

## Solution

* Add `show_hidden` and `show_clipped` fields to `UiDebugOptions`:
```rust
    /// Show outlines for non-visible UI nodes
    pub show_hidden: bool,
    /// Show outlines for clipped sections of UI nodes
    pub show_clipped: bool,
```

* Only extract debug outlines for hidden and clipped UI nodes if the respective field in `UiDebugOptions` is set to `true`.

## Testing

Also added some extra features to the `testbed_ui` example that demonstrate the new options:

cargo run --example testbed_ui --features "bevy_ui_debug"

<img width="641" alt="show-hidden-and-clipped" src="https://github.com/user-attachments/assets/16a68600-170c-469e-a3c7-f7dae411dc40" />
