### PR TITLE
Fix text-2d.

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -485,9 +485,9 @@ pub struct SpriteViewBindGroup {
 }
 
 #[derive(Resource, Deref, DerefMut, Default)]
-pub struct SpriteBatches(HashMap<(RetainedViewEntity, MainEntity), SpriteBatch>);
+pub struct SpriteBatches(HashMap<(RetainedViewEntity, Entity), SpriteBatch>);
 
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct SpriteBatch {
     image_handle_id: AssetId<Image>,
     range: Range<u32>,
@@ -694,7 +694,7 @@ pub fn prepare_sprite_image_bind_groups(
                     });
 
                 batch_item_index = item_index;
-                current_batch = Some(batches.entry((*retained_view, item.main_entity())).insert(
+                current_batch = Some(batches.entry((*retained_view, item.entity())).insert(
                     SpriteBatch {
                         image_handle_id: batch_image_handle,
                         range: index..index,
@@ -846,7 +846,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let image_bind_groups = image_bind_groups.into_inner();
-        let Some(batch) = batches.get(&(view.retained_view_entity, item.main_entity())) else {
+        let Some(batch) = batches.get(&(view.retained_view_entity, item.entity())) else {
             return RenderCommandResult::Skip;
         };
 
@@ -876,7 +876,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let sprite_meta = sprite_meta.into_inner();
-        let Some(batch) = batches.get(&(view.retained_view_entity, item.main_entity())) else {
+        let Some(batch) = batches.get(&(view.retained_view_entity, item.entity())) else {
             return RenderCommandResult::Skip;
         };
 


### PR DESCRIPTION
# Objective

Fix text 2d. Fixes https://github.com/bevyengine/bevy/issues/17670

## Solution

Evidently there's a 1:N extraction going on here that requires using the render entity rather than main entity.

## Testing

Text 2d example