### PR TITLE
Add basic debug checks for read-only `UnsafeWorldCell`

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -134,6 +134,11 @@ impl<'w> UnsafeWorldCell<'w> {
     #[cfg_attr(debug_assertions, inline(never), track_caller)]
     #[cfg_attr(not(debug_assertions), inline(always))]
     pub(crate) fn assert_allows_mutable_access(self) {
+        // This annotation is needed because the
+        // allows_mutable_access field doesn't exist otherwise.
+        // Kinda weird, since debug_assert would never be called,
+        // but CI complained in https://github.com/bevyengine/bevy/pull/17393
+        #[cfg(debug_assertions)]
         debug_assert!(
             self.allows_mutable_access,
             "mutating world data via `World::as_unsafe_world_cell_readonly` is forbidden"

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1254,6 +1254,7 @@ mod tests {
         let mut world = World::new();
         let entity = world.spawn(C).id();
         let world_cell = world.as_unsafe_world_cell_readonly();
-        let _ = unsafe { world_cell.get_entity(entity).unwrap().get_mut::<C>() };
+        let entity_cell = world_cell.get_entity(entity).unwrap();
+        let _ = unsafe { entity_cell.get_mut::<C>() };
     }
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -134,10 +134,10 @@ impl<'w> UnsafeWorldCell<'w> {
     #[cfg_attr(debug_assertions, inline(never), track_caller)]
     #[cfg_attr(not(debug_assertions), inline(always))]
     pub(crate) fn assert_allows_mutable_access(self) {
-        #[cfg(debug_assertions)]
-        if !self.allows_mutable_access {
-            panic!("mutating world data via `World::as_unsafe_world_cell_readonly` is forbidden")
-        }
+        debug_assert!(
+            self.allows_mutable_access,
+            "mutating world data via `World::as_unsafe_world_cell_readonly` is forbidden"
+        );
     }
 
     /// Gets a mutable reference to the [`World`] this [`UnsafeWorldCell`] belongs to.

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1230,6 +1230,7 @@ mod tests {
     fn as_unsafe_world_cell_readonly_world_mut_forbidden() {
         let world = World::new();
         let world_cell = world.as_unsafe_world_cell_readonly();
+        // SAFETY: this invalid usage will be caught by a runtime panic.
         let _ = unsafe { world_cell.world_mut() };
     }
 
@@ -1242,6 +1243,7 @@ mod tests {
         let mut world = World::new();
         world.insert_resource(R);
         let world_cell = world.as_unsafe_world_cell_readonly();
+        // SAFETY: this invalid usage will be caught by a runtime panic.
         let _ = unsafe { world_cell.get_resource_mut::<R>() };
     }
 
@@ -1255,6 +1257,7 @@ mod tests {
         let entity = world.spawn(C).id();
         let world_cell = world.as_unsafe_world_cell_readonly();
         let entity_cell = world_cell.get_entity(entity).unwrap();
+        // SAFETY: this invalid usage will be caught by a runtime panic.
         let _ = unsafe { entity_cell.get_mut::<C>() };
     }
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1220,3 +1220,41 @@ impl EntityBorrow for UnsafeEntityCell<'_> {
         self.id()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as bevy_ecs;
+
+    #[test]
+    #[should_panic = "is forbidden"]
+    fn as_unsafe_world_cell_readonly_world_mut_forbidden() {
+        let world = World::new();
+        let world_cell = world.as_unsafe_world_cell_readonly();
+        let _ = unsafe { world_cell.world_mut() };
+    }
+
+    #[derive(Resource)]
+    struct R;
+
+    #[test]
+    #[should_panic = "is forbidden"]
+    fn as_unsafe_world_cell_readonly_resource_mut_forbidden() {
+        let mut world = World::new();
+        world.insert_resource(R);
+        let world_cell = world.as_unsafe_world_cell_readonly();
+        let _ = unsafe { world_cell.get_resource_mut::<R>() };
+    }
+
+    #[derive(Component)]
+    struct C;
+
+    #[test]
+    #[should_panic = "is forbidden"]
+    fn as_unsafe_world_cell_readonly_component_mut_forbidden() {
+        let mut world = World::new();
+        let entity = world.spawn(C).id();
+        let world_cell = world.as_unsafe_world_cell_readonly();
+        let _ = unsafe { world_cell.get_entity(entity).unwrap().get_mut::<C>() };
+    }
+}

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -882,7 +882,6 @@ impl<'w> UnsafeEntityCell<'w> {
     /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut<T: Component<Mutability = Mutable>>(self) -> Option<Mut<'w, T>> {
-        self.world.assert_allows_mutable_access();
         // SAFETY:
         // - trait bound `T: Component<Mutability = Mutable>` ensures component is mutable
         // - same safety requirements


### PR DESCRIPTION
# Objective

The method `World::as_unsafe_world_cell_readonly` is used to create an `UnsafeWorldCell` which is only allowed to access world data immutably. This can be tricky to use, as the data that an `UnsafeWorldCell` is allowed to access exists only in documentation (you could think of it as a "doc-time abstraction" rather than a "compile-time" abstraction). It's quite easy to forget where a particular instance came from and attempt to use it for mutable access, leading to instant, silent undefined behavior.

## Solution

Add a debug-mode only flag to `UnsafeWorldCell` which tracks whether or not the instance can be used to access world data mutably. This should catch basic improper usages of `as_unsafe_world_cell_readonly`.

## Future work

There are a few ways that you can bypass the runtime checks introduced by this PR:

* Any world accesses done via `UnsafeWorldCell::storages` are completely invisible to these runtime checks. Unfortunately, `storages` constitutes most of the world accesses used in the engine itself, so this PR will mostly benefit downstream users of bevy.
* It's possible to call `get_resource_by_id`, and then convert the returned `Ptr` to a `PtrMut` by calling `assert_unique`. In the future we'll probably want to add a debug-mode only flag to `Ptr` which tracks whether or not it can be upgraded to a `PtrMut`. I didn't include this change in this PR as those types are currently defined using macros which makes it a bit tricky to modify their definitions.
* Any data accesses done through a mutable `UnsafeWorldCell` are completely unchecked, meaning it's possible to unsoundly create multiple mutable references to a single component, for example. In the future we may want to store an `Access<>` set inside of the world's `Storages` to add granular debug-mode runtime checks.

That said, I'd consider this PR to be a good first step towards adding full runtime checks to `UnsafeWorldCell`.

## Testing

Added a few tests that basic invalid mutable world access result in a panic.
