### PR TITLE
Fix `Visibility` link on b0004 error page

### DIFF
--- a/errors/B0004.md
+++ b/errors/B0004.md
@@ -106,7 +106,7 @@ as a child of a pre-existing [`Entity`] that does not have the proper components
 
 [`InheritedVisibility`]: https://docs.rs/bevy/*/bevy/render/view/struct.InheritedVisibility.html
 [`ViewVisibility`]: https://docs.rs/bevy/*/bevy/render/view/struct.ViewVisibility.html
-[`Visibility`]: https://docs.rs/bevy/*/bevy/render/view/struct.Visibility.html
+[`Visibility`]: https://docs.rs/bevy/*/bevy/render/view/enum.Visibility.html
 [`GlobalTransform`]: https://docs.rs/bevy/*/bevy/transform/components/struct.GlobalTransform.html
 [`ChildOf`]: https://docs.rs/bevy/*/bevy/ecs/hierarchy/struct.ChildOf.html
 [`Entity`]: https://docs.rs/bevy/*/bevy/ecs/entity/struct.Entity.html


### PR DESCRIPTION
Per title. Note the "improve this page" link on the [site](https://bevyengine.org/learn/errors/b0004/) gives a 404.