### PR TITLE
Add an `Activate` triggered event to `bevy_ui`

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -20,6 +20,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.16.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.16.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.16.0-dev" }
+bevy_input_focus = { path = "../bevy_input_focus", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "bevy",
@@ -42,11 +43,6 @@ nonmax = "0.5"
 smallvec = "1.11"
 accesskit = "0.17"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-
-[dev-dependencies]
-# This is currently a dev dependency for documentation purposes,
-# but it will likely be used as a full dependency in the future.
-bevy_input_focus = { path = "../bevy_input_focus", version = "0.16.0-dev" }
 
 [features]
 default = []

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -43,6 +43,11 @@ smallvec = "1.11"
 accesskit = "0.17"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
+[dev-dependencies]
+# This is currently a dev dependency for documentation purposes,
+# but it will likely be used as a full dependency in the future.
+bevy_input_focus = { path = "../bevy_input_focus", version = "0.16.0-dev" }
+
 [features]
 default = []
 serialize = ["serde", "smallvec/serde", "bevy_math/serialize"]

--- a/crates/bevy_ui/src/actions.rs
+++ b/crates/bevy_ui/src/actions.rs
@@ -15,10 +15,86 @@
 //!
 //! When responding to these events, make sure to call [`Trigger::propagate`] with `false`
 //! to prevent the event from being consumed by other later entities.
+//!
+//! # Systems
+//!
+//! Various public systems are provided to trigger these actions in response to raw input events.
+//! These systems run in [`PreUpdate`](bevy_app::main_schedule::PreUpdate) as part of [`UiSystem::Actions`](crate::UiSystem::Actions).
+//! They are all enabled by default in the [`UiPlugin`](crate::UiPlugin),
+//! but are split apart for more control over when / if they are run via run conditions.
+//!
+//! To disable them entirely, set [`UiPlugin::actions`](crate::UiPlugin::actions) to `false`.
 
 use bevy_ecs::prelude::*;
 use bevy_hierarchy::Parent;
+use bevy_input::{
+    gamepad::{Gamepad, GamepadButton},
+    keyboard::KeyCode,
+    ButtonInput,
+};
+use bevy_input_focus::InputFocus;
+use bevy_picking::events::{Click, Pointer};
 use bevy_reflect::prelude::*;
+
+use crate::Node;
+
+/// A system which triggers the [`Activate`](crate::Activate) action
+/// when an entity with the [`Node`] component is clicked.
+pub fn activate_ui_elements_on_click(
+    mut click_events: EventReader<Pointer<Click>>,
+    node_query: Query<(), With<Node>>,
+    mut commands: Commands,
+) {
+    for click in click_events.read() {
+        if node_query.contains(click.target) {
+            commands.trigger_targets(Activate, click.target);
+        }
+    }
+}
+
+/// A system which activates the [`Activate`](crate::Activate) action
+/// when [`KeyCode::Enter`] is first pressed.
+pub fn activate_focus_on_enter(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    input_focus: Res<InputFocus>,
+    mut commands: Commands,
+) {
+    if keyboard_input.just_pressed(KeyCode::Enter) {
+        if let Some(focused_entity) = input_focus.get() {
+            commands.trigger_targets(Activate, focused_entity);
+        }
+    }
+}
+
+/// A system which activates the [`Activate`](crate::Activate) action
+/// when [`GamepadButton::South`] is first pressed on any controller.
+///
+/// This system is generally not suitable for local co-op games,
+/// as *any* gamepad can activate the focused element.
+///
+/// # Warning
+///
+/// Note that for Nintendo Switch controllers, the "A" button (commonly used as "activate"),
+///  is *not* the South button. It's instead the [`GamepadButton::East`].
+pub fn activate_focus_on_gamepad_south(
+    input_focus: Res<InputFocus>,
+    gamepads: Query<&Gamepad>,
+    mut commands: Commands,
+) {
+    for gamepad in gamepads.iter() {
+        if gamepad.just_pressed(GamepadButton::South) {
+            if let Some(focused_entity) = input_focus.get() {
+                commands.trigger_targets(Activate, focused_entity);
+                // Only send one activate event per frame,
+                // even if multiple gamepads pressed the button.
+                return;
+            }
+        }
+    }
+}
+
+/// A system which activates the [`Activate`](crate::Activate) action
+/// when the [`GamepadButtonType::South`] is pressed.
 
 /// Activate a UI element.
 ///
@@ -36,9 +112,13 @@ use bevy_reflect::prelude::*;
 /// # Example
 ///
 /// ```rust
+/// use bevy_ecs::prelude::*;
 /// use bevy_input_focus::InputFocus;
+/// use bevy_ui::Activate;
+/// use bevy_input::keyboard::KeyCode;
 ///
-/// fn send_activate_event_to_input_focus(keyboard_input: Res<ButtonInput<KeyCode>>, input_focus: Res<InputFocus>, mut commands: Commands) {
+/// // This system is already added to the `UiPlugin` by default.
+/// fn activate_focus_on_enter(keyboard_input: Res<ButtonInput<KeyCode>>, input_focus: Res<InputFocus>, mut commands: Commands) {
 ///     if keyboard_input.just_pressed(KeyCode::Enter) {
 /// 	   if let Some(focused_entity) = input_focus.get() {
 /// 		   commands.trigger_targets(Activate, focused_entity);
@@ -59,7 +139,7 @@ use bevy_reflect::prelude::*;
 ///    trigger.propagate(false);
 /// }
 ///
-/// # assert_is_system!(send_activate_event_to_input_focus);
+/// # assert_is_system!(activate_focus_on_enter);
 /// # assert_is_system!(spawn_my_button);
 /// ```
 #[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Reflect)]

--- a/crates/bevy_ui/src/actions.rs
+++ b/crates/bevy_ui/src/actions.rs
@@ -1,0 +1,48 @@
+//! Semantically meaningful actions that can be performed on UI elements.
+//!
+//! Rather than listening for raw keyboard or picking events, UI elements should listen to these actions
+//! for all functional behavior. This allows for more consistent behavior across different input devices
+//! and makes it easier to customize input mappings.
+//!
+//! By contrast, cosmetic behavior like hover effects should generally be implemented by reading the [`Interaction`](crate::focus::Interaction) component,
+//! the [`InputFocus`](bevy_input_focus::InputFocus) resource or in response to various [`Pointer`](bevy_picking::events::Pointer) events.
+
+use bevy_ecs::event::Event;
+
+/// Activate a UI element.
+///
+/// This is typically triggered by a mouse click (or press),
+/// the enter key press on the focused element,
+/// or the "A" button on a gamepad.
+///
+/// Buttons should respond to this action via an observer to perform their primary action.
+///
+/// # Example
+///
+/// ```rust
+/// use bevy_input_focus::InputFocus;
+///
+/// fn send_activate_event_to_input_focus(keyboard_input: Res<ButtonInput<KeyCode>>, input_focus: Res<InputFocus>, mut commands: Commands) {
+///     if keyboard_input.just_pressed(KeyCode::Enter) {
+/// 	   if let Some(focused_entity) = input_focus.get() {
+/// 		   commands.trigger_targets(Activate, focused_entity);
+/// 	   }
+///    }
+/// }
+///
+/// fn spawn_my_button(mut commands: Commands) {
+///     // This observer will only watch this entity;
+///     // use a global observer to respond to *any* Activate event.
+///     commands.spawn(Button).observe(activate_my_button);
+/// }
+///
+/// fn activate_my_button(trigger: Trigger<Activate>) {
+///    let button_entity = trigger.target();
+///    println!("The button with the entity ID {button_entity} was activated!");
+/// }
+///
+/// # assert_is_system!(send_activate_event_to_input_focus);
+/// # assert_is_system!(spawn_my_button);
+/// ```
+#[derive(Debug, Event, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Activate;

--- a/crates/bevy_ui/src/actions.rs
+++ b/crates/bevy_ui/src/actions.rs
@@ -26,7 +26,7 @@ use bevy_reflect::prelude::*;
 /// the enter key press on the focused element,
 /// or the "A" button on a gamepad.
 ///
-/// Buttons should respond to this action via an observer to perform their primary action.
+/// [`Button`](crate::widget::Button)s should respond to this action via an observer to perform their primary action.
 ///
 /// # Bubbling
 ///

--- a/crates/bevy_ui/src/actions.rs
+++ b/crates/bevy_ui/src/actions.rs
@@ -6,8 +6,19 @@
 //!
 //! By contrast, cosmetic behavior like hover effects should generally be implemented by reading the [`Interaction`](crate::focus::Interaction) component,
 //! the [`InputFocus`](bevy_input_focus::InputFocus) resource or in response to various [`Pointer`](bevy_picking::events::Pointer) events.
+//!
+//! # Event bubbling
+//!
+//! All of the events in this module are will automatically bubble up the entity hierarchy.
+//! This allows for more responsiveness to the users' input, as the event will be
+//! consumed by the first entity that cares about it.
+//!
+//! When responding to these events, make sure to call [`Trigger::propagate`] with `false`
+//! to prevent the event from being consumed by other later entities.
 
-use bevy_ecs::event::Event;
+use bevy_ecs::prelude::*;
+use bevy_hierarchy::Parent;
+use bevy_reflect::prelude::*;
 
 /// Activate a UI element.
 ///
@@ -16,6 +27,11 @@ use bevy_ecs::event::Event;
 /// or the "A" button on a gamepad.
 ///
 /// Buttons should respond to this action via an observer to perform their primary action.
+///
+/// # Bubbling
+///
+/// This event will bubble up the entity hierarchy.
+/// Make sure to call [`Trigger::propagate`] with `false` to prevent the event from being consumed by other later entities.
 ///
 /// # Example
 ///
@@ -39,10 +55,18 @@ use bevy_ecs::event::Event;
 /// fn activate_my_button(trigger: Trigger<Activate>) {
 ///    let button_entity = trigger.target();
 ///    println!("The button with the entity ID {button_entity} was activated!");
+///    // We've handled the event, so don't let it bubble up.
+///    trigger.propagate(false);
 /// }
 ///
 /// # assert_is_system!(send_activate_event_to_input_focus);
 /// # assert_is_system!(spawn_my_button);
 /// ```
-#[derive(Debug, Event, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Component, Debug, Default, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
+#[reflect(Component, Default, PartialEq, Hash)]
 pub struct Activate;
+
+impl Event for Activate {
+    type Traversal = &'static Parent;
+    const AUTO_PROPAGATE: bool = true;
+}

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -26,6 +26,7 @@ pub mod picking_backend;
 use bevy_derive::{Deref, DerefMut};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 mod accessibility;
+mod actions;
 // This module is not re-exported, but is instead made public.
 // This is intended to discourage accidental use of the experimental API.
 pub mod experimental;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -37,6 +37,7 @@ mod render;
 mod stack;
 mod ui_node;
 
+pub use actions::*;
 pub use focus::*;
 pub use geometry::*;
 pub use layout::*;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -26,7 +26,6 @@ pub mod picking_backend;
 use bevy_derive::{Deref, DerefMut};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 mod accessibility;
-mod actions;
 // This module is not re-exported, but is instead made public.
 // This is intended to discourage accidental use of the experimental API.
 pub mod experimental;
@@ -37,7 +36,8 @@ mod render;
 mod stack;
 mod ui_node;
 
-pub use actions::*;
+pub mod actions;
+
 pub use focus::*;
 pub use geometry::*;
 pub use layout::*;
@@ -164,7 +164,7 @@ impl Plugin for UiPlugin {
         app.init_resource::<UiSurface>()
             .init_resource::<UiScale>()
             .init_resource::<UiStack>()
-            .register_type::<Activate>()
+            .register_type::<actions::Activate>()
             .register_type::<BackgroundColor>()
             .register_type::<CalculatedClip>()
             .register_type::<ComputedNode>()
@@ -209,9 +209,9 @@ impl Plugin for UiPlugin {
             app.add_systems(
                 PreUpdate,
                 (
-                    activate_focus_on_enter,
-                    activate_ui_elements_on_click,
-                    activate_focus_on_gamepad_south,
+                    actions::activate_focus_on_enter,
+                    actions::activate_ui_elements_on_click,
+                    actions::activate_focus_on_gamepad_south,
                 )
                     .in_set(UiSystem::Actions),
             );

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -151,6 +151,7 @@ impl Plugin for UiPlugin {
         app.init_resource::<UiSurface>()
             .init_resource::<UiScale>()
             .init_resource::<UiStack>()
+            .register_type::<Activate>()
             .register_type::<BackgroundColor>()
             .register_type::<CalculatedClip>()
             .register_type::<ComputedNode>()

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -5,7 +5,9 @@ use bevy_ecs::{
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
-/// Marker struct for buttons
+/// A marker struct for buttons.
+///
+/// Buttons should use an observer to listen for the [`Activate`](crate::Activate) action to perform their primary action.
 #[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq)]
 #[require(Node, FocusPolicy(|| FocusPolicy::Block), Interaction)]


### PR DESCRIPTION
# Objective

While working on #17224, I realized that we need a blessed way to activate (trigger, use) UI elements. This needs to work for both pointer clicks and buttons that get dispatched  ("A" or "Enter") to the currently focused element.

We could emulate a pointer click, as that PR does (well, it's a press, but same thing). That's what the web does after all!
That gives buttons a clear signal to respond to, regardless of the input device.

There's a few problems with this:

1. Pointer events in Bevy carry a *ton* of data, most of which doesn't have a sensible default when they're being emulated in this way. See [this permalink](https://github.com/bevyengine/bevy/pull/17224/files#diff-9ab3f6664bcef04c18cd672db9a32abb560bf4b96c3cd8a2e218f3b19b7d35ccR387) for the nonsense data I filled in.
2. Sending pointer events is extremely verbose: this took 27 lines, while it should have taken 1.
3. This privileges one input device over others, and makes it harder and weirder to use bevy_ui on devices without pointers (notably consoles).
4. Application developers can't agree on whether "press" or "click" should be used for buttons: press is more responsive but click allows roll-off cancellation.

## Solution

- Introduce `bevy_ui::actions::Activate`, which is canonically used for "do something with a UI widget when I press enter"
- Add simple hierarchical event bubbling to this action
- Demonstrate how to use observers to respond to listen to the `Activate` action.
- Add systems which listen to the standard inputs to trigger "Activate" to `UiPlugin`
- Make sure users can disable these systems if they want to do something weirder or more sophisticated

## To do (this PR)

- [ ] Update the navigation examples to use this pattern
- [ ] Cut the systems from this PR, to reduce controversy.
- [ ] Remove bubbling: the idea is to have each widget listen for the correct inputs and send these events to themselves.

## Future work

- Migrate *all* of our examples to use this pattern. This has been split out for reviewability.
- Use a more sophisticated bubbling strategy once our requirements are better known. Bubbling to the window adds a lot of complexity, and `PickingTraversal` could not be reused.
- Add other actions: `Cancel` is definitely desired, but other actions are likely valuable

## Testing

- This work builds on https://github.com/bevyengine/bevy/pull/17224, and should be integrated into that + our other examples.

## Additional context

- This design was prompted by @aevyrie and @NthTensor, who were rightly confused that I was trying to make it easier to send stripped-down picking events.
- This "send an event and bubble it up" action pattern is something that @viridia and I have been discussing as a general-purpose tool for focus management / contextual actions. LWIM (and other action managers) should be able to adapt to this pattern pretty comfortably, although users of those crates will want to disable the built-in systems here to enable rebinding.