### PR TITLE
Implement `Clone` for `QueryIter` over read-only data

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -1145,6 +1145,12 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Debug for QueryIter<'w, 's, D, F> {
     }
 }
 
+impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter> Clone for QueryIter<'w, 's, D, F> {
+    fn clone(&self) -> Self {
+        self.remaining()
+    }
+}
+
 /// An [`Iterator`] over sorted query results of a [`Query`](crate::system::Query).
 ///
 /// This struct is created by the [`QueryIter::sort`], [`QueryIter::sort_unstable`],


### PR DESCRIPTION
# Objective

- Fix issue identified on the [Discord server](https://discord.com/channels/691052431525675048/691052431974465548/1328922812530036839)

## Solution

- Implement `Clone` for `QueryIter` using the existing `QueryIter::remaining` method

## Testing

- CI

---

## Showcase

Users can now explicitly clone a read-only `QueryIter`:

```rust
fn combinations(query: Query<&ComponentA>) {
    let mut iter = query.iter();
    while let Some(a) = iter.next() {
        // Can now clone rather than use remaining
        for b in iter.clone() {
            // Check every combination (a, b)
        }
    }
}
```


## Notes

This doesn't add any new functionality outside the context of generic code (e.g., `T: Iterator<...> + Clone`), it's mostly for discoverability. Users are more likely to be familiar with `Clone::clone` than they are with the methods on `QueryIter`.