### PR TITLE
Replace checks for empty uinodes

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -307,7 +307,10 @@ pub fn extract_uinode_background_colors(
         };
 
         // Skip invisible backgrounds
-        if !inherited_visibility.get() || background_color.0.is_fully_transparent() {
+        if !inherited_visibility.get()
+            || background_color.0.is_fully_transparent()
+            || uinode.is_empty()
+        {
             continue;
         }
 
@@ -372,6 +375,7 @@ pub fn extract_uinode_images(
             || image.color.is_fully_transparent()
             || image.image.id() == TRANSPARENT_IMAGE_HANDLE.id()
             || image.image_mode.uses_slices()
+            || uinode.is_empty()
         {
             continue;
         }

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -392,7 +392,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
         };
 
         // skip invisible nodes
-        if !inherited_visibility.get() {
+        if !inherited_visibility.get() || uinode.is_empty() {
             continue;
         }
 


### PR DESCRIPTION
# Objective

The `is_empty` checks that are meant to stop zero-sized uinodes from being extracted are missing from `extract_uinode_background_colors`, `extract_uinode_images` and `extract_ui_material_nodes`. 

## Solution

Put them back.
