### PR TITLE
[`InstanceInputUniformBuffer::remove`] could cause incorrect behaviour.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1038,7 +1038,7 @@ fn remove_mesh_input_uniform(
     let removed_render_mesh_instance = render_mesh_instances.remove(&entity)?;
 
     let removed_uniform_index = removed_render_mesh_instance.current_uniform_index.get();
-    current_input_buffer.remove(removed_uniform_index);
+    current_input_buffer.remove_unchecked(removed_uniform_index);
     Some(removed_uniform_index)
 }
 

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -231,7 +231,7 @@ where
 
     /// Removes a piece of buffered data from the uniform buffer.
     ///
-    /// Ensure uniform_index is within bounds of [`Self::buffer`] and not removed twice,
+    /// Ensure `uniform_index` is within bounds of [`Self::buffer`] and not removed twice,
     /// as this may cause incorrect behavior or panicking when inserting new data.
     pub fn remove_unchecked(&mut self, uniform_index: u32) {
         self.free_uniform_indices.push(uniform_index);
@@ -1499,3 +1499,4 @@ mod tests {
         assert_eq!(instance_buffer.buffer().len(), 2);
     }
 }
+

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1499,4 +1499,3 @@ mod tests {
         assert_eq!(instance_buffer.buffer().len(), 2);
     }
 }
-


### PR DESCRIPTION
# Objective

[`InstanceInputUniformBuffer::remove`] could, when the wrong index was inserted overwrite data when adding it to the buffer.

## Solution

make [`InstanceInputUniformBuffer::remove`] do some checks before removing. And having[`InstanceInputUniformBuffer::remove_unchecked`] for when you don't need that behaviour.


## Testing

Added unit test
