### PR TITLE
feat: impl `Ease` for `Isometry[2/3]d`

### DIFF
--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -770,10 +770,23 @@ mod tests {
             quat_curve.sample(0.0).unwrap(),
             Quat::from_axis_angle(Vec3::Z, 0.0)
         );
-        assert_abs_diff_eq!(
-            quat_curve.sample(0.5).unwrap(),
-            Quat::from_axis_angle(Vec3::Z, 45.0)
-        );
+        // {
+        //     let (before_mid_axis, before_mid_angle) =
+        //         quat_curve.sample(0.25).unwrap().to_axis_angle();
+        //     assert_abs_diff_eq!(before_mid_axis, Vec3::Z);
+        //     assert_abs_diff_eq!(before_mid_angle.to_degrees(), 22.5);
+        // }
+        {
+            // doesnt work ?!
+            let (mid_axis, mid_angle) = quat_curve.sample(0.5).unwrap().to_axis_angle();
+            assert_abs_diff_eq!(mid_axis, Vec3::Z);
+            assert_abs_diff_eq!(mid_angle.to_degrees(), 45.0);
+        }
+        // {
+        //     let (after_mid_axis, after_mid_angle) = quat_curve.sample(0.75).unwrap().to_axis_angle();
+        //     assert_abs_diff_eq!(after_mid_axis, Vec3::Z);
+        //     assert_abs_diff_eq!(after_mid_angle.to_degrees(), 67.5);
+        // }
         assert_abs_diff_eq!(
             quat_curve.sample(1.0).unwrap(),
             Quat::from_axis_angle(Vec3::Z, 90.0)

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -795,76 +795,33 @@ mod tests {
 
     #[test]
     fn ease_isometries_2d() {
-        let mk = Isometry2d::new;
-        let iso_2d_start = mk(Vec2::ZERO, Rot2::degrees(0.0));
-        let iso_2d_end = mk(Vec2::ONE, Rot2::degrees(90.0));
+        let angle = 90.0;
+        let iso_2d_start = Isometry2d::new(Vec2::ZERO, Rot2::degrees(0.0));
+        let iso_2d_end = Isometry2d::new(Vec2::ONE, Rot2::degrees(angle));
 
         let iso_2d_curve = Isometry2d::interpolating_curve_unbounded(iso_2d_start, iso_2d_end);
 
-        assert_abs_diff_eq!(
-            iso_2d_curve.sample(-1.0).unwrap(),
-            mk(Vec2::ONE * -1.0, Rot2::degrees(-90.0))
-        );
-        assert_abs_diff_eq!(
-            iso_2d_curve.sample(0.0).unwrap(),
-            mk(Vec2::ZERO, Rot2::degrees(0.0))
-        );
-        assert_abs_diff_eq!(
-            iso_2d_curve.sample(0.5).unwrap(),
-            mk(Vec2::ONE * 0.5, Rot2::degrees(45.0))
-        );
-        assert_abs_diff_eq!(
-            iso_2d_curve.sample(1.0).unwrap(),
-            mk(Vec2::ONE, Rot2::degrees(90.0))
-        );
-        assert_abs_diff_eq!(
-            iso_2d_curve.sample(2.0).unwrap(),
-            mk(Vec2::ONE * 2.0, Rot2::degrees(180.0))
-        );
+        [-1.0, 0.0, 0.5, 1.0, 2.0].into_iter().for_each(|t| {
+            assert_abs_diff_eq!(
+                iso_2d_curve.sample(t).unwrap(),
+                Isometry2d::new(Vec2::ONE * t, Rot2::degrees(angle * t))
+            );
+        });
     }
 
     #[test]
     fn ease_isometries_3d() {
-        let mk = Isometry3d::new;
-        let iso_3d_start = mk(Vec3A::ZERO, Quat::from_axis_angle(Vec3::Z, 0.0));
-        let iso_3d_end = mk(
-            Vec3A::ONE,
-            Quat::from_axis_angle(Vec3::Z, 90.0_f32.to_radians()),
-        );
+        let angle = 90.0_f32.to_radians();
+        let iso_3d_start = Isometry3d::new(Vec3A::ZERO, Quat::from_axis_angle(Vec3::Z, 0.0));
+        let iso_3d_end = Isometry3d::new(Vec3A::ONE, Quat::from_axis_angle(Vec3::Z, angle));
 
         let iso_3d_curve = Isometry3d::interpolating_curve_unbounded(iso_3d_start, iso_3d_end);
 
-        assert_abs_diff_eq!(
-            iso_3d_curve.sample(-1.0).unwrap(),
-            mk(
-                Vec3A::ONE * -1.0,
-                Quat::from_axis_angle(Vec3::Z, -90.0_f32.to_radians())
-            )
-        );
-        assert_abs_diff_eq!(
-            iso_3d_curve.sample(0.0).unwrap(),
-            mk(Vec3A::ZERO, Quat::from_axis_angle(Vec3::Z, 0.0))
-        );
-        assert_abs_diff_eq!(
-            iso_3d_curve.sample(0.5).unwrap(),
-            mk(
-                Vec3A::ONE * 0.5,
-                Quat::from_axis_angle(Vec3::Z, 45.0_f32.to_radians())
-            )
-        );
-        assert_abs_diff_eq!(
-            iso_3d_curve.sample(1.0).unwrap(),
-            mk(
-                Vec3A::ONE,
-                Quat::from_axis_angle(Vec3::Z, 90.0_f32.to_radians())
-            )
-        );
-        assert_abs_diff_eq!(
-            iso_3d_curve.sample(2.0).unwrap(),
-            mk(
-                Vec3A::ONE * 2.0,
-                Quat::from_axis_angle(Vec3::Z, 180.0_f32.to_radians())
-            )
-        );
+        [-1.0, 0.0, 0.5, 1.0, 2.0].into_iter().for_each(|t| {
+            assert_abs_diff_eq!(
+                iso_3d_curve.sample(t).unwrap(),
+                Isometry3d::new(Vec3A::ONE * t, Quat::from_axis_angle(Vec3::Z, angle * t))
+            );
+        });
     }
 }

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -762,7 +762,7 @@ mod tests {
     #[test]
     fn ease_quats() {
         let quat_start = Quat::from_axis_angle(Vec3::Z, 0.0);
-        let quat_end = Quat::from_axis_angle(Vec3::Z, 90.0);
+        let quat_end = Quat::from_axis_angle(Vec3::Z, 90.0_f32.to_radians());
 
         let quat_curve = Quat::interpolating_curve_unbounded(quat_start, quat_end);
 
@@ -770,26 +770,26 @@ mod tests {
             quat_curve.sample(0.0).unwrap(),
             Quat::from_axis_angle(Vec3::Z, 0.0)
         );
-        // {
-        //     let (before_mid_axis, before_mid_angle) =
-        //         quat_curve.sample(0.25).unwrap().to_axis_angle();
-        //     assert_abs_diff_eq!(before_mid_axis, Vec3::Z);
-        //     assert_abs_diff_eq!(before_mid_angle.to_degrees(), 22.5);
-        // }
         {
-            // doesnt work ?!
+            let (before_mid_axis, before_mid_angle) =
+                quat_curve.sample(0.25).unwrap().to_axis_angle();
+            assert_abs_diff_eq!(before_mid_axis, Vec3::Z);
+            assert_abs_diff_eq!(before_mid_angle, 22.5_f32.to_radians());
+        }
+        {
             let (mid_axis, mid_angle) = quat_curve.sample(0.5).unwrap().to_axis_angle();
             assert_abs_diff_eq!(mid_axis, Vec3::Z);
-            assert_abs_diff_eq!(mid_angle.to_degrees(), 45.0);
+            assert_abs_diff_eq!(mid_angle, 45.0_f32.to_radians());
         }
-        // {
-        //     let (after_mid_axis, after_mid_angle) = quat_curve.sample(0.75).unwrap().to_axis_angle();
-        //     assert_abs_diff_eq!(after_mid_axis, Vec3::Z);
-        //     assert_abs_diff_eq!(after_mid_angle.to_degrees(), 67.5);
-        // }
+        {
+            let (after_mid_axis, after_mid_angle) =
+                quat_curve.sample(0.75).unwrap().to_axis_angle();
+            assert_abs_diff_eq!(after_mid_axis, Vec3::Z);
+            assert_abs_diff_eq!(after_mid_angle, 67.5_f32.to_radians());
+        }
         assert_abs_diff_eq!(
             quat_curve.sample(1.0).unwrap(),
-            Quat::from_axis_angle(Vec3::Z, 90.0)
+            Quat::from_axis_angle(Vec3::Z, 90.0_f32.to_radians())
         );
     }
 
@@ -827,13 +827,19 @@ mod tests {
     fn ease_isometries_3d() {
         let mk = Isometry3d::new;
         let iso_3d_start = mk(Vec3A::ZERO, Quat::from_axis_angle(Vec3::Z, 0.0));
-        let iso_3d_end = mk(Vec3A::ONE, Quat::from_axis_angle(Vec3::Z, 90.0));
+        let iso_3d_end = mk(
+            Vec3A::ONE,
+            Quat::from_axis_angle(Vec3::Z, 90.0_f32.to_radians()),
+        );
 
         let iso_3d_curve = Isometry3d::interpolating_curve_unbounded(iso_3d_start, iso_3d_end);
 
         assert_abs_diff_eq!(
             iso_3d_curve.sample(-1.0).unwrap(),
-            mk(Vec3A::ONE * -1.0, Quat::from_axis_angle(Vec3::Z, -90.0))
+            mk(
+                Vec3A::ONE * -1.0,
+                Quat::from_axis_angle(Vec3::Z, -90.0_f32.to_radians())
+            )
         );
         assert_abs_diff_eq!(
             iso_3d_curve.sample(0.0).unwrap(),
@@ -841,15 +847,24 @@ mod tests {
         );
         assert_abs_diff_eq!(
             iso_3d_curve.sample(0.5).unwrap(),
-            mk(Vec3A::ONE * 0.5, Quat::from_axis_angle(Vec3::Z, 45.0))
+            mk(
+                Vec3A::ONE * 0.5,
+                Quat::from_axis_angle(Vec3::Z, 45.0_f32.to_radians())
+            )
         );
         assert_abs_diff_eq!(
             iso_3d_curve.sample(1.0).unwrap(),
-            mk(Vec3A::ONE, Quat::from_axis_angle(Vec3::Z, 90.0))
+            mk(
+                Vec3A::ONE,
+                Quat::from_axis_angle(Vec3::Z, 90.0_f32.to_radians())
+            )
         );
         assert_abs_diff_eq!(
             iso_3d_curve.sample(2.0).unwrap(),
-            mk(Vec3A::ONE * 2.0, Quat::from_axis_angle(Vec3::Z, 180.0))
+            mk(
+                Vec3A::ONE * 2.0,
+                Quat::from_axis_angle(Vec3::Z, 180.0_f32.to_radians())
+            )
         );
     }
 }

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -663,6 +663,9 @@ impl EaseFunction {
 
 #[cfg(test)]
 mod tests {
+    use crate::{Vec2, Vec3, Vec3A};
+    use approx::assert_abs_diff_eq;
+
     use super::*;
     const MONOTONIC_IN_OUT_INOUT: &[[EaseFunction; 3]] = {
         use EaseFunction::*;
@@ -754,5 +757,86 @@ mod tests {
                 "EaseFunction.{ef_inout:?}(½) was {mid:?}",
             );
         }
+    }
+
+    #[test]
+    fn ease_quats() {
+        let quat_start = Quat::from_axis_angle(Vec3::Z, 0.0);
+        let quat_end = Quat::from_axis_angle(Vec3::Z, 90.0);
+
+        let quat_curve = Quat::interpolating_curve_unbounded(quat_start, quat_end);
+
+        assert_abs_diff_eq!(
+            quat_curve.sample(0.0).unwrap(),
+            Quat::from_axis_angle(Vec3::Z, 0.0)
+        );
+        assert_abs_diff_eq!(
+            quat_curve.sample(0.5).unwrap(),
+            Quat::from_axis_angle(Vec3::Z, 45.0)
+        );
+        assert_abs_diff_eq!(
+            quat_curve.sample(1.0).unwrap(),
+            Quat::from_axis_angle(Vec3::Z, 90.0)
+        );
+    }
+
+    #[test]
+    fn ease_isometries_2d() {
+        let mk = Isometry2d::new;
+        let iso_2d_start = mk(Vec2::ZERO, Rot2::degrees(0.0));
+        let iso_2d_end = mk(Vec2::ONE, Rot2::degrees(90.0));
+
+        let iso_2d_curve = Isometry2d::interpolating_curve_unbounded(iso_2d_start, iso_2d_end);
+
+        assert_abs_diff_eq!(
+            iso_2d_curve.sample(-1.0).unwrap(),
+            mk(Vec2::ONE * -1.0, Rot2::degrees(-90.0))
+        );
+        assert_abs_diff_eq!(
+            iso_2d_curve.sample(0.0).unwrap(),
+            mk(Vec2::ZERO, Rot2::degrees(0.0))
+        );
+        assert_abs_diff_eq!(
+            iso_2d_curve.sample(0.5).unwrap(),
+            mk(Vec2::ONE * 0.5, Rot2::degrees(45.0))
+        );
+        assert_abs_diff_eq!(
+            iso_2d_curve.sample(1.0).unwrap(),
+            mk(Vec2::ONE, Rot2::degrees(90.0))
+        );
+        assert_abs_diff_eq!(
+            iso_2d_curve.sample(2.0).unwrap(),
+            mk(Vec2::ONE * 2.0, Rot2::degrees(180.0))
+        );
+    }
+
+    #[test]
+    fn ease_isometries_3d() {
+        let mk = Isometry3d::new;
+        let iso_3d_start = mk(Vec3A::ZERO, Quat::from_axis_angle(Vec3::Z, 0.0));
+        let iso_3d_end = mk(Vec3A::ONE, Quat::from_axis_angle(Vec3::Z, 90.0));
+
+        let iso_3d_curve = Isometry3d::interpolating_curve_unbounded(iso_3d_start, iso_3d_end);
+
+        assert_abs_diff_eq!(
+            iso_3d_curve.sample(-1.0).unwrap(),
+            mk(Vec3A::ONE * -1.0, Quat::from_axis_angle(Vec3::Z, -90.0))
+        );
+        assert_abs_diff_eq!(
+            iso_3d_curve.sample(0.0).unwrap(),
+            mk(Vec3A::ZERO, Quat::from_axis_angle(Vec3::Z, 0.0))
+        );
+        assert_abs_diff_eq!(
+            iso_3d_curve.sample(0.5).unwrap(),
+            mk(Vec3A::ONE * 0.5, Quat::from_axis_angle(Vec3::Z, 45.0))
+        );
+        assert_abs_diff_eq!(
+            iso_3d_curve.sample(1.0).unwrap(),
+            mk(Vec3A::ONE, Quat::from_axis_angle(Vec3::Z, 90.0))
+        );
+        assert_abs_diff_eq!(
+            iso_3d_curve.sample(2.0).unwrap(),
+            mk(Vec3A::ONE * 2.0, Quat::from_axis_angle(Vec3::Z, 180.0))
+        );
     }
 }

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     curve::{Curve, CurveExt, FunctionCurve, Interval},
-    Dir2, Dir3, Dir3A, Quat, Rot2, VectorSpace,
+    Dir2, Dir3, Dir3A, Isometry2d, Isometry3d, Quat, Rot2, VectorSpace,
 };
 
 use variadics_please::all_tuples_enumerated;
@@ -71,6 +71,42 @@ impl Ease for Dir3A {
         let difference_quat =
             Quat::from_rotation_arc(start.as_vec3a().into(), end.as_vec3a().into());
         Quat::interpolating_curve_unbounded(Quat::IDENTITY, difference_quat).map(move |q| q * start)
+    }
+}
+
+impl Ease for Isometry3d {
+    fn interpolating_curve_unbounded(start: Self, end: Self) -> impl Curve<Self> {
+        FunctionCurve::new(Interval::EVERYWHERE, move |t| {
+            // we can use sample_unchecked here, since both interpolating_curve_unbounded impls
+            // used are defined on the whole domain
+            Isometry3d {
+                rotation: Quat::interpolating_curve_unbounded(start.rotation, end.rotation)
+                    .sample_unchecked(t),
+                translation: crate::Vec3A::interpolating_curve_unbounded(
+                    start.translation,
+                    end.translation,
+                )
+                .sample_unchecked(t),
+            }
+        })
+    }
+}
+
+impl Ease for Isometry2d {
+    fn interpolating_curve_unbounded(start: Self, end: Self) -> impl Curve<Self> {
+        FunctionCurve::new(Interval::EVERYWHERE, move |t| {
+            // we can use sample_unchecked here, since both interpolating_curve_unbounded impls
+            // used are defined on the whole domain
+            Isometry2d {
+                rotation: Rot2::interpolating_curve_unbounded(start.rotation, end.rotation)
+                    .sample_unchecked(t),
+                translation: crate::Vec2::interpolating_curve_unbounded(
+                    start.translation,
+                    end.translation,
+                )
+                .sample_unchecked(t),
+            }
+        })
     }
 }
 


### PR DESCRIPTION
# Objective

- We kind of missed out on implementing the `Ease` trait for some objects like `Isometry2D` and `Isometry3D` even though it makes sense and isn't that hard
- Fixes #17539

## Testing

- wrote some minimal tests
- ~~noticed that quat easing isn't working as expected yet~~ I just confused degrees and radians once again 🙈 