### PR TITLE
Add simple Disabled marker

### DIFF
--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -28,10 +28,14 @@ use crate::{
 };
 use bevy_ecs_macros::{Component, Resource};
 
+#[cfg(feature = "bevy_reflect")]
+use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
+
 /// A marker component for disabled entities. See [the module docs] for more info.
 ///
 /// [the module docs]: crate::entity_disabling
 #[derive(Component)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
 pub struct Disabled;
 
 /// The default filters for all queries, these are used to globally exclude entities from queries.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -26,7 +26,13 @@ use crate::{
     component::{ComponentId, Components, StorageType},
     query::FilteredAccess,
 };
-use bevy_ecs_macros::Resource;
+use bevy_ecs_macros::{Component, Resource};
+
+/// A marker component for disabled entities. See [the module docs] for more info.
+///
+/// [the module docs]: crate::entity_disabling
+#[derive(Component)]
+pub struct Disabled;
 
 /// The default filters for all queries, these are used to globally exclude entities from queries.
 /// See the [module docs](crate::entity_disabling) for more info.
@@ -37,10 +43,6 @@ pub struct DefaultQueryFilters {
 }
 
 impl DefaultQueryFilters {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "No Disabled component exist yet")
-    )]
     /// Set the [`ComponentId`] for the entity disabling marker
     pub(crate) fn set_disabled(&mut self, component_id: ComponentId) -> Option<()> {
         if self.disabled.is_some() {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1531,6 +1531,7 @@ mod tests {
     #[test]
     fn filtered_query_access() {
         let mut world = World::new();
+        // We remove entity disabling so it doesn't affect our query filters
         world.remove_resource::<DefaultQueryFilters>();
         let query = world.query_filtered::<&mut A, Changed<B>>();
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -134,6 +134,7 @@ mod tests {
         change_detection::Ref,
         component::{require, Component, ComponentId, RequiredComponents, RequiredComponentsError},
         entity::Entity,
+        entity_disabling::DefaultQueryFilters,
         prelude::Or,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
         resource::Resource,
@@ -1530,6 +1531,7 @@ mod tests {
     #[test]
     fn filtered_query_access() {
         let mut world = World::new();
+        world.remove_resource::<DefaultQueryFilters>();
         let query = world.query_filtered::<&mut A, Changed<B>>();
 
         let mut expected = FilteredAccess::<ComponentId>::default();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -2516,15 +2516,15 @@ mod tests {
 
         fn nothing() {}
 
-        assert!(world.iter_resources().count() == 0);
+        let resources = world.iter_resources().count();
         let id = world.register_system_cached(nothing);
-        assert!(world.iter_resources().count() == 1);
+        assert_eq!(world.iter_resources().count(), resources + 1);
         assert!(world.get_entity(id.entity).is_ok());
 
         let mut commands = Commands::new(&mut queue, &world);
         commands.unregister_system_cached(nothing);
         queue.apply(&mut world);
-        assert!(world.iter_resources().count() == 0);
+        assert_eq!(world.iter_resources().count(), resources);
         assert!(world.get_entity(id.entity).is_err());
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3963,6 +3963,7 @@ mod tests {
     #[test]
     fn iter_resources() {
         let mut world = World::new();
+        // Remove DefaultQueryFilters so it doesn't show up in the iterator
         world.remove_resource::<DefaultQueryFilters>();
         world.insert_resource(TestResource(42));
         world.insert_resource(TestResource2("Hello, world!".to_string()));
@@ -3990,6 +3991,7 @@ mod tests {
     #[test]
     fn iter_resources_mut() {
         let mut world = World::new();
+        // Remove DefaultQueryFilters so it doesn't show up in the iterator
         world.remove_resource::<DefaultQueryFilters>();
         world.insert_resource(TestResource(42));
         world.insert_resource(TestResource2("Hello, world!".to_string()));
@@ -4465,6 +4467,7 @@ mod tests {
         world.spawn((Foo, Disabled));
         assert_eq!(1, world.query::<&Foo>().iter(&world).count());
 
+        // If we explicitly remove the resource, no entities should be filtered anymore
         world.remove_resource::<DefaultQueryFilters>();
         assert_eq!(2, world.query::<&Foo>().iter(&world).count());
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3223,6 +3223,15 @@ impl World {
 }
 
 impl World {
+    /// Returns true if the type id is used internally, components and resources used internally
+    /// most likely should not be affected by things like saving and loading
+    pub fn is_internal_type(type_id: TypeId) -> bool {
+        if type_id == TypeId::of::<DefaultQueryFilters>() {
+            return true;
+        }
+        false
+    }
+
     /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
     /// The returned pointer must not be used to modify the resource, and must not be
     /// dereferenced after the immutable borrow of the [`World`] ends.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3223,15 +3223,6 @@ impl World {
 }
 
 impl World {
-    /// Returns true if the type id is used internally, components and resources used internally
-    /// most likely should not be affected by things like saving and loading
-    pub fn is_internal_type(type_id: TypeId) -> bool {
-        if type_id == TypeId::of::<DefaultQueryFilters>() {
-            return true;
-        }
-        false
-    }
-
     /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
     /// The returned pointer must not be used to modify the resource, and must not be
     /// dereferenced after the immutable borrow of the [`World`] ends.

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,7 +1,10 @@
+use core::any::TypeId;
+
 use crate::{DynamicEntity, DynamicScene, SceneFilter};
 use alloc::collections::BTreeMap;
 use bevy_ecs::{
     component::{Component, ComponentId},
+    entity_disabling::DefaultQueryFilters,
     prelude::Entity,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
     resource::Resource,
@@ -348,9 +351,17 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// [`deny_resource`]: Self::deny_resource
     #[must_use]
     pub fn extract_resources(mut self) -> Self {
+        let original_world_dqf_id = self
+            .original_world
+            .components()
+            .get_resource_id(TypeId::of::<DefaultQueryFilters>());
+
         let type_registry = self.original_world.resource::<AppTypeRegistry>().read();
 
         for (component_id, _) in self.original_world.storages().resources.iter() {
+            if Some(component_id) == original_world_dqf_id {
+                continue;
+            }
             let mut extract_and_push = || {
                 let type_id = self
                     .original_world

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,6 +1,7 @@
 use crate::{DynamicScene, SceneSpawnError};
 use bevy_asset::Asset;
 use bevy_ecs::{
+    component::ComponentInfo,
     entity::{hash_map::EntityHashMap, Entity, SceneEntityMapper},
     reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
     world::World,
@@ -61,6 +62,15 @@ impl Scene {
 
         // Resources archetype
         for (component_id, resource_data) in self.world.storages().resources.iter() {
+            if world
+                .components()
+                .get_info(component_id)
+                .and_then(ComponentInfo::type_id)
+                .filter(|&type_id| World::is_internal_type(type_id))
+                .is_some()
+            {
+                continue;
+            }
             if !resource_data.is_present() {
                 continue;
             }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,8 +1,10 @@
+use core::any::TypeId;
+
 use crate::{DynamicScene, SceneSpawnError};
 use bevy_asset::Asset;
 use bevy_ecs::{
-    component::ComponentInfo,
     entity::{hash_map::EntityHashMap, Entity, SceneEntityMapper},
+    entity_disabling::DefaultQueryFilters,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
     world::World,
 };
@@ -60,15 +62,14 @@ impl Scene {
     ) -> Result<(), SceneSpawnError> {
         let type_registry = type_registry.read();
 
+        let self_dqf_id = self
+            .world
+            .components()
+            .get_resource_id(TypeId::of::<DefaultQueryFilters>());
+
         // Resources archetype
         for (component_id, resource_data) in self.world.storages().resources.iter() {
-            if world
-                .components()
-                .get_info(component_id)
-                .and_then(ComponentInfo::type_id)
-                .filter(|&type_id| World::is_internal_type(type_id))
-                .is_some()
-            {
+            if Some(component_id) == self_dqf_id {
                 continue;
             }
             if !resource_data.is_present() {

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -1,4 +1,3 @@
-use bevy_ecs::world::World;
 use bevy_utils::{hashbrown::hash_set::IntoIter, HashSet};
 use core::any::{Any, TypeId};
 
@@ -155,9 +154,6 @@ impl SceneFilter {
     ///
     /// [`Unset`]: SceneFilter::Unset
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
-        if World::is_internal_type(type_id) {
-            return false;
-        }
         match self {
             Self::Unset => true,
             Self::Allowlist(list) => list.contains(&type_id),

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -1,3 +1,4 @@
+use bevy_ecs::world::World;
 use bevy_utils::{hashbrown::hash_set::IntoIter, HashSet};
 use core::any::{Any, TypeId};
 
@@ -154,6 +155,9 @@ impl SceneFilter {
     ///
     /// [`Unset`]: SceneFilter::Unset
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
+        if World::is_internal_type(type_id) {
+            return false;
+        }
         match self {
             Self::Unset => true,
             Self::Allowlist(list) => list.contains(&type_id),


### PR DESCRIPTION
# Objective

We have default query filters now, but there is no first-party marker for entity disabling yet
Fixes #17458

## Solution

Add the marker, cool recursive features and/or potential hook changes should be follow up work

## Testing

Added a unit test to check that the new marker is enabled by default