### PR TITLE
chore: impl `PartialEq` for `bevy_ui::Text` and `bevy_text::TextColor`

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -368,8 +368,8 @@ impl Default for LineHeight {
 }
 
 /// The color of the text for this section.
-#[derive(Component, Copy, Clone, Debug, Deref, DerefMut, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[derive(Component, Copy, Clone, Debug, Deref, DerefMut, Reflect, PartialEq)]
+#[reflect(Component, Default, Debug, PartialEq)]
 pub struct TextColor(pub Color);
 
 impl Default for TextColor {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -89,8 +89,8 @@ impl Default for TextNodeFlags {
 ///     TextLayout::new_with_justify(JustifyText::Center)
 /// ));
 /// ```
-#[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect)]
-#[reflect(Component, Default, Debug)]
+#[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect, PartialEq)]
+#[reflect(Component, Default, Debug, PartialEq)]
 #[require(Node, TextLayout, TextFont, TextColor, TextNodeFlags, ContentSize)]
 pub struct Text(pub String);
 


### PR DESCRIPTION
Adding these allows using `DetectChangesMut::set_if_neq` to only update the values when needed. Currently you need to get the inner values first (`String` and `Color`), to do any equality checks.