### PR TITLE
Add diagnostic logging to `many_gizmos`

### DIFF
--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::TAU;
 
 use bevy::{
-    diagnostic::{Diagnostic, DiagnosticsStore, FrameTimeDiagnosticsPlugin},
+    diagnostic::{Diagnostic, DiagnosticsStore, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
@@ -24,6 +24,7 @@ fn main() {
             ..default()
         }),
         FrameTimeDiagnosticsPlugin,
+        LogDiagnosticsPlugin::default(),
     ))
     .insert_resource(WinitSettings {
         focused_mode: UpdateMode::Continuous,


### PR DESCRIPTION
# Objective

Make this `stress_test` more consistent with others.

## Solution

Add `LogDiagnosticsPlugin`

## Testing

`cargo run --example many_gizmos`, observe frame rate now being logged.