### PR TITLE
bevy_render: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1,6 +1,6 @@
 #![expect(
     clippy::module_inception,
-    reason = "The parent module contains all things viewport-related, while this module handles cameras as a component."
+    reason = "The parent module contains all things viewport-related, while this module handles cameras as a component. However, a rename/refactor which should clear up this lint is being discussed; see #17196."
 )]
 use super::{ClearColorConfig, Projection};
 use crate::{

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1,3 +1,7 @@
+#![expect(
+    clippy::module_inception,
+    reason = "The parent module contains all things viewport-related, while this module handles cameras as a component."
+)]
 use super::{ClearColorConfig, Projection};
 use crate::{
     batching::gpu_preprocessing::{GpuPreprocessingMode, GpuPreprocessingSupport},
@@ -893,7 +897,10 @@ impl NormalizedRenderTarget {
 ///
 /// [`OrthographicProjection`]: crate::camera::OrthographicProjection
 /// [`PerspectiveProjection`]: crate::camera::PerspectiveProjection
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+)]
 pub fn camera_system(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -1,4 +1,3 @@
-#[allow(clippy::module_inception)]
 mod camera;
 mod camera_driver_node;
 mod clear_color;

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -43,7 +43,6 @@ use super::{RenderDevice, RenderQueue};
 /// # Supported platforms
 /// Timestamp queries and pipeline statistics are currently supported only on Vulkan and DX12.
 /// On other platforms (Metal, WebGPU, WebGL2) only CPU time will be recorded.
-#[allow(clippy::doc_markdown)]
 #[derive(Default)]
 pub struct RenderDiagnosticsPlugin;
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,5 +1,10 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
-#![expect(unsafe_code)]
+#![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![cfg_attr(
     any(docsrs, docsrs_dep),
     expect(

--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -156,7 +156,6 @@ pub struct MeshBufferSlice<'a> {
 pub struct SlabId(pub NonMaxU32);
 
 /// Data for a single slab.
-#[allow(clippy::large_enum_variant)]
 enum Slab {
     /// A slab that can contain multiple objects.
     General(GeneralSlab),
@@ -527,7 +526,10 @@ impl MeshAllocator {
     }
 
     /// A generic function that copies either vertex or index data into a slab.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+    )]
     fn copy_element_data(
         &mut self,
         mesh_id: &AssetId<Mesh>,

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -53,7 +53,10 @@ pub trait RenderAsset: Send + Sync + 'static + Sized {
     /// Size of the data the asset will upload to the gpu. Specifying a return value
     /// will allow the asset to be throttled via [`RenderAssetBytesPerFrame`].
     #[inline]
-    #[allow(unused_variables)]
+    #[expect(
+        unused_variables,
+        reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."
+    )]
     fn byte_len(source_asset: &Self::SourceAsset) -> Option<usize> {
         None
     }
@@ -235,7 +238,10 @@ pub(crate) fn extract_render_asset<A: RenderAsset>(
             let mut removed = <HashSet<_>>::default();
 
             for event in events.read() {
-                #[allow(clippy::match_same_arms)]
+                #[expect(
+                    clippy::match_same_arms,
+                    reason = "LoadedWithDependencies is marked as a TODO, so it's likely this will no longer lint soon."
+                )]
                 match event {
                     AssetEvent::Added { id } | AssetEvent::Modified { id } => {
                         changed_assets.insert(*id);

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -22,7 +22,10 @@ pub trait Draw<P: PhaseItem>: Send + Sync + 'static {
     /// Prepares the draw function to be used. This is called once and only once before the phase
     /// begins. There may be zero or more [`draw`](Draw::draw) calls following a call to this function.
     /// Implementing this is optional.
-    #[allow(unused_variables)]
+    #[expect(
+        unused_variables,
+        reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."
+    )]
     fn prepare(&mut self, world: &'_ World) {}
 
     /// Draws a [`PhaseItem`] by issuing zero or more `draw` calls via the [`TrackedRenderPass`].
@@ -232,7 +235,14 @@ macro_rules! render_command_tuple_impl {
             type ViewQuery = ($($name::ViewQuery,)*);
             type ItemQuery = ($($name::ItemQuery,)*);
 
-            #[allow(non_snake_case)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "We are in a macro; as such, `non_snake_case` may not always lint."
+            )]
+            #[allow(
+                non_snake_case,
+                reason = "Parameter and variable names are provided by the macro invocation, not by us."
+            )]
             fn render<'w>(
                 _item: &P,
                 ($($view,)*): ROQueryItem<'w, Self::ViewQuery>,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -210,7 +210,6 @@ impl ShaderCache {
         Ok(())
     }
 
-    #[allow(clippy::result_large_err)]
     fn get(
         &mut self,
         render_device: &RenderDevice,
@@ -917,7 +916,10 @@ impl PipelineCache {
         mut events: Extract<EventReader<AssetEvent<Shader>>>,
     ) {
         for event in events.read() {
-            #[allow(clippy::match_same_arms)]
+            #[expect(
+                clippy::match_same_arms,
+                reason = "LoadedWithDependencies is marked as a TODO, so it's likely this will no longer lint soon."
+            )]
             match event {
                 // PERF: Instead of blocking waiting for the shader cache lock, try again next frame if the lock is currently held
                 AssetEvent::Added { id } | AssetEvent::Modified { id } => {

--- a/crates/bevy_render/src/render_resource/resource_macros.rs
+++ b/crates/bevy_render/src/render_resource/resource_macros.rs
@@ -4,9 +4,11 @@ macro_rules! define_atomic_id {
         #[derive(Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
         pub struct $atomic_id_type(core::num::NonZero<u32>);
 
-        // We use new instead of default to indicate that each ID created will be unique.
-        #[allow(clippy::new_without_default)]
         impl $atomic_id_type {
+            #[expect(
+                clippy::new_without_default,
+                reason = "Implementing the `Default` trait on atomic IDs would imply that two `<AtomicIdType>::default()` equal each other. By only implementing `new()`, we indicate that each atomic ID created will be unique."
+            )]
             pub fn new() -> Self {
                 use core::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -86,7 +86,11 @@ impl Default for WgpuSettings {
         {
             wgpu::Limits::downlevel_webgl2_defaults()
         } else {
-            #[allow(unused_mut)]
+            #[expect(clippy::allow_attributes, reason = "`unused_mut` is not always linted")]
+            #[allow(
+                unused_mut,
+                reason = "This variable needs to be mutable if the `ci_limits` feature is enabled"
+            )]
             let mut limits = wgpu::Limits::default();
             #[cfg(feature = "ci_limits")]
             {

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -213,7 +213,6 @@ impl WindowSurfaces {
 ///   another alternative is to try to use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle) and
 ///   [`Backends::GL`](crate::settings::Backends::GL) if your GPU/drivers support `OpenGL 4.3` / `OpenGL ES 3.0` or
 ///   later.
-#[allow(clippy::too_many_arguments)]
 pub fn prepare_windows(
     mut windows: ResMut<ExtractedWindows>,
     mut window_surfaces: ResMut<WindowSurfaces>,

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -251,7 +251,10 @@ fn extract_screenshots(
     system_state.apply(&mut main_world);
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+)]
 fn prepare_screenshots(
     targets: Res<RenderScreenshotTargets>,
     mut prepared: ResMut<RenderScreenshotsPrepared>,
@@ -576,7 +579,10 @@ pub(crate) fn submit_screenshot_commands(world: &World, encoder: &mut CommandEnc
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+)]
 fn render_screenshot(
     encoder: &mut CommandEncoder,
     prepared: &RenderScreenshotsPrepared,


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_render` in line with the new restrictions.

## Testing
`cargo clippy` and `cargo test --package bevy_render` were run, and no errors were encountered.