### PR TITLE
impl Default for StateScoped<S: Default>

### DIFF
--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -60,6 +60,15 @@ use crate::state::{StateTransitionEvent, States};
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
 pub struct StateScoped<S: States>(pub S);
 
+impl<S> Default for StateScoped<S>
+where
+    S: States + Default,
+{
+    fn default() -> Self {
+        Self(S::default())
+    }
+}
+
 /// Removes entities marked with [`StateScoped<S>`]
 /// when their state no longer matches the world state.
 ///


### PR DESCRIPTION
This allows this:

```rust
#[derive(Component)]
#[require(StateScoped<MyState>(StateScoped(MyState)))]
struct ComponentA;
```

To be shortened to this:

```rust
#[derive(Component)]
#[require(StateScoped<MyState>)]
struct ComponentA;
```

When `MyState` implements `Default`.