### PR TITLE
Allow tuple structs in animated_field! macro

### DIFF
--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -984,6 +984,7 @@ where
 ///
 /// ```
 /// # use bevy_animation::{animation_curves::AnimatedField, animated_field};
+/// # use bevy_color::Srgba;
 /// # use bevy_ecs::component::Component;
 /// # use bevy_math::Vec3;
 /// # use bevy_reflect::Reflect;
@@ -993,10 +994,15 @@ where
 /// }
 ///
 /// let field = animated_field!(Transform::translation);
+///
+/// #[derive(Component, Reflect)]
+/// struct Color(Srgba);
+///
+/// let tuple_field = animated_field!(Color::0);
 /// ```
 #[macro_export]
 macro_rules! animated_field {
-    ($component:ident::$field:ident) => {
+    ($component:ident::$field:tt) => {
         AnimatedField::new_unchecked(stringify!($field), |component: &mut $component| {
             &mut component.$field
         })


### PR DESCRIPTION
# Objective

Allow tuple structs in the animated_field macro.
-  for example `animated_field!(MyTupleStruct::0)`.

Fixes #16736 
- This issue was partially fixed in #16747, where support for tuple structs was added to `AnimatedField::new_unchecked`.

## Solution

Change the designator for `$field` in the macro from `ident` to `tt`.

## Testing

Expanded the doc test on `animated_field!` to include an example with a tuple struct.