### PR TITLE
Make `ObservedBy` public

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -64,7 +64,7 @@ pub mod prelude {
         entity::{Entity, EntityBorrow, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         name::{Name, NameOrEntity},
-        observer::{CloneEntityWithObserversExt, Observer, Trigger},
+        observer::{CloneEntityWithObserversExt, ObservedBy, Observer, Trigger},
         query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         removal_detection::RemovedComponents,
         result::{Error, Result},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -64,7 +64,7 @@ pub mod prelude {
         entity::{Entity, EntityBorrow, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         name::{Name, NameOrEntity},
-        observer::{CloneEntityWithObserversExt, ObservedBy, Observer, Trigger},
+        observer::{CloneEntityWithObserversExt, Observer, Trigger},
         query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         removal_detection::RemovedComponents,
         result::{Error, Result},

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 /// Tracks a list of entity observers for the [`Entity`] [`ObservedBy`] is added to.
 #[derive(Default)]
-pub(crate) struct ObservedBy(pub(crate) Vec<Entity>);
+pub struct ObservedBy(pub(crate) Vec<Entity>);
 
 impl Component for ObservedBy {
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -3,14 +3,13 @@
 mod entity_observer;
 mod runner;
 
-pub use entity_observer::CloneEntityWithObserversExt;
+pub use entity_observer::{CloneEntityWithObserversExt, ObservedBy};
 pub use runner::*;
 
 use crate::{
     archetype::ArchetypeFlags,
     component::ComponentId,
     entity::EntityHashMap,
-    observer::entity_observer::ObservedBy,
     prelude::*,
     system::IntoObserverSystem,
     world::{DeferredWorld, *},


### PR DESCRIPTION
# Objective
- Currently, the `ObservedBy`-component is only public within the `bevy_ecs` crate. Sometimes it is desirable to refer to this component in the "game-code". Two examples that come in mind:
  - Clearing all components in an entity, but intending to keep the existing observers: Making `ObservedBy` public allows us to use `commands.entity(entity).retain::<ObservedBy>();`, which clears all other components, but keeps `ObservedBy`, which prevents the Observers from despawning.
  - The opposite of the above, clearing all of entities' Observers: `commands.entity(entity).remove::<ObservedBy>` will despawn all associated Observers. Admittedly, a cleaner solution would be something like `commands.entity(entity).clear_observers()`, but this is sufficient.

## Solution

- Removed `(crate)` "rule" and added `ObservedBy` to the prelude-module

## Testing

- Linked `bevy_ecs` locally with another project to see if `ObservedBy` could be referenced.
