### PR TITLE
Show working urls to screenshot comparisons in output

### DIFF
--- a/.github/workflows/send-screenshots-to-pixeleagle.yml
+++ b/.github/workflows/send-screenshots-to-pixeleagle.yml
@@ -34,13 +34,13 @@ jobs:
         if: ${{ ! fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}
         run: |
           echo "The PIXELEAGLE_TOKEN secret does not exist, so uploading screenshots to Pixel Eagle was skipped." >> $GITHUB_STEP_SUMMARY
-      
+
       - name: Download artifact
         if: ${{ fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}
         uses: actions/download-artifact@v4
         with:
           pattern: ${{ inputs.artifact }}
-      
+
       - name: Send to Pixel Eagle
         if: ${{ fromJSON(env.PIXELEAGLE_TOKEN_EXISTS) }}
         env:
@@ -49,11 +49,11 @@ jobs:
           # Create a new run with its associated metadata
           metadata='{"os":"${{ inputs.os }}", "commit": "${{ inputs.commit }}", "branch": "${{ inputs.branch }}"}'
           run=`curl https://pixel-eagle.vleue.com/$project/runs --json "$metadata" --oauth2-bearer ${{ secrets.PIXELEAGLE_TOKEN }} | jq '.id'`
-          
+
           SAVEIFS=$IFS
-          
+
           cd ${{ inputs.artifact }}
-          
+
           # Read the hashes of the screenshot for fast comparison when they are equal
           IFS=$'\n'
           # Build a json array of screenshots and their hashes
@@ -67,7 +67,7 @@ jobs:
           done
           hashes=`echo $hashes | rev | cut -c 2- | rev`
           hashes="$hashes]"
-          
+
           IFS=$SAVEIFS
 
           # Upload screenshots with unknown hashes
@@ -78,7 +78,7 @@ jobs:
               curl https://pixel-eagle.vleue.com/$project/runs/$run/screenshots -F "data=@./screenshots-$name" -F "screenshot=$name" --oauth2-bearer ${{ secrets.PIXELEAGLE_TOKEN }}
               echo
             done
-          
+
           IFS=$SAVEIFS
 
           cd ..
@@ -93,17 +93,17 @@ jobs:
           missing=`cat pixeleagle.json | jq '.missing | length'`
           if [ ! $missing -eq 0 ]; then
             echo "There are $missing missing screenshots"
-            echo "::warning title=$missing missing screenshots on ${{ inputs.os }}::https://pixel-eagle.vleue.com/$project/runs/$run/compare/$compared_with"
+            echo "::warning title=$missing missing screenshots on ${{ inputs.os }}::https://pixel-eagle.com/project/$project/run/$run/compare/$compared_with"
             status=1
           fi
 
           diff=`cat pixeleagle.json | jq '.diff | length'`
           if [ ! $diff -eq 0 ]; then
             echo "There are $diff screenshots with a difference"
-            echo "::warning title=$diff different screenshots on ${{ inputs.os }}::https://pixel-eagle.vleue.com/$project/runs/$run/compare/$compared_with"
+            echo "::warning title=$diff different screenshots on ${{ inputs.os }}::https://pixel-eagle.com/project/$project/run/$run/compare/$compared_with"
             status=1
           fi
 
-          echo "created run $run: https://pixel-eagle.vleue.com/$project/runs/$run/compare/$compared_with"
+          echo "created run $run: https://pixel-eagle.com/project/$project/run/$run/compare/$compared_with"
 
           exit $status


### PR DESCRIPTION
# Objective

When a PR introduces changes that result in differences in the rendering one of the "testbeds," contributors get a nice email informing them about a [failed workflow run](https://github.com/bevyengine/bevy/actions/runs/12599884045/job/35117729566).

However, this email contains links that just go to a json blob which isn't as helpful as it could be. If you squint real hard, you can figure out which testbed failed and at which frame the screenshot took place. Not ideal.

This changes the urls presented as output in that workflow so that they lead to the actual screenshot comparison screen on pixel-eagle.

![image](https://github.com/user-attachments/assets/36af7f29-9319-4a1f-bf0a-7f7ffd5d613f)

<img width="753" alt="image" src="https://github.com/user-attachments/assets/7d39de37-8cff-4db3-8fbc-288e482d876c" />

## Solution

Change the urls in the output from e.g.

https://pixel-eagle.vleue.com/B04F67C0-C054-4A6F-92EC-F599FEC2FD1D/runs/4591/compare/4568

To

https://pixel-eagle.com/project/B04F67C0-C054-4A6F-92EC-F599FEC2FD1D/run/4591/compare/4568

Without messing with any of the URLs involved in uploading the screenshots.

## Testing

I have not tested this (yet) beyond manual testing of the new URL structure. I suspect it's not possible to test in a fork.
