### PR TITLE
Make sprite picking opt-in

### DIFF
--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -41,10 +41,18 @@ use bevy_reflect::Reflect;
 pub mod prelude {
     pub use super::{ray::RayMap, HitData, PointerHits};
     pub use crate::{
+        backend::Pickable,
         pointer::{PointerId, PointerLocation},
         PickSet, PickingBehavior,
     };
 }
+
+/// Component used to mark entities as pickable by backends.
+///
+/// You should use this component if you are using a backend with opt-in behavior.
+#[derive(Component, Reflect, Debug)]
+#[reflect(Component, Debug)]
+pub struct Pickable;
 
 /// An event produced by a picking backend after it has run its hit tests, describing the entities
 /// under a pointer.

--- a/crates/bevy_picking/src/backend.rs
+++ b/crates/bevy_picking/src/backend.rs
@@ -41,18 +41,10 @@ use bevy_reflect::Reflect;
 pub mod prelude {
     pub use super::{ray::RayMap, HitData, PointerHits};
     pub use crate::{
-        backend::Pickable,
         pointer::{PointerId, PointerLocation},
         PickSet, PickingBehavior,
     };
 }
-
-/// Component used to mark entities as pickable by backends.
-///
-/// You should use this component if you are using a backend with opt-in behavior.
-#[derive(Component, Reflect, Debug)]
-#[reflect(Component, Debug)]
-pub struct Pickable;
 
 /// An event produced by a picking backend after it has run its hit tests, describing the entities
 /// under a pointer.

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -188,9 +188,12 @@ pub mod prelude {
     };
 }
 
-/// An optional component that overrides default picking behavior for an entity, allowing you to
-/// make an entity non-hoverable, or allow items below it to be hovered. See the documentation on
-/// the fields for more details.
+/// An optional component that marks an entity as usable by a backend, and overrides default
+/// picking behavior for an entity.
+///
+/// This allows you to make an entity non-hoverable, or allow items below it to be hovered.
+///
+/// See the documentation on the fields for more details.
 #[derive(Component, Debug, Clone, Reflect, PartialEq, Eq)]
 #[reflect(Component, Default, Debug, PartialEq)]
 pub struct PickingBehavior {
@@ -388,7 +391,6 @@ impl Plugin for PickingPlugin {
             .register_type::<pointer::PointerLocation>()
             .register_type::<pointer::PointerPress>()
             .register_type::<pointer::PointerInteraction>()
-            .register_type::<backend::Pickable>()
             .register_type::<backend::ray::RayId>();
     }
 }

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -388,6 +388,7 @@ impl Plugin for PickingPlugin {
             .register_type::<pointer::PointerLocation>()
             .register_type::<pointer::PointerPress>()
             .register_type::<pointer::PointerInteraction>()
+            .register_type::<backend::Pickable>()
             .register_type::<backend::ray::RayId>();
     }
 }

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -5,7 +5,7 @@
 //! # Usage
 //!
 //! This backend is strictly opt-in. For entities to be considered for sprite picking, you should
-//! mark them and their respective cameras with the [`SpritePickable`] component.
+//! mark them with [`Pickable`] and their respective cameras with [`SpritePickingCamera`].
 
 use crate::{Sprite, TextureAtlasLayout};
 use bevy_app::prelude::*;

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -20,6 +20,11 @@ use bevy_render::prelude::*;
 use bevy_transform::prelude::*;
 use bevy_window::PrimaryWindow;
 
+/// A component that marks cameras that should be used in the [`SpritePickingPlugin`].
+#[derive(Debug, Clone, Default, Component, Reflect)]
+#[reflect(Debug, Default, Component)]
+pub struct SpritePickingCamera;
+
 /// How should the [`SpritePickingPlugin`] handle picking and how should it handle transparent pixels
 #[derive(Debug, Clone, Copy, Reflect)]
 #[reflect(Debug)]
@@ -50,19 +55,17 @@ impl Default for SpritePickingSettings {
     }
 }
 
-/// A component that marks cameras and target entities that should be used in the
-/// [`SpritePickingPlugin`].
-#[derive(Debug, Clone, Default, Component, Reflect)]
-#[reflect(Debug, Default, Component)]
-pub struct SpritePickable;
-
 #[derive(Clone)]
 pub struct SpritePickingPlugin;
 
 impl Plugin for SpritePickingPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SpritePickingSettings>()
-            .register_type::<(SpritePickingMode, SpritePickingSettings, SpritePickable)>()
+            .register_type::<(
+                SpritePickingCamera,
+                SpritePickingMode,
+                SpritePickingSettings,
+            )>()
             .add_systems(PreUpdate, sprite_picking.in_set(PickSet::Backend));
     }
 }
@@ -73,7 +76,7 @@ impl Plugin for SpritePickingPlugin {
 )]
 fn sprite_picking(
     pointers: Query<(&PointerId, &PointerLocation)>,
-    cameras: Query<(Entity, &Camera, &GlobalTransform, &Projection), With<SpritePickable>>,
+    cameras: Query<(Entity, &Camera, &GlobalTransform, &Projection), With<SpritePickingCamera>>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     images: Res<Assets<Image>>,
     texture_atlas_layout: Res<Assets<TextureAtlasLayout>>,
@@ -86,7 +89,7 @@ fn sprite_picking(
             Option<&PickingBehavior>,
             &ViewVisibility,
         ),
-        With<SpritePickable>,
+        With<Pickable>,
     >,
     mut output: EventWriter<PointerHits>,
 ) {

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -1,6 +1,11 @@
 //! A [`bevy_picking`] backend for sprites. Works for simple sprites and sprite atlases. Works for
 //! sprites with arbitrary transforms. Picking is done based on sprite bounds, not visible pixels.
 //! This means a partially transparent sprite is pickable even in its transparent areas.
+//!
+//! # Usage
+//!
+//! This backend is strictly opt-in. For entities to be considered for sprite picking, you should
+//! mark them and their respective cameras with the [`SpritePickable`] component.
 
 use crate::{Sprite, TextureAtlasLayout};
 use bevy_app::prelude::*;

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -1,11 +1,7 @@
 //! Demonstrates picking for sprites and sprite atlases. The picking backend only tests against the
 //! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
 
-use bevy::{
-    picking::backend::prelude::*,
-    prelude::*,
-    sprite::{Anchor, SpritePickingCamera},
-};
+use bevy::{prelude::*, sprite::Anchor};
 use std::fmt::Debug;
 
 fn main() {
@@ -33,14 +29,7 @@ fn move_sprite(
 
 /// Set up a scene that tests all sprite anchor types.
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn((
-        Camera2d,
-        // The sprite picking backend is strictly opt-in. As such, we need to mark this camera with
-        // `SpritePickingCamera` so it may be used in the backend.
-        //
-        // Additionally, any sprite that should be pickable will need a `Pickable` component.
-        SpritePickingCamera,
-    ));
+    commands.spawn(Camera2d);
 
     let len = 128.0;
     let sprite_size = Vec2::splat(len / 2.0);
@@ -70,7 +59,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 commands
                     .spawn((
                         Sprite::from_color(Color::BLACK, sprite_size),
-                        Pickable,
                         Transform::from_xyz(i * len - len, j * len - len, -1.0),
                     ))
                     .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 1.0)))
@@ -87,7 +75,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             anchor: anchor.to_owned(),
                             ..default()
                         },
-                        Pickable,
                         // 3x3 grid of anchor examples by changing transform
                         Transform::from_xyz(i * len - len, j * len - len, 0.0)
                             .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2))
@@ -150,7 +137,6 @@ fn setup_atlas(
                     index: animation_indices.first,
                 },
             ),
-            Pickable,
             Transform::from_xyz(300.0, 0.0, 0.0).with_scale(Vec3::splat(6.0)),
             animation_indices,
             AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -34,8 +34,7 @@ fn move_sprite(
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera2d,
-        // To allow our camera to perform any sprite picking, it needs this component. This
-        // behavior can be changed in `SpritePickingSettings`.
+        // To allow our camera to perform any sprite picking, it needs this component.
         //
         // Any sprite that should be pickable also needs this component.
         SpritePickable,

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -1,7 +1,10 @@
 //! Demonstrates picking for sprites and sprite atlases. The picking backend only tests against the
 //! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
 
-use bevy::{prelude::*, sprite::Anchor};
+use bevy::{
+    prelude::*,
+    sprite::{Anchor, SpritePickable},
+};
 use std::fmt::Debug;
 
 fn main() {
@@ -29,7 +32,14 @@ fn move_sprite(
 
 /// Set up a scene that tests all sprite anchor types.
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2d);
+    commands.spawn((
+        Camera2d,
+        // To allow our camera to perform any sprite picking, it needs this component. This
+        // behavior can be changed in `SpritePickingSettings`.
+        //
+        // Any sprite that should be pickable also needs this component.
+        SpritePickable,
+    ));
 
     let len = 128.0;
     let sprite_size = Vec2::splat(len / 2.0);
@@ -55,10 +65,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 let i = (anchor_index % 3) as f32;
                 let j = (anchor_index / 3) as f32;
 
-                // spawn black square behind sprite to show anchor point
+                // Spawn black square behind sprite to show anchor point
                 commands
                     .spawn((
                         Sprite::from_color(Color::BLACK, sprite_size),
+                        SpritePickable,
                         Transform::from_xyz(i * len - len, j * len - len, -1.0),
                     ))
                     .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 1.0)))
@@ -75,6 +86,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             anchor: anchor.to_owned(),
                             ..default()
                         },
+                        SpritePickable,
                         // 3x3 grid of anchor examples by changing transform
                         Transform::from_xyz(i * len - len, j * len - len, 0.0)
                             .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2))
@@ -137,6 +149,7 @@ fn setup_atlas(
                     index: animation_indices.first,
                 },
             ),
+            SpritePickable,
             Transform::from_xyz(300.0, 0.0, 0.0).with_scale(Vec3::splat(6.0)),
             animation_indices,
             AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -2,8 +2,9 @@
 //! sprite bounds, so the sprite atlas can be picked by clicking on its transparent areas.
 
 use bevy::{
+    picking::backend::prelude::*,
     prelude::*,
-    sprite::{Anchor, SpritePickable},
+    sprite::{Anchor, SpritePickingCamera},
 };
 use std::fmt::Debug;
 
@@ -34,10 +35,11 @@ fn move_sprite(
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera2d,
-        // To allow our camera to perform any sprite picking, it needs this component.
+        // The sprite picking backend is strictly opt-in. As such, we need to mark this camera with
+        // `SpritePickingCamera` so it may be used in the backend.
         //
-        // Any sprite that should be pickable also needs this component.
-        SpritePickable,
+        // Additionally, any sprite that should be pickable will need a `Pickable` component.
+        SpritePickingCamera,
     ));
 
     let len = 128.0;
@@ -68,7 +70,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 commands
                     .spawn((
                         Sprite::from_color(Color::BLACK, sprite_size),
-                        SpritePickable,
+                        Pickable,
                         Transform::from_xyz(i * len - len, j * len - len, -1.0),
                     ))
                     .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 1.0)))
@@ -85,7 +87,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             anchor: anchor.to_owned(),
                             ..default()
                         },
-                        SpritePickable,
+                        Pickable,
                         // 3x3 grid of anchor examples by changing transform
                         Transform::from_xyz(i * len - len, j * len - len, 0.0)
                             .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2))
@@ -148,7 +150,7 @@ fn setup_atlas(
                     index: animation_indices.first,
                 },
             ),
-            SpritePickable,
+            Pickable,
             Transform::from_xyz(300.0, 0.0, 0.0).with_scale(Vec3::splat(6.0)),
             animation_indices,
             AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),


### PR DESCRIPTION
# Objective

Fixes #16903.

## Solution

- Make sprite picking opt-in by requiring a new `SpritePickingCamera` component for cameras and usage of a new `Pickable` component for entities.
- Update the `sprite_picking` example to reflect these changes.
- Some reflection cleanup (I hope that's ok).

## Testing

Ran the `sprite_picking` example

## Open Questions

<del>
   <ul>
    <li>Is the name `SpritePickable` appropriate?</li>
    <li>Should `SpritePickable` be in `bevy_sprite::prelude?</li>
  </ul> 
</del>

## Migration Guide

The sprite picking backend is now strictly opt-in using the `SpritePickingCamera` and `Pickable` components. You should add the `Pickable` component any entities that you want sprite picking to be enabled for, and mark their respective cameras with `SpritePickingCamera`.
