### PR TITLE
Fix documentation for system set method

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -637,7 +637,7 @@ where
         self.into_configs().before(set)
     }
 
-    /// Runs before all systems in `set`. If `set` has any systems that produce [`Commands`](crate::system::Commands)
+    /// Runs after all systems in `set`. If `set` has any systems that produce [`Commands`](crate::system::Commands)
     /// or other [`Deferred`](crate::system::Deferred) operations, all systems in `self` will see their effect.
     ///
     /// If automatically inserting [`ApplyDeferred`](crate::schedule::ApplyDeferred) like


### PR DESCRIPTION
# Objective

Fix incorrect comment on `IntoSystemSetConfigs::after` likely caused by copy-paste error. It said "before" instead of "after".

## Solution

Update the comment to the correct text.

## Testing

CI tests pass. This is just updating a comment.