### PR TITLE
Run handle_lifetime only when AudioSink is added to the world

### DIFF
--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -41,7 +41,16 @@ fn main() {
     // This can help reduce cpu usage on mobile devices
     .insert_resource(WinitSettings::mobile())
     .add_systems(Startup, (setup_scene, setup_music))
-    .add_systems(Update, (touch_camera, button_handler, handle_lifetime))
+    .add_systems(
+        Update,
+        (
+            touch_camera,
+            button_handler,
+            // Only run the lifetime handler when an [`AudioSink`] component exists in the world.
+            // This ensures we don't try to manage audio that hasn't been initialized yet.
+            handle_lifetime.run_if(any_with_component::<AudioSink>),
+        ),
+    )
     .run();
 }
 


### PR DESCRIPTION
# Objective

Fixes: https://discord.com/channels/691052431525675048/756998293665349712/1335019849516056586

## Solution

Let's wait till `AudioSInk` will be added to the world.

## Testing

Run ios example