### PR TITLE
can hide status bar on iOS

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -412,6 +412,16 @@ pub struct Window {
     ///
     /// [`WindowAttributesExtIOS::with_prefers_home_indicator_hidden`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/ios/trait.WindowAttributesExtIOS.html#tymethod.with_prefers_home_indicator_hidden
     pub prefers_home_indicator_hidden: bool,
+    /// Sets whether the Window prefers the status bar hidden.
+    ///
+    /// Corresponds to [`WindowAttributesExtIOS::with_prefers_status_bar_hidden`].
+    ///
+    /// # Platform-specific
+    ///
+    /// - Only used on iOS.
+    ///
+    /// [`WindowAttributesExtIOS::with_prefers_status_bar_hidden`]: https://docs.rs/winit/latest/x86_64-apple-darwin/winit/platform/ios/trait.WindowAttributesExtIOS.html#tymethod.with_prefers_status_bar_hidden
+    pub prefers_status_bar_hidden: bool,
 }
 
 impl Default for Window {
@@ -454,6 +464,7 @@ impl Default for Window {
             titlebar_show_title: true,
             titlebar_show_buttons: true,
             prefers_home_indicator_hidden: false,
+            prefers_status_bar_hidden: false,
         }
     }
 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -147,6 +147,8 @@ impl WinitWindows {
             use winit::platform::ios::WindowAttributesExtIOS;
             winit_window_attributes = winit_window_attributes
                 .with_prefers_home_indicator_hidden(window.prefers_home_indicator_hidden);
+            winit_window_attributes = winit_window_attributes
+                .with_prefers_status_bar_hidden(window.prefers_status_bar_hidden);
         }
 
         let display_info = DisplayInfo {

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -30,6 +30,8 @@ fn main() {
                     recognize_rotation_gesture: true,
                     // Only has an effect on iOS
                     prefers_home_indicator_hidden: true,
+                    // Only has an effect on iOS
+                    prefers_status_bar_hidden: true,
                     ..default()
                 }),
                 ..default()


### PR DESCRIPTION
# Objective

- I want to hide the clock and the battery indicator on iOS

## Solution

- Add the platform specific property `prefers_status_bar_hidden` on Window creation, and map it to `with_prefers_status_bar_hidden` in winit.

## Testing

- Tested on iOS