### PR TITLE
Remove `bevy_core_pipeline::core_2d::Camera2dBundle`

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -5,10 +5,7 @@ use crate::{
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    camera::{
-        Camera, CameraProjection, CameraRenderGraph,
-        OrthographicProjection, Projection,
-    },
+    camera::{Camera, CameraProjection, CameraRenderGraph, OrthographicProjection, Projection},
     extract_component::ExtractComponent,
     primitives::Frustum,
 };

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -6,13 +6,11 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::{
-        Camera, CameraMainTextureUsages, CameraProjection, CameraRenderGraph,
+        Camera, CameraProjection, CameraRenderGraph,
         OrthographicProjection, Projection,
     },
     extract_component::ExtractComponent,
     primitives::Frustum,
-    sync_world::SyncToRenderWorld,
-    view::{Msaa, VisibleEntities},
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
@@ -29,78 +27,3 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
     Tonemapping(|| Tonemapping::None),
 )]
 pub struct Camera2d;
-
-#[derive(Bundle, Clone)]
-pub struct Camera2dBundle {
-    pub camera: Camera,
-    pub camera_render_graph: CameraRenderGraph,
-    pub projection: Projection,
-    pub visible_entities: VisibleEntities,
-    pub frustum: Frustum,
-    pub transform: Transform,
-    pub global_transform: GlobalTransform,
-    pub camera_2d: Camera2d,
-    pub tonemapping: Tonemapping,
-    pub deband_dither: DebandDither,
-    pub main_texture_usages: CameraMainTextureUsages,
-    pub msaa: Msaa,
-    /// Marker component that indicates that its entity needs to be synchronized to the render world
-    pub sync: SyncToRenderWorld,
-}
-
-impl Default for Camera2dBundle {
-    fn default() -> Self {
-        let projection = Projection::Orthographic(OrthographicProjection::default_2d());
-        let transform = Transform::default();
-        let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
-        Self {
-            camera_render_graph: CameraRenderGraph::new(Core2d),
-            projection,
-            visible_entities: VisibleEntities::default(),
-            frustum,
-            transform,
-            global_transform: Default::default(),
-            camera: Camera::default(),
-            camera_2d: Camera2d,
-            tonemapping: Tonemapping::None,
-            deband_dither: DebandDither::Disabled,
-            main_texture_usages: Default::default(),
-            msaa: Default::default(),
-            sync: Default::default(),
-        }
-    }
-}
-
-impl Camera2dBundle {
-    /// Create an orthographic projection camera with a custom `Z` position.
-    ///
-    /// The camera is placed at `Z=far-0.1`, looking toward the world origin `(0,0,0)`.
-    /// Its orthographic projection extends from `0.0` to `-far` in camera view space,
-    /// corresponding to `Z=far-0.1` (closest to camera) to `Z=-0.1` (furthest away from
-    /// camera) in world space.
-    pub fn new_with_far(far: f32) -> Self {
-        // we want 0 to be "closest" and +far to be "farthest" in 2d, so we offset
-        // the camera's translation by far and use a right handed coordinate system
-        let projection = Projection::Orthographic(OrthographicProjection {
-            far,
-            ..OrthographicProjection::default_2d()
-        });
-        let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
-        let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
-        Self {
-            camera_render_graph: CameraRenderGraph::new(Core2d),
-            projection,
-            visible_entities: VisibleEntities::default(),
-            frustum,
-            transform,
-            global_transform: Default::default(),
-            camera: Camera::default(),
-            camera_2d: Camera2d,
-            tonemapping: Tonemapping::None,
-            deband_dither: DebandDither::Disabled,
-            main_texture_usages: Default::default(),
-            msaa: Default::default(),
-            sync: Default::default(),
-        }
-    }
-}


### PR DESCRIPTION
# Objective
https://github.com/bevyengine/bevy/pull/16338 forgot to remove this previously-deprecated item. In fact, it only removed the `#[deprecated]` attribute attached to it.

## Solution
Removes `bevy_core_pipeline::core_2d::Camera2dBundle`.

## Testing
CI.