### PR TITLE
Query by Indexed Component Value using Fragmenting Marker Components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2044,6 +2044,7 @@ wasm = false
 name = "index"
 path = "examples/ecs/index.rs"
 doc-scrape-examples = true
+required-features = ["bevy_dev_tools"]
 
 [package.metadata.example.index]
 name = "Indexes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2050,7 +2050,7 @@ required-features = ["bevy_dev_tools"]
 name = "Indexes"
 description = "Demonstrates querying by component value using indexing"
 category = "ECS (Entity Component System)"
-wasm = false
+wasm = true
 
 [[example]]
 name = "iter_combinations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2041,6 +2041,17 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "index"
+path = "examples/ecs/index.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.index]
+name = "Indexes"
+description = "Demonstrates the creation and utility of indexes"
+category = "ECS (Entity Component System)"
+wasm = false
+
+[[example]]
 name = "iter_combinations"
 path = "examples/ecs/iter_combinations.rs"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2047,7 +2047,7 @@ doc-scrape-examples = true
 
 [package.metadata.example.index]
 name = "Indexes"
-description = "Demonstrates the creation and utility of indexes"
+description = "Demonstrates querying by component value using indexing"
 category = "ECS (Entity Component System)"
 wasm = false
 

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -1,0 +1,38 @@
+use bevy_ecs::{prelude::*, system::SystemId};
+use criterion::black_box;
+use glam::*;
+
+const PLANETS: u8 = 16;
+const SPAWNS: usize = 10_000;
+
+#[derive(Component, Copy, Clone, PartialEq, Eq, Hash)]
+#[component(immutable)]
+struct Planet(u8);
+
+fn find_planet_zeroes_indexed(mut query: QueryByIndex<Planet, &Planet>) {
+    let query = query.at(&Planet(0));
+    for planet in query.iter() {
+        let _ = black_box(planet);
+    }
+}
+
+pub struct Benchmark(World, SystemId);
+
+impl Benchmark {
+    pub fn new() -> Self {
+        let mut world = World::new();
+
+        world.add_index::<Planet>();
+
+        world.spawn_batch((0..PLANETS).map(Planet).cycle().take(SPAWNS));
+
+        let id = world.register_system(find_planet_zeroes_indexed);
+
+        Self(world, id)
+    }
+
+    #[inline(never)]
+    pub fn run(&mut self) {
+        let _ = self.0.run_system(self.1);
+    }
+}

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -9,7 +9,7 @@ const SPAWNS: usize = 1_000_000;
 #[component(immutable)]
 struct Planet(u16);
 
-fn find_planet_zeroes_indexed(mut query: QueryByIndex<Planet, &Planet>) {
+fn find_planet_zeroes_indexed(query: QueryByIndex<Planet, &Planet>) {
     let mut query = query.at(&Planet(0));
     for planet in query.query().iter() {
         let _ = black_box(planet);

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -10,8 +10,8 @@ const SPAWNS: usize = 1_000_000;
 struct Planet(u16);
 
 fn find_planet_zeroes_indexed(mut query: QueryByIndex<Planet, &Planet>) {
-    let query = query.at_mut(&Planet(0));
-    for planet in query.iter() {
+    let mut query = query.at(&Planet(0));
+    for planet in query.query().iter() {
         let _ = black_box(planet);
     }
 }

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::{prelude::*, system::SystemId};
-use criterion::black_box;
+use core::hint::black_box;
 use glam::*;
 
 const PLANETS: u8 = 16;

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -22,7 +22,7 @@ impl Benchmark {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        world.add_index::<Planet>();
+        world.add_index(IndexOptions::<Planet>::default());
 
         world.spawn_batch((0..PLANETS).map(Planet).cycle().take(SPAWNS));
 

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -2,12 +2,12 @@ use bevy_ecs::{prelude::*, system::SystemId};
 use core::hint::black_box;
 use glam::*;
 
-const PLANETS: u8 = 16;
-const SPAWNS: usize = 10_000;
+const PLANETS: u16 = 1_000;
+const SPAWNS: usize = 1_000_000;
 
 #[derive(Component, Copy, Clone, PartialEq, Eq, Hash)]
 #[component(immutable)]
-struct Planet(u8);
+struct Planet(u16);
 
 fn find_planet_zeroes_indexed(mut query: QueryByIndex<Planet, &Planet>) {
     let query = query.at(&Planet(0));

--- a/benches/benches/bevy_ecs/index/index_iter_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_indexed.rs
@@ -10,7 +10,7 @@ const SPAWNS: usize = 1_000_000;
 struct Planet(u16);
 
 fn find_planet_zeroes_indexed(mut query: QueryByIndex<Planet, &Planet>) {
-    let query = query.at(&Planet(0));
+    let query = query.at_mut(&Planet(0));
     for planet in query.iter() {
         let _ = black_box(planet);
     }

--- a/benches/benches/bevy_ecs/index/index_iter_naive.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_naive.rs
@@ -2,12 +2,12 @@ use bevy_ecs::{prelude::*, system::SystemId};
 use core::hint::black_box;
 use glam::*;
 
-const PLANETS: u8 = 16;
-const SPAWNS: usize = 10_000;
+const PLANETS: u16 = 1_000;
+const SPAWNS: usize = 1_000_000;
 
 #[derive(Component, Copy, Clone, PartialEq, Eq, Hash)]
 #[component(immutable)]
-struct Planet(u8);
+struct Planet(u16);
 
 fn find_planet_zeroes_naive(query: Query<&Planet>) {
     for planet in query.iter().filter(|&&planet| planet == Planet(0)) {

--- a/benches/benches/bevy_ecs/index/index_iter_naive.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_naive.rs
@@ -1,0 +1,35 @@
+use bevy_ecs::{prelude::*, system::SystemId};
+use criterion::black_box;
+use glam::*;
+
+const PLANETS: u8 = 16;
+const SPAWNS: usize = 10_000;
+
+#[derive(Component, Copy, Clone, PartialEq, Eq, Hash)]
+#[component(immutable)]
+struct Planet(u8);
+
+fn find_planet_zeroes_naive(query: Query<&Planet>) {
+    for planet in query.iter().filter(|&&planet| planet == Planet(0)) {
+        let _ = black_box(planet);
+    }
+}
+
+pub struct Benchmark(World, SystemId);
+
+impl Benchmark {
+    pub fn new() -> Self {
+        let mut world = World::new();
+
+        world.spawn_batch((0..PLANETS).map(Planet).cycle().take(SPAWNS));
+
+        let id = world.register_system(find_planet_zeroes_naive);
+
+        Self(world, id)
+    }
+
+    #[inline(never)]
+    pub fn run(&mut self) {
+        let _ = self.0.run_system(self.1);
+    }
+}

--- a/benches/benches/bevy_ecs/index/index_iter_naive.rs
+++ b/benches/benches/bevy_ecs/index/index_iter_naive.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::{prelude::*, system::SystemId};
-use criterion::black_box;
+use core::hint::black_box;
 use glam::*;
 
 const PLANETS: u8 = 16;

--- a/benches/benches/bevy_ecs/index/index_update_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_update_indexed.rs
@@ -9,7 +9,7 @@ const SPAWNS: usize = 10_000;
 struct Planet(u8);
 
 fn increment_planet_zeroes_indexed(
-    mut query: QueryByIndex<Planet, (Entity, &Planet)>,
+    query: QueryByIndex<Planet, (Entity, &Planet)>,
     mut local: Local<u8>,
     mut commands: Commands,
 ) {

--- a/benches/benches/bevy_ecs/index/index_update_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_update_indexed.rs
@@ -1,0 +1,47 @@
+use bevy_ecs::{prelude::*, system::SystemId};
+use glam::*;
+
+const PLANETS: u8 = 16;
+const SPAWNS: usize = 10_000;
+
+#[derive(Component, Copy, Clone, PartialEq, Eq, Hash)]
+#[component(immutable)]
+struct Planet(u8);
+
+fn increment_planet_zeroes_indexed(
+    mut query: QueryByIndex<Planet, (Entity, &Planet)>,
+    mut local: Local<u8>,
+    mut commands: Commands,
+) {
+    let target = Planet(*local);
+    let next_planet = Planet(target.0 + 1);
+
+    let query = query.at(&target);
+    for (entity, _planet) in query.iter() {
+        commands.entity(entity).insert(next_planet);
+    }
+
+    *local += 1;
+}
+
+pub struct Benchmark(World, SystemId);
+
+impl Benchmark {
+    pub fn new() -> Self {
+        let mut world = World::new();
+
+        world.add_index::<Planet>();
+
+        world.spawn_batch((0..PLANETS).map(Planet).cycle().take(SPAWNS));
+
+        let id = world.register_system(increment_planet_zeroes_indexed);
+
+        Self(world, id)
+    }
+
+    #[inline(never)]
+    pub fn run(&mut self) {
+        let _ = self.0.run_system(self.1);
+        self.0.flush();
+    }
+}

--- a/benches/benches/bevy_ecs/index/index_update_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_update_indexed.rs
@@ -16,8 +16,8 @@ fn increment_planet_zeroes_indexed(
     let target = Planet(*local);
     let next_planet = Planet(target.0 + 1);
 
-    let query = query.at_mut(&target);
-    for (entity, _planet) in query.iter() {
+    let mut query = query.at(&target);
+    for (entity, _planet) in query.query().iter() {
         commands.entity(entity).insert(next_planet);
     }
 

--- a/benches/benches/bevy_ecs/index/index_update_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_update_indexed.rs
@@ -30,7 +30,7 @@ impl Benchmark {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        world.add_index::<Planet>();
+        world.add_index(IndexOptions::<Planet>::default());
 
         world.spawn_batch((0..PLANETS).map(Planet).cycle().take(SPAWNS));
 

--- a/benches/benches/bevy_ecs/index/index_update_indexed.rs
+++ b/benches/benches/bevy_ecs/index/index_update_indexed.rs
@@ -16,7 +16,7 @@ fn increment_planet_zeroes_indexed(
     let target = Planet(*local);
     let next_planet = Planet(target.0 + 1);
 
-    let query = query.at(&target);
+    let query = query.at_mut(&target);
     for (entity, _planet) in query.iter() {
         commands.entity(entity).insert(next_planet);
     }

--- a/benches/benches/bevy_ecs/index/index_update_naive.rs
+++ b/benches/benches/bevy_ecs/index/index_update_naive.rs
@@ -1,0 +1,44 @@
+use bevy_ecs::{prelude::*, system::SystemId};
+use glam::*;
+
+const PLANETS: u8 = 16;
+const SPAWNS: usize = 10_000;
+
+#[derive(Component, Copy, Clone, PartialEq, Eq, Hash)]
+#[component(immutable)]
+struct Planet(u8);
+
+fn increment_planet_zeroes_naive(
+    query: Query<(Entity, &Planet)>,
+    mut local: Local<u8>,
+    mut commands: Commands,
+) {
+    let target = Planet(*local);
+    let next_planet = Planet(target.0 + 1);
+
+    for (entity, _planet) in query.iter().filter(|(_, planet)| **planet == target) {
+        commands.entity(entity).insert(next_planet);
+    }
+
+    *local += 1;
+}
+
+pub struct Benchmark(World, SystemId);
+
+impl Benchmark {
+    pub fn new() -> Self {
+        let mut world = World::new();
+
+        world.spawn_batch((0..PLANETS).map(Planet).cycle().take(SPAWNS));
+
+        let id = world.register_system(increment_planet_zeroes_naive);
+
+        Self(world, id)
+    }
+
+    #[inline(never)]
+    pub fn run(&mut self) {
+        let _ = self.0.run_system(self.1);
+        self.0.flush();
+    }
+}

--- a/benches/benches/bevy_ecs/index/mod.rs
+++ b/benches/benches/bevy_ecs/index/mod.rs
@@ -1,0 +1,38 @@
+mod index_iter_indexed;
+mod index_iter_naive;
+mod index_update_indexed;
+mod index_update_naive;
+
+use criterion::{criterion_group, Criterion};
+
+criterion_group!(benches, index_iter, index_update,);
+
+fn index_iter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("index_iter");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+    group.bench_function("naive", |b| {
+        let mut bench = index_iter_naive::Benchmark::new();
+        b.iter(move || bench.run());
+    });
+    group.bench_function("indexed", |b| {
+        let mut bench = index_iter_indexed::Benchmark::new();
+        b.iter(move || bench.run());
+    });
+    group.finish();
+}
+
+fn index_update(c: &mut Criterion) {
+    let mut group = c.benchmark_group("index_update");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+    group.bench_function("naive", |b| {
+        let mut bench = index_update_naive::Benchmark::new();
+        b.iter(move || bench.run());
+    });
+    group.bench_function("indexed", |b| {
+        let mut bench = index_update_indexed::Benchmark::new();
+        b.iter(move || bench.run());
+    });
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/main.rs
+++ b/benches/benches/bevy_ecs/main.rs
@@ -11,6 +11,7 @@ mod empty_archetypes;
 mod entity_cloning;
 mod events;
 mod fragmentation;
+mod index;
 mod iteration;
 mod observers;
 mod param;
@@ -23,6 +24,7 @@ criterion_main!(
     empty_archetypes::benches,
     entity_cloning::benches,
     events::benches,
+    index::benches,
     iteration::benches,
     fragmentation::benches,
     observers::benches,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1351,7 +1351,7 @@ impl App {
     /// app.add_index::<FavoriteColor>();
     ///
     /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
-    ///     for entity in query.at(FavoriteColor::Red).iter() {
+    ///     for entity in query.at(&FavoriteColor::Red).iter() {
     ///         println!("{entity:?} likes the color Red!");
     ///     }
     /// }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
     system::{IntoObserverSystem, SystemId, SystemInput},
 };
 use bevy_platform_support::collections::HashMap;
-use core::{fmt::Debug, hash::Hash, num::NonZero, panic::AssertUnwindSafe};
+use core::{fmt::Debug, num::NonZero, panic::AssertUnwindSafe};
 use log::debug;
 use thiserror::Error;
 
@@ -1460,7 +1460,7 @@ impl Termination for AppExit {
 
 #[cfg(test)]
 mod tests {
-    use core::{iter, marker::PhantomData};
+    use core::{iter, marker::PhantomData, hash::Hash};
     use std::sync::Mutex;
 
     use bevy_ecs::{

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1331,7 +1331,7 @@ impl App {
     /// This allows querying by component _value_ to be very performant, at the expense of a small
     /// amount of overhead when modifying the indexed component.
     ///
-    /// See [`IndexComponent`] for further details.
+    /// See [`IndexableComponent`] for further details.
     ///
     /// # Examples
     ///

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1331,55 +1331,14 @@ impl App {
     /// This allows querying by component _value_ to be very performant, at the expense of a small
     /// amount of overhead when modifying the indexed component.
     ///
-    /// See also [`add_index_with_options`](App::add_index_with_options).
+    /// The [options](IndexOptions) provided allow control over how `C` is indexed, which may
+    /// allow you to improve the ergonomics or performance of an index over recommended defaults.
     ///
     /// # Examples
     ///
     /// ```rust
     /// # use bevy_app::prelude::*;
     /// # use bevy_ecs::prelude::*;
-    /// #
-    /// # let mut app = App::new();
-    /// #[derive(Component, PartialEq, Eq, Hash, Clone)]
-    /// #[component(immutable)]
-    /// enum FavoriteColor {
-    ///     Red,
-    ///     Green,
-    ///     Blue,
-    /// }
-    ///
-    /// app.add_index::<FavoriteColor>();
-    ///
-    /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
-    ///     let mut lens = query.at(&FavoriteColor::Red);
-    ///     for entity in lens.query().iter() {
-    ///         println!("{entity:?} likes the color Red!");
-    ///     }
-    /// }
-    /// # app.add_systems(Update, find_red_fans);
-    /// ```
-    pub fn add_index<C: Component<Mutability = Immutable> + Eq + Hash + Clone>(
-        &mut self,
-    ) -> &mut Self {
-        self.world_mut().add_index::<C>();
-        self
-    }
-
-    /// Creates and maintains an index for the provided immutable [`Component`] `C` using observers.
-    ///
-    /// This allows querying by component _value_ to be very performant, at the expense of a small
-    /// amount of overhead when modifying the indexed component.
-    ///
-    /// The [options](IndexOptions) provided allow finer control over how `C` is indexed, which may
-    /// allow you to improve the ergonomics or performance of an index over recommended defaults.
-    ///
-    /// See also [`add_index`](App::add_index).
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use bevy_app::prelude::*;
-    /// # use bevy_ecs::{prelude::*, index::IndexOptions};
     /// # use bevy_utils::default;
     /// #
     /// # let mut app = App::new();
@@ -1391,7 +1350,7 @@ impl App {
     ///     Blue,
     /// }
     ///
-    /// app.add_index_with_options(IndexOptions::<FavoriteColor> {
+    /// app.add_index(IndexOptions::<FavoriteColor> {
     ///     // FavoriteColor only has 3 states, so can be totally addressed in 2 bits.
     ///     address_space: 2,
     ///     ..default()
@@ -1405,11 +1364,11 @@ impl App {
     /// }
     /// # app.add_systems(Update, find_red_fans);
     /// ```
-    pub fn add_index_with_options<C: Component<Mutability = Immutable>, S: IndexStorage<C>>(
+    pub fn add_index<C: Component<Mutability = Immutable>, S: IndexStorage<C>>(
         &mut self,
         options: IndexOptions<C, S>,
     ) -> &mut Self {
-        self.world_mut().add_index_with_options(options);
+        self.world_mut().add_index(options);
         self
     }
 }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1460,7 +1460,7 @@ impl Termination for AppExit {
 
 #[cfg(test)]
 mod tests {
-    use core::{iter, marker::PhantomData, hash::Hash};
+    use core::{hash::Hash, iter, marker::PhantomData};
     use std::sync::Mutex;
 
     use bevy_ecs::{

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -11,6 +11,7 @@ pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     component::RequiredComponentsError,
     event::{event_update_system, EventCursor},
+    index::IndexComponent,
     intern::Interned,
     prelude::*,
     schedule::{ScheduleBuildSettings, ScheduleLabel},
@@ -1322,6 +1323,42 @@ impl App {
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
         self.world_mut().add_observer(observer);
+        self
+    }
+
+    /// Creates and maintains an index for the provided immutable [`Component`] `C` using observers.
+    ///
+    /// This allows querying by component _value_ to be very performant, at the expense of a small
+    /// amount of overhead when modifying the indexed component.
+    ///
+    /// See [`IndexComponent`] for further details.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// # let mut app = App::new();
+    /// #[derive(Component, PartialEq, Eq, Hash, Clone)]
+    /// #[component(immutable)]
+    /// enum FavoriteColor {
+    ///     Red,
+    ///     Green,
+    ///     Blue,
+    /// }
+    ///
+    /// app.add_index::<FavoriteColor>();
+    ///
+    /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
+    ///     for entity in query.at(FavoriteColor::Red).iter() {
+    ///         println!("{entity:?} likes the color Red!");
+    ///     }
+    /// }
+    /// # app.add_systems(Update, find_red_fans);
+    /// ```
+    pub fn add_index<C: IndexComponent>(&mut self) -> &mut Self {
+        self.world_mut().add_index::<C>();
         self
     }
 }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -11,7 +11,7 @@ pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     component::RequiredComponentsError,
     event::{event_update_system, EventCursor},
-    index::IndexComponent,
+    index::IndexableComponent,
     intern::Interned,
     prelude::*,
     schedule::{ScheduleBuildSettings, ScheduleLabel},
@@ -1357,7 +1357,7 @@ impl App {
     /// }
     /// # app.add_systems(Update, find_red_fans);
     /// ```
-    pub fn add_index<C: IndexComponent>(&mut self) -> &mut Self {
+    pub fn add_index<C: IndexableComponent>(&mut self) -> &mut Self {
         self.world_mut().add_index::<C>();
         self
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1351,7 +1351,8 @@ impl App {
     /// app.add_index::<FavoriteColor>();
     ///
     /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
-    ///     for entity in query.at(&FavoriteColor::Red).iter() {
+    ///     let mut lens = query.at(&FavoriteColor::Red);
+    ///     for entity in lens.query().iter() {
     ///         println!("{entity:?} likes the color Red!");
     ///     }
     /// }

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -137,7 +137,6 @@ use crate::{
     component::{Component, ComponentDescriptor, ComponentId, Immutable, StorageType},
     entity::Entity,
     prelude::Trigger,
-    query::{QueryBuilder, QueryData, QueryFilter},
     system::{Commands, Query, ResMut},
     world::{FromWorld, OnInsert, OnReplace, World},
 };
@@ -310,26 +309,6 @@ impl<C: IndexableComponent> Index<C> {
             .enumerate()
             .filter_map(|(i, &id)| (index & (1 << i) > 0).then_some(id))
             .collect::<Vec<_>>()
-    }
-
-    fn filter_query_for<D: QueryData, F: QueryFilter>(
-        &self,
-        builder: &mut QueryBuilder<D, F>,
-        value: &C,
-    ) {
-        let Some(&index) = self.mapping.get(value) else {
-            // If there is no marker, create a no-op query by including With<C> and Without<C>
-            builder.without::<C>();
-            return;
-        };
-
-        for (i, &id) in self.markers.iter().enumerate() {
-            if index & (1 << i) > 0 {
-                builder.with_id(id);
-            } else {
-                builder.without_id(id);
-            }
-        }
     }
 }
 

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -92,7 +92,7 @@
 //! fn get_earthlings(mut query: QueryByIndex<Planet, Entity>) {
 //!     let earthlings = query.at(&Planet("Earth"));
 //!
-//!     for earthling in &earthlings {
+//!     for earthling in &earthlings.query() {
 //!         // ...
 //!     }
 //! }

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -34,7 +34,9 @@ impl WorldIndexExtension for World {
     }
 }
 
-/// Marker describing the requirements for a [`Component`] to be suitable for indexing.
+/// A marker trait describing the requirements for a [`Component`] to be indexed and accessed via [`QueryByIndex`].
+///
+/// See the module docs for more information.
 pub trait IndexableComponent: Component<Mutability = Immutable> + Eq + Hash + Clone {}
 
 impl<C: Component<Mutability = Immutable> + Eq + Hash + Clone> IndexableComponent for C {}

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -231,15 +231,9 @@ impl<C: IndexableComponent> Index<C> {
     ) {
         let entity = trigger.target();
 
-        let value = query
-            .get(entity)
-            .expect("observer should see a component in on_replace");
+        let value = query.get(entity).unwrap();
 
-        let component_id = index
-            .mapping
-            .get(value)
-            .copied()
-            .expect("somehow didn't track this value");
+        let component_id = index.mapping.get(value).copied().unwrap();
 
         commands.queue(move |world: &mut World| {
             world.resource_scope::<Self, _>(|world, mut index| {

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -112,13 +112,14 @@
 //!
 //! To provide the maximum iteration speed, the indexable component is fragmented, meaning each unique
 //! value is stored in its own archetype.
+//! Archetypes are reused when values are no longer in use;
+//! and so the cost paid scales with the maximum number of unique values alive _simultaneously_.
 //! This makes iterating through a subset of the total archetypes faster, but decreases the performance
 //! of iterating all archetypes by a small amount.
-//! 
-//! This also has the potential to multiply the number of unused [`Archetypes`](crate::archetype::Archetype)
-//! by the number of _simultaneously living_ unique values within an index.
-//! Since Bevy does not currently have a mechanism for cleaning up [`Archetypes`](crate::archetype::Archetype)
-//! that are no longer used, this can present itself like a memory leak.
+//!
+//! This also has the potential to multiply the number of unused [`Archetypes`](crate::archetype::Archetype).
+//! Since Bevy does not currently have a mechanism for cleaning up unused [`Archetypes`](crate::archetype::Archetype),
+//! this can present itself like a memory leak.
 //! If you find your application consuming substantially more memory when using indexing, please
 //! [open an issue on GitHub](https://github.com/bevyengine/bevy/issues/new/choose) to help us
 //! improve memory performance in real-world applications.

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -128,14 +128,12 @@
 //! This is great for usability, but means all mutations of indexed components will carry a small but
 //! existent overhead.
 
+mod query_by_index;
+
+pub use query_by_index::*;
+
 use crate::{
-    self as bevy_ecs,
-    component::{Component, ComponentDescriptor, ComponentId, Immutable, StorageType, Tick},
-    entity::Entity,
-    prelude::Trigger,
-    query::{QueryBuilder, QueryData, QueryFilter, QueryState, With},
-    system::{Commands, Query, Res, ResMut, SystemMeta, SystemParam},
-    world::{unsafe_world_cell::UnsafeWorldCell, OnInsert, OnReplace, World},
+    self as bevy_ecs, component::{Component, ComponentDescriptor, ComponentId, Immutable, StorageType}, entity::Entity, prelude::Trigger, query::{QueryBuilder, QueryData, QueryFilter}, system::{Commands, Query, ResMut, SystemParam}, world::{OnInsert, OnReplace, World}
 };
 use alloc::{format, vec::Vec};
 use bevy_ecs_macros::Resource;
@@ -179,153 +177,6 @@ impl WorldIndexExtension for World {
 pub trait IndexableComponent: Component<Mutability = Immutable> + Eq + Hash + Clone {}
 
 impl<C: Component<Mutability = Immutable> + Eq + Hash + Clone> IndexableComponent for C {}
-
-/// This system parameter allows querying by an [indexable component](`IndexableComponent`) value.
-///
-/// # Examples
-///
-/// ```rust
-/// # use bevy_ecs::prelude::*;
-/// # let mut world = World::new();
-/// #[derive(Component, PartialEq, Eq, Hash, Clone)]
-/// #[component(immutable)]
-/// struct Player(u8);
-///
-/// // Indexing is opt-in through `World::add_index`
-/// world.add_index::<Player>();
-/// # world.spawn(Player(0));
-/// # world.spawn(Player(0));
-/// # world.spawn(Player(1));
-/// # world.spawn(Player(1));
-/// # world.spawn(Player(1));
-/// # world.spawn(Player(2));
-/// # world.spawn(Player(2));
-/// # world.spawn(Player(2));
-/// # world.spawn(Player(2));
-/// # world.flush();
-///
-/// fn find_all_player_one_entities(mut query: QueryByIndex<Player, Entity>) {
-///     for entity in query.at(&Player(0)).iter() {
-///         println!("{entity:?} belongs to Player 1!");
-///     }
-/// #   assert_eq!(query.at(&Player(0)).iter().count(), 2);
-/// #   assert_eq!(query.at(&Player(1)).iter().count(), 3);
-/// #   assert_eq!(query.at(&Player(2)).iter().count(), 4);
-/// }
-/// # world.run_system_cached(find_all_player_one_entities);
-/// ```
-pub struct QueryByIndex<'world, C: IndexableComponent, D: QueryData, F: QueryFilter = ()> {
-    world: UnsafeWorldCell<'world>,
-    state: Option<QueryState<D, (F, With<C>)>>,
-    last_run: Tick,
-    this_run: Tick,
-    index: Res<'world, Index<C>>,
-}
-
-impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, C, D, F> {
-    /// Return a [`Query`] only returning entities with a component `C` of the provided value.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use bevy_ecs::prelude::*;
-    /// # let mut world = World::new();
-    /// #[derive(Component, PartialEq, Eq, Hash, Clone)]
-    /// #[component(immutable)]
-    /// enum FavoriteColor {
-    ///     Red,
-    ///     Green,
-    ///     Blue,
-    /// }
-    ///
-    /// world.add_index::<FavoriteColor>();
-    ///
-    /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
-    ///     for entity in query.at(&FavoriteColor::Red).iter() {
-    ///         println!("{entity:?} likes the color Red!");
-    ///     }
-    /// }
-    /// ```
-    pub fn at(&mut self, value: &C) -> Query<'_, '_, D, (F, With<C>)> {
-        self.state = {
-            // SAFETY: Mutable references do not alias and will be dropped after this block
-            let mut builder = unsafe { QueryBuilder::new(self.world.world_mut()) };
-
-            match self.index.mapping.get(value) {
-                // If there is a marker, restrict to it
-                Some(state) => builder.with_id(state.component_id),
-                // Otherwise, create a no-op query by including With<C> and Without<C>
-                None => builder.without::<C>(),
-            };
-
-            Some(builder.build())
-        };
-
-        // SAFETY: We have registered all of the query's world accesses,
-        // so the caller ensures that `world` has permission to access any
-        // world data that the query needs.
-        unsafe {
-            Query::new(
-                self.world,
-                self.state.as_mut().unwrap(),
-                self.last_run,
-                self.this_run,
-            )
-        }
-    }
-}
-
-// SAFETY: We rely on the known-safe implementations of `SystemParam` for `Res` and `Query`.
-unsafe impl<C: IndexableComponent, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
-    for QueryByIndex<'_, C, D, F>
-{
-    type State = (QueryState<D, (F, With<C>)>, ComponentId);
-    type Item<'w, 's> = QueryByIndex<'w, C, D, F>;
-
-    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
-        let query_state = <Query<D, (F, With<C>)> as SystemParam>::init_state(world, system_meta);
-        let res_state = <Res<Index<C>> as SystemParam>::init_state(world, system_meta);
-
-        (query_state, res_state)
-    }
-
-    #[inline]
-    unsafe fn validate_param(
-        (query_state, res_state): &Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell,
-    ) -> bool {
-        let query_valid = <Query<D, (F, With<C>)> as SystemParam>::validate_param(
-            query_state,
-            system_meta,
-            world,
-        );
-        let res_valid =
-            <Res<Index<C>> as SystemParam>::validate_param(res_state, system_meta, world);
-
-        query_valid && res_valid
-    }
-
-    unsafe fn get_param<'world, 'state>(
-        (query_state, res_state): &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Self::Item<'world, 'state> {
-        query_state.validate_world(world.id());
-
-        let index =
-            <Res<Index<C>> as SystemParam>::get_param(res_state, system_meta, world, change_tick);
-
-        QueryByIndex {
-            world,
-            state: None,
-            last_run: system_meta.last_run,
-            this_run: change_tick,
-            index,
-        }
-    }
-}
 
 /// This [`Resource`] is responsible for managing a value-to-[`ComponentId`] mapping, allowing
 /// [`QueryByIndex`] to simply filter by [`ComponentId`] on a standard [`Query`].
@@ -465,4 +316,29 @@ impl<C: IndexableComponent> Index<C> {
 
         world.register_component_with_descriptor(descriptor)
     }
+
+    fn filter_query_for<D: QueryData, F: QueryFilter>(&self, builder: &mut QueryBuilder<D, F>, value: &C) {
+        let Some(state) = self.mapping.get(value) else {
+            // If there is no marker, create a no-op query by including With<C> and Without<C>
+            builder.without::<C>();
+            return;
+        };
+
+        // If there is a marker, restrict to it
+        builder.with_id(state.component_id);
+    }
+}
+
+/// Converts a [`usize`] into a [`bool`] array.
+const fn usize_to_bool_array(value: usize) -> [bool; size_of::<usize>() * 8] {
+    const LENGTH: usize = size_of::<usize>() * 8;
+    let mut array = [false; LENGTH];
+
+    let mut index = 0;
+    while index < LENGTH {
+        array[index] = value & (1 << index) > 0;
+        index += 1;
+    }
+
+    array
 }

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -353,7 +353,9 @@ pub struct IndexOptions<
     /// Marker components will be added to indexed entities to allow for efficient lookups.
     /// This controls the [`StorageType`] that will be used with these markers.
     /// It is recommended to use [`Table`](StorageType::Table) for more efficient querying, but a
-    /// [`SpareSet`](StorageType::SparseSet) may be more appropriate in certain circumstances.
+    /// [`SpareSet`](StorageType::SparseSet) may be more appropriate where iteration performance is
+    /// of lesser importance and the number of simultaneous unique values of `C` is large.
+    /// Ensure you benchmark both options appropriately if you are experiencing performance issues.
     ///
     /// This defaults to [`Table`](StorageType::Table).
     pub marker_storage: StorageType,

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -198,9 +198,7 @@ impl<C: Component<Mutability = Immutable>> Index<C> {
 
         let markers = (0..bits)
             .map(|bit| Self::alloc_new_marker(world, bit, options.marker_storage))
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
-            .into();
+            .collect();
 
         Self {
             mapping: Box::new(options.index_storage),

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -403,7 +403,7 @@ impl<C: Component<Mutability = Immutable> + Eq + Hash + Clone> Default
     fn default() -> Self {
         Self {
             marker_storage: StorageType::SparseSet,
-            address_space: size_of::<C>() as u8,
+            address_space: size_of::<C>().saturating_mul(8) as u8,
             index_storage: HashMap::with_hasher(FixedHasher),
             _phantom: PhantomData,
         }

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -156,7 +156,7 @@ impl WorldIndexExtension for World {
             let mut index = Index::<C>::default();
 
             self.query::<(Entity, &C)>()
-                .iter(&self)
+                .iter(self)
                 .map(|(entity, _)| entity)
                 .collect::<Vec<_>>()
                 .into_iter()

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -180,7 +180,6 @@ impl<C: IndexableComponent> FromWorld for Index<C> {
 
         let markers = (0..bits)
             .map(|bit| Self::alloc_new_marker(world, bit, StorageType::Table))
-            .take(bits)
             .collect::<Vec<_>>();
 
         Self {

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -1,0 +1,177 @@
+//! Provides indexing support for the ECS.
+
+use crate::{
+    self as bevy_ecs,
+    component::{Component, ComponentDescriptor, ComponentId, Immutable, StorageType},
+    prelude::Trigger,
+    query::{QueryBuilder, QueryData, QueryFilter, QueryState, With},
+    system::{Commands, Query, Res},
+    world::{OnInsert, OnReplace, World},
+};
+use alloc::{format, vec::Vec};
+use bevy_ecs_macros::Resource;
+use bevy_platform_support::collections::HashMap;
+use bevy_ptr::OwningPtr;
+use core::{alloc::Layout, hash::Hash, ptr::NonNull};
+
+/// Extension methods for [`World`] to assist with indexing components.
+pub trait WorldIndexExtension {
+    /// Create and track an index for `C`.
+    fn index_component<C: IndexComponent>(&mut self) -> &mut Self;
+
+    /// Query by an indexed component's value.
+    fn query_by_index<C: IndexComponent, D: QueryData, F: QueryFilter>(
+        &mut self,
+        value: &C,
+    ) -> QueryState<D, (F, With<C>)>;
+}
+
+impl WorldIndexExtension for World {
+    fn index_component<C: IndexComponent>(&mut self) -> &mut Self {
+        if self.get_resource::<Index<C>>().is_none() {
+            self.add_observer(Index::<C>::on_insert);
+            self.add_observer(Index::<C>::on_replace);
+        }
+
+        self.init_resource::<Index<C>>();
+
+        self
+    }
+
+    fn query_by_index<C: IndexComponent, D: QueryData, F: QueryFilter>(
+        &mut self,
+        value: &C,
+    ) -> QueryState<D, (F, With<C>)> {
+        self.resource_scope::<Index<C>, _>(|world, index| {
+            let mut builder = QueryBuilder::<D, (F, With<C>)>::new(world);
+
+            match index.mapping.get(value).copied() {
+                // If there is a marker, restrict to it
+                Some(component_id) => builder.with_id(component_id),
+                // Otherwise, create a no-op query by including With<C> and Without<C>
+                None => builder.without::<C>(),
+            };
+
+            let query = builder.build();
+
+            query
+        })
+    }
+}
+
+/// Marker describing the requirements for a [`Component`] to be suitable for indexing.
+pub trait IndexComponent: Component<Mutability = Immutable> + Eq + Hash + Clone {}
+
+impl<C: Component<Mutability = Immutable> + Eq + Hash + Clone> IndexComponent for C {}
+
+#[derive(Resource)]
+struct Index<C: IndexComponent> {
+    mapping: HashMap<C, ComponentId>,
+    spare_markers: Vec<ComponentId>,
+}
+
+impl<C: IndexComponent> Default for Index<C> {
+    fn default() -> Self {
+        Self {
+            mapping: Default::default(),
+            spare_markers: Default::default(),
+        }
+    }
+}
+
+impl<C: IndexComponent> Index<C> {
+    fn on_insert(trigger: Trigger<OnInsert, C>, mut commands: Commands) {
+        let entity = trigger.target();
+
+        commands.queue(move |world: &mut World| {
+            world.resource_scope::<Self, _>(|world, mut index| {
+                let Some(value) = world.get::<C>(entity) else {
+                    return;
+                };
+
+                let component_id = match index.mapping.get(value).copied() {
+                    Some(component_id) => component_id,
+                    None => {
+                        let value = value.clone();
+                        let component_id = index
+                            .spare_markers
+                            .pop()
+                            .unwrap_or_else(|| Self::alloc_new_marker(world));
+                        index.mapping.insert(value, component_id);
+                        component_id
+                    }
+                };
+
+                unsafe {
+                    world
+                        .entity_mut(entity)
+                        .insert_by_id(component_id, OwningPtr::new(NonNull::dangling()));
+                }
+            });
+        });
+    }
+
+    fn on_replace(
+        trigger: Trigger<OnReplace, C>,
+        query: Query<&C>,
+        index: Res<Index<C>>,
+        mut commands: Commands,
+    ) {
+        let entity = trigger.target();
+
+        let value = query
+            .get(entity)
+            .expect("observer should see a component in on_replace");
+
+        let component_id = index
+            .mapping
+            .get(value)
+            .copied()
+            .expect("somehow didn't track this value");
+
+        commands.queue(move |world: &mut World| {
+            world.resource_scope::<Self, _>(|world, mut index| {
+                world.entity_mut(entity).remove_by_id(component_id);
+
+                let Self {
+                    ref mut mapping,
+                    ref mut spare_markers,
+                    ..
+                } = index.as_mut();
+
+                mapping.retain(|_key, &mut component_id_other| {
+                    if component_id_other != component_id {
+                        return true;
+                    }
+
+                    let mut builder = QueryBuilder::<(), With<C>>::new(world);
+                    builder.with_id(component_id);
+                    let mut query = builder.build();
+
+                    // is_empty
+                    if query.iter(world).next().is_none() {
+                        spare_markers.push(component_id);
+                        false
+                    } else {
+                        true
+                    }
+                });
+            });
+        });
+    }
+
+    /// Creates a new marker component for this index.
+    /// It represents a ZST and is not tied to a particular value.
+    /// This allows moving entities into new archetypes based on the indexed value.
+    fn alloc_new_marker(world: &mut World) -> ComponentId {
+        world.register_component_with_descriptor(unsafe {
+            ComponentDescriptor::new_with_layout(
+                format!("Index Marker ({})", core::any::type_name::<Self>()),
+                StorageType::Table,
+                Layout::new::<()>(),
+                None,
+                false,
+            )
+        })
+    }
+}

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -90,7 +90,7 @@
 //! # #[component(immutable)]
 //! # struct Planet(&'static str);
 //! fn get_earthlings(mut query: QueryByIndex<Planet, Entity>) {
-//!     let earthlings = query.at(&Planet("Earth"));
+//!     let mut earthlings = query.at(&Planet("Earth"));
 //!
 //!     for earthling in &earthlings.query() {
 //!         // ...

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -195,7 +195,9 @@ enum TrackEntityError {
 
 impl<C: Component<Mutability = Immutable>> Index<C> {
     fn new<S: IndexStorage<C>>(world: &mut World, options: IndexOptions<C, S>) -> Self {
-        let bits = options.address_space.min(size_of::<u32>().saturating_mul(8) as u8) as u16;
+        let bits = options
+            .address_space
+            .min(size_of::<u32>().saturating_mul(8) as u8) as u16;
 
         let markers = (0..bits)
             .map(|bit| Self::alloc_new_marker(world, bit, options.marker_storage))

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -360,12 +360,13 @@ pub struct IndexOptions<
 > {
     /// Marker components will be added to indexed entities to allow for efficient lookups.
     /// This controls the [`StorageType`] that will be used with these markers.
-    /// It is recommended to use [`Table`](StorageType::Table) for more efficient querying, but a
-    /// [`SpareSet`](StorageType::SparseSet) may be more appropriate where iteration performance is
-    /// of lesser importance and the number of simultaneous unique values of `C` is large.
+    ///
+    /// - [`Table`](StorageType::Table) is faster for querying
+    /// - [`SpareSet`](StorageType::SparseSet) is more memory efficient
+    ///
     /// Ensure you benchmark both options appropriately if you are experiencing performance issues.
     ///
-    /// This defaults to [`Table`](StorageType::Table).
+    /// This defaults to [`SparseSet`](StorageType::SparseSet).
     pub marker_storage: StorageType,
     /// Marker components are combined into a unique address for each distinct value of the indexed
     /// component.
@@ -396,7 +397,7 @@ impl<C: Component<Mutability = Immutable> + Eq + Hash + Clone> Default
 {
     fn default() -> Self {
         Self {
-            marker_storage: StorageType::Table,
+            marker_storage: StorageType::SparseSet,
             address_space: size_of::<C>() as u8,
             index_storage: HashMap::with_hasher(FixedHasher),
             _phantom: PhantomData,

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -187,7 +187,7 @@ enum TrackEntityError {
 
 impl<C: Component<Mutability = Immutable>> Index<C> {
     fn new<S: IndexStorage<C>>(world: &mut World, options: IndexOptions<C, S>) -> Self {
-        let bits = 8 * options.address_space.min(size_of::<u32>());
+        let bits = 8 * (options.address_space.min(size_of::<u32>() as u8) as u16);
 
         let markers = (0..bits)
             .map(|bit| Self::alloc_new_marker(world, bit, options.marker_storage))
@@ -317,7 +317,7 @@ impl<C: Component<Mutability = Immutable>> Index<C> {
     /// Creates a new marker component for this index.
     /// It represents a ZST and is not tied to a particular value.
     /// This allows moving entities into new archetypes based on the indexed value.
-    fn alloc_new_marker(world: &mut World, bit: usize, storage_type: StorageType) -> ComponentId {
+    fn alloc_new_marker(world: &mut World, bit: u16, storage_type: StorageType) -> ComponentId {
         // SAFETY:
         // - ZST is Send + Sync
         // - No drop function provided or required
@@ -368,7 +368,7 @@ pub struct IndexOptions<
     /// index if the address space is exhausted.
     ///
     /// This defaults to [`size_of<C>`]
-    pub address_space: usize,
+    pub address_space: u8,
     /// A storage backend for this index.
     /// For certain indexing strategies and [`Component`] types, you may be able to greatly
     /// optimize the utility and performance of an index by creating a custom backend.
@@ -387,7 +387,7 @@ impl<C: Component<Mutability = Immutable> + Eq + Hash + Clone> Default
     fn default() -> Self {
         Self {
             marker_storage: StorageType::Table,
-            address_space: size_of::<C>(),
+            address_space: size_of::<C>() as u8,
             index_storage: HashMap::with_hasher(FixedHasher),
             _phantom: PhantomData,
         }

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -195,7 +195,7 @@ enum TrackEntityError {
 
 impl<C: Component<Mutability = Immutable>> Index<C> {
     fn new<S: IndexStorage<C>>(world: &mut World, options: IndexOptions<C, S>) -> Self {
-        let bits = 8 * (options.address_space.min(size_of::<u32>() as u8) as u16);
+        let bits = options.address_space.min(size_of::<u32>().saturating_mul(8) as u8) as u16;
 
         let markers = (0..bits)
             .map(|bit| Self::alloc_new_marker(world, bit, options.marker_storage))

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -67,7 +67,7 @@ impl<C: IndexComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, C, D, F> 
     /// world.add_index::<FavoriteColor>();
     ///
     /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
-    ///     for entity in query.at(FavoriteColor::Red).iter() {
+    ///     for entity in query.at(&FavoriteColor::Red).iter() {
     ///         println!("{entity:?} likes the color Red!");
     ///     }
     /// }

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! # Background
 //!
-//! The most common way of querying for data within the [`World`] is with [`Query`] as a [system parameter](`SystemParam`).
+//! The most common way of querying for data within the [`World`] is with [`Query`] as a system parameter.
 //! This requires specifying all the parameters of your query up-front in the type-signature of system.
 //! This is problematic when you don't want to query for _all_ entities with a particular set of components,
 //! and instead want entities who have particular _values_ for a given component.

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -138,7 +138,9 @@ pub use storage::*;
 
 use crate::{
     self as bevy_ecs,
-    component::{Component, ComponentDescriptor, ComponentId, Immutable, StorageType},
+    component::{
+        Component, ComponentCloneBehavior, ComponentDescriptor, ComponentId, Immutable, StorageType,
+    },
     entity::Entity,
     prelude::Trigger,
     system::{Commands, Query, ResMut},
@@ -338,6 +340,7 @@ impl<C: Component<Mutability = Immutable>> Index<C> {
                 Layout::new::<()>(),
                 None,
                 false,
+                ComponentCloneBehavior::default(),
             )
         };
 

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -115,12 +115,6 @@
 //! This makes iterating through a subset of the total archetype faster, but decreases the performance
 //! of iterating the whole archetype by a small amount.
 //!
-//! ## Component ID Exhaustion
-//!
-//! Fragmenting requires unique [component IDs](ComponentId), and they are finite.
-//! For components with a small number of values in use at any one time, this is acceptable.
-//! But for components with a _large_ number of unique values (e.g., components containing floating point numbers),
-//! the pool of available component IDs will be quickly exhausted.
 //!
 //! ## Mutation Overhead
 //!

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -364,8 +364,8 @@ pub struct IndexOptions<
     /// Bevy's [`World`] only supports 2^32 entities alive at any one moment in time, so an address space
     /// of 32 is sufficient to uniquely refer to every individual [`Entity`] in the entire [`World`].
     ///
-    /// Selecting a non-default value may lead to a panic at runtime or entities missing from the
-    /// index if the address space is exhausted.
+    /// Selecting a value lower than the default value may lead to a panic at runtime or entities
+    /// missing from the index if the address space is exhausted.
     ///
     /// This defaults to [`size_of<C>`]
     pub address_space: u8,

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -155,9 +155,18 @@ unsafe impl<C: IndexableComponent, D: QueryData + 'static, F: QueryFilter + 'sta
     }
 }
 
+/// This [`Resource`] is responsible for managing a value-to-[`ComponentId`] mapping, allowing
+/// [`QueryByIndex`] to simply filter by [`ComponentId`] on a standard [`Query`].
 #[derive(Resource)]
 struct Index<C: IndexableComponent> {
+    /// Maps `C` values to a marking ZST component.
     mapping: HashMap<C, ComponentId>,
+    /// Previously registered but currently unused marking ZSTs.
+    /// If a value _was_ tracked in [`mapping`](Index::mapping) but no entity
+    /// has that value anymore, its marker is pushed here for reuse when a _new_
+    /// value for `C` needs to be tracked.
+    ///
+    /// When exhausted, new markers must be registered from a [`World`].
     spare_markers: Vec<ComponentId>,
 }
 

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -248,7 +248,7 @@ impl<C: IndexableComponent> Index<C> {
                     ..
                 } = index.as_mut();
 
-                // TODO: It may be more performant to make a clone of the old value and lookup directly
+                // PERF: It may be more performant to make a clone of the old value and lookup directly
                 // rather than iterating the whole map.
                 mapping.retain(|_key, &mut component_id_other| {
                     if component_id_other != component_id {

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -170,7 +170,9 @@ struct Index<C: IndexableComponent> {
     spare_markers: Vec<ComponentId>,
 }
 
-impl<C: IndexableComponent> Default for Index<C> {
+// Rust's derives assume that C must impl Default for this to hold,
+// but that's not true.
+impl<C: IndexComponent> Default for Index<C> {
     fn default() -> Self {
         Self {
             mapping: Default::default(),

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -112,9 +112,16 @@
 //!
 //! To provide the maximum iteration speed, the indexable component is fragmented, meaning each unique
 //! value is stored in its own archetype.
-//! This makes iterating through a subset of the total archetype faster, but decreases the performance
-//! of iterating the whole archetype by a small amount.
-//!
+//! This makes iterating through a subset of the total archetypes faster, but decreases the performance
+//! of iterating all archetypes by a small amount.
+//! 
+//! This also has the potential to multiply the number of unused [`Archetypes`](crate::archetype::Archetype)
+//! by the number of _simultaneously living_ unique values within an index.
+//! Since Bevy does not currently have a mechanism for cleaning up [`Archetypes`](crate::archetype::Archetype)
+//! that are no longer used, this can present itself like a memory leak.
+//! If you find your application consuming substantially more memory when using indexing, please
+//! [open an issue on GitHub](https://github.com/bevyengine/bevy/issues/new/choose) to help us
+//! improve memory performance in real-world applications.
 //!
 //! ## Mutation Overhead
 //!

--- a/crates/bevy_ecs/src/index/mod.rs
+++ b/crates/bevy_ecs/src/index/mod.rs
@@ -210,14 +210,17 @@ impl<C: IndexableComponent> Index<C> {
                     })
                     .flatten();
 
+                let value = value.clone();
+
                 match spare_slot {
                     Some((index, slot)) => {
                         slot.active += 1;
+                        self.mapping.insert(value, index);
                         index
                     }
                     None => {
                         let index = self.slots.len();
-                        self.mapping.insert(value.clone(), index);
+                        self.mapping.insert(value, index);
                         self.slots.push(IndexState { active: 1 });
 
                         index

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -31,17 +31,19 @@ use super::{Index, IndexableComponent};
 /// #
 /// # world.flush();
 ///
-/// fn find_all_player_one_entities(mut query: QueryByIndex<Player, Entity>) {
-///     for entity in query.at(&Player(0)).iter() {
+/// fn find_all_player_one_entities(by_player: QueryByIndex<Player, Entity>) {
+///     let mut lens = by_player.at(&Player(0));
+///     
+///     for entity in lens.query().iter() {
 ///         println!("{entity:?} belongs to Player 1!");
 ///     }
 /// #   assert_eq!((
-/// #       query.at(&Player(0)).iter().count(),
-/// #       query.at(&Player(1)).iter().count(),
-/// #       query.at(&Player(2)).iter().count(),
-/// #       query.at(&Player(3)).iter().count(),
-/// #       query.at(&Player(4)).iter().count(),
-/// #       query.at(&Player(5)).iter().count(),
+/// #       by_player.at(&Player(0)).query().iter().count(),
+/// #       by_player.at(&Player(1)).query().iter().count(),
+/// #       by_player.at(&Player(2)).query().iter().count(),
+/// #       by_player.at(&Player(3)).query().iter().count(),
+/// #       by_player.at(&Player(4)).query().iter().count(),
+/// #       by_player.at(&Player(5)).query().iter().count(),
 /// #    ), (1, 2, 3, 4, 5, 6));
 /// }
 /// # world.run_system_cached(find_all_player_one_entities);
@@ -78,8 +80,10 @@ impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, '_, C
     ///
     /// world.add_index::<FavoriteColor>();
     ///
-    /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
-    ///     for entity in query.at(&FavoriteColor::Red).iter() {
+    /// fn find_red_fans(mut by_color: QueryByIndex<FavoriteColor, Entity>) {
+    ///     let mut lens = by_color.at(&FavoriteColor::Red);
+    /// 
+    ///     for entity in lens.query().iter() {
     ///         println!("{entity:?} likes the color Red!");
     ///     }
     /// }

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -113,6 +113,14 @@ unsafe impl<C: IndexableComponent, D: QueryData + 'static, F: QueryFilter + 'sta
         (query_state, res_state)
     }
 
+    unsafe fn new_archetype(
+        (query_state, res_state): &mut Self::State,
+        archetype: &Archetype,
+        system_meta: &mut SystemMeta,
+    ) {
+        <Query<D, (F, With<C>)> as SystemParam>::new_archetype(query_state, archetype, system_meta);
+    }
+
     #[inline]
     unsafe fn validate_param(
         (query_state, res_state): &Self::State,

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -1,4 +1,9 @@
-use crate::{component::{ComponentId, Tick}, query::{QueryBuilder, QueryData, QueryFilter, QueryState, With}, system::{Query, Res, SystemMeta, SystemParam}, world::{unsafe_world_cell::UnsafeWorldCell, World}};
+use crate::{
+    component::{ComponentId, Tick},
+    query::{QueryBuilder, QueryData, QueryFilter, QueryState, With},
+    system::{Query, Res, SystemMeta, SystemParam},
+    world::{unsafe_world_cell::UnsafeWorldCell, World},
+};
 
 use super::{Index, IndexableComponent};
 
@@ -15,24 +20,26 @@ use super::{Index, IndexableComponent};
 ///
 /// // Indexing is opt-in through `World::add_index`
 /// world.add_index::<Player>();
-/// # world.spawn(Player(0));
-/// # world.spawn(Player(0));
-/// # world.spawn(Player(1));
-/// # world.spawn(Player(1));
-/// # world.spawn(Player(1));
-/// # world.spawn(Player(2));
-/// # world.spawn(Player(2));
-/// # world.spawn(Player(2));
-/// # world.spawn(Player(2));
+/// # for i in 0..6 {
+/// #   for _ in 0..(i + 1) {
+/// #       world.spawn(Player(i));
+/// #   }
+/// # }
+/// #
 /// # world.flush();
 ///
 /// fn find_all_player_one_entities(mut query: QueryByIndex<Player, Entity>) {
 ///     for entity in query.at(&Player(0)).iter() {
 ///         println!("{entity:?} belongs to Player 1!");
 ///     }
-/// #   assert_eq!(query.at(&Player(0)).iter().count(), 2);
-/// #   assert_eq!(query.at(&Player(1)).iter().count(), 3);
-/// #   assert_eq!(query.at(&Player(2)).iter().count(), 4);
+/// #   assert_eq!((
+/// #       query.at(&Player(0)).iter().count(),
+/// #       query.at(&Player(1)).iter().count(),
+/// #       query.at(&Player(2)).iter().count(),
+/// #       query.at(&Player(3)).iter().count(),
+/// #       query.at(&Player(4)).iter().count(),
+/// #       query.at(&Player(5)).iter().count(),
+/// #    ), (1, 2, 3, 4, 5, 6));
 /// }
 /// # world.run_system_cached(find_all_player_one_entities);
 /// ```

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -181,20 +181,12 @@ impl<C: IndexableComponent, D: QueryData + 'static, F: QueryFilter + 'static>
 
         let with_states = ids
             .iter()
-            .map(|&id| {
-                let mut builder = QueryBuilder::<(), With<C>>::new(world);
-                builder.with_id(id);
-                builder.build()
-            })
+            .map(|&id| QueryBuilder::new(world).with_id(id).build())
             .collect::<Vec<_>>();
 
         let without_states = ids
             .iter()
-            .map(|&id| {
-                let mut builder = QueryBuilder::<(), With<C>>::new(world);
-                builder.without_id(id);
-                builder.build()
-            })
+            .map(|&id| QueryBuilder::new(world).without_id(id).build())
             .collect::<Vec<_>>();
 
         Self {

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -89,34 +89,43 @@ impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, '_, C
     ///     }
     /// }
     /// ```
-    pub fn at_mut(&mut self, value: &C) -> QueryLens<'_, D, (F, With<C>)> {
-        let primary = &self.state.primary_query_state;
-
-        // TODO: Placeholder for Clone
-        let mut state: QueryState<D, (F, With<C>)> = primary.join_filtered(self.world, primary);
-
-        state = self.filter_for_value(value, state);
+    pub fn at_mut(&mut self, value: &C) -> QueryLens<'_, D, (F, With<C>)>
+    where
+        QueryState<D, (F, With<C>)>: Clone,
+    {
+        let state = self.state.primary_query_state.clone();
 
         // SAFETY: We have registered all of the query's world accesses,
         // so the caller ensures that `world` has permission to access any
         // world data that the query needs.
-        unsafe { QueryLens::new(self.world, state, self.last_run, self.this_run) }
+        unsafe {
+            QueryLens::new(
+                self.world,
+                self.filter_for_value(value, state),
+                self.last_run,
+                self.this_run,
+            )
+        }
     }
 
     /// Return a read-only [`QueryLens`] returning entities with a component `C` of the provided value.
-    pub fn at(&self, value: &C) -> QueryLens<'_, D::ReadOnly, (F, With<C>)> {
-        let primary = self.state.primary_query_state.as_readonly();
-
-        // TODO: Placeholder for Clone
-        let mut state: QueryState<D::ReadOnly, (F, With<C>)> =
-            primary.join_filtered(self.world, primary);
-
-        state = self.filter_for_value(value, state);
+    pub fn at(&self, value: &C) -> QueryLens<'_, D::ReadOnly, (F, With<C>)>
+    where
+        QueryState<D::ReadOnly, (F, With<C>)>: Clone,
+    {
+        let state = self.state.primary_query_state.as_readonly().clone();
 
         // SAFETY: We have registered all of the query's world accesses,
         // so the caller ensures that `world` has permission to access any
         // world data that the query needs.
-        unsafe { QueryLens::new(self.world, state, self.last_run, self.this_run) }
+        unsafe {
+            QueryLens::new(
+                self.world,
+                self.filter_for_value(value, state),
+                self.last_run,
+                self.this_run,
+            )
+        }
     }
 
     fn filter_for_value<T: QueryData, U: QueryFilter>(

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use crate::{
     archetype::Archetype,
     component::{ComponentId, Tick},
+    index::WorldIndexExtension,
     query::{QueryBuilder, QueryData, QueryFilter, QueryState, With},
     system::{Query, QueryLens, Res, SystemMeta, SystemParam},
     world::{unsafe_world_cell::UnsafeWorldCell, World},

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -169,11 +169,7 @@ impl<C: Component<Mutability = Immutable>, D: QueryData, F: QueryFilter>
 /// Hidden from documentation as it is purely an implementation detail for [`QueryByIndex`] that may
 /// change at any time to better suit [`QueryByIndex`]s needs.
 #[doc(hidden)]
-pub struct QueryByIndexState<
-    C: Component<Mutability = Immutable>,
-    D: QueryData + 'static,
-    F: QueryFilter + 'static,
-> {
+pub struct QueryByIndexState<C: Component<Mutability = Immutable>, D: QueryData, F: QueryFilter> {
     primary_query_state: QueryState<D, (F, With<C>)>,
     index_state: ComponentId,
 

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -82,7 +82,7 @@ impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, '_, C
     ///
     /// fn find_red_fans(mut by_color: QueryByIndex<FavoriteColor, Entity>) {
     ///     let mut lens = by_color.at(&FavoriteColor::Red);
-    /// 
+    ///
     ///     for entity in lens.query().iter() {
     ///         println!("{entity:?} likes the color Red!");
     ///     }

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -95,10 +95,20 @@ impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, '_, C
         for i in 0..self.index.markers.len() {
             if index & (1 << i) > 0 {
                 let filter = &self.system_param_state.with_states[i];
-                self.state = Some(self.state.as_ref().unwrap_or(&self.system_param_state.primary_query_state).join_filtered(self.world, filter));
+                self.state = Some(
+                    self.state
+                        .as_ref()
+                        .unwrap_or(&self.system_param_state.primary_query_state)
+                        .join_filtered(self.world, filter),
+                );
             } else {
                 let filter = &self.system_param_state.without_states[i];
-                self.state = Some(self.state.as_ref().unwrap_or(&self.system_param_state.primary_query_state).join_filtered(self.world, filter));
+                self.state = Some(
+                    self.state
+                        .as_ref()
+                        .unwrap_or(&self.system_param_state.primary_query_state)
+                        .join_filtered(self.world, filter),
+                );
             }
         }
 
@@ -108,7 +118,9 @@ impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, '_, C
         unsafe {
             Query::new(
                 self.world,
-                self.state.as_ref().unwrap_or(&self.system_param_state.primary_query_state),
+                self.state
+                    .as_ref()
+                    .unwrap_or(&self.system_param_state.primary_query_state),
                 self.last_run,
                 self.this_run,
             )

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -130,9 +130,11 @@ impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, '_, C
                     .map(|i| (i, 1 << i))
                     .take_while(|&(_, mask)| mask <= self.index.slots.len())
                     .map(|(i, mask)| {
-                        (index & mask > 0)
-                            .then_some(&self.state.with_states[i])
-                            .unwrap_or(&self.state.without_states[i])
+                        if index & mask > 0 {
+                            &self.state.with_states[i]
+                        } else {
+                            &self.state.without_states[i]
+                        }
                     })
                     .fold(state, |state, filter| {
                         state.join_filtered(self.world, filter)

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -23,7 +23,7 @@ use super::Index;
 /// struct Player(u8);
 ///
 /// // Indexing is opt-in through `World::add_index`
-/// world.add_index::<Player>();
+/// world.add_index(IndexOptions::<Player>::default());
 /// # for i in 0..6 {
 /// #   for _ in 0..(i + 1) {
 /// #       world.spawn(Player(i));
@@ -81,7 +81,7 @@ impl<C: Component<Mutability = Immutable>, D: QueryData, F: QueryFilter>
     ///     Blue,
     /// }
     ///
-    /// world.add_index::<FavoriteColor>();
+    /// world.add_index(IndexOptions::<FavoriteColor>::default());
     ///
     /// fn find_red_fans(mut by_color: QueryByIndex<FavoriteColor, Entity>) {
     ///     let mut lens = by_color.at(&FavoriteColor::Red);
@@ -185,7 +185,7 @@ impl<C: Component<Mutability = Immutable>, D: QueryData + 'static, F: QueryFilte
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         let Some(index) = world.get_resource::<Index<C>>() else {
             panic!(
-                "Index not setup prior to usage. Please call `app.add_index::<{}>()` during setup",
+                "Index not setup prior to usage. Please call `app.add_index(IndexOptions::<{}>::default())` during setup",
                 disqualified::ShortName::of::<C>(),
             );
         };

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -165,6 +165,9 @@ impl<C: Component<Mutability = Immutable>, D: QueryData, F: QueryFilter>
     }
 }
 
+/// The [`SystemParam::State`] type for [`QueryByIndex`], which caches information needed for queries.
+/// Hidden from documentation as it is purely an implementation detail for [`QueryByIndex`] that may
+/// change at any time to better suit [`QueryByIndex`]s needs.
 #[doc(hidden)]
 pub struct QueryByIndexState<
     C: Component<Mutability = Immutable>,

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -174,9 +174,18 @@ pub struct QueryByIndexState<
     primary_query_state: QueryState<D, (F, With<C>)>,
     index_state: ComponentId,
 
-    // TODO: THERE MUST BE A BETTER WAY
-    without_states: Vec<QueryState<(), With<C>>>, // No, With<C> is not a typo
+    // TODO: Instead of storing 1 QueryState per marker component, it would be nice to instead
+    // track all marker components and then "somehow" create a `With<Marker #N>`/`Without<Marker #N>`
+    // query filter from that.
+    /// A list of [`QueryState`]s which each include a filter condition of `With<Marker #N>`.
+    /// Since the marking component is dynamic, it is missing from the type signature of the state.
+    /// Note that this includes `With<C>` purely for communicative purposes, `With<Marker #N>` is a
+    /// strict subset of `With<C>`.
     with_states: Vec<QueryState<(), With<C>>>,
+    /// A list of [`QueryState`]s which each include a filter condition of `Without<Marker #N>`.
+    /// Since the marking component is dynamic, it is missing from the type signature of the state.
+    /// Note that this includes `With<C>` to limit the scope of this `QueryState`.
+    without_states: Vec<QueryState<(), With<C>>>, // No, With<C> is not a typo
 }
 
 impl<C: Component<Mutability = Immutable>, D: QueryData + 'static, F: QueryFilter + 'static>

--- a/crates/bevy_ecs/src/index/query_by_index.rs
+++ b/crates/bevy_ecs/src/index/query_by_index.rs
@@ -1,0 +1,145 @@
+use crate::{component::{ComponentId, Tick}, query::{QueryBuilder, QueryData, QueryFilter, QueryState, With}, system::{Query, Res, SystemMeta, SystemParam}, world::{unsafe_world_cell::UnsafeWorldCell, World}};
+
+use super::{Index, IndexableComponent};
+
+/// This system parameter allows querying by an [indexable component](`IndexableComponent`) value.
+///
+/// # Examples
+///
+/// ```rust
+/// # use bevy_ecs::prelude::*;
+/// # let mut world = World::new();
+/// #[derive(Component, PartialEq, Eq, Hash, Clone)]
+/// #[component(immutable)]
+/// struct Player(u8);
+///
+/// // Indexing is opt-in through `World::add_index`
+/// world.add_index::<Player>();
+/// # world.spawn(Player(0));
+/// # world.spawn(Player(0));
+/// # world.spawn(Player(1));
+/// # world.spawn(Player(1));
+/// # world.spawn(Player(1));
+/// # world.spawn(Player(2));
+/// # world.spawn(Player(2));
+/// # world.spawn(Player(2));
+/// # world.spawn(Player(2));
+/// # world.flush();
+///
+/// fn find_all_player_one_entities(mut query: QueryByIndex<Player, Entity>) {
+///     for entity in query.at(&Player(0)).iter() {
+///         println!("{entity:?} belongs to Player 1!");
+///     }
+/// #   assert_eq!(query.at(&Player(0)).iter().count(), 2);
+/// #   assert_eq!(query.at(&Player(1)).iter().count(), 3);
+/// #   assert_eq!(query.at(&Player(2)).iter().count(), 4);
+/// }
+/// # world.run_system_cached(find_all_player_one_entities);
+/// ```
+pub struct QueryByIndex<'world, C: IndexableComponent, D: QueryData, F: QueryFilter = ()> {
+    world: UnsafeWorldCell<'world>,
+    state: Option<QueryState<D, (F, With<C>)>>,
+    last_run: Tick,
+    this_run: Tick,
+    index: Res<'world, Index<C>>,
+}
+
+impl<C: IndexableComponent, D: QueryData, F: QueryFilter> QueryByIndex<'_, C, D, F> {
+    /// Return a [`Query`] only returning entities with a component `C` of the provided value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bevy_ecs::prelude::*;
+    /// # let mut world = World::new();
+    /// #[derive(Component, PartialEq, Eq, Hash, Clone)]
+    /// #[component(immutable)]
+    /// enum FavoriteColor {
+    ///     Red,
+    ///     Green,
+    ///     Blue,
+    /// }
+    ///
+    /// world.add_index::<FavoriteColor>();
+    ///
+    /// fn find_red_fans(mut query: QueryByIndex<FavoriteColor, Entity>) {
+    ///     for entity in query.at(&FavoriteColor::Red).iter() {
+    ///         println!("{entity:?} likes the color Red!");
+    ///     }
+    /// }
+    /// ```
+    pub fn at(&mut self, value: &C) -> Query<'_, '_, D, (F, With<C>)> {
+        self.state = {
+            // SAFETY: Mutable references do not alias and will be dropped after this block
+            let mut builder = unsafe { QueryBuilder::new(self.world.world_mut()) };
+
+            self.index.filter_query_for(&mut builder, value);
+
+            Some(builder.build())
+        };
+
+        // SAFETY: We have registered all of the query's world accesses,
+        // so the caller ensures that `world` has permission to access any
+        // world data that the query needs.
+        unsafe {
+            Query::new(
+                self.world,
+                self.state.as_mut().unwrap(),
+                self.last_run,
+                self.this_run,
+            )
+        }
+    }
+}
+
+// SAFETY: We rely on the known-safe implementations of `SystemParam` for `Res` and `Query`.
+unsafe impl<C: IndexableComponent, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
+    for QueryByIndex<'_, C, D, F>
+{
+    type State = (QueryState<D, (F, With<C>)>, ComponentId);
+    type Item<'w, 's> = QueryByIndex<'w, C, D, F>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        let query_state = <Query<D, (F, With<C>)> as SystemParam>::init_state(world, system_meta);
+        let res_state = <Res<Index<C>> as SystemParam>::init_state(world, system_meta);
+
+        (query_state, res_state)
+    }
+
+    #[inline]
+    unsafe fn validate_param(
+        (query_state, res_state): &Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell,
+    ) -> bool {
+        let query_valid = <Query<D, (F, With<C>)> as SystemParam>::validate_param(
+            query_state,
+            system_meta,
+            world,
+        );
+        let res_valid =
+            <Res<Index<C>> as SystemParam>::validate_param(res_state, system_meta, world);
+
+        query_valid && res_valid
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        (query_state, res_state): &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        query_state.validate_world(world.id());
+
+        let index =
+            <Res<Index<C>> as SystemParam>::get_param(res_state, system_meta, world, change_tick);
+
+        QueryByIndex {
+            world,
+            state: None,
+            last_run: system_meta.last_run,
+            this_run: change_tick,
+            index,
+        }
+    }
+}

--- a/crates/bevy_ecs/src/index/storage.rs
+++ b/crates/bevy_ecs/src/index/storage.rs
@@ -1,0 +1,59 @@
+use alloc::collections::BTreeMap;
+use core::hash::{BuildHasher, Hash};
+
+use bevy_platform_support::collections::HashMap;
+
+use crate::{component::Immutable, prelude::Component};
+
+/// A storage backend for indexing the [`Component`] `C`.
+///
+/// Typically, you would use a [`HashMap`] for this purpose, but you may be able to further optimize
+/// the indexing performance of a particular component with a custom implementation of this backend.
+///
+/// For example, the component `C` may be uniquely identifiable with a subset of its data, or implement
+/// traits like [`Hash`] or [`Ord`] which would allow for specialized storage options.
+pub trait IndexStorage<C: Component<Mutability = Immutable>>: 'static + Send + Sync {
+    /// Get the identifier of the provided value for `C`.
+    ///
+    /// Returns [`None`] if no identifier for the given value has been provided.
+    fn get(&self, value: &C) -> Option<usize>;
+    /// Sets the identifier of the provided value for `C`.
+    fn insert(&mut self, value: &C, index: usize);
+    /// Removes the identifier of the provided value for `C`.
+    fn remove(&mut self, value: &C);
+}
+
+impl<C, S> IndexStorage<C> for HashMap<C, usize, S>
+where
+    C: Component<Mutability = Immutable> + Eq + Hash + Clone,
+    S: BuildHasher + Send + Sync + 'static,
+{
+    fn get(&self, value: &C) -> Option<usize> {
+        self.get(value).copied()
+    }
+
+    fn insert(&mut self, value: &C, index: usize) {
+        self.insert(C::clone(value), index);
+    }
+
+    fn remove(&mut self, value: &C) {
+        self.remove(value);
+    }
+}
+
+impl<C> IndexStorage<C> for BTreeMap<C, usize>
+where
+    C: Component<Mutability = Immutable> + Ord + Clone,
+{
+    fn get(&self, value: &C) -> Option<usize> {
+        self.get(value).copied()
+    }
+
+    fn insert(&mut self, value: &C, index: usize) {
+        self.insert(C::clone(value), index);
+    }
+
+    fn remove(&mut self, value: &C) {
+        self.remove(value);
+    }
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -79,7 +79,7 @@ pub mod prelude {
         entity::{Entity, EntityBorrow, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
-        index::{QueryByIndex, WorldIndexExtension},
+        index::{IndexOptions, QueryByIndex},
         name::{Name, NameOrEntity},
         observer::{CloneEntityWithObserversExt, Observer, Trigger},
         query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -43,6 +43,7 @@ pub mod entity_disabling;
 pub mod event;
 pub mod hierarchy;
 pub mod identifier;
+pub mod index;
 pub mod intern;
 pub mod label;
 pub mod name;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -79,6 +79,7 @@ pub mod prelude {
         entity::{Entity, EntityBorrow, EntityMapper},
         event::{Event, EventMutator, EventReader, EventWriter, Events},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
+        index::{QueryByIndex, WorldIndexExtension},
         name::{Name, NameOrEntity},
         observer::{CloneEntityWithObserversExt, Observer, Trigger},
         query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -91,13 +91,13 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            world_id: self.world_id.clone(),
-            archetype_generation: self.archetype_generation.clone(),
+            world_id: self.world_id,
+            archetype_generation: self.archetype_generation,
             matched_tables: self.matched_tables.clone(),
             matched_archetypes: self.matched_archetypes.clone(),
             component_access: self.component_access.clone(),
             matched_storage_ids: self.matched_storage_ids.clone(),
-            is_dense: self.is_dense.clone(),
+            is_dense: self.is_dense,
             fetch_state: self.fetch_state.clone(),
             filter_state: self.filter_state.clone(),
             #[cfg(feature = "trace")]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -84,6 +84,28 @@ pub struct QueryState<D: QueryData, F: QueryFilter = ()> {
     par_iter_span: Span,
 }
 
+impl<D: QueryData, F: QueryFilter> Clone for QueryState<D, F>
+where
+    D::State: Clone,
+    F::State: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            world_id: self.world_id.clone(),
+            archetype_generation: self.archetype_generation.clone(),
+            matched_tables: self.matched_tables.clone(),
+            matched_archetypes: self.matched_archetypes.clone(),
+            component_access: self.component_access.clone(),
+            matched_storage_ids: self.matched_storage_ids.clone(),
+            is_dense: self.is_dense.clone(),
+            fetch_state: self.fetch_state.clone(),
+            filter_state: self.filter_state.clone(),
+            #[cfg(feature = "trace")]
+            par_iter_span: self.par_iter_span.clone(),
+        }
+    }
+}
+
 impl<D: QueryData, F: QueryFilter> fmt::Debug for QueryState<D, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryState")

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1881,6 +1881,33 @@ impl<'w, Q: QueryData, F: QueryFilter> QueryLens<'w, Q, F> {
             this_run: self.this_run,
         }
     }
+
+    /// Creates a new [`QueryLens`].
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the world used to create `state` is not `world`.
+    ///
+    /// # Safety
+    ///
+    /// This will create a query that could violate memory safety rules. Make sure that this is only
+    /// called in ways that ensure the queries have unique mutable access.
+    #[inline]
+    pub(crate) unsafe fn new(
+        world: UnsafeWorldCell<'w>,
+        state: QueryState<Q, F>,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Self {
+        state.validate_world(world.id());
+
+        Self {
+            world,
+            state,
+            last_run,
+            this_run,
+        }
+    }
 }
 
 impl<'w, 's, Q: QueryData, F: QueryFilter> From<&'s mut QueryLens<'w, Q, F>>

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2098,12 +2098,9 @@ pub struct QueryLens<'w, Q: QueryData, F: QueryFilter = ()> {
 impl<'w, Q: QueryData, F: QueryFilter> QueryLens<'w, Q, F> {
     /// Create a [`Query`] from the underlying [`QueryState`].
     pub fn query(&mut self) -> Query<'w, '_, Q, F> {
-        Query {
-            world: self.world,
-            state: &self.state,
-            last_run: self.last_run,
-            this_run: self.this_run,
-        }
+        // SAFETY: construction of a `QueryLens` requires ensuring the provided parameters will
+        // uphold the safety invariants of `Query::new`
+        unsafe { Query::new(self.world, &self.state, self.last_run, self.this_run) }
     }
 
     /// Creates a new [`QueryLens`].
@@ -2114,8 +2111,8 @@ impl<'w, Q: QueryData, F: QueryFilter> QueryLens<'w, Q, F> {
     ///
     /// # Safety
     ///
-    /// This will create a query that could violate memory safety rules. Make sure that this is only
-    /// called in ways that ensure the queries have unique mutable access.
+    /// `QueryLens` can be used to construct a `Query` by internally calling `Query::new`.
+    /// All safety invariants of `Query::new` must be upheld when calling `QueryLens::new`.
     #[inline]
     pub(crate) unsafe fn new(
         world: UnsafeWorldCell<'w>,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -36,12 +36,13 @@ use crate::{
     change_detection::{MutUntyped, TicksMut},
     component::{
         Component, ComponentCloneHandlers, ComponentDescriptor, ComponentHooks, ComponentId,
-        ComponentInfo, ComponentTicks, Components, Mutable, RequiredComponents,
+        ComponentInfo, ComponentTicks, Components, Immutable, Mutable, RequiredComponents,
         RequiredComponentsError, Tick,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
     entity_disabling::{DefaultQueryFilters, Disabled},
     event::{Event, EventId, Events, SendBatchIds},
+    index::{IndexOptions, IndexStorage},
     observer::Observers,
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     removal_detection::RemovedComponentEvents,
@@ -3695,6 +3696,20 @@ impl World {
         let mut schedules = self.remove_resource::<Schedules>().unwrap_or_default();
         schedules.allow_ambiguous_resource::<T>(self);
         self.insert_resource(schedules);
+    }
+}
+
+// Methods relating to component indexing
+impl World {
+    /// Create and track an index for `C`.
+    /// This is required to use the [`QueryByIndex`](crate::index::QueryByIndex) system parameter.
+    pub fn add_index<C: Component<Mutability = Immutable>, S: IndexStorage<C>>(
+        &mut self,
+        options: IndexOptions<C, S>,
+    ) -> &mut Self {
+        options.setup_index(self);
+
+        self
     }
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -313,7 +313,7 @@ Example | Description
 [Generic System](../examples/ecs/generic_system.rs) | Shows how to create systems that can be reused with different types
 [Hierarchy](../examples/ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 [Immutable Components](../examples/ecs/immutable_components.rs) | Demonstrates the creation and utility of immutable components
-[Indexes](../examples/ecs/index.rs) | Demonstrates the creation and utility of indexes
+[Indexes](../examples/ecs/index.rs) | Demonstrates querying by component value using indexing
 [Iter Combinations](../examples/ecs/iter_combinations.rs) | Shows how to iterate over combinations of query results
 [Nondeterministic System Order](../examples/ecs/nondeterministic_system_order.rs) | Systems run in parallel, but their order isn't always deterministic. Here's how to detect and fix this.
 [Observer Propagation](../examples/ecs/observer_propagation.rs) | Demonstrates event propagation with observers

--- a/examples/README.md
+++ b/examples/README.md
@@ -313,6 +313,7 @@ Example | Description
 [Generic System](../examples/ecs/generic_system.rs) | Shows how to create systems that can be reused with different types
 [Hierarchy](../examples/ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities
 [Immutable Components](../examples/ecs/immutable_components.rs) | Demonstrates the creation and utility of immutable components
+[Indexes](../examples/ecs/index.rs) | Demonstrates the creation and utility of indexes
 [Iter Combinations](../examples/ecs/iter_combinations.rs) | Shows how to iterate over combinations of query results
 [Nondeterministic System Order](../examples/ecs/nondeterministic_system_order.rs) | Systems run in parallel, but their order isn't always deterministic. Here's how to detect and fix this.
 [Observer Propagation](../examples/ecs/observer_propagation.rs) | Demonstrates event propagation with observers

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -25,7 +25,7 @@ fn main() {
             }),
             FpsOverlayPlugin::default(),
         ))
-        .add_index::<Chunk>()
+        .add_index(IndexOptions::<Chunk>::default())
         .insert_resource(Time::<Fixed>::from_seconds(0.1))
         .add_systems(Startup, setup)
         .add_systems(Update, randomly_revive)

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -1,18 +1,31 @@
-//! Demonstrates how to use indexes.
+//! Demonstrates how to query for a component _value_ using indexes.
 
 use bevy::prelude::*;
+
+// To query by component value, first we need to ensure our component is suitable
+// for indexing.
+//
+// The hard requirements are:
+// * Immutability
+// * Eq + Hash + Clone
 
 #[derive(Component, PartialEq, Eq, Hash, Clone, Debug)]
 #[component(immutable)]
 struct TilePosition {
+    // It's strongly recommended to keep the range of possible values for an index component small.
+    // Each unique value in use at the same time will require a ComponentId, so large spaces like `f32` are highly discouraged.
     x: i8,
     y: i8,
 }
 
 fn main() {
     App::new()
+        // Simply call `add_index` to start indexing a component.
+        // Make sure to call this _before_ any components are spawned, otherwise
+        // the index will miss those entities!
         .add_index::<TilePosition>()
         .add_systems(Startup, spawn_tiles)
+        // Simply spawn some indexed components and move them around.
         .add_systems(
             Update,
             (
@@ -34,8 +47,15 @@ fn spawn_tiles(mut commands: Commands) {
     }
 }
 
+// To query using an index, use `QueryByIndex`.
 fn query_for_tiles(mut index_query: QueryByIndex<TilePosition, (Entity, &TilePosition)>) {
-    let count = index_query.at(&TilePosition { x: 1, y: 1 }).iter().count();
+    // To specify the value you wish to lookup, use `at(...)` within the system.
+    // This returns a `Query`, supporting all the same methods and APIs you're used to!
+    let mut tiles_at_1_1: Query<(Entity, &TilePosition)> =
+        index_query.at(&TilePosition { x: 1, y: 1 });
+
+    // The Query returned by `at(...)` will _only_ return entities with the given value.
+    let count = tiles_at_1_1.iter().count();
     println!("Found {count} at (1,1)!");
 }
 

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -1,0 +1,63 @@
+//! Demonstrates how to use indexes.
+
+use bevy::{ecs::index::WorldIndexExtension, prelude::*};
+
+#[derive(Component, PartialEq, Eq, Hash, Clone, Debug)]
+#[component(immutable)]
+struct TilePosition {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let mut app = App::new();
+
+    // TODO: Expose directly on App
+    app.world_mut().index_component::<TilePosition>();
+
+    app.add_systems(Startup, spawn_tiles)
+        .add_systems(
+            Update,
+            (
+                query_for_tiles,
+                move_all_tiles_to,
+                query_for_tiles,
+                move_all_tiles_from,
+                query_for_tiles,
+            )
+                .chain(),
+        )
+        .run();
+}
+
+fn spawn_tiles(mut commands: Commands) {
+    for _ in 0..10 {
+        commands.spawn(TilePosition { x: 1, y: 1 });
+        commands.spawn(TilePosition { x: -1, y: 1 });
+    }
+}
+
+fn query_for_tiles(world: &mut World) {
+    // TODO: Create SystemParam since this shouldn't need anything more than access to &Index<C> and Query<D, (F, With<C>)>
+    let mut query =
+        world.query_by_index::<_, (Entity, &TilePosition), ()>(&TilePosition { x: 1, y: 1 });
+
+    let count = query.iter(world).count();
+    println!("Found {count} at (1,1)!");
+}
+
+fn move_all_tiles_to(query: Query<Entity, With<TilePosition>>, mut commands: Commands) {
+    println!("Moving tiles to observation point...");
+    for entity in query.iter() {
+        commands.entity(entity).insert(TilePosition { x: 1, y: 1 });
+    }
+}
+
+fn move_all_tiles_from(query: Query<Entity, With<TilePosition>>, mut commands: Commands) {
+    println!("Moving tiles away from observation point...");
+    for entity in query.iter() {
+        commands
+            .entity(entity)
+            .insert(TilePosition { x: -1, y: -1 });
+    }
+}

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -51,7 +51,7 @@ fn spawn_tiles(mut commands: Commands) {
 fn query_for_tiles(mut index_query: QueryByIndex<TilePosition, (Entity, &TilePosition)>) {
     // To specify the value you wish to lookup, use `at(...)` within the system.
     // This returns a `Query`, supporting all the same methods and APIs you're used to!
-    let mut tiles_at_1_1: Query<(Entity, &TilePosition), _> =
+    let tiles_at_1_1: Query<(Entity, &TilePosition), _> =
         index_query.at(&TilePosition { x: 1, y: 1 });
 
     // The Query returned by `at(...)` will _only_ return entities with the given value.

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -51,7 +51,7 @@ fn spawn_tiles(mut commands: Commands) {
 fn query_for_tiles(mut index_query: QueryByIndex<TilePosition, (Entity, &TilePosition)>) {
     // To specify the value you wish to lookup, use `at(...)` within the system.
     // This returns a `Query`, supporting all the same methods and APIs you're used to!
-    let mut tiles_at_1_1: Query<(Entity, &TilePosition)> =
+    let mut tiles_at_1_1: Query<(Entity, &TilePosition), _> =
         index_query.at(&TilePosition { x: 1, y: 1 });
 
     // The Query returned by `at(...)` will _only_ return entities with the given value.

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -5,8 +5,8 @@ use bevy::prelude::*;
 #[derive(Component, PartialEq, Eq, Hash, Clone, Debug)]
 #[component(immutable)]
 struct TilePosition {
-    x: i32,
-    y: i32,
+    x: i8,
+    y: i8,
 }
 
 fn main() {

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to use indexes.
 
-use bevy::{ecs::index::WorldIndexExtension, prelude::*};
+use bevy::prelude::*;
 
 #[derive(Component, PartialEq, Eq, Hash, Clone, Debug)]
 #[component(immutable)]
@@ -10,12 +10,9 @@ struct TilePosition {
 }
 
 fn main() {
-    let mut app = App::new();
-
-    // TODO: Expose directly on App
-    app.world_mut().index_component::<TilePosition>();
-
-    app.add_systems(Startup, spawn_tiles)
+    App::new()
+        .add_index::<TilePosition>()
+        .add_systems(Startup, spawn_tiles)
         .add_systems(
             Update,
             (
@@ -37,12 +34,8 @@ fn spawn_tiles(mut commands: Commands) {
     }
 }
 
-fn query_for_tiles(world: &mut World) {
-    // TODO: Create SystemParam since this shouldn't need anything more than access to &Index<C> and Query<D, (F, With<C>)>
-    let mut query =
-        world.query_by_index::<_, (Entity, &TilePosition), ()>(&TilePosition { x: 1, y: 1 });
-
-    let count = query.iter(world).count();
+fn query_for_tiles(mut index_query: QueryByIndex<TilePosition, (Entity, &TilePosition)>) {
+    let count = index_query.at(&TilePosition { x: 1, y: 1 }).iter().count();
     println!("Found {count} at (1,1)!");
 }
 

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -1,4 +1,9 @@
-//! Demonstrates how to query for a component _value_ using indexes.
+//! Demonstrates how to efficiently query for a component _value_ using automatically updated indexes.
+//!
+//! This pattern can be substantially faster than iterating over and filtering for matching components,
+//! at the expense of slower mutations and component insertion.
+//!
+//! See the [`bevy::ecs::index`] module docs for in-depth information.
 
 use bevy::{dev_tools::fps_overlay::FpsOverlayPlugin, prelude::*};
 use rand::{Rng, SeedableRng};

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -50,7 +50,6 @@ struct LivingNeighbors(u8);
 
 #[derive(Resource)]
 struct LivingHandles {
-    mesh: Handle<Mesh>,
     alive_material: Handle<ColorMaterial>,
     dead_material: Handle<ColorMaterial>,
 }
@@ -70,7 +69,6 @@ fn setup(
     let dead = materials.add(Color::WHITE);
 
     commands.insert_resource(LivingHandles {
-        mesh: rect.clone(),
         alive_material: alive.clone(),
         dead_material: dead.clone(),
     });

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -29,7 +29,7 @@ fn main() {
         .insert_resource(Time::<Fixed>::from_seconds(0.1))
         .add_systems(Startup, setup)
         .add_systems(Update, randomly_revive)
-        .add_systems(FixedUpdate, (spread_livlihood, update_state).chain())
+        .add_systems(FixedUpdate, (spread_livelihood, update_state).chain())
         .run();
 }
 
@@ -113,8 +113,8 @@ fn randomly_revive(
     }
 }
 
-fn spread_livlihood(
     mut neighbors: QueryByIndex<Chunk, (&Position, &mut LivingNeighbors)>,
+fn spread_livelihood(
     living: Query<(&Position, &Chunk), With<Alive>>,
 ) {
     for (this, Chunk(cx, cy)) in living.iter() {

--- a/examples/ecs/index.rs
+++ b/examples/ecs/index.rs
@@ -1,6 +1,8 @@
 //! Demonstrates how to query for a component _value_ using indexes.
 
-use bevy::prelude::*;
+use bevy::{dev_tools::fps_overlay::FpsOverlayPlugin, prelude::*};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
 
 // To query by component value, first we need to ensure our component is suitable
 // for indexing.
@@ -9,68 +11,171 @@ use bevy::prelude::*;
 // * Immutability
 // * Eq + Hash + Clone
 
-#[derive(Component, PartialEq, Eq, Hash, Clone, Debug)]
-#[component(immutable)]
-struct TilePosition {
-    // It's strongly recommended to keep the range of possible values for an index component small.
-    // Each unique value in use at the same time will require a ComponentId, so large spaces like `f32` are highly discouraged.
-    x: i8,
-    y: i8,
-}
-
 fn main() {
     App::new()
-        // Simply call `add_index` to start indexing a component.
-        // Make sure to call this _before_ any components are spawned, otherwise
-        // the index will miss those entities!
-        .add_index::<TilePosition>()
-        .add_systems(Startup, spawn_tiles)
-        // Simply spawn some indexed components and move them around.
-        .add_systems(
-            Update,
-            (
-                query_for_tiles,
-                move_all_tiles_to,
-                query_for_tiles,
-                move_all_tiles_from,
-                query_for_tiles,
-            )
-                .chain(),
-        )
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "Conway's Game of Life".into(),
+                    name: Some("conway.app".into()),
+                    resolution: (680., 700.).into(),
+                    ..default()
+                }),
+                ..default()
+            }),
+            FpsOverlayPlugin::default(),
+        ))
+        .add_index::<Chunk>()
+        .insert_resource(Time::<Fixed>::from_seconds(0.1))
+        .add_systems(Startup, setup)
+        .add_systems(Update, randomly_revive)
+        .add_systems(FixedUpdate, (spread_livlihood, update_state).chain())
         .run();
 }
 
-fn spawn_tiles(mut commands: Commands) {
-    for _ in 0..10 {
-        commands.spawn(TilePosition { x: 1, y: 1 });
-        commands.spawn(TilePosition { x: -1, y: 1 });
+#[derive(Component, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[component(immutable, storage = "SparseSet")]
+struct Alive;
+
+#[derive(Component, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[component(immutable)]
+struct Position(i8, i8);
+
+#[derive(Component, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+#[component(immutable)]
+struct Chunk(i8, i8);
+
+#[derive(Component, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+struct LivingNeighbors(u8);
+
+#[derive(Resource)]
+struct LivingHandles {
+    mesh: Handle<Mesh>,
+    alive_material: Handle<ColorMaterial>,
+    dead_material: Handle<ColorMaterial>,
+}
+
+#[derive(Resource)]
+struct SeededRng(ChaCha8Rng);
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    commands.spawn(Camera2d);
+
+    let rect = meshes.add(Rectangle::new(10., 10.));
+    let alive = materials.add(Color::BLACK);
+    let dead = materials.add(Color::WHITE);
+
+    commands.insert_resource(LivingHandles {
+        mesh: rect.clone(),
+        alive_material: alive.clone(),
+        dead_material: dead.clone(),
+    });
+
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
+    let seeded_rng = ChaCha8Rng::seed_from_u64(19878367467712);
+    commands.insert_resource(SeededRng(seeded_rng));
+
+    // Spawn the cells
+    commands.spawn_batch((-30..30).flat_map(|x| (-30..30).map(move |y| (x, y))).map(
+        move |(x, y)| {
+            (
+                Position(x, y),
+                Chunk(x / 4, y / 4),
+                LivingNeighbors(0),
+                Mesh2d(rect.clone()),
+                MeshMaterial2d(dead.clone()),
+                Transform::from_xyz(11. * x as f32 + 5.5, 11. * y as f32 + 5.5 - 20., 0.),
+            )
+        },
+    ));
+}
+
+fn randomly_revive(
+    mut commands: Commands,
+    mut rng: ResMut<SeededRng>,
+    handles: Res<LivingHandles>,
+    mut query: Query<
+        (Entity, &mut MeshMaterial2d<ColorMaterial>),
+        (With<Position>, Without<Alive>),
+    >,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        for (entity, mut material) in query.iter_mut() {
+            if rng.0.gen::<f32>() < 0.25 {
+                commands.entity(entity).insert(Alive);
+                material.0 = handles.alive_material.clone();
+            }
+        }
     }
 }
 
-// To query using an index, use `QueryByIndex`.
-fn query_for_tiles(mut index_query: QueryByIndex<TilePosition, (Entity, &TilePosition)>) {
-    // To specify the value you wish to lookup, use `at(...)` within the system.
-    // This returns a `Query`, supporting all the same methods and APIs you're used to!
-    let tiles_at_1_1: Query<(Entity, &TilePosition), _> =
-        index_query.at(&TilePosition { x: 1, y: 1 });
+fn spread_livlihood(
+    mut neighbors: QueryByIndex<Chunk, (&Position, &mut LivingNeighbors)>,
+    living: Query<(&Position, &Chunk), With<Alive>>,
+) {
+    for (this, Chunk(cx, cy)) in living.iter() {
+        let mut found = 0;
 
-    // The Query returned by `at(...)` will _only_ return entities with the given value.
-    let count = tiles_at_1_1.iter().count();
-    println!("Found {count} at (1,1)!");
-}
+        'cell: for dx in [0, -1, 1] {
+            for dy in [0, -1, 1] {
+                let mut lens = neighbors.at_mut(&Chunk(cx + dx, cy + dy));
+                let mut query = lens.query();
 
-fn move_all_tiles_to(query: Query<Entity, With<TilePosition>>, mut commands: Commands) {
-    println!("Moving tiles to observation point...");
-    for entity in query.iter() {
-        commands.entity(entity).insert(TilePosition { x: 1, y: 1 });
+                for (other, mut count) in query.iter_mut() {
+                    let diff_x = this.0.abs_diff(other.0);
+                    let diff_y = this.1.abs_diff(other.1);
+
+                    let is_self = diff_x == 0 && diff_y == 0;
+                    let is_adjacent = diff_x < 2 && diff_y < 2;
+
+                    if is_adjacent && !is_self {
+                        count.0 += 1;
+                        found += 1;
+
+                        if found == 8 {
+                            break 'cell;
+                        }
+
+                        if count.0 > 8 {
+                            panic!("Wait how did that happen???");
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
-fn move_all_tiles_from(query: Query<Entity, With<TilePosition>>, mut commands: Commands) {
-    println!("Moving tiles away from observation point...");
-    for entity in query.iter() {
-        commands
-            .entity(entity)
-            .insert(TilePosition { x: -1, y: -1 });
+fn update_state(
+    mut commands: Commands,
+    mut query: Query<(
+        Entity,
+        &mut LivingNeighbors,
+        Has<Alive>,
+        &mut MeshMaterial2d<ColorMaterial>,
+    )>,
+    handles: Res<LivingHandles>,
+) {
+    for (entity, mut count, alive, mut color) in query.iter_mut() {
+        match count.0 {
+            0 | 1 | 3.. if alive => {
+                commands.entity(entity).remove::<Alive>();
+                color.0 = handles.dead_material.clone();
+            }
+            3 if !alive => {
+                commands.entity(entity).insert(Alive);
+                color.0 = handles.alive_material.clone();
+            }
+            _ => {}
+        }
+
+        // Reset for next frame
+        count.0 = 0;
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #4513
- Possible fix for #1592
- Fixes #6556
- Fixes #5639
- Add a first-class option for querying by component _value_.

## Solution

Users can now call `app.add_index(...)` for an appropriate component `C` to have Bevy automatically track its value and provide a high-performance archetypical indexing solution. Users can then query by-value using the `QueryByIndex` system parameter all entities with a specific indexed value. The value is provided within the body of a system, meaning `QueryByIndex` can access any entity matching the provided compile-time query filters.

This is achieved by adding `OnInsert` and `OnReplace` observers and requiring that the index component `C` be immutable, ensuring those two hooks are able to capture all mutations. Since this is done with observers, users can index 3rd party components, provided they are immutable and implement the traits required by the index storage back-end chosen.

By default, indexing uses a `HashMap` as its backing storage, which requires that the indexed component implements `Eq + Hash + Clone`. If these traits aren't available on the component to be indexed, users can either use `BTreeMap` as a back-end, only requiring `Ord + Clone`, or implement the `IndexStorage` trait on their own type. Any storage back-end can be used with an index, but only _one_ index will ever exist for a given component.

Within the observers, a private index resource is managed which tracks the component value against a collection of runtime marker components. These runtime marker components are used to group entities by-value at the archetype level for the index component. By using multiple marking components, their combination can be used to uniquely address a particular component value, allowing a relatively small number of markers to totally service even complex components.

This grouping allows for maximum performance in iteration, since querying is simply filtering for a hidden component by-archetype. 

## To-Do / Follow-up

- It would be nice to index against a whole _bundle_ instead. This requires an immutable-bundle concept and for the user to provide a function to create their derived index from the supplied bundle.

## Testing

- New `index` example
- CI

## Performance

I've added some `index` benchmarks to the `ecs` bench which test _iteration_ speed (`index_iter`) and _mutation_ speed (`index_update`). Running these benchmarks locally, I see a large performance improvement (20x) when looking for rare values amongst a large selection of entities (1-in-1,000 amongst 1,000,000), and a notable performance loss (6x) when mutating indexed components. This confirms expectation: indexing is only a performance win in scenarios where a value is rarely updated but frequently searched for.

## Indexing Strategy

To find an `Entity` with a particular value of a component `C`, a first choice might just be to use `filter` on a `Query`. No setup required, no cache invalidation, nice and simple.

![Untitled](https://github.com/user-attachments/assets/cad9aed6-82b6-46c5-890f-a63b279d625a)

Big downside to this approach is you need to iterate _all_ entities matching your `Query`. If _most_ entities match your filter, this may be perfectly fine, but if you have a large number of entities to search, and only a small number with the value you're searching for, it quickly becomes too costly.

First optimisation available: store a mapping from `C` to `Entity` and use `Query::get`.

![Untitled](https://github.com/user-attachments/assets/a883db1a-ba0b-4dc6-8b97-a07d87ce951d)

This avoids iterating all entities, but introduces some new problems to solve. First, multiple entities could have the same value for `C`, so we need a mapping from `C` to many entities such as an `EntityHashSet`. Next, iteration performance suffers as we're no longer iterating over entities and tables in-order; we're randomly selecting entities based on however they're stored in our index. For the best performance, we want to iterate the `Query` and _check_ against the index, just "somehow" skipping entities that don't match our value.

Second optimisation: use marker components to group entities with like `C` values.

![Untitled-1](https://github.com/user-attachments/assets/2f40ad76-91a4-496f-8fc1-024ae8cf0e77)

What we do here is we instead map values of `C` to `ComponentId`s rather than `Entity`s, and then ensure every entity with a `C` has the required marker component for that value _and only that marker component_. This fragments the archetypes on the value of `C`, grouping all entities with the `C` component by its value, giving us maximum iteration performance. This isn't free however. First, changing the value of `C` now requires an archetype move. Secondly, we need 1 `ComponentId` per unique value of `C` currently in the `World`. Since there are only `usize` `ComponentId`s, that limits us to 2^64 unique values _across all indexes_ (on 64-bit platforms, even worse on 32-bit). We _could_ just hope users don't have too many unique values in the index, but this is an easy mistake to make. Indexing a component that internally stores just _2_ `usize`s would allow for the index to totally exhaust all `ComponentId`s.

Final optimisation: use the _absence_ of a marker component to contain information. Instead of marking all entities of a certain value with a _single_ marker component, we could instead encode a binary address using `With` and `Without` of several marker components to build a unique filter. This allows us to address 2^64 unique values with only 64 unique marker components, exponentially fewer components required.

![Untitled](https://github.com/user-attachments/assets/5f34d0b5-6eb8-4138-83fe-4365ae77be2c)

This still gives us fragmentation on `C` values for dense iteration, at the expense of a slightly more complex `QueryFilter`, since we need to _exclude_ and _include_ some combination of markers. This is the technique adopted by this PR.

---

## Release Notes

Users can now query by-value using indexes. To setup an index, first create an immutable component with `Clone`, `Eq`, and `Hash` implementations:

```rust
#[derive(Component, PartialEq, Eq, Hash, Clone)]
#[component(immutable)]
struct TilePosition {
    x: i32,
    y: i32,
}
```

Next, request that an index be managed for this component:

```rust
app.add_index(IndexOptions::<TilePosition>::default());
```

Finally, you can query by-value using the new `QueryByIndex` system parameter:

```rust
fn query_for_tiles(mut query: QueryByIndex<TilePosition, (Entity, &TilePosition)>) {
    let mut lens = query.at(&TilePosition { x: 1, y: 1 });
    let count = lens.query().iter().count();

    println!("Found {count} at (1,1)!");
}
```

`QueryByIndex` is just like `Query` except it has a third generic argument, `C`, which denotes the component you'd like to use as the index:

```rust
// Typical query
query: Query<&Foo, With<Bar>>,

// Indexed query
query: QueryByIndex<MyIndex, &Foo, With<Bar>>,
```

Internally, the index will move entities with differing values into their own archetypes, allowing for fast iteration at the cost of some added overhead when modifying the indexed value. As such, indexes are best used where you have an infrequently changing component that you frequently need to access a subset of.

Additional control around _how_ a component is indexed is provided by the `IndexOptions` argument passed to `add_index`. This allows controlling:
* the storage type of the marker components (`SparseSet` or `Table`),
* the address space used, limiting the number of marker components allocated
* the storage back-end used to map component values to a unique ID number

```rust
#[derive(Component, PartialEq, Eq, PartialOrd, Ord, Clone)]
#[component(immutable)]
enum Planet {
    Mercury,
    Venus,
    Earth,
    Mars,
    Jupiter,
    Saturn,
    Uranus,
    Neptune,
}

app.add_index(IndexOptions::<Planet, _> {
    // SparseSet may give better performance if an indexed
    // value frequently changes.
    marker_storage: StorageType::Table,

    // The above Planet enum only has 8 possible values,
    // so only 4 bits are required instead of the implied 8.
    // By default, the index will use `size_of` to determine the
    // number of bits required, which can be excessive for certain types.
    address_space: 4,

    // An alternate storage back-end may be more appropriate
    // for your index component, always benchmark to confirm!
    index_storage: BTreeMap::<Planet, usize>::new(),

    ..default()
});
```