### PR TITLE
Revert "Fix sprite performance regression since retained render world (#17078)"

### DIFF
--- a/crates/bevy_sprite/src/texture_slice/computed_slices.rs
+++ b/crates/bevy_sprite/src/texture_slice/computed_slices.rs
@@ -28,7 +28,6 @@ impl ComputedTextureSlices {
         &'a self,
         transform: &'a GlobalTransform,
         original_entity: Entity,
-        render_entity: Entity,
         sprite: &'a Sprite,
     ) -> impl ExactSizeIterator<Item = ExtractedSprite> + 'a {
         let mut flip = Vec2::ONE;
@@ -54,7 +53,6 @@ impl ComputedTextureSlices {
                 flip_y,
                 image_handle_id: sprite.image.id(),
                 anchor: Self::redepend_anchor_from_sprite_to_slice(sprite, slice),
-                render_entity,
             }
         })
     }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -206,7 +206,10 @@ pub fn extract_text2d_sprite(
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
             extracted_sprites.sprites.insert(
-                original_entity.into(),
+                (
+                    commands.spawn(TemporaryRenderEntity).id(),
+                    original_entity.into(),
+                ),
                 ExtractedSprite {
                     transform: transform * GlobalTransform::from_translation(position.extend(0.)),
                     color,
@@ -217,7 +220,6 @@ pub fn extract_text2d_sprite(
                     flip_y: false,
                     anchor: Anchor::Center.as_vec(),
                     original_entity: Some(original_entity),
-                    render_entity: commands.spawn(TemporaryRenderEntity).id(),
                 },
             );
         }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -13,7 +13,7 @@ use bevy::{
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat},
     },
-    sprite::{AlphaMode2d, SpritePlugin},
+    sprite::AlphaMode2d,
     utils::Duration,
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
@@ -132,21 +132,16 @@ fn main() {
 
     App::new()
         .add_plugins((
-            DefaultPlugins
-                .set(WindowPlugin {
-                    primary_window: Some(Window {
-                        title: "BevyMark".into(),
-                        resolution: WindowResolution::new(1920.0, 1080.0)
-                            .with_scale_factor_override(1.0),
-                        present_mode: PresentMode::AutoNoVsync,
-                        ..default()
-                    }),
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "BevyMark".into(),
+                    resolution: WindowResolution::new(1920.0, 1080.0)
+                        .with_scale_factor_override(1.0),
+                    present_mode: PresentMode::AutoNoVsync,
                     ..default()
-                })
-                .set(SpritePlugin {
-                    #[cfg(feature = "bevy_sprite_picking_backend")]
-                    add_picking: false,
                 }),
+                ..default()
+            }),
             FrameTimeDiagnosticsPlugin,
             LogDiagnosticsPlugin::default(),
         ))


### PR DESCRIPTION
# Objective

Fixes #17098

It seems that it's not totally obvious how to fix this, but that reverting might be part of the solution anyway.

Let's get the repo back into a working state.

## Solution

Revert the [recent optimization](https://github.com/bevyengine/bevy/pull/17078) that broke "many-to-one main->render world entities" for 2d.

## Testing

`cargo run --example text2d`
`cargo run --example sprite_slice`
