### PR TITLE
Add docs to custom vertex attribute example

### DIFF
--- a/examples/2d/custom_gltf_vertex_attribute.rs
+++ b/examples/2d/custom_gltf_vertex_attribute.rs
@@ -33,6 +33,9 @@ fn main() {
             DefaultPlugins.set(
                 GltfPlugin::default()
                     // Map a custom glTF attribute name to a `MeshVertexAttribute`.
+                    // The glTF file used here has an attribute name with *two*
+                    // underscores: __BARYCENTRIC
+                    // One is stripped to do the comparison here.
                     .add_custom_vertex_attribute("_BARYCENTRIC", ATTRIBUTE_BARYCENTRIC),
             ),
             Material2dPlugin::<CustomMaterial>::default(),


### PR DESCRIPTION
# Objective

The gltf-json crate seems like it strips/adds an `_` when doing the name comparison for custom vertex attributes.

* gltf-json [add](https://github.com/gltf-rs/gltf/blob/88e719d5de9268318aa922e38fd54f4844bea18c/gltf-json/src/mesh.rs#L341)
* gltf-json [strip](https://github.com/gltf-rs/gltf/blob/88e719d5de9268318aa922e38fd54f4844bea18c/gltf-json/src/mesh.rs#L298C12-L298C42)
* [bevy's handling](https://github.com/bevyengine/bevy/blob/b66c3ceb0ee39374ff1759ffb1b5bee2e4b93e99/crates/bevy_gltf/src/vertex_attributes.rs#L273-L276) seems like it uses the non-underscore'd version.

The bevy example gltf: [barycentric.gltf](https://github.com/bevyengine/bevy/blob/b66c3ceb0ee39374ff1759ffb1b5bee2e4b93e99/assets/models/barycentric/barycentric.gltf), includes two underscores: `__BARYCENTRIC` in the gltf file, resulting in needing `_BARYCENTRIC` (one underscore) as the attribute name in Bevy. This extra underscore is redundant and does not appear if exporting from blender, which only requires a single underscore to trigger the attribute export.

I'm not sure if we want to change the example itself (maybe there's a reason it has two underscores, I couldn't find a reason), but a docs comment would help.

## Solution

add docs detailing the behavior


