### PR TITLE
Create missing constructors for 2D primitive mesh builders

### DIFF
--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -754,7 +754,10 @@ pub struct RhombusMeshBuilder {
 impl RhombusMeshBuilder {
     /// Creates a new [`RhombusMeshBuilder`] from a horizontal and vertical diagonal size.
     pub const fn new(horizontal_diagonal: f32, vertical_diagonal: f32) -> Self {
-        debug_assert!(horizontal_diagonal >= 0.0, "rhombus has a negative horizontal");
+        debug_assert!(
+            horizontal_diagonal >= 0.0,
+            "rhombus has a negative horizontal",
+        );
         debug_assert!(vertical_diagonal >= 0.0, "rhombus has a negative vertical");
 
         Self {

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -462,7 +462,7 @@ impl RegularPolygonMeshBuilder {
     ///
     /// # Panics
     ///
-    /// Panics if `circumradius` is negative, or if `sides` is less than 3.
+    /// Panics in debug mode if `circumradius` is negative, or if `sides` is less than 3.
     pub const fn new(circumradius: f32, sides: u32) -> Self {
         debug_assert!(
             circumradius.is_sign_positive(),
@@ -753,6 +753,10 @@ pub struct RhombusMeshBuilder {
 
 impl RhombusMeshBuilder {
     /// Creates a new [`RhombusMeshBuilder`] from a horizontal and vertical diagonal size.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics in debug mode if `horizontal_diagonal` or `vertical_diagonal` is negative.
     pub const fn new(horizontal_diagonal: f32, vertical_diagonal: f32) -> Self {
         debug_assert!(
             horizontal_diagonal >= 0.0,
@@ -896,6 +900,10 @@ pub struct RectangleMeshBuilder {
 
 impl RectangleMeshBuilder {
     /// Creates a new [`RectangleMeshBuilder`] from a full width and height.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics in debug mode if `width` or `height` is negative.
     pub const fn new(width: f32, height: f32) -> Self {
         debug_assert!(width >= 0.0, "rectangle has a negative width");
         debug_assert!(height >= 0.0, "rectangle has a negative height");

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -464,11 +464,11 @@ impl RegularPolygonMeshBuilder {
     ///
     /// Panics if `circumradius` is negative, or if `sides` is less than 3.
     pub const fn new(circumradius: f32, sides: u32) -> Self {
-        assert!(
+        debug_assert!(
             circumradius.is_sign_positive(),
             "polygon has a negative radius"
         );
-        assert!(sides > 2, "polygon has less than 3 sides");
+        debug_assert!(sides > 2, "polygon has less than 3 sides");
 
         Self {
             circumradius,
@@ -754,6 +754,9 @@ pub struct RhombusMeshBuilder {
 impl RhombusMeshBuilder {
     /// Creates a new [`RhombusMeshBuilder`] from a horizontal and vertical diagonal size.
     pub const fn new(horizontal_diagonal: f32, vertical_diagonal: f32) -> Self {
+        debug_assert!(horizontal_diagonal >= 0.0, "rhombus has a negative horizontal");
+        debug_assert!(vertical_diagonal >= 0.0, "rhombus has a negative vertical");
+
         Self {
             half_diagonals: Vec2::new(horizontal_diagonal / 2.0, vertical_diagonal / 2.0),
         }
@@ -891,6 +894,9 @@ pub struct RectangleMeshBuilder {
 impl RectangleMeshBuilder {
     /// Creates a new [`RectangleMeshBuilder`] from a full width and height.
     pub const fn new(width: f32, height: f32) -> Self {
+        debug_assert!(width >= 0, "rectangle has a negative width");
+        debug_assert!(height >= 0, "rectangle has a negative height");
+
         Self {
             half_size: Vec2::new(width / 2.0, height / 2.0),
         }

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -753,16 +753,19 @@ pub struct RhombusMeshBuilder {
 
 impl RhombusMeshBuilder {
     /// Creates a new [`RhombusMeshBuilder`] from a horizontal and vertical diagonal size.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics in debug mode if `horizontal_diagonal` or `vertical_diagonal` is negative.
     pub const fn new(horizontal_diagonal: f32, vertical_diagonal: f32) -> Self {
         debug_assert!(
             horizontal_diagonal >= 0.0,
             "rhombus has a negative horizontal size",
         );
-        debug_assert!(vertical_diagonal >= 0.0, "rhombus has a negative vertical size");
+        debug_assert!(
+            vertical_diagonal >= 0.0,
+            "rhombus has a negative vertical size"
+        );
 
         Self {
             half_diagonals: Vec2::new(horizontal_diagonal / 2.0, vertical_diagonal / 2.0),
@@ -900,9 +903,9 @@ pub struct RectangleMeshBuilder {
 
 impl RectangleMeshBuilder {
     /// Creates a new [`RectangleMeshBuilder`] from a full width and height.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics in debug mode if `width` or `height` is negative.
     pub const fn new(width: f32, height: f32) -> Self {
         debug_assert!(width >= 0.0, "rectangle has a negative width");

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -399,6 +399,9 @@ impl From<CircularSegment> for Mesh {
 }
 
 /// A builder used for creating a [`Mesh`] with a [`ConvexPolygon`] shape.
+///
+/// You must verify that the `vertices` are not concave when constructing this type. You can
+/// guarantee this by creating a [`ConvexPolygon`] first, then calling [`ConvexPolygon::mesh()`].
 pub struct ConvexPolygonMeshBuilder<const N: usize> {
     pub vertices: [Vec2; N],
 }
@@ -452,6 +455,28 @@ pub struct RegularPolygonMeshBuilder {
     circumradius: f32,
     sides: u32,
 }
+
+impl RegularPolygonMeshBuilder {
+    /// Creates a new [`RegularPolygonMeshBuilder`] from the radius of a circumcircle and a number
+    /// of sides.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `circumradius` is negative, or if `sides` is less than 3.
+    pub const fn new(circumradius: f32, sides: u32) -> Self {
+        assert!(
+            circumradius.is_sign_positive(),
+            "polygon has a negative radius"
+        );
+        assert!(sides > 2, "polygon has less than 3 sides");
+
+        Self {
+            circumradius,
+            sides,
+        }
+    }
+}
+
 impl Meshable for RegularPolygon {
     type Output = RegularPolygonMeshBuilder;
 
@@ -726,6 +751,15 @@ pub struct RhombusMeshBuilder {
     half_diagonals: Vec2,
 }
 
+impl RhombusMeshBuilder {
+    /// Creates a new [`RhombusMeshBuilder`] from a horizontal and vertical diagonal size.
+    pub const fn new(horizontal_diagonal: f32, vertical_diagonal: f32) -> Self {
+        Self {
+            half_diagonals: Vec2::new(horizontal_diagonal / 2.0, vertical_diagonal / 2.0),
+        }
+    }
+}
+
 impl MeshBuilder for RhombusMeshBuilder {
     fn build(&self) -> Mesh {
         let [hhd, vhd] = [self.half_diagonals.x, self.half_diagonals.y];
@@ -778,6 +812,16 @@ impl From<Rhombus> for Mesh {
 pub struct Triangle2dMeshBuilder {
     triangle: Triangle2d,
 }
+
+impl Triangle2dMeshBuilder {
+    /// Creates a new [`Triangle2dMeshBuilder`] from the points `a`, `b`, and `c`.
+    pub const fn new(a: Vec2, b: Vec2, c: Vec2) -> Self {
+        Self {
+            triangle: Triangle2d::new(a, b, c),
+        }
+    }
+}
+
 impl Meshable for Triangle2d {
     type Output = Triangle2dMeshBuilder;
 
@@ -785,6 +829,7 @@ impl Meshable for Triangle2d {
         Self::Output { triangle: *self }
     }
 }
+
 impl MeshBuilder for Triangle2dMeshBuilder {
     fn build(&self) -> Mesh {
         let vertices_3d = self.triangle.vertices.map(|v| v.extend(0.));
@@ -841,6 +886,15 @@ impl From<Triangle2d> for Mesh {
 /// A builder used for creating a [`Mesh`] with a [`Rectangle`] shape.
 pub struct RectangleMeshBuilder {
     half_size: Vec2,
+}
+
+impl RectangleMeshBuilder {
+    /// Creates a new [`RectangleMeshBuilder`] from a full width and height.
+    pub const fn new(width: f32, height: f32) -> Self {
+        Self {
+            half_size: Vec2::new(width / 2.0, height / 2.0),
+        }
+    }
 }
 
 impl MeshBuilder for RectangleMeshBuilder {

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -897,8 +897,8 @@ pub struct RectangleMeshBuilder {
 impl RectangleMeshBuilder {
     /// Creates a new [`RectangleMeshBuilder`] from a full width and height.
     pub const fn new(width: f32, height: f32) -> Self {
-        debug_assert!(width >= 0, "rectangle has a negative width");
-        debug_assert!(height >= 0, "rectangle has a negative height");
+        debug_assert!(width >= 0.0, "rectangle has a negative width");
+        debug_assert!(height >= 0.0, "rectangle has a negative height");
 
         Self {
             half_size: Vec2::new(width / 2.0, height / 2.0),

--- a/crates/bevy_mesh/src/primitives/dim2.rs
+++ b/crates/bevy_mesh/src/primitives/dim2.rs
@@ -756,9 +756,9 @@ impl RhombusMeshBuilder {
     pub const fn new(horizontal_diagonal: f32, vertical_diagonal: f32) -> Self {
         debug_assert!(
             horizontal_diagonal >= 0.0,
-            "rhombus has a negative horizontal",
+            "rhombus has a negative horizontal size",
         );
-        debug_assert!(vertical_diagonal >= 0.0, "rhombus has a negative vertical");
+        debug_assert!(vertical_diagonal >= 0.0, "rhombus has a negative vertical size");
 
         Self {
             half_diagonals: Vec2::new(horizontal_diagonal / 2.0, vertical_diagonal / 2.0),


### PR DESCRIPTION
# Objective

- While all [`MeshBuilder`](https://dev-docs.bevyengine.org/bevy/prelude/trait.MeshBuilder.html)s can be created by first creating the primitive `bevy_math` type and using [`Meshable`](https://dev-docs.bevyengine.org/bevy/prelude/trait.Meshable.html), most builders have their own `const` constructors that can be used instead. Some builders are missing constructors, however, making them unavailable in `const` contexts.

## Solution

- Add a `const` constructor for `RegularPolygonMeshBuilder`, `RhombusMeshBuilder`, `Triangle2dMeshBuilder`, and `RectangleMeshBuilder`.
- Add a note on the requirements of `ConvexPolygonMeshBuilder`, and recommend using `ConvexPolygon::new().mesh()` instead.
  - A constructor cannot easily be created for this type, since it requires duplicating all of `ConvexPolygon::new()`'s verification code. I may be able to work around this, but it requires touching a bit more code surface. Opinions?

## Testing

Not much beyond CI! The changes are trivial enough that only a cursory glance for typos and switched variables should be necessary.

## Note for Reviewers

Hi! I haven't directly used the types I modify in this PR beyond some benchmarking work I did this morning. If you're familiar with these types, please let me know if any of the constructors need additional validation (or if the constructors shouldn't be there at all). Thanks!