### PR TITLE
Diagnostics for label traits

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -32,6 +32,9 @@ use std::{
 
 bevy_ecs::define_label!(
     /// A strongly-typed class of labels used to identify an [`App`].
+    #[diagnostic::on_unimplemented(
+        note = "consider annotating `{Self}` with `#[derive(AppLabel)]`"
+    )]
     AppLabel,
     APP_LABEL_INTERNER
 );

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -142,6 +142,7 @@ macro_rules! define_label {
             }
         }
 
+        #[diagnostic::do_not_recommend]
         impl $label_trait_name for $crate::intern::Interned<dyn $label_trait_name> {
 
             $($interned_extra_methods_impl)*

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -142,38 +142,27 @@ macro_rules! define_label {
             }
         }
 
-        const _: () = {
-            #[expect(clippy::allow_attributes, reason = "Expect would break upon stabilization")]
-            #[allow(unknown_or_malformed_diagnostic_attributes,
-                reason = "do_not_recommend is not stable yet"
-            )]
-            mod with_lint_workaround {
-                use super::*;
+        impl $label_trait_name for $crate::intern::Interned<dyn $label_trait_name> {
 
-                #[diagnostic::do_not_recommend]
-                impl $label_trait_name for $crate::intern::Interned<dyn $label_trait_name> {
+            $($interned_extra_methods_impl)*
 
-                    $($interned_extra_methods_impl)*
-
-                    fn dyn_clone(&self) -> $crate::label::Box<dyn $label_trait_name> {
-                        (**self).dyn_clone()
-                    }
-
-                    /// Casts this value to a form where it can be compared with other type-erased values.
-                    fn as_dyn_eq(&self) -> &dyn $crate::label::DynEq {
-                        (**self).as_dyn_eq()
-                    }
-
-                    fn dyn_hash(&self, state: &mut dyn ::core::hash::Hasher) {
-                        (**self).dyn_hash(state);
-                    }
-
-                    fn intern(&self) -> Self {
-                        *self
-                    }
-                }
+            fn dyn_clone(&self) -> $crate::label::Box<dyn $label_trait_name> {
+                (**self).dyn_clone()
             }
-        };
+
+            /// Casts this value to a form where it can be compared with other type-erased values.
+            fn as_dyn_eq(&self) -> &dyn $crate::label::DynEq {
+                (**self).as_dyn_eq()
+            }
+
+            fn dyn_hash(&self, state: &mut dyn ::core::hash::Hasher) {
+                (**self).dyn_hash(state);
+            }
+
+            fn intern(&self) -> Self {
+                *self
+            }
+        }
 
         impl PartialEq for dyn $label_trait_name {
             fn eq(&self, other: &Self) -> bool {

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -142,6 +142,10 @@ macro_rules! define_label {
             }
         }
 
+        #[expect(clippy::allow_attributes, reason = "Expect would break upon stabilization")]
+        #[allow(unknown_or_malformed_diagnostic_attributes,
+            reason = "do_not_recommend is not stable yet"
+        )]
         #[diagnostic::do_not_recommend]
         impl $label_trait_name for $crate::intern::Interned<dyn $label_trait_name> {
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -20,12 +20,18 @@ use crate::{
 
 define_label!(
     /// A strongly-typed class of labels used to identify a [`Schedule`](crate::schedule::Schedule).
+    #[diagnostic::on_unimplemented(
+        note = "consider annotating `{Self}` with `#[derive(ScheduleLabel)]`"
+    )]
     ScheduleLabel,
     SCHEDULE_LABEL_INTERNER
 );
 
 define_label!(
     /// Types that identify logical groups of systems.
+    #[diagnostic::on_unimplemented(
+        note = "consider annotating `{Self}` with `#[derive(SystemSet)]`"
+    )]
     SystemSet,
     SYSTEM_SET_INTERNER,
     extra_methods: {

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -14,6 +14,9 @@ use super::{EdgeExistence, InternedRenderLabel, IntoRenderNodeArray};
 pub use bevy_render_macros::RenderSubGraph;
 
 define_label!(
+    #[diagnostic::on_unimplemented(
+        note = "consider annotating `{Self}` with `#[derive(RenderSubGraph)]`"
+    )]
     /// A strongly-typed class of labels used to identify a [`SubGraph`] in a render graph.
     RenderSubGraph,
     RENDER_SUB_GRAPH_INTERNER

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -23,6 +23,9 @@ pub use bevy_render_macros::RenderLabel;
 use super::{InternedRenderSubGraph, RenderSubGraph};
 
 define_label!(
+    #[diagnostic::on_unimplemented(
+        note = "consider annotating `{Self}` with `#[derive(RenderLabel)]`"
+    )]
     /// A strongly-typed class of labels used to identify a [`Node`] in a render graph.
     RenderLabel,
     RENDER_LABEL_INTERNER


### PR DESCRIPTION
# Objective

Diagnostics for labels don't suggest how to best implement them.
```
error[E0277]: the trait bound `Label: ScheduleLabel` is not satisfied
   --> src/main.rs:15:35
    |
15  |     let mut sched = Schedule::new(Label);
    |                     ------------- ^^^^^ the trait `ScheduleLabel` is not implemented for `Label`
    |                     |
    |                     required by a bound introduced by this call
    |
    = help: the trait `ScheduleLabel` is implemented for `Interned<(dyn ScheduleLabel + 'static)>`
note: required by a bound in `bevy_ecs::schedule::Schedule::new`
   --> /home/vj/workspace/rust/bevy/crates/bevy_ecs/src/schedule/schedule.rs:297:28
    |
297 |     pub fn new(label: impl ScheduleLabel) -> Self {
    |                            ^^^^^^^^^^^^^ required by this bound in `Schedule::new`
```

## Solution

`diagnostics::on_unimplemented` and `diagnostics::do_not_recommend`

## Showcase

New error message:
```
error[E0277]: the trait bound `Label: ScheduleLabel` is not satisfied
   --> src/main.rs:15:35
    |
15  |     let mut sched = Schedule::new(Label);
    |                     ------------- ^^^^^ the trait `ScheduleLabel` is not implemented for `Label`
    |                     |
    |                     required by a bound introduced by this call
    |
    = note: consider annotating `Label` with `#[derive(ScheduleLabel)]`
note: required by a bound in `bevy_ecs::schedule::Schedule::new`
   --> /home/vj/workspace/rust/bevy/crates/bevy_ecs/src/schedule/schedule.rs:297:28
    |
297 |     pub fn new(label: impl ScheduleLabel) -> Self {
    |                            ^^^^^^^^^^^^^ required by this bound in `Schedule::new`
```