### PR TITLE
Add `no_std` support to `bevy_diagnostic`

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -9,26 +9,80 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-# Disables diagnostics that are unsupported when Bevy is dynamically linked
+default = ["std", "bevy_ecs/default"]
+
+# Functionality
+
+## Adds serialization support through `serde`.
+serialize = [
+  "dep:serde",
+  "bevy_ecs/serialize",
+  "bevy_time/serialize",
+  "bevy_utils/serde",
+]
+
+## Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
-sysinfo_plugin = ["sysinfo"]
-serialize = ["dep:serde"]
+
+## Adds integration with `sysinfo`.
+sysinfo_plugin = ["sysinfo", "dep:bevy_tasks"]
+
+# Platform Compatibility
+
+## Allows access to the `std` crate. Enabling this feature will prevent compilation
+## on `no_std` targets, but provides access to certain additional features on
+## supported platforms.
+std = [
+  "serde?/std",
+  "bevy_ecs/std",
+  "bevy_app/std",
+  "bevy_platform_support/std",
+  "bevy_time/std",
+  "bevy_utils/std",
+  "bevy_tasks?/std",
+]
+
+## `critical-section` provides the building blocks for synchronization primitives
+## on all platforms, including `no_std`.
+critical-section = [
+  "bevy_ecs/critical-section",
+  "bevy_app/critical-section",
+  "bevy_platform_support/critical-section",
+  "bevy_time/critical-section",
+  "bevy_utils/critical-section",
+  "bevy_tasks?/critical-section",
+]
+
+## `portable-atomic` provides additional platform support for atomic types and
+## operations, even on targets without native support. 
+portable-atomic = [
+  "bevy_ecs/portable-atomic",
+  "bevy_app/portable-atomic",
+  "bevy_platform_support/portable-atomic",
+  "bevy_time/portable-atomic",
+  "bevy_utils/portable-atomic",
+  "bevy_tasks?/portable-atomic",
+]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.16.0-dev" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
-bevy_time = { path = "../bevy_time", version = "0.16.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev" }
+bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false }
+bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = false }
+bevy_time = { path = "../bevy_time", version = "0.16.0-dev", default-features = false }
+bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false, features = [
+  "alloc",
+] }
+bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false, optional = true }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
-  "std",
+  "alloc",
 ] }
 
 # other
 const-fnv1a-hash = "1.1.0"
-serde = { version = "1.0", optional = true }
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+serde = { version = "1.0", default-features = false, features = [
+  "alloc",
+], optional = true }
+log = { version = "0.4", default-features = false }
 
 # macOS
 [target.'cfg(all(target_os="macos"))'.dependencies]

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::Cow, collections::VecDeque};
+use alloc::{borrow::Cow, collections::VecDeque, string::String};
 use core::{
     hash::{Hash, Hasher},
     time::Duration,

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -5,10 +5,14 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+#![no_std]
 
 //! This crate provides a straightforward solution for integrating diagnostics in the [Bevy game engine](https://bevyengine.org/).
 //! It allows users to easily add diagnostic functionality to their Bevy applications, enhancing
 //! their ability to monitor and optimize their game's.
+
+#[cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -1,9 +1,10 @@
 use super::{Diagnostic, DiagnosticPath, DiagnosticsStore};
+use alloc::vec::Vec;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_time::{Real, Time, Timer, TimerMode};
 use core::time::Duration;
-use tracing::{debug, info};
+use log::{debug, info};
 
 /// An App Plugin that logs diagnostics to the console.
 ///

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -1,4 +1,5 @@
 use crate::DiagnosticPath;
+use alloc::string::String;
 use bevy_app::prelude::*;
 use bevy_ecs::resource::Resource;
 
@@ -56,7 +57,8 @@ pub struct SystemInfo {
         target_os = "android",
         target_os = "macos"
     ),
-    not(feature = "dynamic_linking")
+    not(feature = "dynamic_linking"),
+    feature = "std",
 ))]
 pub mod internal {
     use alloc::sync::Arc;
@@ -67,7 +69,7 @@ pub mod internal {
     use bevy_ecs::resource::Resource;
     use bevy_tasks::{available_parallelism, block_on, poll_once, AsyncComputeTaskPool, Task};
     use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
-    use tracing::info;
+    use log::info;
 
     use crate::{Diagnostic, Diagnostics, DiagnosticsStore};
 
@@ -200,9 +202,11 @@ pub mod internal {
         target_os = "android",
         target_os = "macos"
     ),
-    not(feature = "dynamic_linking")
+    not(feature = "dynamic_linking"),
+    feature = "std",
 )))]
 pub mod internal {
+    use alloc::string::ToString;
     use bevy_app::{App, Startup};
 
     pub(super) fn setup_plugin(app: &mut App) {
@@ -210,7 +214,7 @@ pub mod internal {
     }
 
     fn setup_system() {
-        tracing::warn!("This platform and/or configuration is not supported!");
+        log::warn!("This platform and/or configuration is not supported!");
     }
 
     impl Default for super::SystemInfo {

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -61,15 +61,20 @@ pub struct SystemInfo {
     feature = "std",
 ))]
 pub mod internal {
-    use alloc::sync::Arc;
-    use bevy_ecs::{prelude::ResMut, system::Local};
-    use std::{sync::Mutex, time::Instant};
-
+    use alloc::{
+        format,
+        string::{String, ToString},
+        sync::Arc,
+        vec::Vec,
+    };
     use bevy_app::{App, First, Startup, Update};
     use bevy_ecs::resource::Resource;
+    use bevy_ecs::{prelude::ResMut, system::Local};
+    use bevy_platform_support::time::Instant;
     use bevy_tasks::{available_parallelism, block_on, poll_once, AsyncComputeTaskPool, Task};
-    use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
     use log::info;
+    use std::sync::Mutex;
+    use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
     use crate::{Diagnostic, Diagnostics, DiagnosticsStore};
 

--- a/tools/ci/src/commands/compile_check_no_std.rs
+++ b/tools/ci/src/commands/compile_check_no_std.rs
@@ -166,6 +166,14 @@ impl Prepare for CompileCheckNoStdCommand {
             "Please fix compiler errors in output above for bevy_a11y no_std compatibility.",
         ));
 
+        commands.push(PreparedCommand::new::<Self>(
+            cmd!(
+                sh,
+                "cargo check -p bevy_diagnostic --no-default-features --features serialize --target {target}"
+            ),
+            "Please fix compiler errors in output above for bevy_diagnostic no_std compatibility.",
+        ));
+
         commands
     }
 }


### PR DESCRIPTION
# Objective

- Contributes to #15460

## Solution

- Added required features
- Switched from `tracing` to `log`
- Fixed imports

## Testing

- CI
