### PR TITLE
Renamed members of `ParamWarnPolicy` to reflect new behaviour.

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -344,7 +344,7 @@ mod tests {
                 (|mut commands: Commands| {
                     commands.insert_resource(R2);
                 })
-                .param_warn_once(),
+                .warn_param_missing(),
             )
                 .chain(),
         );
@@ -367,20 +367,20 @@ mod tests {
         let mut world = World::new();
         let mut schedule = Schedule::default();
         schedule.set_executor_kind(executor);
-        schedule.configure_sets(S1.run_if((|_: Res<R1>| true).param_warn_once()));
+        schedule.configure_sets(S1.run_if((|_: Res<R1>| true).warn_param_missing()));
         schedule.add_systems((
             // System gets skipped if system set run conditions fail validation.
             (|mut commands: Commands| {
                 commands.insert_resource(R1);
             })
-            .param_warn_once()
+            .warn_param_missing()
             .in_set(S1),
             // System gets skipped if run conditions fail validation.
             (|mut commands: Commands| {
                 commands.insert_resource(R2);
             })
-            .param_warn_once()
-            .run_if((|_: Res<R2>| true).param_warn_once()),
+            .warn_param_missing()
+            .run_if((|_: Res<R2>| true).warn_param_missing()),
         ));
         schedule.run(&mut world);
         assert!(world.get_resource::<R1>().is_none());

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -195,7 +195,7 @@ pub enum ParamWarnPolicy {
     /// No warning should ever be emitted.
     Never,
     /// The warning will be emitted once and status will update to [`Self::Never`].
-    Once,
+    Warn,
 }
 
 impl ParamWarnPolicy {
@@ -218,7 +218,7 @@ impl ParamWarnPolicy {
                 name,
                 disqualified::ShortName::of::<P>()
             ),
-            Self::Once => {
+            Self::Warn => {
                 log::warn!(
                     "{0} did not run because it requested inaccessible system parameter {1}",
                     name,
@@ -241,13 +241,13 @@ where
     /// Set warn policy.
     fn with_param_warn_policy(self, warn_policy: ParamWarnPolicy) -> FunctionSystem<M, F>;
 
-    /// Warn only once about invalid system parameters.
-    fn param_warn_once(self) -> FunctionSystem<M, F> {
-        self.with_param_warn_policy(ParamWarnPolicy::Once)
+    /// Warn and ignore systems with invalid parameters.
+    fn warn_param_missing(self) -> FunctionSystem<M, F> {
+        self.with_param_warn_policy(ParamWarnPolicy::Warn)
     }
 
-    /// Disable all param warnings.
-    fn never_param_warn(self) -> FunctionSystem<M, F> {
+    /// Silently ignore systems with invalid parameters.
+    fn ignore_param_missing(self) -> FunctionSystem<M, F> {
         self.with_param_warn_policy(ParamWarnPolicy::Never)
     }
 }

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -450,7 +450,7 @@ mod tests {
 
         let mut world = World::default();
         // This fails because `T` has not been added to the world yet.
-        let result = world.run_system_once(system.param_warn_once());
+        let result = world.run_system_once(system.warn_param_missing());
 
         assert!(matches!(result, Err(RunSystemError::InvalidParams(_))));
     }

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -805,7 +805,7 @@ mod tests {
         fn system(_: Res<T>) {}
 
         let mut world = World::new();
-        let id = world.register_system(system.param_warn_once());
+        let id = world.register_system(system.warn_param_missing());
         // This fails because `T` has not been added to the world yet.
         let result = world.run_system(id);
 

--- a/examples/ecs/fallible_params.rs
+++ b/examples/ecs/fallible_params.rs
@@ -27,13 +27,13 @@ fn main() {
         .add_systems(
             Update,
             (
-                user_input.param_warn_once(),
-                move_targets.never_param_warn(),
-                move_pointer.never_param_warn(),
+                user_input.warn_param_missing(),
+                move_targets.ignore_param_missing(),
+                move_pointer.ignore_param_missing(),
             )
                 .chain(),
         )
-        .add_systems(Update, do_nothing_fail_validation.param_warn_once())
+        .add_systems(Update, do_nothing_fail_validation.warn_param_missing())
         .run();
 }
 


### PR DESCRIPTION
- `Once` renamed to `Warn`.
- `param_warn_once()` renamed to `warn_param_missing()`.
- `never_param_warn()` renamed to `ignore_param_missing()`.

Also includes changes to the documentation of the above methods.

Fixes #17262.

## Migration Guide
- `ParamWarnPolicy::Once` has been renamed to `ParamWarnPolicy::Warn`.
- `ParamWarnPolicy::param_warn_once` has been renamed to `ParamWarnPolicy::warn_param_missing`.
- `ParamWarnPolicy::never_param_warn` has been renamed to `ParamWarnPolicy::ignore_param_missing`.