### PR TITLE
Add Cursor* things to bevy::prelude

### DIFF
--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -2,6 +2,9 @@
 
 extern crate alloc;
 
+/// The image prelude.
+///
+/// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     pub use crate::{
         dynamic_texture_atlas_builder::DynamicTextureAtlasBuilder,

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -60,6 +60,10 @@ pub use crate::text::prelude::*;
 pub use crate::ui::prelude::*;
 
 #[doc(hidden)]
+#[cfg(feature = "bevy_winit")]
+pub use crate::winit::prelude::*;
+
+#[doc(hidden)]
 #[cfg(feature = "bevy_gizmos")]
 pub use crate::gizmos::prelude::*;
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -49,8 +49,9 @@ pub use window::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime, MonitorSelection, Window,
-        WindowMoved, WindowPlugin, WindowPosition, WindowResizeConstraints,
+        CursorEntered, CursorGrabMode, CursorLeft, CursorMoved, FileDragAndDrop, Ime,
+        MonitorSelection, SystemCursorIcon, Window, WindowMoved, WindowPlugin, WindowPosition,
+        WindowResizeConstraints,
     };
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -14,6 +14,15 @@
 
 extern crate alloc;
 
+/// The winit prelude.
+///
+/// This includes the most common types in this crate, re-exported for your convenience.
+pub mod prelude {
+    pub use crate::cursor::CursorIcon;
+    #[cfg(feature = "custom_cursor")]
+    pub use crate::custom_cursor::CustomCursor;
+}
+
 use bevy_derive::Deref;
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;

--- a/examples/window/custom_cursor_image.rs
+++ b/examples/window/custom_cursor_image.rs
@@ -3,8 +3,7 @@
 
 use std::time::Duration;
 
-use bevy::winit::cursor::CustomCursor;
-use bevy::{prelude::*, winit::cursor::CursorIcon};
+use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -3,8 +3,6 @@
 use bevy::{
     prelude::*,
     render::view::screenshot::{save_to_disk, Capturing, Screenshot},
-    window::SystemCursorIcon,
-    winit::cursor::CursorIcon,
 };
 
 fn main() {

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -1,13 +1,10 @@
 //! Illustrates how to change window settings and shows how to affect
 //! the mouse pointer in various ways.
 
-#[cfg(feature = "custom_cursor")]
-use bevy::winit::cursor::CustomCursor;
 use bevy::{
     diagnostic::{FrameCount, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{CursorGrabMode, PresentMode, SystemCursorIcon, WindowLevel, WindowTheme},
-    winit::cursor::CursorIcon,
+    window::{PresentMode, WindowLevel, WindowTheme},
 };
 
 fn main() {


### PR DESCRIPTION
# Objective and solution

- Add useful cursor types to `bevy::prelude`.
- Also add `bevy_image::prelude` doc while I was here since it seemed to be the only one missing the doc boilerplate.

## Testing

- CI
- Ran example: `cargo run --example custom_cursor_image --features=custom_cursor`
- Observed that we removed a bunch of manually imported types from 3 examples which is the goal of the PR.

## Changes

- `CursorGrabMode`, `SystemCursorIcon`, `CursorIcon` and `CustomCursor` are now a part of `bevy::prelude`.
