### PR TITLE
Fix calculation of skybox rotation

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -34,13 +34,13 @@ fn coords_to_ray_direction(position: vec2<f32>, viewport: vec4<f32>) -> vec3<f32
     // Transforming the view space ray direction by the skybox transform matrix, it is 
     // equivalent to rotating the skybox itself.
     var view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
-    view_ray_direction = (uniforms.transform * vec4(view_ray_direction, 1.0)).xyz;
+    view_ray_direction = (view.world_from_view * vec4(view_ray_direction, 0.0)).xyz;
 
     // Transforming the view space ray direction by the view matrix, transforms the
     // direction to world space. Note that the w element is set to 0.0, as this is a
     // vector direction, not a position, That causes the matrix multiplication to ignore
     // the translations from the view matrix.
-    let ray_direction = (view.world_from_view * vec4(view_ray_direction, 0.0)).xyz;
+    let ray_direction = (uniforms.transform * vec4(view_ray_direction, 0.0)).xyz;
 
     return normalize(ray_direction);
 }
@@ -63,14 +63,12 @@ struct VertexOutput {
 @vertex
 fn skybox_vertex(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     // See the explanation above for how this works.
-    let clip_position = vec4(
+    let clip_position = vec2(
         f32(vertex_index & 1u),
         f32((vertex_index >> 1u) & 1u),
-        0.25,
-        0.5
-    ) * 4.0 - vec4(1.0);
+    ) * 4.0 - vec2(1.0);
 
-    return VertexOutput(clip_position);
+    return VertexOutput(vec4(clip_position, 0.0, 1.0));
 }
 
 @fragment


### PR DESCRIPTION
# Objective

Fixes #16628 

## Solution

Matrices were being applied in the wrong order.

## Testing

Ran `skybox` example with rotations applied to the `Skybox` on the `x`, `y`, and `z` axis (one at a time).

e.g.
```rust
Skybox {
    image: skybox_handle.clone(),
    brightness: 1000.0,
    rotation: Quat::from_rotation_y(-45.0_f32.to_radians()),
}
```

## Showcase

[Screencast_20250121_151232.webm](https://github.com/user-attachments/assets/3df68714-f5f1-4d8c-8e08-cbab525a8bda)

