### PR TITLE
bevy_mesh: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -1,4 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 
 extern crate alloc;
 extern crate core;

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -491,7 +491,6 @@ impl Mesh {
     ///
     /// This can dramatically increase the vertex count, so make sure this is what you want.
     /// Does nothing if no [Indices] are set.
-    #[allow(clippy::match_same_arms)]
     pub fn duplicate_vertices(&mut self) {
         fn duplicate<T: Copy>(values: &[T], indices: impl Iterator<Item = usize>) -> Vec<T> {
             indices.map(|i| values[i]).collect()
@@ -503,6 +502,10 @@ impl Mesh {
 
         for attributes in self.attributes.values_mut() {
             let indices = indices.iter();
+            #[expect(
+                clippy::match_same_arms,
+                reason = "Although the `vec` binding on some match arms may have different types, each variant has different semantics; thus it's not guaranteed that they will use the same type forever."
+            )]
             match &mut attributes.values {
                 VertexAttributeValues::Float32(vec) => *vec = duplicate(vec, indices),
                 VertexAttributeValues::Sint32(vec) => *vec = duplicate(vec, indices),
@@ -789,7 +792,6 @@ impl Mesh {
     ///
     /// Panics if the vertex attribute values of `other` are incompatible with `self`.
     /// For example, [`VertexAttributeValues::Float32`] is incompatible with [`VertexAttributeValues::Float32x3`].
-    #[allow(clippy::match_same_arms)]
     pub fn merge(&mut self, other: &Mesh) {
         use VertexAttributeValues::*;
 
@@ -800,6 +802,10 @@ impl Mesh {
         for (attribute, values) in self.attributes_mut() {
             let enum_variant_name = values.enum_variant_name();
             if let Some(other_values) = other.attribute(attribute.id) {
+                #[expect(
+                    clippy::match_same_arms,
+                    reason = "Although the bindings on some match arms may have different types, each variant has different semantics; thus it's not guaranteed that they will use the same type forever."
+                )]
                 match (values, other_values) {
                     (Float32(vec1), Float32(vec2)) => vec1.extend(vec2),
                     (Sint32(vec1), Sint32(vec2)) => vec1.extend(vec2),

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -171,47 +171,40 @@ pub trait VertexFormatSize {
 
 impl VertexFormatSize for VertexFormat {
     fn get_size(self) -> u64 {
-        match self {
-            VertexFormat::Uint8x2
-            | VertexFormat::Sint8x2
-            | VertexFormat::Unorm8x2
-            | VertexFormat::Snorm8x2 => 2,
+        use core::mem::size_of;
+        let size = match self {
+            VertexFormat::Uint8x2 | VertexFormat::Unorm8x2 => size_of::<u8>() * 2,
+            VertexFormat::Uint8x4 | VertexFormat::Unorm8x4 => size_of::<u8>() * 4,
+            VertexFormat::Sint8x2 | VertexFormat::Snorm8x2 => size_of::<i8>() * 2,
+            VertexFormat::Sint8x4 | VertexFormat::Snorm8x4 => size_of::<i8>() * 4,
+            VertexFormat::Unorm10_10_10_2 => 10 + 10 + 10 + 2,
+            VertexFormat::Uint16x2 | VertexFormat::Unorm16x2 => size_of::<u16>() * 2,
+            VertexFormat::Uint16x4 | VertexFormat::Unorm16x4 => size_of::<u16>() * 4,
+            VertexFormat::Sint16x2 | VertexFormat::Snorm16x2 => size_of::<i16>() * 2,
+            VertexFormat::Sint16x4 | VertexFormat::Snorm16x4 => size_of::<i16>() * 4,
+            VertexFormat::Float16x2 => 2 * 2,
+            VertexFormat::Float16x4 => 2 * 4,
+            VertexFormat::Float32 => size_of::<f32>(),
+            VertexFormat::Float32x2 => size_of::<f32>() * 2,
+            VertexFormat::Float32x3 => size_of::<f32>() * 3,
+            VertexFormat::Float32x4 => size_of::<f32>() * 4,
+            VertexFormat::Uint32 => size_of::<u32>(),
+            VertexFormat::Uint32x2 => size_of::<u32>() * 2,
+            VertexFormat::Uint32x3 => size_of::<u32>() * 3,
+            VertexFormat::Uint32x4 => size_of::<u32>() * 4,
+            VertexFormat::Sint32 => size_of::<i32>(),
+            VertexFormat::Sint32x2 => size_of::<i32>() * 2,
+            VertexFormat::Sint32x3 => size_of::<i32>() * 3,
+            VertexFormat::Sint32x4 => size_of::<i32>() * 4,
+            VertexFormat::Float64 => size_of::<f64>(),
+            VertexFormat::Float64x2 => size_of::<f64>() * 2,
+            VertexFormat::Float64x3 => size_of::<f64>() * 3,
+            VertexFormat::Float64x4 => size_of::<f64>() * 4,
+        };
 
-            VertexFormat::Uint8x4
-            | VertexFormat::Sint8x4
-            | VertexFormat::Unorm8x4
-            | VertexFormat::Snorm8x4
-            | VertexFormat::Unorm10_10_10_2
-            | VertexFormat::Uint16x2
-            | VertexFormat::Sint16x2
-            | VertexFormat::Unorm16x2
-            | VertexFormat::Snorm16x2
-            | VertexFormat::Float16x2
-            | VertexFormat::Float32
-            | VertexFormat::Uint32
-            | VertexFormat::Sint32 => 4,
-
-            VertexFormat::Uint16x4
-            | VertexFormat::Sint16x4
-            | VertexFormat::Unorm16x4
-            | VertexFormat::Snorm16x4
-            | VertexFormat::Float16x4
-            | VertexFormat::Float32x2
-            | VertexFormat::Uint32x2
-            | VertexFormat::Sint32x2
-            | VertexFormat::Float64 => 8,
-
-            VertexFormat::Float32x3 | VertexFormat::Uint32x3 | VertexFormat::Sint32x3 => 12,
-
-            VertexFormat::Float32x4
-            | VertexFormat::Uint32x4
-            | VertexFormat::Sint32x4
-            | VertexFormat::Float64x2 => 16,
-
-            VertexFormat::Float64x3 => 24,
-
-            VertexFormat::Float64x4 => 32,
-        }
+        // We can safely cast `size` (a `usize`) into a `u64`, as we don't even reach the limits of
+        // of a `u8`.
+        size.try_into().unwrap()
     }
 }
 

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -170,44 +170,49 @@ pub trait VertexFormatSize {
 }
 
 impl VertexFormatSize for VertexFormat {
-    #[allow(clippy::match_same_arms)]
     fn get_size(self) -> u64 {
         match self {
-            VertexFormat::Uint8x2 => 2,
-            VertexFormat::Uint8x4 => 4,
-            VertexFormat::Sint8x2 => 2,
-            VertexFormat::Sint8x4 => 4,
-            VertexFormat::Unorm8x2 => 2,
-            VertexFormat::Unorm8x4 => 4,
-            VertexFormat::Snorm8x2 => 2,
-            VertexFormat::Snorm8x4 => 4,
-            VertexFormat::Unorm10_10_10_2 => 4,
-            VertexFormat::Uint16x2 => 2 * 2,
-            VertexFormat::Uint16x4 => 2 * 4,
-            VertexFormat::Sint16x2 => 2 * 2,
-            VertexFormat::Sint16x4 => 2 * 4,
-            VertexFormat::Unorm16x2 => 2 * 2,
-            VertexFormat::Unorm16x4 => 2 * 4,
-            VertexFormat::Snorm16x2 => 2 * 2,
-            VertexFormat::Snorm16x4 => 2 * 4,
-            VertexFormat::Float16x2 => 2 * 2,
-            VertexFormat::Float16x4 => 2 * 4,
-            VertexFormat::Float32 => 4,
-            VertexFormat::Float32x2 => 4 * 2,
-            VertexFormat::Float32x3 => 4 * 3,
-            VertexFormat::Float32x4 => 4 * 4,
-            VertexFormat::Uint32 => 4,
-            VertexFormat::Uint32x2 => 4 * 2,
-            VertexFormat::Uint32x3 => 4 * 3,
-            VertexFormat::Uint32x4 => 4 * 4,
-            VertexFormat::Sint32 => 4,
-            VertexFormat::Sint32x2 => 4 * 2,
-            VertexFormat::Sint32x3 => 4 * 3,
-            VertexFormat::Sint32x4 => 4 * 4,
-            VertexFormat::Float64 => 8,
-            VertexFormat::Float64x2 => 8 * 2,
-            VertexFormat::Float64x3 => 8 * 3,
-            VertexFormat::Float64x4 => 8 * 4,
+            VertexFormat::Uint8x2
+            | VertexFormat::Sint8x2
+            | VertexFormat::Unorm8x2
+            | VertexFormat::Snorm8x2 => 2,
+            
+            VertexFormat::Uint8x4
+            | VertexFormat::Sint8x4
+            | VertexFormat::Unorm8x4
+            | VertexFormat::Snorm8x4
+            | VertexFormat::Unorm10_10_10_2
+            | VertexFormat::Uint16x2
+            | VertexFormat::Sint16x2
+            | VertexFormat::Unorm16x2
+            | VertexFormat::Snorm16x2
+            | VertexFormat::Float16x2
+            | VertexFormat::Float32
+            | VertexFormat::Uint32
+            | VertexFormat::Sint32 => 4,
+            
+            VertexFormat::Uint16x4
+            | VertexFormat::Sint16x4
+            | VertexFormat::Unorm16x4
+            | VertexFormat::Snorm16x4
+            | VertexFormat::Float16x4
+            | VertexFormat::Float32x2
+            | VertexFormat::Uint32x2
+            | VertexFormat::Sint32x2
+            | VertexFormat::Float64 => 8,
+            
+            VertexFormat::Float32x3
+            | VertexFormat::Uint32x3
+            | VertexFormat::Sint32x3 => 12,
+            
+            VertexFormat::Float32x4
+            | VertexFormat::Uint32x4
+            | VertexFormat::Sint32x4
+            | VertexFormat::Float64x2 => 16,
+            
+            VertexFormat::Float64x3 => 24,
+            
+            VertexFormat::Float64x4 => 32,
         }
     }
 }
@@ -249,7 +254,10 @@ pub enum VertexAttributeValues {
 impl VertexAttributeValues {
     /// Returns the number of vertices in this [`VertexAttributeValues`]. For a single
     /// mesh, all of the [`VertexAttributeValues`] must have the same length.
-    #[allow(clippy::match_same_arms)]
+    #[expect(
+        clippy::match_same_arms,
+        reason = "Although the `values` binding on some match arms may have matching types, each variant has different semantics; thus it's not guaranteed that they will use the same type forever."
+    )]
     pub fn len(&self) -> usize {
         match self {
             VertexAttributeValues::Float32(values) => values.len(),
@@ -299,7 +307,10 @@ impl VertexAttributeValues {
     // TODO: add vertex format as parameter here and perform type conversions
     /// Flattens the [`VertexAttributeValues`] into a sequence of bytes. This is
     /// useful for serialization and sending to the GPU.
-    #[allow(clippy::match_same_arms)]
+    #[expect(
+        clippy::match_same_arms,
+        reason = "Although the `values` binding on some match arms may have matching types, each variant has different semantics; thus it's not guaranteed that they will use the same type forever."
+    )]
     pub fn get_bytes(&self) -> &[u8] {
         match self {
             VertexAttributeValues::Float32(values) => cast_slice(values),

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -176,7 +176,7 @@ impl VertexFormatSize for VertexFormat {
             | VertexFormat::Sint8x2
             | VertexFormat::Unorm8x2
             | VertexFormat::Snorm8x2 => 2,
-            
+
             VertexFormat::Uint8x4
             | VertexFormat::Sint8x4
             | VertexFormat::Unorm8x4
@@ -190,7 +190,7 @@ impl VertexFormatSize for VertexFormat {
             | VertexFormat::Float32
             | VertexFormat::Uint32
             | VertexFormat::Sint32 => 4,
-            
+
             VertexFormat::Uint16x4
             | VertexFormat::Sint16x4
             | VertexFormat::Unorm16x4
@@ -200,18 +200,16 @@ impl VertexFormatSize for VertexFormat {
             | VertexFormat::Uint32x2
             | VertexFormat::Sint32x2
             | VertexFormat::Float64 => 8,
-            
-            VertexFormat::Float32x3
-            | VertexFormat::Uint32x3
-            | VertexFormat::Sint32x3 => 12,
-            
+
+            VertexFormat::Float32x3 | VertexFormat::Uint32x3 | VertexFormat::Sint32x3 => 12,
+
             VertexFormat::Float32x4
             | VertexFormat::Uint32x4
             | VertexFormat::Sint32x4
             | VertexFormat::Float64x2 => 16,
-            
+
             VertexFormat::Float64x3 => 24,
-            
+
             VertexFormat::Float64x4 => 32,
         }
     }

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -182,6 +182,8 @@ impl VertexFormatSize for VertexFormat {
             VertexFormat::Uint16x4 | VertexFormat::Unorm16x4 => size_of::<u16>() * 4,
             VertexFormat::Sint16x2 | VertexFormat::Snorm16x2 => size_of::<i16>() * 2,
             VertexFormat::Sint16x4 | VertexFormat::Snorm16x4 => size_of::<i16>() * 4,
+            // NOTE: As of the time of writing this code, `f16` is not a stabilized primitive, so we
+            // can't use `size_of::<f16>()` here.
             VertexFormat::Float16x2 => 2 * 2,
             VertexFormat::Float16x4 => 2 * 4,
             VertexFormat::Float32 => size_of::<f32>(),


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_mesh` in line with the new restrictions.

## Testing
`cargo clippy --tests` and `cargo test --package bevy_mesh` were run, and no errors were encountered.