### PR TITLE
Allow users to easily use `bevy_sprite` and `bevy_ui` without picking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,6 @@ bevy_sprite = [
   "bevy_render",
   "bevy_core_pipeline",
   "bevy_color",
-  "bevy_sprite_picking_backend",
 ]
 
 # Provides text functionality
@@ -226,7 +225,6 @@ bevy_ui = [
   "bevy_text",
   "bevy_sprite",
   "bevy_color",
-  "bevy_ui_picking_backend",
 ]
 
 # Windowing layer


### PR DESCRIPTION
# Objective

RIght now it's not possible to opt out of sprite or ui picking at the feature level without jumping through some hoops.

If you add the `bevy_sprite` feature, you get `bevy_sprite_picking_backend`.

If you add the `bevy_ui` feature, you get `bevy_ui_picking_backend`

To get `bevy_sprite` without picking, I think you would have to do something like this, which seems **very** annoying.

```toml
[dependencies]
bevy = { version = "0.15", default-features = false, features = [
    # ... omitted
    # "bevy_sprite",
    # "bevy_ui", # this also brings in bevy_sprite
    # "bevy_text", # this also brings in bevy_sprite
    "bevy_render",
    "bevy_core_pipeline",
    "bevy_color",
] }
bevy_internal = { version = "0.15", default-features = false, features = [
    "bevy_sprite",
    "bevy_ui",
    "bevy_text"
] }
```

## Solution

- Remove `bevy_sprite_picking_backend` from the `bevy_sprite` feature.
- Remove `bevy_ui_picking_backend` from the `bevy_ui` feature.

These are still in Bevy's `default-plugins`.

## Testing

I did some basic testing in a minimal project based on the `sprite_picking` example to verify that "picking stuff" didn't get included with `bevy_sprite`.

I would appreciate help testing. I am just unraveling these features and think that this is correct, but I am not 100% sure.

## Migration Guide

`bevy_sprite_picking_backend` is no longer included by default when using the `bevy_sprite` feature. If you are using Bevy without default features and relied on sprite picking, add this feature to your `Cargo.toml`.

`bevy_ui_picking_backend` is no longer included by default when using the `bevy_ui` feature. If you are using Bevy without default features and relied on sprite picking, add this feature to your `Cargo.toml`.

## Additional info

It looks like we attempted to fix this earlier in #16469, but the fix was incomplete?