### PR TITLE
Set certain workflows to run in the merge queue, but not on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
       - release-*
 
 env:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,7 @@
 name: Dependencies
 
 on:
+  merge_group:
   pull_request:
     paths:
       - '**/Cargo.toml'
@@ -9,8 +10,6 @@ on:
     paths:
       - '**/Cargo.toml'
       - 'deny.toml'
-    branches:
-      - main
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
       - release-*
 
 concurrency:


### PR DESCRIPTION
# Objective
I discovered that certain workflows run more often than they need to. In particular, the CI and Validation Jobs workflows run twice when merged - once in the merge queue, and another when properly merged into `main`.

Additionally, the Dependencies workflow was not running in the merge queue at all.

## Solution
Set CI, Validation Jobs, and Dependencies to run in the merge queue, but not in workflows.

The "Deploy Docs" workflow has not been changed; it will continue to run only on pushes to `main` (and when dispatched manually), as it deploys to Github pages - and we don't want failed merge queue stuff to deploy to github pages!

## Testing
Well I guess we'll find out if these changes work, won't we?