### PR TITLE
Switch `bevy_asset` to `core::prelude`

### DIFF
--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -288,7 +288,9 @@ unsafe impl<A: AsAssetId> QueryFilter for AssetChanged<A> {
 #[cfg(test)]
 mod tests {
     use crate::{self as bevy_asset, AssetEvents, AssetPlugin, Handle};
+    use alloc::{vec, vec::Vec};
     use core::num::NonZero;
+    use std::println;
 
     use crate::{AssetApp, Assets};
     use bevy_app::{App, AppExit, Last, Startup, TaskPoolPlugin, Update};

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -3,7 +3,7 @@ use crate::{
     self as bevy_asset, Asset, AssetEvent, AssetHandleProvider, AssetId, AssetServer, Handle,
     UntypedHandle,
 };
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use bevy_ecs::{
     prelude::EventWriter,
     system::{Res, ResMut, Resource, SystemChangeTick},

--- a/crates/bevy_asset/src/folder.rs
+++ b/crates/bevy_asset/src/folder.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate as bevy_asset;
 use crate::{Asset, UntypedHandle};
 use bevy_reflect::TypePath;

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -514,6 +514,7 @@ pub enum UntypedAssetConversionError {
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
     use bevy_reflect::PartialReflect;
     use bevy_utils::FixedHasher;
     use core::hash::BuildHasher;

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -1,8 +1,7 @@
 use crate::io::{get_meta_path, AssetReader, AssetReaderError, PathStream, Reader, VecReader};
-use alloc::ffi::CString;
+use alloc::{borrow::ToOwned, boxed::Box, ffi::CString, vec::Vec};
 use futures_lite::stream;
 use std::path::Path;
-use tracing::error;
 
 /// [`AssetReader`] implementation for Android devices, built on top of Android's [`AssetManager`].
 ///
@@ -73,10 +72,7 @@ impl AssetReader for AndroidAssetReader {
         Ok(read_dir)
     }
 
-    async fn is_directory<'a>(
-        &'a self,
-        path: &'a Path,
-    ) -> std::result::Result<bool, AssetReaderError> {
+    async fn is_directory<'a>(&'a self, path: &'a Path) -> Result<bool, AssetReaderError> {
         let asset_manager = bevy_window::ANDROID_APP
             .get()
             .expect("Bevy must be setup with the #[bevy_main] macro on Android")

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -1,6 +1,7 @@
 use crate::io::{get_meta_path, AssetReader, AssetReaderError, PathStream, Reader, VecReader};
+use alloc::ffi::CString;
 use futures_lite::stream;
-use std::{ffi::CString, path::Path};
+use std::path::Path;
 use tracing::error;
 
 /// [`AssetReader`] implementation for Android devices, built on top of Android's [`AssetManager`].

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -3,7 +3,7 @@ use crate::io::{
     memory::Dir,
     AssetSourceEvent, AssetWatcher,
 };
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use bevy_utils::HashMap;
 use core::time::Duration;
 use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, RecommendedCache};

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -8,6 +8,7 @@ use crate::io::{
     memory::{Dir, MemoryAssetReader, Value},
     AssetSource, AssetSourceBuilders,
 };
+use alloc::{borrow::ToOwned, boxed::Box};
 use bevy_ecs::system::Resource;
 use std::path::{Path, PathBuf};
 

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -8,9 +8,12 @@ use crate::io::{
     memory::{Dir, MemoryAssetReader, Value},
     AssetSource, AssetSourceBuilders,
 };
-use alloc::{borrow::ToOwned, boxed::Box};
+use alloc::boxed::Box;
 use bevy_ecs::system::Resource;
 use std::path::{Path, PathBuf};
+
+#[cfg(feature = "embedded_watcher")]
+use alloc::borrow::ToOwned;
 
 pub const EMBEDDED: &str = "embedded";
 

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -33,7 +33,7 @@ impl EmbeddedAssetRegistry {
     /// Inserts a new asset. `full_path` is the full path (as [`file`] would return for that file, if it was capable of
     /// running in a non-rust file). `asset_path` is the path that will be used to identify the asset in the `embedded`
     /// [`AssetSource`]. `value` is the bytes that will be returned for the asset. This can be _either_ a `&'static [u8]`
-    /// or a [`Vec<u8>`].
+    /// or a [`Vec<u8>`](alloc::vec::Vec).
     #[cfg_attr(
         not(feature = "embedded_watcher"),
         expect(
@@ -52,7 +52,7 @@ impl EmbeddedAssetRegistry {
     /// Inserts new asset metadata. `full_path` is the full path (as [`file`] would return for that file, if it was capable of
     /// running in a non-rust file). `asset_path` is the path that will be used to identify the asset in the `embedded`
     /// [`AssetSource`]. `value` is the bytes that will be returned for the asset. This can be _either_ a `&'static [u8]`
-    /// or a [`Vec<u8>`].
+    /// or a [`Vec<u8>`](alloc::vec::Vec).
     #[cfg_attr(
         not(feature = "embedded_watcher"),
         expect(

--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -6,6 +6,7 @@ use async_fs::{read_dir, File};
 use futures_io::AsyncSeek;
 use futures_lite::StreamExt;
 
+use alloc::{borrow::ToOwned, boxed::Box};
 use core::{pin::Pin, task, task::Poll};
 use std::path::Path;
 

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -2,6 +2,7 @@ use crate::{
     io::{AssetSourceEvent, AssetWatcher},
     path::normalize_path,
 };
+use alloc::borrow::ToOwned;
 use core::time::Duration;
 use crossbeam_channel::Sender;
 use notify_debouncer_full::{

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -10,6 +10,7 @@ mod sync_file_asset;
 pub use file_watcher::*;
 use tracing::{debug, error};
 
+use alloc::borrow::ToOwned;
 use std::{
     env,
     path::{Path, PathBuf},

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -6,6 +6,7 @@ use crate::io::{
     PathStream, Reader, Writer,
 };
 
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use core::{pin::Pin, task::Poll};
 use std::{
     fs::{read_dir, File},

--- a/crates/bevy_asset/src/io/gated.rs
+++ b/crates/bevy_asset/src/io/gated.rs
@@ -1,5 +1,5 @@
 use crate::io::{AssetReader, AssetReaderError, PathStream, Reader};
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
 use bevy_utils::HashMap;
 use crossbeam_channel::{Receiver, Sender};
 use parking_lot::RwLock;

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -1,5 +1,5 @@
 use crate::io::{AssetReader, AssetReaderError, PathStream, Reader};
-use alloc::sync::Arc;
+use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
 use bevy_utils::HashMap;
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -21,7 +21,7 @@ mod source;
 pub use futures_lite::AsyncWriteExt;
 pub use source::*;
 
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use core::future::Future;
 use core::{

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -3,7 +3,7 @@ use crate::{
     processor::{AssetProcessorData, ProcessStatus},
     AssetPath,
 };
-use alloc::sync::Arc;
+use alloc::{borrow::ToOwned, boxed::Box, sync::Arc, vec::Vec};
 use async_lock::RwLockReadGuardArc;
 use core::{pin::Pin, task::Poll};
 use futures_io::AsyncRead;

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -2,7 +2,11 @@ use crate::{
     io::{processor_gated::ProcessorGatedReader, AssetSourceEvent, AssetWatcher},
     processor::AssetProcessorData,
 };
-use alloc::sync::Arc;
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+};
 use atomicow::CowArc;
 use bevy_ecs::system::Resource;
 use bevy_utils::HashMap;

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -1,6 +1,7 @@
 use crate::io::{
     get_meta_path, AssetReader, AssetReaderError, EmptyPathStream, PathStream, Reader, VecReader,
 };
+use alloc::{borrow::ToOwned, boxed::Box, format};
 use js_sys::{Uint8Array, JSON};
 use std::path::{Path, PathBuf};
 use tracing::error;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -144,9 +144,10 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+#![no_std]
 
 extern crate alloc;
-extern crate core;
+extern crate std;
 
 pub mod io;
 pub mod meta;
@@ -206,7 +207,11 @@ use crate::{
     io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
     processor::{AssetProcessor, Process},
 };
-use alloc::sync::Arc;
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 use bevy_app::{App, Last, Plugin, PreUpdate};
 use bevy_ecs::prelude::Component;
 use bevy_ecs::{
@@ -633,7 +638,14 @@ mod tests {
         Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
         AssetPlugin, AssetServer, Assets,
     };
-    use alloc::sync::Arc;
+    use alloc::{
+        boxed::Box,
+        format,
+        string::{String, ToString},
+        sync::Arc,
+        vec,
+        vec::Vec,
+    };
     use bevy_app::{App, TaskPoolPlugin, Update};
     use bevy_ecs::{
         event::EventCursor,

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -6,6 +6,11 @@ use crate::{
     Asset, AssetLoadError, AssetServer, AssetServerMode, Assets, Handle, UntypedAssetId,
     UntypedHandle,
 };
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use atomicow::CowArc;
 use bevy_ecs::world::World;
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -7,7 +7,7 @@ use crate::{
     Asset, AssetLoadError, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext,
     LoadDirectError, LoadedAsset, LoadedUntypedAsset, UntypedHandle,
 };
-use alloc::sync::Arc;
+use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
 use core::any::TypeId;
 
 // Utility type for handling the sources of reader references

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -1,3 +1,9 @@
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use crate::{
     self as bevy_asset, loader::AssetLoader, processor::Process, Asset, AssetPath,
     DeserializeMetaError, VisitAssetDependencies,

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,4 +1,8 @@
 use crate::io::AssetSourceId;
+use alloc::{
+    borrow::ToOwned,
+    string::{String, ToString},
+};
 use atomicow::CowArc;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use core::{
@@ -316,7 +320,7 @@ impl<'a> AssetPath<'a> {
     /// If internally a value is a static reference, the static reference will be used unchanged.
     /// If internally a value is an "owned [`Arc`]", it will remain unchanged.
     ///
-    /// [`Arc`]: std::sync::Arc
+    /// [`Arc`]: alloc::sync::Arc
     pub fn into_owned(self) -> AssetPath<'static> {
         AssetPath {
             source: self.source.into_owned(),
@@ -329,7 +333,7 @@ impl<'a> AssetPath<'a> {
     /// If internally a value is a static reference, the static reference will be used unchanged.
     /// If internally a value is an "owned [`Arc`]", the [`Arc`] will be cloned.
     ///
-    /// [`Arc`]: std::sync::Arc
+    /// [`Arc`]: alloc::sync::Arc
     #[inline]
     pub fn clone_owned(&self) -> AssetPath<'static> {
         self.clone().into_owned()
@@ -629,6 +633,7 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use crate::AssetPath;
+    use alloc::string::ToString;
     use std::path::Path;
 
     #[test]

--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -1,4 +1,9 @@
 use crate::AssetPath;
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use async_fs::File;
 use bevy_utils::HashSet;
 use futures_lite::{AsyncReadExt, AsyncWriteExt};

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -56,12 +56,8 @@ use crate::{
     AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
     MissingAssetLoaderForExtensionError,
 };
-use alloc::{
-    borrow::ToOwned, boxed::Box, collections::VecDeque, string::ToString, sync::Arc, vec, vec::Vec,
-};
+use alloc::{borrow::ToOwned, boxed::Box, collections::VecDeque, sync::Arc, vec, vec::Vec};
 use bevy_ecs::prelude::*;
-#[cfg(feature = "trace")]
-use bevy_tasks::ConditionalSendFuture;
 use bevy_tasks::IoTaskPool;
 use bevy_utils::{HashMap, HashSet};
 use futures_io::ErrorKind;
@@ -70,8 +66,13 @@ use parking_lot::RwLock;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::{debug, error, trace, warn};
+
 #[cfg(feature = "trace")]
-use tracing::{info_span, instrument::Instrument};
+use {
+    alloc::string::ToString,
+    bevy_tasks::ConditionalSendFuture,
+    tracing::{info_span, instrument::Instrument},
+};
 
 /// A "background" asset processor that reads asset values from a source [`AssetSource`] (which corresponds to an [`AssetReader`](crate::io::AssetReader) / [`AssetWriter`](crate::io::AssetWriter) pair),
 /// processes them in some way, and writes them to a destination [`AssetSource`].

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -56,7 +56,9 @@ use crate::{
     AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
     MissingAssetLoaderForExtensionError,
 };
-use alloc::{collections::VecDeque, sync::Arc};
+use alloc::{
+    borrow::ToOwned, boxed::Box, collections::VecDeque, string::ToString, sync::Arc, vec, vec::Vec,
+};
 use bevy_ecs::prelude::*;
 #[cfg(feature = "trace")]
 use bevy_tasks::ConditionalSendFuture;

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -10,6 +10,11 @@ use crate::{
     AssetLoadError, AssetLoader, AssetPath, DeserializeMetaError, ErasedLoadedAsset,
     MissingAssetLoaderForExtensionError, MissingAssetLoaderForTypeNameError,
 };
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    string::{String, ToString},
+};
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use core::marker::PhantomData;
 use serde::{Deserialize, Serialize};

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::any::{Any, TypeId};
 
 use bevy_ecs::world::{unsafe_world_cell::UnsafeWorldCell, World};
@@ -243,6 +244,7 @@ impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{string::String, vec::Vec};
     use core::any::TypeId;
 
     use crate as bevy_asset;

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -2,6 +2,7 @@ use crate::{
     io::Writer, meta::Settings, transformer::TransformedAsset, Asset, AssetLoader,
     ErasedLoadedAsset, Handle, LabeledAsset, UntypedHandle,
 };
+use alloc::boxed::Box;
 use atomicow::CowArc;
 use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use bevy_utils::HashMap;

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -4,7 +4,12 @@ use crate::{
     Handle, InternalAssetEvent, LoadState, RecursiveDependencyLoadState, StrongHandle,
     UntypedAssetId, UntypedHandle,
 };
-use alloc::sync::{Arc, Weak};
+use alloc::{
+    borrow::ToOwned,
+    boxed::Box,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
 use bevy_ecs::world::World;
 use bevy_tasks::Task;
 use bevy_utils::{Entry, HashMap, HashSet, TypeIdMap};

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -2,7 +2,7 @@ use crate::{
     loader::{AssetLoader, ErasedAssetLoader},
     path::AssetPath,
 };
-use alloc::sync::Arc;
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use async_broadcast::RecvError;
 #[cfg(feature = "trace")]
 use bevy_tasks::ConditionalSendFuture;
@@ -338,6 +338,7 @@ impl<T: AssetLoader> AssetLoader for InstrumentedAssetLoader<T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{format, string::String};
     use core::marker::PhantomData;
     use std::{
         path::Path,

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -2,17 +2,20 @@ use crate::{
     loader::{AssetLoader, ErasedAssetLoader},
     path::AssetPath,
 };
-use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use async_broadcast::RecvError;
-#[cfg(feature = "trace")]
-use bevy_tasks::ConditionalSendFuture;
 use bevy_tasks::IoTaskPool;
 use bevy_utils::{HashMap, TypeIdMap};
 use core::any::TypeId;
 use thiserror::Error;
 use tracing::warn;
+
 #[cfg(feature = "trace")]
-use tracing::{info_span, instrument::Instrument};
+use {
+    alloc::string::ToString,
+    bevy_tasks::ConditionalSendFuture,
+    tracing::{info_span, instrument::Instrument},
+};
 
 #[derive(Default)]
 pub(crate) struct AssetLoaders {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -17,7 +17,12 @@ use crate::{
     DeserializeMetaError, ErasedLoadedAsset, Handle, LoadedUntypedAsset, UntypedAssetId,
     UntypedAssetLoadFailedEvent, UntypedHandle,
 };
-use alloc::sync::Arc;
+use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::Arc,
+};
 use atomicow::CowArc;
 use bevy_ecs::prelude::*;
 use bevy_tasks::IoTaskPool;
@@ -198,7 +203,7 @@ impl AssetServer {
         loader.ok_or_else(error)?.get().await.map_err(|_| error())
     }
 
-    /// Returns the registered [`AssetLoader`] associated with the given [`std::any::type_name`], if it exists.
+    /// Returns the registered [`AssetLoader`] associated with the given [`core::any::type_name`], if it exists.
     pub async fn get_asset_loader_with_type_name(
         &self,
         type_name: &str,
@@ -1472,7 +1477,8 @@ impl AssetServer {
 pub fn handle_internal_asset_events(world: &mut World) {
     world.resource_scope(|world, server: Mut<AssetServer>| {
         let mut infos = server.data.infos.write();
-        let mut untyped_failures = vec![];
+        let var_name = vec![];
+        let mut untyped_failures = var_name;
         for event in server.data.asset_event_receiver.try_iter() {
             match event {
                 InternalAssetEvent::Loaded { id, loaded_asset } => {
@@ -1812,7 +1818,7 @@ pub struct MissingAssetLoaderForExtensionError {
     extensions: Vec<String>,
 }
 
-/// An error that occurs when an [`AssetLoader`] is not registered for a given [`std::any::type_name`].
+/// An error that occurs when an [`AssetLoader`] is not registered for a given [`core::any::type_name`].
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 #[error("no `AssetLoader` found with the name '{type_name}'")]
 pub struct MissingAssetLoaderForTypeNameError {

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,4 +1,5 @@
 use crate::{meta::Settings, Asset, ErasedLoadedAsset, Handle, LabeledAsset, UntypedHandle};
+use alloc::boxed::Box;
 use atomicow::CowArc;
 use bevy_tasks::ConditionalSendFuture;
 use bevy_utils::HashMap;


### PR DESCRIPTION
Makes use of `std` explicit, simplifying a possible `no_std` port.

# Objective

- Contributes to #15460
- Simplify future `no_std` work on `bevy_asset`

## Solution

- Add `#![no_std]` to switch to `core::prelude` instead of `std::prelude`

## Testing

- CI

---

## Notes

This is entirely a change around the names of imports and has no impact on functionality. This just reduces the quantity of changes involved in the (likely more controversial) `no_std`-ification of `bevy_asset`.
