### PR TITLE
Update safety docs for `Ptr::assert_unique`

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -289,7 +289,9 @@ impl<'a, A: IsAligned> Ptr<'a, A> {
     /// Transforms this [`Ptr`] into an [`PtrMut`]
     ///
     /// # Safety
-    /// Another [`PtrMut`] for the same [`Ptr`] must not be created until the first is dropped.
+    /// * There must be no active references (mutable or otherwise) to the data underlying this `Ptr`.
+    ///   This means that it is unsound to call this fn using a `Ptr` that was originally created from an immutable reference.
+    /// * Another [`PtrMut`] for the same [`Ptr`] must not be created until the first is dropped.
     #[inline]
     pub unsafe fn assert_unique(self) -> PtrMut<'a, A> {
         PtrMut(self.0, PhantomData)

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -289,7 +289,7 @@ impl<'a, A: IsAligned> Ptr<'a, A> {
     /// Transforms this [`Ptr`] into an [`PtrMut`]
     ///
     /// # Safety
-    /// * The data pointed to by this `Ptr` must be safe for writes.
+    /// * The data pointed to by this `Ptr` must be valid for writes.
     /// * There must be no active references (mutable or otherwise) to the data underlying this `Ptr`.
     /// * Another [`PtrMut`] for the same [`Ptr`] must not be created until the first is dropped.
     #[inline]

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -289,8 +289,8 @@ impl<'a, A: IsAligned> Ptr<'a, A> {
     /// Transforms this [`Ptr`] into an [`PtrMut`]
     ///
     /// # Safety
+    /// * The data pointed to by this `Ptr` must be safe for writes.
     /// * There must be no active references (mutable or otherwise) to the data underlying this `Ptr`.
-    ///   This means that it is unsound to call this fn using a `Ptr` that was originally created from an immutable reference.
     /// * Another [`PtrMut`] for the same [`Ptr`] must not be created until the first is dropped.
     #[inline]
     pub unsafe fn assert_unique(self) -> PtrMut<'a, A> {


### PR DESCRIPTION
# Objective

The safety documentation for `Ptr::assert_unique` is incomplete. Currently it only mentions the existence of other `Ptr` instances, but it should also mention that the underlying data must be mutable and that there cannot be active references to it.
