### PR TITLE
`extract_shadows` responsive coords fix

### DIFF
--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -259,7 +259,7 @@ pub fn extract_shadows(
             continue;
         };
 
-        let Ok(camera_entity) = mapping.get(camera_entity) else {
+        let Ok(render_entity) = mapping.get(camera_entity) else {
             continue;
         };
 
@@ -326,7 +326,7 @@ pub fn extract_shadows(
                     color: drop_shadow.color.into(),
                     bounds: shadow_size + 6. * blur_radius,
                     clip: clip.map(|clip| clip.clip),
-                    camera_entity,
+                    camera_entity: render_entity,
                     radius,
                     blur_radius,
                     size: shadow_size,


### PR DESCRIPTION
# Objective

`extract_shadows` uses the render world entity corresponding to the extracted camera when it queries the main world for the camera to get the viewport size for the responsive viewport coords resolution and fails. This means that viewport coords get resolved based on a viewport size of zero.

## Solution

Use the main world camera entity.


