### PR TITLE
Fix update execute while app exit

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -571,12 +571,17 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
             // If no windows exist, this will evaluate to `true`.
             let all_invisible = windows.iter().all(|w| !w.1.visible);
 
+            let app_is_exit = matches!(self.app_exit, Some(AppExit::Success));
+
+            // If all windows are invisible and the app is not exiting, need to update the app.
+            let need_update = all_invisible && !app_is_exit;
+
             // Not redrawing, but the timeout elapsed.
             //
             // Additional condition for Windows OS.
             // If no windows are visible, redraw calls will never succeed, which results in no app update calls being performed.
             // This is a temporary solution, full solution is mentioned here: https://github.com/bevyengine/bevy/issues/1343#issuecomment-770091684
-            if !self.ran_update_since_last_redraw || all_invisible {
+            if !self.ran_update_since_last_redraw || need_update {
                 self.run_app_update();
                 #[cfg(feature = "custom_cursor")]
                 self.update_cursors(event_loop);


### PR DESCRIPTION
# Objective

Fixes #17533  #16066 

update execute while app is exit, if we query object in update, it will cause panic becuse these object has been recycle

this problem is caused from #14155, by fix  App hanging in example window_settings. when windows all destroyed to be zero the all_invisible  will be true, then cause update execute after app exit.

## Solution

before update check app state is exit. if exit no execute.

another choice is to see the number of windows if it goes to zero, just make all_invisible to be false

but I think check app state is more reliable, because maybe in some case we need app to run background with no window. 

for now, I just check if app is exit.
