### PR TITLE
Fixing ui antialiasing clamp call parameters order (#14970)

### DIFF
--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -117,7 +117,7 @@ fn sd_inset_rounded_box(point: vec2<f32>, size: vec2<f32>, radius: vec4<f32>, in
 // get alpha for antialiasing for sdf
 fn antialias(distance: f32) -> f32 {
     // Using the fwidth(distance) was causing artifacts, so just use the distance.
-    return clamp(0.0, 1.0, (0.5 - distance));
+    return saturate(0.5 - distance);
 }
 
 fn draw(in: VertexOutput, texture_color: vec4<f32>) -> vec4<f32> {


### PR DESCRIPTION
# Objective

Fixes #14970

## Solution

It seems the clamp call in `ui.wgsl` had the parameters order incorrect.

## Testing

Tested using examples/ui in native and my current project in wasm - both in linux.
Could use some help with testing in other platforms.

---