### PR TITLE
Feature gate `bevy_reflect` in `bevy_image`.

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+default = ["bevy_reflect"]
+
+bevy_reflect = ["dep:bevy_reflect", "bevy_math/bevy_reflect"]
+
 # Image formats
 basis-universal = ["dep:basis-universal"]
 bmp = ["image/bmp"]
@@ -26,7 +30,7 @@ qoi = ["image/qoi"]
 tga = ["image/tga"]
 tiff = ["image/tiff"]
 webp = ["image/webp"]
-serialize = []
+serialize = ["bevy_reflect"]
 
 # For ktx2 supercompression
 zlib = ["flate2"]
@@ -40,12 +44,10 @@ bevy_color = { path = "../bevy_color", version = "0.16.0-dev", features = [
   "serialize",
   "wgpu-types",
 ] }
-bevy_math = { path = "../bevy_math", version = "0.16.0-dev", features = [
-  "bevy_reflect",
-] }
+bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "bevy",
-] }
+], optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 
 # rendering

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -4,12 +4,12 @@ use super::basis::*;
 use super::dds::*;
 #[cfg(feature = "ktx2")]
 use super::ktx2::*;
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 use bevy_asset::{Asset, RenderAssetUsages};
 use bevy_color::{Color, ColorToComponents, Gray, LinearRgba, Srgba, Xyza};
 use bevy_math::{AspectRatio, UVec2, UVec3, Vec2};
-use bevy_reflect::std_traits::ReflectDefault;
-use bevy_reflect::Reflect;
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -331,9 +331,12 @@ impl ImageFormat {
     }
 }
 
-#[derive(Asset, Reflect, Debug, Clone)]
-#[reflect(opaque)]
-#[reflect(Default, Debug)]
+#[derive(Asset, Debug, Clone)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(opaque, Default, Debug)
+)]
 pub struct Image {
     pub data: Vec<u8>,
     // TODO: this nesting makes accessing Image metadata verbose. Either flatten out descriptor or add accessors

--- a/crates/bevy_image/src/texture_atlas.rs
+++ b/crates/bevy_image/src/texture_atlas.rs
@@ -15,7 +15,7 @@ pub struct TextureAtlasPlugin;
 impl Plugin for TextureAtlasPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<TextureAtlasLayout>();
-        
+
         #[cfg(feature = "bevy_reflect")]
         app.register_asset_reflect::<TextureAtlasLayout>()
             .register_type::<TextureAtlas>();

--- a/crates/bevy_image/src/texture_atlas.rs
+++ b/crates/bevy_image/src/texture_atlas.rs
@@ -1,6 +1,7 @@
 use bevy_app::prelude::*;
 use bevy_asset::{Asset, AssetApp as _, AssetId, Assets, Handle};
 use bevy_math::{URect, UVec2};
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -13,8 +14,10 @@ pub struct TextureAtlasPlugin;
 
 impl Plugin for TextureAtlasPlugin {
     fn build(&self, app: &mut App) {
-        app.init_asset::<TextureAtlasLayout>()
-            .register_asset_reflect::<TextureAtlasLayout>()
+        app.init_asset::<TextureAtlasLayout>();
+        
+        #[cfg(feature = "bevy_reflect")]
+        app.register_asset_reflect::<TextureAtlasLayout>()
             .register_type::<TextureAtlas>();
     }
 }
@@ -69,10 +72,13 @@ impl TextureAtlasSources {
 /// [Example usage loading sprite sheet.](https://github.com/bevyengine/bevy/blob/latest/examples/2d/texture_atlas.rs)
 ///
 /// [`TextureAtlasBuilder`]: crate::TextureAtlasBuilder
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Asset, Reflect, PartialEq, Eq, Debug, Clone)]
-#[reflect(Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[derive(Asset, PartialEq, Eq, Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
 pub struct TextureAtlasLayout {
     /// Total size of texture atlas.
     pub size: UVec2,
@@ -176,8 +182,8 @@ impl TextureAtlasLayout {
 /// - [`animated sprite sheet example`](https://github.com/bevyengine/bevy/blob/latest/examples/2d/sprite_sheet.rs)
 /// - [`sprite animation event example`](https://github.com/bevyengine/bevy/blob/latest/examples/2d/sprite_animation.rs)
 /// - [`texture atlas example`](https://github.com/bevyengine/bevy/blob/latest/examples/2d/texture_atlas.rs)
-#[derive(Default, Debug, Clone, Reflect)]
-#[reflect(Default, Debug)]
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Default, Debug))]
 pub struct TextureAtlas {
     /// Texture atlas layout handle
     pub layout: Handle<TextureAtlasLayout>,


### PR DESCRIPTION
Fixes #17294.