### PR TITLE
Make `bevy_remote` feature enable `serialize` feature

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -220,7 +220,7 @@ meshlet_processor = ["bevy_pbr?/meshlet_processor"]
 bevy_dev_tools = ["dep:bevy_dev_tools"]
 
 # Enable support for the Bevy Remote Protocol
-bevy_remote = ["dep:bevy_remote"]
+bevy_remote = ["dep:bevy_remote", "serialize"]
 
 # Provides picking functionality
 bevy_picking = ["dep:bevy_picking"]


### PR DESCRIPTION
# Objective

`bevy_remote`'s reflection deserialization basically requires `ReflectDeserialize` registrations in order to work correctly. In the context of `bevy` (the library), this means that using `bevy_remote` without using the `serialize` feature is a footgun, since `#[reflect(Serialize)]` etc. are gated behind this feature. 

The goal of this PR is to avoid this mistake by default.

## Solution

Make the `bevy_remote` feature enable the `serialize` feature, so that it works as expected.

---

## Migration Guide

The `bevy_remote` feature of `bevy` now enables the `serialize` feature automatically. If you wish to use `bevy_remote` without enabling the `serialize` feature for Bevy subcrates, you must import `bevy_remote` on its own. 
