### PR TITLE
Make `EntityHashMap::new` and `EntityHashSet::new` const

### DIFF
--- a/crates/bevy_ecs/src/entity/hash_map.rs
+++ b/crates/bevy_ecs/src/entity/hash_map.rs
@@ -26,7 +26,7 @@ impl<V> EntityHashMap<V> {
     /// Equivalent to [`HashMap::with_hasher(EntityHash)`].
     ///
     /// [`HashMap::with_hasher(EntityHash)`]: HashMap::with_hasher
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(HashMap::with_hasher(EntityHash))
     }
 

--- a/crates/bevy_ecs/src/entity/hash_set.rs
+++ b/crates/bevy_ecs/src/entity/hash_set.rs
@@ -29,7 +29,7 @@ impl EntityHashSet {
     /// Equivalent to [`HashSet::with_hasher(EntityHash)`].
     ///
     /// [`HashSet::with_hasher(EntityHash)`]: HashSet::with_hasher
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(HashSet::with_hasher(EntityHash))
     }
 


### PR DESCRIPTION
# Objective

#16912 turned `EntityHashMap` and `EntityHashSet` into proper newtypes instead of type aliases. However, this removed the ability to create these collections in const contexts; previously, you could use `EntityHashSet::with_hasher(EntityHash)`, but it doesn't exist anymore.

## Solution

Make `EntityHashMap::new` and `EntityHashSet::new` const methods.