### PR TITLE
Fix confusing variable name

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -83,7 +83,7 @@ fn sprite_picking(
             }
         })
         .collect();
-    sorted_sprites.sort_by_key(|x| Reverse(FloatOrd(x.2.translation().z)));
+    sorted_sprites.sort_by_key(|(_, _, transform, _)| Reverse(FloatOrd(transform.translation().z)));
 
     let primary_window = primary_window.get_single().ok();
 


### PR DESCRIPTION
# Objective

Make a confusing variable name less confusing.

`x` is presumably short for `xform` which is short for `transform`. But it just reads like "x", which is confusing when we're sorting by `z`. And in this case, `x` isn't the transform, it's a tuple with the transform in the middle somewhere.

`x.2.translation().z` -> `transform.translation().z`

## Solution

Destructure the tuple and name the thing what it is
