### PR TITLE
added Hash to MouseScrollUnit;

### DIFF
--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -105,7 +105,7 @@ pub struct MouseMotion {
 ///
 /// The value of the event can either be interpreted as the amount of lines or the amount of pixels
 /// to scroll.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Hash, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(


### PR DESCRIPTION
# Objective

This allows for the usage of the MouseScrollUnit as a key to a HashSet and HashMap. I have a need for this, but this basic functionality is currently missing.

## Solution

Add the derive Hash attribute to the MouseScrollUnit type.

## Testing

- Did you test these changes? If so, how?
No, but I did perform a `cargo build`. My laptop is failing to run `cargo test` without crashing.
- Are there any parts that need more testing?
If someone could run a `cargo test` for completeness, that would be great but this is a trivial change.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
They simply need to ensure that the common Hash derive macro works as expected for the basic MouseScrollUnit type.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Ubuntu 22.04
