### PR TITLE
Use `radsort` for sprite picking

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -2,15 +2,13 @@
 //! sprites with arbitrary transforms. Picking is done based on sprite bounds, not visible pixels.
 //! This means a partially transparent sprite is pickable even in its transparent areas.
 
-use core::cmp::Reverse;
-
 use crate::{Sprite, TextureAtlasLayout};
 use bevy_app::prelude::*;
 use bevy_asset::prelude::*;
 use bevy_color::Alpha;
 use bevy_ecs::prelude::*;
 use bevy_image::Image;
-use bevy_math::{prelude::*, FloatExt, FloatOrd};
+use bevy_math::{prelude::*, FloatExt};
 use bevy_picking::backend::prelude::*;
 use bevy_reflect::prelude::*;
 use bevy_render::prelude::*;
@@ -83,7 +81,11 @@ fn sprite_picking(
             }
         })
         .collect();
-    sorted_sprites.sort_by_key(|(_, _, transform, _)| Reverse(FloatOrd(transform.translation().z)));
+
+    // radsort is a stable radix sort that performed better than `slice::sort_by_key`
+    radsort::sort_by_key(&mut sorted_sprites, |(_, _, transform, _)| {
+        -transform.translation().z
+    });
 
     let primary_window = primary_window.get_single().ok();
 

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -83,7 +83,7 @@ fn sprite_picking(
             }
         })
         .collect();
-    sorted_sprites.sort_by_key(|x| Reverse(FloatOrd(x.2.translation().z)));
+    sorted_sprites.sort_by_key(|(_, _, transform, _)| Reverse(FloatOrd(transform.translation().z)));
 
     let primary_window = primary_window.get_single().ok();
 


### PR DESCRIPTION
# Objective

Optimization for sprite picking

## Solution

Use `radsort` for the sort.

We already have `radsort` in tree for sorting various phase items (including `Transparent2d` / sprites). It's a stable parallel radix sort.

## Testing

Tested on an M1 Max.

`cargo run --example sprite_picking`

`cargo run --example bevymark --release --features=trace,trace_tracy -- --waves 100 --per-wave 1000 --benchmark`

<img width="983" alt="image" src="https://github.com/user-attachments/assets/0f7a8c3a-006b-4323-a2ed-03788918dffa" />
