### PR TITLE
remove unsound DerefMut impls from `EntityHashMap`/`EntityHashSet`

### DIFF
--- a/crates/bevy_ecs/src/entity/hash_map.rs
+++ b/crates/bevy_ecs/src/entity/hash_map.rs
@@ -165,12 +165,6 @@ impl<'a, V> Deref for Keys<'a, V> {
     }
 }
 
-impl<V> DerefMut for Keys<'_, V> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl<'a, V> Iterator for Keys<'a, V> {
     type Item = &'a Entity;
 
@@ -226,12 +220,6 @@ impl<V> Deref for IntoKeys<V> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl<V> DerefMut for IntoKeys<V> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/crates/bevy_ecs/src/entity/hash_set.rs
+++ b/crates/bevy_ecs/src/entity/hash_set.rs
@@ -203,12 +203,6 @@ impl<'a> Deref for Iter<'a> {
     }
 }
 
-impl DerefMut for Iter<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl<'a> Iterator for Iter<'a> {
     type Item = &'a Entity;
 
@@ -264,12 +258,6 @@ impl Deref for IntoIter {
     }
 }
 
-impl DerefMut for IntoIter {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl Iterator for IntoIter {
     type Item = Entity;
 
@@ -322,12 +310,6 @@ impl<'a> Deref for Drain<'a> {
     }
 }
 
-impl DerefMut for Drain<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl<'a> Iterator for Drain<'a> {
     type Item = Entity;
 
@@ -374,12 +356,6 @@ impl<'a, F: FnMut(&Entity) -> bool> Deref for ExtractIf<'a, F> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl<F: FnMut(&Entity) -> bool> DerefMut for ExtractIf<'_, F> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
# Objective

Noticed while doing #17449, I had left these `DerefMut` impls in.
Obtaining mutable references to those inner iterator types allows for `mem::swap`, which can be used to swap an incorrectly behaving instance into the wrappers.

## Solution

Remove them!