### PR TITLE
Improve Compiler Errors for `bevy_tasks`

### DIFF
--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -16,6 +16,9 @@ extern crate std;
 
 extern crate alloc;
 
+#[cfg(not(any(feature = "async_executor", feature = "edge_executor")))]
+compile_error!("Either of the `async_executor` or the `edge_executor` features must be enabled.");
+
 #[cfg(not(target_arch = "wasm32"))]
 mod conditional_send {
     /// Use [`ConditionalSend`] to mark an optional Send trait bound. Useful as on certain platforms (eg. Wasm),
@@ -45,6 +48,7 @@ pub type BoxedFuture<'a, T> = core::pin::Pin<Box<dyn ConditionalSendFuture<Outpu
 
 pub mod futures;
 
+#[cfg(any(feature = "async_executor", feature = "edge_executor"))]
 mod executor;
 
 mod slice;

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -12,11 +12,49 @@ use portable_atomic_util::Arc;
 #[cfg(not(feature = "portable-atomic"))]
 use alloc::sync::Arc;
 
-#[cfg(feature = "std")]
+#[cfg(all(
+    feature = "std",
+    any(feature = "async_executor", feature = "edge_executor")
+))]
 use crate::executor::LocalExecutor;
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(
+    not(feature = "std"),
+    any(feature = "async_executor", feature = "edge_executor")
+))]
 use crate::executor::Executor as LocalExecutor;
+
+#[cfg(not(any(feature = "async_executor", feature = "edge_executor")))]
+mod dummy_executor {
+    use async_task::Task;
+    use core::{future::Future, marker::PhantomData};
+
+    /// Dummy implementation of a `LocalExecutor` to allow for a cleaner compiler error
+    /// due to missing feature flags.
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub struct LocalExecutor<'a>(PhantomData<fn(&'a ())>);
+
+    impl<'a> LocalExecutor<'a> {
+        /// Dummy implementation
+        pub const fn new() -> Self {
+            Self(PhantomData)
+        }
+
+        /// Dummy implementation
+        pub fn try_tick(&self) -> bool {
+            unimplemented!()
+        }
+
+        /// Dummy implementation
+        pub fn spawn<T: 'a>(&self, _: impl Future<Output = T> + 'a) -> Task<T> {
+            unimplemented!()
+        }
+    }
+}
+
+#[cfg(not(any(feature = "async_executor", feature = "edge_executor")))]
+use dummy_executor::LocalExecutor;
 
 #[cfg(feature = "std")]
 thread_local! {


### PR DESCRIPTION
# Objective

- Fixes #17287

## Solution

- Added a dummy `LocalExecutor` (un)implementation to suppress irrelevant errors.
- Added explicit `compiler_error!` when _not_ selecting either the `async_executor` or `edge_executor` features

## Testing

- CI