### PR TITLE
implement UniqueEntitySlice

### DIFF
--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -13,7 +13,7 @@ use core::{
     option, result,
 };
 
-use super::Entity;
+use super::{Entity, UniqueEntitySlice};
 
 use bevy_platform_support::sync::Arc;
 
@@ -350,6 +350,7 @@ impl<I: EntitySetIterator> UniqueEntityIter<I> {
         Self { iter }
     }
 }
+
 impl<I: Iterator<Item: TrustedEntityBorrow>> UniqueEntityIter<I> {
     /// Constructs a [`UniqueEntityIter`] from an iterator unsafely.
     ///
@@ -358,6 +359,26 @@ impl<I: Iterator<Item: TrustedEntityBorrow>> UniqueEntityIter<I> {
     /// As in, the resulting iterator must adhere to the safety contract of [`EntitySetIterator`].
     pub unsafe fn from_iterator_unchecked(iter: I) -> Self {
         Self { iter }
+    }
+
+    /// Returns the inner [`I`].
+    pub fn into_inner(self) -> I {
+        self.iter
+    }
+
+    /// Returns a reference to the inner [`I`].
+    pub fn as_inner(&self) -> &I {
+        &self.iter
+    }
+
+    /// Returns a mutable reference to the inner [`I`].
+    ///
+    /// # Safety
+    ///
+    /// `self` must always contain an iterator that yields unique elements,
+    /// even while this reference is live.
+    pub unsafe fn as_mut_inner(&mut self) -> &mut I {
+        &mut self.iter
     }
 }
 
@@ -391,6 +412,24 @@ unsafe impl<I: Iterator<Item: TrustedEntityBorrow>> EntitySetIterator for Unique
 impl<T, I: Iterator<Item: TrustedEntityBorrow> + AsRef<[T]>> AsRef<[T]> for UniqueEntityIter<I> {
     fn as_ref(&self) -> &[T] {
         self.iter.as_ref()
+    }
+}
+
+impl<T: TrustedEntityBorrow, I: Iterator<Item: TrustedEntityBorrow> + AsRef<[T]>>
+    AsRef<UniqueEntitySlice<T>> for UniqueEntityIter<I>
+{
+    fn as_ref(&self) -> &UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.iter.as_ref()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, I: Iterator<Item: TrustedEntityBorrow> + AsMut<[T]>>
+    AsMut<UniqueEntitySlice<T>> for UniqueEntityIter<I>
+{
+    fn as_mut(&mut self) -> &mut UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.iter.as_mut()) }
     }
 }
 

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -361,17 +361,17 @@ impl<I: Iterator<Item: TrustedEntityBorrow>> UniqueEntityIter<I> {
         Self { iter }
     }
 
-    /// Returns the inner [`I`].
+    /// Returns the inner `I`.
     pub fn into_inner(self) -> I {
         self.iter
     }
 
-    /// Returns a reference to the inner [`I`].
+    /// Returns a reference to the inner `I`.
     pub fn as_inner(&self) -> &I {
         &self.iter
     }
 
-    /// Returns a mutable reference to the inner [`I`].
+    /// Returns a mutable reference to the inner `I`.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -66,6 +66,10 @@ mod index_set;
 pub use index_map::EntityIndexMap;
 pub use index_set::EntityIndexSet;
 
+mod unique_slice;
+
+pub use unique_slice::*;
+
 use crate::{
     archetype::{ArchetypeId, ArchetypeRow},
     identifier::{

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -16,12 +16,12 @@ use alloc::{
     collections::VecDeque,
     rc::Rc,
     sync::Arc,
-    vec::{self, Vec},
+    vec::Vec,
 };
 
 use super::{
-    EntitySet, EntitySetIterator, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
-    UniqueEntityVec,
+    unique_vec, EntitySet, EntitySetIterator, FromEntitySetIterator, TrustedEntityBorrow,
+    UniqueEntityIter, UniqueEntityVec,
 };
 
 /// A slice that contains only unique entities.
@@ -514,7 +514,7 @@ impl<'a, T: TrustedEntityBorrow> IntoIterator for &'a Box<UniqueEntitySlice<T>> 
 impl<T: TrustedEntityBorrow> IntoIterator for Box<UniqueEntitySlice<T>> {
     type Item = T;
 
-    type IntoIter = UniqueEntityIter<vec::IntoIter<T>>;
+    type IntoIter = unique_vec::IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.into_vec().into_iter()

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -473,6 +473,50 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     }
 }
 
+/// Converts a reference to T into a slice of length 1 (without copying).
+pub const fn from_ref<T: TrustedEntityBorrow>(s: &T) -> &UniqueEntitySlice<T> {
+    // SAFETY: A slice with a length of 1 is always unique.
+    unsafe { UniqueEntitySlice::from_slice_unchecked(slice::from_ref(s)) }
+}
+
+/// Converts a reference to T into a slice of length 1 (without copying).
+pub const fn from_mut<T: TrustedEntityBorrow>(s: &mut T) -> &mut UniqueEntitySlice<T> {
+    // SAFETY: A slice with a length of 1 is always unique.
+    unsafe { UniqueEntitySlice::from_slice_unchecked_mut(slice::from_mut(s)) }
+}
+
+/// Forms a slice from a pointer and a length.
+///
+/// Equivalent to [`slice::from_raw_parts`].
+///
+/// # Safety
+///
+/// [`slice::from_raw_parts`] must be safe to call with `data` and `len`.
+/// Additionally, all elements in the resulting slice must be unique.
+pub const unsafe fn from_raw_parts<'a, T: TrustedEntityBorrow>(
+    data: *const T,
+    len: usize,
+) -> &'a UniqueEntitySlice<T> {
+    // SAFETY: The safety contract is upheld by the caller.
+    unsafe { UniqueEntitySlice::from_slice_unchecked(slice::from_raw_parts(data, len)) }
+}
+
+/// Performs the same functionality as [`from_raw_parts`], except that a mutable slice is returned.
+///
+/// Equivalent to [`slice::from_raw_parts_mut`].
+///
+/// # Safety
+///
+/// [`slice::from_raw_parts_mut`] must be safe to call with `data` and `len`.
+/// Additionally, all elements in the resulting slice must be unique.
+pub const unsafe fn from_raw_parts_mut<'a, T: TrustedEntityBorrow>(
+    data: *mut T,
+    len: usize,
+) -> &'a mut UniqueEntitySlice<T> {
+    // SAFETY: The safety contract is upheld by the caller.
+    unsafe { UniqueEntitySlice::from_slice_unchecked_mut(slice::from_raw_parts_mut(data, len)) }
+}
+
 impl<'a, T: TrustedEntityBorrow> IntoIterator for &'a UniqueEntitySlice<T> {
     type Item = &'a T;
 

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -53,8 +53,8 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     }
 
     /// Casts to `self` to a standard slice.
-    pub fn as_inner(&self) -> &[T] {
-        self
+    pub const fn as_inner(&self) -> &[T] {
+        &self.0
     }
 
     /// Constructs a `UniqueEntitySlice` from a [`Box<[T]>`] unsafely.

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -381,16 +381,6 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
         self.0.rotate_right(mid);
     }
 
-    /// Copies all elements from `src` into `self`, using a memcpy.
-    ///
-    /// Equivalent to [`[T]::copy_from_slice`](slice::copy_from_slice).
-    pub fn copy_from_slice(&mut self, src: &Self)
-    where
-        T: Copy,
-    {
-        self.0.copy_from_slice(src);
-    }
-
     /// Sorts the slice, preserving initial order of equal elements.
     ///
     /// Equivalent to [`[T]::sort`](slice::sort()).

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -409,7 +409,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
 
     /// Sorts the slice, preserving initial order of equal elements.
     ///
-    /// Equivalent to [`[T]::sort`](slice::sort).
+    /// Equivalent to [`[T]::sort`](slice::sort()).
     pub fn sort(&mut self)
     where
         T: Ord,

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -1,0 +1,957 @@
+use core::{
+    borrow::Borrow,
+    cmp::Ordering,
+    fmt::Debug,
+    ops::{
+        Bound, Deref, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo,
+        RangeToInclusive,
+    },
+    ptr,
+    slice::{self, SliceIndex},
+};
+
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    collections::VecDeque,
+    rc::Rc,
+    sync::Arc,
+    vec::{self, Vec},
+};
+
+use super::{
+    EntitySet, EntitySetIterator, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
+    UniqueEntityVec,
+};
+
+/// A slice that contains only unique entities.
+///
+/// It can be obtained by slicing [`UniqueEntityVec`].
+#[repr(transparent)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UniqueEntitySlice<T: TrustedEntityBorrow>([T]);
+
+impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
+    /// Constructs a `UniqueEntitySlice` from a [`&[T]`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub const unsafe fn from_slice_unchecked(slice: &[T]) -> &Self {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { &*(ptr::from_ref(slice) as *const Self) }
+    }
+
+    /// Constructs a `UniqueEntitySlice` from a [`&mut [T]`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub const unsafe fn from_slice_unchecked_mut(slice: &mut [T]) -> &mut Self {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { &mut *(ptr::from_mut(slice) as *mut Self) }
+    }
+
+    /// Casts to `self` to a standard slice.
+    pub fn as_inner(&self) -> &[T] {
+        self
+    }
+
+    /// Constructs a `UniqueEntitySlice` from a [`Box<[T]>`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub unsafe fn from_boxed_slice_unchecked(slice: Box<[T]>) -> Box<Self> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { Box::from_raw(Box::into_raw(slice) as *mut Self) }
+    }
+
+    /// Casts `self` to the inner slice.
+    pub fn into_boxed_inner(self: Box<Self>) -> Box<[T]> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { Box::from_raw(Box::into_raw(self) as *mut [T]) }
+    }
+
+    /// Constructs a `UniqueEntitySlice` from a [`Arc<[T]>`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub unsafe fn from_arc_slice_unchecked(slice: Arc<[T]>) -> Arc<Self> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { Arc::from_raw(Arc::into_raw(slice) as *mut Self) }
+    }
+
+    /// Casts `self` to the inner slice.
+    pub fn into_arc_inner(self: Arc<Self>) -> Arc<[T]> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { Arc::from_raw(Arc::into_raw(self) as *mut [T]) }
+    }
+
+    // Constructs a `UniqueEntitySlice` from a [`Rc<[T]>`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub unsafe fn from_rc_slice_unchecked(slice: Rc<[T]>) -> Rc<Self> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { Rc::from_raw(Rc::into_raw(slice) as *mut Self) }
+    }
+
+    /// Casts `self` to the inner slice.
+    pub fn into_rc_inner(self: Rc<Self>) -> Rc<[T]> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { Rc::from_raw(Rc::into_raw(self) as *mut [T]) }
+    }
+
+    /// Returns the first and all the rest of the elements of the slice, or `None` if it is empty.
+    ///
+    /// Equivalent to [`[T]::split_first`](slice::split_first).
+    pub const fn split_first(&self) -> Option<(&T, &UniqueEntitySlice<T>)> {
+        let Some((first, rest)) = self.0.split_first() else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        Some((first, unsafe { Self::from_slice_unchecked(rest) }))
+    }
+
+    /// Returns the last and all the rest of the elements of the slice, or `None` if it is empty.
+    ///
+    /// Equivalent to [`[T]::split_last`](slice::split_last).
+    pub const fn split_last(&self) -> Option<(&T, &UniqueEntitySlice<T>)> {
+        let Some((last, rest)) = self.0.split_last() else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        Some((last, unsafe { Self::from_slice_unchecked(rest) }))
+    }
+
+    /// Returns a reference to a subslice.
+    ///
+    /// Equivalent to the range functionality of [`[T]::get`].
+    ///
+    /// Note that calling `UniqueEntitySlice::get` with an index will deref to [`[T]::get`].
+    ///
+    /// [`[T]::get`]: `slice::get`
+    pub fn get<I>(&self, index: I) -> Option<&Self>
+    where
+        Self: Index<I>,
+        I: SliceIndex<[T], Output = [T]>,
+    {
+        self.0.get(index).map(|slice|
+            // SAFETY: All elements in the original slice are unique.
+            unsafe { Self::from_slice_unchecked(slice) })
+    }
+
+    /// Returns a mutable reference to a subslice.
+    ///
+    /// Equivalent to the range functionality of [`[T]::get_mut`].
+    ///
+    /// Note that `UniqueEntitySlice::get_mut` cannot be called with an index.
+    ///
+    /// [`[T]::get`]: `slice::get_mut`s
+    pub fn get_mut<I>(&mut self, index: I) -> Option<&mut Self>
+    where
+        Self: Index<I>,
+        I: SliceIndex<[T], Output = [T]>,
+    {
+        self.0.get_mut(index).map(|slice|
+            // SAFETY: All elements in the original slice are unique.
+            unsafe { Self::from_slice_unchecked_mut(slice) })
+    }
+
+    /// Returns a reference to a subslice, without doing bounds checking.
+    ///
+    /// Equivalent to the range functionality of [`[T]::get_unchecked`].
+    ///
+    /// Note that calling `UniqueEntitySlice::get_unchecked` with an index will deref
+    /// to [`[T]::get_unchecked`].
+    ///
+    /// # Safety
+    ///
+    /// `index` must be safe to use with [`[T]::get_unchecked`]
+    ///
+    /// [`[T]::get_unchecked`]: `slice::get_unchecked`
+    pub unsafe fn get_unchecked<I>(&self, index: I) -> &Self
+    where
+        Self: Index<I>,
+        I: SliceIndex<[T], Output = [T]>,
+    {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.get_unchecked(index)) }
+    }
+    /// Returns a mutable reference to a subslice, without doing bounds checking.
+    ///
+    /// Equivalent to the range functionality of [`[T]::get_unchecked_mut`].
+    ///
+    /// Note that `UniqueEntitySlice::get_unchecked_mut` cannot be called with an index.
+    ///
+    /// # Safety
+    ///
+    /// `index` must be safe to use with [`[T]::get_unchecked_mut`]
+    ///
+    /// [`[T]::get_unchecked_mut`]: `slice::get_unchecked_mut`
+    pub unsafe fn get_unchecked_mut<I>(&mut self, index: I) -> &mut Self
+    where
+        Self: Index<I>,
+        I: SliceIndex<[T], Output = [T]>,
+    {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.get_unchecked_mut(index)) }
+    }
+
+    /// Returns an unsafe mutable pointer to the slice's buffer.
+    pub const fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_mut_ptr()
+    }
+
+    /// Returns the two unsafe mutable pointers spanning the slice.
+    pub const fn as_mut_ptr_range(&mut self) -> Range<*mut T> {
+        self.0.as_mut_ptr_range()
+    }
+
+    /// Swaps two elements in the slice.
+    pub fn swap(&mut self, a: usize, b: usize) {
+        self.0.swap(a, b);
+    }
+
+    /// Reverses the order of elements in the slice, in place.
+    pub fn reverse(&mut self) {
+        self.0.reverse();
+    }
+
+    /// Returns an iterator over the slice.
+    pub fn iter(&self) -> Iter<'_, T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntityIter::from_iterator_unchecked(self.0.iter()) }
+    }
+
+    /// Divides one slice into two at an index.
+    ///
+    /// Equivalent to [`[T]::split_at`](slice::split_at)
+    pub const fn split_at(&self, mid: usize) -> (&UniqueEntitySlice<T>, &UniqueEntitySlice<T>) {
+        let (left, right) = self.0.split_at(mid);
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            (
+                Self::from_slice_unchecked(left),
+                Self::from_slice_unchecked(right),
+            )
+        }
+    }
+
+    /// Divides one mutable slice into two at an index.
+    ///
+    /// Equivalent to [`[T]::split_at_mut`](slice::split_at_mut)
+    pub const fn split_at_mut(
+        &mut self,
+        mid: usize,
+    ) -> (&mut UniqueEntitySlice<T>, &mut UniqueEntitySlice<T>) {
+        let (left, right) = self.0.split_at_mut(mid);
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            (
+                Self::from_slice_unchecked_mut(left),
+                Self::from_slice_unchecked_mut(right),
+            )
+        }
+    }
+
+    /// Divides one slice into two at an index, without doing bounds checking.
+    ///
+    /// Equivalent to [`[T]::split_at_unchecked`](slice::split_at_unchecked)
+    ///
+    /// # Safety
+    ///
+    /// `mid` must be safe to use in [`[T]::split_at_unchecked`].
+    ///
+    /// [`[T]::split_at_unchecked`]: `slice::split_at_unchecked`
+    pub const unsafe fn split_at_unchecked(
+        &self,
+        mid: usize,
+    ) -> (&UniqueEntitySlice<T>, &UniqueEntitySlice<T>) {
+        // SAFETY: The safety contract is upheld by the caller.
+        let (left, right) = unsafe { self.0.split_at_unchecked(mid) };
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            (
+                Self::from_slice_unchecked(left),
+                Self::from_slice_unchecked(right),
+            )
+        }
+    }
+
+    /// Divides one mutable slice into two at an index, without doing bounds checking.
+    ///
+    /// Equivalent to [`[T]::split_at_mut_unchecked`](slice::split_at_mut_unchecked).
+    ///
+    /// # Safety
+    ///
+    /// `mid` must be safe to use in [`[T]::split_at_mut_unchecked`].
+    ///
+    /// [`[T]::split_at_mut_unchecked`]: `slice::split_at_mut_unchecked`
+    pub const unsafe fn split_at_mut_unchecked(
+        &mut self,
+        mid: usize,
+    ) -> (&mut UniqueEntitySlice<T>, &mut UniqueEntitySlice<T>) {
+        // SAFETY: The safety contract is upheld by the caller.
+        let (left, right) = unsafe { self.0.split_at_mut_unchecked(mid) };
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            (
+                Self::from_slice_unchecked_mut(left),
+                Self::from_slice_unchecked_mut(right),
+            )
+        }
+    }
+
+    /// Divides one slice into two at an index, returning `None` if the slice is
+    /// too short.
+    ///
+    /// Equivalent to [`[T]::split_at_checked`](slice::split_at_checked).
+    pub const fn split_at_checked(
+        &self,
+        mid: usize,
+    ) -> Option<(&UniqueEntitySlice<T>, &UniqueEntitySlice<T>)> {
+        let Some((left, right)) = self.0.split_at_checked(mid) else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            Some((
+                Self::from_slice_unchecked(left),
+                Self::from_slice_unchecked(right),
+            ))
+        }
+    }
+
+    /// Divides one mutable slice into two at an index, returning `None` if the
+    /// slice is too short.
+    ///
+    /// Equivalent to [`[T]::split_at_mut_checked`](slice::split_at_mut_checked).
+    pub const fn split_at_mut_checked(
+        &mut self,
+        mid: usize,
+    ) -> Option<(&mut UniqueEntitySlice<T>, &mut UniqueEntitySlice<T>)> {
+        let Some((left, right)) = self.0.split_at_mut_checked(mid) else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            Some((
+                Self::from_slice_unchecked_mut(left),
+                Self::from_slice_unchecked_mut(right),
+            ))
+        }
+    }
+
+    /// Sorts the slice **without** preserving the initial order of equal elements.
+    ///
+    /// Equivalent to [`[T]::sort_unstable`](slice::sort_unstable).
+    pub fn sort_unstable(&mut self)
+    where
+        T: Ord,
+    {
+        self.0.sort_unstable();
+    }
+
+    /// Sorts the slice with a comparison function, **without** preserving the initial order of
+    /// equal elements.
+    ///
+    /// Equivalent to [`[T]::sort_unstable_by`](slice::sort_unstable_by).
+    pub fn sort_unstable_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&T, &T) -> Ordering,
+    {
+        self.0.sort_unstable_by(compare);
+    }
+
+    /// Sorts the slice with a key extraction function, **without** preserving the initial order of
+    /// equal elements.
+    ///
+    /// Equivalent to [`[T]::sort_unstable_by_key`](slice::sort_unstable_by_key).
+    pub fn sort_unstable_by_key<K, F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> K,
+        K: Ord,
+    {
+        self.0.sort_unstable_by_key(f);
+    }
+
+    /// Rotates the slice in-place such that the first `mid` elements of the
+    /// slice move to the end while the last `self.len() - mid` elements move to
+    /// the front.
+    ///
+    /// Equivalent to [`[T]::rotate_left`](slice::rotate_left).
+    pub fn rotate_left(&mut self, mid: usize) {
+        self.0.rotate_left(mid);
+    }
+
+    /// Rotates the slice in-place such that the first `self.len() - k`
+    /// elements of the slice move to the end while the last `k` elements move
+    /// to the front.
+    ///
+    /// Equivalent to [`[T]::rotate_right`](slice::rotate_right).
+    pub fn rotate_right(&mut self, mid: usize) {
+        self.0.rotate_right(mid);
+    }
+
+    /// Copies all elements from `src` into `self`, using a memcpy.
+    ///
+    /// Equivalent to [`[T]::copy_from_slice`](slice::copy_from_slice).
+    pub fn copy_from_slice(&mut self, src: &UniqueEntitySlice<T>)
+    where
+        T: Copy,
+    {
+        self.0.copy_from_slice(src);
+    }
+
+    /// Sorts the slice, preserving initial order of equal elements.
+    ///
+    /// Equivalent to [`[T]::sort`](slice::sort).
+    pub fn sort(&mut self)
+    where
+        T: Ord,
+    {
+        self.0.sort();
+    }
+
+    /// Sorts the slice with a comparison function, preserving initial order of equal elements.
+    ///
+    /// Equivalent to [`[T]::sort_by`](slice::sort_by).
+    pub fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&T, &T) -> Ordering,
+    {
+        self.0.sort_by(compare);
+    }
+
+    /// Sorts the slice with a key extraction function, preserving initial order of equal elements.
+    ///
+    /// Equivalent to [`[T]::sort_by_key`](slice::sort_by_key).
+    pub fn sort_by_key<K, F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> K,
+        K: Ord,
+    {
+        self.0.sort_by_key(f);
+    }
+
+    // Sorts the slice with a key extraction function, preserving initial order of equal elements.
+    ///
+    /// Equivalent to [`[T]::sort_by_cached_key`](slice::sort_by_cached_key).
+    pub fn sort_by_cached_key<K, F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> K,
+        K: Ord,
+    {
+        self.0.sort_by_cached_key(f);
+    }
+
+    /// Copies self into a new `UniqueEntityVec`.
+    pub fn to_vec(&self) -> UniqueEntityVec<T>
+    where
+        T: Clone,
+    {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntityVec::from_vec_unchecked(self.0.to_vec()) }
+    }
+
+    /// Converts `self` into a vector without clones or allocation.
+    ///
+    /// Equivalent to [`[T]::into_vec`](slice::into_vec).
+    pub fn into_vec(self: Box<UniqueEntitySlice<T>>) -> UniqueEntityVec<T> {
+        // SAFETY:
+        // This matches the implementation of `slice::into_vec`.
+        // All elements in the original slice are unique.
+        unsafe {
+            let len = self.len();
+            let vec = Vec::from_raw_parts(Box::into_raw(self).cast::<T>(), len, len);
+            UniqueEntityVec::from_vec_unchecked(vec)
+        }
+    }
+}
+
+impl<'a, T: TrustedEntityBorrow> IntoIterator for &'a UniqueEntitySlice<T> {
+    type Item = &'a T;
+
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T: TrustedEntityBorrow> IntoIterator for &'a Box<UniqueEntitySlice<T>> {
+    type Item = &'a T;
+
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T: TrustedEntityBorrow> IntoIterator for Box<UniqueEntitySlice<T>> {
+    type Item = T;
+
+    type IntoIter = UniqueEntityIter<vec::IntoIter<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_vec().into_iter()
+    }
+}
+
+impl<T: TrustedEntityBorrow> Deref for UniqueEntitySlice<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: TrustedEntityBorrow> AsRef<[T]> for UniqueEntitySlice<T> {
+    fn as_ref(&self) -> &[T] {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow> AsRef<Self> for UniqueEntitySlice<T> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow> AsMut<Self> for UniqueEntitySlice<T> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow> Borrow<[T]> for UniqueEntitySlice<T> {
+    fn borrow(&self) -> &[T] {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> Clone for Box<UniqueEntitySlice<T>> {
+    fn clone(&self) -> Self {
+        self.to_vec().into_boxed_slice()
+    }
+}
+
+impl<T: TrustedEntityBorrow> Default for &UniqueEntitySlice<T> {
+    fn default() -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(Default::default()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Default for &mut UniqueEntitySlice<T> {
+    fn default() -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(Default::default()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Default for Box<UniqueEntitySlice<T>> {
+    fn default() -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_boxed_slice_unchecked(Default::default()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&UniqueEntitySlice<T>> for Box<UniqueEntitySlice<T>> {
+    fn from(value: &UniqueEntitySlice<T>) -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_boxed_slice_unchecked(value.0.into()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&UniqueEntitySlice<T>> for Arc<UniqueEntitySlice<T>> {
+    fn from(value: &UniqueEntitySlice<T>) -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_arc_slice_unchecked(value.0.into()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&UniqueEntitySlice<T>> for Rc<UniqueEntitySlice<T>> {
+    fn from(value: &UniqueEntitySlice<T>) -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_rc_slice_unchecked(value.0.into()) }
+    }
+}
+
+impl<'a, T: TrustedEntityBorrow + Clone> From<&'a UniqueEntitySlice<T>>
+    for Cow<'a, UniqueEntitySlice<T>>
+{
+    fn from(value: &'a UniqueEntitySlice<T>) -> Self {
+        Cow::Borrowed(value)
+    }
+}
+
+impl<'a, T: TrustedEntityBorrow + Clone> From<Cow<'a, UniqueEntitySlice<T>>>
+    for Box<UniqueEntitySlice<T>>
+{
+    fn from(value: Cow<'a, UniqueEntitySlice<T>>) -> Self {
+        match value {
+            Cow::Borrowed(slice) => Box::from(slice),
+            Cow::Owned(slice) => Box::from(slice),
+        }
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Box<UniqueEntitySlice<T>> {
+    fn from(value: UniqueEntityVec<T>) -> Self {
+        value.into_boxed_slice()
+    }
+}
+
+impl<T: TrustedEntityBorrow> FromIterator<T> for Box<UniqueEntitySlice<T>> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        iter.into_iter()
+            .collect::<UniqueEntityVec<T>>()
+            .into_boxed_slice()
+    }
+}
+
+impl<T: TrustedEntityBorrow> FromEntitySetIterator<T> for Box<UniqueEntitySlice<T>> {
+    fn from_entity_set_iter<I: EntitySet<Item = T>>(iter: I) -> Self {
+        iter.into_iter()
+            .collect_set::<UniqueEntityVec<T>>()
+            .into_boxed_slice()
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntityVec<U>>
+    for &UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &UniqueEntityVec<U>) -> bool {
+        self.0.eq(other.as_vec())
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntityVec<U>>
+    for &mut UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &UniqueEntityVec<U>) -> bool {
+        self.0.eq(other.as_vec())
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntityVec<U>>
+    for UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &UniqueEntityVec<U>) -> bool {
+        self.0.eq(other.as_vec())
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntitySlice<U>>
+    for [T; N]
+{
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U> + Clone, U: TrustedEntityBorrow> PartialEq<&UniqueEntitySlice<U>>
+    for Cow<'_, [T]>
+{
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.eq(&&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U> + Clone, U: TrustedEntityBorrow>
+    PartialEq<&UniqueEntitySlice<U>> for Cow<'_, UniqueEntitySlice<T>>
+{
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow> PartialEq<&UniqueEntitySlice<U>> for Vec<T> {
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow> PartialEq<&UniqueEntitySlice<U>> for VecDeque<T> {
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.eq(&&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&mut UniqueEntitySlice<U>>
+    for [T; N]
+{
+    fn eq(&self, other: &&mut UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U> + Clone, U: TrustedEntityBorrow> PartialEq<&mut UniqueEntitySlice<U>>
+    for Cow<'_, [T]>
+{
+    fn eq(&self, other: &&mut UniqueEntitySlice<U>) -> bool {
+        self.eq(&&**other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U> + Clone, U: TrustedEntityBorrow>
+    PartialEq<&mut UniqueEntitySlice<U>> for Cow<'_, UniqueEntitySlice<T>>
+{
+    fn eq(&self, other: &&mut UniqueEntitySlice<U>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U> + Clone, U: TrustedEntityBorrow>
+    PartialEq<UniqueEntityVec<U>> for Cow<'_, UniqueEntitySlice<T>>
+{
+    fn eq(&self, other: &UniqueEntityVec<U>) -> bool {
+        self.0.eq(other.as_vec())
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow> PartialEq<&mut UniqueEntitySlice<U>> for Vec<T> {
+    fn eq(&self, other: &&mut UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow> PartialEq<&mut UniqueEntitySlice<U>> for VecDeque<T> {
+    fn eq(&self, other: &&mut UniqueEntitySlice<U>) -> bool {
+        self.eq(&&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntitySlice<U>>
+    for [T]
+{
+    fn eq(&self, other: &UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntitySlice<U>>
+    for [T; N]
+{
+    fn eq(&self, other: &UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntitySlice<U>>
+    for Vec<T>
+{
+    fn eq(&self, other: &UniqueEntitySlice<U>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<[U; N]>
+    for &UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &[U; N]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<[U; N]>
+    for &mut UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &[U; N]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<[U; N]>
+    for UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &[U; N]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<Vec<U>> for &UniqueEntitySlice<T> {
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<Vec<U>> for &mut UniqueEntitySlice<T> {
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<Vec<U>> for UniqueEntitySlice<T> {
+    fn eq(&self, other: &Vec<U>) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> ToOwned for UniqueEntitySlice<T> {
+    type Owned = UniqueEntityVec<T>;
+
+    fn to_owned(&self) -> Self::Owned {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntityVec::from_vec_unchecked(self.0.to_owned()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<(Bound<usize>, Bound<usize>)> for UniqueEntitySlice<T> {
+    type Output = Self;
+    fn index(&self, key: (Bound<usize>, Bound<usize>)) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<Range<usize>> for UniqueEntitySlice<T> {
+    type Output = Self;
+    fn index(&self, key: Range<usize>) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeFrom<usize>> for UniqueEntitySlice<T> {
+    type Output = Self;
+    fn index(&self, key: RangeFrom<usize>) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeFull> for UniqueEntitySlice<T> {
+    type Output = Self;
+    fn index(&self, key: RangeFull) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeInclusive<usize>> for UniqueEntitySlice<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeInclusive<usize>) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeTo<usize>> for UniqueEntitySlice<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeTo<usize>) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeToInclusive<usize>> for UniqueEntitySlice<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeToInclusive<usize>) -> &Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<usize> for UniqueEntitySlice<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &T {
+        &self.0[index]
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<(Bound<usize>, Bound<usize>)> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: (Bound<usize>, Bound<usize>)) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<Range<usize>> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: Range<usize>) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeFrom<usize>> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: RangeFrom<usize>) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeFull> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: RangeFull) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeInclusive<usize>> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: RangeInclusive<usize>) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeTo<usize>> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: RangeTo<usize>) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeToInclusive<usize>> for UniqueEntitySlice<T> {
+    fn index_mut(&mut self, key: RangeToInclusive<usize>) -> &mut Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { Self::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+/// Immutable slice iterator.
+///
+/// This struct is created by [`iter`] method on [`UniqueEntitySlice`] and
+/// the [`IntoIterator`] impls on it and [`UniqueEntityVec`].
+///
+/// [`iter`]: `UniqueEntitySlice::iter`
+/// [`into_iter`]: UniqueEntitySlice::into_iter
+pub type Iter<'a, T> = UniqueEntityIter<slice::Iter<'a, T>>;
+
+impl<'a, T: TrustedEntityBorrow> UniqueEntityIter<slice::Iter<'a, T>> {
+    /// Views the underlying data as a subslice of the original data.
+    ///
+    /// Equivalent to [`slice::Iter::as_slice`].
+    pub fn as_slice(&self) -> &'a UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.as_inner().as_slice()) }
+    }
+}
+
+/// Mutable slice iterator.
+pub type IterMut<'a, T> = UniqueEntityIter<slice::IterMut<'a, T>>;
+
+impl<'a, T: TrustedEntityBorrow> UniqueEntityIter<slice::IterMut<'a, T>> {
+    /// Views the underlying data as a mutable subslice of the original data.
+    ///
+    /// Equivalent to [`slice::IterMut::into_slice`].
+    pub fn into_slice(self) -> &'a mut UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.into_inner().into_slice()) }
+    }
+
+    /// Views the underlying data as a subslice of the original data.
+    ///
+    /// Equivalent to [`slice::IterMut::as_slice`].
+    pub fn as_slice(&self) -> &UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.as_inner().as_slice()) }
+    }
+}

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -108,7 +108,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Returns the first and all the rest of the elements of the slice, or `None` if it is empty.
     ///
     /// Equivalent to [`[T]::split_first`](slice::split_first).
-    pub const fn split_first(&self) -> Option<(&T, &UniqueEntitySlice<T>)> {
+    pub const fn split_first(&self) -> Option<(&T, &Self)> {
         let Some((first, rest)) = self.0.split_first() else {
             return None;
         };
@@ -119,7 +119,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Returns the last and all the rest of the elements of the slice, or `None` if it is empty.
     ///
     /// Equivalent to [`[T]::split_last`](slice::split_last).
-    pub const fn split_last(&self) -> Option<(&T, &UniqueEntitySlice<T>)> {
+    pub const fn split_last(&self) -> Option<(&T, &Self)> {
         let Some((last, rest)) = self.0.split_last() else {
             return None;
         };
@@ -150,7 +150,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     ///
     /// Note that `UniqueEntitySlice::get_mut` cannot be called with a [`usize`].
     ///
-    /// [`[T]::get`]: `slice::get_mut`s
+    /// [`[T]::get_mut`]: `slice::get_mut`s
     pub fn get_mut<I>(&mut self, index: I) -> Option<&mut Self>
     where
         Self: Index<I>,
@@ -165,8 +165,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     ///
     /// Equivalent to the range functionality of [`[T]::get_unchecked`].
     ///
-    /// Note that calling `UniqueEntitySlice::get_unchecked` with an index will deref
-    /// to [`[T]::get_unchecked`].
+    /// Note that only the inner [`[T]::get_unchecked`] supports indexing with a [`usize`].
     ///
     /// # Safety
     ///
@@ -230,7 +229,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Divides one slice into two at an index.
     ///
     /// Equivalent to [`[T]::split_at`](slice::split_at)
-    pub const fn split_at(&self, mid: usize) -> (&UniqueEntitySlice<T>, &UniqueEntitySlice<T>) {
+    pub const fn split_at(&self, mid: usize) -> (&Self, &Self) {
         let (left, right) = self.0.split_at(mid);
         // SAFETY: All elements in the original slice are unique.
         unsafe {
@@ -244,10 +243,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Divides one mutable slice into two at an index.
     ///
     /// Equivalent to [`[T]::split_at_mut`](slice::split_at_mut)
-    pub const fn split_at_mut(
-        &mut self,
-        mid: usize,
-    ) -> (&mut UniqueEntitySlice<T>, &mut UniqueEntitySlice<T>) {
+    pub const fn split_at_mut(&mut self, mid: usize) -> (&mut Self, &mut Self) {
         let (left, right) = self.0.split_at_mut(mid);
         // SAFETY: All elements in the original slice are unique.
         unsafe {
@@ -267,10 +263,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// `mid` must be safe to use in [`[T]::split_at_unchecked`].
     ///
     /// [`[T]::split_at_unchecked`]: `slice::split_at_unchecked`
-    pub const unsafe fn split_at_unchecked(
-        &self,
-        mid: usize,
-    ) -> (&UniqueEntitySlice<T>, &UniqueEntitySlice<T>) {
+    pub const unsafe fn split_at_unchecked(&self, mid: usize) -> (&Self, &Self) {
         // SAFETY: The safety contract is upheld by the caller.
         let (left, right) = unsafe { self.0.split_at_unchecked(mid) };
         // SAFETY: All elements in the original slice are unique.
@@ -291,10 +284,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// `mid` must be safe to use in [`[T]::split_at_mut_unchecked`].
     ///
     /// [`[T]::split_at_mut_unchecked`]: `slice::split_at_mut_unchecked`
-    pub const unsafe fn split_at_mut_unchecked(
-        &mut self,
-        mid: usize,
-    ) -> (&mut UniqueEntitySlice<T>, &mut UniqueEntitySlice<T>) {
+    pub const unsafe fn split_at_mut_unchecked(&mut self, mid: usize) -> (&mut Self, &mut Self) {
         // SAFETY: The safety contract is upheld by the caller.
         let (left, right) = unsafe { self.0.split_at_mut_unchecked(mid) };
         // SAFETY: All elements in the original slice are unique.
@@ -310,10 +300,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// too short.
     ///
     /// Equivalent to [`[T]::split_at_checked`](slice::split_at_checked).
-    pub const fn split_at_checked(
-        &self,
-        mid: usize,
-    ) -> Option<(&UniqueEntitySlice<T>, &UniqueEntitySlice<T>)> {
+    pub const fn split_at_checked(&self, mid: usize) -> Option<(&Self, &Self)> {
         let Some((left, right)) = self.0.split_at_checked(mid) else {
             return None;
         };
@@ -330,10 +317,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// slice is too short.
     ///
     /// Equivalent to [`[T]::split_at_mut_checked`](slice::split_at_mut_checked).
-    pub const fn split_at_mut_checked(
-        &mut self,
-        mid: usize,
-    ) -> Option<(&mut UniqueEntitySlice<T>, &mut UniqueEntitySlice<T>)> {
+    pub const fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut Self, &mut Self)> {
         let Some((left, right)) = self.0.split_at_mut_checked(mid) else {
             return None;
         };
@@ -400,7 +384,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Copies all elements from `src` into `self`, using a memcpy.
     ///
     /// Equivalent to [`[T]::copy_from_slice`](slice::copy_from_slice).
-    pub fn copy_from_slice(&mut self, src: &UniqueEntitySlice<T>)
+    pub fn copy_from_slice(&mut self, src: &Self)
     where
         T: Copy,
     {
@@ -461,7 +445,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Converts `self` into a vector without clones or allocation.
     ///
     /// Equivalent to [`[T]::into_vec`](slice::into_vec).
-    pub fn into_vec(self: Box<UniqueEntitySlice<T>>) -> UniqueEntityVec<T> {
+    pub fn into_vec(self: Box<Self>) -> UniqueEntityVec<T> {
         // SAFETY:
         // This matches the implementation of `slice::into_vec`.
         // All elements in the original slice are unique.

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -131,7 +131,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     ///
     /// Equivalent to the range functionality of [`[T]::get`].
     ///
-    /// Note that calling `UniqueEntitySlice::get` with an index will deref to [`[T]::get`].
+    /// Note that only the inner [`[T]::get`] supports indexing with a [`usize`].
     ///
     /// [`[T]::get`]: `slice::get`
     pub fn get<I>(&self, index: I) -> Option<&Self>
@@ -148,7 +148,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     ///
     /// Equivalent to the range functionality of [`[T]::get_mut`].
     ///
-    /// Note that `UniqueEntitySlice::get_mut` cannot be called with an index.
+    /// Note that `UniqueEntitySlice::get_mut` cannot be called with a [`usize`].
     ///
     /// [`[T]::get`]: `slice::get_mut`s
     pub fn get_mut<I>(&mut self, index: I) -> Option<&mut Self>

--- a/crates/bevy_ecs/src/entity/unique_vec.rs
+++ b/crates/bevy_ecs/src/entity/unique_vec.rs
@@ -1,12 +1,14 @@
 use core::{
-    borrow::Borrow,
+    borrow::{Borrow, BorrowMut},
     mem::MaybeUninit,
-    ops::{Index, RangeBounds},
-    slice,
+    ops::{
+        Bound, Deref, DerefMut, Index, IndexMut, Range, RangeBounds, RangeFrom, RangeFull,
+        RangeInclusive, RangeTo, RangeToInclusive,
+    },
 };
 
 use alloc::{
-    borrow::Cow,
+    borrow::{Cow, ToOwned},
     boxed::Box,
     collections::{BTreeSet, BinaryHeap, TryReserveError, VecDeque},
     rc::Rc,
@@ -14,7 +16,10 @@ use alloc::{
     vec::{self, Vec},
 };
 
-use super::{EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter};
+use super::{
+    unique_slice, EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
+    UniqueEntitySlice,
+};
 
 /// A `Vec` that contains only unique entities.
 ///
@@ -138,6 +143,22 @@ impl<T: TrustedEntityBorrow> UniqueEntityVec<T> {
     /// Equivalent to [`Vec::shrink_to`].
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.0.shrink_to(min_capacity);
+    }
+
+    /// Converts the vector into `Box<UniqueEntitySlice<T>>`.
+    pub fn into_boxed_slice(self) -> Box<UniqueEntitySlice<T>> {
+        // SAFETY: UniqueEntitySlice is a transparent wrapper around [T].
+        unsafe { UniqueEntitySlice::from_boxed_slice_unchecked(self.0.into_boxed_slice()) }
+    }
+
+    /// Extracts a slice containing the entire vector.
+    pub fn as_slice(&self) -> &UniqueEntitySlice<T> {
+        self
+    }
+
+    /// Extracts a mutable slice of the entire vector.
+    pub fn as_mut_slice(&mut self) -> &mut UniqueEntitySlice<T> {
+        self
     }
 
     /// Shortens the vector, keeping the first `len` elements and dropping
@@ -343,6 +364,12 @@ impl<T: TrustedEntityBorrow> UniqueEntityVec<T> {
         self.0.resize_with(new_len, f);
     }
 
+    /// Consumes and leaks the Vec, returning a mutable reference to the contents, `&'a mut UniqueEntitySlice<T>`.
+    pub fn leak<'a>(self) -> &'a mut UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.leak()) }
+    }
+
     /// Returns the remaining spare capacity of the vector as a slice of
     /// [`MaybeUninit<T>`].
     ///
@@ -370,7 +397,7 @@ impl<T: TrustedEntityBorrow> UniqueEntityVec<T> {
         I: EntitySet<Item = T>,
     {
         // SAFETY: `self` and thus `range` contains only unique elements.
-        UniqueEntityIter::from_iterator_unchecked(self.0.splice(range, replace_with))
+        unsafe { UniqueEntityIter::from_iterator_unchecked(self.0.splice(range, replace_with)) }
     }
 }
 
@@ -380,13 +407,29 @@ impl<T: TrustedEntityBorrow> Default for UniqueEntityVec<T> {
     }
 }
 
+impl<T: TrustedEntityBorrow> Deref for UniqueEntityVec<T> {
+    type Target = UniqueEntitySlice<T>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(&self.0) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> DerefMut for UniqueEntityVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(&mut self.0) }
+    }
+}
+
 impl<'a, T: TrustedEntityBorrow> IntoIterator for &'a UniqueEntityVec<T>
 where
     &'a T: TrustedEntityBorrow,
 {
     type Item = &'a T;
 
-    type IntoIter = UniqueEntityIter<slice::Iter<'a, T>>;
+    type IntoIter = unique_slice::Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         // SAFETY: `self` contains only unique elements.
@@ -407,6 +450,12 @@ impl<T: TrustedEntityBorrow> IntoIterator for UniqueEntityVec<T> {
 
 impl<T: TrustedEntityBorrow> AsMut<Self> for UniqueEntityVec<T> {
     fn as_mut(&mut self) -> &mut UniqueEntityVec<T> {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow> AsMut<UniqueEntitySlice<T>> for UniqueEntityVec<T> {
+    fn as_mut(&mut self) -> &mut UniqueEntitySlice<T> {
         self
     }
 }
@@ -435,9 +484,27 @@ impl<T: TrustedEntityBorrow> AsRef<[T]> for UniqueEntityVec<T> {
     }
 }
 
+impl<T: TrustedEntityBorrow> AsRef<UniqueEntitySlice<T>> for UniqueEntityVec<T> {
+    fn as_ref(&self) -> &UniqueEntitySlice<T> {
+        self
+    }
+}
+
 impl<T: TrustedEntityBorrow> Borrow<[T]> for UniqueEntityVec<T> {
     fn borrow(&self) -> &[T] {
         &self.0
+    }
+}
+
+impl<T: TrustedEntityBorrow> Borrow<UniqueEntitySlice<T>> for UniqueEntityVec<T> {
+    fn borrow(&self) -> &UniqueEntitySlice<T> {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow> BorrowMut<UniqueEntitySlice<T>> for UniqueEntityVec<T> {
+    fn borrow_mut(&mut self) -> &mut UniqueEntitySlice<T> {
+        self
     }
 }
 
@@ -453,8 +520,24 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<&[U]> for UniqueEntityV
     }
 }
 
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<&UniqueEntitySlice<U>>
+    for UniqueEntityVec<T>
+{
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.0.eq(other)
+    }
+}
+
 impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<&mut [U]> for UniqueEntityVec<T> {
     fn eq(&self, other: &&mut [U]) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow>
+    PartialEq<&mut UniqueEntitySlice<U>> for UniqueEntityVec<T>
+{
+    fn eq(&self, other: &&mut UniqueEntitySlice<U>) -> bool {
         self.0.eq(other)
     }
 }
@@ -478,6 +561,14 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<&mut [U
 impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<[U]> for UniqueEntityVec<T> {
     fn eq(&self, other: &[U]) -> bool {
         self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntitySlice<U>>
+    for UniqueEntityVec<T>
+{
+    fn eq(&self, other: &UniqueEntitySlice<U>) -> bool {
+        self.0.eq(&**other)
     }
 }
 
@@ -529,6 +620,33 @@ impl<T: PartialEq<U>, U: TrustedEntityBorrow> PartialEq<UniqueEntityVec<U>> for 
     }
 }
 
+impl<T: TrustedEntityBorrow + Clone> From<&UniqueEntitySlice<T>> for UniqueEntityVec<T> {
+    fn from(value: &UniqueEntitySlice<T>) -> Self {
+        value.to_vec()
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&mut UniqueEntitySlice<T>> for UniqueEntityVec<T> {
+    fn from(value: &mut UniqueEntitySlice<T>) -> Self {
+        value.to_vec()
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<Box<UniqueEntitySlice<T>>> for UniqueEntityVec<T> {
+    fn from(value: Box<UniqueEntitySlice<T>>) -> Self {
+        value.into_vec()
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<Cow<'_, UniqueEntitySlice<T>>> for UniqueEntityVec<T>
+where
+    UniqueEntitySlice<T>: ToOwned<Owned = UniqueEntityVec<T>>,
+{
+    fn from(value: Cow<UniqueEntitySlice<T>>) -> Self {
+        value.into_owned()
+    }
+}
+
 impl<T: TrustedEntityBorrow + Clone> From<&[T; 1]> for UniqueEntityVec<T> {
     fn from(value: &[T; 1]) -> Self {
         Self(Vec::from(value))
@@ -577,9 +695,24 @@ impl<'a, T: TrustedEntityBorrow + Clone> From<UniqueEntityVec<T>> for Cow<'a, [T
     }
 }
 
+impl<'a, T: TrustedEntityBorrow + Clone> From<UniqueEntityVec<T>>
+    for Cow<'a, UniqueEntitySlice<T>>
+{
+    fn from(value: UniqueEntityVec<T>) -> Self {
+        Cow::Owned(value)
+    }
+}
+
 impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Arc<[T]> {
     fn from(value: UniqueEntityVec<T>) -> Self {
         Arc::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Arc<UniqueEntitySlice<T>> {
+    fn from(value: UniqueEntityVec<T>) -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_arc_slice_unchecked(Arc::from(value.0)) }
     }
 }
 
@@ -598,6 +731,13 @@ impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Box<[T]> {
 impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Rc<[T]> {
     fn from(value: UniqueEntityVec<T>) -> Self {
         Rc::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Rc<UniqueEntitySlice<T>> {
+    fn from(value: UniqueEntityVec<T>) -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_rc_slice_unchecked(Rc::from(value.0)) }
     }
 }
 
@@ -709,10 +849,139 @@ impl<'a, T: TrustedEntityBorrow + Copy + 'a> Extend<&'a T> for UniqueEntityVec<T
     }
 }
 
+impl<T: TrustedEntityBorrow> Index<(Bound<usize>, Bound<usize>)> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: (Bound<usize>, Bound<usize>)) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<Range<usize>> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: Range<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeFrom<usize>> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeFrom<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeFull> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeFull) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeInclusive<usize>> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeInclusive<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeTo<usize>> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeTo<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> Index<RangeToInclusive<usize>> for UniqueEntityVec<T> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeToInclusive<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
 impl<T: TrustedEntityBorrow> Index<usize> for UniqueEntityVec<T> {
     type Output = T;
     fn index(&self, key: usize) -> &T {
         self.0.index(key)
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<(Bound<usize>, Bound<usize>)> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: (Bound<usize>, Bound<usize>)) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<Range<usize>> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: Range<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeFrom<usize>> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: RangeFrom<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeFull> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: RangeFull) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeInclusive<usize>> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: RangeInclusive<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeTo<usize>> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: RangeTo<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow> IndexMut<RangeToInclusive<usize>> for UniqueEntityVec<T> {
+    fn index_mut(&mut self, key: RangeToInclusive<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+/// An iterator that moves out of a vector.
+///
+/// This `struct` is created by the [`IntoIterator::into_iter`] trait
+/// method on [`UniqueEntityVec`].
+pub type IntoIter<T> = UniqueEntityIter<vec::IntoIter<T>>;
+
+impl<T: TrustedEntityBorrow> UniqueEntityIter<vec::IntoIter<T>> {
+    /// Returns the remaining items of this iterator as a slice.
+    ///
+    /// Equivalent to [`vec::IntoIter::as_slice`].
+    pub fn as_slice(&self) -> &UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.as_inner().as_slice()) }
+    }
+
+    /// Returns the remaining items of this iterator as a mutable slice.
+    ///
+    /// Equivalent to [`vec::IntoIter::as_mut_slice`].
+    pub fn as_mut_slice(&mut self) -> &mut UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.as_mut_inner().as_mut_slice()) }
     }
 }
 
@@ -722,14 +991,18 @@ impl<T: TrustedEntityBorrow> Index<usize> for UniqueEntityVec<T> {
 /// See its documentation for more.
 pub type Drain<'a, T> = UniqueEntityIter<vec::Drain<'a, T>>;
 
+impl<'a, T: TrustedEntityBorrow> UniqueEntityIter<vec::Drain<'a, T>> {
+    /// Returns the remaining items of this iterator as a slice.
+    ///
+    /// Equivalent to [`vec::Drain::as_slice`].
+    pub fn as_slice(&self) -> &UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.as_inner().as_slice()) }
+    }
+}
+
 /// A splicing iterator for [`UniqueEntityVec`].
 ///
 /// This struct is created by [`UniqueEntityVec::splice`].
 /// See its documentation for more.
 pub type Splice<'a, I> = UniqueEntityIter<vec::Splice<'a, I>>;
-
-/// An iterator that moves out of a vector.
-///
-/// This `struct` is created by the [`IntoIterator::into_iter`] trait
-/// method on [`UniqueEntityVec`].
-pub type IntoIter<T> = UniqueEntityIter<vec::IntoIter<T>>;


### PR DESCRIPTION
# Objective

Follow-up to #17549 and #16547.

A large part of `Vec`s usefulness is behind its ability to be sliced, like sorting f.e., so we want the same to be possible for `UniqueEntityVec`.

## Solution

Add a `UniqueEntitySlice` type. It is a wrapper around `[T]`, and itself a DST.

Because `mem::swap` has a `Sized` bound, DSTs cannot be swapped, and we can freely hand out mutable subslices without worrying about the uniqueness invariant of the backing collection!
`UniqueEntityVec` and the relevant `UniqueEntityIter`s now have methods and trait impls that return `UniqueEntitySlice`s.
`UniqueEntitySlice` itself can deref into normal slices, which means we can avoid implementing the vast majority of immutable slice methods. 

Most of the remaining methods:
- split a slice/collection in further unique subsections/slices
- reorder the slice: `sort`, `rotate_*`, `swap`
- construct/deconstruct/convert pointer-like types: `Box`, `Arc`, `Rc`, `Cow`
- are comparison trait impls

As this PR is already larger than I'd like, we leave several things to follow-ups:
- `UniqueEntityArray` and the related slice methods that would return it 
    - denoted by "chunk", "array_*" for iterators
- Methods that return iterators with `UniqueEntitySlice` as their item 
    - `windows`, `chunks` and `split` families
- All methods that are capable of actively mutating individual elements. While they could be offered unsafely, subslicing makes their safety contract weird enough to warrant its own discussion. 
    - `fill_with`, `swap_with_slice`, `iter_mut`, `split_first/last_mut`, `select_nth_unstable_*`

Note that `Arc`, `Rc` and `Cow` are not fundamental types, so even if they contain `UniqueEntitySlice`, we cannot write direct trait impls for them. 
On top of that, `Cow` is not a receiver (like `self:  Arc<Self>` is) so we cannot write inherent methods for it either.




