### PR TITLE
Fix some syntax error in example bounding 2d

### DIFF
--- a/examples/2d/bounding_2d.rs
+++ b/examples/2d/bounding_2d.rs
@@ -106,22 +106,22 @@ fn render_shapes(mut gizmos: Gizmos, query: Query<(&Shape, &Transform)>) {
         let isometry = Isometry2d::new(translation, Rot2::radians(rotation));
         match shape {
             Shape::Rectangle(r) => {
-                gizmos.primitive_2d(r, isometry, color);
+                gizmos.primitive_2d(&*r, isometry, color);
             }
             Shape::Circle(c) => {
-                gizmos.primitive_2d(c, isometry, color);
+                gizmos.primitive_2d(&*c, isometry, color);
             }
             Shape::Triangle(t) => {
-                gizmos.primitive_2d(t, isometry, color);
+                gizmos.primitive_2d(&*t, isometry, color);
             }
             Shape::Line(l) => {
-                gizmos.primitive_2d(l, isometry, color);
+                gizmos.primitive_2d(&*l, isometry, color);
             }
             Shape::Capsule(c) => {
-                gizmos.primitive_2d(c, isometry, color);
+                gizmos.primitive_2d(&*c, isometry, color);
             }
             Shape::Polygon(p) => {
-                gizmos.primitive_2d(p, isometry, color);
+                gizmos.primitive_2d(&*p, isometry, color);
             }
         }
     }
@@ -301,8 +301,8 @@ fn ray_cast_system(
 
     for (volume, mut intersects) in volumes.iter_mut() {
         let toi = match volume {
-            CurrentVolume::Aabb(a) => ray_cast.aabb_intersection_at(a),
-            CurrentVolume::Circle(c) => ray_cast.circle_intersection_at(c),
+            CurrentVolume::Aabb(a) => ray_cast.aabb_intersection_at(&*a),
+            CurrentVolume::Circle(c) => ray_cast.circle_intersection_at(&*c),
         };
         **intersects = toi.is_some();
         if let Some(toi) = toi {
@@ -388,8 +388,8 @@ fn aabb_intersection_system(
 
     for (volume, mut intersects) in volumes.iter_mut() {
         let hit = match volume {
-            CurrentVolume::Aabb(a) => aabb.intersects(a),
-            CurrentVolume::Circle(c) => aabb.intersects(c),
+            CurrentVolume::Aabb(a) => aabb.intersects(&*a),
+            CurrentVolume::Circle(c) => aabb.intersects(&*c),
         };
 
         **intersects = hit;
@@ -407,8 +407,8 @@ fn circle_intersection_system(
 
     for (volume, mut intersects) in volumes.iter_mut() {
         let hit = match volume {
-            CurrentVolume::Aabb(a) => circle.intersects(a),
-            CurrentVolume::Circle(c) => circle.intersects(c),
+            CurrentVolume::Aabb(a) => circle.intersects(&*a),
+            CurrentVolume::Circle(c) => circle.intersects(&*c),
         };
 
         **intersects = hit;


### PR DESCRIPTION
# Environment
```bash
rustup 1.27.1 (54dd3d00f 2024-04-24)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.84.0 (9fc6b4312 2025-01-07)`
```

os: windows 11 24h2 && macos 15.2 apple silicon

# Objective

- In example bounding_2d, sample code below
```rust
fn render_shapes(mut gizmos: Gizmos, query: Query<(&Shape, &Transform)>) {
    let color = GRAY;
    for (shape, transform) in query.iter() {
        let translation = transform.translation.xy();
        let rotation = transform.rotation.to_euler(EulerRot::YXZ).2;
        let isometry = Isometry2d::new(translation, Rot2::radians(rotation));
        match shape {
            Shape::Rectangle(r) => {
                gizmos.primitive_2d(r, isometry, color);
            }
```
the r will cause 

expected &{unknown}, found Rectanglerust-analyzer[E0308](https://doc.rust-lang.org/stable/error_codes/E0308.html)


## Solution
make ```r``` to ```&*r```




