### PR TITLE
Child spawning optimizations

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -84,6 +84,11 @@ path = "benches/bevy_picking/main.rs"
 harness = false
 
 [[bench]]
+name = "hierarchy"
+path = "benches/bevy_hierarchy/main.rs"
+harness = false
+
+[[bench]]
 name = "reflect"
 path = "benches/bevy_reflect/main.rs"
 harness = false

--- a/benches/benches/bevy_hierarchy/main.rs
+++ b/benches/benches/bevy_hierarchy/main.rs
@@ -1,0 +1,5 @@
+use criterion::criterion_main;
+
+mod spawn;
+
+criterion_main!(spawn::benches);

--- a/benches/benches/bevy_hierarchy/spawn.rs
+++ b/benches/benches/bevy_hierarchy/spawn.rs
@@ -1,0 +1,41 @@
+use bevy_ecs::prelude::*;
+use bevy_ecs::world::CommandQueue;
+use bevy_hierarchy::prelude::*;
+use core::hint::black_box;
+use criterion::{criterion_group, Criterion};
+
+criterion_group!(benches, spawn_children);
+
+fn spawn_children(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spawn_children");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+
+    for entity_count in (1..7).map(|i| 10i32.pow(i)) {
+        group.bench_function(format!("{}_entities", entity_count), |bencher| {
+            let mut world = World::default();
+            let mut command_queue = CommandQueue::default();
+
+            bencher.iter(|| {
+                let mut commands = Commands::new(&mut command_queue, &world);
+                let mut entity = commands.spawn_empty();
+
+                entity.with_children(|c| {
+                    for _ in 0..entity_count {
+                        c.spawn_empty();
+                    }
+                });
+
+                entity.with_child(());
+                entity.with_children(|c| {
+                    for _ in 0..entity_count {
+                        c.spawn_empty();
+                    }
+                });
+                command_queue.apply(black_box(&mut world));
+            });
+
+            black_box(world);
+        });
+    }
+}


### PR DESCRIPTION
# Objective

- Fixes some of #17301 

## Solution

- Avoid re-parenting and related checks when spawning new entities, which cannot exist in the hierarchy yet.

## Testing

- Added a `spawn_children` benchmark

---

## Showcase

Fixed exponential time complexity when spawning children on an entity that already has existing children. This case can now complete in linear time.

```
spawn_children/10_entities
                        time:   [1.4008 µs 1.4195 µs 1.4392 µs]
                        change: [-7.2431% -5.7892% -4.2650%] (p = 0.00 < 0.05)
spawn_children/100_entities
                        time:   [10.150 µs 10.302 µs 10.461 µs]
                        change: [-22.516% -21.350% -20.218%] (p = 0.00 < 0.05)
spawn_children/1000_entities
                        time:   [88.756 µs 89.768 µs 90.867 µs]
                        change: [-75.726% -75.512% -75.309%] (p = 0.00 < 0.05)
spawn_children/10000_entities
                        time:   [912.39 µs 924.42 µs 936.40 µs]
                        change: [-96.697% -96.659% -96.618%] (p = 0.00 < 0.05)
spawn_children/100000_entities
                        time:   [9.3389 ms 9.3936 ms 9.4529 ms]
                        change: [-99.655% -99.653% -99.651%] (p = 0.00 < 0.05)
spawn_children/1000000_entities
                        time:   [111.12 ms 111.84 ms 112.58 ms]
```

Note the 1 million case takes 111ms on this branch. On `main`, I had to kill the test because it was estimated to take 8 hours.