### PR TITLE
Minor `TextPipeline` cleanup

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -171,8 +171,7 @@ impl TextPipeline {
 
         // Update the buffer.
         let buffer = &mut computed.buffer;
-        buffer.set_metrics(font_system, metrics);
-        buffer.set_size(font_system, bounds.width, bounds.height);
+        buffer.set_metrics_and_size(font_system, metrics, bounds.width, bounds.height);
 
         buffer.set_wrap(
             font_system,


### PR DESCRIPTION
# Objective

Both `set_metrics` and `set_size` **can** trigger text re-layout and re-shaping, if the values provided are different form what is already in the `Buffer`.

## Solution

Combine the `set_metrics` and `set_size` calls.

This might be a small optimization in some situations, maybe when both font size and text bounds change in the same frame, or when spawning new text.

I did measure a ~500 microsecond improvement in `text_system` for `many_buttons --respawn`, but that may have just been noise.