### PR TITLE
Remove everything except `Instant` from `bevy_utils::time`

### DIFF
--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_time::Time;
-use bevy_utils::Duration;
+use core::time::Duration;
 
 use crate::{graph::AnimationNodeIndex, ActiveAnimation, AnimationPlayer};
 

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -3,7 +3,7 @@ use crate::{
     plugin::Plugin,
     PluginsState,
 };
-use bevy_utils::Duration;
+use core::time::Duration;
 
 #[cfg(any(target_arch = "wasm32", feature = "std"))]
 use bevy_utils::Instant;

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -4,7 +4,8 @@ use crate::io::{
     AssetSourceEvent, AssetWatcher,
 };
 use alloc::sync::Arc;
-use bevy_utils::{tracing::warn, Duration, HashMap};
+use bevy_utils::{tracing::warn, HashMap};
+use core::time::Duration;
 use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, RecommendedCache};
 use parking_lot::RwLock;
 use std::{

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -2,7 +2,8 @@ use crate::{
     io::{AssetSourceEvent, AssetWatcher},
     path::normalize_path,
 };
-use bevy_utils::{tracing::error, Duration};
+use bevy_utils::tracing::error;
+use core::time::Duration;
 use crossbeam_channel::Sender;
 use notify_debouncer_full::{
     new_debouncer,

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -7,9 +7,9 @@ use atomicow::CowArc;
 use bevy_ecs::system::Resource;
 use bevy_utils::{
     tracing::{error, warn},
-    Duration, HashMap,
+    HashMap,
 };
-use core::{fmt::Display, hash::Hash};
+use core::{fmt::Display, hash::Hash, time::Duration};
 use thiserror::Error;
 
 use super::{ErasedAssetReader, ErasedAssetWriter};

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -641,7 +641,8 @@ mod tests {
     };
     use bevy_log::LogPlugin;
     use bevy_reflect::TypePath;
-    use bevy_utils::{Duration, HashMap};
+    use bevy_utils::HashMap;
+    use core::time::Duration;
     use serde::{Deserialize, Serialize};
     use std::path::Path;
     use thiserror::Error;

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,9 +1,12 @@
 use alloc::{borrow::Cow, collections::VecDeque};
-use core::hash::{Hash, Hasher};
+use core::{
+    hash::{Hash, Hasher},
+    time::Duration,
+};
 
 use bevy_app::{App, SubApp};
 use bevy_ecs::system::{Deferred, Res, Resource, SystemBuffer, SystemParam};
-use bevy_utils::{Duration, HashMap, Instant, PassHash};
+use bevy_utils::{HashMap, Instant, PassHash};
 use const_fnv1a_hash::fnv1a_hash_str_64;
 
 use crate::DEFAULT_MAX_HISTORY_LENGTH;

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -2,10 +2,8 @@ use super::{Diagnostic, DiagnosticPath, DiagnosticsStore};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time, Timer, TimerMode};
-use bevy_utils::{
-    tracing::{debug, info},
-    Duration,
-};
+use bevy_utils::tracing::{debug, info};
+use core::time::Duration;
 
 /// An App Plugin that logs diagnostics to the console.
 ///

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -8,8 +8,9 @@ use bevy_time::{Real, Time};
 use bevy_utils::{
     synccell::SyncCell,
     tracing::{debug, warn},
-    Duration, HashMap,
+    HashMap,
 };
+use core::time::Duration;
 use gilrs::{
     ff::{self, BaseEffect, BaseEffectType, Repeat, Replay},
     GamepadId,

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,6 +1,6 @@
 //! The gamepad input functionality.
 
-use core::ops::RangeInclusive;
+use core::{ops::RangeInclusive, time::Duration};
 
 use crate::{Axis, ButtonInput, ButtonState};
 use alloc::string::String;
@@ -21,7 +21,7 @@ use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
-use bevy_utils::{Duration, HashMap};
+use bevy_utils::HashMap;
 use derive_more::derive::From;
 use log::{info, warn};
 use thiserror::Error;
@@ -1693,7 +1693,7 @@ impl GamepadRumbleIntensity {
 /// ```
 /// # use bevy_input::gamepad::{Gamepad, GamepadRumbleRequest, GamepadRumbleIntensity};
 /// # use bevy_ecs::prelude::{EventWriter, Res, Query, Entity, With};
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// fn rumble_gamepad_system(
 ///     mut rumble_requests: EventWriter<GamepadRumbleRequest>,
 ///     gamepads: Query<Entity, With<Gamepad>>,

--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -37,14 +37,14 @@
 //! When received by an observer, these events will always be wrapped by the [`Pointer`] type, which contains
 //! general metadata about the pointer event.
 
-use core::fmt::Debug;
+use core::{fmt::Debug, time::Duration};
 
 use bevy_ecs::{prelude::*, query::QueryData, system::SystemParam, traversal::Traversal};
 use bevy_hierarchy::Parent;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
 use bevy_render::camera::NormalizedRenderTarget;
-use bevy_utils::{tracing::debug, Duration, HashMap, Instant};
+use bevy_utils::{tracing::debug, HashMap, Instant};
 use bevy_window::Window;
 
 use crate::{

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -118,7 +118,7 @@ impl_reflect_opaque!(::core::ops::RangeTo<T: Clone + Send + Sync>());
 impl_reflect_opaque!(::core::ops::RangeToInclusive<T: Clone + Send + Sync>());
 impl_reflect_opaque!(::core::ops::RangeFull());
 impl_reflect_opaque!(::core::ops::Bound<T: Clone + Send + Sync>());
-impl_reflect_opaque!(::bevy_utils::Duration(
+impl_reflect_opaque!(::core::time::Duration(
     Debug,
     Hash,
     PartialEq,
@@ -2430,8 +2430,11 @@ mod tests {
         TypeInfo, TypeRegistry, Typed, VariantInfo, VariantType,
     };
     use alloc::{collections::BTreeMap, string::String, vec};
-    use bevy_utils::{Duration, HashMap, Instant};
-    use core::f32::consts::{PI, TAU};
+    use bevy_utils::{HashMap, Instant};
+    use core::{
+        f32::consts::{PI, TAU},
+        time::Duration,
+    };
     use static_assertions::assert_impl_all;
     use std::path::Path;
 

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -1,6 +1,6 @@
 use crate::{Real, Time, Timer, TimerMode, Virtual};
 use bevy_ecs::system::Res;
-use bevy_utils::Duration;
+use core::time::Duration;
 
 /// Run condition that is active on a regular time interval, using [`Time`] to advance
 /// the timer. The timer ticks at the rate of [`Time::relative_speed`].
@@ -8,7 +8,7 @@ use bevy_utils::Duration;
 /// ```no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// # use bevy_time::common_conditions::on_timer;
 /// fn main() {
 ///     App::new()
@@ -48,7 +48,7 @@ pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
 /// ```no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// # use bevy_time::common_conditions::on_real_timer;
 /// fn main() {
 ///     App::new()
@@ -88,7 +88,7 @@ pub fn on_real_timer(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool 
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// # use bevy_time::common_conditions::once_after_delay;
 /// fn main() {
 ///     App::new()
@@ -118,7 +118,7 @@ pub fn once_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + C
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// # use bevy_time::common_conditions::once_after_delay;
 /// fn main() {
 ///     App::new()
@@ -148,7 +148,7 @@ pub fn once_after_real_delay(duration: Duration) -> impl FnMut(Res<Time<Real>>) 
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// # use bevy_time::common_conditions::repeating_after_delay;
 /// fn main() {
 ///     App::new()
@@ -178,7 +178,7 @@ pub fn repeating_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> boo
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
+/// # use core::time::Duration;
 /// # use bevy_time::common_conditions::repeating_after_real_delay;
 /// fn main() {
 ///     App::new()

--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -2,7 +2,7 @@ use bevy_app::FixedMain;
 use bevy_ecs::world::World;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
-use bevy_utils::Duration;
+use core::time::Duration;
 
 use crate::{time::Time, virt::Virtual};
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -35,7 +35,8 @@ use bevy_ecs::{
     event::{event_update_system, signal_event_update_system, EventRegistry, ShouldUpdateEvents},
     prelude::*,
 };
-use bevy_utils::{tracing::warn, Duration, Instant};
+use bevy_utils::{tracing::warn, Instant};
+use core::time::Duration;
 pub use crossbeam_channel::TrySendError;
 use crossbeam_channel::{Receiver, Sender};
 
@@ -161,8 +162,8 @@ mod tests {
         event::{Event, EventReader, EventRegistry, EventWriter, Events, ShouldUpdateEvents},
         system::{Local, Res, ResMut, Resource},
     };
-    use bevy_utils::Duration;
     use core::error::Error;
+    use core::time::Duration;
 
     #[derive(Event)]
     struct TestEvent<T: Default> {

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
-use bevy_utils::{Duration, Instant};
+use bevy_utils::Instant;
+use core::time::Duration;
 
 use crate::time::Time;
 

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{prelude::*, Reflect};
-use bevy_utils::Duration;
+use core::time::Duration;
 
 /// A Stopwatch is a struct that tracks elapsed time when started.
 ///

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::system::Resource;
-use bevy_utils::Duration;
+use core::time::Duration;
 #[cfg(feature = "bevy_reflect")]
 use {
     bevy_ecs::reflect::ReflectResource,

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -1,7 +1,7 @@
 use crate::Stopwatch;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
-use bevy_utils::Duration;
+use core::time::Duration;
 
 /// Tracks elapsed time. Enters the finished state once `duration` is reached.
 ///

--- a/crates/bevy_time/src/virt.rs
+++ b/crates/bevy_time/src/virt.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
-use bevy_utils::{tracing::debug, Duration};
+use bevy_utils::tracing::debug;
+use core::time::Duration;
 
 use crate::{real::Real, time::Time};
 

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -61,6 +61,7 @@ pub use foldhash::fast::{FixedState, FoldHasher as DefaultHasher, RandomState};
 pub use hashbrown;
 #[cfg(feature = "std")]
 pub use parallel_queue::*;
+#[cfg(any(feature = "std", target_arch = "wasm32"))]
 pub use time::*;
 #[cfg(feature = "tracing")]
 pub use tracing;

--- a/crates/bevy_utils/src/time.rs
+++ b/crates/bevy_utils/src/time.rs
@@ -1,11 +1,5 @@
 #[cfg(target_arch = "wasm32")]
-pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
+pub use web_time::Instant;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
-pub use {
-    core::time::{Duration, TryFromFloatSecsError},
-    std::time::{Instant, SystemTime, SystemTimeError},
-};
-
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "std")))]
-pub use core::time::{Duration, TryFromFloatSecsError};
+pub use std::time::Instant;

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::system::Resource;
-use bevy_utils::Duration;
+use core::time::Duration;
 
 /// Settings for the [`WinitPlugin`](super::WinitPlugin).
 #[derive(Debug, Resource, Clone)]

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -10,7 +10,8 @@
 //!
 //! And then enabling the features you need.
 //! See the full list: <https://docs.rs/bevy/latest/bevy/#cargo-features>
-use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*, utils::Duration};
+use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*};
+use core::time::Duration;
 
 fn main() {
     if cfg!(feature = "bevy_window") {

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -4,7 +4,8 @@
 //! that provide a specific piece of functionality (generally the smaller the scope, the better).
 //! This example illustrates how to create a simple plugin that prints out a message.
 
-use bevy::{prelude::*, utils::Duration};
+use bevy::prelude::*;
+use core::time::Duration;
 
 fn main() {
     App::new()

--- a/examples/audio/decodable.rs
+++ b/examples/audio/decodable.rs
@@ -5,8 +5,8 @@ use bevy::{
     math::ops,
     prelude::*,
     reflect::TypePath,
-    utils::Duration,
 };
+use core::time::Duration;
 
 // This struct usually contains the data for the audio being played.
 // This is where data read from an audio file would be stored, for example.

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -27,8 +27,8 @@
 use bevy::{
     app::{AppExit, ScheduleRunnerPlugin},
     prelude::*,
-    utils::Duration,
 };
+use core::time::Duration;
 use rand::random;
 use std::fmt;
 

--- a/examples/input/gamepad_rumble.rs
+++ b/examples/input/gamepad_rumble.rs
@@ -4,8 +4,8 @@
 use bevy::{
     input::gamepad::{Gamepad, GamepadRumbleIntensity, GamepadRumbleRequest},
     prelude::*,
-    utils::Duration,
 };
+use core::time::Duration;
 
 fn main() {
     App::new()

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -1,5 +1,6 @@
 //! This example illustrates loading scenes from files.
-use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
+use bevy::{prelude::*, tasks::IoTaskPool};
+use core::time::Duration;
 use std::{fs::File, io::Write};
 
 fn main() {

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -2,6 +2,7 @@
 //!
 //! Usage: spawn more entities by clicking on the screen.
 
+use core::time::Duration;
 use std::str::FromStr;
 
 use argh::FromArgs;
@@ -14,7 +15,6 @@ use bevy::{
         render_resource::{Extent3d, TextureDimension, TextureFormat},
     },
     sprite::AlphaMode2d,
-    utils::Duration,
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -1,6 +1,7 @@
 //! This example illustrates the [`UiScale`] resource from `bevy_ui`.
 
-use bevy::{color::palettes::css::*, prelude::*, utils::Duration};
+use bevy::{color::palettes::css::*, prelude::*};
+use core::time::Duration;
 
 const SCALE_TIME: u64 = 400;
 

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -5,10 +5,10 @@
 
 use bevy::{
     prelude::*,
-    utils::Duration,
     window::{PresentMode, RequestRedraw, WindowPlugin},
     winit::{EventLoopProxyWrapper, WakeUp, WinitSettings},
 };
+use core::time::Duration;
 
 fn main() {
     App::new()


### PR DESCRIPTION
# Objective

- Contributes to #11478
- Contributes to #16877

## Solution

- Removed everything except `Instant` from `bevy_utils::time`

## Testing

- CI

---

## Migration Guide

If you relied on any of the following from `bevy_utils::time`:

- `Duration`
- `TryFromFloatSecsError`

Import these directly from `core::time` regardless of platform target (WASM, mobile, etc.)

If you relied on any of the following from `bevy_utils::time`:

- `SystemTime`
- `SystemTimeError`

Instead import these directly from either `std::time` or `web_time` as appropriate for your target platform.

## Notes

`Duration` and `TryFromFloatSecsError` are both re-exports from `core::time` regardless of whether they are used from `web_time` or `std::time`, so there is no value gained from re-exporting them from `bevy_utils::time` as well. As for `SystemTime` and `SystemTimeError`, no Bevy internal crates or examples rely on these types. Since Bevy doesn't have a `Time<Wall>` resource for interacting with wall-time (and likely shouldn't need one), I think removing these from `bevy_utils` entirely and waiting for a use-case to justify inclusion is a reasonable path forward.