### PR TITLE
Update `typos`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.28.4
+        uses: crate-ci/typos@v1.29.4
       - name: Typos info
         if: failure()
         run: |

--- a/assets/shaders/specialized_mesh_pipeline.wgsl
+++ b/assets/shaders/specialized_mesh_pipeline.wgsl
@@ -30,7 +30,7 @@ struct VertexOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     // This is how bevy computes the world position
-    // The vertex.instance_index is very important. Esepecially if you are using batching and gpu preprocessing
+    // The vertex.instance_index is very important. Especially if you are using batching and gpu preprocessing
     var world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
     out.world_position = mesh_functions::mesh_position_local_to_world(world_from_local, vec4(vertex.position, 1.0));
     out.clip_position = position_world_to_clip(out.world_position.xyz);

--- a/crates/bevy_core_pipeline/src/smaa/smaa.wgsl
+++ b/crates/bevy_core_pipeline/src/smaa/smaa.wgsl
@@ -44,7 +44,7 @@
  * Here you'll find instructions to get the shader up and running as fast as
  * possible.
  *
- * IMPORTANTE NOTICE: when updating, remember to update both this file and the
+ * IMPORTANT NOTICE: when updating, remember to update both this file and the
  * precomputed textures! They may change from version to version.
  *
  * The shader has three passes, chained together as follows:

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -50,7 +50,7 @@ impl Component for ObservedBy {
 
 /// Trait that holds functions for configuring interaction with observers during entity cloning.
 pub trait CloneEntityWithObserversExt {
-    /// Sets the option to automatically add cloned entities to the obsevers targeting source entity.
+    /// Sets the option to automatically add cloned entities to the observers targeting source entity.
     fn add_observers(&mut self, add_observers: bool) -> &mut Self;
 }
 

--- a/crates/bevy_ecs/src/schedule/graph/graph_map.rs
+++ b/crates/bevy_ecs/src/schedule/graph/graph_map.rs
@@ -437,7 +437,7 @@ mod tests {
         assert_eq!(graph.nodes().collect::<Vec<_>>(), vec![]);
     }
 
-    /// Nodes that have bidrectional edges (or any edge in the case of undirected graphs) are
+    /// Nodes that have bidirectional edges (or any edge in the case of undirected graphs) are
     /// considered strongly connected. A strongly connected component is a collection of
     /// nodes where there exists a path from any node to any other node in the collection.
     #[test]

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// # Performance
 ///
-/// - The slice and array implementations perform an aliased mutabiltiy check
+/// - The slice and array implementations perform an aliased mutability check
 ///   in [`WorldEntityFetch::fetch_mut`] that is `O(N^2)`.
 /// - The [`EntityHashSet`] implementation performs no such check as the type
 ///   itself guarantees no duplicates.

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -2242,9 +2242,9 @@ mod tests {
         let mut rotated_vertices = polygon.vertices(core::f32::consts::FRAC_PI_4).into_iter();
 
         // Distance from the origin to the middle of a side, derived using Pythagorean theorem
-        let side_sistance = FRAC_1_SQRT_2;
+        let side_distance = FRAC_1_SQRT_2;
         assert!(
-            (rotated_vertices.next().unwrap() - Vec2::new(-side_sistance, side_sistance)).length()
+            (rotated_vertices.next().unwrap() - Vec2::new(-side_distance, side_distance)).length()
                 < 1e-7,
         );
     }

--- a/crates/bevy_pbr/src/render/pbr_transmission.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_transmission.wgsl
@@ -15,7 +15,7 @@
 #endif
 
 fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>, view_z: f32, N: vec3<f32>, V: vec3<f32>, F0: vec3<f32>, ior: f32, thickness: f32, perceptual_roughness: f32, specular_transmissive_color: vec3<f32>, transmitted_environment_light_specular: vec3<f32>) -> vec3<f32> {
-    // Calculate the ratio between refaction indexes. Assume air/vacuum for the space outside the mesh
+    // Calculate the ratio between refraction indexes. Assume air/vacuum for the space outside the mesh
     let eta = 1.0 / ior;
 
     // Calculate incidence vector (opposite to view vector) and its dot product with the mesh normal
@@ -26,7 +26,7 @@ fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>,
     let k = 1.0 - eta * eta * (1.0 - NdotI * NdotI);
     let T = eta * I - (eta * NdotI + sqrt(k)) * N;
 
-    // Calculate the exit position of the refracted ray, by propagating refacted direction through thickness
+    // Calculate the exit position of the refracted ray, by propagating refracted direction through thickness
     let exit_position = world_position.xyz + T * thickness;
 
     // Transform exit_position into clip space

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -393,7 +393,7 @@ pub struct PickingEventWriters<'w> {
 /// Both [`Click`] and [`Released`] target the entity hovered in the *previous frame*,
 /// rather than the current frame. This is because touch pointers hover nothing
 /// on the frame they are released. The end effect is that these two events can
-/// be received sequentally after an [`Out`] event (but always on the same frame
+/// be received sequentially after an [`Out`] event (but always on the same frame
 /// as the [`Out`] event).
 ///
 /// Note: Though it is common for the [`PointerInput`] stream may contain

--- a/crates/bevy_reflect/src/func/mod.rs
+++ b/crates/bevy_reflect/src/func/mod.rs
@@ -96,7 +96,7 @@
 //!
 //! # Generic Functions
 //!
-//! In Rust, generic functions are [monomophized] by the compiler,
+//! In Rust, generic functions are [monomorphized] by the compiler,
 //! which means that a separate copy of the function is generated for each concrete set of type parameters.
 //!
 //! When converting a generic function to a [`DynamicFunction`] or [`DynamicFunctionMut`],
@@ -153,7 +153,7 @@
 //! [`Reflect`]: crate::Reflect
 //! [lack of variadic generics]: https://poignardazur.github.io/2024/05/25/report-on-rustnl-variadics/
 //! [coherence issues]: https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#coherence-leak-check
-//! [monomophized]: https://en.wikipedia.org/wiki/Monomorphization
+//! [monomorphized]: https://en.wikipedia.org/wiki/Monomorphization
 //! [overloading]: #overloading-functions
 //! [function overloading]: https://en.wikipedia.org/wiki/Function_overloading
 //! [variadic functions]: https://en.wikipedia.org/wiki/Variadic_function

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -34,7 +34,7 @@ pub enum SpritePickingMode {
 pub struct SpritePickingSettings {
     /// Should the backend count transparent pixels as part of the sprite for picking purposes or should it use the bounding box of the sprite alone.
     ///
-    /// Defaults to an incusive alpha threshold of 0.1
+    /// Defaults to an inclusive alpha threshold of 0.1
     pub picking_mode: SpritePickingMode,
 }
 


### PR DESCRIPTION
# Objective

Use the latest version of `typos` and fix the typos that it now detects

# Additional Info

By the way, `typos` has a "low priority typo suggestions issue" where we can throw typos we find that `typos` doesn't catch.

(This link may go stale) https://github.com/crate-ci/typos/issues/1200
