### PR TITLE
Fix `scale_factor_override` not used in window creation

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -77,7 +77,17 @@ pub fn create_windows<F: QueryFilter + 'static>(
             window.window_theme = Some(convert_winit_theme(theme));
         }
 
-        if window.resolution.scale_factor_override().is_none() {
+        if let Some(forced_factor) = window.resolution.scale_factor_override() {
+            let size = window.resolution.physical_size();
+            let size = PhysicalSize::new(
+                ((size.x as f32) * forced_factor) as u32,
+                ((size.y as f32) * forced_factor) as u32,
+            );
+            window
+                .resolution
+                .set_physical_resolution(size.width, size.height);
+            let _ = winit_window.request_inner_size(size);
+        } else {
             window
                 .resolution
                 .set_scale_factor_and_apply_to_physical_size(winit_window.scale_factor() as f32);

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -77,9 +77,11 @@ pub fn create_windows<F: QueryFilter + 'static>(
             window.window_theme = Some(convert_winit_theme(theme));
         }
 
-        window
-            .resolution
-            .set_scale_factor_and_apply_to_physical_size(winit_window.scale_factor() as f32);
+        if window.resolution.scale_factor_override().is_none() {
+            window
+                .resolution
+                .set_scale_factor_and_apply_to_physical_size(winit_window.scale_factor() as f32);
+        }
 
         commands.entity(entity).insert(CachedWindow {
             window: window.clone(),


### PR DESCRIPTION
# Objective

Fixes #17188. When `scale_factor_override` is set on `WindowResolution`, the resulting `WindowResolution` is incorrect for the first frame. This is because when windows are first created in `bevy::winit::create_windows`, the resolution is set without respect to `WindowResolution::scale_factor_override`:
```rust
window
    .resolution
    .set_scale_factor_and_apply_to_physical_size(winit_window.scale_factor() as f32);
```
Afterwards, `bevy::winit::changed_windows` updates the resolution at the end of the first frame.

## Solution

Check if `scale_factor_override` is set before using OS resolution settings on window creation.

## Testing

Tested using the code from the linked issue.
