### PR TITLE
Name component simplification

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -7,10 +7,7 @@
   entities: {
     4294967296: (
       components: {
-        "bevy_ecs::name::Name": (
-          hash: 17588334858059901562,
-          name: "joe",
-        ),
+        "bevy_ecs::name::Name": "joe",
         "bevy_transform::components::global_transform::GlobalTransform": ((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)),
         "bevy_transform::components::transform::Transform": (
           translation: (0.0, 0.0, 0.0),

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -114,6 +114,7 @@ disqualified = { version = "1.0", default-features = false }
 fixedbitset = { version = "0.5", default-features = false }
 serde = { version = "1", default-features = false, features = [
   "alloc",
+  "derive"
 ], optional = true }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = [

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -114,7 +114,7 @@ disqualified = { version = "1.0", default-features = false }
 fixedbitset = { version = "0.5", default-features = false }
 serde = { version = "1", default-features = false, features = [
   "alloc",
-  "derive"
+  "derive",
 ], optional = true }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = [


### PR DESCRIPTION
# Objective

- While checking how `Name` component was built, it catch my attention how needlessly complex it was.
- It's storing a pre-computed hash internally, and it's only used for `PartialEq` for the case where both hashes are different, as it's assumed that both are Names are different.
  - This is what was bringing most complexity to the component since it forced custom trait implementations instead of directly using `#[derive]`

## Solution

- Removing custom `Debug`, `Hash`, `PartialOrd`, `PartialEq`, `Serialize` and `Deserialize`. Substituting them with `#[derive]`
- Simplify `set()` and `mutate::<F: FnOnce(&mut String)>()` with a simpler `to_mut()`

## Testing

- Did you test these changes? If so, how?
  - `cargo run -p ci` Locally

## Perfomance testing:

I was curious if the performance would suffer or improve compared to the previous implementation, so I've created [some benchmarks](https://gist.github.com/eckz/00cf9872785292c0db362a8908af2f56) to compare the `PartialEq` implementations (since it was the only place where the internal hash was used).
It also tests how it would behave if a lot of `Name`'s are inserted in a `HashSet`.

The benchmarks are not included in this PR, since I don't see really any value in benchmarking default `PartialEq` in the future.

The results are the following:

![Screenshot 2025-01-28 at 11 19 00](https://github.com/user-attachments/assets/9a0006b5-6b72-4b61-b0c1-1e595757a452)

Which kind of shows that previous implementation is only better if somehow you create a ton of small `Name's`, and compare them where internal strings are relatively small.

Just to be clear, I don't think any of this benchmarks represents any real usage of the `Name` component, making the previous complex implementation harder to justify.

---


## Migration Guide


- Name's `mutate ` and `set` are replaced with a `into_mut()` that returns a mutable `String`.
