### PR TITLE
Combine the shader point and spot light lookup into one loop.

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -547,7 +547,7 @@ fn point_light(
 // light to give it the spot shape.
 //
 // The resulting value should be multiplied by the luminance that results from
-// treating the spot light as thought it were a point light (i.e. the results of
+// treating the spot light as though it were a point light (i.e. the results of
 // calling `point_light`).
 fn spot_light(light_id: u32, input: ptr<function, LightingInput>) -> f32 {
     let light = &view_bindings::clusterable_objects.data[light_id];

--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -543,14 +543,13 @@ fn point_light(
         (rangeAttenuation * derived_input.NdotL);
 }
 
-fn spot_light(
-    light_id: u32,
-    input: ptr<function, LightingInput>,
-    enable_diffuse: bool
-) -> vec3<f32> {
-    // reuse the point light calculations
-    let point_light = point_light(light_id, input, enable_diffuse);
-
+// Returns the additional attenuation that should be applied to the given spot
+// light to give it the spot shape.
+//
+// The resulting value should be multiplied by the luminance that results from
+// treating the spot light as thought it were a point light (i.e. the results of
+// calling `point_light`).
+fn spot_light(light_id: u32, input: ptr<function, LightingInput>) -> f32 {
     let light = &view_bindings::clusterable_objects.data[light_id];
 
     // reconstruct spot dir from x/z and y-direction flag
@@ -566,9 +565,7 @@ fn spot_light(
     // note we normalize here to get "l" from the filament listing. spot_dir is already normalized
     let cd = dot(-spot_dir, normalize(light_to_frag));
     let attenuation = saturate(cd * (*light).light_custom_data.z + (*light).light_custom_data.w);
-    let spot_attenuation = attenuation * attenuation;
-
-    return point_light * spot_attenuation;
+    return attenuation * attenuation;
 }
 
 fn directional_light(

--- a/crates/bevy_pbr/src/render/shadows.wgsl
+++ b/crates/bevy_pbr/src/render/shadows.wgsl
@@ -33,7 +33,7 @@ fn fetch_point_shadow(light_id: u32, frag_position: vec4<f32>, surface_normal: v
     let offset_position = frag_position.xyz + normal_offset + depth_offset;
 
     // similar largest-absolute-axis trick as above, but now with the offset fragment position
-    let frag_ls = offset_position.xyz - (*light).position_radius.xyz ;
+    let frag_ls = offset_position.xyz - (*light).position_radius.xyz;
     let abs_position_ls = abs(frag_ls);
     let major_axis_magnitude = max(abs_position_ls.x, max(abs_position_ls.y, abs_position_ls.z));
 


### PR DESCRIPTION
Point and spot lights are treated similarly. In fact, the point light calculations are part of the spot light calculations. So we can simplify the code by unifying the two loops. This might make life easier for the shader compiler too.