### PR TITLE
Update `from_reflect` to return a `Result` with `FromReflectError`

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2211,7 +2211,7 @@ pub fn component_clone_via_reflect(world: &mut DeferredWorld, ctx: &mut Componen
     if let Some(reflect_from_reflect) =
         registry.get_type_data::<bevy_reflect::ReflectFromReflect>(type_id)
     {
-        if let Some(component) =
+        if let Ok(component) =
             reflect_from_reflect.from_reflect(source_component_reflect.as_partial_reflect())
         {
             drop(registry);

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -111,7 +111,7 @@ pub fn from_reflect_with_fallback<T: Reflect + TypePath>(
         registry.get_type_data::<ReflectFromReflect>(TypeId::of::<T>())
     {
         // If it fails it's ok, we can continue checking `Default` and `FromWorld`.
-        if let Some(value) = reflect_from_reflect.from_reflect(reflected) {
+        if let Ok(value) = reflect_from_reflect.from_reflect(reflected) {
             return value
                 .take::<T>()
                 .unwrap_or_else(|_| different_type_error::<T>("FromReflect"));

--- a/crates/bevy_reflect/derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/derive/src/enum_utility.rs
@@ -2,7 +2,7 @@ use crate::{
     derive_data::ReflectEnum, derive_data::StructField, field_attributes::DefaultBehavior,
     ident::ident_or_index,
 };
-use bevy_macro_utils::fq_std::{FQBox, FQDefault, FQOption};
+use bevy_macro_utils::fq_std::{FQDefault, FQOption};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
@@ -222,7 +222,10 @@ impl<'a> VariantBuilder for FromReflectVariantBuilder<'a> {
             quote!(#bevy_reflect_path::FromReflectError::MissingTupleIndex(#index))
         };
 
-        quote!(#alias.ok_or_else(|| #bevy_reflect_path::FromReflectError::VariantError(::core::convert::Into::into(#variant_name), #FQBox::new(#error)))?)
+        quote!(#alias.ok_or_else(|| #bevy_reflect_path::FromReflectError::VariantError(
+            ::core::convert::Into::into(#variant_name),
+            #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(#error)
+        ))?)
     }
 
     fn construct_field(&self, field: VariantField) -> TokenStream {
@@ -238,15 +241,24 @@ impl<'a> VariantBuilder for FromReflectVariantBuilder<'a> {
 
         let error = if let Some(field_name) = &field.data.ident {
             let field_name = field_name.to_string();
-            quote!(#bevy_reflect_path::FromReflectError::FieldError(::core::convert::Into::into(#field_name), #FQBox::new(err)))
+            quote!(#bevy_reflect_path::FromReflectError::FieldError(
+                ::core::convert::Into::into(#field_name),
+                #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(err)
+            ))
         } else {
             let index = field.declaration_index;
-            quote!(#bevy_reflect_path::FromReflectError::TupleIndexError(#index, #FQBox::new(err)))
+            quote!(#bevy_reflect_path::FromReflectError::TupleIndexError(
+                #index,
+                #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(err)
+            ))
         };
 
         quote! {
             <#field_ty as #bevy_reflect_path::FromReflect>::from_reflect(#alias)
-                .map_err(|err| #bevy_reflect_path::FromReflectError::VariantError(::core::convert::Into::into(#variant_name), #FQBox::new(#error)))?
+                .map_err(|err| #bevy_reflect_path::FromReflectError::VariantError(
+                    ::core::convert::Into::into(#variant_name),
+                    #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(#error)
+                ))?
         }
     }
 }

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -7,7 +7,7 @@ use crate::{
     where_clause_options::WhereClauseOptions,
     ReflectMeta, ReflectStruct,
 };
-use bevy_macro_utils::fq_std::{FQBox, FQClone, FQDefault, FQResult};
+use bevy_macro_utils::fq_std::{FQClone, FQDefault, FQResult};
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{Field, Ident, Lit, LitInt, LitStr, Member};
@@ -257,9 +257,15 @@ fn get_active_fields(
                 };
 
                 let internal_error = if is_tuple {
-                    quote! {#bevy_reflect_path::FromReflectError::TupleIndexError(#accessor, #FQBox::new(err))}
+                    quote! {#bevy_reflect_path::FromReflectError::TupleIndexError(
+                        #accessor,
+                        #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(err)
+                    )}
                 } else {
-                    quote! {#bevy_reflect_path::FromReflectError::FieldError(::core::convert::Into::into(#accessor), #FQBox::new(err))}
+                    quote! {#bevy_reflect_path::FromReflectError::FieldError(
+                        ::core::convert::Into::into(#accessor),
+                        #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(err)
+                    )}
                 };
 
                 let get_field = quote! {

--- a/crates/bevy_reflect/derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/derive/src/from_reflect.rs
@@ -7,7 +7,7 @@ use crate::{
     where_clause_options::WhereClauseOptions,
     ReflectMeta, ReflectStruct,
 };
-use bevy_macro_utils::fq_std::{FQClone, FQDefault, FQOption};
+use bevy_macro_utils::fq_std::{FQBox, FQClone, FQDefault, FQResult};
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{Field, Ident, Lit, LitInt, LitStr, Member};
@@ -29,10 +29,16 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     let where_from_reflect_clause = WhereClauseOptions::new(meta).extend_where_clause(where_clause);
     quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #type_path #ty_generics #where_from_reflect_clause  {
-            fn from_reflect(reflect: &dyn #bevy_reflect_path::PartialReflect) -> #FQOption<Self> {
-                #FQOption::Some(
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::PartialReflect) -> #FQResult<Self, #bevy_reflect_path::FromReflectError> {
+                #FQResult::Ok(
                     #FQClone::clone(
-                        <dyn #bevy_reflect_path::PartialReflect>::try_downcast_ref::<#type_path #ty_generics>(reflect)?
+                        <dyn #bevy_reflect_path::PartialReflect>::try_downcast_ref::<#type_path #ty_generics>(reflect)
+                            .ok_or(#bevy_reflect_path::FromReflectError::MismatchedTypes {
+                                from_type: ::core::convert::Into::into(
+                                    #bevy_reflect_path::DynamicTypePath::reflect_type_path(reflect)
+                                ),
+                                to_type: ::core::convert::Into::into(<#type_path #ty_generics as #bevy_reflect_path::TypePath>::type_path())
+                            })?
                     )
                 )
             }
@@ -42,7 +48,7 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
 
 /// Implements `FromReflect` for the given enum type
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream {
-    let fqoption = FQOption.into_token_stream();
+    let fqresult = FQResult.into_token_stream();
 
     let enum_path = reflect_enum.meta().type_path();
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
@@ -57,11 +63,11 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
     let match_branches = if reflect_enum.meta().is_remote_wrapper() {
         quote! {
-            #(#variant_names => #fqoption::Some(Self(#variant_constructors)),)*
+            #(#variant_names => #fqresult::Ok(Self(#variant_constructors)),)*
         }
     } else {
         quote! {
-            #(#variant_names => #fqoption::Some(#variant_constructors),)*
+            #(#variant_names => #fqresult::Ok(#variant_constructors),)*
         }
     };
 
@@ -74,16 +80,19 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
     quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #enum_path #ty_generics #where_from_reflect_clause  {
-            fn from_reflect(#ref_value: &dyn #bevy_reflect_path::PartialReflect) -> #FQOption<Self> {
+            fn from_reflect(#ref_value: &dyn #bevy_reflect_path::PartialReflect) -> #FQResult<Self, #bevy_reflect_path::FromReflectError> {
                 if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) =
                     #bevy_reflect_path::PartialReflect::reflect_ref(#ref_value)
                 {
                     match #bevy_reflect_path::Enum::variant_name(#ref_value) {
                         #match_branches
-                        name => panic!("variant with name `{}` does not exist on enum `{}`", name, <Self as #bevy_reflect_path::TypePath>::type_path()),
+                        name => #FQResult::Err(#bevy_reflect_path::FromReflectError::MissingEnumVariant(::core::convert::Into::into(name))),
                     }
                 } else {
-                    #FQOption::None
+                    #FQResult::Err(#bevy_reflect_path::ReflectKindMismatchError {
+                        expected: #bevy_reflect_path::ReflectKind::Enum,
+                        received: #ref_value.reflect_kind(),
+                    })?
                 }
             }
         }
@@ -104,7 +113,7 @@ fn impl_struct_internal(
     reflect_struct: &ReflectStruct,
     is_tuple: bool,
 ) -> proc_macro2::TokenStream {
-    let fqoption = FQOption.into_token_stream();
+    let fqresult = FQResult.into_token_stream();
 
     let struct_path = reflect_struct.meta().type_path();
     let remote_ty = reflect_struct.meta().remote_ty();
@@ -146,12 +155,12 @@ fn impl_struct_internal(
         quote! {
             let mut #__this = <#reflect_ty as #FQDefault>::default();
             #(
-                if let #fqoption::Some(__field) = #active_values() {
+                if let #fqresult::Ok(__field) = #active_values() {
                     // Iff field exists -> use its value
                     #__this.#active_members = __field;
                 }
             )*
-            #FQOption::Some(#retval)
+            #FQResult::Ok(#retval)
         }
     } else {
         let MemberValuePair(ignored_members, ignored_values) = get_ignored_fields(reflect_struct);
@@ -161,7 +170,7 @@ fn impl_struct_internal(
                 #(#active_members: #active_values()?,)*
                 #(#ignored_members: #ignored_values,)*
             };
-            #FQOption::Some(#retval)
+            #FQResult::Ok(#retval)
         }
     };
 
@@ -178,13 +187,16 @@ fn impl_struct_internal(
 
     quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #struct_path #ty_generics #where_from_reflect_clause {
-            fn from_reflect(reflect: &dyn #bevy_reflect_path::PartialReflect) -> #FQOption<Self> {
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::PartialReflect) -> #FQResult<Self, #bevy_reflect_path::FromReflectError> {
                 if let #bevy_reflect_path::ReflectRef::#ref_struct_type(#ref_struct)
                     = #bevy_reflect_path::PartialReflect::reflect_ref(reflect)
                 {
                     #constructor
                 } else {
-                    #FQOption::None
+                    #FQResult::Err(#bevy_reflect_path::ReflectKindMismatchError {
+                        expected: #bevy_reflect_path::ReflectKind::#ref_struct_type,
+                        received: reflect.reflect_kind(),
+                    })?
                 }
             }
         }
@@ -238,14 +250,26 @@ fn get_active_fields(
                 let ty = field.reflected_type().clone();
                 let real_ty = &field.data.ty;
 
+                let missing_error = if is_tuple {
+                    quote! {#bevy_reflect_path::FromReflectError::MissingTupleIndex(#accessor)}
+                } else {
+                    quote! {#bevy_reflect_path::FromReflectError::MissingField(::core::convert::Into::into(#accessor))}
+                };
+
+                let internal_error = if is_tuple {
+                    quote! {#bevy_reflect_path::FromReflectError::TupleIndexError(#accessor, #FQBox::new(err))}
+                } else {
+                    quote! {#bevy_reflect_path::FromReflectError::FieldError(::core::convert::Into::into(#accessor), #FQBox::new(err))}
+                };
+
                 let get_field = quote! {
-                    #bevy_reflect_path::#struct_type::field(#dyn_struct_name, #accessor)
+                    #bevy_reflect_path::#struct_type::field(#dyn_struct_name, #accessor).ok_or(#missing_error)
                 };
 
                 let into_remote = |value: proc_macro2::TokenStream| {
                     if field.attrs.is_remote_generic().unwrap_or_default() {
                         quote! {
-                            #FQOption::Some(
+                            #FQResult::Ok(
                                 // SAFETY: The remote type should always be a `#[repr(transparent)]` for the actual field type
                                 unsafe {
                                     ::core::mem::transmute_copy::<#ty, #real_ty>(
@@ -256,7 +280,7 @@ fn get_active_fields(
                         }
                     } else if field.attrs().remote.is_some() {
                         quote! {
-                            #FQOption::Some(
+                            #FQResult::Ok(
                                 // SAFETY: The remote type should always be a `#[repr(transparent)]` for the actual field type
                                 unsafe {
                                     ::core::mem::transmute::<#ty, #real_ty>(#value?)
@@ -274,13 +298,13 @@ fn get_active_fields(
                             <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
                         });
                         quote! {
-                            (||
-                                if let #FQOption::Some(field) = #get_field {
-                                    #value
+                            (|| -> #FQResult<_, #bevy_reflect_path::FromReflectError> {
+                                if let #FQResult::Ok(field) = #get_field {
+                                    #value.map_err(|err| #internal_error)
                                 } else {
-                                    #FQOption::Some(#path())
+                                    #FQResult::Ok(#path())
                                 }
-                            )
+                            })
                         }
                     }
                     DefaultBehavior::Default => {
@@ -288,13 +312,13 @@ fn get_active_fields(
                             <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
                         });
                         quote! {
-                            (||
-                                if let #FQOption::Some(field) = #get_field {
-                                    #value
+                            (|| -> #FQResult<_, #bevy_reflect_path::FromReflectError>  {
+                                if let #FQResult::Ok(field) = #get_field {
+                                    #value.map_err(|err| #internal_error)
                                 } else {
-                                    #FQOption::Some(#FQDefault::default())
+                                    #FQResult::Ok(#FQDefault::default())
                                 }
-                            )
+                            })
                         }
                     }
                     DefaultBehavior::Required => {
@@ -302,7 +326,7 @@ fn get_active_fields(
                             <#ty as #bevy_reflect_path::FromReflect>::from_reflect(#get_field?)
                         });
                         quote! {
-                            (|| #value)
+                            (|| -> #FQResult<_, #bevy_reflect_path::FromReflectError> { #value.map_err(|err| #internal_error) })
                         }
                     }
                 };

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -135,7 +135,7 @@ impl<T: FromReflect> FromType<T> for ReflectFromReflect {
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum FromReflectError {
     #[error("attempted to convert `{}` to `{}`", .0.received, .0.expected)]
-    /// Attempted to convert the wrong [kind](ReflectKind) to a type, e.g. a struct to a enum.
+    /// Attempted to convert the wrong [kind](crate::ReflectKind) to a type, e.g. a struct to a enum.
     MismatchedKinds(#[from] ReflectKindMismatchError),
 
     #[error("`{from_type}` is not `{to_type}`")]

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -1,5 +1,7 @@
-use crate::{FromType, PartialReflect, Reflect};
-use alloc::boxed::Box;
+use crate::{FromType, PartialReflect, Reflect, ReflectKindMismatchError};
+use alloc::string::{String, ToString};
+use alloc::{boxed::Box, vec::Vec};
+use thiserror::Error;
 
 /// A trait that enables types to be dynamically constructed from reflected data.
 ///
@@ -28,7 +30,7 @@ use alloc::boxed::Box;
 )]
 pub trait FromReflect: Reflect + Sized {
     /// Constructs a concrete instance of `Self` from a reflected value.
-    fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self>;
+    fn from_reflect(reflect: &dyn PartialReflect) -> Result<Self, FromReflectError>;
 
     /// Attempts to downcast the given value to `Self` using,
     /// constructing the value using [`from_reflect`] if that fails.
@@ -42,12 +44,12 @@ pub trait FromReflect: Reflect + Sized {
     /// [`DynamicList`]: crate::DynamicList
     fn take_from_reflect(
         reflect: Box<dyn PartialReflect>,
-    ) -> Result<Self, Box<dyn PartialReflect>> {
+    ) -> Result<Self, (FromReflectError, Box<dyn PartialReflect>)> {
         match reflect.try_take::<Self>() {
             Ok(value) => Ok(value),
             Err(value) => match Self::from_reflect(value.as_ref()) {
-                None => Err(value),
-                Some(value) => Ok(value),
+                Err(err) => Err((err, value)),
+                Ok(value) => Ok(value),
             },
         }
     }
@@ -104,7 +106,7 @@ pub trait FromReflect: Reflect + Sized {
 /// [`DynamicEnum`]: crate::DynamicEnum
 #[derive(Clone)]
 pub struct ReflectFromReflect {
-    from_reflect: fn(&dyn PartialReflect) -> Option<Box<dyn Reflect>>,
+    from_reflect: fn(&dyn PartialReflect) -> Result<Box<dyn Reflect>, FromReflectError>,
 }
 
 impl ReflectFromReflect {
@@ -112,7 +114,10 @@ impl ReflectFromReflect {
     ///
     /// This will convert the object to a concrete type if it wasn't already, and return
     /// the value as `Box<dyn Reflect>`.
-    pub fn from_reflect(&self, reflect_value: &dyn PartialReflect) -> Option<Box<dyn Reflect>> {
+    pub fn from_reflect(
+        &self,
+        reflect_value: &dyn PartialReflect,
+    ) -> Result<Box<dyn Reflect>, FromReflectError> {
         (self.from_reflect)(reflect_value)
     }
 }
@@ -123,6 +128,81 @@ impl<T: FromReflect> FromType<T> for ReflectFromReflect {
             from_reflect: |reflect_value| {
                 T::from_reflect(reflect_value).map(|value| Box::new(value) as Box<dyn Reflect>)
             },
+        }
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum FromReflectError {
+    #[error("attempted to convert `{}` to `{}`", .0.received, .0.expected)]
+    /// Attempted to convert the wrong [kind](ReflectKind) to a type, e.g. a struct to a enum.
+    MismatchedKinds(#[from] ReflectKindMismatchError),
+
+    #[error("`{from_type}` is not `{to_type}`")]
+    /// Tried to convert incompatible types.
+    MismatchedTypes {
+        from_type: Box<str>,
+        to_type: Box<str>,
+    },
+
+    #[error("attempted to convert type with {from_size} size to a type with {to_size} size")]
+    /// Attempted to convert to types with mismatched sizes, e.g. a [u8; 4] to [u8; 3].
+    DifferentSize { from_size: usize, to_size: usize },
+
+    #[error("attempted to convert missing tuple index `{0}`")]
+    MissingTupleIndex(usize),
+
+    #[error("attempted to convert missing field `{0}`")]
+    MissingField(Box<str>),
+
+    #[error("attempted to convert missing enum variant `{0}`")]
+    MissingEnumVariant(Box<str>),
+
+    #[error("{} at path `{}`", self.leaf_error(), self.path())]
+    FieldError(Box<str>, Box<FromReflectError>),
+
+    #[error("{} at path `{}`", self.leaf_error(), self.path())]
+    TupleIndexError(usize, Box<FromReflectError>),
+
+    #[error("{} at path `{}`", self.leaf_error(), self.path())]
+    VariantError(Box<str>, Box<FromReflectError>),
+}
+
+impl FromReflectError {
+    fn leaf_error(&self) -> String {
+        match self {
+            FromReflectError::FieldError(_, error)
+            | FromReflectError::TupleIndexError(_, error)
+            | FromReflectError::VariantError(_, error) => error.leaf_error(),
+            other => other.to_string(),
+        }
+    }
+
+    fn path(&self) -> String {
+        self.reverse_path()
+            .iter()
+            .rev()
+            .fold(String::new(), |acc, x| acc + x)
+    }
+
+    fn reverse_path(&self) -> Vec<String> {
+        match self {
+            FromReflectError::FieldError(field, error) => {
+                let mut path = error.reverse_path();
+                path.push(".".to_string() + field);
+                path
+            }
+            FromReflectError::TupleIndexError(index, error) => {
+                let mut path = error.reverse_path();
+                path.push(".".to_string() + &index.to_string());
+                path
+            }
+            FromReflectError::VariantError(variant, error) => {
+                let mut path = error.reverse_path();
+                path.push("::".to_string() + variant);
+                path
+            }
+            _other => Vec::new(),
         }
     }
 }

--- a/crates/bevy_reflect/src/impls/smol_str.rs
+++ b/crates/bevy_reflect/src/impls/smol_str.rs
@@ -30,6 +30,6 @@ mod tests {
     fn smolstr_should_from_reflect() {
         let smolstr = SmolStr::new("hello_world.rs");
         let output = <SmolStr as FromReflect>::from_reflect(&smolstr);
-        assert_eq!(Some(smolstr), output);
+        assert_eq!(Ok(smolstr), output);
     }
 }

--- a/crates/bevy_reflect/src/kind.rs
+++ b/crates/bevy_reflect/src/kind.rs
@@ -131,7 +131,7 @@ macro_rules! impl_reflect_kind_conversions {
 /// Caused when a type was expected to be of a certain [kind], but was not.
 ///
 /// [kind]: ReflectKind
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 #[error("kind mismatch: expected {expected:?}, received {received:?}")]
 pub struct ReflectKindMismatchError {
     pub expected: ReflectKind,

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1036,7 +1036,7 @@ mod tests {
         dyn_tuple_struct.insert(3_i32);
         let my_tuple_struct = <MyTupleStruct as FromReflect>::from_reflect(&dyn_tuple_struct);
 
-        assert_eq!(Some(expected), my_tuple_struct);
+        assert_eq!(Ok(expected), my_tuple_struct);
 
         #[derive(Reflect, Eq, PartialEq, Debug)]
         enum MyEnum {
@@ -1054,7 +1054,7 @@ mod tests {
 
         let my_enum = <MyEnum as FromReflect>::from_reflect(&dyn_enum);
 
-        assert_eq!(Some(expected), my_enum);
+        assert_eq!(Ok(expected), my_enum);
     }
 
     #[test]
@@ -1092,7 +1092,7 @@ mod tests {
         let dyn_struct = DynamicStruct::default();
         let my_struct = <MyStruct as FromReflect>::from_reflect(&dyn_struct);
 
-        assert_eq!(Some(expected), my_struct);
+        assert_eq!(Ok(expected), my_struct);
     }
 
     #[test]
@@ -1116,7 +1116,7 @@ mod tests {
         let dyn_enum = DynamicEnum::new("Foo", DynamicTuple::default());
         let my_enum = <MyEnum as FromReflect>::from_reflect(&dyn_enum);
 
-        assert_eq!(Some(expected), my_enum);
+        assert_eq!(Ok(expected), my_enum);
 
         let expected = MyEnum::Bar {
             baz: get_baz_default(),
@@ -1125,7 +1125,7 @@ mod tests {
         let dyn_enum = DynamicEnum::new("Bar", DynamicStruct::default());
         let my_enum = <MyEnum as FromReflect>::from_reflect(&dyn_enum);
 
-        assert_eq!(Some(expected), my_enum);
+        assert_eq!(Ok(expected), my_enum);
     }
 
     #[test]
@@ -1155,7 +1155,7 @@ mod tests {
         let dyn_struct = DynamicStruct::default();
         let my_struct = <MyStruct as FromReflect>::from_reflect(&dyn_struct);
 
-        assert_eq!(Some(expected), my_struct);
+        assert_eq!(Ok(expected), my_struct);
     }
 
     #[test]

--- a/crates/bevy_reflect/src/serde/de/mod.rs
+++ b/crates/bevy_reflect/src/serde/de/mod.rs
@@ -762,7 +762,7 @@ mod tests {
             .deserialize(&mut ron_deserializer)
             .unwrap();
 
-        assert!(<Foo as FromReflect>::from_reflect(dynamic_output.as_partial_reflect()).is_none());
+        assert!(<Foo as FromReflect>::from_reflect(dynamic_output.as_partial_reflect()).is_err());
     }
 
     #[cfg(feature = "functions")]

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -693,7 +693,7 @@ impl<T: TypePath + FromReflect + erased_serde::Serialize> FromType<T> for Reflec
                 value
                     .downcast_ref::<T>()
                     .map(|value| Serializable::Borrowed(value))
-                    .or_else(|| T::from_reflect(value.as_partial_reflect()).map(|value| Serializable::Owned(Box::new(value))))
+                    .or_else(|| T::from_reflect(value.as_partial_reflect()).ok().map(|value| Serializable::Owned(Box::new(value))))
                     .unwrap_or_else(|| {
                         panic!(
                             "FromReflect::from_reflect failed when called on type `{}` with this value: {value:?}",

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -305,7 +305,7 @@ impl<'w> DynamicSceneBuilder<'w> {
                     // deserialize.
                     let component = type_registration
                         .data::<ReflectFromReflect>()
-                        .and_then(|fr| fr.from_reflect(component.as_partial_reflect()))
+                        .and_then(|fr| fr.from_reflect(component.as_partial_reflect()).ok())
                         .map(PartialReflect::into_partial_reflect)
                         .unwrap_or_else(|| component.clone_value());
 
@@ -373,7 +373,7 @@ impl<'w> DynamicSceneBuilder<'w> {
 
                 let resource = type_registration
                     .data::<ReflectFromReflect>()
-                    .and_then(|fr| fr.from_reflect(resource.as_partial_reflect()))
+                    .and_then(|fr| fr.from_reflect(resource.as_partial_reflect()).ok())
                     .map(PartialReflect::into_partial_reflect)
                     .unwrap_or_else(|| resource.clone_value());
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -496,7 +496,7 @@ impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
                 .registry
                 .get(registration.type_id())
                 .and_then(|tr| tr.data::<ReflectFromReflect>())
-                .and_then(|fr| fr.from_reflect(value.as_partial_reflect()))
+                .and_then(|fr| fr.from_reflect(value.as_partial_reflect()).ok())
                 .map(PartialReflect::into_partial_reflect)
                 .unwrap_or(value);
 


### PR DESCRIPTION
# Objective

- Fixes #5967.

## Solution

- Create a new Error type `FromReflectError` that enumerates all possible failure cases.
- It can pinpoint the exact path of error within a large structure.

## Testing

TODO

---

## Showcase

TODO

<details>
  <summary>TODO</summary>

```rust
println!("My super cool code.");
```

</details>

## Migration Guide

- Append all `from_reflect` calls with `.ok()` to convert a `Result` to an `Option`.
