### PR TITLE
Insert children

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -204,7 +204,7 @@ impl<'w> EntityWorldMut<'w> {
             }
             children_component.0.reserve(children.len());
             let mut v = children_component.0.split_off(index);
-            children_component.0.extend_from_slice(&children);
+            children_component.0.extend_from_slice(children);
             children_component.0.append(&mut v);
         } else {
             self.insert(Children(children.to_vec()));

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -192,7 +192,11 @@ impl<'w> EntityWorldMut<'w> {
             panic!("Cannot insert entity as a child of itself.");
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
+
             children_component.0.retain(|value| !children.contains(value));
+            if index >= children_component.len() {
+                panic!("Index {} out of bounds! There are only {} children!", index, children.len());
+            }
             children_component.0.reserve(children.len());
             let mut v = children_component.0.split_off(index);
             children_component.0.extend_from_slice(&children);

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -192,16 +192,20 @@ impl<'w> EntityWorldMut<'w> {
             panic!("Cannot insert entity as a child of itself.");
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
-
-            children_component.0.retain(|value| !children.contains(value));
+            children_component
+                .0
+                .retain(|value| !children.contains(value));
             if index >= children_component.len() {
-                panic!("Index {} out of bounds! There are only {} children!", index, children.len());
+                panic!(
+                    "Index {} out of bounds! There are only {} children!",
+                    index,
+                    children.len()
+                );
             }
             children_component.0.reserve(children.len());
             let mut v = children_component.0.split_off(index);
             children_component.0.extend_from_slice(&children);
             children_component.0.append(&mut v);
-
         } else {
             self.insert(Children(children.to_vec()));
         }
@@ -378,7 +382,6 @@ mod tests {
             )
         );
 
-
         // Removal
         world.entity_mut(child1).remove::<ChildOf>();
         let hierarchy = get_hierarchy(&world, root);
@@ -397,7 +400,6 @@ mod tests {
                 ]
             )
         );
-
 
         // Recursive Despawn
         world.entity_mut(root).despawn();
@@ -458,7 +460,15 @@ mod tests {
         let hierarchy = get_hierarchy(&world, root);
         assert_eq!(
             hierarchy,
-            Node::new_with(root, vec![Node::new(child1), Node::new(child3), Node::new(child4), Node::new(child2)])
+            Node::new_with(
+                root,
+                vec![
+                    Node::new(child1),
+                    Node::new(child3),
+                    Node::new(child4),
+                    Node::new(child2)
+                ]
+            )
         );
     }
 


### PR DESCRIPTION
# Objective

This PR implements the requested, previously deprecated feature from #17478. Which is concerning the `insert_children` of `EntityWorldMut`. This method inserts children into the tree, at a specific index.

## Solution

I mostly copied the code from the deprecated crate [`bevy_hierarchy`](https://docs.rs/bevy_hierarchy/0.15.1/src/bevy_hierarchy/child_builder.rs.html#379) though this is no longer a trait method.
This code also used `SmallVec` which has later been switched by `Vec`. This was easily interchangeable with working code.

## Testing

I wrote a unit test covering both `EntityWorldMut::add_entities` and `EntityWorldMut::insert_entities`, simply called `hierarchy::tests::insert_children`. I was unsure what error handling architecture i should be using, but i think the simplest to debug in this case would just be a panic in the case of an index out of bounds.

## Showcase

I find this feature pretty self exoplanetary, but the unit test can also bee informing about what this feature implements:
<details>
  <summary>Click to view showcase</summary>

```rust
let mut world = World::new();
let child1 = world.spawn_empty().id();
let child2 = world.spawn_empty().id();
let child3 = world.spawn_empty().id();
let child4 = world.spawn_empty().id();

let mut entity_world_mut = world.spawn_empty();

let first_children = entity_world_mut.add_children(&[child1, child2]);

let root = first_children.insert_children(1, &[child3, child4]).id();

let hierarchy = get_hierarchy(&world, root);
assert_eq!(
     hierarchy,
     Node::new_with(root, vec![Node::new(child1), Node::new(child3), Node::new(child4), Node::new(child2)])
);
```

</details>
