### PR TITLE
`queue_sprites` comment fix

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -573,7 +573,7 @@ pub fn queue_sprites(
                 pipeline,
                 entity: (*entity, *main_entity),
                 sort_key,
-                // batch_range and dynamic_offset will be calculated in prepare_sprites
+                // `batch_range` is calculated in `prepare_sprite_image_bind_groups`
                 batch_range: 0..0,
                 extra_index: PhaseItemExtraIndex::None,
                 indexed: true,


### PR DESCRIPTION
# Objective

Fix this comment in `queue_sprites`:
```
// batch_range and dynamic_offset will be calculated in prepare_sprites.
```
 `Transparent2d` no longer has a `dynamic_offset` field and the `batch_range` is calculated in `prepare_sprite_image_bind_groups` now.
