### PR TITLE
Fix entity does not exist message on index reuse

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.83.0"
 
 [features]
-default = ["std", "bevy_reflect", "async_executor", "track_location"] #TMP
+default = ["std", "bevy_reflect", "async_executor"]
 
 # Functionality
 

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.83.0"
 
 [features]
-default = ["std", "bevy_reflect", "async_executor", "track_location"]
+default = ["std", "bevy_reflect", "async_executor"]
 
 # Functionality
 

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.83.0"
 
 [features]
-default = ["std", "bevy_reflect", "async_executor"]
+default = ["std", "bevy_reflect", "async_executor", "track_location"] #TMP
 
 # Functionality
 

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.83.0"
 
 [features]
-default = ["std", "bevy_reflect", "async_executor"]
+default = ["std", "bevy_reflect", "async_executor", "track_location"]
 
 # Functionality
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -997,8 +997,12 @@ impl Entities {
     ) -> EntityDoesNotExistDetails {
         #[cfg(feature = "track_location")]
         if let Some(location) = self.entity_get_spawned_or_despawned_by(_entity) {
-            if self.resolve_from_id(_entity.index()).is_some() {
-                EntityDoesNotExistDetails::Reused
+            if let Some(found) = self.resolve_from_id(_entity.index()) {
+                if found.generation > _entity.generation {
+                    EntityDoesNotExistDetails::None
+                } else {
+                    EntityDoesNotExistDetails::Reused
+                }
             } else {
                 EntityDoesNotExistDetails::DespawnedBy(location)
             }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -986,17 +986,14 @@ impl Entities {
         &self,
         entity: Entity,
     ) -> Option<&'static Location<'static>> {
-        self.meta.get(entity.index() as usize).and_then(|meta| {
-            // Generation is incremented immediately upon despawn
-            if (meta.generation == entity.generation)
-                | (meta.location.archetype_id == ArchetypeId::INVALID)
-                    & (meta.generation == IdentifierMask::inc_masked_high_by(entity.generation, 1))
-            {
-                meta.spawned_or_despawned_by
-            } else {
-                None
-            }
-        })
+        self.meta
+            .get(entity.index() as usize)
+            .filter(|meta|
+                // Generation is incremented immediately upon despawn
+                (meta.generation == entity.generation)
+                || (meta.location.archetype_id == ArchetypeId::INVALID)
+                && (meta.generation == IdentifierMask::inc_masked_high_by(entity.generation, 1)))
+            .and_then(|meta| meta.spawned_or_despawned_by)
     }
 
     /// Constructs a message explaining why an entity does not exists, if known.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -986,8 +986,6 @@ impl Entities {
         &self,
         entity: Entity,
     ) -> Option<&'static Location<'static>> {
-        let meta = self.meta.get(entity.index() as usize);
-        std::println!("{entity} → {meta:?}");
         self.meta.get(entity.index() as usize).and_then(|meta| {
             // Generation is incremented immediately upon despawn
             if (meta.generation == entity.generation)
@@ -1006,7 +1004,6 @@ impl Entities {
         &self,
         _entity: Entity,
     ) -> EntityDoesNotExistDetails {
-        #[cfg(feature = "track_location")]
         EntityDoesNotExistDetails {
             #[cfg(feature = "track_location")]
             location: self.entity_get_spawned_or_despawned_by(_entity),

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1018,9 +1018,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             .get(entity)
             .ok_or(QueryEntityError::NoSuchEntity(
                 entity,
-                world
-                    .entities()
-                    .entity_does_not_exist_error_details(entity),
+                world.entities().entity_does_not_exist_error_details(entity),
             ))?;
         if !self
             .matched_archetypes

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1020,7 +1020,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                 entity,
                 world
                     .entities()
-                    .entity_does_not_exist_error_details_message(entity),
+                    .entity_does_not_exist_error_details(entity),
             ))?;
         if !self
             .matched_archetypes

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -349,7 +349,7 @@ fn insert_reflect_with_registry_ref(
     let type_path = type_info.type_path();
     let Ok(mut entity) = world.get_entity_mut(entity) else {
         panic!("error[B0003]: Could not insert a reflected component (of type {type_path}) for entity {entity}, which {}. See: https://bevyengine.org/learn/errors/b0003",
-        world.entities().entity_does_not_exist_error_details_message(entity));
+        world.entities().entity_does_not_exist_error_details(entity));
     };
     let Some(type_registration) = type_registry.get(type_info.type_id()) else {
         panic!("`{type_path}` should be registered in type registry via `App::register_type<{type_path}>`");

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -446,7 +446,7 @@ impl<'w, 's> Commands<'w, 's> {
         fn panic_no_entity(entities: &Entities, entity: Entity) -> ! {
             panic!(
                 "Attempting to create an EntityCommands for entity {entity}, which {}",
-                entities.entity_does_not_exist_error_details_message(entity)
+                entities.entity_does_not_exist_error_details(entity)
             );
         }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -107,8 +107,7 @@ impl<'w> DeferredWorld<'w> {
             Err(EntityFetchError::NoSuchEntity(..)) => {
                 return Err(EntityFetchError::NoSuchEntity(
                     entity,
-                    self.entities()
-                        .entity_does_not_exist_error_details_message(entity),
+                    self.entities().entity_does_not_exist_error_details(entity),
                 ))
             }
         };

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -124,8 +124,7 @@ unsafe impl WorldEntityFetch for Entity {
             .get(self)
             .ok_or(EntityFetchError::NoSuchEntity(
                 self,
-                cell.entities()
-                    .entity_does_not_exist_error_details(self),
+                cell.entities().entity_does_not_exist_error_details(self),
             ))?;
         // SAFETY: caller ensures that the world cell has mutable access to the entity.
         let world = unsafe { cell.world_mut() };
@@ -139,8 +138,7 @@ unsafe impl WorldEntityFetch for Entity {
     ) -> Result<Self::DeferredMut<'_>, EntityFetchError> {
         let ecell = cell.get_entity(self).ok_or(EntityFetchError::NoSuchEntity(
             self,
-            cell.entities()
-                .entity_does_not_exist_error_details(self),
+            cell.entities().entity_does_not_exist_error_details(self),
         ))?;
         // SAFETY: caller ensures that the world cell has mutable access to the entity.
         Ok(unsafe { EntityMut::new(ecell) })
@@ -215,8 +213,7 @@ unsafe impl<const N: usize> WorldEntityFetch for &'_ [Entity; N] {
         for (r, &id) in core::iter::zip(&mut refs, self) {
             let ecell = cell.get_entity(id).ok_or(EntityFetchError::NoSuchEntity(
                 id,
-                cell.entities()
-                    .entity_does_not_exist_error_details(id),
+                cell.entities().entity_does_not_exist_error_details(id),
             ))?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
             *r = MaybeUninit::new(unsafe { EntityMut::new(ecell) });
@@ -275,8 +272,7 @@ unsafe impl WorldEntityFetch for &'_ [Entity] {
         for &id in self {
             let ecell = cell.get_entity(id).ok_or(EntityFetchError::NoSuchEntity(
                 id,
-                cell.entities()
-                    .entity_does_not_exist_error_details(id),
+                cell.entities().entity_does_not_exist_error_details(id),
             ))?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
             refs.push(unsafe { EntityMut::new(ecell) });
@@ -322,8 +318,7 @@ unsafe impl WorldEntityFetch for &'_ EntityHashSet {
         for &id in self {
             let ecell = cell.get_entity(id).ok_or(EntityFetchError::NoSuchEntity(
                 id,
-                cell.entities()
-                    .entity_does_not_exist_error_details(id),
+                cell.entities().entity_does_not_exist_error_details(id),
             ))?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
             refs.insert(id, unsafe { EntityMut::new(ecell) });

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -125,7 +125,7 @@ unsafe impl WorldEntityFetch for Entity {
             .ok_or(EntityFetchError::NoSuchEntity(
                 self,
                 cell.entities()
-                    .entity_does_not_exist_error_details_message(self),
+                    .entity_does_not_exist_error_details(self),
             ))?;
         // SAFETY: caller ensures that the world cell has mutable access to the entity.
         let world = unsafe { cell.world_mut() };
@@ -140,7 +140,7 @@ unsafe impl WorldEntityFetch for Entity {
         let ecell = cell.get_entity(self).ok_or(EntityFetchError::NoSuchEntity(
             self,
             cell.entities()
-                .entity_does_not_exist_error_details_message(self),
+                .entity_does_not_exist_error_details(self),
         ))?;
         // SAFETY: caller ensures that the world cell has mutable access to the entity.
         Ok(unsafe { EntityMut::new(ecell) })
@@ -216,7 +216,7 @@ unsafe impl<const N: usize> WorldEntityFetch for &'_ [Entity; N] {
             let ecell = cell.get_entity(id).ok_or(EntityFetchError::NoSuchEntity(
                 id,
                 cell.entities()
-                    .entity_does_not_exist_error_details_message(id),
+                    .entity_does_not_exist_error_details(id),
             ))?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
             *r = MaybeUninit::new(unsafe { EntityMut::new(ecell) });
@@ -276,7 +276,7 @@ unsafe impl WorldEntityFetch for &'_ [Entity] {
             let ecell = cell.get_entity(id).ok_or(EntityFetchError::NoSuchEntity(
                 id,
                 cell.entities()
-                    .entity_does_not_exist_error_details_message(id),
+                    .entity_does_not_exist_error_details(id),
             ))?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
             refs.push(unsafe { EntityMut::new(ecell) });
@@ -323,7 +323,7 @@ unsafe impl WorldEntityFetch for &'_ EntityHashSet {
             let ecell = cell.get_entity(id).ok_or(EntityFetchError::NoSuchEntity(
                 id,
                 cell.entities()
-                    .entity_does_not_exist_error_details_message(id),
+                    .entity_does_not_exist_error_details(id),
             ))?;
             // SAFETY: caller ensures that the world cell has mutable access to the entity.
             refs.insert(id, unsafe { EntityMut::new(ecell) });

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1001,7 +1001,7 @@ impl<'w> EntityWorldMut<'w> {
             self.entity,
             self.world
                 .entities()
-                .entity_does_not_exist_error_details_message(self.entity)
+                .entity_does_not_exist_error_details(self.entity)
         );
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -674,9 +674,7 @@ impl World {
         fn panic_no_entity(world: &World, entity: Entity) -> ! {
             panic!(
                 "Entity {entity} {}",
-                world
-                    .entities
-                    .entity_does_not_exist_error_details_message(entity)
+                world.entities.entity_does_not_exist_error_details(entity)
             );
         }
 
@@ -1245,8 +1243,7 @@ impl World {
             Err(EntityFetchError::NoSuchEntity(..)) => {
                 return Err(EntityFetchError::NoSuchEntity(
                     entity,
-                    self.entities()
-                        .entity_does_not_exist_error_details_message(entity),
+                    self.entities().entity_does_not_exist_error_details(entity),
                 ))
             }
         };
@@ -1309,7 +1306,7 @@ impl World {
             true
         } else {
             if log_warning {
-                warn!("error[B0003]: {caller}: Could not despawn entity {entity}, which {}. See: https://bevyengine.org/learn/errors/b0003", self.entities.entity_does_not_exist_error_details_message(entity));
+                warn!("error[B0003]: {caller}: Could not despawn entity {entity}, which {}. See: https://bevyengine.org/learn/errors/b0003", self.entities.entity_does_not_exist_error_details(entity));
             }
             false
         }
@@ -2468,11 +2465,11 @@ impl World {
                             )
                         };
                     } else {
-                        panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {entity}, which {}. See: https://bevyengine.org/learn/errors/b0003", core::any::type_name::<B>(), self.entities.entity_does_not_exist_error_details_message(entity));
+                        panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {entity}, which {}. See: https://bevyengine.org/learn/errors/b0003", core::any::type_name::<B>(), self.entities.entity_does_not_exist_error_details(entity));
                     }
                 }
             } else {
-                panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {first_entity}, which {}. See: https://bevyengine.org/learn/errors/b0003", core::any::type_name::<B>(), self.entities.entity_does_not_exist_error_details_message(first_entity));
+                panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {first_entity}, which {}. See: https://bevyengine.org/learn/errors/b0003", core::any::type_name::<B>(), self.entities.entity_does_not_exist_error_details(first_entity));
             }
         }
     }
@@ -4320,5 +4317,35 @@ mod tests {
                 .get_entity_mut(&EntityHashSet::from_iter([e1, e2]))
                 .map(|_| {}),
             Err(EntityFetchError::NoSuchEntity(e, ..)) if e == e1));
+    }
+
+    #[cfg(feature = "track_location")]
+    #[test]
+    #[track_caller]
+    fn entity_spawn_despawn_tracking() {
+        use core::panic::Location;
+
+        let mut world = World::new();
+        let entity = world.spawn_empty().id();
+        assert_eq!(
+            world.entities.entity_get_spawned_or_despawned_by(entity),
+            Some(Location::caller())
+        );
+        world.despawn(entity);
+        assert_eq!(
+            world.entities.entity_get_spawned_or_despawned_by(entity),
+            Some(Location::caller())
+        );
+        let new = world.spawn_empty().id();
+        assert_eq!(entity.index(), new.index());
+        assert_eq!(
+            world.entities.entity_get_spawned_or_despawned_by(entity),
+            None
+        );
+        world.despawn(new);
+        assert_eq!(
+            world.entities.entity_get_spawned_or_despawned_by(entity),
+            None
+        );
     }
 }


### PR DESCRIPTION
# Objective

With the `track_location` feature, the error message of trying to acquire an entity that was despawned pointed to the wrong line if the entity index has been reused.

## Showcase

```rust
use bevy_ecs::prelude::*;

fn main() {
    let mut world = World::new();
    let e = world.spawn_empty().id();
    world.despawn(e);
    world.flush();
    let _ = world.spawn_empty();
    world.entity(e);
}
```
Old message:
```
Entity 0v1 was despawned by src/main.rs:8:19
```
New message:
```
Entity 0v1 does not exist (its index has been reused)
```