### PR TITLE
Implement `Serialize`/`Deserialize` for entity collections

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -20,7 +20,12 @@ default = ["std", "bevy_reflect", "async_executor"]
 multi_threaded = ["bevy_tasks/multi_threaded", "dep:arrayvec"]
 
 ## Adds serialization support through `serde`.
-serialize = ["dep:serde", "bevy_utils/serde", "bevy_platform_support/serialize"]
+serialize = [
+  "dep:serde",
+  "bevy_utils/serde",
+  "bevy_platform_support/serialize",
+  "indexmap/serde",
+]
 
 ## Adds runtime reflection support using `bevy_reflect`.
 bevy_reflect = ["dep:bevy_reflect"]

--- a/crates/bevy_ecs/src/entity/hash_map.rs
+++ b/crates/bevy_ecs/src/entity/hash_map.rs
@@ -17,6 +17,7 @@ use super::{Entity, EntityHash, EntitySetIterator, TrustedEntityBorrow};
 
 /// A [`HashMap`] pre-configured to use [`EntityHash`] hashing.
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EntityHashMap<V>(pub(crate) HashMap<Entity, V, EntityHash>);
 

--- a/crates/bevy_ecs/src/entity/hash_set.rs
+++ b/crates/bevy_ecs/src/entity/hash_set.rs
@@ -20,6 +20,7 @@ use super::{Entity, EntityHash, EntitySet, EntitySetIterator, FromEntitySetItera
 
 /// A [`HashSet`] pre-configured to use [`EntityHash`] hashing.
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct EntityHashSet(pub(crate) HashSet<Entity, EntityHash>);
 

--- a/crates/bevy_ecs/src/entity/index_map.rs
+++ b/crates/bevy_ecs/src/entity/index_map.rs
@@ -14,6 +14,7 @@ use super::{Entity, EntityHash, EntitySetIterator, TrustedEntityBorrow};
 
 /// A [`IndexMap`] pre-configured to use [`EntityHash`] hashing.
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone)]
 pub struct EntityIndexMap<V>(pub(crate) IndexMap<Entity, V, EntityHash>);
 
@@ -23,7 +24,7 @@ impl<V> EntityIndexMap<V> {
     /// Equivalent to [`IndexMap::with_hasher(EntityHash)`].
     ///
     /// [`IndexMap::with_hasher(EntityHash)`]: IndexMap::with_hasher
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(IndexMap::with_hasher(EntityHash))
     }
 

--- a/crates/bevy_ecs/src/entity/index_set.rs
+++ b/crates/bevy_ecs/src/entity/index_set.rs
@@ -11,6 +11,7 @@ use indexmap::set::{self, IndexSet};
 use super::{Entity, EntityHash, EntitySetIterator};
 
 /// An [`IndexSet`] pre-configured to use [`EntityHash`] hashing.
+#[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Debug, Clone, Default)]
 pub struct EntityIndexSet(pub(crate) IndexSet<Entity, EntityHash>);
 
@@ -20,7 +21,7 @@ impl EntityIndexSet {
     /// Equivalent to [`IndexSet::with_hasher(EntityHash)`].
     ///
     /// [`IndexSet::with_hasher(EntityHash)`]: IndexSet::with_hasher
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(IndexSet::with_hasher(EntityHash))
     }
 


### PR DESCRIPTION
# Objective

Follow-up to #17615.

Bevy's entity collection types like `EntityHashSet` no longer implement serde's `Serialize` and `Deserialize` after becoming newtypes instead of type aliases in #16912. This broke some types that support serde for me in Avian.

I also missed creating const constructors for `EntityIndexMap` and `EntityIndexSet` in #17615. Oops!

## Solution

Implement `Serialize` and `Deserialize` for Bevy's entity collection types, and add const constructors for `EntityIndexMap` and `EntityIndexSet`.

I didn't implement `ReflectSerialize` or `ReflectDeserialize` here, because I had some trouble fixing the resulting errors, and they were not implemented previously either.