### PR TITLE
bevy_gltf: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -454,7 +454,10 @@ async fn load_gltf<'a, 'b, 'c>(
                         ReadOutputs::MorphTargetWeights(weights) => {
                             let weights: Vec<f32> = weights.into_f32().collect();
                             if keyframe_timestamps.len() == 1 {
-                                #[allow(clippy::unnecessary_map_on_constructor)]
+                                #[expect(
+                                    clippy::unnecessary_map_on_constructor,
+                                    reason = "While the mapping is unnecessary, it is much more readable at this level of indentation. Additionally, mapping makes it more consistent with the other branches."
+                                )]
                                 Some(ConstantCurve::new(Interval::EVERYWHERE, weights))
                                     .map(WeightsCurve)
                                     .map(VariableCurve::new)
@@ -1368,7 +1371,10 @@ fn warn_on_differing_texture_transforms(
 }
 
 /// Loads a glTF node.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "`GltfError` is only barely past the threshold for large errors."
+)]
 fn load_node(
     gltf_node: &Node,
     world_builder: &mut WorldChildBuilder,
@@ -1723,7 +1729,6 @@ fn texture_handle(load_context: &mut LoadContext, texture: &gltf::Texture) -> Ha
 ///
 /// This is a low-level function only used when the `gltf` crate has no support
 /// for an extension, forcing us to parse its texture references manually.
-#[allow(dead_code)]
 fn texture_handle_from_info(
     load_context: &mut LoadContext,
     document: &Document,
@@ -1806,7 +1811,10 @@ fn texture_address_mode(gltf_address_mode: &WrappingMode) -> ImageAddressMode {
 }
 
 /// Maps the `primitive_topology` form glTF to `wgpu`.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "`GltfError` is only barely past the threshold for large errors."
+)]
 fn get_primitive_topology(mode: Mode) -> Result<PrimitiveTopology, GltfError> {
     match mode {
         Mode::Points => Ok(PrimitiveTopology::PointList),
@@ -1876,7 +1884,10 @@ struct GltfTreeIterator<'a> {
 }
 
 impl<'a> GltfTreeIterator<'a> {
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "`GltfError` is only barely past the threshold for large errors."
+    )]
     fn try_new(gltf: &'a gltf::Gltf) -> Result<Self, GltfError> {
         let nodes = gltf.nodes().collect::<Vec<_>>();
 
@@ -2088,7 +2099,6 @@ struct ClearcoatExtension {
 }
 
 impl ClearcoatExtension {
-    #[allow(unused_variables)]
     fn parse(
         load_context: &mut LoadContext,
         document: &Document,
@@ -2171,7 +2181,6 @@ struct AnisotropyExtension {
 }
 
 impl AnisotropyExtension {
-    #[allow(unused_variables)]
     fn parse(
         load_context: &mut LoadContext,
         document: &Document,
@@ -2305,7 +2314,10 @@ mod test {
     }
 
     fn load_gltf_into_app(gltf_path: &str, gltf: &str) -> App {
-        #[expect(unused)]
+        #[expect(
+            dead_code,
+            reason = "This struct is used to keep the handle alive. As such, we have no need to handle the handle directly."
+        )]
         #[derive(Resource)]
         struct GltfHandle(Handle<Gltf>);
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1729,6 +1729,11 @@ fn texture_handle(load_context: &mut LoadContext, texture: &gltf::Texture) -> Ha
 ///
 /// This is a low-level function only used when the `gltf` crate has no support
 /// for an extension, forcing us to parse its texture references manually.
+#[expect(clippy::allow_attributes, reason = "`dead_code` is not always linted")]
+#[allow(
+    dead_code,
+    reason = "Depending on what features are used to compile this crate, this function may end up uncalled."
+)]
 fn texture_handle_from_info(
     load_context: &mut LoadContext,
     document: &Document,
@@ -2099,6 +2104,14 @@ struct ClearcoatExtension {
 }
 
 impl ClearcoatExtension {
+    #[expect(
+        clippy::allow_attributes,
+        reason = "`unused_variable` is not always linted"
+    )]
+    #[allow(
+        unused_variable,
+        reason = "Depending on what features are used to compile this crate, certain parameters may end up unused."
+    )]
     fn parse(
         load_context: &mut LoadContext,
         document: &Document,
@@ -2181,6 +2194,14 @@ struct AnisotropyExtension {
 }
 
 impl AnisotropyExtension {
+    #[expect(
+        clippy::allow_attributes,
+        reason = "`unused_variable` is not always linted"
+    )]
+    #[allow(
+        unused_variable,
+        reason = "Depending on what features are used to compile this crate, certain parameters may end up unused."
+    )]
     fn parse(
         load_context: &mut LoadContext,
         document: &Document,

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1729,11 +1729,7 @@ fn texture_handle(load_context: &mut LoadContext, texture: &gltf::Texture) -> Ha
 ///
 /// This is a low-level function only used when the `gltf` crate has no support
 /// for an extension, forcing us to parse its texture references manually.
-#[expect(clippy::allow_attributes, reason = "`dead_code` is not always linted")]
-#[allow(
-    dead_code,
-    reason = "Depending on what features are used to compile this crate, this function may end up uncalled."
-)]
+#[cfg(feature = "pbr_multi_layer_material_textures")]
 fn texture_handle_from_info(
     load_context: &mut LoadContext,
     document: &Document,

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -2106,10 +2106,10 @@ struct ClearcoatExtension {
 impl ClearcoatExtension {
     #[expect(
         clippy::allow_attributes,
-        reason = "`unused_variable` is not always linted"
+        reason = "`unused_variables` is not always linted"
     )]
     #[allow(
-        unused_variable,
+        unused_variables,
         reason = "Depending on what features are used to compile this crate, certain parameters may end up unused."
     )]
     fn parse(
@@ -2196,10 +2196,10 @@ struct AnisotropyExtension {
 impl AnisotropyExtension {
     #[expect(
         clippy::allow_attributes,
-        reason = "`unused_variable` is not always linted"
+        reason = "`unused_variables` is not always linted"
     )]
     #[allow(
-        unused_variable,
+        unused_variables,
         reason = "Depending on what features are used to compile this crate, certain parameters may end up unused."
     )]
     fn parse(

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1729,7 +1729,10 @@ fn texture_handle(load_context: &mut LoadContext, texture: &gltf::Texture) -> Ha
 ///
 /// This is a low-level function only used when the `gltf` crate has no support
 /// for an extension, forcing us to parse its texture references manually.
-#[cfg(feature = "pbr_multi_layer_material_textures")]
+#[cfg(any(
+    feature = "pbr_anisotropy_texture",
+    feature = "pbr_multi_layer_material_textures"
+))]
 fn texture_handle_from_info(
     load_context: &mut LoadContext,
     document: &Document,


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_gltf` in line with the new restrictions.

## Testing
`cargo clippy --tests --all-features --package bevy_gltf` was run, and no errors were encountered.