### PR TITLE
BRP resource methods

### DIFF
--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -519,9 +519,10 @@ pub fn process_remote_get_resource_request(
         });
     };
 
-    // MATTY: Probably get rid of this unwrap?
     // Get the single value out of the map.
-    let value = serialized_object.into_values().next().unwrap();
+    let value = serialized_object.into_values().next().ok_or_else(|| {
+        BrpError::internal(anyhow!("Unexpected format of serialized resource value"))
+    })?;
     let response = BrpGetResourceResponse { value };
     serde_json::to_value(response).map_err(BrpError::internal)
 }

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -1682,7 +1682,7 @@ fn deserialize_resource(
     resource_path: &str,
     value: Value,
 ) -> AnyhowResult<Box<dyn PartialReflect>> {
-    let Some(resource_type) = type_registry.get_with_type_path(&resource_path) else {
+    let Some(resource_type) = type_registry.get_with_type_path(resource_path) else {
         return Err(anyhow!("Unknown resource type: `{}`", resource_path));
     };
     let reflected: Box<dyn PartialReflect> =

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -87,6 +87,14 @@ pub struct BrpGetParams {
     pub strict: bool,
 }
 
+/// `bevy/get_resource`: Retrieves the value of a given resource.
+pub struct BrpGetResourceParams {
+    /// The [full path] of the resource type being requested.
+    ///
+    /// [full path]: bevy_reflect::TypePath::type_path
+    pub resource: String,
+}
+
 /// `bevy/query`: Performs a query over components in the ECS, returning entities
 /// and component values that match.
 ///
@@ -153,6 +161,14 @@ pub struct BrpRemoveParams {
     pub components: Vec<String>,
 }
 
+/// `bevy/remove_resource`: Removes the given resource from the world.
+pub struct BrpRemoveResourceParams {
+    /// The [full path] of the resource type to remove.
+    ///
+    /// [full path]: bevy_reflect::TypePath::type_path
+    pub resource: String,
+}
+
 /// `bevy/insert`: Adds one or more components to an entity.
 ///
 /// The server responds with a null.
@@ -171,6 +187,18 @@ pub struct BrpInsertParams {
     ///
     /// [full type paths]: bevy_reflect::TypePath::type_path
     pub components: HashMap<String, Value>,
+}
+
+/// `bevy/insert_resource`: Inserts a resource into the world with a given
+/// value.
+pub struct BrpInsertResourceParams {
+    /// The [full path] of the resource type to insert.
+    ///
+    /// [full path]: bevy_reflect::TypePath::type_path
+    pub resource: String,
+
+    /// The serialized value of the resource to be inserted.
+    pub value: Value,
 }
 
 /// `bevy/reparent`: Assign a new parent to one or more entities.

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     query::QueryBuilder,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
     removal_detection::RemovedComponentEntity,
-    system::{In, Local, ParamSet},
+    system::{In, Local},
     world::{EntityRef, EntityWorldMut, FilteredEntityRef, World},
 };
 use bevy_hierarchy::BuildChildren as _;

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -194,7 +194,7 @@
 //!
 //! `result`: null.
 //!
-//! ### `bevy/mutate_component`
+//! ### bevy/mutate_component
 //!
 //! Mutate a field in a component.
 //!
@@ -274,6 +274,52 @@
 //! - `removed`: An array of fully-qualified type names of components removed from the entity
 //!   in the last tick.
 //!
+//! ### bevy/get_resource
+//!
+//! Extract the value of a given resource from the world.
+//!
+//! `params`:
+//! - `resource`: The [fully-qualified type name] of the resource to get.
+//!
+//! `result`:
+//! - `value`: The value of the resource in the world.
+//!
+//! ### bevy/insert_resource
+//!
+//! Insert the given resource into the world with the given value.
+//!
+//! `params`:
+//! - `resource`: The [fully-qualified type name] of the resource to insert.
+//! - `value`: The value of the resource to be inserted.
+//!
+//! `result`: null.
+//!
+//! ### bevy/remove_resource
+//!
+//! Remove the given resource from the world.
+//!
+//! `params`
+//! - `resource`: The [fully-qualified type name] of the resource to remove.
+//!
+//! `result`: null.
+//!
+//! ### bevy/mutate_resource
+//!
+//! Mutate a field in a resource.
+//!
+//! `params`:
+//! - `resource`: The [fully-qualified type name] of the resource to mutate.
+//! - `path`: The path of the field within the resource. See
+//!   [`GetPath`](bevy_reflect::GetPath#syntax) for more information on formatting this string.
+//! - `value`: The value to be inserted at `path`.
+//!
+//! `result`: null.
+//!
+//! ### bevy/list_resources
+//!
+//! List all reflectable registered resource types. This method has no parameters.
+//!
+//! `result`: An array of [fully-qualified type names] of registered resource types.
 //!
 //! ## Custom methods
 //!

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -787,7 +787,7 @@ impl BrpError {
     pub fn resource_not_present(resource: &str) -> Self {
         Self {
             code: error_codes::RESOURCE_NOT_PRESENT,
-            message: format!("Resource `{resource}` not present in the world."),
+            message: format!("Resource `{resource}` not present in the world"),
             data: None,
         }
     }

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -720,9 +720,9 @@ impl BrpError {
     #[must_use]
     pub fn resource_not_present(resource: &str) -> Self {
         Self {
-            code: todo!(),
+            code: error_codes::RESOURCE_NOT_PRESENT,
             message: format!("Resource `{resource}` not present in the world."),
-            data: todo!(),
+            data: None,
         }
     }
 

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -435,7 +435,7 @@ impl Default for RemotePlugin {
                 builtin_methods::process_remote_list_watching_request,
             )
             .with_method(
-                builtin_methods::BRP_LIST_RESOURCES_METHOD,
+                builtin_methods::BRP_GET_RESOURCE_METHOD,
                 builtin_methods::process_remote_get_resource_request,
             )
             .with_method(

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -423,10 +423,6 @@ impl Default for RemotePlugin {
                 builtin_methods::process_remote_list_request,
             )
             .with_method(
-                builtin_methods::BRP_REGISTRY_SCHEMA_METHOD,
-                builtin_methods::export_registry_types,
-            )
-            .with_method(
                 builtin_methods::BRP_MUTATE_COMPONENT_METHOD,
                 builtin_methods::process_remote_mutate_component_request,
             )
@@ -437,6 +433,30 @@ impl Default for RemotePlugin {
             .with_watching_method(
                 builtin_methods::BRP_LIST_AND_WATCH_METHOD,
                 builtin_methods::process_remote_list_watching_request,
+            )
+            .with_method(
+                builtin_methods::BRP_LIST_RESOURCES_METHOD,
+                builtin_methods::process_remote_get_resource_request,
+            )
+            .with_method(
+                builtin_methods::BRP_INSERT_RESOURCE_METHOD,
+                builtin_methods::process_remote_insert_resource_request,
+            )
+            .with_method(
+                builtin_methods::BRP_REMOVE_RESOURCE_METHOD,
+                builtin_methods::process_remote_remove_resource_request,
+            )
+            .with_method(
+                builtin_methods::BRP_MUTATE_RESOURCE_METHOD,
+                builtin_methods::process_remote_mutate_resource_request,
+            )
+            .with_method(
+                builtin_methods::BRP_LIST_RESOURCES_METHOD,
+                builtin_methods::process_remote_list_resources_request,
+            )
+            .with_method(
+                builtin_methods::BRP_REGISTRY_SCHEMA_METHOD,
+                builtin_methods::export_registry_types,
             )
     }
 }

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -102,7 +102,7 @@
 //! in the ECS. Each of these methods uses the `bevy/` prefix, which is a namespace reserved for
 //! BRP built-in methods.
 //!
-//! ### bevy/get
+//! ### `bevy/get`
 //!
 //! Retrieve the values of one or more components from an entity.
 //!
@@ -123,7 +123,7 @@
 //!
 //! `result`: A map associating each type name to its value on the requested entity.
 //!
-//! ### bevy/query
+//! ### `bevy/query`
 //!
 //! Perform a query over components in the ECS, returning all matching entities and their associated
 //! component values.
@@ -155,7 +155,7 @@
 //!
 //!
 //!
-//! ### bevy/spawn
+//! ### `bevy/spawn`
 //!
 //! Create a new entity with the provided components and return the resulting entity ID.
 //!
@@ -165,7 +165,7 @@
 //! `result`:
 //! - `entity`: The ID of the newly spawned entity.
 //!
-//! ### bevy/destroy
+//! ### `bevy/destroy`
 //!
 //! Despawn the entity with the given ID.
 //!
@@ -174,7 +174,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/remove
+//! ### `bevy/remove`
 //!
 //! Delete one or more components from an entity.
 //!
@@ -184,7 +184,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/insert
+//! ### `bevy/insert`
 //!
 //! Insert one or more components into an entity.
 //!
@@ -194,7 +194,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/mutate_component
+//! ### `bevy/mutate_component`
 //!
 //! Mutate a field in a component.
 //!
@@ -207,7 +207,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/reparent
+//! ### `bevy/reparent`
 //!
 //! Assign a new parent to one or more entities.
 //!
@@ -218,7 +218,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/list
+//! ### `bevy/list`
 //!
 //! List all registered components or all components present on an entity.
 //!
@@ -230,7 +230,7 @@
 //!
 //! `result`: An array of fully-qualified type names of components.
 //!
-//! ### bevy/get+watch
+//! ### `bevy/get+watch`
 //!
 //! Watch the values of one or more components from an entity.
 //!
@@ -258,7 +258,7 @@
 //! - `removed`: An array of fully-qualified type names of components removed from the entity
 //!   in the last tick.
 //!
-//! ### bevy/list+watch
+//! ### `bevy/list+watch`
 //!
 //! Watch all components present on an entity.
 //!
@@ -274,7 +274,7 @@
 //! - `removed`: An array of fully-qualified type names of components removed from the entity
 //!   in the last tick.
 //!
-//! ### bevy/get_resource
+//! ### `bevy/get_resource`
 //!
 //! Extract the value of a given resource from the world.
 //!
@@ -284,7 +284,7 @@
 //! `result`:
 //! - `value`: The value of the resource in the world.
 //!
-//! ### bevy/insert_resource
+//! ### `bevy/insert_resource`
 //!
 //! Insert the given resource into the world with the given value.
 //!
@@ -294,7 +294,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/remove_resource
+//! ### `bevy/remove_resource`
 //!
 //! Remove the given resource from the world.
 //!
@@ -303,7 +303,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/mutate_resource
+//! ### `bevy/mutate_resource`
 //!
 //! Mutate a field in a resource.
 //!
@@ -315,7 +315,7 @@
 //!
 //! `result`: null.
 //!
-//! ### bevy/list_resources
+//! ### `bevy/list_resources`
 //!
 //! List all reflectable registered resource types. This method has no parameters.
 //!

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -716,6 +716,26 @@ impl BrpError {
         }
     }
 
+    /// Resource was not present in the world.
+    #[must_use]
+    pub fn resource_not_present(resource: &str) -> Self {
+        Self {
+            code: todo!(),
+            message: format!("Resource `{resource}` not present in the world."),
+            data: todo!(),
+        }
+    }
+
+    /// An arbitrary resource error. Possibly related to reflection.
+    #[must_use]
+    pub fn resource_error<E: ToString>(error: E) -> Self {
+        Self {
+            code: error_codes::RESOURCE_ERROR,
+            message: error.to_string(),
+            data: None,
+        }
+    }
+
     /// An arbitrary internal error.
     #[must_use]
     pub fn internal<E: ToString>(error: E) -> Self {
@@ -770,6 +790,14 @@ pub mod error_codes {
 
     /// Cannot reparent an entity to itself.
     pub const SELF_REPARENT: i16 = -23404;
+
+    // MATTY: Clean these up :)
+
+    /// Could not reflect or find resource.
+    pub const RESOURCE_ERROR: i16 = -23501;
+
+    /// Could not find resource in the world.
+    pub const RESOURCE_NOT_PRESENT: i16 = -23502;
 }
 
 /// The result of a request.

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -857,8 +857,6 @@ pub mod error_codes {
     /// Cannot reparent an entity to itself.
     pub const SELF_REPARENT: i16 = -23404;
 
-    // MATTY: Clean these up :)
-
     /// Could not reflect or find resource.
     pub const RESOURCE_ERROR: i16 = -23501;
 

--- a/examples/remote/server.rs
+++ b/examples/remote/server.rs
@@ -16,7 +16,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, remove.run_if(input_just_pressed(KeyCode::Space)))
         .add_systems(Update, move_cube)
-        // New types must be registed in order to be usable with reflection.
+        // New types must be registered in order to be usable with reflection.
         .register_type::<Cube>()
         .register_type::<TestResource>()
         .run();

--- a/examples/remote/server.rs
+++ b/examples/remote/server.rs
@@ -16,7 +16,9 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, remove.run_if(input_just_pressed(KeyCode::Space)))
         .add_systems(Update, move_cube)
+        // New types must be registed in order to be usable with reflection.
         .register_type::<Cube>()
+        .register_type::<TestResource>()
         .run();
 }
 
@@ -40,6 +42,12 @@ fn setup(
         Cube(1.0),
     ));
 
+    // test resource
+    commands.insert_resource(TestResource {
+        foo: Vec2::new(1.0, -1.0),
+        bar: false,
+    });
+
     // light
     commands.spawn((
         PointLight {
@@ -54,6 +62,17 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
+}
+
+/// An arbitrary resource that can be inspected and manipulated with remote methods.
+#[derive(Resource, Reflect, Serialize, Deserialize)]
+#[reflect(Resource, Serialize, Deserialize)]
+pub struct TestResource {
+    /// An arbitrary field of the test resource.
+    pub foo: Vec2,
+
+    /// Another arbitrary field.
+    pub bar: bool,
 }
 
 fn move_cube(mut query: Query<&mut Transform, With<Cube>>, time: Res<Time>) {


### PR DESCRIPTION
# Objective

So far, built-in BRP methods allow users to interact with entities' components, but global resources have remained beyond its reach. The goal of this PR is to take the first steps in rectifying this shortfall.

## Solution

Added five new default methods to BRP:
- `bevy/get_resource`: Extracts the value of a given resource from the world.
- `bevy/insert_resource`: Serializes an input value to a given resource type and inserts it into the world.
- `bevy/remove_resource`: Removes the given resource from the world.
- `bevy/mutate_resource`: Replaces the value of a field in a given resource with the result of serializing a given input value.
- `bevy/list_resources`: Lists all resources in the type registry with an available `ReflectResource`. 

## Testing

Added a test resource to the `server` example scene that you can use to mess around with the new BRP methods.

## Showcase

Resources can now be retrieved and manipulated remotely using a handful of new BRP methods. For example, a resource that looks like this:
```rust
#[derive(Resource, Reflect, Serialize, Deserialize)]
#[reflect(Resource, Serialize, Deserialize)]
pub struct PlayerSpawnSettings {
  pub location: Vec2,
  pub lives: u8,
}
```

can be manipulated remotely as follows.

Retrieving the value of the resource:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "bevy/get_resource",
  "params": {
    "resource": "path::to::my::module::PlayerSpawnSettings"
  }
}
```

Inserting a resource value into the world:
```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "bevy/insert_resource",
  "params": {
    "resource": "path::to::my::module::PlayerSpawnSettings",
    "value": {
      "location": [
        2.5, 
        2.5
      ],
      "lives": 25
    }
  }
}
```

Removing the resource from the world:
```json
{
  "jsonrpc": "2.0",
  "id": 3,
  "method": "bevy/remove_resource",
  "params": {
    "resource": "path::to::my::module::PlayerSpawnSettings"
  }
}
```

Mutating a field of the resource specified by a path:
```json
{
  "jsonrpc": "2.0",
  "id": 4,
  "method": "bevy/mutate_resource",
  "params": {
    "resource": "path::to::my::module::PlayerSpawnSettings",
    "path": ".location.x",
    "value": -3.0
  }
}
```

Listing all manipulable resources in the type registry:
```json
{
  "jsonrpc": "2.0",
  "id": 5,
  "method": "bevy/list_resources"
}
```