### PR TITLE
Fixes #16480: Prevent exponential denormalization on `Transform::rotate_axis`

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -315,6 +315,8 @@ impl Transform {
     #[inline]
     pub fn rotate_axis(&mut self, axis: Dir3, angle: f32) {
         self.rotate(Quat::from_axis_angle(axis.into(), angle));
+        // Normalize rotation due to potential for exponential denormalization (#16480)
+        self.rotation = self.rotation.normalize();
     }
 
     /// Rotates this [`Transform`] around the `X` axis by `angle` (in radians).
@@ -353,6 +355,8 @@ impl Transform {
     #[inline]
     pub fn rotate_local_axis(&mut self, axis: Dir3, angle: f32) {
         self.rotate_local(Quat::from_axis_angle(axis.into(), angle));
+        // Normalize rotation due to potential for exponential denormalization (#16480)
+        self.rotation = self.rotation.normalize();
     }
 
     /// Rotates this [`Transform`] around its local `X` axis by `angle` (in radians).


### PR DESCRIPTION
# Objective

Fixes #16480

When repeatedly using `Transform::roatate_axis` and feeding a `axis` that is based on the current `Transform::rotation`, the floating point errors could accumulate exponentially, resulting in denormalized rotation, which panics.

## Solution

Normalize the quaternion in `Transform::rotate_axis`.

## Testing

I confirmed that this fixes the issue reported in #16480.
