### PR TITLE
Adds update interval config for FpsOverlayPlugin

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -116,7 +116,6 @@ fn update_text(
     diagnostic: Res<DiagnosticsStore>,
     query: Query<Entity, With<FpsText>>,
     mut writer: TextUiWriter,
-    //
     time: Res<Time>,
     config: Res<FpsOverlayConfig>,
     mut time_since_rerender: Local<Duration>,

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -21,7 +21,7 @@ use bevy_ui::{
     widget::{Text, TextUiWriter},
     GlobalZIndex, Node, PositionType,
 };
-use std::time::Duration;
+use core::time::Duration;
 
 /// [`GlobalZIndex`] used to render the fps overlay.
 ///

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -122,7 +122,7 @@ fn update_text(
 ) {
     *time_since_rerender += time.delta();
     if *time_since_rerender >= config.refresh_interval {
-        *time_since_rerender = Duration::default();
+        *time_since_rerender = Duration::ZERO;
         for entity in &query {
             if let Some(fps) = diagnostic.get(&FrameTimeDiagnosticsPlugin::FPS) {
                 if let Some(value) = fps.smoothed() {

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -68,7 +68,9 @@ pub struct FpsOverlayConfig {
     pub text_color: Color,
     /// Displays the FPS overlay if true.
     pub enabled: bool,
-    /// How often the FPS overlay re-renders.
+    /// The period after which the FPS overlay re-renders.
+    ///
+    /// Defaults to once every 100 ms.
     pub refresh_interval: Duration,
 }
 

--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -30,6 +30,8 @@ fn main() {
                     },
                     // We can also change color of the overlay
                     text_color: OverlayColor::GREEN,
+                    // We can also set the refresh interval for the FPS counter
+                    refresh_interval: core::time::Duration::from_millis(100),
                     enabled: true,
                 },
             },


### PR DESCRIPTION
# Objective
Fixes #17487 

- Adds a new field `refresh_interval` to `FpsOverlayConfig` to allow the user setting a minimum time before each refresh of the FPS display

## Solution

- Add `refresh_interval` to `FpsOverlayConfig`
- When updating the on screen text, check a duration of `refresh_interval` has passed, if not, don't update the FPS counter

## Testing

- Created a new bevy project
- Included the `FpsOverlayPlugin` with the default `refresh_interval` (100 ms)
- Included the `FpsOverlayPlugin` with an obnoxious `refresh_interval` (2 seconds)
---
