### PR TITLE
Expose ObserverDescriptor fields

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -270,13 +270,13 @@ impl TriggerTargets for &Vec<Entity> {
 #[derive(Default, Clone)]
 pub struct ObserverDescriptor {
     /// The events the observer is watching.
-    events: Vec<ComponentId>,
+    pub events: Vec<ComponentId>,
 
     /// The components the observer is watching.
-    components: Vec<ComponentId>,
+    pub components: Vec<ComponentId>,
 
     /// The entities the observer is watching.
-    entities: Vec<Entity>,
+    pub entities: Vec<Entity>,
 }
 
 impl ObserverDescriptor {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -270,13 +270,13 @@ impl TriggerTargets for &Vec<Entity> {
 #[derive(Default, Clone)]
 pub struct ObserverDescriptor {
     /// The events the observer is watching.
-    pub events: Vec<ComponentId>,
+    events: Vec<ComponentId>,
 
     /// The components the observer is watching.
-    pub components: Vec<ComponentId>,
+    components: Vec<ComponentId>,
 
     /// The entities the observer is watching.
-    pub entities: Vec<Entity>,
+    entities: Vec<Entity>,
 }
 
 impl ObserverDescriptor {
@@ -306,6 +306,21 @@ impl ObserverDescriptor {
         self.components
             .extend(descriptor.components.iter().copied());
         self.entities.extend(descriptor.entities.iter().copied());
+    }
+
+    /// Returns the `events` that the observer is watching.
+    pub fn events(&self) -> &[ComponentId] {
+        &self.events
+    }
+
+    /// Returns the `components` that the observer is watching.
+    pub fn components(&self) -> &[ComponentId] {
+        &self.components
+    }
+
+    /// Returns the `entities` that the observer is watching.
+    pub fn entities(&self) -> &[Entity] {
+        &self.entities
     }
 }
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -267,7 +267,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// [`SystemParam`]: crate::system::SystemParam
 pub struct Observer {
     system: Box<dyn Any + Send + Sync + 'static>,
-    descriptor: ObserverDescriptor,
+    pub descriptor: ObserverDescriptor,
     hook_on_add: ComponentHook,
 }
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -267,7 +267,7 @@ pub type ObserverRunner = fn(DeferredWorld, ObserverTrigger, PtrMut, propagate: 
 /// [`SystemParam`]: crate::system::SystemParam
 pub struct Observer {
     system: Box<dyn Any + Send + Sync + 'static>,
-    pub descriptor: ObserverDescriptor,
+    descriptor: ObserverDescriptor,
     hook_on_add: ComponentHook,
 }
 
@@ -311,6 +311,11 @@ impl Observer {
     pub unsafe fn with_event(mut self, event: ComponentId) -> Self {
         self.descriptor.events.push(event);
         self
+    }
+
+    /// Returns the [`ObserverDescriptor`] for this [`Observer`].
+    pub fn descriptor(&self) -> &ObserverDescriptor {
+        &self.descriptor
     }
 }
 


### PR DESCRIPTION
# Objective

Expose accessor functions to the `ObserverDescriptor`, so that users can use the `Observer` component to inspect what the observer is watching.
This would be useful for me, I don't think there's any reason to hide these.

