### PR TITLE
Make the `animated_mesh` example more intuitive 

### DIFF
--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -21,7 +21,7 @@ fn main() {
 }
 
 // A component that records what animation we want to play. This is created when
-// we start loading the mesh (see `setup_mesh_and_animation`) and picked up when
+// we start loading the mesh (see `setup_mesh_and_animation`) and read when
 // the mesh is spawned (see `play_animation_once_loaded`).
 #[derive(Component)]
 struct AnimationToPlay {
@@ -43,7 +43,7 @@ fn setup_mesh_and_animation(
     // Register the animation graph as an asset.
     let graph_handle = graphs.add(graph);
 
-    // Create a component that will spawn our mesh after it has loaded.
+    // Create a SceneRoot component that will spawn our mesh after it has loaded.
     let mesh_scene = SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH)));
 
     // Create a component that records which animation we want to play on the
@@ -53,7 +53,7 @@ fn setup_mesh_and_animation(
         index,
     };
 
-    // Spawn an entity containing our components, and connect it to our
+    // Spawn an entity with our components and connect it to our
     // play_animation_once_loaded trigger.
     commands
         .spawn((mesh_scene, animation_to_play))
@@ -67,12 +67,12 @@ fn play_animation_once_loaded(
     animations_to_play: Query<&AnimationToPlay>,
     mut players: Query<&mut AnimationPlayer>,
 ) {
-    // The entity we spawned in setup_mesh_and_animation is the trigger's target.
+    // The entity we spawned in `setup_mesh_and_animation` is the trigger's target.
     // Start by finding the AnimationToPlay component we added to that entity.
     if let Ok(animation_to_play) = animations_to_play.get(trigger.target()) {
-        // The mesh and an animation player will have been spawned in a
-        // descendent of this entity. Search the descendents to find the
-        // animation player.
+        // The SceneRoot component will have spawned the mesh and an animation
+        // player as a descendent of our entity. Search the descendents to find
+        // the animation player.
         for child in children.iter_descendants(trigger.target()) {
             if let Ok(mut player) = players.get_mut(child) {
                 // Tell the animation player to start the animation and keep

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -89,10 +89,6 @@ fn play_animation_when_ready(
                 commands
                     .entity(child)
                     .insert(AnimationGraphHandle(animation_to_play.graph_handle.clone()));
-
-                // We know that our scene will only contain a single mesh and
-                // animation player, so stop searching.
-                break;
             }
         }
     }

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -86,6 +86,10 @@ fn play_animation_once_loaded(
                 commands
                     .entity(child)
                     .insert(AnimationGraphHandle(animation_to_play.graph_handle.clone()));
+
+                // We know that our scene will only contain a single mesh and
+                // animation player, so stop searching.
+                break;
             }
         }
     }

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -74,7 +74,7 @@ fn play_animation_when_ready(
         // The SceneRoot component will have spawned the scene as a hierarchy
         // of entities parented to our entity. Since the asset contained a skinned
         // mesh and animations, it will also have spawned an animation player
-        // component. Search our entity's descendents to find the animation player.
+        // component. Search our entity's descendants to find the animation player.
         for child in children.iter_descendants(trigger.target()) {
             if let Ok(mut player) = players.get_mut(child) {
                 // Tell the animation player to start the animation and keep

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -20,9 +20,9 @@ fn main() {
         .run();
 }
 
-// A component that records what animation we want to play. This is created when
-// we start loading the mesh (see `setup_mesh_and_animation`) and read when
-// the mesh is spawned (see `play_animation_once_loaded`).
+// A component that stores a reference to an animation we want to play. This is
+// created when we start loading the mesh (see `setup_mesh_and_animation`) and
+// read when the mesh has spawned (see `play_animation_once_loaded`).
 #[derive(Component)]
 struct AnimationToPlay {
     graph_handle: Handle<AnimationGraph>,
@@ -40,14 +40,13 @@ fn setup_mesh_and_animation(
         asset_server.load(GltfAssetLabel::Animation(2).from_asset(GLTF_PATH)),
     );
 
-    // Register the animation graph as an asset.
+    // Store the animation graph as an asset.
     let graph_handle = graphs.add(graph);
 
     // Create a SceneRoot component that will spawn our mesh after it has loaded.
     let mesh_scene = SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH)));
 
-    // Create a component that records which animation we want to play on the
-    // mesh once it has spawned.
+    // Create a component that stores a reference to our animation.
     let animation_to_play = AnimationToPlay {
         graph_handle,
         index,

--- a/examples/animation/animated_mesh.rs
+++ b/examples/animation/animated_mesh.rs
@@ -2,7 +2,7 @@
 
 use std::f32::consts::PI;
 
-use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
+use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*, scene::SceneInstanceReady};
 
 // An example asset that contains a mesh and animation.
 const GLTF_PATH: &str = "models/animated/Fox.glb";
@@ -17,62 +17,78 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup_mesh_and_animation)
         .add_systems(Startup, setup_camera_and_environment)
-        .add_systems(Update, play_animation_once_loaded)
         .run();
 }
 
-#[derive(Resource)]
-struct Animations {
+// A component that records what animation we want to play. This is created when
+// we start loading the mesh (see `setup_mesh_and_animation`) and picked up when
+// the mesh is spawned (see `play_animation_once_loaded`).
+#[derive(Component)]
+struct AnimationToPlay {
     graph_handle: Handle<AnimationGraph>,
     index: AnimationNodeIndex,
 }
 
-// Create an animation graph and start loading the mesh and animation.
 fn setup_mesh_and_animation(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut graphs: ResMut<Assets<AnimationGraph>>,
 ) {
-    // Build an animation graph containing a single animation.
+    // Create an animation graph containing a single animation. We want the "run"
+    // animation from our example asset, which has an index of two.
     let (graph, index) = AnimationGraph::from_clip(
-        // We want the "run" animation from our example asset, which has an
-        // index of two.
         asset_server.load(GltfAssetLabel::Animation(2).from_asset(GLTF_PATH)),
     );
 
-    // Keep our animation graph in a Resource so that it can be added to the
-    // correct entity once the scene loads.
+    // Register the animation graph as an asset.
     let graph_handle = graphs.add(graph);
-    commands.insert_resource(Animations {
+
+    // Create a component that will spawn our mesh after it has loaded.
+    let mesh_scene = SceneRoot(asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH)));
+
+    // Create a component that records which animation we want to play on the
+    // mesh once it has spawned.
+    let animation_to_play = AnimationToPlay {
         graph_handle,
         index,
-    });
+    };
 
-    // Tell the engine to start loading our mesh and animation, and then spawn
-    // them as a scene when ready.
-    commands.spawn(SceneRoot(
-        asset_server.load(GltfAssetLabel::Scene(0).from_asset(GLTF_PATH)),
-    ));
+    // Spawn an entity containing our components, and connect it to our
+    // play_animation_once_loaded trigger.
+    commands
+        .spawn((mesh_scene, animation_to_play))
+        .observe(play_animation_once_loaded);
 }
 
-// Detect that the scene is loaded and spawned, then play the animation.
 fn play_animation_once_loaded(
+    trigger: Trigger<SceneInstanceReady>,
     mut commands: Commands,
-    animations: Res<Animations>,
-    mut players: Query<(Entity, &mut AnimationPlayer), Added<AnimationPlayer>>,
+    children: Query<&Children>,
+    animations_to_play: Query<&AnimationToPlay>,
+    mut players: Query<&mut AnimationPlayer>,
 ) {
-    for (entity, mut player) in &mut players {
-        // Start the animation player and tell it to repeat forever.
-        //
-        // If you want to try stopping and switching animations, see the
-        // `animated_mesh_control.rs` example.
-        player.play(animations.index).repeat();
+    // The entity we spawned in setup_mesh_and_animation is the trigger's target.
+    // Start by finding the AnimationToPlay component we added to that entity.
+    if let Ok(animation_to_play) = animations_to_play.get(trigger.target()) {
+        // The mesh and an animation player will have been spawned in a
+        // descendent of this entity. Search the descendents to find the
+        // animation player.
+        for child in children.iter_descendants(trigger.target()) {
+            if let Ok(mut player) = players.get_mut(child) {
+                // Tell the animation player to start the animation and keep
+                // repeating it.
+                //
+                // If you want to try stopping and switching animations, see the
+                // `animated_mesh_control.rs` example.
+                player.play(animation_to_play.index).repeat();
 
-        // Insert the animation graph with our selected animation. This
-        // connects the animation player to the mesh.
-        commands
-            .entity(entity)
-            .insert(AnimationGraphHandle(animations.graph_handle.clone()));
+                // Add the animation graph. This only needs to be done once to
+                // connect the animation player to the mesh.
+                commands
+                    .entity(child)
+                    .insert(AnimationGraphHandle(animation_to_play.graph_handle.clone()));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

Make the `animated_mesh` example more intuitive and easier for the user to extend.

# Solution

The `animated_mesh` example shows how to spawn a single mesh and play a single animation. The original code is roughly:

1. In `setup_mesh_and_animation`, spawn an entity with a SceneRoot that will load and spawn the mesh. Also record the animation to play as a resource.
2. Use  `play_animation_once_loaded` to detect when any animation players are spawned, then play the animation from the resource.

When I used this example as a starting point for my own app, I hit a wall when trying to spawn multiple meshes with different animations. `play_animation_once_loaded` tells me an animation player spawned somewhere, but how do I get from there to the right animation? The entity it runs on is spawned by the scene so I can't attach any data to it?

The new code takes a different approach. Instead of a global resource, the animation is recorded as a component on the entity with the SceneRoot. Instead of detecting animation players spawning wherever, an observer is attached to that specific entity.

This feels more intuitive and localised, and I think most users will work out how to get from there to different animations and meshes. The downside is more lines of code, and the "find the animation players" part still feels a bit magical and inefficient.

# Side Notes

- The solution was mostly stolen from https://github.com/bevyengine/bevy/issues/14852#issuecomment-2481401769.
- The example still feels too complicated.
    - "Why do I have to make this graph to play one animation?"
    - "Why can't I choose and play the animation in one step and avoid this temporary component?"
    - I think this requires engine changes.
- I originally started on a separate example of multiple meshes ([branch](https://github.com/bevyengine/bevy/compare/main...greeble-dev:bevy:animated-mesh-multiple)).
    - I decided that the user could probably work this out themselves from the single animation example.
    - But maybe still worth following through.

# Testing

`cargo run --example animated_mesh`
