### PR TITLE
Store resources as components on singleton entities

### DIFF
--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -57,7 +57,7 @@ pub fn run_condition_no(criterion: &mut Criterion) {
     group.finish();
 }
 
-#[derive(Component, Resource)]
+#[derive(Resource)]
 struct TestBool(pub bool);
 
 pub fn run_condition_yes_with_query(criterion: &mut Criterion) {

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -34,6 +34,11 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 }
 
 pub fn derive_resource(input: TokenStream) -> TokenStream {
+    // The resource derive *also* implements the Component trait
+    // We generate the Component implementation first, then add the Resource implementation,
+    // so then we can pick up all of the attributes from the Component derive
+    let component_derive_token_stream = derive_component(input.clone());
+
     let mut ast = parse_macro_input!(input as DeriveInput);
     let bevy_ecs_path: Path = crate::bevy_ecs_path();
 
@@ -45,10 +50,15 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
-    TokenStream::from(quote! {
+    let resource_impl_token_stream = TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::resource::Resource for #struct_name #type_generics #where_clause {
         }
-    })
+    });
+
+    resource_impl_token_stream
+        .into_iter()
+        .chain(component_derive_token_stream.into_iter())
+        .collect()
 }
 
 pub fn derive_component(input: TokenStream) -> TokenStream {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -156,7 +156,7 @@ mod tests {
     };
     use std::sync::Mutex;
 
-    #[derive(Component, Resource, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+    #[derive(Resource, Debug, PartialEq, Eq, Hash, Clone, Copy)]
     struct A(usize);
     #[derive(Component, Debug, PartialEq, Eq, Hash, Clone, Copy)]
     struct B(usize);

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -32,6 +32,11 @@ pub use bevy_ecs_macros::Resource;
 ///
 /// Only one resource of each type can be stored in a [`World`] at any given time.
 ///
+/// # Deriving this trait
+///
+/// This trait can be derived! The derive macro also implements the [`Component`] trait for the type,
+/// and any attributes that are valid for the [`Component`] derive are also applied.
+///
 /// # Examples
 ///
 /// ```
@@ -95,7 +100,7 @@ pub use bevy_ecs_macros::Resource;
     label = "invalid `Resource`",
     note = "consider annotating `{Self}` with `#[derive(Resource)]`"
 )]
-pub trait Resource: Send + Sync + 'static {}
+pub trait Resource: Component {}
 
 /// A marker component for the entity that stores the resource of type `T`.
 ///
@@ -114,3 +119,19 @@ pub struct ResourceEntity<R: Resource>(PhantomData<R>);
 /// This component is required by the [`ResourceEntity<R>`] component, and will automatically be added.
 #[derive(Component, Default, Debug)]
 pub struct IsResource;
+
+#[cfg(test)]
+mod tests {
+    use crate as bevy_ecs;
+    use crate::prelude::*;
+
+    #[test]
+    fn resource_with_component_attributes() {
+        #[derive(Resource, Default)]
+        struct RA;
+
+        #[derive(Resource)]
+        #[require(RA)]
+        struct RB;
+    }
+}

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -1,4 +1,23 @@
 //! Resources are unique, singleton-like data types that can be accessed from systems and stored in the [`World`](crate::world::World).
+//!
+//! Under the hood, each resource of type `R` is stored in a dedicated entity in the world,
+//! with the data of type `R` stored as a component on that entity.
+//! These entities are marked with the [`ResourceEntity<R>`] component and the [`IsResource`] component.
+//! This strategy allows Bevy to reuse the existing ECS tools for working with resources:
+//! storage, querying, hooks, observers, relationships and more.
+//!
+//! While resources are components, not all resources are components!
+//! The [`Resource`] trait is used to mark components which can be used as such,
+//! and must be derived for any type that is to be used as a resource.
+//! The various methods for inserting and accessing resources require this trait bound (when working with Rust types),
+//! and the simplest, clearest way to access resource data in systems is to use the [`Res`] and [`ResMut`] system parameters.
+//!
+//! Because resources are *also* components, queries will find the component on the entity which stores the resource
+//! by default, and operate on it like any other entity. If this behavior is not desired, filter out
+//! entities with the [`IsResource`] component.
+//!
+//! [`Res`]: crate::system::Res
+//! [`ResMut`]: crate::system::ResMut
 
 // The derive macro for the `Resource` trait
 pub use bevy_ecs_macros::Resource;

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -109,9 +109,15 @@ pub trait Resource: Component {}
 ///
 /// By contrast, the [`IsResource`] component is used to find all entities that store resources,
 /// regardless of the type of resource they store.
-#[derive(Component, Default, Debug)]
+#[derive(Component, Debug)]
 #[require(IsResource)]
 pub struct ResourceEntity<R: Resource>(PhantomData<R>);
+
+impl<R: Resource> Default for ResourceEntity<R> {
+    fn default() -> Self {
+        ResourceEntity(PhantomData)
+    }
+}
 
 /// A marker component for entities which store resources.
 ///

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -19,6 +19,10 @@
 //! [`Res`]: crate::system::Res
 //! [`ResMut`]: crate::system::ResMut
 
+use crate as bevy_ecs;
+use crate::prelude::{require, Component};
+use core::marker::PhantomData;
+
 // The derive macro for the `Resource` trait
 pub use bevy_ecs_macros::Resource;
 
@@ -92,3 +96,21 @@ pub use bevy_ecs_macros::Resource;
     note = "consider annotating `{Self}` with `#[derive(Resource)]`"
 )]
 pub trait Resource: Send + Sync + 'static {}
+
+/// A marker component for the entity that stores the resource of type `T`.
+///
+/// This component is automatically inserted when a resource of type `T` is inserted into the world,
+/// and can be used to find the entity that stores a particular resource.
+///
+/// By contrast, the [`IsResource`] component is used to find all entities that store resources,
+/// regardless of the type of resource they store.
+#[derive(Component, Default, Debug)]
+#[require(IsResource)]
+pub struct ResourceEntity<R: Resource>(PhantomData<R>);
+
+/// A marker component for entities which store resources.
+///
+/// By contrast, the [`ResourceEntity<R>`] component is used to find the entity that stores a particular resource.
+/// This component is required by the [`ResourceEntity<R>`] component, and will automatically be added.
+#[derive(Component, Default, Debug)]
+pub struct IsResource;

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -737,7 +737,7 @@ mod tests {
         #[derive(Event)]
         struct E;
 
-        #[derive(Resource, Component)]
+        #[derive(Resource)]
         struct RC;
 
         fn empty_system() {}

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2200,7 +2200,7 @@ mod tests {
         }
     }
 
-    #[derive(Component, Resource)]
+    #[derive(Resource)]
     struct W<T>(T);
 
     fn simple_command(world: &mut World) {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -358,17 +358,17 @@ mod tests {
         No,
     }
 
-    #[derive(Component, Resource, Debug, Eq, PartialEq, Default)]
+    #[derive(Resource, Debug, Eq, PartialEq, Default)]
     struct A;
-    #[derive(Component, Resource)]
+    #[derive(Resource)]
     struct B;
-    #[derive(Component, Resource)]
+    #[derive(Resource)]
     struct C;
-    #[derive(Component, Resource)]
+    #[derive(Resource)]
     struct D;
-    #[derive(Component, Resource)]
+    #[derive(Resource)]
     struct E;
-    #[derive(Component, Resource)]
+    #[derive(Resource)]
     struct F;
 
     #[derive(Component, Debug)]

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -386,9 +386,8 @@ mod tests {
 
     #[test]
     fn run_system_once() {
+        #[derive(Resource)]
         struct T(usize);
-
-        impl Resource for T {}
 
         fn system(In(n): In<usize>, mut commands: Commands) -> usize {
             commands.insert_resource(T(n));
@@ -446,8 +445,8 @@ mod tests {
 
     #[test]
     fn run_system_once_invalid_params() {
+        #[derive(Resource)]
         struct T;
-        impl Resource for T {}
         fn system(_: Res<T>) {}
 
         let mut world = World::default();

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -800,8 +800,8 @@ mod tests {
     fn run_system_invalid_params() {
         use crate::system::RegisteredSystemError;
 
+        #[derive(Resource)]
         struct T;
-        impl Resource for T {}
         fn system(_: Res<T>) {}
 
         let mut world = World::new();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1345,7 +1345,7 @@ impl<'w> EntityWorldMut<'w> {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
-    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+    pub fn resource_mut<R: Resource + Component<Mutability = Mutable>>(&mut self) -> Mut<'_, R> {
         self.world.resource_mut::<R>()
     }
 
@@ -1357,7 +1357,9 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Gets a mutable reference to the resource of the given type if it exists
     #[inline]
-    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+    pub fn get_resource_mut<R: Resource + Component<Mutability = Mutable>>(
+        &mut self,
+    ) -> Option<Mut<'_, R>> {
         self.world.get_resource_mut()
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3729,7 +3729,7 @@ mod tests {
         Drop(ID),
     }
 
-    #[derive(Resource, Component)]
+    #[derive(Resource)]
     struct MayPanicInDrop {
         drop_log: Arc<Mutex<Vec<DropLogItem>>>,
         expected_panic_flag: Arc<AtomicBool>,

--- a/crates/bevy_pbr/src/light/ambient_light.rs
+++ b/crates/bevy_pbr/src/light/ambient_light.rs
@@ -17,7 +17,7 @@ use super::*;
 ///    ambient_light.brightness = 100.0;
 /// }
 /// ```
-#[derive(Resource, Component, Clone, Debug, ExtractResource, ExtractComponent, Reflect)]
+#[derive(Resource, Clone, Debug, ExtractResource, ExtractComponent, Reflect)]
 #[reflect(Resource, Component, Debug, Default)]
 #[require(Camera)]
 pub struct AmbientLight {

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn should_use_from_reflect() {
-        #[derive(Resource, Component, Reflect)]
+        #[derive(Resource, Reflect)]
         #[reflect(Resource, Component)]
         struct SomeType(i32);
 

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -16,7 +16,7 @@ enum GameState {
 }
 
 // One of the two settings that can be set through the menu. It will be a resource in the app
-#[derive(Resource, Debug, Component, PartialEq, Eq, Clone, Copy)]
+#[derive(Resource, Debug, PartialEq, Eq, Clone, Copy)]
 enum DisplayQuality {
     Low,
     Medium,
@@ -24,7 +24,7 @@ enum DisplayQuality {
 }
 
 // One of the two settings that can be set through the menu. It will be a resource in the app
-#[derive(Resource, Debug, Component, PartialEq, Eq, Clone, Copy)]
+#[derive(Resource, Debug, PartialEq, Eq, Clone, Copy)]
 struct Volume(u32);
 
 fn main() {


### PR DESCRIPTION
# Objective

Various ECS features (hooks,  observers, immutable components, relationships) don't work with resources.
Users (and engine devs) rightfully expect that they would, and are frustrated that they don't.

While we could replicate these features (and all future ECS features) to support resources, this is a serious source of complexity and slows down implementation.

Additionally, various patterns (networking and serialization in particular) would like to operate generically over data, regardless of whether it's a resource or a component.

## Solution

- [x] make Resource require a Component trait bound, and make the Resource derive also derive Component
- [x] add a `ResourceEntity<R>` component, which marks an entity as holding a resource of type `R`. This component is "unique": only entity with this component (for a given `R`) can exist at once (using hooks)
- [x] add a `IsResource` marker component, used for all resource entities, regardless of their type. This will mostly be useful to allow inspectors to sort resources into their own list. 
- [x] store the resource data of type `R` as a component  on `R`
- [x] spawn an entity with the right data when inserting a resource
- [ ] despawn the matching entity when removing a resource
- [x] look up the matching entity when fetching resource data from the `World`
- [ ] rewrite the internal logic of `Res` and `ResMut` to look up entity data
- [ ] rewrite system building logic to ensure that it works under the new model
- [ ] migrate dynamic resource logic
- [ ] make `ReflectResource` compile by respecting immutable resources
- [ ] remove the now-unused internals for working with resources

Note: we fully expect this to slow down resource look-ups relative to the previous tightly optimized implementation. While we can likely claw back some of that performance (see future work), we think that the simpler code base and added features are worth it.

## Controversial choices

Please argue with these if you disagree!

1. The Resource derive also derives Component. This is somewhat implicit, and of questionable Rust style. This is much less breaking for existing users, and less confusing for beginners. 
2. The Resource trait (and all existing APIs) continue to exist. As discussed in [this HackMD](https://hackmd.io/_uB08OiAT4GqOXPE-X76eQ), we think that this better communicates intent and eases learning, even though all of the methods *could* just use bare entity-component APIs
3. Components on resource entities will show up in queries by default. While the new default query filters feature would let us exclude them, being able to operate generically is useful for code that can be flexibly used as either a resource or component.
4. The resource marker components are publicly constructable, and rely on hooks to ensure correctness. We could instead refuse to expose any constructors, and avoid the use of hooks by auditing and testing all call sites.
5. Resource data is stored directly as `R` on the resource entity, instead of inside of a wrapper type. This allows users to operate abstractly over types which can be used as either resources or components more easily.

## Future work

1. By storing the `Entity` of each resource type in the ECS itself (possibly as part of a components-as-entities push), we could make looking up resources substantially faster, as we wouldn't need to query for matching entities.
2. We could remove or greatly strip down the `ReflectResource` trait, as all resources are now components.

## Testing

TODO

## Migration Guide

TODO