### PR TITLE
bevy_dylib: Apply `#![warn(clippy::allow_attributes, clippy::allow_attributes_without_reason)]`

### DIFF
--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -1,4 +1,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![warn(
+    clippy::allow_attributes,
+    clippy::allow_attributes_without_reason,
+    reason = "See #17111; To be removed once all crates are in-line with these attributes"
+)]
 #![doc(
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
@@ -54,6 +59,9 @@
 //! ```
 
 // Force linking of the main bevy crate
-#[allow(unused_imports)]
-#[allow(clippy::single_component_path_imports)]
+#[expect(
+    unused_imports,
+    clippy::single_component_path_imports,
+    reason = "This links the main bevy crate when using dynamic linking, and as such cannot be removed or changed without affecting dynamic linking."
+)]
 use bevy_internal;


### PR DESCRIPTION
# Objective
- https://github.com/bevyengine/bevy/issues/17111

## Solution
Set the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints to `warn`, and bring `bevy_dylib` in line with the new restrictions.

## Testing
`cargo clippy --tests --all-features --package bevy_dylib` was run, and no warnings were encountered.

I would've skipped over this crate if there weren't the two lint attributes in it - might as well handle it now, y'know?