### PR TITLE
Derived `Default` for all public unit components.

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -47,11 +47,11 @@ impl Default for AudioOutput {
 }
 
 /// Marker for internal use, to despawn entities when playback finishes.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct PlaybackDespawnMarker;
 
 /// Marker for internal use, to remove audio components when playback finishes.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct PlaybackRemoveMarker;
 
 #[derive(SystemParam)]

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -119,7 +119,7 @@ pub struct PreprocessBindGroup(BindGroup);
 
 /// Stops the `GpuPreprocessNode` attempting to generate the buffer for this view
 /// useful to avoid duplicating effort if the bind group is shared between views
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct SkipGpuPreprocess;
 
 impl Plugin for GpuMeshPreprocessPlugin {

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -20,7 +20,7 @@ pub mod gpu_preprocessing;
 pub mod no_gpu_preprocessing;
 
 /// Add this component to mesh entities to disable automatic batching
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct NoAutomaticBatching;
 
 /// Data necessary to be equal for two draw commands to be mergeable

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -631,10 +631,10 @@ impl From<ColorGrading> for ColorGradingUniform {
 ///
 /// The vast majority of applications will not need to use this component, as it
 /// generally reduces rendering performance.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct NoIndirectDrawing;
 
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct NoCpuCulling;
 
 impl ViewTarget {

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -74,12 +74,12 @@ pub struct ScreenshotCaptured(pub Image);
 pub struct Screenshot(pub RenderTarget);
 
 /// A marker component that indicates that a screenshot is currently being captured.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct Capturing;
 
 /// A marker component that indicates that a screenshot has been captured, the image is ready, and
 /// the screenshot entity can be despawned.
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct Captured;
 
 impl Screenshot {

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -203,7 +203,7 @@ pub struct RenderMesh2dInstance {
 #[derive(Default, Resource, Deref, DerefMut)]
 pub struct RenderMesh2dInstances(MainEntityHashMap<RenderMesh2dInstance>);
 
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct Mesh2dMarker;
 
 pub fn extract_mesh2d(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2622,7 +2622,6 @@ impl TargetCamera {
     }
 }
 
-#[derive(Component)]
 /// Marker used to identify default cameras, they will have priority over the [`PrimaryWindow`] camera.
 ///
 /// This is useful if the [`PrimaryWindow`] has two cameras, one of them used
@@ -2656,6 +2655,7 @@ impl TargetCamera {
 ///     ));
 /// }
 /// ```
+#[derive(Component, Default)]
 pub struct IsDefaultUiCamera;
 
 #[derive(SystemParam)]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1379,7 +1379,7 @@ impl Default for EnabledButtons {
 
 /// Marker component for a [`Window`] that has been requested to close and
 /// is in the process of closing (on the next frame).
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct ClosingWindow;
 
 #[cfg(test)]


### PR DESCRIPTION
Derived `Default` for all public unit structs that already derive from `Component`. This allows them to be used more easily as required components.
To avoid clutter in tests/examples, only public components were affected, but this could easily be expanded to affect all unit components.

Fixes #17052.