### PR TITLE
Fix up the reason given for a couple of `too_many_arguments` lints

### DIFF
--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -528,7 +528,7 @@ impl MeshAllocator {
     /// A generic function that copies either vertex or index data into a slab.
     #[expect(
         clippy::too_many_arguments,
-        reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+        reason = "Used in systems to reduce the amount of code duplication"
     )]
     fn copy_element_data(
         &mut self,

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -581,7 +581,7 @@ pub(crate) fn submit_screenshot_commands(world: &World, encoder: &mut CommandEnc
 
 #[expect(
     clippy::too_many_arguments,
-    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+    reason = "Used in systems to reduce the amount of code duplication"
 )]
 fn render_screenshot(
     encoder: &mut CommandEncoder,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -190,7 +190,7 @@ impl Measure for TextMeasure {
 
 #[expect(
     clippy::too_many_arguments,
-    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+    reason = "Used in measure_text_system to make the function body easier to read"
 )]
 #[inline]
 fn create_text_measure<'a>(
@@ -318,7 +318,7 @@ pub fn measure_text_system(
 
 #[expect(
     clippy::too_many_arguments,
-    reason = "Could be rewritten with less arguments using a QueryData-implementing struct, but doesn't need to be."
+    reason = "Used in text_system to make the function body easier to read"
 )]
 #[inline]
 fn queue_text(


### PR DESCRIPTION
# Objective
In my crusade to give every lint attribute a reason, it appears I got too complacent and copy-pasted this expect onto non-system functions.

## Solution
Fix up the reason on those non-system functions

## Testing
N/A