### PR TITLE
Make InputFocus optional in bevy_winit

### DIFF
--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -181,7 +181,7 @@ fn should_update_accessibility_nodes(
 
 fn update_accessibility_nodes(
     mut adapters: NonSendMut<AccessKitAdapters>,
-    focus: Res<InputFocus>,
+    focus: Option<Res<InputFocus>>,
     primary_window: Query<(Entity, &Window), With<PrimaryWindow>>,
     nodes: Query<(
         Entity,
@@ -195,6 +195,9 @@ fn update_accessibility_nodes(
         return;
     };
     let Some(adapter) = adapters.get_mut(&primary_window_id) else {
+        return;
+    };
+    let Some(focus) = focus else {
         return;
     };
     if focus.is_changed() || !nodes.is_empty() {


### PR DESCRIPTION
# Objective

- Stop bevy from crashing when losing window focus

## Solution

- The InputFocus resource is optional but is accessed unconditionally in bevy_winit. Make it optional.

## Testing

- Ran the window_settings example

## Note

It's possible this might not be a full fix for the issue, but this stop bevy from crashing.

Closes #16961 
Closes #17227