### PR TITLE
Add a test for direct recursion in required components.

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2189,7 +2189,7 @@ pub fn enforce_no_required_components_recursion(
                     .join(" → "),
                 if direct_recursion {
                     format!(
-                        "Remove require({})",
+                        "Remove require({}).",
                         ShortName(components.get_name(requiree).unwrap())
                     )
                 } else {
@@ -2225,7 +2225,7 @@ pub fn component_clone_via_clone<C: Clone + Component>(
 /// - Component has [`ReflectFromPtr`](bevy_reflect::ReflectFromPtr) registered
 /// - Component has one of the following registered: [`ReflectFromReflect`](bevy_reflect::ReflectFromReflect),
 ///   [`ReflectDefault`](bevy_reflect::std_traits::ReflectDefault), [`ReflectFromWorld`](crate::reflect::ReflectFromWorld)
-///   
+///
 /// If any of the conditions is not satisfied, the component will be skipped.
 ///
 /// See [`EntityCloneBuilder`](crate::entity::EntityCloneBuilder) for details.

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2662,6 +2662,18 @@ mod tests {
         World::new().register_component::<A>();
     }
 
+    #[test]
+    #[should_panic = "Recursive required components detected: A → A\nhelp: Remove require(A)."]
+    fn required_components_self_errors() {
+        #[derive(Component, Default)]
+        #[require(A)]
+        struct A;
+
+        World::new().register_component::<A>();
+    }
+
+    // These structs are primarily compilation tests to test the derive macros. Because they are
+    // never constructed, we have to manually silence the `dead_code` lint.
     #[expect(
         dead_code,
         reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2672,8 +2672,6 @@ mod tests {
         World::new().register_component::<A>();
     }
 
-    // These structs are primarily compilation tests to test the derive macros. Because they are
-    // never constructed, we have to manually silence the `dead_code` lint.
     #[expect(
         dead_code,
         reason = "This struct is used as a compilation test to test the derive macros, and as such is intentionally never constructed."


### PR DESCRIPTION
I realized there wasn't a test for this yet and figured it would be trivial to add. Why not? Unless there was a test for this, and I just missed it?

I appreciate the unique error message it gives and wanted to make sure it doesn't get broken at some point. Or worse, endlessly recurse.