### PR TITLE
Improve `TextSpan` docs

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -158,7 +158,10 @@ impl TextLayout {
     }
 }
 
-/// A span of UI text in a tree of spans under an entity with [`TextLayout`] and `Text` or `Text2d`.
+/// A span of text in a tree of spans.
+///
+/// `TextSpan` is only valid as a child of an entity with [`TextLayout`], which is provided by `Text`
+/// for text in `bevy_ui` or `Text2d` for text in 2d world-space.
 ///
 /// Spans are collected in hierarchy traversal order into a [`ComputedTextBlock`] for layout.
 ///

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -173,6 +173,8 @@ impl TextLayout {
 /// # let mut world = World::default();
 /// #
 /// world.spawn((
+///     // `Text` or `Text2d` are needed, and will provide default instances
+///     // of the following components.
 ///     TextLayout::default(),
 ///     TextFont {
 ///         font: font_handle.clone().into(),
@@ -182,6 +184,7 @@ impl TextLayout {
 ///     TextColor(BLUE.into()),
 /// ))
 /// .with_child((
+///     // Children must be `TextSpan`, not `Text` or `Text2d`.
 ///     TextSpan::new("Hello!"),
 ///     TextFont {
 ///         font: font_handle.into(),

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -47,7 +47,7 @@ use bevy_window::{PrimaryWindow, Window};
 /// ```
 /// # use bevy_asset::Handle;
 /// # use bevy_color::Color;
-/// # use bevy_color::palettes::basic::{BLUE, RED};
+/// # use bevy_color::palettes::basic::BLUE;
 /// # use bevy_ecs::world::World;
 /// # use bevy_ecs::prelude::Component;
 /// # use bevy_hierarchy::{ChildBuild, BuildChildren};
@@ -79,7 +79,7 @@ use bevy_window::{PrimaryWindow, Window};
 /// // With spans
 /// world.spawn(Text2d::new("hello ")).with_children(|parent| {
 ///     parent.spawn(TextSpan::new("world"));
-///     parent.spawn((TextSpan::new("!"), TextColor(RED.into())));
+///     parent.spawn((TextSpan::new("!"), TextColor(BLUE.into())));
 /// });
 /// ```
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect)]

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -47,12 +47,17 @@ use bevy_window::{PrimaryWindow, Window};
 /// ```
 /// # use bevy_asset::Handle;
 /// # use bevy_color::Color;
-/// # use bevy_color::palettes::basic::BLUE;
+/// # use bevy_color::palettes::basic::{BLUE, RED};
 /// # use bevy_ecs::world::World;
-/// # use bevy_text::{Font, JustifyText, Text2d, TextLayout, TextFont, TextColor};
+/// # use bevy_ecs::prelude::Component;
+/// # use bevy_hierarchy::{ChildBuild, BuildChildren};
+/// # use bevy_text::{Font, JustifyText, Text2d, TextLayout, TextFont, TextColor, TextSpan};
 /// #
 /// # let font_handle: Handle<Font> = Default::default();
 /// # let mut world = World::default();
+/// #
+/// # #[derive(Component)]
+/// # struct WorldSpan;
 /// #
 /// // Basic usage.
 /// world.spawn(Text2d::new("hello world!"));
@@ -73,6 +78,12 @@ use bevy_window::{PrimaryWindow, Window};
 ///     Text2d::new("hello world\nand bevy!"),
 ///     TextLayout::new_with_justify(JustifyText::Center)
 /// ));
+///
+/// // With spans
+/// world.spawn(Text2d::new("hello ")).with_children(|parent| {
+///     parent.spawn((TextSpan::new("world"), WorldSpan));
+///     parent.spawn((TextSpan::new("!"), TextColor(RED.into())));
+/// });
 /// ```
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect)]
 #[reflect(Component, Default, Debug)]

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -56,9 +56,6 @@ use bevy_window::{PrimaryWindow, Window};
 /// # let font_handle: Handle<Font> = Default::default();
 /// # let mut world = World::default();
 /// #
-/// # #[derive(Component)]
-/// # struct WorldSpan;
-/// #
 /// // Basic usage.
 /// world.spawn(Text2d::new("hello world!"));
 ///
@@ -81,7 +78,7 @@ use bevy_window::{PrimaryWindow, Window};
 ///
 /// // With spans
 /// world.spawn(Text2d::new("hello ")).with_children(|parent| {
-///     parent.spawn((TextSpan::new("world"), WorldSpan));
+///     parent.spawn(TextSpan::new("world"));
 ///     parent.spawn((TextSpan::new("!"), TextColor(RED.into())));
 /// });
 /// ```

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -50,7 +50,6 @@ use bevy_window::{PrimaryWindow, Window};
 /// # use bevy_color::palettes::basic::BLUE;
 /// # use bevy_ecs::world::World;
 /// # use bevy_ecs::prelude::Component;
-/// # use bevy_hierarchy::{ChildBuild, BuildChildren};
 /// # use bevy_text::{Font, JustifyText, Text2d, TextLayout, TextFont, TextColor, TextSpan};
 /// #
 /// # let font_handle: Handle<Font> = Default::default();

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -49,7 +49,6 @@ use bevy_window::{PrimaryWindow, Window};
 /// # use bevy_color::Color;
 /// # use bevy_color::palettes::basic::BLUE;
 /// # use bevy_ecs::world::World;
-/// # use bevy_ecs::prelude::Component;
 /// # use bevy_text::{Font, JustifyText, Text2d, TextLayout, TextFont, TextColor, TextSpan};
 /// #
 /// # let font_handle: Handle<Font> = Default::default();

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -64,7 +64,6 @@ impl Default for TextNodeFlags {
 /// # use bevy_color::palettes::basic::BLUE;
 /// # use bevy_ecs::world::World;
 /// # use bevy_ecs::prelude::Component;
-/// # use bevy_hierarchy::{ChildBuild, BuildChildren};
 /// # use bevy_text::{Font, JustifyText, TextLayout, TextFont, TextColor, TextSpan};
 /// # use bevy_ui::prelude::Text;
 /// #

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -71,9 +71,6 @@ impl Default for TextNodeFlags {
 /// # let font_handle: Handle<Font> = Default::default();
 /// # let mut world = World::default();
 /// #
-/// # #[derive(Component)]
-/// # struct WorldSpan;
-/// #
 /// // Basic usage.
 /// world.spawn(Text::new("hello world!"));
 ///
@@ -96,7 +93,7 @@ impl Default for TextNodeFlags {
 ///
 /// // With spans
 /// world.spawn(Text::new("hello ")).with_children(|parent| {
-///     parent.spawn((TextSpan::new("world"), WorldSpan));
+///     parent.spawn(TextSpan::new("world"));
 ///     parent.spawn((TextSpan::new("!"), TextColor(RED.into())));
 /// });
 /// ```

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -63,7 +63,6 @@ impl Default for TextNodeFlags {
 /// # use bevy_color::Color;
 /// # use bevy_color::palettes::basic::BLUE;
 /// # use bevy_ecs::world::World;
-/// # use bevy_ecs::prelude::Component;
 /// # use bevy_text::{Font, JustifyText, TextLayout, TextFont, TextColor, TextSpan};
 /// # use bevy_ui::prelude::Text;
 /// #

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -61,7 +61,7 @@ impl Default for TextNodeFlags {
 /// ```
 /// # use bevy_asset::Handle;
 /// # use bevy_color::Color;
-/// # use bevy_color::palettes::basic::{BLUE, RED};
+/// # use bevy_color::palettes::basic::BLUE;
 /// # use bevy_ecs::world::World;
 /// # use bevy_ecs::prelude::Component;
 /// # use bevy_hierarchy::{ChildBuild, BuildChildren};
@@ -94,7 +94,7 @@ impl Default for TextNodeFlags {
 /// // With spans
 /// world.spawn(Text::new("hello ")).with_children(|parent| {
 ///     parent.spawn(TextSpan::new("world"));
-///     parent.spawn((TextSpan::new("!"), TextColor(RED.into())));
+///     parent.spawn((TextSpan::new("!"), TextColor(BLUE.into())));
 /// });
 /// ```
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect, PartialEq)]

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -61,13 +61,18 @@ impl Default for TextNodeFlags {
 /// ```
 /// # use bevy_asset::Handle;
 /// # use bevy_color::Color;
-/// # use bevy_color::palettes::basic::BLUE;
+/// # use bevy_color::palettes::basic::{BLUE, RED};
 /// # use bevy_ecs::world::World;
-/// # use bevy_text::{Font, JustifyText, TextLayout, TextFont, TextColor};
+/// # use bevy_ecs::prelude::Component;
+/// # use bevy_hierarchy::{ChildBuild, BuildChildren};
+/// # use bevy_text::{Font, JustifyText, TextLayout, TextFont, TextColor, TextSpan};
 /// # use bevy_ui::prelude::Text;
 /// #
 /// # let font_handle: Handle<Font> = Default::default();
 /// # let mut world = World::default();
+/// #
+/// # #[derive(Component)]
+/// # struct WorldSpan;
 /// #
 /// // Basic usage.
 /// world.spawn(Text::new("hello world!"));
@@ -88,6 +93,12 @@ impl Default for TextNodeFlags {
 ///     Text::new("hello world\nand bevy!"),
 ///     TextLayout::new_with_justify(JustifyText::Center)
 /// ));
+///
+/// // With spans
+/// world.spawn(Text::new("hello ")).with_children(|parent| {
+///     parent.spawn((TextSpan::new("world"), WorldSpan));
+///     parent.spawn((TextSpan::new("!"), TextColor(RED.into())));
+/// });
 /// ```
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect, PartialEq)]
 #[reflect(Component, Default, Debug, PartialEq)]


### PR DESCRIPTION
# Objective

Our [`TextSpan`](https://docs.rs/bevy/latest/bevy/prelude/struct.TextSpan.html) docs include a code example that does not actually "work." The code silently does not render anything, and the `Text*Writer` helpers fail.

This seems to be by design, because we can't use `Text` or `Text2d` from `bevy_ui` or `bevy_sprite` within docs in `bevy_text`. (Correct me if I am wrong)

I have seen multiple users confused by these docs.

Also fixes #16794

## Solution

Remove the code example from `TextSpan`, and instead encourage users to seek docs on `Text` or `Text2d`.

Add examples with nested `TextSpan`s in those areas.