### PR TITLE
`no_std` Support for `bevy_input_focus`

### DIFF
--- a/crates/bevy_input_focus/Cargo.toml
+++ b/crates/bevy_input_focus/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["bevy"]
 rust-version = "1.83.0"
 
 [features]
-default = ["bevy_reflect"]
+default = ["std", "bevy_reflect", "bevy_ecs/async_executor"]
+
+# Functionality
 
 ## Adds runtime reflection support using `bevy_reflect`.
 bevy_reflect = [
@@ -18,7 +20,52 @@ bevy_reflect = [
   "bevy_app/bevy_reflect",
   "bevy_ecs/bevy_reflect",
   "bevy_math/bevy_reflect",
+  "bevy_input/bevy_reflect",
+  "bevy_window/bevy_reflect",
 ]
+
+## Adds serialization support through `serde`.
+serialize = [
+  "bevy_ecs/serialize",
+  "bevy_math/serialize",
+  "bevy_input/serialize",
+  "bevy_window/serialize",
+]
+
+# Platform Compatibility
+
+## Allows access to the `std` crate. Enabling this feature will prevent compilation
+## on `no_std` targets, but provides access to certain additional features on
+## supported platforms.
+std = [
+  "bevy_app/std",
+  "bevy_ecs/std",
+  "bevy_math/std",
+  "bevy_reflect/std",
+  "bevy_input/std",
+  "bevy_window/std",
+]
+
+## `critical-section` provides the building blocks for synchronization primitives
+## on all platforms, including `no_std`.
+critical-section = [
+  "bevy_app/critical-section",
+  "bevy_ecs/critical-section",
+  "bevy_reflect?/critical-section",
+  "bevy_input/critical-section",
+]
+
+## `portable-atomic` provides additional platform support for atomic types and
+## operations, even on targets without native support. 
+portable-atomic = [
+  "bevy_app/portable-atomic",
+  "bevy_ecs/portable-atomic",
+  "bevy_reflect?/portable-atomic",
+  "bevy_input/portable-atomic",
+]
+
+## Uses the `libm` maths library instead of the one provided in `std` and `core`.
+libm = ["bevy_math/libm", "bevy_window/libm"]
 
 [dependencies]
 # bevy
@@ -33,7 +80,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
 
 # other
 thiserror = { version = "2", default-features = false }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+log = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 smol_str = "0.2"

--- a/crates/bevy_input_focus/src/autofocus.rs
+++ b/crates/bevy_input_focus/src/autofocus.rs
@@ -1,10 +1,11 @@
 //! Contains the [`AutoFocus`] component and related machinery.
 
 use bevy_ecs::{component::ComponentId, prelude::*, world::DeferredWorld};
-#[cfg(feature = "bevy_reflect")]
-use bevy_reflect::{prelude::*, Reflect};
 
 use crate::InputFocus;
+
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::{prelude::*, Reflect};
 
 /// Indicates that this widget should automatically receive [`InputFocus`].
 ///

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -131,7 +131,7 @@ impl DirectionalNavigationMap {
     /// it is more efficient than calling [`remove`](Self::remove) multiple times,
     /// as we can check for connections to all removed entities in a single pass.
     ///
-    /// An [`EntityHashSet`] must be provided as it is noticeably faster than the standard hasher or a [`Vec`].
+    /// An [`EntityHashSet`] must be provided as it is noticeably faster than the standard hasher or a [`Vec`](`alloc::vec::Vec`).
     pub fn remove_multiple(&mut self, entities: EntityHashSet) {
         for entity in &entities {
             self.neighbors.remove(entity);

--- a/crates/bevy_input_focus/src/directional_navigation.rs
+++ b/crates/bevy_input_focus/src/directional_navigation.rs
@@ -22,11 +22,12 @@ use bevy_ecs::{
     system::SystemParam,
 };
 use bevy_math::CompassOctant;
-#[cfg(feature = "bevy_reflect")]
-use bevy_reflect::{prelude::*, Reflect};
 use thiserror::Error;
 
 use crate::InputFocus;
+
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::{prelude::*, Reflect};
 
 /// A plugin that sets up the directional navigation systems and resources.
 #[derive(Default)]

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -4,6 +4,7 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+#![no_std]
 
 //! A UI-centric focus system for Bevy.
 //!
@@ -16,6 +17,11 @@
 //! This crate does *not* provide any integration with UI widgets: this is the responsibility of the widget crate,
 //! which should depend on [`bevy_input_focus`](crate).
 
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
+
 pub mod directional_navigation;
 pub mod tab_navigation;
 
@@ -27,10 +33,11 @@ pub use autofocus::*;
 use bevy_app::{App, Plugin, PreUpdate, Startup};
 use bevy_ecs::{prelude::*, query::QueryData, system::SystemParam, traversal::Traversal};
 use bevy_input::{gamepad::GamepadButtonChangedEvent, keyboard::KeyboardInput, mouse::MouseWheel};
-#[cfg(feature = "bevy_reflect")]
-use bevy_reflect::{prelude::*, Reflect};
 use bevy_window::{PrimaryWindow, Window};
 use core::fmt::Debug;
+
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::{prelude::*, Reflect};
 
 /// Resource representing which entity has input focus, if any. Input events (other than pointer-like inputs) will be
 /// dispatched to the current focus entity, or to the primary window if no entity has focus.

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -359,6 +359,7 @@ impl IsFocused for World {
 mod tests {
     use super::*;
 
+    use alloc::string::String;
     use bevy_ecs::{
         component::ComponentId, observer::Trigger, system::RunSystemOnce, world::DeferredWorld,
     };

--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -23,9 +23,8 @@
 //! you can use the [`TabNavigation`] system parameter directly instead.
 //! This object can be injected into your systems, and provides a [`navigate`](`TabNavigation::navigate`) method which can be
 //! used to navigate between focusable entities.
+use alloc::vec::Vec;
 use bevy_app::{App, Plugin, Startup};
-#[cfg(feature = "bevy_reflect")]
-use bevy_ecs::prelude::ReflectComponent;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -38,13 +37,17 @@ use bevy_input::{
     keyboard::{KeyCode, KeyboardInput},
     ButtonInput, ButtonState,
 };
-#[cfg(feature = "bevy_reflect")]
-use bevy_reflect::{prelude::*, Reflect};
 use bevy_window::PrimaryWindow;
+use log::warn;
 use thiserror::Error;
-use tracing::warn;
 
 use crate::{FocusedInput, InputFocus, InputFocusVisible};
+
+#[cfg(feature = "bevy_reflect")]
+use {
+    bevy_ecs::prelude::ReflectComponent,
+    bevy_reflect::{prelude::*, Reflect},
+};
 
 /// A component which indicates that an entity wants to participate in tab navigation.
 ///

--- a/tools/ci/src/commands/compile_check_no_std.rs
+++ b/tools/ci/src/commands/compile_check_no_std.rs
@@ -142,6 +142,14 @@ impl Prepare for CompileCheckNoStdCommand {
             "Please fix compiler errors in output above for bevy_transform no_std compatibility.",
         ));
 
+        commands.push(PreparedCommand::new::<Self>(
+            cmd!(
+                sh,
+                "cargo check -p bevy_input_focus --no-default-features --features libm,serialize,bevy_reflect --target {target}"
+            ),
+            "Please fix compiler errors in output above for bevy_input no_std compatibility.",
+        ));
+
         commands
     }
 }


### PR DESCRIPTION
# Objective

- Contributes to #15460

## Solution

- Switched `tracing` for `log` for the atomically challenged platforms
- Setup feature flags as required
- Added to `compile-check-no-std` CI task

## Testing

- CI

---

## Notes

- _Very_ easy one this time. Most of the changes here are just feature definitions and documentation within the `Cargo.toml`
