### PR TITLE
Change `OrthographicProjection::area` creation to use `Rect::from_center_half_size`

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -602,8 +602,8 @@ impl CameraProjection for OrthographicProjection {
     }
 
     fn update(&mut self, width: f32, height: f32) {
-        let (projection_width, projection_height) = match self.scaling_mode {
-            ScalingMode::WindowSize => (width, height),
+        let projection_dimensions = match self.scaling_mode {
+            ScalingMode::WindowSize => Vec2::new(width, height),
             ScalingMode::AutoMin {
                 min_width,
                 min_height,
@@ -611,9 +611,9 @@ impl CameraProjection for OrthographicProjection {
                 // Compare Pixels of current width and minimal height and Pixels of minimal width with current height.
                 // Then use bigger (min_height when true) as what it refers to (height when true) and calculate rest so it can't get under minimum.
                 if width * min_height > min_width * height {
-                    (width * min_height / height, min_height)
+                    Vec2::new(width * min_height / height, min_height)
                 } else {
-                    (min_width, height * min_width / width)
+                    Vec2::new(min_width, height * min_width / width)
                 }
             }
             ScalingMode::AutoMax {
@@ -623,29 +623,23 @@ impl CameraProjection for OrthographicProjection {
                 // Compare Pixels of current width and maximal height and Pixels of maximal width with current height.
                 // Then use smaller (max_height when true) as what it refers to (height when true) and calculate rest so it can't get over maximum.
                 if width * max_height < max_width * height {
-                    (width * max_height / height, max_height)
+                    Vec2::new(width * max_height / height, max_height)
                 } else {
-                    (max_width, height * max_width / width)
+                    Vec2::new(max_width, height * max_width / width)
                 }
             }
             ScalingMode::FixedVertical { viewport_height } => {
-                (width * viewport_height / height, viewport_height)
+                Vec2::new(width * viewport_height / height, viewport_height)
             }
             ScalingMode::FixedHorizontal { viewport_width } => {
-                (viewport_width, height * viewport_width / width)
+                Vec2::new(viewport_width, height * viewport_width / width)
             }
-            ScalingMode::Fixed { width, height } => (width, height),
+            ScalingMode::Fixed { width, height } => Vec2::new(width, height),
         };
 
-        let origin_x = projection_width * self.viewport_origin.x;
-        let origin_y = projection_height * self.viewport_origin.y;
+        let origin = projection_dimensions * self.viewport_origin;
 
-        self.area = Rect::new(
-            self.scale * -origin_x,
-            self.scale * -origin_y,
-            self.scale * (projection_width - origin_x),
-            self.scale * (projection_height - origin_y),
-        );
+        self.area = Rect::from_center_half_size(Vec2::default(), origin * self.scale);
     }
 
     fn far(&self) -> f32 {


### PR DESCRIPTION
# Objective

Changing the creation of `OrthographicProjection::area` in `OrthographicProjection::update` to use `Rect::from_center_half_size` instead of `Rect::new` will decrease the likelyhood of an error on the calculation to shift the center of the view.

## Solution

Change the creation of `OrthographicProjection::area` in `OrthographicProjection::update` to use `Rect::from_center_half_size`.

## Testing

Ran the examples mentioned on #16856

## Showcase
`orthographic` example
![image](https://github.com/user-attachments/assets/d3bb1480-5908-4427-b1f2-af8a5c411745)

`projection_zoom` example
![image](https://github.com/user-attachments/assets/e560c81b-db8f-44f0-91f4-d6bae3ae7f32)

`camera_sub_view` example
![image](https://github.com/user-attachments/assets/615e9eb8-f4e5-406a-b98a-501f7d652145)

`custom_primitives` example
![image](https://github.com/user-attachments/assets/8fd7702e-07e7-47e3-9510-e247d268a3e7)
