### PR TITLE
Run example validation jobs on `ubuntu-latest`

### DIFF
--- a/.github/start-wasm-example/package.json
+++ b/.github/start-wasm-example/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.28.1"
+    "@playwright/test": "^1.49.1"
   },
   "dependencies": {
     "dotenv": "^16.0.1"

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -80,7 +80,7 @@ jobs:
   run-examples-linux-vulkan:
     # also run when pushed to main to update reference screenshots
     if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
       - name: Install additional Linux dependencies for Vulkan
         run: |
           sudo add-apt-repository ppa:kisak/turtle -y
-          sudo apt-get install --no-install-recommends libxkbcommon-x11-0 xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt-get install --no-install-recommends libxkbcommon-x11-0 xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - uses: actions/cache@v4
         with:
           path: |
@@ -185,7 +185,7 @@ jobs:
 
   run-examples-on-wasm:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -210,7 +210,7 @@ jobs:
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:kisak/turtle -y
           sudo apt-get update
-          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt install -y xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Install wasm-bindgen
         run: cargo install --force wasm-bindgen-cli


### PR DESCRIPTION
# Objective

Fixes #17164

## Solution

- Switch to `ubuntu-latest`
- Remove `libegl1-mesa`. It seems that whatever this was providing is now covered by other deps or their deps?

## Testing

Tested [over here](https://github.com/rparrett/bevy/pull/21) by commenting out workflow `if` condition.
