### PR TITLE
Relax documented safety requirements for `*_assume_mut`

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -581,7 +581,11 @@ impl<'w> EntityMut<'w> {
     ///
     /// # Safety
     ///
-    /// - `T` must be a mutable component
+    /// - One of the following should be true:
+    ///   - Either `T` is mutable, or
+    ///   - `OnReplace` hooks and observers for that component on that entity should trigger immediately before the mutation
+    ///     and `OnInsert` should trigger immediately after the mutation, or
+    ///   - The user should uphold documented invariants of `T`. If no such documentation provided, it is impossible for the end user to uphold this.
     #[inline]
     pub unsafe fn get_mut_assume_mutable<T: Component>(&mut self) -> Option<Mut<'_, T>> {
         // SAFETY: &mut self implies exclusive access for duration of returned value
@@ -1262,7 +1266,11 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// # Safety
     ///
-    /// - `T` must be a mutable component
+    /// - One of the following should be true:
+    ///   - Either `T` is mutable, or
+    ///   - `OnReplace` hooks and observers for that component on that entity should trigger immediately before the mutation
+    ///     and `OnInsert` should trigger immediately after the mutation, or
+    ///   - The user should uphold documented invariants of `T`. If no such documentation provided, it is impossible for the end user to uphold this.
     #[inline]
     pub unsafe fn get_mut_assume_mutable<T: Component>(&mut self) -> Option<Mut<'_, T>> {
         // SAFETY:
@@ -3313,7 +3321,11 @@ impl<'w> FilteredEntityMut<'w> {
     ///
     /// # Safety
     ///
-    /// - `T` must be a mutable component
+    /// - One of the following should be true:
+    ///   - Either `T` is mutable, or
+    ///   - `OnReplace` hooks and observers for that component on that entity should trigger immediately before the mutation
+    ///     and `OnInsert` should trigger immediately after the mutation, or
+    ///   - The user should uphold documented invariants of `T`. If no such documentation provided, it is impossible for the end user to uphold this.
     #[inline]
     pub unsafe fn into_mut_assume_mutable<T: Component>(self) -> Option<Mut<'w, T>> {
         let id = self.entity.world().components().get_id(TypeId::of::<T>())?;

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -863,7 +863,11 @@ impl<'w> UnsafeEntityCell<'w> {
     /// It is the callers responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
-    /// - the component `T` is mutable
+    /// - One of the following should be true:
+    ///   - Either `T` is mutable, or
+    ///   - `OnReplace` hooks and observers for that component on that entity should trigger immediately before the mutation
+    ///     and `OnInsert` should trigger immediately after the mutation, or
+    ///   - The user should uphold documented invariants of `T`. If no such documentation provided, it is impossible for the end user to uphold this.
     #[inline]
     pub unsafe fn get_mut_assume_mutable<T: Component>(self) -> Option<Mut<'w, T>> {
         // SAFETY: same safety requirements
@@ -879,7 +883,11 @@ impl<'w> UnsafeEntityCell<'w> {
     /// It is the callers responsibility to ensure that
     /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
-    /// - The component `T` is mutable
+    /// - One of the following should be true:
+    ///   - Either `T` is mutable, or
+    ///   - `OnReplace` hooks and observers for that component on that entity should trigger immediately before the mutation
+    ///     and `OnInsert` should trigger immediately after the mutation, or
+    ///   - The user should uphold documented invariants of `T`. If no such documentation provided, it is impossible for the end user to uphold this.
     #[inline]
     pub(crate) unsafe fn get_mut_using_ticks_assume_mutable<T: Component>(
         &self,


### PR DESCRIPTION
# Objective

Often you want to lock end users from mutating component, while still having the ability to mutate it in the library internals. For example there is a `Child` and `Parent` relationship in the `bevy_hierarchy` https://github.com/bevyengine/bevy/pull/16662

For that to be possible, the safety requirements of `*_assume_mutable` methods should be relaxed, since they are currently too restrictive for no reason, and do not allow mutation of an immutable component under any circumstances.

## Solution


Current safety requirements:
```
- T must be a mutable component
```
Replaced with:
```
- One of the following should be true:
   - Either `T` is mutable, or
   - `OnReplace` hooks and observers for that component on that entity should trigger immediately before the mutation
     and `OnInsert` should trigger immediately after the mutation, or
   - The user should uphold documented invariants of `T`. If no such documentation provided, it is impossible for the end user to uphold this.
```

# Note

[The pr linked above already breaks current safety requirements](https://github.com/bevyengine/bevy/pull/16662#discussion_r1872019871), and the [suggested alternative](https://github.com/bevyengine/bevy/pull/16662#discussion_r1872303035) also breaks it.
