### PR TITLE
Add Image constructor specialised for rendering to a texture

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -761,6 +761,26 @@ impl Image {
         value
     }
 
+    /// Create a new zero-filled image with a given size, which can be rendered to.
+    /// This is primarily for use as a render target for a [`Camera`](`bevy_render::camera::Camera`).
+    /// See [`RenderTarget::Image`](`bevy_render::camera::RenderTarget::Image`).
+    pub fn new_target_texture(width: u32, height: u32) -> Self {
+        let mut image = Self::default();
+
+        image.resize(Extent3d {
+            width,
+            height,
+            ..Default::default()
+        });
+
+        // You need to set these texture usage flags in order to use the image as a render target
+        image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
+            | TextureUsages::COPY_DST
+            | TextureUsages::RENDER_ATTACHMENT;
+
+        image
+    }
+
     /// Returns the width of a 2D image.
     #[inline]
     pub fn width(&self) -> u32 {

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -2,14 +2,7 @@
 
 use std::f32::consts::PI;
 
-use bevy::{
-    prelude::*,
-    render::{
-        render_asset::RenderAssetUsages,
-        render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
-        view::RenderLayers,
-    },
-};
+use bevy::{prelude::*, render::view::RenderLayers};
 
 fn main() {
     App::new()
@@ -33,23 +26,8 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut images: ResMut<Assets<Image>>,
 ) {
-    let size = Extent3d {
-        width: 512,
-        height: 512,
-        ..default()
-    };
-
     // This is the texture that will be rendered to.
-    let mut image = Image::new_fill(
-        size,
-        TextureDimension::D2,
-        &[0, 0, 0, 0],
-        TextureFormat::Bgra8UnormSrgb,
-        RenderAssetUsages::default(),
-    );
-    // You need to set these texture usage flags in order to use the image as a render target
-    image.texture_descriptor.usage =
-        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST | TextureUsages::RENDER_ATTACHMENT;
+    let image = Image::new_target_texture(512, 512);
 
     let image_handle = images.add(image);
 


### PR DESCRIPTION
# Objective

Fixes #7358
Redo of #7360

Ergonomics. There's a bunch of enigmatic boilerplate for constructing a texture for rendering to, which could be greatly simplified for the external user-facing API.

## Solution

- Take part of the render_to_target example and turn it into a new constructor for `Image`, with minimal changes beyond the `Default` implementation.
- Update the render_to_target example to use the new API.

Strictly speaking, there are two small differences between the constructor and the example:

1. The example sets the `size` when initially constructing the `Image`, then `resize`s, but `resize` sets the `size` anyway so we don't need to do this extra step.

2. The example sets `Image.texture_descriptor.format` to `TextureFormat::Bgra8UnormSrgb`, but the default impl sets this to `TextureFormat::Rgba8UnormSrgb` via `wgpu::TextureFormat::bevy_default()`. I don't know what sort of impact this has, but it works on my machine.

I've deliberately chosen to only include `width` and `height` as parameters, but maybe it makes sense for some of the other properties to be exposed as parameters.

---

## Changelog

### Added

Added `Image::new_target_texture` constructor for simpler creation of render target textures.

---

Notes:

- This is a re-do of https://github.com/bevyengine/bevy/pull/7360 - there's some relevant discussion on code style there.
- The docs for the method want to refer to `bevy_render::camera::Camera` and bevy_render::camera::RenderTarget::Image`. `bevy_image` used to be part of `bevy_render` and was split out in the past, and `bevy_image` doesn't depend on `bevy_render`. What's the recommendation here?