### PR TITLE
Rename `DefaultCameraView`

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -138,7 +138,7 @@ pub fn build_ui_render(app: &mut App) {
         .add_systems(
             ExtractSchedule,
             (
-                extract_default_ui_camera_view,
+                extract_ui_camera_view,
                 extract_uinode_background_colors.in_set(RenderUiSystem::ExtractBackgrounds),
                 extract_uinode_images.in_set(RenderUiSystem::ExtractImages),
                 extract_uinode_borders.in_set(RenderUiSystem::ExtractBorders),
@@ -533,10 +533,10 @@ const UI_CAMERA_FAR: f32 = 1000.0;
 const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 
 #[derive(Component)]
-pub struct DefaultCameraView(pub Entity);
+pub struct UiCameraView(pub Entity);
 
 /// Extracts all UI elements associated with a camera into the render world.
-pub fn extract_default_ui_camera_view(
+pub fn extract_ui_camera_view(
     mut commands: Commands,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentUi>>,
     query: Extract<
@@ -560,7 +560,7 @@ pub fn extract_default_ui_camera_view(
             commands
                 .get_entity(entity)
                 .expect("Camera entity wasn't synced.")
-                .remove::<(DefaultCameraView, UiAntiAlias, BoxShadowSamples)>();
+                .remove::<(UiCameraView, UiAntiAlias, BoxShadowSamples)>();
             continue;
         }
 
@@ -574,7 +574,7 @@ pub fn extract_default_ui_camera_view(
                 0.0,
                 UI_CAMERA_FAR,
             );
-            let default_camera_view = commands
+            let ui_camera_view = commands
                 .spawn((
                     ExtractedView {
                         clip_from_view: projection_matrix,
@@ -597,7 +597,7 @@ pub fn extract_default_ui_camera_view(
             let mut entity_commands = commands
                 .get_entity(entity)
                 .expect("Camera entity wasn't synced.");
-            entity_commands.insert(DefaultCameraView(default_camera_view));
+            entity_commands.insert(UiCameraView(ui_camera_view));
             if let Some(ui_anti_alias) = ui_anti_alias {
                 entity_commands.insert(*ui_anti_alias);
             }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -533,6 +533,7 @@ const UI_CAMERA_FAR: f32 = 1000.0;
 const UI_CAMERA_TRANSFORM_OFFSET: f32 = -0.1;
 
 #[derive(Component)]
+/// Entity id of the temporary render entity with the corresponding extracted UI view.
 pub struct UiCameraView(pub Entity);
 
 /// Extracts all UI elements associated with a camera into the render world.
@@ -554,11 +555,11 @@ pub fn extract_ui_camera_view(
 ) {
     live_entities.clear();
 
-    for (entity, camera, ui_anti_alias, shadow_samples) in &query {
+    for (render_entity, camera, ui_anti_alias, shadow_samples) in &query {
         // ignore inactive cameras
         if !camera.is_active {
             commands
-                .get_entity(entity)
+                .get_entity(render_entity)
                 .expect("Camera entity wasn't synced.")
                 .remove::<(UiCameraView, UiAntiAlias, BoxShadowSamples)>();
             continue;
@@ -595,7 +596,7 @@ pub fn extract_ui_camera_view(
                 ))
                 .id();
             let mut entity_commands = commands
-                .get_entity(entity)
+                .get_entity(render_entity)
                 .expect("Camera entity wasn't synced.");
             entity_commands.insert(UiCameraView(ui_camera_view));
             if let Some(ui_anti_alias) = ui_anti_alias {
@@ -604,9 +605,9 @@ pub fn extract_ui_camera_view(
             if let Some(shadow_samples) = shadow_samples {
                 entity_commands.insert(*shadow_samples);
             }
-            transparent_render_phases.insert_or_clear(entity);
+            transparent_render_phases.insert_or_clear(render_entity);
 
-            live_entities.insert(entity);
+            live_entities.insert(render_entity);
         }
     }
 


### PR DESCRIPTION
# Objective

The name `DefaultCameraView` is confusing and misleading:
* It isn't the default UI camera, which is either the camera with the `IsDefaultUiCamera` marker component or, if no such camera is found, the camera with the highest order which has the primary window as its render target.
* It doesn't make sense to call it a "default", every active 2d and 3d camera is given its own `DefaultCameraView`.
* The name doesn't make it clear that it's UI specific component.

## Solution

Rename `DefaultCameraView` to `UiCameraView`, add a doc comment for it and rename a few other fields and variables.

## Migration Guide

`DefaultCameraView` has been renamed to `UiCameraView`