### PR TITLE
Remove unsound SystemParam impl for DeferredWorld

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1066,27 +1066,6 @@ unsafe impl SystemParam for &'_ World {
     }
 }
 
-/// SAFETY: `DeferredWorld` can read all components and resources but cannot be used to gain any other mutable references.
-unsafe impl<'w> SystemParam for DeferredWorld<'w> {
-    type State = ();
-    type Item<'world, 'state> = DeferredWorld<'world>;
-
-    fn init_state(_world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
-        system_meta.component_access_set.read_all();
-        system_meta.component_access_set.write_all();
-        system_meta.set_has_deferred();
-    }
-
-    unsafe fn get_param<'world, 'state>(
-        _state: &'state mut Self::State,
-        _system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        _change_tick: Tick,
-    ) -> Self::Item<'world, 'state> {
-        world.into_deferred()
-    }
-}
-
 /// A system local [`SystemParam`].
 ///
 /// A local may only be accessed by the system itself and is therefore not visible to other systems.

--- a/crates/bevy_input_focus/src/lib.rs
+++ b/crates/bevy_input_focus/src/lib.rs
@@ -421,7 +421,7 @@ mod tests {
             .unwrap();
 
         app.world_mut()
-            .run_system_once(move |world: DeferredWorld| {
+            .run_system_once(move |world: &mut World| {
                 assert!(!world.is_focused(entity));
                 assert!(!world.is_focus_within(entity));
                 assert!(!world.is_focus_visible(entity));
@@ -541,7 +541,7 @@ mod tests {
             .unwrap();
 
         app.world_mut()
-            .run_system_once(move |world: DeferredWorld| {
+            .run_system_once(move |world: &mut World| {
                 assert!(!world.is_focused(entity_a));
                 assert!(!world.is_focus_within(entity_a));
                 assert!(!world.is_focus_visible(entity_a));


### PR DESCRIPTION
# Objective

The following test currently passes (i.e. no panic) on main:

```rust
#[test]
fn deferred_world_last() {
    #[derive(Resource)]
    struct FooRes;

    fn bad_system(foo: ResMut<FooRes>, mut world: DeferredWorld) {
        let foo = foo.into_inner();
        let foo2 = world.get_resource_mut::<FooRes>().unwrap().into_inner();
    }

    let mut world = World::new();
    world.insert_resource(FooRes);
    let mut bad_system = IntoSystem::into_system(bad_system);
    bad_system.initialize(&mut world);
    bad_system.run((), &mut world);
}
```

## Solution

Remove the unsound `SystemParam` impl for `DeferredWorld`.

---

## Migration Guide

The `SystemParam` implementation for `DeferredWorld` was removed due to unsoundness. Consider using `Commands` instead.