### PR TITLE
Change Camera.viewport_to_world_2d to rescale according to the rendering target's scaling factor

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -593,7 +593,7 @@ impl Camera {
 
         // Rescale by the rendering target's scaling factor if we have it.
         let scale_factor = self.target_scaling_factor().unwrap_or(1.);
-        viewport_position = viewport_position / scale_factor;
+        viewport_position /= scale_factor;
 
         // Flip the Y co-ordinate origin from the top to the bottom.
         viewport_position.y = target_size.y - viewport_position.y;

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -590,6 +590,11 @@ impl Camera {
         let target_size = self
             .logical_viewport_size()
             .ok_or(ViewportConversionError::NoViewportSize)?;
+
+        // Rescale by the rendering target's scaling factor if we have it.
+        let scale_factor = self.target_scaling_factor().unwrap_or(1.);
+        viewport_position = viewport_position / scale_factor;
+
         // Flip the Y co-ordinate origin from the top to the bottom.
         viewport_position.y = target_size.y - viewport_position.y;
         let ndc = viewport_position * 2. / target_size - Vec2::ONE;


### PR DESCRIPTION
Camera.viewport_to_world_2d doesn't behave as expected with the target window is rescaled, or didn't have a 1:1 scale factor in the first place. If the rendering target has enough information for us to get its scaling factor, we should use it to rescale the viewport coordinates before computing normalized device coordinates and then converting to world coordinates. This change should preserve the existing behavior if rendering target information is not available.


Fixes #17312



## Solution

Get the target_scaling_factor option from our camera and unwrap_or, with default 1.0, so we will use the scaling factor if it exists. It might be that we want to return an error if this option is `None`, but it didn't care before, so perhaps the safer change is to default to the previous behavior if we can't rescale in the first place.

## Testing

Issue reported included an MRE here:

[Issue MRE](https://gist.github.com/GitGhillie/44e02ab79f7e054ba939281b738fa10f)

This change successfully addresses the undesirable behavior in the MRE

<img width="983" alt="Screenshot 2025-01-12 at 9 05 39 PM" src="https://github.com/user-attachments/assets/fee7021f-6008-4826-bcd5-62eabd10abe5" />


---

## Migration Guide

If you were using Camera.viewport_to_world_2d previously and manually correcting for scaling, it will probably break!