### PR TITLE
Fixing `ValArithmeticError` typo and unused variant

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -250,15 +250,13 @@ impl Neg for Val {
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Error)]
 pub enum ValArithmeticError {
-    #[error("the variants of the Vals don't match")]
-    NonIdenticalVariants,
-    #[error("the given variant of Val is not evaluateable (non-numeric)")]
-    NonEvaluateable,
+    #[error("the given variant of Val is not evaluable (non-numeric)")]
+    NonEvaluable,
 }
 
 impl Val {
     /// Resolves a [`Val`] to its value in logical pixels and returns this as an [`f32`].
-    /// Returns a [`ValArithmeticError::NonEvaluateable`] if the [`Val`] is impossible to resolve into a concrete value.
+    /// Returns a [`ValArithmeticError::NonEvaluable`] if the [`Val`] is impossible to resolve into a concrete value.
     ///
     /// **Note:** If a [`Val::Px`] is resolved, its inner value is returned unchanged.
     pub fn resolve(self, parent_size: f32, viewport_size: Vec2) -> Result<f32, ValArithmeticError> {
@@ -269,7 +267,7 @@ impl Val {
             Val::Vh(value) => Ok(viewport_size.y * value / 100.0),
             Val::VMin(value) => Ok(viewport_size.min_element() * value / 100.0),
             Val::VMax(value) => Ok(viewport_size.max_element() * value / 100.0),
-            Val::Auto => Err(ValArithmeticError::NonEvaluateable),
+            Val::Auto => Err(ValArithmeticError::NonEvaluable),
         }
     }
 }
@@ -743,23 +741,19 @@ mod tests {
     }
 
     #[test]
-    fn val_auto_is_non_resolveable() {
+    fn val_auto_is_non_evaluable() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
         let resolve_auto = Val::Auto.resolve(size, viewport_size);
 
-        assert_eq!(resolve_auto, Err(ValArithmeticError::NonEvaluateable));
+        assert_eq!(resolve_auto, Err(ValArithmeticError::NonEvaluable));
     }
 
     #[test]
     fn val_arithmetic_error_messages() {
         assert_eq!(
-            format!("{}", ValArithmeticError::NonIdenticalVariants),
-            "the variants of the Vals don't match"
-        );
-        assert_eq!(
-            format!("{}", ValArithmeticError::NonEvaluateable),
-            "the given variant of Val is not evaluateable (non-numeric)"
+            format!("{}", ValArithmeticError::NonEvaluable),
+            "the given variant of Val is not evaluable (non-numeric)"
         );
     }
 


### PR DESCRIPTION
# Objective

- `ValArithmeticError` contains a typo, and one of it's variants is not used

## Solution

- Rename `NonEvaluateable::NonEvaluateable ` variant to `NonEvaluateable::NonEvaluable`.
- Remove variant `ValArithmeticError:: NonIdenticalVariants`.

## Testing

- `cargo run -p ci`

---

## Migration Guide


- `ValArithmeticError::NonEvaluateable` has been renamed to `NonEvaluateable::NonEvaluable`
- `ValArithmeticError::NonIdenticalVariants ` has been removed

