### PR TITLE
More DefaultUiCamera fixes

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -213,6 +213,8 @@ pub fn ui_focus_system(
         })
         .collect();
 
+    let default_camera_entity = default_ui_camera.get();
+
     // prepare an iterator that contains all the nodes that have the cursor in their rect,
     // from the top node to the bottom one. this will also reset the interaction to `None`
     // for all nodes encountered that are no longer hovered.
@@ -239,7 +241,7 @@ pub fn ui_focus_system(
             let camera_entity = node
                 .target_camera
                 .map(TargetCamera::entity)
-                .or(default_ui_camera.get())?;
+                .or(default_camera_entity)?;
 
             let node_rect = Rect::from_center_size(
                 node.global_transform.translation().truncate(),

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -72,6 +72,8 @@ pub fn ui_picking(
     // For each camera, the pointer and its position
     let mut pointer_pos_by_camera = HashMap::<Entity, HashMap<PointerId, Vec2>>::default();
 
+    let default_camera_entity = default_ui_camera.get();
+
     for (pointer_id, pointer_location) in
         pointers.iter().filter_map(|(pointer, pointer_location)| {
             Some(*pointer).zip(pointer_location.location().cloned())
@@ -133,7 +135,7 @@ pub fn ui_picking(
         let Some(camera_entity) = node
             .target_camera
             .map(TargetCamera::entity)
-            .or(default_ui_camera.get())
+            .or(default_camera_entity)
         else {
             continue;
         };
@@ -189,7 +191,7 @@ pub fn ui_picking(
             let Some(camera_entity) = node
                 .target_camera
                 .map(TargetCamera::entity)
-                .or(default_ui_camera.get())
+                .or(default_camera_entity)
             else {
                 continue;
             };

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,3 +1,5 @@
+use std::default;
+
 use crate::{
     ComputedNode, ContentSize, DefaultUiCamera, FixedMeasure, Measure, MeasureArgs, Node,
     NodeMeasure, TargetCamera, UiScale,
@@ -279,10 +281,12 @@ pub fn measure_text_system(
 ) {
     scale_factors_buffer.clear();
 
+    let default_camera_entity = default_ui_camera.get();
+
     for (entity, block, content_size, text_flags, computed, maybe_camera) in &mut text_query {
         let Some(camera_entity) = maybe_camera
             .map(TargetCamera::entity)
-            .or(default_ui_camera.get())
+            .or(default_camera_entity)
         else {
             continue;
         };

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,5 +1,3 @@
-use std::default;
-
 use crate::{
     ComputedNode, ContentSize, DefaultUiCamera, FixedMeasure, Measure, MeasureArgs, Node,
     NodeMeasure, TargetCamera, UiScale,


### PR DESCRIPTION
# Objective

Found more excessive `DefaultUiCamera` queries outside of extraction.
The default UI camera lookup only needs to be done once. Do it first, not per node.
