### PR TITLE
Remove references to old sample_texture function

### DIFF
--- a/crates/bevy_pbr/src/meshlet/asset.rs
+++ b/crates/bevy_pbr/src/meshlet/asset.rs
@@ -31,7 +31,6 @@ pub const MESHLET_MESH_ASSET_VERSION: u64 = 1;
 /// * Do not use normal maps baked from higher-poly geometry. Use the high-poly geometry directly and skip the normal map.
 ///   * If additional detail is needed, a smaller tiling normal map not baked from a mesh is ok.
 /// * Material shaders must not use builtin functions that automatically calculate derivatives <https://gpuweb.github.io/gpuweb/wgsl/#derivatives>.
-///   * Use `pbr_functions::sample_texture` to sample textures instead.
 ///   * Performing manual arithmetic on texture coordinates (UVs) is forbidden. Use the chain-rule version of arithmetic functions instead (TODO: not yet implemented).
 /// * Limited control over [`bevy_render::render_resource::RenderPipelineDescriptor`] attributes.
 /// * Materials must use the [`crate::Material::meshlet_mesh_fragment_shader`] method (and similar variants for prepass/deferred shaders)

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -33,9 +33,8 @@
 #endif
 
 
-// Biasing info needed to sample from a texture when calling `sample_texture`.
-// How this is done depends on whether we're rendering meshlets or regular
-// meshes.
+// Biasing info needed to sample from a texture. How this is done depends on
+// whether we're rendering meshlets or regular meshes.
 struct SampleBias {
 #ifdef MESHLET_MESH_MATERIAL_PASS
     ddx_uv: vec2<f32>,


### PR DESCRIPTION
# Objective

Remove some outdated docs from 0.15 that mention a removed function.

## Solution

In `pbr_functions.wgsl`, I think it's fine to just remove the mention. In `meshlet/asset.rs`, I think it would be nice to still have a note on how texture samples should be done. Unfortunately, there isn't a nice abstraction for it any more. Current workaround, for reference:

https://github.com/bevyengine/bevy/blob/b386d08d0f905d07843ddfed936e404845a6a10b/crates/bevy_pbr/src/render/pbr_fragment.wgsl#L184-L208

For now, I've just removed the mention.
