### PR TITLE
Remove `Event: Component` trait bound

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1098,6 +1098,20 @@ pub struct Components {
 }
 
 impl Components {
+    /// Generates a new [`ComponentId`] for the provided Rust type from its [`TypeId`],
+    /// returning any existing [`ComponentId`] if the type has already been registered.
+    ///
+    /// For read-only access, see [`Components::component_id`].
+    pub fn generate_component_id<T: ?Sized + 'static>(&mut self) -> ComponentId {
+        if let Some(component_id) = self.indices.get(&TypeId::of::<T>()) {
+            component_id.clone()
+        } else {
+            let id = ComponentId(self.components.len());
+            self.indices.insert(TypeId::of::<T>(), id);
+            id
+        }
+    }
+
     /// Registers a [`Component`] of type `T` with this instance.
     /// If a component of this type has already been registered, this will return
     /// the ID of the pre-existing component.

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -20,7 +20,7 @@ use core::{
 /// This trait can be derived.
 ///
 /// Each event type has a unique [`ComponentId`] associated with it, which is used to store the event in the world.
-/// This can be obtained using [`World::generate_component_id<Self>`].
+/// This can be obtained using [`World::generate_component_id<Self>`](crate::world::World::generate_component_id).
 ///
 /// Each individual event sent has an [`EventId`] associated with it, which can be used to trace the flow of an event.
 ///

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -19,8 +19,10 @@ use core::{
 ///
 /// This trait can be derived.
 ///
-/// Each event has a unique [`ComponentId`] associated with it, which is used to store the event in the world.
+/// Each event type has a unique [`ComponentId`] associated with it, which is used to store the event in the world.
 /// This can be obtained using [`World::generate_component_id<Self>`].
+///
+/// Each individual event sent has an [`EventId`] associated with it, which can be used to trace the flow of an event.
 ///
 /// Events must be thread-safe.
 ///

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -1,4 +1,4 @@
-use crate::{component::Component, traversal::Traversal};
+use crate::traversal::Traversal;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 #[cfg(feature = "track_location")]
@@ -35,7 +35,7 @@ use core::{
     label = "invalid `Event`",
     note = "consider annotating `{Self}` with `#[derive(Event)]`"
 )]
-pub trait Event: Component {
+pub trait Event: Send + Sync + 'static {
     /// The component that describes which Entity to propagate this event to next, when [propagation] is enabled.
     ///
     /// [propagation]: crate::observer::Trigger::propagate

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -19,9 +19,8 @@ use core::{
 ///
 /// This trait can be derived.
 ///
-/// Events implement the [`Component`] type (and they automatically do when they are derived). Events are (generally)
-/// not directly inserted as components. More often, the [`ComponentId`] is used to identify the event type within the
-/// context of the ECS.
+/// Each event has a unique [`ComponentId`] associated with it, which is used to store the event in the world.
+/// This can be obtained using [`World::generate_component_id<Self>`].
 ///
 /// Events must be thread-safe.
 ///

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -522,7 +522,7 @@ impl World {
     /// those that don't will be consumed and will no longer be accessible.
     /// If you need to use the event after triggering it, use [`World::trigger_ref`] instead.
     pub fn trigger<E: Event>(&mut self, mut event: E) {
-        let event_id = self.register_component::<E>();
+        let event_id = self.generate_component_id::<E>();
         // SAFETY: We just registered `event_id` with the type of `event`
         unsafe { self.trigger_targets_dynamic_ref(event_id, &mut event, ()) };
     }
@@ -532,7 +532,7 @@ impl World {
     /// Compared to [`World::trigger`], this method is most useful when it's necessary to check
     /// or use the event after it has been modified by observers.
     pub fn trigger_ref<E: Event>(&mut self, event: &mut E) {
-        let event_id = self.register_component::<E>();
+        let event_id = self.generate_component_id::<E>();
         // SAFETY: We just registered `event_id` with the type of `event`
         unsafe { self.trigger_targets_dynamic_ref(event_id, event, ()) };
     }
@@ -543,7 +543,7 @@ impl World {
     /// those that don't will be consumed and will no longer be accessible.
     /// If you need to use the event after triggering it, use [`World::trigger_targets_ref`] instead.
     pub fn trigger_targets<E: Event>(&mut self, mut event: E, targets: impl TriggerTargets) {
-        let event_id = self.register_component::<E>();
+        let event_id = self.generate_component_id::<E>();
         // SAFETY: We just registered `event_id` with the type of `event`
         unsafe { self.trigger_targets_dynamic_ref(event_id, &mut event, targets) };
     }
@@ -554,7 +554,7 @@ impl World {
     /// Compared to [`World::trigger_targets`], this method is most useful when it's necessary to check
     /// or use the event after it has been modified by observers.
     pub fn trigger_targets_ref<E: Event>(&mut self, event: &mut E, targets: impl TriggerTargets) {
-        let event_id = self.register_component::<E>();
+        let event_id = self.generate_component_id::<E>();
         // SAFETY: We just registered `event_id` with the type of `event`
         unsafe { self.trigger_targets_dynamic_ref(event_id, event, targets) };
     }

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -398,13 +398,13 @@ fn hook_on_add<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     _: ComponentId,
 ) {
     world.commands().queue(move |world: &mut World| {
-        let event_type = world.register_component::<E>();
+        let event_id = world.generate_component_id::<E>();
         let mut components = Vec::new();
         B::component_ids(&mut world.components, &mut world.storages, &mut |id| {
             components.push(id);
         });
         let mut descriptor = ObserverDescriptor {
-            events: vec![event_type],
+            events: vec![event_id],
             components,
             ..Default::default()
         };

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -236,6 +236,14 @@ impl World {
         unsafe { Commands::new_raw_from_entities(self.command_queue.clone(), &self.entities) }
     }
 
+    /// Generates a new [`ComponentId`] for the provided Rust type from its [`TypeId`],
+    /// returning any existing [`ComponentId`] if the type has already been registered.
+    ///
+    /// For read-only access, see [`World::component_id`].
+    pub fn generate_component_id<T: ?Sized + 'static>(&mut self) -> ComponentId {
+        self.components.generate_component_id::<T>()
+    }
+
     /// Registers a new [`Component`] type and returns the [`ComponentId`] created for it.
     pub fn register_component<T: Component>(&mut self) -> ComponentId {
         self.components.register_component::<T>(&mut self.storages)


### PR DESCRIPTION
# Objective

As raised in https://github.com/bevyengine/bevy/pull/17317, the `Event: Component` trait bound is confusing to users.

In general, a type `E` (like `AppExit`) which implements `Event` should not:

- be stored as a component on an entity
- be a valid option for `Query<&AppExit>`
- require the storage type and other component metadata to be specified

Events are not components (even if they one day use some of the same internal mechanisms), and this trait bound is confusing to users.

We're also automatically generating `Component` impls with our derive macro, which should be avoided when possible to improve explicitness and avoid conflicts with user impls.

P.S. This prompted a [larger hackmd design](https://hackmd.io/@bevy/SypE1qZP1l) from me about the core principles of "make everything entities and components". 

## Context

Dynamic events (which observers support IIRC) require a mapping from `TypeId` to "some arbitrary stable ID". We decided to use `ComponentId` there when implementing this, as the code / concept already exists. The easiest way to get the observers API compiling as a result was to just add a `Component` trait bound.

## Solution

1. Add a dead simple way to get a `ComponentId` for any Rust types.
2. Generate the `ComponentId` for events (inside of the observers API) using this new method.
3. Relax the `Component` trait bound on `Event` to `Send + Sync + 'static`.

Unlike I initially thought, we cannot (and should not) relax the `Component` trait bound on `register_component`, as other work is done to make sure the component is properly set up (like registering hooks).

This change does not:

- restrict our ability to implement dynamic buffered events (the main improvement over #17317)
   - there's still a fair bit of work to do, but this is a step in the right direction
- limit our ability to store event metadata on entities in the future
- make it harder for users to work with types that are both events and components (just add the derive / trait bound)

## Future work

1. Use `generate_component_id` inside of our existing methods to improve clarity and reduce duplication.
2. Consider renaming `ComponentId` to something that isn't component-specific.

## Testing

Code compiles, and `alien_cake_addict` works. If something goes wrong here *everything* will break.

## Migration Guide

The `Event` trait no longer requires the `Component` trait. If you were relying on this behavior, change your trait bounds from `Event` to `Event + Component`. If you also want your `Event` type to implement `Component`, add a derive.
