### PR TITLE
`Text2d` and sprite slicing fix

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -396,7 +396,7 @@ pub fn extract_sprites(
                         commands.spawn(TemporaryRenderEntity).id(),
                         sprite,
                     )
-                    .map(|e| (original_entity.into(), e)),
+                    .map(|e| (commands.spawn(TemporaryRenderEntity).id().into(), e)),
             );
         } else {
             let atlas_rect = sprite
@@ -417,7 +417,7 @@ pub fn extract_sprites(
 
             // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
             extracted_sprites.sprites.insert(
-                original_entity.into(),
+                commands.spawn(TemporaryRenderEntity).id().into(),
                 ExtractedSprite {
                     color: sprite.color.into(),
                     transform: *transform,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -206,7 +206,7 @@ pub fn extract_text2d_sprite(
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
             extracted_sprites.sprites.insert(
-                original_entity.into(),
+                commands.spawn(TemporaryRenderEntity).id().into(),
                 ExtractedSprite {
                     transform: transform * GlobalTransform::from_translation(position.extend(0.)),
                     color,


### PR DESCRIPTION
# Objective

Fix #17098

`text2d` example:
![image](https://github.com/user-attachments/assets/9f2b40d4-2ffe-4341-9b8b-0a527933e436)


## Solution

When extracting multiple sprites for text2d and texture slicing spawn new temporary render entities to act as keys in the `ExtractedSprites` `MainEntityHashMap`.

It wraps a temporary render world entity inside a `MainEntity` which doesn't seem great, but it seems to work?