### PR TITLE
Add reflection to the remaining `glam` `Vec` types

### DIFF
--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -49,6 +49,66 @@ impl_reflect!(
 impl_reflect!(
     #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
     #[type_path = "glam"]
+    struct I8Vec2 {
+        x: i8,
+        y: i8,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct I8Vec3 {
+        x: i8,
+        y: i8,
+        z: i8,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct I8Vec4 {
+        x: i8,
+        y: i8,
+        z: i8,
+        w: i8,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct I16Vec2 {
+        x: i16,
+        y: i16,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct I16Vec3 {
+        x: i16,
+        y: i16,
+        z: i16,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct I16Vec4 {
+        x: i16,
+        y: i16,
+        z: i16,
+        w: i16,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
     struct I64Vec2 {
         x: i64,
         y: i64,
@@ -101,6 +161,62 @@ impl_reflect!(
         y: u32,
         z: u32,
         w: u32,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct U8Vec2 {
+        x: u8,
+        y: u8,
+    }
+);
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct U8Vec3 {
+        x: u8,
+        y: u8,
+        z: u8,
+    }
+);
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct U8Vec4 {
+        x: u8,
+        y: u8,
+        z: u8,
+        w: u8,
+    }
+);
+
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct U16Vec2 {
+        x: u16,
+        y: u16,
+    }
+);
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct U16Vec3 {
+        x: u16,
+        y: u16,
+        z: u16,
+    }
+);
+impl_reflect!(
+    #[reflect(Debug, Hash, PartialEq, Default, Deserialize, Serialize)]
+    #[type_path = "glam"]
+    struct U16Vec4 {
+        x: u16,
+        y: u16,
+        z: u16,
+        w: u16,
     }
 );
 


### PR DESCRIPTION
# Objective

Add reflection support to more `glam` `Vec` types, specifically

* I8Vec2
* I8Vec3
* I8Vec4
* U8Vec2
* U8Vec3
* U8Vec4
* I16Vec2
* I16Vec3
* I16Vec4
* U16Vec2
* U16Vec3
* U16Vec4

I needed to do this because I'm using various of these in my Bevy types, and due to the orphan rules, I can't make these impls locally.

## Solution

Used `impl_reflect!` like for the existing types.

## Testing

This should not require additional testing, though I have verified that reflection now works for these types in my own project.