### PR TITLE
bevy_hierarchy: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -783,7 +783,10 @@ mod tests {
         );
     }
 
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "The inner field is used to differentiate the different instances of this struct."
+    )]
     #[derive(Component)]
     struct C(u32);
 

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_hierarchy` in line with the new restrictions.

## Testing
Rust-analyzer did not discern any errors.