### PR TITLE
bevy_image: Apply `#![deny(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -45,6 +45,10 @@ impl AssetSaver for CompressedImageSaver {
             source_image.init(&image.data, size.x, size.y, 4);
 
             let mut compressor = basis_universal::Compressor::new(4);
+            #[expect(
+                unsafe_code,
+                reason = "The basis-universal compressor cannot be interacted with except through unsafe functions"
+            )]
             // SAFETY: the CompressorParams are "valid" to the best of our knowledge. The basis-universal
             // library bindings note that invalid params might produce undefined behavior.
             unsafe {

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -117,7 +117,14 @@ impl ImageFormat {
             #[cfg(feature = "webp")]
             ImageFormat::WebP => &["webp"],
             // FIXME: https://github.com/rust-lang/rust/issues/129031
-            #[allow(unreachable_patterns)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "`unreachable_patterns` may not always lint"
+            )]
+            #[allow(
+                unreachable_patterns,
+                reason = "The wildcard pattern will be unreachable if all formats are enabled, but otherwise it will be reachable"
+            )]
             _ => &[],
         }
     }
@@ -165,13 +172,27 @@ impl ImageFormat {
             #[cfg(feature = "webp")]
             ImageFormat::WebP => &["image/webp"],
             // FIXME: https://github.com/rust-lang/rust/issues/129031
-            #[allow(unreachable_patterns)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "`unreachable_patterns` may not always lint"
+            )]
+            #[allow(
+                unreachable_patterns,
+                reason = "The wildcard pattern will be unreachable if all formats are enabled, but otherwise it will be reachable"
+            )]
             _ => &[],
         }
     }
 
     pub fn from_mime_type(mime_type: &str) -> Option<Self> {
-        #[allow(unreachable_code)]
+        #[expect(
+            clippy::allow_attributes,
+            reason = "`unreachable_code` may not always lint"
+        )]
+        #[allow(
+            unreachable_code,
+            reason = "If all features listed below are disabled, then all arms will have a `return None`, keeping the surrounding `Some()` from being constructed."
+        )]
         Some(match mime_type.to_ascii_lowercase().as_str() {
             // note: farbfeld does not have a MIME type
             "image/basis" | "image/x-basis" => feature_gate!("basis-universal", Basis),
@@ -197,7 +218,14 @@ impl ImageFormat {
     }
 
     pub fn from_extension(extension: &str) -> Option<Self> {
-        #[allow(unreachable_code)]
+        #[expect(
+            clippy::allow_attributes,
+            reason = "`unreachable_code` may not always lint"
+        )]
+        #[allow(
+            unreachable_code,
+            reason = "If all features listed below are disabled, then all arms will have a `return None`, keeping the surrounding `Some()` from being constructed."
+        )]
         Some(match extension.to_ascii_lowercase().as_str() {
             "basis" => feature_gate!("basis-universal", Basis),
             "bmp" => feature_gate!("bmp", Bmp),
@@ -220,7 +248,14 @@ impl ImageFormat {
     }
 
     pub fn as_image_crate_format(&self) -> Option<image::ImageFormat> {
-        #[allow(unreachable_code)]
+        #[expect(
+            clippy::allow_attributes,
+            reason = "`unreachable_code` may not always lint"
+        )]
+        #[allow(
+            unreachable_code,
+            reason = "If all features listed below are disabled, then all arms will have a `return None`, keeping the surrounding `Some()` from being constructed."
+        )]
         Some(match self {
             #[cfg(feature = "bmp")]
             ImageFormat::Bmp => image::ImageFormat::Bmp,
@@ -255,13 +290,27 @@ impl ImageFormat {
             #[cfg(feature = "ktx2")]
             ImageFormat::Ktx2 => return None,
             // FIXME: https://github.com/rust-lang/rust/issues/129031
-            #[allow(unreachable_patterns)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "`unreachable_patterns` may not always lint"
+            )]
+            #[allow(
+                unreachable_patterns,
+                reason = "The wildcard pattern will be unreachable if all formats are enabled, but otherwise it will be reachable"
+            )]
             _ => return None,
         })
     }
 
     pub fn from_image_crate_format(format: image::ImageFormat) -> Option<ImageFormat> {
-        #[allow(unreachable_code)]
+        #[expect(
+            clippy::allow_attributes,
+            reason = "`unreachable_code` may not always lint"
+        )]
+        #[allow(
+            unreachable_code,
+            reason = "If all features listed below are disabled, then all arms will have a `return None`, keeping the surrounding `Some()` from being constructed."
+        )]
         Some(match format {
             image::ImageFormat::Bmp => feature_gate!("bmp", Bmp),
             image::ImageFormat::Dds => feature_gate!("dds", Dds),
@@ -874,7 +923,15 @@ impl Image {
         #[cfg(all(debug_assertions, feature = "dds"))] name: String,
         buffer: &[u8],
         image_type: ImageType,
-        #[allow(unused_variables)] supported_compressed_formats: CompressedImageFormats,
+        #[expect(
+            clippy::allow_attributes,
+            reason = "`unused_variables` may not always lint"
+        )]
+        #[allow(
+            unused_variables,
+            reason = "`supported_compressed_formats` is needed where the image format is `Basis`, `Dds`, or `Ktx2`; if these are disabled, then `supported_compressed_formats` is unused."
+        )]
+        supported_compressed_formats: CompressedImageFormats,
         is_srgb: bool,
         image_sampler: ImageSampler,
         asset_usage: RenderAssetUsages,
@@ -904,7 +961,14 @@ impl Image {
             ImageFormat::Ktx2 => {
                 ktx2_buffer_to_image(buffer, supported_compressed_formats, is_srgb)?
             }
-            #[allow(unreachable_patterns)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "`unreachable_patterns` may not always lint"
+            )]
+            #[allow(
+                unreachable_patterns,
+                reason = "The wildcard pattern may be unreachable if only the specially-handled formats are enabled; however, the wildcard pattern is needed for any formats not specially handled"
+            )]
             _ => {
                 let image_crate_format = format
                     .as_image_crate_format()

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -123,7 +123,7 @@ impl ImageFormat {
             )]
             #[allow(
                 unreachable_patterns,
-                reason = "The wildcard pattern will be unreachable if all formats are enabled, but otherwise it will be reachable"
+                reason = "The wildcard pattern will be unreachable if all formats are enabled; otherwise, it will be reachable"
             )]
             _ => &[],
         }
@@ -178,7 +178,7 @@ impl ImageFormat {
             )]
             #[allow(
                 unreachable_patterns,
-                reason = "The wildcard pattern will be unreachable if all formats are enabled, but otherwise it will be reachable"
+                reason = "The wildcard pattern will be unreachable if all formats are enabled; otherwise, it will be reachable"
             )]
             _ => &[],
         }
@@ -296,7 +296,7 @@ impl ImageFormat {
             )]
             #[allow(
                 unreachable_patterns,
-                reason = "The wildcard pattern will be unreachable if all formats are enabled, but otherwise it will be reachable"
+                reason = "The wildcard pattern will be unreachable if all formats are enabled; otherwise, it will be reachable"
             )]
             _ => return None,
         })

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -1,5 +1,9 @@
 #![expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
-#![allow(unsafe_code)]
+#![deny(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 
 extern crate alloc;
 


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `deny`, and bring `bevy_image` in line with the new restrictions.

## Testing
`cargo clippy --tests --package bevy_image` was run, and no errors were encountered.

I could not run the above command with `--all-features` due to some compilation errors with `bevy_core_pipeline` and `bevy_math` - but hopefully CI catches anything I missed.