### PR TITLE
docs: enhance documentation in `query.rs` to clarify borrowing rules

### DIFF
--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -229,7 +229,7 @@ use core::{
 /// // This will panic!
 /// // EntityRef provides read access to ALL components on an entity.
 /// // When combined with &mut ComponentA in the same query, it creates
-/// // a conflict because EntityRef could read ComponentA while the &mut 
+/// // a conflict because EntityRef could read ComponentA while the &mut
 /// // attempts to modify it - violating Rust's borrowing rules of no
 /// // simultaneous read+write access.
 /// query: Query<(EntityRef, &mut ComponentA)>
@@ -253,8 +253,8 @@ use core::{
 /// # ) {}
 /// # bevy_ecs::system::assert_system_does_not_conflict(system);
 /// ```
-/// The fundamental rule: EntityRef's ability to read all components means it can never 
-/// coexist with mutable access. With/Without filters guarantee this by keeping the 
+/// The fundamental rule: EntityRef's ability to read all components means it can never
+/// coexist with mutable access. With/Without filters guarantee this by keeping the
 /// queries on completely separate entities.
 ///
 /// # Accessing query items

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -253,7 +253,7 @@ use core::{
 /// # ) {}
 /// # bevy_ecs::system::assert_system_does_not_conflict(system);
 /// ```
-/// The fundamental rule: EntityRef's ability to read all components means it can never
+/// The fundamental rule: [`EntityRef`]'s ability to read all components means it can never
 /// coexist with mutable access. With/Without filters guarantee this by keeping the
 /// queries on completely separate entities.
 ///

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -253,7 +253,9 @@ use core::{
 /// # ) {}
 /// # bevy_ecs::system::assert_system_does_not_conflict(system);
 /// ```
-/// The core principle is immutable: `EntityRef` can read everything on an entity, so it must be completely separated from any mutable access. The `With`/`Without` filters achieve this by ensuring the queries operate on entirely different sets of entities.
+/// The fundamental rule: EntityRef's ability to read all components means it can never 
+/// coexist with mutable access. With/Without filters guarantee this by keeping the 
+/// queries on completely separate entities.
 ///
 /// # Accessing query items
 ///


### PR DESCRIPTION
docs: enhance documentation in `query.rs` to clarify borrowing rules.

Please, let me know if you don't agree with the wording.. There is always room for improvement.

Tested locally and it looks like this:

![image](https://github.com/user-attachments/assets/1283fcac-c5f7-426f-844f-fc2a12ce2b42)
