### PR TITLE
Fix Typo in `bevy_platform_support`'s `spin` Feature

### DIFF
--- a/crates/bevy_platform_support/Cargo.toml
+++ b/crates/bevy_platform_support/Cargo.toml
@@ -41,7 +41,7 @@ critical-section = ["dep:critical-section", "portable-atomic?/critical-section"]
 portable-atomic = [
   "dep:portable-atomic",
   "dep:portable-atomic-util",
-  "spin/portable-atomic",
+  "spin/portable_atomic",
 ]
 
 [dependencies]


### PR DESCRIPTION
# Objective

- Fix typo in `spin/portable-atomic` feature.

## Solution

- Replace with `spin/portable_atomic`

## Testing

- CI

---

## Notes

This is a very annoying design choice the `spin` developers made. Because the _crate_ is called `portable-atomic` and is optional, Cargo automatically registers the feature `portable-atomic`. But the maintainers use `portable_atomic` for their _feature_ which enables the support. Sneaks through CI because it's a valid feature and will only cause breakage on atomically challenged platforms (which we currently aren't testing in CI).

Should we test atomically challenged in CI? Right now I don't think so, at least not until we've made "normal" `no_std` CI better with the main `bevy` crate as the test-case rather than each individual crate.