### PR TITLE
Add warning for font sizes `<= 0.0`

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -20,6 +20,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.16.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.16.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "bevy",

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
     system::{ResMut, Resource},
 };
 use bevy_image::prelude::*;
+use bevy_log::{once, warn};
 use bevy_math::{UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_utils::HashMap;
@@ -141,6 +142,10 @@ impl TextPipeline {
 
             // Save spans that aren't zero-sized.
             if scale_factor <= 0.0 || text_font.font_size <= 0.0 {
+                once!(warn!(
+                    "Text span {entity} has a font size <= 0.0. Nothing will be displayed.",
+                ));
+
                 continue;
             }
             spans.push((span_index, span, text_font, face_info, color));


### PR DESCRIPTION
# Objective

Alternative to #9660, which is outdated since "required components" landed.

Fixes #9655

## Solution

This is a different approach than the linked PR, slotting the warning into an existing check for zero or negative font sizes in the text pipeline.

## Testing

Replaced a font size with `0.0` in `examples/ui/text.rs`.

```
2025-01-22T23:26:08.239688Z  INFO bevy_winit::system: Creating new window App (0v1)
2025-01-22T23:26:08.617505Z  WARN bevy_text::pipeline: Text span 10v1 has a font size <= 0.0. Nothing will be displayed.
```

