### PR TITLE
Decouple the main sub app update and render sub app update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1610,11 +1610,23 @@ name = "without_winit"
 path = "examples/app/without_winit.rs"
 doc-scrape-examples = true
 
+
 [package.metadata.example.without_winit]
 name = "Without Winit"
 description = "Create an application without winit (runs single time, no event loop)"
 category = "Application"
 wasm = false
+
+[[example]]
+name = "update_mode"
+path = "examples/app/update_mode.rs"
+doc-scrape-examples = true
+
+
+[package.metadata.example.update_mode]
+name = "Main & Render Update Mode"
+description = "Set different update modes for the main app and the renderer"
+category = "Application"
 
 # Assets
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1610,7 +1610,6 @@ name = "without_winit"
 path = "examples/app/without_winit.rs"
 doc-scrape-examples = true
 
-
 [package.metadata.example.without_winit]
 name = "Without Winit"
 description = "Create an application without winit (runs single time, no event loop)"
@@ -1622,11 +1621,11 @@ name = "update_mode"
 path = "examples/app/update_mode.rs"
 doc-scrape-examples = true
 
-
 [package.metadata.example.update_mode]
 name = "Main & Render Update Mode"
 description = "Set different update modes for the main app and the renderer"
 category = "Application"
+wasm = true
 
 # Assets
 [[example]]

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -99,7 +99,7 @@ impl Debug for App {
 }
 
 /// Tracks which [`SubApp`] don't want to be updated in the [`App::update`].
-/// These [`SubApp`]s will still exectute their extract method on [`App::update`].
+/// These [`SubApp`]s will still execute their extract method on [`App::update`].
 #[derive(Default, Resource)]
 pub struct DontUpdateOnUpdate(HashSet<InternedAppLabel>);
 

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -75,7 +75,7 @@ pub struct SubApp {
     /// A function that gives mutable access to two app worlds. This is primarily
     /// intended for copying data from the main world to secondary worlds.
     extract: Option<ExtractFn>,
-    /// A function to finialize any changes made in the extract.
+    /// A function to finalize any changes made in the extract.
     /// This is always executed after the [`ExtractFn`].
     /// The main difference between this and extract is that extract often needs to
     /// run on the main thread to the facilitate extraction from the main world.

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -524,14 +524,14 @@ impl SubApps {
         for (label, sub_app) in self.sub_apps.iter_mut() {
             {
                 #[cfg(feature = "trace")]
-                let _sub_app_span = info_span!("extract sub app", name = ?_label).entered();
+                let _sub_app_span = info_span!("extract sub app", name = ?label).entered();
                 sub_app.extract(&mut self.main.world);
                 sub_app.finalize_extract();
             }
 
             if !only_extract.contains(label) {
                 #[cfg(feature = "trace")]
-                let _sub_app_span = info_span!("update sub app", name = ?_label).entered();
+                let _sub_app_span = info_span!("update sub app", name = ?label).entered();
                 sub_app.update();
             }
         }

--- a/crates/bevy_core_pipeline/src/auto_exposure/mod.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/mod.rs
@@ -18,7 +18,7 @@ mod node;
 mod pipeline;
 mod settings;
 
-use buffers::{extract_buffers, prepare_buffers, AutoExposureBuffers};
+use buffers::{extract_buffers, prepare_buffers, AutoExposureBuffers, ExtractedStateBuffers};
 pub use compensation_curve::{AutoExposureCompensationCurve, AutoExposureCompensationCurveError};
 use node::AutoExposureNode;
 use pipeline::{
@@ -68,6 +68,7 @@ impl Plugin for AutoExposurePlugin {
         render_app
             .init_resource::<SpecializedComputePipelines<AutoExposurePipeline>>()
             .init_resource::<AutoExposureBuffers>()
+            .init_resource::<ExtractedStateBuffers>()
             .add_systems(ExtractSchedule, extract_buffers)
             .add_systems(
                 Render,

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -1,4 +1,5 @@
-use std::sync::{Arc, Mutex};
+use alloc::sync::Arc;
+use std::sync::Mutex;
 
 use bevy_app::{App, AppExit, AppLabel, DontUpdateOnUpdate, Plugin, SubApp};
 use bevy_ecs::{
@@ -186,7 +187,7 @@ impl Plugin for PipelinedRenderingPlugin {
                         if let Some(render_app) = render_app {
                             match command {
                                 SharedRenderCommand::FinalizeExtract => {
-                                    render_app.finalize_extract()
+                                    render_app.finalize_extract();
                                 }
                                 SharedRenderCommand::Render => {
                                     #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -111,6 +111,10 @@ pub fn render_system(world: &mut World, state: &mut SystemState<Query<Entity, Wi
     // update the time and send it to the app world
     let time_sender = world.resource::<TimeSender>();
     if let Err(error) = time_sender.0.try_send(Instant::now()) {
+        #[expect(
+            clippy::match_same_arms,
+            reason = "Provide different comments for each case"
+        )]
         match error {
             bevy_time::TrySendError::Full(_) => {
                 // ignore full errors, the main world is probably updating at a slower rate than the render world

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -113,7 +113,7 @@ pub fn render_system(world: &mut World, state: &mut SystemState<Query<Entity, Wi
     if let Err(error) = time_sender.0.try_send(Instant::now()) {
         match error {
             bevy_time::TrySendError::Full(_) => {
-                panic!("The TimeSender channel should always be empty during render. You might need to add the bevy::core::time_system to your app.",);
+                // ignore full errors, the main world is probably updating at a slower rate than the render world
             }
             bevy_time::TrySendError::Disconnected(_) => {
                 // ignore disconnected errors, the main world probably just got dropped during shutdown

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -150,6 +150,7 @@ impl Plugin for SpritePlugin {
                             .ambiguous_with(queue_material2d_meshes::<ColorMaterial>),
                         prepare_sprite_image_bind_groups.in_set(RenderSet::PrepareBindGroups),
                         prepare_sprite_view_bind_groups.in_set(RenderSet::PrepareBindGroups),
+                        clear_sprite_events.in_set(RenderSet::Cleanup),
                     ),
                 );
         };

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -357,11 +357,14 @@ pub fn extract_sprite_events(
     mut image_events: Extract<EventReader<AssetEvent<Image>>>,
 ) {
     let SpriteAssetEvents { ref mut images } = *events;
-    images.clear();
 
     for event in image_events.read() {
         images.push(*event);
     }
+}
+
+pub fn clear_sprite_events(mut events: ResMut<SpriteAssetEvents>) {
+    events.images.clear();
 }
 
 pub fn extract_sprites(

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -142,22 +142,12 @@ pub fn time_system(
     mut time: ResMut<Time>,
     update_strategy: Res<TimeUpdateStrategy>,
     #[cfg(feature = "std")] time_recv: Option<Res<TimeReceiver>>,
-    #[cfg(feature = "std")] mut has_received_time: Local<bool>,
 ) {
     #[cfg(feature = "std")]
     // TODO: Figure out how to handle this when using pipelined rendering.
     let sent_time = match time_recv.map(|res| res.0.try_recv()) {
-        Some(Ok(new_time)) => {
-            *has_received_time = true;
-            Some(new_time)
-        }
-        Some(Err(_)) => {
-            if *has_received_time {
-                log::warn!("time_system did not receive the time from the render world! Calculations depending on the time may be incorrect.");
-            }
-            None
-        }
-        None => None,
+        Some(Ok(new_time)) => Some(new_time),
+        Some(Err(_)) | None => None,
     };
 
     #[cfg(not(feature = "std"))]

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -251,6 +251,12 @@ pub fn extract_shadows(
     >,
     mapping: Extract<Query<RenderEntity>>,
 ) {
+    extracted_box_shadows
+        .box_shadows
+        .iter()
+        .for_each(|(entity, _)| commands.entity(*entity).despawn());
+    extracted_box_shadows.box_shadows.clear();
+
     let default_camera_entity = default_ui_camera.get();
 
     for (entity, uinode, transform, visibility, box_shadow, clip, camera) in &box_shadow_query {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -99,6 +99,7 @@ pub const UI_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(130128470471
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum RenderUiSystem {
+    Clear,
     ExtractCameraViews,
     ExtractBoxShadows,
     ExtractBackgrounds,
@@ -128,6 +129,7 @@ pub fn build_ui_render(app: &mut App) {
         .configure_sets(
             ExtractSchedule,
             (
+                RenderUiSystem::Clear,
                 RenderUiSystem::ExtractCameraViews,
                 RenderUiSystem::ExtractBoxShadows,
                 RenderUiSystem::ExtractBackgrounds,
@@ -142,6 +144,7 @@ pub fn build_ui_render(app: &mut App) {
         .add_systems(
             ExtractSchedule,
             (
+                clear_extracted_ui_nodes.in_set(RenderUiSystem::Clear),
                 extract_ui_camera_view.in_set(RenderUiSystem::ExtractCameraViews),
                 extract_uinode_background_colors.in_set(RenderUiSystem::ExtractBackgrounds),
                 extract_uinode_images.in_set(RenderUiSystem::ExtractImages),
@@ -274,6 +277,17 @@ impl RenderGraphNode for RunUiSubgraphOnUiViewNode {
         graph.run_sub_graph(SubGraphUi, vec![], Some(default_camera_view.0))?;
         Ok(())
     }
+}
+
+pub fn clear_extracted_ui_nodes(
+    mut commands: Commands,
+    mut extracted_uinodes: ResMut<ExtractedUiNodes>,
+) {
+    extracted_uinodes
+        .uinodes
+        .drain()
+        .for_each(|(entity, _)| commands.entity(entity).despawn());
+    extracted_uinodes.glyphs.clear();
 }
 
 pub fn extract_uinode_background_colors(

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -376,6 +376,12 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
     >,
     mapping: Extract<Query<RenderEntity>>,
 ) {
+    extracted_uinodes
+        .uinodes
+        .iter()
+        .for_each(|(entity, _)| commands.entity(*entity).despawn());
+    extracted_uinodes.uinodes.clear();
+
     // If there is only one camera, we use it as default
     let default_single_camera = default_ui_camera.get();
 

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -262,6 +262,12 @@ pub fn extract_ui_texture_slices(
     >,
     mapping: Extract<Query<RenderEntity>>,
 ) {
+    extracted_ui_slicers
+        .slices
+        .iter()
+        .for_each(|(entity, _)| commands.entity(*entity).despawn());
+    extracted_ui_slicers.slices.clear();
+
     let default_camera_entity = default_ui_camera.get();
 
     for (entity, uinode, transform, inherited_visibility, clip, camera, image) in &slicers_query {

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -48,7 +48,7 @@ pub struct WindowResized {
     all(feature = "serialize", feature = "bevy_reflect"),
     reflect(Serialize, Deserialize)
 )]
-pub struct RequestRedraw;
+pub struct RequestUpdate;
 
 /// An event that is sent whenever a new window is created.
 ///
@@ -427,7 +427,7 @@ pub enum WindowEvent {
     CursorMoved(CursorMoved),
     FileDragAndDrop(FileDragAndDrop),
     Ime(Ime),
-    RequestRedraw(RequestRedraw),
+    RequestUpdate(RequestUpdate),
     WindowBackendScaleFactorChanged(WindowBackendScaleFactorChanged),
     WindowCloseRequested(WindowCloseRequested),
     WindowCreated(WindowCreated),
@@ -484,9 +484,9 @@ impl From<Ime> for WindowEvent {
         Self::Ime(e)
     }
 }
-impl From<RequestRedraw> for WindowEvent {
-    fn from(e: RequestRedraw) -> Self {
-        Self::RequestRedraw(e)
+impl From<RequestUpdate> for WindowEvent {
+    fn from(e: RequestUpdate) -> Self {
+        Self::RequestUpdate(e)
     }
 }
 impl From<WindowBackendScaleFactorChanged> for WindowEvent {

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -589,3 +589,46 @@ impl From<KeyboardFocusLost> for WindowEvent {
         Self::KeyboardFocusLost(e)
     }
 }
+
+/// The kind of [`WindowEvent`] enum variant
+#[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
+#[expect(missing_docs, reason = "Not all docs are written yet, see #3492.")]
+pub enum WindowEventKind {
+    AppLifecycle,
+    CursorEntered,
+    CursorLeft,
+    CursorMoved,
+    FileDragAndDrop,
+    Ime,
+    RequestRedraw,
+    WindowBackendScaleFactorChanged,
+    WindowCloseRequested,
+    WindowCreated,
+    WindowDestroyed,
+    WindowFocused,
+    WindowMoved,
+    WindowOccluded,
+    WindowResized,
+    WindowScaleFactorChanged,
+    WindowThemeChanged,
+
+    MouseButtonInput,
+    MouseMotion,
+    MouseWheel,
+
+    PinchGesture,
+    RotationGesture,
+    DoubleTapGesture,
+    PanGesture,
+
+    TouchInput,
+
+    KeyboardInput,
+    KeyboardFocusLost,
+}

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -108,7 +108,7 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowClosed>()
             .add_event::<WindowCloseRequested>()
             .add_event::<WindowDestroyed>()
-            .add_event::<RequestRedraw>()
+            .add_event::<RequestUpdate>()
             .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()
             .add_event::<CursorLeft>()
@@ -148,7 +148,7 @@ impl Plugin for WindowPlugin {
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<WindowEvent>()
             .register_type::<WindowResized>()
-            .register_type::<RequestRedraw>()
+            .register_type::<RequestUpdate>()
             .register_type::<WindowCreated>()
             .register_type::<WindowCloseRequested>()
             .register_type::<WindowClosing>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -208,14 +208,14 @@ pub struct UpdateSubAppOnWindowEvent(HashMap<WindowEventKind, HashSet<InternedAp
 
 impl UpdateSubAppOnWindowEvent {
     /// Register a [`SubApp`] with the given label when there is a [`WindowEvent`] on the
-    /// given event_kind.
+    /// given `event_kind`.
     pub fn add(&mut self, event_kind: WindowEventKind, label: impl AppLabel) -> &mut Self {
         self.0.entry(event_kind).or_default().insert(label.intern());
         self
     }
 
     /// Unregister a [`SubApp`] with the given label when there is a [`WindowEvent`] on the
-    /// given event_kind.
+    /// given `event_kind`.
     pub fn remove(&mut self, event_kind: WindowEventKind, label: impl AppLabel) -> &mut Self {
         self.0
             .entry(event_kind)
@@ -225,7 +225,7 @@ impl UpdateSubAppOnWindowEvent {
     }
 
     /// Gets the labels for the [`SubApp`]s to execute on a [`WindowEvent`] with the given
-    /// event_kind.
+    /// `event_kind`.
     pub fn get_app_labels(
         &self,
         event_kind: WindowEventKind,

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -224,7 +224,7 @@ impl UpdateSubAppOnWindowEvent {
         self
     }
 
-    /// Gets the labels for the [`SubApp`]s to execture on a [`WindowEvent`] with the given
+    /// Gets the labels for the [`SubApp`]s to execute on a [`WindowEvent`] with the given
     /// event_kind.
     pub fn get_app_labels(
         &self,

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -1,5 +1,4 @@
 use core::marker::PhantomData;
-use std::time::SystemTime;
 
 use approx::relative_eq;
 use bevy_app::{App, AppExit, PluginsState};
@@ -115,11 +114,6 @@ impl<T: Event> WinitAppRunnerState<T> {
             NonSendMut<AccessKitAdapters>,
         )> = SystemState::new(app.world_mut());
 
-        let unix_epoch_instant = Instant::now()
-            - SystemTime::UNIX_EPOCH
-                .elapsed()
-                .expect("Failed to get duration since unix epoch");
-
         Self {
             app,
             lifecycle: AppLifecycle::Idle,
@@ -140,8 +134,8 @@ impl<T: Event> WinitAppRunnerState<T> {
             raw_winit_events: Vec::new(),
             _marker: PhantomData,
             event_writer_system_state,
-            last_update_timestamp: unix_epoch_instant,
-            last_draw_timestamp: unix_epoch_instant,
+            last_update_timestamp: Instant::now(),
+            last_draw_timestamp: Instant::now(),
         }
     }
 

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -57,7 +57,7 @@ use crate::{
 };
 
 /// Persistent state that is used to run the [`App`] according to the current
-/// [`UpdateMode`].
+/// [`MainUpdateMode`] and [`RenderUpdateMode`].
 struct WinitAppRunnerState<T: Event> {
     /// The running app.
     app: App,

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -2,56 +2,92 @@ use bevy_ecs::resource::Resource;
 use core::time::Duration;
 
 /// Settings for the [`WinitPlugin`](super::WinitPlugin).
-#[derive(Debug, Resource, Clone)]
+#[derive(Debug, Resource, Clone, Copy)]
 pub struct WinitSettings {
     /// Determines how frequently the application can update when it has focus.
-    pub focused_mode: UpdateMode,
+    pub focused_mode: (MainUpdateMode, RenderUpdateMode),
     /// Determines how frequently the application can update when it's out of focus.
-    pub unfocused_mode: UpdateMode,
+    pub unfocused_mode: (MainUpdateMode, RenderUpdateMode),
 }
 
 impl WinitSettings {
     /// Default settings for games.
     ///
-    /// [`Continuous`](UpdateMode::Continuous) if windows have focus,
-    /// [`reactive_low_power`](UpdateMode::reactive_low_power) otherwise.
+    /// [`OnEachFrame`](MainUpdateMode::OnEachFrame) if windows have focus,
+    /// [`reactive_low_power`](MainUpdateMode::reactive_low_power) otherwise.
     pub fn game() -> Self {
         WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::reactive_low_power(Duration::from_secs_f64(1.0 / 60.0)), /* 60Hz, */
+            focused_mode: (
+                MainUpdateMode::OnEachFrame { min_ticktime: None },
+                RenderUpdateMode::Continuous,
+            ),
+            unfocused_mode: (
+                MainUpdateMode::reactive_low_power(Duration::from_secs_f64(1.0 / 60.0)), /* 60Hz, */
+                RenderUpdateMode::OnEachMainUpdate {
+                    min_frametime: None,
+                },
+            ),
         }
     }
 
     /// Default settings for desktop applications.
     ///
-    /// [`Reactive`](UpdateMode::Reactive) if windows have focus,
-    /// [`reactive_low_power`](UpdateMode::reactive_low_power) otherwise.
+    /// [`Reactive`](MainUpdateMode::Reactive) if windows have focus,
+    /// [`reactive_low_power`](MainUpdateMode::reactive_low_power) otherwise.
     ///
     /// Use the [`EventLoopProxy`](crate::EventLoopProxy) to request a redraw from outside bevy.
     pub fn desktop_app() -> Self {
         WinitSettings {
-            focused_mode: UpdateMode::reactive(Duration::from_secs(5)),
-            unfocused_mode: UpdateMode::reactive_low_power(Duration::from_secs(60)),
+            focused_mode: (
+                MainUpdateMode::reactive(Duration::from_secs(5)),
+                RenderUpdateMode::OnEachMainUpdate {
+                    min_frametime: None,
+                },
+            ),
+            unfocused_mode: (
+                MainUpdateMode::reactive_low_power(Duration::from_secs(60)),
+                RenderUpdateMode::OnEachMainUpdate {
+                    min_frametime: None,
+                },
+            ),
         }
     }
 
     /// Default settings for mobile.
     ///
-    /// [`Reactive`](UpdateMode::Reactive) if windows have focus,
-    /// [`reactive_low_power`](UpdateMode::reactive_low_power) otherwise.
+    /// [`Reactive`](MainUpdateMode::Reactive) if windows have focus,
+    /// [`reactive_low_power`](MainUpdateMode::reactive_low_power) otherwise.
     ///
     /// Use the [`EventLoopProxy`](crate::EventLoopProxy) to request a redraw from outside bevy.
     pub fn mobile() -> Self {
         WinitSettings {
-            focused_mode: UpdateMode::reactive(Duration::from_secs_f32(1.0 / 60.0)),
-            unfocused_mode: UpdateMode::reactive_low_power(Duration::from_secs(1)),
+            focused_mode: (
+                MainUpdateMode::reactive(Duration::from_secs_f32(1.0 / 60.0)),
+                RenderUpdateMode::OnEachMainUpdate {
+                    min_frametime: None,
+                },
+            ),
+            unfocused_mode: (
+                MainUpdateMode::reactive_low_power(Duration::from_secs(1)),
+                RenderUpdateMode::OnEachMainUpdate {
+                    min_frametime: None,
+                },
+            ),
+        }
+    }
+
+    /// Setting for continous update of the application
+    pub fn continous_update() -> Self {
+        WinitSettings {
+            focused_mode: (MainUpdateMode::Continuous, RenderUpdateMode::Continuous),
+            unfocused_mode: (MainUpdateMode::Continuous, RenderUpdateMode::Continuous),
         }
     }
 
     /// Returns the current [`UpdateMode`].
     ///
     /// **Note:** The output depends on whether the window has focus or not.
-    pub fn update_mode(&self, focused: bool) -> UpdateMode {
+    pub fn update_mode(&self, focused: bool) -> (MainUpdateMode, RenderUpdateMode) {
         match focused {
             true => self.focused_mode,
             false => self.unfocused_mode,
@@ -65,23 +101,33 @@ impl Default for WinitSettings {
     }
 }
 
-/// Determines how frequently an [`App`](bevy_app::App) should update.
+/// Determines how frequently the main [`SubApp`](bevy_app::SubApp) should update.
 ///
-/// **Note:** This setting is independent of VSync. VSync is controlled by a window's
-/// [`PresentMode`](bevy_window::PresentMode) setting. If an app can update faster than the refresh
-/// rate, but VSync is enabled, the update rate will be indirectly limited by the renderer.
+/// **Note:** This only controls how fast the main [`SubApp`](bevy_app::SubApp) is updated.
+/// To control the update behavior of the rendering [`SubApp`](bevy_app::SubApp) use
+/// [`RenderUpdateMode`].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum UpdateMode {
-    /// The [`App`](bevy_app::App) will update over and over, as fast as it possibly can, until an
-    /// [`AppExit`](bevy_app::AppExit) event appears.
+pub enum MainUpdateMode {
+    /// The main [`SubApp`](bevy_app::SubApp) will update over and over, as fast as it possibly can,
+    /// until an [`AppExit`](bevy_app::AppExit) event appears.
     Continuous,
-    /// The [`App`](bevy_app::App) will update in response to the following, until an
+    /// The main [`SubApp`](bevy_app::SubApp) will update after every [`Duration`] has passed, until an
+    /// [`AppExit`](bevy_app::AppExit) event appears.
+    Fixed(Duration),
+    /// The main [`SubApp`](bevy_app::SubApp) will update after every frame is presented, until an
+    /// [`AppExit`](bevy_app::AppExit) event appears.
+    /// This should be used to update the main [`SubApp`](bevy_app::SubApp) at the same rate as the
+    /// present rate (framerate) of the window.
+    OnEachFrame {
+        /// A floor on the time that needs to pass before the main [`SubApp`](bevy_app::SubApp) is
+        /// updated. It can be set to 1.0 / TPS to achive a desired upper bound on the TPS.
+        min_ticktime: Option<Duration>,
+    },
+    /// The main [`SubApp`](bevy_app::SubApp) will update in response to the following, until an
     /// [`AppExit`](bevy_app::AppExit) event appears:
     /// - `wait` time has elapsed since the previous update
-    /// - a redraw has been requested by [`RequestRedraw`](bevy_window::RequestRedraw)
     /// - new [window](`winit::event::WindowEvent`), [raw input](`winit::event::DeviceEvent`), or custom
     ///     events have appeared
-    /// - a redraw has been requested with the [`EventLoopProxy`](crate::EventLoopProxy)
     Reactive {
         /// The approximate time from the start of one update to the next.
         ///
@@ -93,11 +139,12 @@ pub enum UpdateMode {
         /// Reacts to user events, that will wake up the loop if it's in a wait state
         react_to_user_events: bool,
         /// Reacts to window events, that will wake up the loop if it's in a wait state
+        /// IMPORTANT: Does not react to [`winit::event::WindowEvent::RedrawRequested`]
         react_to_window_events: bool,
     },
 }
 
-impl UpdateMode {
+impl MainUpdateMode {
     /// Reactive mode, will update the app for any kind of event
     pub fn reactive(wait: Duration) -> Self {
         Self::Reactive {
@@ -122,4 +169,29 @@ impl UpdateMode {
             react_to_window_events: true,
         }
     }
+}
+
+/// Determines how frequently the render [`SubApp`](bevy_app::SubApp) should update. This
+/// determines how often frames are generated. This does not determine how often they are
+/// presented. This setting is independent of VSync. VSync is controlled by a window's
+/// [`PresentMode`](bevy_window::PresentMode) setting. If the render [`SubApp`](bevy_app::SubApp)
+/// tries to update update faster than the refresh rate, but VSync is enabled, the update rate
+/// will be limited to match the refresh rate.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RenderUpdateMode {
+    /// The render [`SubApp`](bevy_app::SubApp) will update over and over, as fast as it possibly
+    /// can only limited by the window setting (in case of VSync) and the GPU.
+    Continuous,
+    /// The render [`SubApp`](bevy_app::SubApp) will update after every [`Duration`] has passed.
+    Fixed(Duration),
+    /// The render [`SubApp`](bevy_app::SubApp) will update after every main [`SubApp`](bevy_app::SubApp)
+    /// update.
+    ///
+    /// **Note:** You can control the update rate of the main [`SubApp`](bevy_app::SubApp) using
+    /// [`MainUpdateMode`].
+    OnEachMainUpdate {
+        /// A floor on the time that needs to pass before the render [`SubApp`](bevy_app::SubApp) is
+        /// updated. It can be set to 1.0 / FPS to achive a desired upper bound on the FPS.
+        min_frametime: Option<Duration>,
+    },
 }

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -76,8 +76,8 @@ impl WinitSettings {
         }
     }
 
-    /// Setting for continous update of the application
-    pub fn continous_update() -> Self {
+    /// Setting for continuous update of the application
+    pub fn continuous_update() -> Self {
         WinitSettings {
             focused_mode: (MainUpdateMode::Continuous, RenderUpdateMode::Continuous),
             unfocused_mode: (MainUpdateMode::Continuous, RenderUpdateMode::Continuous),
@@ -120,7 +120,7 @@ pub enum MainUpdateMode {
     /// present rate (framerate) of the window.
     OnEachFrame {
         /// A floor on the time that needs to pass before the main [`SubApp`](bevy_app::SubApp) is
-        /// updated. It can be set to 1.0 / TPS to achive a desired upper bound on the TPS.
+        /// updated. It can be set to 1.0 / TPS to achieve a desired upper bound on the TPS.
         min_ticktime: Option<Duration>,
     },
     /// The main [`SubApp`](bevy_app::SubApp) will update in response to the following, until an
@@ -191,7 +191,7 @@ pub enum RenderUpdateMode {
     /// [`MainUpdateMode`].
     OnEachMainUpdate {
         /// A floor on the time that needs to pass before the render [`SubApp`](bevy_app::SubApp) is
-        /// updated. It can be set to 1.0 / FPS to achive a desired upper bound on the FPS.
+        /// updated. It can be set to 1.0 / FPS to achieve a desired upper bound on the FPS.
         min_frametime: Option<Duration>,
     },
 }

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -84,7 +84,7 @@ impl WinitSettings {
         }
     }
 
-    /// Returns the current [`UpdateMode`].
+    /// Returns the current [`MainUpdateMode`] and [`RenderUpdateMode`].
     ///
     /// **Note:** The output depends on whether the window has focus or not.
     pub fn update_mode(&self, focused: bool) -> (MainUpdateMode, RenderUpdateMode) {
@@ -157,7 +157,7 @@ impl MainUpdateMode {
 
     /// Low power mode
     ///
-    /// Unlike [`Reactive`](`UpdateMode::reactive()`), this will ignore events that
+    /// Unlike [`Reactive`](`MainUpdateMode::reactive()`), this will ignore events that
     /// don't come from interacting with a window, like [`MouseMotion`](winit::event::DeviceEvent::MouseMotion).
     /// Use this if, for example, you only want your app to update when the mouse cursor is
     /// moving over a window, not just moving in general. This can greatly reduce power consumption.

--- a/examples/README.md
+++ b/examples/README.md
@@ -228,6 +228,7 @@ Example | Description
 [Headless Renderer](../examples/app/headless_renderer.rs) | An application that runs with no window, but renders into image file
 [Log layers](../examples/app/log_layers.rs) | Illustrate how to add custom log layers
 [Logs](../examples/app/logs.rs) | Illustrate how to use generate log output
+[Main & Render Update Mode](../examples/app/update_mode.rs) | Set different update modes for the main app and the renderer
 [No Renderer](../examples/app/no_renderer.rs) | An application that runs with default plugins and displays an empty window, but without an actual renderer
 [Plugin](../examples/app/plugin.rs) | Demonstrates the creation and registration of a custom plugin
 [Plugin Group](../examples/app/plugin_group.rs) | Demonstrates the creation and registration of a custom plugin group

--- a/examples/app/update_mode.rs
+++ b/examples/app/update_mode.rs
@@ -10,9 +10,9 @@ use std::f32::consts::TAU;
 
 use bevy::{
     prelude::*,
+    render::{Render, RenderApp},
     winit::{MainUpdateMode, RenderUpdateMode, WinitSettings},
 };
-use bevy_render::{Render, RenderApp};
 
 fn main() {
     let mut app = App::new();

--- a/examples/app/update_mode.rs
+++ b/examples/app/update_mode.rs
@@ -110,7 +110,7 @@ fn switch_update_modes(
                 },
             ),
             (
-                "Simulation (Continous, Fixed(6 FPS))",
+                "Simulation (Continuous, Fixed(6 FPS))",
                 WinitSettings {
                     focused_mode: (
                         MainUpdateMode::Continuous,

--- a/examples/app/update_mode.rs
+++ b/examples/app/update_mode.rs
@@ -1,0 +1,175 @@
+//! Using different [`MainUpdateMode`] and [`RenderUpdateMode`] to run the application at various
+//! different TPS and FPS.
+
+use std::{
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
+
+use std::f32::consts::TAU;
+
+use bevy::{
+    prelude::*,
+    winit::{MainUpdateMode, RenderUpdateMode, WinitSettings},
+};
+use bevy_render::{Render, RenderApp};
+
+fn main() {
+    let mut app = App::new();
+
+    let (render_time_tx, render_time_rx) = crossbeam_channel::unbounded();
+
+    app.insert_resource(RenderTimeRx(render_time_rx))
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (switch_update_modes, rotate_cube));
+
+    let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+        panic!("Failed to get render app");
+    };
+
+    render_app
+        .insert_resource(RenderTimeTx(render_time_tx))
+        .add_systems(Render, update_render_duration);
+
+    app.run();
+}
+
+// Define a component to designate a rotation speed to an entity.
+#[derive(Component)]
+struct Rotatable {
+    speed: f32,
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Spawn a cube to rotate.
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform::from_translation(Vec3::ZERO),
+        Rotatable { speed: 0.3 },
+    ));
+
+    // Spawn a camera looking at the entities to show what's happening in this example.
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 10.0, 20.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    // Add a light source so we can see clearly.
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    commands.spawn(Text::default());
+}
+
+#[derive(Resource)]
+struct RenderTimeTx(crossbeam_channel::Sender<Duration>);
+
+#[derive(Resource)]
+struct RenderTimeRx(crossbeam_channel::Receiver<Duration>);
+
+fn switch_update_modes(
+    mut offset: Local<usize>,
+    mut last_instant: Local<Option<Instant>>,
+    mut last_render_duration: Local<Option<Duration>>,
+    mut settings: ResMut<WinitSettings>,
+    render_time_rx: Res<RenderTimeRx>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    text: Query<Entity, With<Text>>,
+    mut writer: TextUiWriter,
+) {
+    static SETTINGS: LazyLock<[(&str, WinitSettings); 4]> = LazyLock::new(|| {
+        [
+            ("Game (OnEachFrame, Continuous)", WinitSettings::game()),
+            (
+                "Desktop App (Reactive, OnEachMainUpdate)",
+                WinitSettings::desktop_app(),
+            ),
+            (
+                "Desktop App 2 (Reactive, OnEachMainUpdate { capped at 6 fps })",
+                WinitSettings {
+                    focused_mode: (
+                        MainUpdateMode::reactive(Duration::from_secs(5)),
+                        RenderUpdateMode::OnEachMainUpdate {
+                            min_frametime: Some(Duration::from_secs_f64(1.0 / 6.0)),
+                        },
+                    ),
+                    unfocused_mode: (
+                        MainUpdateMode::reactive(Duration::from_secs(5)),
+                        RenderUpdateMode::OnEachMainUpdate {
+                            min_frametime: Some(Duration::from_secs_f64(1.0 / 6.0)),
+                        },
+                    ),
+                },
+            ),
+            (
+                "Simulation (Continous, Fixed(6 FPS))",
+                WinitSettings {
+                    focused_mode: (
+                        MainUpdateMode::Continuous,
+                        RenderUpdateMode::Fixed(Duration::from_secs_f64(1.0 / 6.0)),
+                    ),
+                    unfocused_mode: (
+                        MainUpdateMode::Continuous,
+                        RenderUpdateMode::Fixed(Duration::from_secs_f64(1.0 / 6.0)),
+                    ),
+                },
+            ),
+        ]
+    });
+
+    let mode_name = SETTINGS[*offset % SETTINGS.len()].0;
+
+    if let Ok(duration) = render_time_rx.0.try_recv() {
+        *last_render_duration = Some(duration);
+    }
+
+    if let Some((last_instant, render_duration)) =
+        last_instant.as_ref().zip(last_render_duration.as_ref())
+    {
+        *writer.text(text.single(), 0) = format!(
+            "Mode: {mode_name}\nTime between main update: {:?}, Time between render update: {:?}",
+            last_instant.elapsed(),
+            render_duration
+        );
+    }
+
+    *last_instant = Some(Instant::now());
+
+    if keyboard.just_pressed(KeyCode::Space) {
+        *offset += 1;
+    }
+
+    *settings = SETTINGS[*offset % SETTINGS.len()].1;
+}
+
+fn update_render_duration(
+    mut last_instant: Local<Option<Instant>>,
+    render_time_tx: Res<RenderTimeTx>,
+) {
+    if let Some(last_instant) = last_instant.as_mut() {
+        render_time_tx
+            .0
+            .send(last_instant.elapsed())
+            .expect("Failed to send time");
+    }
+
+    *last_instant = Some(Instant::now());
+}
+
+// This system will rotate any entity in the scene with a Rotatable component around its y-axis.
+fn rotate_cube(mut cubes: Query<(&mut Transform, &Rotatable)>, timer: Res<Time>) {
+    for (mut transform, cube) in &mut cubes {
+        // The speed is first multiplied by TAU which is a full rotation (360deg) in radians,
+        // and then multiplied by delta_secs which is the time that passed last frame.
+        // In other words. Speed is equal to the amount of rotations per second.
+        transform.rotate_y(cube.speed * TAU * timer.delta_secs());
+    }
+}

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -145,7 +145,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .insert_resource(args)
         .insert_resource(BevyCounter {
             count: 0,

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -16,7 +16,7 @@ use bevy::{
     },
     sprite::AlphaMode2d,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use rand::{seq::SliceRandom, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -145,10 +145,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .insert_resource(args)
         .insert_resource(BevyCounter {
             count: 0,

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -9,7 +9,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 use rand::Rng;
@@ -32,10 +32,7 @@ fn main() {
                 ..default()
             }),
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .add_systems(Startup, setup)
         .add_systems(
             Update,

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -32,7 +32,7 @@ fn main() {
                 ..default()
             }),
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .add_systems(Startup, setup)
         .add_systems(
             Update,

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -76,7 +76,7 @@ fn main() {
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
-    .insert_resource(WinitSettings::continous_update())
+    .insert_resource(WinitSettings::continuous_update())
     .add_systems(Update, (button_system, set_text_colors_changed));
 
     app.add_systems(Startup, |mut commands: Commands| {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -7,7 +7,7 @@ use bevy::{
     prelude::*,
     text::TextColor,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 const FONT_SIZE: f32 = 7.0;
@@ -76,10 +76,7 @@ fn main() {
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
-    .insert_resource(WinitSettings {
-        focused_mode: UpdateMode::Continuous,
-        unfocused_mode: UpdateMode::Continuous,
-    })
+    .insert_resource(WinitSettings::continous_update())
     .add_systems(Update, (button_system, set_text_colors_changed));
 
     app.add_systems(Startup, |mut commands: Commands| {

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -114,7 +114,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .insert_resource(args)
         .add_systems(Startup, setup)
         .add_systems(Update, (move_camera, print_mesh_count))

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -23,7 +23,7 @@ use bevy::{
         view::{NoCpuCulling, NoFrustumCulling, NoIndirectDrawing},
     },
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use rand::{seq::SliceRandom, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -114,10 +114,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .insert_resource(args)
         .add_systems(Startup, setup)
         .add_systems(Update, (move_camera, print_mesh_count))

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -54,7 +54,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .insert_resource(Foxes {
             count: args.count,
             speed: 2.0,

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -9,7 +9,7 @@ use bevy::{
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 #[derive(FromArgs, Resource)]
@@ -54,10 +54,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .insert_resource(Foxes {
             count: args.count,
             speed: 2.0,

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -6,7 +6,7 @@ use bevy::{
     diagnostic::{Diagnostic, DiagnosticsStore, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 const SYSTEM_COUNT: u32 = 10;
@@ -26,10 +26,7 @@ fn main() {
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
-    .insert_resource(WinitSettings {
-        focused_mode: UpdateMode::Continuous,
-        unfocused_mode: UpdateMode::Continuous,
-    })
+    .insert_resource(WinitSettings::continous_update())
     .insert_resource(Config {
         line_count: 50_000,
         fancy: false,

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -26,7 +26,7 @@ fn main() {
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
-    .insert_resource(WinitSettings::continous_update())
+    .insert_resource(WinitSettings::continuous_update())
     .insert_resource(Config {
         line_count: 50_000,
         fancy: false,

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -51,7 +51,7 @@ fn main() {
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
-    .insert_resource(WinitSettings::continous_update())
+    .insert_resource(WinitSettings::continuous_update())
     .add_systems(Startup, setup);
 
     if args.recompute_text {

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -12,7 +12,7 @@ use bevy::{
     prelude::*,
     text::{LineBreak, TextBounds},
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 #[derive(FromArgs, Resource)]
@@ -51,10 +51,7 @@ fn main() {
         FrameTimeDiagnosticsPlugin::default(),
         LogDiagnosticsPlugin::default(),
     ))
-    .insert_resource(WinitSettings {
-        focused_mode: UpdateMode::Continuous,
-        unfocused_mode: UpdateMode::Continuous,
-    })
+    .insert_resource(WinitSettings::continous_update())
     .add_systems(Startup, setup);
 
     if args.recompute_text {

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -32,7 +32,7 @@ fn main() {
             LogDiagnosticsPlugin::default(),
             LogVisibleLights,
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .add_systems(Startup, setup)
         .add_systems(Update, (move_camera, print_light_count))
         .run();

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -11,7 +11,7 @@ use bevy::{
     prelude::*,
     render::{camera::ScalingMode, Render, RenderApp, RenderSet},
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 use rand::{thread_rng, Rng};
 
@@ -32,10 +32,7 @@ fn main() {
             LogDiagnosticsPlugin::default(),
             LogVisibleLights,
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .add_systems(Startup, setup)
         .add_systems(Update, (move_camera, print_light_count))
         .run();

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -43,7 +43,7 @@ fn main() {
                 ..default()
             }),
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .add_systems(Startup, setup)
         .add_systems(
             Update,

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -12,7 +12,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 use rand::Rng;
@@ -43,10 +43,7 @@ fn main() {
                 ..default()
             }),
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .add_systems(Startup, setup)
         .add_systems(
             Update,

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -8,7 +8,7 @@ use bevy::{
     prelude::*,
     text::{LineBreak, TextBounds},
     window::{PresentMode, WindowResolution},
-    winit::{UpdateMode, WinitSettings},
+    winit::WinitSettings,
 };
 
 fn main() {
@@ -26,10 +26,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        })
+        .insert_resource(WinitSettings::continous_update())
         .add_systems(Startup, spawn)
         .add_systems(Update, update_text_bounds)
         .run();

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -26,7 +26,7 @@ fn main() {
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))
-        .insert_resource(WinitSettings::continous_update())
+        .insert_resource(WinitSettings::continuous_update())
         .add_systems(Startup, spawn)
         .add_systems(Update, update_text_bounds)
         .run();

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -5,7 +5,7 @@
 
 use bevy::{
     prelude::*,
-    window::{PresentMode, RequestRedraw, WindowPlugin},
+    window::{PresentMode, RequestUpdate, WindowPlugin},
     winit::{EventLoopProxyWrapper, WakeUp, WinitSettings},
 };
 use core::time::Duration;
@@ -55,7 +55,7 @@ fn main() {
 enum ExampleMode {
     Game,
     Application,
-    ApplicationWithRequestRedraw,
+    ApplicationWithRequestUpdate,
     ApplicationWithWakeUp,
 }
 
@@ -64,7 +64,7 @@ fn update_winit(
     mode: Res<ExampleMode>,
     mut winit_config: ResMut<WinitSettings>,
     event_loop_proxy: Res<EventLoopProxyWrapper<WakeUp>>,
-    mut redraw_request_events: EventWriter<RequestRedraw>,
+    mut request_update_events: EventWriter<RequestUpdate>,
 ) {
     use ExampleMode::*;
     *winit_config = match *mode {
@@ -73,29 +73,29 @@ fn update_winit(
             //   * When focused: the event loop runs as fast as possible
             //   * When not focused: the app will update when the window is directly interacted with
             //     (e.g. the mouse hovers over a visible part of the out of focus window), a
-            //     [`RequestRedraw`] event is received, or one sixtieth of a second has passed
+            //     [`RequestUpdate`] event is received, or one sixtieth of a second has passed
             //     without the app updating (60 Hz refresh rate max).
             WinitSettings::game()
         }
         Application => {
             // While in `WinitSettings::desktop_app()` mode:
             //   * When focused: the app will update any time a winit event (e.g. the window is
-            //     moved/resized, the mouse moves, a button is pressed, etc.), a [`RequestRedraw`]
+            //     moved/resized, the mouse moves, a button is pressed, etc.), a [`RequestUpdate`]
             //     event is received, or after 5 seconds if the app has not updated.
             //   * When not focused: the app will update when the window is directly interacted with
             //     (e.g. the mouse hovers over a visible part of the out of focus window), a
-            //     [`RequestRedraw`] event is received, or one minute has passed without the app
+            //     [`RequestUpdate`] event is received, or one minute has passed without the app
             //     updating.
             WinitSettings::desktop_app()
         }
-        ApplicationWithRequestRedraw => {
-            // Sending a `RequestRedraw` event is useful when you want the app to update the next
+        ApplicationWithRequestUpdate => {
+            // Sending a `RequestUpdate` event is useful when you want the app to update the next
             // frame regardless of any user input. For example, your application might use
             // `WinitSettings::desktop_app()` to reduce power use, but UI animations need to play even
             // when there are no inputs, so you send redraw requests while the animation is playing.
-            // Note that in this example the RequestRedraw winit event will make the app run in the same
+            // Note that in this example the RequestUpdate winit event will make the app run in the same
             // way as continuous
-            redraw_request_events.send(RequestRedraw);
+            request_update_events.send(RequestUpdate);
             WinitSettings::desktop_app()
         }
         ApplicationWithWakeUp => {
@@ -117,7 +117,7 @@ pub(crate) mod test_setup {
     use bevy::{
         color::palettes::basic::{LIME, YELLOW},
         prelude::*,
-        window::RequestRedraw,
+        window::RequestUpdate,
     };
 
     /// Switch between update modes when the mouse is clicked.
@@ -128,8 +128,8 @@ pub(crate) mod test_setup {
         if button_input.just_pressed(KeyCode::Space) {
             *mode = match *mode {
                 ExampleMode::Game => ExampleMode::Application,
-                ExampleMode::Application => ExampleMode::ApplicationWithRequestRedraw,
-                ExampleMode::ApplicationWithRequestRedraw => ExampleMode::ApplicationWithWakeUp,
+                ExampleMode::Application => ExampleMode::ApplicationWithRequestUpdate,
+                ExampleMode::ApplicationWithRequestUpdate => ExampleMode::ApplicationWithWakeUp,
                 ExampleMode::ApplicationWithWakeUp => ExampleMode::Game,
             };
         }
@@ -162,8 +162,8 @@ pub(crate) mod test_setup {
         let mode = match *mode {
             ExampleMode::Game => "game(), continuous, default",
             ExampleMode::Application => "desktop_app(), reactive",
-            ExampleMode::ApplicationWithRequestRedraw => {
-                "desktop_app(), reactive, RequestRedraw sent"
+            ExampleMode::ApplicationWithRequestUpdate => {
+                "desktop_app(), reactive, RequestUpdate sent"
             }
             ExampleMode::ApplicationWithWakeUp => "desktop_app(), reactive, WakeUp sent",
         };
@@ -176,7 +176,7 @@ pub(crate) mod test_setup {
         mut commands: Commands,
         mut meshes: ResMut<Assets<Mesh>>,
         mut materials: ResMut<Assets<StandardMaterial>>,
-        mut event: EventWriter<RequestRedraw>,
+        mut event: EventWriter<RequestUpdate>,
     ) {
         commands.spawn((
             Mesh3d(meshes.add(Cuboid::new(0.5, 0.5, 0.5))),
@@ -192,7 +192,7 @@ pub(crate) mod test_setup {
             Camera3d::default(),
             Transform::from_xyz(-2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y),
         ));
-        event.send(RequestRedraw);
+        event.send(RequestUpdate);
         commands
             .spawn((
                 Text::default(),

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -18,8 +18,16 @@ fn main() {
         .insert_resource(WinitSettings::desktop_app())
         // You can also customize update behavior with the fields of [`WinitSettings`]
         .insert_resource(WinitSettings {
-            focused_mode: bevy::winit::UpdateMode::Continuous,
-            unfocused_mode: bevy::winit::UpdateMode::reactive_low_power(Duration::from_millis(10)),
+            focused_mode: (
+                bevy::winit::MainUpdateMode::OnEachFrame { min_ticktime: None },
+                bevy::winit::RenderUpdateMode::Continuous,
+            ),
+            unfocused_mode: (
+                bevy::winit::MainUpdateMode::reactive_low_power(Duration::from_millis(10)),
+                bevy::winit::RenderUpdateMode::OnEachMainUpdate {
+                    min_frametime: None,
+                },
+            ),
         })
         .insert_resource(ExampleMode::Game)
         .add_plugins(DefaultPlugins.set(WindowPlugin {


### PR DESCRIPTION
# Objective

- Decouple the main sub app update and the render sub app update so that they can run at different speeds. The is really useful for creating desktop applications where we don't need to render a frame every world update. 
- Add a reliable way to cap the frame rate.
- Resolves #1343

## Solution

- Allow users to disable sub apps from updating with the main sub app update.
- Allow users to define a which sub apps to update on each window event.
- Disable the render sub app from updating with the main world.
- Add the render sub app to update on request redraw.
- Provide a new set of `UpdateMode` to control the update of the main and render sub apps.

## Testing

- Tested it by creating the `update_mode.rs` example.
- Most of the other features like 2d_sprites and animation need more testing.
- You can test these changes by inserting a `WinitSettings` where the main sub app update rate is faster than the render sub app.
- I have only tested these changes on linux.

---

## Showcase

The new `update_mode.rs` example:

![output](https://github.com/user-attachments/assets/1e60b836-28e2-4a85-bbd3-471744d23327)

## Migration Guide

- If the user is setting the `WinitSettings` they will need to add the `RenderUpdateMode` to both of the its fields.
- Any system that executes in the `ExtractSchedule` now can run multiple times before a the render sub app is updated. This means that the systems running inside the `ExtractSchedule` should no longer assume that the render sub app will cleanup any resources or entities that are spawned.
