### PR TITLE
Add `weak_handle!` convenience macro

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -501,6 +501,24 @@ impl<A: Asset> TryFrom<UntypedHandle> for Handle<A> {
     }
 }
 
+/// Creates a weak [`Handle`] from a string literal containing a UUID.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_asset::{Handle, weak_handle};
+/// # type Shader = ();
+/// const SHADER: Handle<Shader> = weak_handle!("1347c9b7-c46a-48e7-b7b8-023a354b7cac");
+/// ```
+#[macro_export]
+macro_rules! weak_handle {
+    ($uuid:expr) => {{
+        $crate::Handle::Weak($crate::AssetId::Uuid {
+            uuid: $crate::uuid::uuid!($uuid),
+        })
+    }};
+}
+
 /// Errors preventing the conversion of to/from an [`UntypedHandle`] and a [`Handle`].
 #[derive(Error, Debug, PartialEq, Clone)]
 #[non_exhaustive]

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -201,6 +201,7 @@ pub use server::*;
 
 /// Rusty Object Notation, a crate used to serialize and deserialize bevy assets.
 pub use ron;
+pub use uuid;
 
 use crate::{
     io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},


### PR DESCRIPTION
# Objective

- A common bevy pattern is to pre-allocate a weak `Handle` with a static, random ID and fill it during `Plugin::build` via `load_internal_asset!`
- This requires generating a random 128-bit number that is interpreted as a UUID. This is much less convenient than generating a UUID directly, and also, strictly speaking, error prone, since it often results in an invalid UUIDv4 – they have to follow the pattern `xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx`, where `x` is a random nibble (in practice this doesn't matter, since the UUID is just interpreted as a bag of bytes).

## Solution

- Add a `weak_handle!` macro that internally calls [`uuid::uuid!`](https://docs.rs/uuid/1.12.0/uuid/macro.uuid.html) to parse a UUID from a string literal.
- Now any random UUID generation tool can be used to generate an asset ID, such as `uuidgen` or entering "uuid" in DuckDuckGo.

Previously:

```rust
const SHADER: Handle<Shader> = Handle::weak_from_u128(314685653797097581405914117016993910609);
```

After this PR:

```rust
const SHADER: Handle<Shader> = weak_handle!("1347c9b7-c46a-48e7-b7b8-023a354b7cac");
```

Note that I did not yet migrate any of the existing uses. I can do that if desired, but want to have some feedback first to avoid wasted effort.

## Testing

Tested via the included doctest.