### PR TITLE
bevy_input_focus: Apply `#![warn(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
+#![warn(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `warn`, and bring `bevy_input_focus` in line with the new restrictions.

## Testing
`cargo clippy --tests --all-features --features bevy_math/std,bevy_input/smol_str --package bevy_input_focus` was run, and only an unrelated warning from `bevy_ecs` was encountered.

I could not test without the `bevy_math/std` feature due to compilation errors with `glam`. Additionally, I had to use the `bevy_input/smol_str` feature, as it appears some of `bevy_input_focus`' tests rely on that feature. I will investigate these issues further, and make issues/PRs as necessary.