### PR TITLE
Add builder method for `TextFont::line_height`

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -323,6 +323,12 @@ impl TextFont {
         self.font_smoothing = font_smoothing;
         self
     }
+
+    /// Returns this [`TextFont`] with the specified [`LineHeight`].
+    pub const fn with_line_height(mut self, line_height: LineHeight) -> Self {
+        self.line_height = line_height;
+        self
+    }
 }
 
 impl Default for TextFont {


### PR DESCRIPTION
# Objective

Followup from #16614

`TextFont` has builder methods for its other fields. Add `with_line_height` for consistency.

## Solution

Add it
