### PR TITLE
Make mocking picking events for bevy_ui easier

### DIFF
--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -79,7 +79,7 @@ impl Default for PointerInputPlugin {
 impl Plugin for PointerInputPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(*self)
-            .add_systems(Startup, spawn_mouse_pointer)
+            .add_systems(Startup, (spawn_mouse_pointer, spawn_focus_pointer))
             .add_systems(
                 First,
                 (
@@ -101,6 +101,11 @@ impl Plugin for PointerInputPlugin {
 /// Spawns the default mouse pointer.
 pub fn spawn_mouse_pointer(mut commands: Commands) {
     commands.spawn(PointerId::Mouse);
+}
+
+/// Spawns the default focus pointer.
+pub fn spawn_focus_pointer(mut commands: Commands) {
+    commands.spawn(PointerId::Focus);
 }
 
 /// Sends mouse pointer events to be processed by the core plugin

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -244,6 +244,8 @@ impl Location {
 }
 
 /// Types of actions that can be taken by pointers.
+///
+/// These are sent as the payload of [`PointerInput`] events.
 #[derive(Debug, Clone, Copy, Reflect)]
 pub enum PointerAction {
     /// A button has been pressed on the pointer.
@@ -263,13 +265,25 @@ pub enum PointerAction {
 }
 
 /// An input event effecting a pointer.
+///
+/// These events are generated from user input in the [`PointerInputPlugin`](crate::input::PointerInputPlugin)
+/// and are read by the [`PointerInput::receive`] system
+/// to modify the state of existing pointer entities.
 #[derive(Event, Debug, Clone, Reflect)]
 pub struct PointerInput {
     /// The id of the pointer.
+    ///
+    /// Used to identify which pointer entity to update.
+    /// If no match is found, the event is ignored: no new pointer entity is created.
     pub pointer_id: PointerId,
     /// The location of the pointer. For [`PointerAction::Moved`], this is the location after the movement.
+    ///
+    /// Defines exactly where, on the [`NormalizedRenderTarget`] that the pointer event came from,
+    /// the event occurred.
     pub location: Location,
     /// The action that the event describes.
+    ///
+    /// This is the action that the pointer took, such as pressing a button or moving.
     pub action: PointerAction,
 }
 
@@ -306,6 +320,8 @@ impl PointerInput {
     }
 
     /// Updates pointer entities according to the input events.
+    ///
+    /// Entities are matched by their [`PointerId`]. If no match is found, the event is ignored.
     pub fn receive(
         mut events: EventReader<PointerInput>,
         mut pointers: Query<(&PointerId, &mut PointerLocation, &mut PointerPress)>,

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -201,13 +201,15 @@ impl PointerLocation {
 /// The location of a pointer, including the current [`NormalizedRenderTarget`], and the x/y
 /// position of the pointer on this render target.
 ///
+/// This is stored as a [`PointerLocation`] component on the pointer entity.
+///
 /// Note that:
 /// - a pointer can move freely between render targets
 /// - a pointer is not associated with a [`Camera`] because multiple cameras can target the same
 ///   render target. It is up to picking backends to associate a Pointer's `Location` with a
 ///   specific `Camera`, if any.
-#[derive(Debug, Clone, Component, Reflect, PartialEq)]
-#[reflect(Component, Debug, PartialEq)]
+#[derive(Debug, Clone, Reflect, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub struct Location {
     /// The [`NormalizedRenderTarget`] associated with the pointer, usually a window.
     pub target: NormalizedRenderTarget,

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -34,6 +34,10 @@ pub enum PointerId {
     Mouse,
     /// A touch input, usually numbered by window touch events from `winit`.
     Touch(u64),
+    /// An emulated pointer linked to the focused entity.
+    ///
+    /// Generally triggered by the `Enter` key or an `A` input on a gamepad.
+    Focus,
     /// A custom, uniquely identified pointer. Useful for mocking inputs or implementing a software
     /// controlled cursor.
     #[reflect(ignore)]

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -267,7 +267,7 @@ pub enum PointerAction {
 pub struct PointerInput {
     /// The id of the pointer.
     pub pointer_id: PointerId,
-    /// The location of the pointer. For [[`PointerAction::Moved`]], this is the location after the movement.
+    /// The location of the pointer. For [`PointerAction::Moved`], this is the location after the movement.
     pub location: Location,
     /// The action that the event describes.
     pub action: PointerAction,

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -341,11 +341,11 @@ pub trait UiPointerMockingExt {
     ///
     /// If the node is not pickable, or is blocked by a higher node,
     /// these events may not have any effect, even if sent correctly!
-    fn simulate_pointer_on_node(&mut self, pointer_id: PointerId, pointer_action: PointerAction);
+    fn emulate_pointer(&mut self, pointer_id: PointerId, pointer_action: PointerAction);
 }
 
 impl UiPointerMockingExt for EntityCommands<'_> {
-    fn simulate_pointer_on_node(&mut self, pointer_id: PointerId, pointer_action: PointerAction) {
+    fn emulate_pointer(&mut self, pointer_id: PointerId, pointer_action: PointerAction) {
         let node_entity = self.id();
         self.commands_mut().queue(move |world: &mut World| {
             simulate_pointer_on_node(world, pointer_id, pointer_action, node_entity)

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -58,6 +58,9 @@ pub struct NodeQuery {
 ///
 /// Bevy's [`UiStack`] orders all nodes in the order they will be rendered, which is the same order
 /// we need for determining picking.
+///
+/// Like all picking backends, this system reads the [`PointerId`] and [`PointerLocation`] components,
+/// and produces [`PointerHits`] events.
 pub fn ui_picking(
     pointers: Query<(&PointerId, &PointerLocation)>,
     camera_query: Query<(Entity, &Camera, Has<IsDefaultUiCamera>)>,

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -393,5 +393,18 @@ fn interact_with_focused_button(
                 },
             );
         }
+    } else {
+        // If the button was not pressed, we simulate a release event
+        if let Some(focused_entity) = input_focus.0 {
+            commands.entity(focused_entity).simulate_pointer_on_node(
+                PointerId::Focus,
+                PointerAction::Pressed {
+                    direction: PressDirection::Released,
+                    button: PointerButton::Primary,
+                },
+            );
+        }
+    }
+}
     }
 }

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -385,7 +385,7 @@ fn interact_with_focused_button(
         .contains(&DirectionalNavigationAction::Select)
     {
         if let Some(focused_entity) = input_focus.0 {
-            commands.entity(focused_entity).simulate_pointer_on_node(
+            commands.entity(focused_entity).emulate_pointer(
                 PointerId::Focus,
                 PointerAction::Pressed {
                     direction: PressDirection::Pressed,
@@ -396,7 +396,7 @@ fn interact_with_focused_button(
     } else {
         // If the button was not pressed, we simulate a release event
         if let Some(focused_entity) = input_focus.0 {
-            commands.entity(focused_entity).simulate_pointer_on_node(
+            commands.entity(focused_entity).emulate_pointer(
                 PointerId::Focus,
                 PointerAction::Pressed {
                     direction: PressDirection::Released,
@@ -404,7 +404,5 @@ fn interact_with_focused_button(
                 },
             );
         }
-    }
-}
     }
 }

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -387,8 +387,7 @@ fn interact_with_focused_button(
             commands.trigger_targets(
                 Pointer::<Pressed> {
                     target: focused_entity,
-                    // We're pretending that we're a mouse
-                    pointer_id: PointerId::Mouse,
+                    pointer_id: PointerId::Focus,
                     // This field isn't used, so we're just setting it to a placeholder value
                     pointer_location: Location {
                         target: NormalizedRenderTarget::Image(


### PR DESCRIPTION
# Objective

As discussed in https://github.com/bevyengine/bevy/pull/17267, we'd like to unify input-focus driven widget activations (e.g. press enter to click the focused button) with mouse-driven picking interactions by going through the bevy_picking infrastructure.

While you *can* fake this with observer triggers, it is:

- inaccurate: you're feeding in garbage information
- extremely verbose
- rather arcane

## Solution

As @aevyrie points out, we have access to everything we need to send realistic pointer events! Doing this *correctly* requires rather a lot of information. To make users lives easier, I've introduced a system param with all of the required information, which simulates pointer events at the center of the UI node specified.

The `directional_navigation` example has been updated to demonstrate / test this change.

## Discussion

- Some small improvements to this general area of the code have been split out into #17395. They'd be nice here, but I wanted to reduce complexity here.
- While PointerId::Custom exists, it is challenging to both generate a UUID and to match against it if you want to respond differently if the Pointer event is from a focused element. While I could have used sentinel values here, I think it's more idiomatic and nicer to use if we just add an enum arm for a common use.
- We should probably rename `bevy_ui/picking_backend.rs`, but I've opted to defer that to make the diff easier to read.
- This was originally a custom command, but has been refactored to a `SystemParam` for flexibility, easier error handling and performance.
- As follow-up, we could add some simple helper methods to the `SystemParam` to make certain actions even easier.
- In theory, other backends could do the same thing! The logic required is slightly specialized, so I stuck to just UI for now.

## Testing

I've tested this with the `directional_navigation` example. While I hope that this works properly with more exotic windowing / rendering target setups (viewports, portals, multiple windows), we're not equipped to do that effectively right now.

## Migration Guide

TODO