### PR TITLE
Revert "Fix rounding bug in camera projection (#16828)"

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -637,8 +637,8 @@ impl CameraProjection for OrthographicProjection {
             ScalingMode::Fixed { width, height } => (width, height),
         };
 
-        let origin_x = (projection_width * self.viewport_origin.x).round();
-        let origin_y = (projection_height * self.viewport_origin.y).round();
+        let origin_x = projection_width * self.viewport_origin.x;
+        let origin_y = projection_height * self.viewport_origin.y;
 
         self.area = Rect::new(
             self.scale * -origin_x,


### PR DESCRIPTION
This reverts commit ae522225cdb6af6159eeec6490c5d27e0e6cf504.

# Objective

Fixes #16856

## Solution

Remove rounding from `OrthographicProjection::update`, which was causing the center of the orthographic projection to be off center.

## Testing

Ran the examples mentioned on #16856 and code from #16773

## Showcase
`orthographic` example
![image](https://github.com/user-attachments/assets/d3bb1480-5908-4427-b1f2-af8a5c411745)

`projection_zoom` example
![image](https://github.com/user-attachments/assets/e560c81b-db8f-44f0-91f4-d6bae3ae7f32)

`camera_sub_view` example
![image](https://github.com/user-attachments/assets/615e9eb8-f4e5-406a-b98a-501f7d652145)

`custom_primitives` example
![image](https://github.com/user-attachments/assets/8fd7702e-07e7-47e3-9510-e247d268a3e7)

#16773 code
![image](https://github.com/user-attachments/assets/1b759e90-6c53-4279-987e-284518db034b)
