### PR TITLE
Rename `TargetCamera` to `UiTargetCamera`

### DIFF
--- a/crates/bevy_dev_tools/src/picking_debug.rs
+++ b/crates/bevy_dev_tools/src/picking_debug.rs
@@ -294,7 +294,7 @@ pub fn debug_draw(
                     },
                 ))
                 .insert(Pickable::IGNORE)
-                .insert(TargetCamera(camera));
+                .insert(UiTargetCamera(camera));
         }
     }
 }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CalculatedClip, ComputedNode, DefaultUiCamera, ResolvedBorderRadius, UiTargetCamera, UiStack,
+    CalculatedClip, ComputedNode, DefaultUiCamera, ResolvedBorderRadius, UiStack, UiTargetCamera,
 };
 use bevy_ecs::{
     change_detection::DetectChangesMut,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CalculatedClip, ComputedNode, DefaultUiCamera, ResolvedBorderRadius, TargetCamera, UiStack,
+    CalculatedClip, ComputedNode, DefaultUiCamera, ResolvedBorderRadius, UiTargetCamera, UiStack,
 };
 use bevy_ecs::{
     change_detection::DetectChangesMut,
@@ -141,7 +141,7 @@ pub struct NodeQuery {
     focus_policy: Option<&'static FocusPolicy>,
     calculated_clip: Option<&'static CalculatedClip>,
     view_visibility: Option<&'static ViewVisibility>,
-    target_camera: Option<&'static TargetCamera>,
+    target_camera: Option<&'static UiTargetCamera>,
 }
 
 /// The system that sets Interaction for all UI elements based on the mouse cursor activity
@@ -239,7 +239,7 @@ pub fn ui_focus_system(
             }
             let camera_entity = node
                 .target_camera
-                .map(TargetCamera::entity)
+                .map(UiTargetCamera::entity)
                 .or(default_camera_entity)?;
 
             let node_rect = Rect::from_center_size(

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -170,7 +170,7 @@ pub fn ui_layout_system(
                 Some(camera_entity) => {
                     let Ok((_, camera)) = cameras.get(camera_entity) else {
                         warn!(
-                            "TargetCamera (of root UI node {entity}) is pointing to a camera {} which doesn't exist",
+                            "UiTargetCamera (of root UI node {entity}) is pointing to a camera {} which doesn't exist",
                             camera_entity
                         );
                         return;
@@ -186,7 +186,7 @@ pub fn ui_layout_system(
                     } else {
                         warn!(
                             "Multiple cameras found, causing UI target ambiguity. \
-                            To fix this, add an explicit `TargetCamera` component to the root UI node {}",
+                            To fix this, add an explicit `UiTargetCamera` component to the root UI node {}",
                             entity
                         );
                     }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     BorderRadius, ComputedNode, ContentSize, DefaultUiCamera, Display, LayoutConfig, Node, Outline,
-    OverflowAxis, ScrollPosition, UiTargetCamera, UiScale, Val,
+    OverflowAxis, ScrollPosition, UiScale, UiTargetCamera, Val,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     BorderRadius, ComputedNode, ContentSize, DefaultUiCamera, Display, LayoutConfig, Node, Outline,
-    OverflowAxis, ScrollPosition, TargetCamera, UiScale, Val,
+    OverflowAxis, ScrollPosition, UiTargetCamera, UiScale, Val,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
@@ -110,7 +110,7 @@ pub fn ui_layout_system(
         Entity,
         Ref<Node>,
         Option<&mut ContentSize>,
-        Option<&TargetCamera>,
+        Option<&UiTargetCamera>,
     )>,
     computed_node_query: Query<(Entity, Option<Ref<Parent>>), With<ComputedNode>>,
     ui_children: UiChildren,
@@ -137,8 +137,8 @@ pub fn ui_layout_system(
     let (cameras, default_ui_camera) = camera_data;
 
     let default_camera = default_ui_camera.get();
-    let camera_with_default = |target_camera: Option<&TargetCamera>| {
-        target_camera.map(TargetCamera::entity).or(default_camera)
+    let camera_with_default = |target_camera: Option<&UiTargetCamera>| {
+        target_camera.map(UiTargetCamera::entity).or(default_camera)
     };
 
     resized_windows.clear();
@@ -637,7 +637,7 @@ mod tests {
         let camera_entity = world.spawn(Camera2d).id();
 
         let ui_entity = world
-            .spawn((Node::default(), TargetCamera(camera_entity)))
+            .spawn((Node::default(), UiTargetCamera(camera_entity)))
             .id();
 
         // `ui_layout_system` should map `camera_entity` to a ui node in `UiSurface::camera_entity_to_taffy`
@@ -942,7 +942,7 @@ mod tests {
             for moving_ui_entity in moving_ui_query.iter() {
                 commands
                     .entity(moving_ui_entity)
-                    .insert(TargetCamera(target_camera_entity))
+                    .insert(UiTargetCamera(target_camera_entity))
                     .insert(Node {
                         position_type: PositionType::Absolute,
                         top: Val::Px(pos.y),
@@ -960,8 +960,8 @@ mod tests {
         ) {
             world.run_system_once_with(move_ui_node, new_pos).unwrap();
             ui_schedule.run(world);
-            let (ui_node_entity, TargetCamera(target_camera_entity)) = world
-                .query_filtered::<(Entity, &TargetCamera), With<MovingUiNode>>()
+            let (ui_node_entity, UiTargetCamera(target_camera_entity)) = world
+                .query_filtered::<(Entity, &UiTargetCamera), With<MovingUiNode>>()
                 .get_single(world)
                 .expect("missing MovingUiNode");
             assert_eq!(expected_camera_entity, target_camera_entity);

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -153,7 +153,7 @@ impl Plugin for UiPlugin {
             .register_type::<Node>()
             .register_type::<RelativeCursorPosition>()
             .register_type::<ScrollPosition>()
-            .register_type::<TargetCamera>()
+            .register_type::<UiTargetCamera>()
             .register_type::<ImageNode>()
             .register_type::<ImageNodeSize>()
             .register_type::<UiRect>()

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -51,7 +51,7 @@ pub struct NodeQuery {
     pickable: Option<&'static Pickable>,
     calculated_clip: Option<&'static CalculatedClip>,
     view_visibility: Option<&'static ViewVisibility>,
-    target_camera: Option<&'static TargetCamera>,
+    target_camera: Option<&'static UiTargetCamera>,
 }
 
 /// Computes the UI node entities under each pointer.
@@ -132,7 +132,7 @@ pub fn ui_picking(
         }
         let Some(camera_entity) = node
             .target_camera
-            .map(TargetCamera::entity)
+            .map(UiTargetCamera::entity)
             .or(default_camera_entity)
         else {
             continue;
@@ -188,7 +188,7 @@ pub fn ui_picking(
         for node in node_query.iter_many(hovered_nodes) {
             let Some(camera_entity) = node
                 .target_camera
-                .map(TargetCamera::entity)
+                .map(UiTargetCamera::entity)
                 .or(default_camera_entity)
             else {
                 continue;

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -4,7 +4,7 @@ use core::{hash::Hash, ops::Range};
 
 use crate::{
     BoxShadow, BoxShadowSamples, CalculatedClip, ComputedNode, DefaultUiCamera, RenderUiSystem,
-    ResolvedBorderRadius, UiTargetCamera, TransparentUi, Val,
+    ResolvedBorderRadius, TransparentUi, UiTargetCamera, Val,
 };
 use bevy_app::prelude::*;
 use bevy_asset::*;
@@ -255,7 +255,8 @@ pub fn extract_shadows(
 
     for (entity, uinode, transform, view_visibility, box_shadow, clip, camera) in &box_shadow_query
     {
-        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity)
+        else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -4,7 +4,7 @@ use core::{hash::Hash, ops::Range};
 
 use crate::{
     BoxShadow, BoxShadowSamples, CalculatedClip, ComputedNode, DefaultUiCamera, RenderUiSystem,
-    ResolvedBorderRadius, TargetCamera, TransparentUi, Val,
+    ResolvedBorderRadius, UiTargetCamera, TransparentUi, Val,
 };
 use bevy_app::prelude::*;
 use bevy_asset::*;
@@ -246,7 +246,7 @@ pub fn extract_shadows(
             &ViewVisibility,
             &BoxShadow,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
         )>,
     >,
     mapping: Extract<Query<RenderEntity>>,
@@ -255,7 +255,7 @@ pub fn extract_shadows(
 
     for (entity, uinode, transform, view_visibility, box_shadow, clip, camera) in &box_shadow_query
     {
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity) else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/debug_overlay.rs
+++ b/crates/bevy_ui/src/render/debug_overlay.rs
@@ -1,7 +1,7 @@
 use crate::CalculatedClip;
 use crate::ComputedNode;
 use crate::DefaultUiCamera;
-use crate::TargetCamera;
+use crate::UiTargetCamera;
 use bevy_asset::AssetId;
 use bevy_color::Hsla;
 use bevy_ecs::entity::Entity;
@@ -66,7 +66,7 @@ pub fn extract_debug_overlay(
             &ViewVisibility,
             Option<&CalculatedClip>,
             &GlobalTransform,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
         )>,
     >,
     mapping: Extract<Query<RenderEntity>>,
@@ -82,7 +82,8 @@ pub fn extract_debug_overlay(
             continue;
         }
 
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity)
+        else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -10,7 +10,7 @@ mod debug_overlay;
 use crate::widget::ImageNode;
 use crate::{
     BackgroundColor, BorderColor, BoxShadowSamples, CalculatedClip, ComputedNode, DefaultUiCamera,
-    Outline, ResolvedBorderRadius, TargetCamera, UiAntiAlias,
+    Outline, ResolvedBorderRadius, UiAntiAlias, UiTargetCamera,
 };
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};
@@ -287,7 +287,7 @@ pub fn extract_uinode_background_colors(
             &GlobalTransform,
             &ViewVisibility,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
             &BackgroundColor,
         )>,
     >,
@@ -297,7 +297,8 @@ pub fn extract_uinode_background_colors(
     for (entity, uinode, transform, view_visibility, clip, camera, background_color) in
         &uinode_query
     {
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity)
+        else {
             continue;
         };
 
@@ -349,7 +350,7 @@ pub fn extract_uinode_images(
             &GlobalTransform,
             &ViewVisibility,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
             &ImageNode,
         )>,
     >,
@@ -357,7 +358,8 @@ pub fn extract_uinode_images(
 ) {
     let default_camera_entity = default_ui_camera.get();
     for (entity, uinode, transform, view_visibility, clip, camera, image) in &uinode_query {
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity)
+        else {
             continue;
         };
 
@@ -439,7 +441,7 @@ pub fn extract_uinode_borders(
             &GlobalTransform,
             &ViewVisibility,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
             AnyOf<(&BorderColor, &Outline)>,
         )>,
     >,
@@ -459,7 +461,7 @@ pub fn extract_uinode_borders(
     ) in &uinode_query
     {
         let Some(camera_entity) = maybe_camera
-            .map(TargetCamera::entity)
+            .map(UiTargetCamera::entity)
             .or(default_camera_entity)
         else {
             continue;
@@ -678,7 +680,7 @@ pub fn extract_text_sections(
             &GlobalTransform,
             &ViewVisibility,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
             &ComputedTextBlock,
             &TextLayoutInfo,
         )>,
@@ -701,7 +703,7 @@ pub fn extract_text_sections(
         text_layout_info,
     ) in &uinode_query
     {
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_ui_camera) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_ui_camera) else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -380,7 +380,8 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
     let default_single_camera = default_ui_camera.get();
 
     for (entity, uinode, transform, handle, view_visibility, clip, camera) in uinode_query.iter() {
-        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_single_camera) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_single_camera)
+        else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -371,7 +371,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
             &MaterialNode<M>,
             &ViewVisibility,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
         )>,
     >,
     mapping: Extract<Query<RenderEntity>>,
@@ -380,7 +380,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
     let default_single_camera = default_ui_camera.get();
 
     for (entity, uinode, transform, handle, view_visibility, clip, camera) in uinode_query.iter() {
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_single_camera) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_single_camera) else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -256,7 +256,7 @@ pub fn extract_ui_texture_slices(
             &GlobalTransform,
             &ViewVisibility,
             Option<&CalculatedClip>,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
             &ImageNode,
         )>,
     >,
@@ -265,7 +265,7 @@ pub fn extract_ui_texture_slices(
     let default_camera_entity = default_ui_camera.get();
 
     for (entity, uinode, transform, view_visibility, clip, camera, image) in &slicers_query {
-        let Some(camera_entity) = camera.map(TargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity) else {
             continue;
         };
 

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -265,7 +265,8 @@ pub fn extract_ui_texture_slices(
     let default_camera_entity = default_ui_camera.get();
 
     for (entity, uinode, transform, view_visibility, clip, camera, image) in &slicers_query {
-        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity) else {
+        let Some(camera_entity) = camera.map(UiTargetCamera::entity).or(default_camera_entity)
+        else {
             continue;
         };
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2625,7 +2625,7 @@ impl UiTargetCamera {
 ///
 /// This is useful if the [`PrimaryWindow`] has two cameras, one of them used
 /// just for debug purposes and the user wants a way to choose the default [`Camera`]
-/// without having to add a [`TargetCamera`] to the root node.
+/// without having to add a [`UiTargetCamera`] to the root node.
 ///
 /// Another use is when the user wants the Ui to be in another window by default,
 /// all that is needed is to place this component on the camera
@@ -2649,7 +2649,7 @@ impl UiTargetCamera {
 ///             ..Default::default()
 ///         },
 ///         // We add the Marker here so all Ui will spawn in
-///         // another window if no TargetCamera is specified
+///         // another window if no UiTargetCamera is specified
 ///         IsDefaultUiCamera
 ///     ));
 /// }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2613,9 +2613,9 @@ mod tests {
 /// Optional if there is only one camera in the world. Required otherwise.
 #[derive(Component, Clone, Debug, Reflect, Eq, PartialEq)]
 #[reflect(Component, Debug, PartialEq)]
-pub struct TargetCamera(pub Entity);
+pub struct UiTargetCamera(pub Entity);
 
-impl TargetCamera {
+impl UiTargetCamera {
     pub fn entity(&self) -> Entity {
         self.0
     }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     experimental::{UiChildren, UiRootNodes},
-    CalculatedClip, Display, Node, OverflowAxis, TargetCamera,
+    CalculatedClip, Display, Node, OverflowAxis, UiTargetCamera,
 };
 
 use super::ComputedNode;
@@ -137,10 +137,10 @@ fn update_clipping(
 pub fn update_target_camera_system(
     mut commands: Commands,
     changed_root_nodes_query: Query<
-        (Entity, Option<&TargetCamera>),
-        (With<Node>, Changed<TargetCamera>),
+        (Entity, Option<&UiTargetCamera>),
+        (With<Node>, Changed<UiTargetCamera>),
     >,
-    node_query: Query<(Entity, Option<&TargetCamera>), With<Node>>,
+    node_query: Query<(Entity, Option<&UiTargetCamera>), With<Node>>,
     ui_root_nodes: UiRootNodes,
     ui_children: UiChildren,
 ) {
@@ -182,8 +182,8 @@ pub fn update_target_camera_system(
 
 fn update_children_target_camera(
     entity: Entity,
-    camera_to_set: Option<&TargetCamera>,
-    node_query: &Query<(Entity, Option<&TargetCamera>), With<Node>>,
+    camera_to_set: Option<&UiTargetCamera>,
+    node_query: &Query<(Entity, Option<&UiTargetCamera>), With<Node>>,
     ui_children: &UiChildren,
     commands: &mut Commands,
     updated_entities: &mut HashSet<Entity>,
@@ -201,7 +201,7 @@ fn update_children_target_camera(
                 commands.entity(child).try_insert(camera.clone());
             }
             None => {
-                commands.entity(child).remove::<TargetCamera>();
+                commands.entity(child).remove::<UiTargetCamera>();
             }
         }
         updated_entities.insert(child);

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -148,7 +148,7 @@ pub fn update_target_camera_system(
     // and updates done for changed_children_query can overlap with itself or with root_node_query
     let mut updated_entities = <HashSet<_>>::default();
 
-    // Assuming that TargetCamera is manually set on the root node only,
+    // Assuming that UiTargetCamera is manually set on the root node only,
     // update root nodes first, since it implies the biggest change
     for (root_node, target_camera) in changed_root_nodes_query.iter_many(ui_root_nodes.iter()) {
         update_children_target_camera(
@@ -161,7 +161,7 @@ pub fn update_target_camera_system(
         );
     }
 
-    // If the root node TargetCamera was changed, then every child is updated
+    // If the root node UiTargetCamera was changed, then every child is updated
     // by this point, and iteration will be skipped.
     // Otherwise, update changed children
     for (parent, target_camera) in &node_query {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
     ComputedNode, ContentSize, DefaultUiCamera, FixedMeasure, Measure, MeasureArgs, Node,
-    NodeMeasure, TargetCamera, UiScale,
+    NodeMeasure, UiTargetCamera, UiScale,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;
@@ -255,7 +255,7 @@ pub fn measure_text_system(
             &mut ContentSize,
             &mut TextNodeFlags,
             &mut ComputedTextBlock,
-            Option<&TargetCamera>,
+            Option<&UiTargetCamera>,
         ),
         With<Node>,
     >,
@@ -269,7 +269,7 @@ pub fn measure_text_system(
 
     for (entity, block, content_size, text_flags, computed, maybe_camera) in &mut text_query {
         let Some(camera_entity) = maybe_camera
-            .map(TargetCamera::entity)
+            .map(UiTargetCamera::entity)
             .or(default_camera_entity)
         else {
             continue;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
     ComputedNode, ContentSize, DefaultUiCamera, FixedMeasure, Measure, MeasureArgs, Node,
-    NodeMeasure, UiTargetCamera, UiScale,
+    NodeMeasure, UiScale, UiTargetCamera,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -84,7 +84,7 @@ fn setup(
         // Set up UI
         commands
             .spawn((
-                TargetCamera(camera),
+                UiTargetCamera(camera),
                 Node {
                     width: Val::Percent(100.),
                     height: Val::Percent(100.),
@@ -183,7 +183,7 @@ fn set_camera_viewports(
 
 fn button_system(
     interaction_query: Query<
-        (&Interaction, &TargetCamera, &RotateCamera),
+        (&Interaction, &UiTargetCamera, &RotateCamera),
         (Changed<Interaction>, With<Button>),
     >,
     mut camera_query: Query<&mut Transform, With<Camera>>,

--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -333,7 +333,7 @@ fn update_active_cameras(
     state: Res<State<CameraActive>>,
     camera_2d: Single<(Entity, &mut Camera), With<Camera2d>>,
     camera_3d: Single<(Entity, &mut Camera), (With<Camera3d>, Without<Camera2d>)>,
-    mut text: Query<&mut TargetCamera, With<HeaderNode>>,
+    mut text: Query<&mut UiTargetCamera, With<HeaderNode>>,
 ) {
     let (entity_2d, mut cam_2d) = camera_2d.into_inner();
     let (entity_3d, mut cam_3d) = camera_3d.into_inner();
@@ -349,7 +349,7 @@ fn update_active_cameras(
     };
 
     text.iter_mut().for_each(|mut target_camera| {
-        *target_camera = TargetCamera(active_camera);
+        *target_camera = UiTargetCamera(active_camera);
     });
 }
 
@@ -374,7 +374,7 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
                 top: Val::Px(5.0),
                 ..Default::default()
             },
-            TargetCamera(active_camera),
+            UiTargetCamera(active_camera),
         ))
         .with_children(|p| {
             p.spawn((

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -75,7 +75,7 @@ fn setup(
                 ..default()
             },
             BackgroundColor(GOLD.into()),
-            TargetCamera(texture_camera),
+            UiTargetCamera(texture_camera),
         ))
         .with_children(|parent| {
             parent.spawn((

--- a/examples/window/monitor_info.rs
+++ b/examples/window/monitor_info.rs
@@ -73,7 +73,7 @@ fn update(
                 width: Val::Percent(100.0),
                 ..default()
             },
-            TargetCamera(camera),
+            UiTargetCamera(camera),
             MonitorRef(entity),
         ));
     }

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -1,7 +1,6 @@
 //! Uses two windows to visualize a 3D model from different angles.
 
 use bevy::{prelude::*, render::camera::RenderTarget, window::WindowRef};
-use bevy_render::view::RenderLayers;
 
 fn main() {
     App::new()

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -1,6 +1,7 @@
 //! Uses two windows to visualize a 3D model from different angles.
 
 use bevy::{prelude::*, render::camera::RenderTarget, window::WindowRef};
+use bevy_render::view::RenderLayers;
 
 fn main() {
     App::new()
@@ -58,12 +59,12 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         Text::new("First window"),
         node.clone(),
         // Since we are using multiple cameras, we need to specify which camera UI should be rendered to
-        TargetCamera(first_window_camera),
+        UiTargetCamera(first_window_camera),
     ));
 
     commands.spawn((
         Text::new("Second window"),
         node,
-        TargetCamera(second_window_camera),
+        UiTargetCamera(second_window_camera),
     ));
 }


### PR DESCRIPTION
# Objective

It's not immediately obvious that `TargetCamera` only works with UI node entities. It's natural to assume from looking at something like the `multiple_windows` example that it will work with everything.

## Solution

Rename `TargetCamera` to `UiTargetCamera`.

## Migration Guide

`TargetCamera` has been renamed to `UiTargetCamera`.