### PR TITLE
Fix "Unrecognized Option" error when using Criterion-specific arguments in benchmarks

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -60,6 +60,13 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
+[lib]
+# This fixes the "Unrecognized Option" error when running commands like
+# `cargo bench -- --save-baseline before` by disabling the default benchmark harness.
+# See <https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options>
+# for more information.
+bench = false
+
 [[bench]]
 name = "ecs"
 path = "benches/bevy_ecs/main.rs"

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -4,7 +4,6 @@ use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 pub use bevy_render_macros::ExtractResource;
 use bevy_utils::once;
-use tracing::{error, warn};
 
 use crate::{Extract, ExtractSchedule, RenderApp};
 
@@ -36,7 +35,7 @@ impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(ExtractSchedule, extract_resource::<R>);
         } else {
-            once!(error!(
+            once!(tracing::error!(
                 "Render app did not exist when trying to add `extract_resource` for <{}>.",
                 core::any::type_name::<R>()
             ));
@@ -58,12 +57,13 @@ pub fn extract_resource<R: ExtractResource>(
         } else {
             #[cfg(debug_assertions)]
             if !main_resource.is_added() {
-                once!(warn!(
+                once!(tracing::warn!(
                     "Removing resource {} from render world not expected, adding using `Commands`.
                 This may decrease performance",
                     core::any::type_name::<R>()
                 ));
             }
+
             commands.insert_resource(R::extract_resource(main_resource));
         }
     }


### PR DESCRIPTION
# Objective

- Commands like `cargo bench -- --save-baseline before` do not work because the default `libtest` is intercepting Criterion-specific CLI arguments.
- Fixes #17200.

## Solution

- Disable the default `libtest` benchmark harness for the library crate, as per [the Criterion book](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options).

## Testing

- `cargo bench -p benches -- --save-baseline before`
  - You don't need to run the entire benchmarks, just make sure that they start without any errors. :)
