### PR TITLE
Change `bevy_reflect::RegisterForReflection::__register()` to expect unused variables, rather than putting underscores on the parameter names

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -691,7 +691,11 @@ pub mod __macro_exports {
         note = "consider annotating `{Self}` with `#[derive(Reflect)]`"
     )]
     pub trait RegisterForReflection {
-        fn __register(_registry: &mut TypeRegistry) {}
+        #[expect(
+            unused_variables,
+            reason = "The parameters here are intentionally unused by the default implementation; however, putting understores here will result in the underscores being copied by rust-analyzer's tab completion."
+        )]
+        fn __register(registry: &mut TypeRegistry) {}
     }
 
     impl<T: GetTypeRegistration> RegisterForReflection for T {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -693,7 +693,7 @@ pub mod __macro_exports {
     pub trait RegisterForReflection {
         #[expect(
             unused_variables,
-            reason = "The parameters here are intentionally unused by the default implementation; however, putting understores here will result in the underscores being copied by rust-analyzer's tab completion."
+            reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."
         )]
         fn __register(registry: &mut TypeRegistry) {}
     }


### PR DESCRIPTION
# Objective
While checking over https://github.com/bevyengine/bevy/pull/17160, it occurred to me that rust-analyzer will copy the method signature exactly, when using tab completion trait methods. This includes provided trait methods that use underscores to silence the `unused_variables` lint. This probably isn't good for users, seeing as how they'll have to remove the underscore if they want to use the parameters.

(I mean, they technically don't have to remove the underscore... but usually you don't keep a leading underscore on parameters you're using.)

## Solution
Changes `bevy_reflect::RegisterForReflection::__register()` to `#[expect(unused_variables)]`, and removes the underscores from its parameter names.

## Testing
N/A