### PR TITLE
bevy_winit: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -42,7 +42,6 @@ use crate::{
 ///
 /// If any of these entities are missing required components, those will be added with their
 /// default values.
-#[allow(clippy::too_many_arguments)]
 pub fn create_windows<F: QueryFilter + 'static>(
     event_loop: &ActiveEventLoop,
     (
@@ -203,7 +202,10 @@ pub fn create_monitors(
     });
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+)]
 pub(crate) fn despawn_windows(
     closing: Query<Entity, With<ClosingWindow>>,
     mut closed: RemovedComponents<Window>,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -43,7 +43,10 @@ pub struct WinitWindows {
 
 impl WinitWindows {
     /// Creates a `winit` window and associates it with our entity.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+    )]
     pub fn create_window(
         &mut self,
         event_loop: &ActiveEventLoop,
@@ -243,7 +246,11 @@ impl WinitWindows {
                 winit_window_attributes.with_min_inner_size(min_inner_size)
             };
 
-        #[allow(unused_mut)]
+        #[expect(clippy::allow_attributes, reason = "`unused_mut` is not always linted")]
+        #[allow(
+            unused_mut,
+            reason = "This variable needs to be mutable if `cfg(target_arch = "wasm32")`"
+        )]
         let mut winit_window_attributes = winit_window_attributes.with_title(window.title.as_str());
 
         #[cfg(target_arch = "wasm32")]

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -249,7 +249,7 @@ impl WinitWindows {
         #[expect(clippy::allow_attributes, reason = "`unused_mut` is not always linted")]
         #[allow(
             unused_mut,
-            reason = "This variable needs to be mutable if `cfg(target_arch = "wasm32")`"
+            reason = "This variable needs to be mutable if `cfg(target_arch = \"wasm32\")`"
         )]
         let mut winit_window_attributes = winit_window_attributes.with_title(window.title.as_str());
 


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_winit` in line with the new restrictions.

## Testing
`cargo clippy --tests` was run, and no errors were encountered.