### PR TITLE
Add type registration for PickingInteraction

### DIFF
--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -392,6 +392,7 @@ impl Plugin for PickingPlugin {
             )
             .register_type::<Self>()
             .register_type::<Pickable>()
+            .register_type::<hover::PickingInteraction>()
             .register_type::<pointer::PointerId>()
             .register_type::<pointer::PointerLocation>()
             .register_type::<pointer::PointerPress>()


### PR DESCRIPTION
I noticed that this component was not being returned correctly by the `bevy_remote` api

```json
"errors": {
  "bevy_picking::focus::PickingInteraction": {
    "code": -23402,
    "message": "Unknown component type: `bevy_picking::focus::PickingInteraction`"
  }
}
```