### PR TITLE
Make CustomCursor variants CustomCursorImage/CustomCursorUrl structs

### DIFF
--- a/crates/bevy_winit/src/cursor.rs
+++ b/crates/bevy_winit/src/cursor.rs
@@ -37,7 +37,7 @@ use bevy_window::{SystemCursorIcon, Window};
 use tracing::warn;
 
 #[cfg(feature = "custom_cursor")]
-pub use crate::custom_cursor::CustomCursor;
+pub use crate::custom_cursor::{CustomCursor, CustomCursorImage};
 
 pub(crate) struct CursorPlugin;
 
@@ -91,14 +91,16 @@ fn update_cursors(
 
         let cursor_source = match cursor.as_ref() {
             #[cfg(feature = "custom_cursor")]
-            CursorIcon::Custom(CustomCursor::Image {
-                handle,
-                texture_atlas,
-                flip_x,
-                flip_y,
-                rect,
-                hotspot,
-            }) => {
+            CursorIcon::Custom(CustomCursor::Image(c)) => {
+                let CustomCursorImage {
+                    handle,
+                    texture_atlas,
+                    flip_x,
+                    flip_y,
+                    rect,
+                    hotspot,
+                } = c;
+
                 let cache_key = CustomCursorCacheKey::Image {
                     id: handle.id(),
                     texture_atlas_layout_id: texture_atlas.as_ref().map(|a| a.layout.id()),
@@ -155,14 +157,15 @@ fn update_cursors(
                 target_family = "wasm",
                 target_os = "unknown"
             ))]
-            CursorIcon::Custom(CustomCursor::Url { url, hotspot }) => {
-                let cache_key = CustomCursorCacheKey::Url(url.clone());
+            CursorIcon::Custom(CustomCursor::Url(c)) => {
+                let cache_key = CustomCursorCacheKey::Url(c.url.clone());
 
                 if cursor_cache.0.contains_key(&cache_key) {
                     CursorSource::CustomCached(cache_key)
                 } else {
                     use crate::CustomCursorExtWebSys;
-                    let source = WinitCustomCursor::from_url(url.clone(), hotspot.0, hotspot.1);
+                    let source =
+                        WinitCustomCursor::from_url(c.url.clone(), c.hotspot.0, c.hotspot.1);
                     CursorSource::Custom((cache_key, source))
                 }
             }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -2,7 +2,7 @@
 //! the mouse pointer in various ways.
 
 #[cfg(feature = "custom_cursor")]
-use bevy::winit::cursor::CustomCursor;
+use bevy::winit::cursor::{CustomCursor, CustomCursorImage};
 use bevy::{
     diagnostic::{FrameCount, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
@@ -163,14 +163,11 @@ fn init_cursor_icons(
         SystemCursorIcon::Wait.into(),
         SystemCursorIcon::Text.into(),
         #[cfg(feature = "custom_cursor")]
-        CustomCursor::Image {
+        CustomCursor::Image(CustomCursorImage {
             handle: asset_server.load("branding/icon.png"),
-            texture_atlas: None,
-            flip_x: false,
-            flip_y: false,
-            rect: None,
             hotspot: (128, 128),
-        }
+            ..Default::default()
+        })
         .into(),
     ]));
 }


### PR DESCRIPTION
# Objective

- Make `CustomCursor::Image` easier to work with by splitting the enum variants off into `CustomCursorImage` and `CustomCursorUrl` structs and deriving `Default` on those structs.
- Refs #17276.

## Testing

- Ran two examples: `cargo run --example custom_cursor_image --features=custom_cursor` and `cargo run --example window_settings --features=custom_cursor`
- CI.

---

## Migration Guide

The `CustomCursor` enum's variants now hold instances of `CustomCursorImage` or `CustomCursorUrl`. Update your uses of `CustomCursor` accordingly.
