### PR TITLE
bevy_gizmos: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -182,7 +182,10 @@ where
     state: <GizmosState<Config, Clear> as SystemParam>::State,
 }
 
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "We cannot implement SystemParam without using unsafe code."
+)]
 // SAFETY: All methods are delegated to existing `SystemParam` implementations
 unsafe impl<Config, Clear> SystemParam for Gizmos<'_, '_, Config, Clear>
 where
@@ -254,7 +257,10 @@ where
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "We cannot implement ReadOnlySystemParam without using unsafe code."
+)]
 // Safety: Each field is `ReadOnlySystemParam`, and Gizmos SystemParam does not mutate world
 unsafe impl<'w, 's, Config, Clear> ReadOnlySystemParam for Gizmos<'w, 's, Config, Clear>
 where

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -1,4 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_gizmos` in line with the new restrictions.

## Testing
`cargo clippy --tests --all-features --package bevy_gizmos` was run, and no errors were encountered.