### PR TITLE
Cleanup instances of `#[allow(clippy::type_complexity)]`

### DIFF
--- a/benches/benches/bevy_ecs/main.rs
+++ b/benches/benches/bevy_ecs/main.rs
@@ -2,7 +2,6 @@
     dead_code,
     reason = "Many fields are unused/unread as they are just for benchmarking purposes."
 )]
-#![expect(clippy::type_complexity)]
 
 use criterion::criterion_main;
 

--- a/benches/benches/bevy_reflect/main.rs
+++ b/benches/benches/bevy_reflect/main.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::type_complexity)]
-
 use criterion::criterion_main;
 
 mod function;

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -233,7 +233,6 @@ pub struct OrderIndependentTransparencySettingsOffset {
 /// This creates or resizes the oit buffers for each camera.
 /// It will always create one big buffer that's as big as the biggest buffer needed.
 /// Cameras with smaller viewports or less layers will simply use the big buffer and ignore the rest.
-#[allow(clippy::type_complexity)]
 pub fn prepare_oit_buffers(
     mut commands: Commands,
     render_device: Res<RenderDevice>,

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -146,7 +146,6 @@ pub enum TabNavigationError {
 /// An injectable helper object that provides tab navigation functionality.
 #[doc(hidden)]
 #[derive(SystemParam)]
-#[allow(clippy::type_complexity)]
 pub struct TabNavigation<'w, 's> {
     // Query for tab groups.
     tabgroup_query: Query<'w, 's, (Entity, &'static TabGroup, &'static Children)>,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -127,7 +127,6 @@ fn global_color_changed(
 }
 
 /// Updates the wireframe material when the color in [`WireframeColor`] changes
-#[allow(clippy::type_complexity)]
 fn wireframe_color_changed(
     mut materials: ResMut<Assets<WireframeMaterial>>,
     mut colors_changed: Query<

--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -124,10 +124,6 @@ fn global_color_changed(
 }
 
 /// Updates the wireframe material when the color in [`Wireframe2dColor`] changes
-#[expect(
-    clippy::type_complexity,
-    reason = "Can't be rewritten with less complex arguments."
-)]
 fn wireframe_color_changed(
     mut materials: ResMut<Assets<Wireframe2dMaterial>>,
     mut colors_changed: Query<

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -29,8 +29,6 @@
 //! 3. [`PositionedGlyph`]s are stored in a [`TextLayoutInfo`],
 //!    which contains all the information that downstream systems need for rendering.
 
-#![allow(clippy::type_complexity)]
-
 extern crate alloc;
 
 mod bounds;

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -181,7 +181,6 @@ fn set_camera_viewports(
     }
 }
 
-#[allow(clippy::type_complexity)]
 fn button_system(
     interaction_query: Query<
         (&Interaction, &TargetCamera, &RotateCamera),


### PR DESCRIPTION
# Objective
I never realized `clippy::type_complexity` was an allowed lint - I've been assuming it'd generate a warning when performing my linting PRs.

## Solution
Removes any instances of `#[allow(clippy::type_complexity)]` and `#[expect(clippy::type_complexity)]`

## Testing
`cargo clippy` ran without errors or warnings.