### PR TITLE
Add some multi-span text to the `text2d` example

### DIFF
--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -125,13 +125,23 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         (Anchor::BottomRight, Color::Srgba(BLUE)),
         (Anchor::BottomLeft, Color::Srgba(YELLOW)),
     ] {
-        commands.spawn((
-            Text2d::new(format!(" Anchor::{text_anchor:?} ")),
-            slightly_smaller_text_font.clone(),
-            TextColor(color),
-            Transform::from_translation(250. * Vec3::Y),
-            text_anchor,
-        ));
+        commands
+            .spawn((
+                Text2d::new(" Anchor".to_string()),
+                slightly_smaller_text_font.clone(),
+                Transform::from_translation(250. * Vec3::Y),
+                text_anchor,
+            ))
+            .with_child((
+                TextSpan("::".to_string()),
+                slightly_smaller_text_font.clone(),
+                TextColor(LIGHT_GREY.into()),
+            ))
+            .with_child((
+                TextSpan(format!("{text_anchor:?} ")),
+                slightly_smaller_text_font.clone(),
+                TextColor(color),
+            ));
     }
 }
 


### PR DESCRIPTION
# Objective

The `Text2d` example should have have some multi-span text.