### PR TITLE
Update GetPath unit test and documentation for empty path usecase

### DIFF
--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -127,10 +127,12 @@ impl<'a> ReflectPath<'a> for &'a str {
 /// Note that a leading dot (`.`) or hash (`#`) token is implied for the first item in a path,
 /// and may therefore be omitted.
 ///
+/// Additionally, an empty path may be used to get the struct itself.
+///
 /// ### Example
 /// ```
 /// # use bevy_reflect::{GetPath, Reflect};
-/// #[derive(Reflect)]
+/// #[derive(Reflect, PartialEq, Debug)]
 /// struct MyStruct {
 ///   value: u32
 /// }
@@ -140,6 +142,8 @@ impl<'a> ReflectPath<'a> for &'a str {
 /// assert_eq!(my_struct.path::<u32>(".value").unwrap(), &123);
 /// // Access via field index
 /// assert_eq!(my_struct.path::<u32>("#0").unwrap(), &123);
+/// // Access self
+/// assert_eq!(*my_struct.path::<MyStruct>("").unwrap(), my_struct);
 /// ```
 ///
 /// ## Tuples and Tuple Structs
@@ -508,7 +512,7 @@ mod tests {
     use crate as bevy_reflect;
     use crate::*;
 
-    #[derive(Reflect)]
+    #[derive(Reflect, PartialEq, Debug)]
     struct A {
         w: usize,
         x: B,
@@ -521,21 +525,21 @@ mod tests {
         tuple: (bool, f32),
     }
 
-    #[derive(Reflect)]
+    #[derive(Reflect, PartialEq, Debug)]
     struct B {
         foo: usize,
         łørđ: C,
     }
 
-    #[derive(Reflect)]
+    #[derive(Reflect, PartialEq, Debug)]
     struct C {
         mосква: f32,
     }
 
-    #[derive(Reflect)]
+    #[derive(Reflect, PartialEq, Debug)]
     struct D(E);
 
-    #[derive(Reflect)]
+    #[derive(Reflect, PartialEq, Debug)]
     struct E(f32, usize);
 
     #[derive(Reflect, PartialEq, Debug)]
@@ -735,6 +739,7 @@ mod tests {
     fn reflect_path() {
         let mut a = a_sample();
 
+        assert_eq!(*a.path::<A>("").unwrap(), a);
         assert_eq!(*a.path::<usize>("w").unwrap(), 1);
         assert_eq!(*a.path::<usize>("x.foo").unwrap(), 10);
         assert_eq!(*a.path::<f32>("x.łørđ.mосква").unwrap(), 3.14);


### PR DESCRIPTION
# Objective

- `GetPath` `path` related methods allow an empty string as the parameter, but this is not included as a test or in documentation. This PR adds both.
- Fixes #13459

## Solution

- Updates the `bevy_reflect` `GetPath` documentation and unit tests

## Testing

- `cargo run -p ci`