### PR TITLE
Fix broken import in dev_tools fps_overlay.rs example

### DIFF
--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -1,10 +1,7 @@
 //! Showcase how to use and configure FPS overlay.
 
-use bevy::{
-    dev_tools::fps_overlay::{FpsOverlayConfig, FpsOverlayPlugin},
-    prelude::*,
-    text::FontSmoothing,
-};
+use bevy::{prelude::*, text::FontSmoothing};
+use bevy_dev_tools::fps_overlay::{FpsOverlayConfig, FpsOverlayPlugin};
 
 struct OverlayColor;
 


### PR DESCRIPTION
dev_tools Example uses bevy::dev_tools::{FpsOverlayConfig, FpsOverlayPlugin} but this is a broken import path.

It appears at some point bevy::dev_tools was split into a separate crate, bevy_dev_tools and this is a minor revision to the example to reflect that.

This is my first ever pull request (just a wannabe developer) so let me know if I did something wrong.