### PR TITLE
Add external assets to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ assets/**/*.meta
 crates/bevy_asset/imported_assets
 imported_assets
 
+# External Assets
+assets/models/bunny.meshlet_mesh
+
 # Bevy Examples
 example_showcase_config.ron
 example-showcase-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@ assets/**/*.meta
 crates/bevy_asset/imported_assets
 imported_assets
 
-# External Assets
-assets/models/bunny.meshlet_mesh
-
 # Bevy Examples
 example_showcase_config.ron
 example-showcase-reports/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1249,7 +1249,11 @@ description = "Meshlet rendering for dense high-poly scenes (experimental)"
 category = "3D Rendering"
 wasm = false
 setup = [
-  ["mkdir", "-p", "assets/external/models"],
+  [
+    "mkdir",
+    "-p",
+    "assets/external/models",
+  ],
   [
     "curl",
     "-o",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1249,10 +1249,11 @@ description = "Meshlet rendering for dense high-poly scenes (experimental)"
 category = "3D Rendering"
 wasm = false
 setup = [
+  ["mkdir", "-p", "assets/external/models"],
   [
     "curl",
     "-o",
-    "assets/models/bunny.meshlet_mesh",
+    "assets/external/models/bunny.meshlet_mesh",
     "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/7a7c14138021f63904b584d5f7b73b695c7f4bbf/bunny.meshlet_mesh",
   ],
 ]

--- a/assets/external/.gitignore
+++ b/assets/external/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/3d/meshlet.rs
+++ b/examples/3d/meshlet.rs
@@ -20,8 +20,8 @@ const ASSET_URL: &str =
     "https://raw.githubusercontent.com/JMS55/bevy_meshlet_asset/7a7c14138021f63904b584d5f7b73b695c7f4bbf/bunny.meshlet_mesh";
 
 fn main() -> ExitCode {
-    if !Path::new("./assets/models/bunny.meshlet_mesh").exists() {
-        eprintln!("ERROR: Asset at path <bevy>/assets/models/bunny.meshlet_mesh is missing. Please download it from {ASSET_URL}");
+    if !Path::new("./assets/external/models/bunny.meshlet_mesh").exists() {
+        eprintln!("ERROR: Asset at path <bevy>/assets/external/models/bunny.meshlet_mesh is missing. Please download it from {ASSET_URL}");
         return ExitCode::FAILURE;
     }
 
@@ -80,7 +80,7 @@ fn setup(
     // that has been converted to a [`bevy_pbr::meshlet::MeshletMesh`]
     // using [`bevy_pbr::meshlet::MeshletMesh::from_mesh`], which is
     // a function only available when the `meshlet_processor` cargo feature is enabled.
-    let meshlet_mesh_handle = asset_server.load("models/bunny.meshlet_mesh");
+    let meshlet_mesh_handle = asset_server.load("external/models/bunny.meshlet_mesh");
     let debug_material = debug_materials.add(MeshletDebugMaterial::default());
 
     for x in -2..=2 {


### PR DESCRIPTION
Added an external assets section to .gitignore. This prevents contributors from accidentally adding or committing them.

I believe currently the only externel asset is the meshlet bunny.