### PR TITLE
Ambient component

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -342,7 +342,7 @@ impl Plugin for PbrPlugin {
                 SyncComponentPlugin::<PointLight>::default(),
                 SyncComponentPlugin::<SpotLight>::default(),
                 ExtractComponentPlugin::<AmbientLight>::default(),
-            )
+            ))
             .configure_sets(
                 PostUpdate,
                 (

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -341,7 +341,8 @@ impl Plugin for PbrPlugin {
                 SyncComponentPlugin::<DirectionalLight>::default(),
                 SyncComponentPlugin::<PointLight>::default(),
                 SyncComponentPlugin::<SpotLight>::default(),
-            ))
+                ExtractComponentPlugin::<AmbientLight>::default(),
+            )
             .configure_sets(
                 PostUpdate,
                 (

--- a/crates/bevy_pbr/src/light/ambient_light.rs
+++ b/crates/bevy_pbr/src/light/ambient_light.rs
@@ -4,6 +4,8 @@ use super::*;
 ///
 /// This resource is inserted by the [`PbrPlugin`] and by default it is set to a low ambient light.
 ///
+/// It can also be added to a camera to override the resource (or default) ambient for that camera only.
+/// 
 /// # Examples
 ///
 /// Make ambient light slightly brighter:
@@ -15,8 +17,8 @@ use super::*;
 ///    ambient_light.brightness = 100.0;
 /// }
 /// ```
-#[derive(Resource, Clone, Debug, ExtractResource, Reflect)]
-#[reflect(Resource, Debug, Default)]
+#[derive(Resource, Component, Clone, Debug, ExtractResource, Reflect)]
+#[reflect(Resource, Component, Debug, Default)]
 pub struct AmbientLight {
     pub color: Color,
 
@@ -51,4 +53,24 @@ impl AmbientLight {
         brightness: 0.0,
         affects_lightmapped_meshes: true,
     };
+}
+
+impl ExtractComponent for AmbientLight {
+    type QueryData = &'static Self;
+    type QueryFilter = ();
+    type Out = Self;
+
+    fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
+        Some(item.clone())
+    }
+}
+
+impl ExtractComponent for AmbientLight {
+    type QueryData = &'static Self;
+    type QueryFilter = ();
+    type Out = Self;
+
+    fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
+        Some(item.clone())
+    }
 }

--- a/crates/bevy_pbr/src/light/ambient_light.rs
+++ b/crates/bevy_pbr/src/light/ambient_light.rs
@@ -5,7 +5,7 @@ use super::*;
 /// This resource is inserted by the [`PbrPlugin`] and by default it is set to a low ambient light.
 ///
 /// It can also be added to a camera to override the resource (or default) ambient for that camera only.
-/// 
+///
 /// # Examples
 ///
 /// Make ambient light slightly brighter:
@@ -17,8 +17,9 @@ use super::*;
 ///    ambient_light.brightness = 100.0;
 /// }
 /// ```
-#[derive(Resource, Component, Clone, Debug, ExtractResource, Reflect)]
+#[derive(Resource, Component, Clone, Debug, ExtractResource, ExtractComponent, Reflect)]
 #[reflect(Resource, Component, Debug, Default)]
+#[require(Camera)]
 pub struct AmbientLight {
     pub color: Color,
 
@@ -53,24 +54,4 @@ impl AmbientLight {
         brightness: 0.0,
         affects_lightmapped_meshes: true,
     };
-}
-
-impl ExtractComponent for AmbientLight {
-    type QueryData = &'static Self;
-    type QueryFilter = ();
-    type Out = Self;
-
-    fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
-        Some(item.clone())
-    }
-}
-
-impl ExtractComponent for AmbientLight {
-    type QueryData = &'static Self;
-    type QueryFilter = ();
-    type Out = Self;
-
-    fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
-        Some(item.clone())
-    }
 }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -705,6 +705,7 @@ pub fn prepare_lights(
             &ExtractedClusterConfig,
             Option<&RenderLayers>,
             Has<NoIndirectDrawing>,
+            Option<&AmbientLight>,
         ),
         With<Camera3d>,
     >,
@@ -1138,6 +1139,7 @@ pub fn prepare_lights(
         );
 
         let n_clusters = clusters.dimensions.x * clusters.dimensions.y * clusters.dimensions.z;
+        let ambient_light = maybe_ambient_override.unwrap_or(&ambient_light);
         let mut gpu_lights = GpuLights {
             directional_lights: gpu_directional_lights,
             ambient_color: Vec4::from_slice(&LinearRgba::from(ambient_light.color).to_f32_array())

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1116,7 +1116,14 @@ pub fn prepare_lights(
     let mut live_views = EntityHashSet::with_capacity(views_count);
 
     // set up light data for each view
-    for (entity, extracted_view, clusters, maybe_layers, no_indirect_drawing) in sorted_cameras
+    for (
+        entity,
+        extracted_view,
+        clusters,
+        maybe_layers,
+        no_indirect_drawing,
+        maybe_ambient_override,
+    ) in sorted_cameras
         .0
         .iter()
         .filter_map(|sorted_camera| views.get(sorted_camera.entity).ok())


### PR DESCRIPTION
# Objective

allow setting ambient light via component on cameras. 
arguably fixes #7193
note i chose to use a component rather than an entity since it was not clear to me how to manage multiple ambient sources for a single renderlayer, and it makes for a very small changeset.

## Solution

- make ambient light a component as well as a resource
- extract it
- use the component if present on a camera, fallback to the resource

## Testing

i added 
```rs
        if index == 1 {
            commands.entity(camera).insert(AmbientLight{
                color: Color::linear_rgba(1.0, 0.0, 0.0, 1.0),
                brightness: 1000.0,
                ..Default::default()                
            });
        }
```
at line 84 of the split_screen example
