### PR TITLE
msrv needs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: build
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4


### PR DESCRIPTION
# Objective

My previous PR is causing the github bot to comment whenver a PR build fails

## Solution

msrv should depend on build succeeding
