### PR TITLE
Update `downcast-rs` to version 2

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -32,7 +32,7 @@ petgraph = { version = "0.6", features = ["serde-1"] }
 ron = "0.8"
 serde = "1"
 blake3 = { version = "1.0" }
-downcast-rs = "1.2.0"
+downcast-rs = { version = "2", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 either = "1.13"

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["std", "bevy_reflect", "bevy_tasks", "bevy_ecs/default", "downcast"]
+default = ["std", "bevy_reflect", "bevy_tasks", "bevy_ecs/default"]
 
 # Functionality
 
@@ -25,9 +25,6 @@ reflect_functions = [
 
 ## Adds support for running async background tasks
 bevy_tasks = ["dep:bevy_tasks"]
-
-## Adds `downcast-rs` integration for `Plugin`
-downcast = ["dep:downcast-rs"]
 
 # Debugging Features
 
@@ -48,7 +45,7 @@ std = [
   "bevy_reflect?/std",
   "bevy_ecs/std",
   "dep:ctrlc",
-  "downcast-rs?/std",
+  "downcast-rs/std",
   "bevy_utils/std",
   "bevy_tasks?/std",
 ]
@@ -81,7 +78,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features 
 bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false, optional = true }
 
 # other
-downcast-rs = { version = "1.2.0", default-features = false, optional = true }
+downcast-rs = { version = "2", default-features = false }
 thiserror = { version = "2", default-features = false }
 variadics_please = "1.1"
 tracing = { version = "0.1", default-features = false, optional = true }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -5,6 +5,7 @@ use crate::{
 use alloc::{
     boxed::Box,
     string::{String, ToString},
+    vec::Vec,
 };
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
@@ -28,9 +29,6 @@ use std::{
     panic::{catch_unwind, resume_unwind},
     process::{ExitCode, Termination},
 };
-
-#[cfg(feature = "downcast")]
-use alloc::vec::Vec;
 
 bevy_ecs::define_label!(
     /// A strongly-typed class of labels used to identify an [`App`].
@@ -522,7 +520,6 @@ impl App {
     /// # app.add_plugins(ImagePlugin::default());
     /// let default_sampler = app.get_added_plugins::<ImagePlugin>()[0].default_sampler;
     /// ```
-    #[cfg(feature = "downcast")]
     pub fn get_added_plugins<T>(&self) -> Vec<&T>
     where
         T: Plugin,

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -1,20 +1,6 @@
-// TODO: Upstream `portable-atomic` support to `downcast_rs` and unconditionally
-// include it as a dependency.
-// See https://github.com/marcianx/downcast-rs/pull/22 for details
-#[cfg(feature = "downcast")]
-use downcast_rs::{impl_downcast, Downcast};
-
 use crate::App;
 use core::any::Any;
-
-/// Dummy trait with the same name as `downcast_rs::Downcast`. This is to ensure
-/// the `Plugin: Downcast` bound can remain even when `downcast` isn't enabled.
-#[cfg(not(feature = "downcast"))]
-#[doc(hidden)]
-pub trait Downcast {}
-
-#[cfg(not(feature = "downcast"))]
-impl<T: ?Sized> Downcast for T {}
+use downcast_rs::{impl_downcast, Downcast};
 
 /// A collection of Bevy app logic and configuration.
 ///
@@ -105,7 +91,6 @@ pub trait Plugin: Downcast + Any + Send + Sync {
     }
 }
 
-#[cfg(feature = "downcast")]
 impl_downcast!(Plugin);
 
 impl<T: Fn(&mut App) + Send + Sync + 'static> Plugin for T {

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -362,7 +362,6 @@ impl SubApp {
     }
 
     /// See [`App::get_added_plugins`].
-    #[cfg(feature = "downcast")]
     pub fn get_added_plugins<T>(&self) -> Vec<&T>
     where
         T: Plugin,

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -35,7 +35,7 @@ async-fs = "2.0"
 async-lock = "3.0"
 bitflags = { version = "2.3", features = ["serde"] }
 crossbeam-channel = "0.5"
-downcast-rs = "1.2"
+downcast-rs = { version = "2", default-features = false, features = ["std"] }
 disqualified = "1.0"
 either = "1.13"
 futures-io = "0.3"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -53,7 +53,7 @@ erased-serde = { version = "0.4", default-features = false, features = [
   "alloc",
 ] }
 disqualified = { version = "1.0", default-features = false }
-downcast-rs = { version = "1.2", default-features = false }
+downcast-rs = { version = "2", default-features = false }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 serde = { version = "1", default-features = false, features = ["alloc"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -77,7 +77,7 @@ wgpu = { version = "23.0.1", default-features = false, features = [
 naga = { version = "23", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }
 bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
-downcast-rs = "1.2.0"
+downcast-rs = { version = "2", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 futures-lite = "2.0.1"


### PR DESCRIPTION
# Objective & Solution

- Update `downcast-rs` to the latest version, 2.
- Disable (new) `sync` feature to improve compatibility with atomically challenged platforms.
- Remove stub `downcast-rs` alternative code from `bevy_app`

## Testing

- CI

## Notes

The only change from version 1 to version 2 is the addition of a new `sync` feature, which allows disabling the `DowncastSync` parts of `downcast-rs`, which require access to `alloc::sync::Arc`, which is not available on atomically challenged platforms. Since Bevy makes no use of the functionality provided by the `sync` feature, I've disabled it in all crates. Further details can be found [here](https://github.com/marcianx/downcast-rs/pull/22).
