### PR TITLE
`add_edges` and `add_grid` helpers for `DirectionalNavMap`

### DIFF
--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -31,6 +31,7 @@ bevy_window = { path = "../bevy_window", version = "0.16.0-dev", default-feature
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "glam",
 ], default-features = false, optional = true }
+bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false }
 
 # other
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -25,6 +25,7 @@ use bevy_math::{CompassOctant, IVec2};
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{prelude::*, Reflect};
 use bevy_utils::{hashbrown, HashMap};
+use core::ops::Deref;
 use thiserror::Error;
 
 use crate::InputFocus;
@@ -402,7 +403,7 @@ impl Default for NavGrid {
     }
 }
 
-impl core::ops::Deref for NavGrid {
+impl Deref for NavGrid {
     type Target = HashMap<IVec2, Entity>;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -513,6 +513,25 @@ mod tests {
     }
 
     #[test]
+    fn edges() {
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        let b = world.spawn_empty().id();
+        let c = world.spawn_empty().id();
+
+        let mut map = DirectionalNavigationMap::default();
+        map.add_edges(&[a, b, c], CompassOctant::East);
+
+        assert_eq!(map.get_neighbor(a, CompassOctant::East), Some(b));
+        assert_eq!(map.get_neighbor(b, CompassOctant::East), Some(c));
+        assert_eq!(map.get_neighbor(c, CompassOctant::East), None);
+
+        assert_eq!(map.get_neighbor(a, CompassOctant::West), None);
+        assert_eq!(map.get_neighbor(b, CompassOctant::West), Some(a));
+        assert_eq!(map.get_neighbor(c, CompassOctant::West), Some(b));
+    }
+
+    #[test]
     fn looping_edges() {
         let mut world = World::new();
         let a = world.spawn_empty().id();

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -173,7 +173,18 @@ impl DirectionalNavigationMap {
         self.add_edge(b, a, direction.opposite());
     }
 
-    /// Add symmetrical edges between all entities in the provided slice, looping back to the first entity at the end.
+    /// Add symettrical edges between each consecutive pair of entities in the provided slice.
+    ///
+    /// Unlike [`add_looping_edges`](Self::add_looping_edges), this method does not loop back to the first entity.
+    pub fn add_edges(&mut self, entities: &[Entity], direction: CompassOctant) {
+        for i in 0..entities.len() - 1 {
+            let a = entities[i];
+            let b = entities[i + 1];
+            self.add_symmetrical_edge(a, b, direction);
+        }
+    }
+
+    /// Add symmetrical edges between each consecutive pair of entities in the provided slice, looping back to the first entity at the end.
     ///
     /// This is useful for creating a circular navigation path between a set of entities, such as a menu.
     pub fn add_looping_edges(&mut self, entities: &[Entity], direction: CompassOctant) {

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -175,7 +175,7 @@ impl DirectionalNavigationMap {
         self.add_edge(b, a, direction.opposite());
     }
 
-    /// Add symettrical edges between each consecutive pair of entities in the provided slice.
+    /// Add symmetrical edges between each consecutive pair of entities in the provided slice.
     ///
     /// Unlike [`add_looping_edges`](Self::add_looping_edges), this method does not loop back to the first entity.
     pub fn add_edges(&mut self, entities: &[Entity], direction: CompassOctant) {

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -562,4 +562,93 @@ mod tests {
         world.run_system_once(navigate_east).unwrap();
         assert_eq!(world.resource::<InputFocus>().get(), Some(a));
     }
+
+    #[test]
+    fn non_looping_grid_edges() {
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        let b = world.spawn_empty().id();
+        let c = world.spawn_empty().id();
+        let d = world.spawn_empty().id();
+
+        let mut nav_map = DirectionalNavigationMap::default();
+        // a b
+        // c d
+        let mut grid = HashMap::default();
+        grid.insert(IVec2::new(0, 0), a);
+        grid.insert(IVec2::new(1, 0), b);
+        grid.insert(IVec2::new(0, 1), c);
+        grid.insert(IVec2::new(1, 1), d);
+
+        nav_map.add_grid(grid, false);
+
+        // Cardinal directions
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::East), Some(b));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::West), Some(a));
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::South), Some(c));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::North), Some(a));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::South), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::North), Some(b));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::East), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::West), Some(c));
+
+        // Diagonal directions
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::SouthEast), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::NorthWest), Some(a));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::SouthWest), Some(c));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::NorthEast), Some(b));
+
+        // Out of bounds
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::North), None);
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::West), None);
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::NorthEast), None);
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::NorthWest), None);
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::SouthWest), None);
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::East), None);
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::South), None);
+    }
+
+    #[test]
+    fn looping_grid_edges() {
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        let b = world.spawn_empty().id();
+        let c = world.spawn_empty().id();
+        let d = world.spawn_empty().id();
+
+        let mut nav_map = DirectionalNavigationMap::default();
+        // a b
+        // c d
+        let mut grid = HashMap::default();
+        grid.insert(IVec2::new(0, 0), a);
+        grid.insert(IVec2::new(1, 0), b);
+        grid.insert(IVec2::new(0, 1), c);
+        grid.insert(IVec2::new(1, 1), d);
+
+        nav_map.add_grid(grid, false);
+
+        // Cardinal directions
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::East), Some(b));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::West), Some(a));
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::South), Some(c));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::North), Some(a));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::South), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::North), Some(b));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::East), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::West), Some(c));
+
+        // Diagonal directions
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::SouthEast), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::NorthWest), Some(a));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::SouthWest), Some(c));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::NorthEast), Some(b));
+
+        // Out of bounds
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::North), Some(c));
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::West), Some(b));
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::NorthWest), Some(d));
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::SouthWest), None);
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::East), Some(c));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::South), Some(b));
+    }
 }

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -715,4 +715,41 @@ mod tests {
         assert_eq!(nav_map.get_neighbor(d, CompassOctant::East), None);
         assert_eq!(nav_map.get_neighbor(d, CompassOctant::West), None);
     }
+
+    #[test]
+    fn sparse_grid() {
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        let b = world.spawn_empty().id();
+        let c = world.spawn_empty().id();
+        let d = world.spawn_empty().id();
+
+        let mut nav_map = DirectionalNavigationMap::default();
+        // a x b
+        // x x x
+        // c x d
+        let mut grid = HashMap::default();
+        grid.insert(IVec2::new(0, 0), a);
+        grid.insert(IVec2::new(2, 0), b);
+        grid.insert(IVec2::new(0, 2), c);
+        grid.insert(IVec2::new(2, 2), d);
+
+        nav_map.add_grid(grid, false);
+
+        // Cardinal directions
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::East), Some(b));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::West), Some(a));
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::South), Some(c));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::North), Some(a));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::South), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::North), Some(b));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::East), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::West), Some(c));
+
+        // Diagonal directions
+        assert_eq!(nav_map.get_neighbor(a, CompassOctant::SouthEast), Some(d));
+        assert_eq!(nav_map.get_neighbor(d, CompassOctant::NorthWest), Some(a));
+        assert_eq!(nav_map.get_neighbor(b, CompassOctant::SouthWest), Some(c));
+        assert_eq!(nav_map.get_neighbor(c, CompassOctant::NorthEast), Some(b));
+    }
 }

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -259,11 +259,16 @@ impl DirectionalNavigationMap {
                 };
 
                 if let Some(neighbor) = maybe_neighbor {
-                    // PERF: we could also add the reverse edge here, to save work later
-                    // Doing so is tricky with the borrow checker though, since we already have one mutable borrow alive
-                    // We could construct the borrow at the last minute, but then we'd need to look up the `neighbors` entry every time
-                    // and it's not clear that that would be faster
-                    neighbors.set(direction, neighbor);
+                    // Entities should not be neighbors of themselves
+                    // Inserting the same entity at multiple locations is supported,
+                    // so we need to check for this case
+                    if neighbor != entity {
+                        // PERF: we could also add the reverse edge here, to save work later
+                        // Doing so is tricky with the borrow checker though, since we already have one mutable borrow alive
+                        // We could construct the borrow at the last minute, but then we'd need to look up the `neighbors` entry every time
+                        // and it's not clear that that would be faster
+                        neighbors.set(direction, neighbor);
+                    }
                 }
             }
         }

--- a/crates/bevy_math/src/compass.rs
+++ b/crates/bevy_math/src/compass.rs
@@ -5,6 +5,7 @@ use crate::Dir2;
 use bevy_reflect::Reflect;
 #[cfg(all(feature = "serialize", feature = "bevy_reflect"))]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+use glam::IVec2;
 
 /// A compass enum with 4 directions.
 /// ```text
@@ -67,6 +68,20 @@ impl CompassQuadrant {
             Self::East => 1,
             Self::South => 2,
             Self::West => 3,
+        }
+    }
+
+    /// Converts a [`CompassQuadrant`] to a [`IVec2`] offset.
+    ///
+    /// For example, [`CompassQuadrant::North`] would return `IVec2{x: 0, y: 1}`.
+    ///
+    /// This is useful when moving along a grid.
+    pub const fn to_offset(self) -> IVec2 {
+        match self {
+            Self::North => IVec2::Y,
+            Self::East => IVec2::X,
+            Self::South => IVec2::NEG_Y,
+            Self::West => IVec2::NEG_X,
         }
     }
 
@@ -164,6 +179,24 @@ impl CompassOctant {
             Self::SouthWest => 5,
             Self::West => 6,
             Self::NorthWest => 7,
+        }
+    }
+
+    /// Converts a [`CompassOctant`] to a [`IVec2`] offset.
+    ///
+    /// For example, [`CompassOctant::NorthEast`] would return `IVec2{x: 1, y: 1}`.
+    ///
+    /// This is useful when moving along a grid.
+    pub const fn to_offset(self) -> IVec2 {
+        match self {
+            Self::North => IVec2::Y,
+            Self::NorthEast => IVec2 { x: 1, y: 1 },
+            Self::East => IVec2::X,
+            Self::SouthEast => IVec2 { x: 1, y: -1 },
+            Self::South => IVec2::NEG_Y,
+            Self::SouthWest => IVec2 { x: -1, y: -1 },
+            Self::West => IVec2::NEG_X,
+            Self::NorthWest => IVec2 { x: -1, y: 1 },
         }
     }
 

--- a/crates/bevy_math/src/compass.rs
+++ b/crates/bevy_math/src/compass.rs
@@ -37,6 +37,14 @@ pub enum CompassQuadrant {
 }
 
 impl CompassQuadrant {
+    /// The list of all possible [`CompassQuadrant`] variants.
+    pub const VARIANTS: [CompassQuadrant; 4] = [
+        CompassQuadrant::North,
+        CompassQuadrant::East,
+        CompassQuadrant::South,
+        CompassQuadrant::West,
+    ];
+
     /// Converts a standard index to a [`CompassQuadrant`].
     ///
     /// Starts at 0 for [`CompassQuadrant::North`] and increments clockwise.
@@ -114,6 +122,18 @@ pub enum CompassOctant {
 }
 
 impl CompassOctant {
+    /// The list of all possible [`CompassOctant`] variants.
+    pub const VARIANTS: [CompassOctant; 8] = [
+        CompassOctant::North,
+        CompassOctant::NorthEast,
+        CompassOctant::East,
+        CompassOctant::SouthEast,
+        CompassOctant::South,
+        CompassOctant::SouthWest,
+        CompassOctant::West,
+        CompassOctant::NorthWest,
+    ];
+
     /// Converts a standard index to a [`CompassOctant`].
     ///
     /// Starts at 0 for [`CompassOctant::North`] and increments clockwise.


### PR DESCRIPTION
# Objective

Prompted by #17224, I realized that we need more helpers to make configuring `DirectionalNavMap`s for directional (gamepad) navigation easier.

## Solution

- Add a simple `add_edges` helper, which does not loop around the end of the list.
- Add a `add_grid` helper for working with grids.
  - Obviously, this is really helpful for wiring up e.g. Terraria-style inventory screens.
  - Less obviously, this is a powerful mid-level API for defining directional nav layouts more broadly. The coordinates don't need to be physical, and the ability to duplicate entities in the map makes modelling large objects a breeze.
- Added more helpers to CompassQuadrant / CompassOctant to make this code prettier: these simple methods should be generally useful to users.

## Testing

I'm currently relying on unit tests for these changes. Once #17224 is merged, we can update that the example to test these in a more hands-on way.


## To do

- [ ] make sure tests pass and logic is correct