### PR TITLE
`bevy_image` now enables reflection on `bevy_math`

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -41,7 +41,7 @@ bevy_color = { path = "../bevy_color", version = "0.16.0-dev", features = [
   "wgpu-types",
 ] }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev", features = [
-  "bevy_reflect"
+  "bevy_reflect",
 ] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "bevy",

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -40,7 +40,9 @@ bevy_color = { path = "../bevy_color", version = "0.16.0-dev", features = [
   "serialize",
   "wgpu-types",
 ] }
-bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
+bevy_math = { path = "../bevy_math", version = "0.16.0-dev", features = [
+  "bevy_reflect"
+] }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "bevy",
 ] }


### PR DESCRIPTION
# Objective
`bevy_image` appears to expect `bevy_math` to have reflection enabled. If you attempt to build `bevy_image` without another dependency enabling the `bevy_math/bevy_reflect` feature, then `bevy_image` will fail to compile.

## Solution
Ideally, `bevy_image` would feature-gate all of its reflection behind a new feature. However, for the sake of getting compilation fixed immediately, I'm opting to specify the `bevy_math/bevy_reflect` feature in `bevy_image`'s `Cargo.toml`.

Perhaps an upcoming PR can remove the forced `bevy_math/bevy_reflect` feature, in favor of feature-gating `bevy_image`'s reflecton.

## Testing
`cargo clippy --package bevy_image` was ran, and no longer returns the compilation errors that it did before.