### PR TITLE
If there is no movement, DragStart is not triggered.

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -668,6 +668,9 @@ pub fn pointer_events(
 
                     // Emit DragEntry and DragStart the first time we move while pressing an entity
                     for (press_target, (location, _, hit)) in state.pressing.iter() {
+                        if delta == Vec2::ZERO {
+                            continue; // No need to emit a DragStart event if there is no movement
+                        }
                         if state.dragging.contains_key(press_target) {
                             continue; // This entity is already logged as being dragged
                         }


### PR DESCRIPTION
# Objective

Fixed the issue where DragStart was triggered even when there was no movement
https://github.com/bevyengine/bevy/issues/17230

## Solution

- When position delta is zero, don't trigger DragStart events, DragStart is not triggered, so DragEnd is not triggered either. Everything is fine.

## Testing

- tested with the code from the issue

---

## Migration Guide

> Fix the missing part of Drag https://github.com/bevyengine/bevy/pull/16950 
