### PR TITLE
Add missing return in default `Relationship::on_insert` impl

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -83,6 +83,7 @@ pub trait Relationship: Component + Sized {
                 core::any::type_name::<Self>()
             );
             world.commands().entity(entity).remove::<Self>();
+            return;
         }
         if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity) {
             if let Some(mut relationship_target) =
@@ -275,5 +276,28 @@ mod tests {
         let b = world.spawn(Likes(a)).id();
         let c = world.spawn(Likes(a)).id();
         assert_eq!(world.entity(a).get::<LikedBy>().unwrap().0, &[b, c]);
+    }
+
+    #[test]
+    fn self_relationship_fails() {
+        use crate::hierarchy::{ChildOf, Children};
+
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        world.entity_mut(a).insert(ChildOf(a));
+        assert!(!world.entity(a).contains::<ChildOf>());
+        assert!(!world.entity(a).contains::<Children>());
+    }
+
+    #[test]
+    fn relationship_with_missing_target_fails() {
+        use crate::hierarchy::{ChildOf, Children};
+
+        let mut world = World::new();
+        let a = world.spawn_empty().id();
+        world.despawn(a);
+        let b = world.spawn(ChildOf(a)).id();
+        assert!(!world.entity(b).contains::<ChildOf>());
+        assert!(!world.entity(b).contains::<Children>());
     }
 }

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -280,24 +280,36 @@ mod tests {
 
     #[test]
     fn self_relationship_fails() {
-        use crate::hierarchy::{ChildOf, Children};
+        #[derive(Component)]
+        #[relationship(relationship_target = RelTarget)]
+        struct Rel(Entity);
+
+        #[derive(Component)]
+        #[relationship_target(relationship = Rel)]
+        struct RelTarget(Vec<Entity>);
 
         let mut world = World::new();
         let a = world.spawn_empty().id();
-        world.entity_mut(a).insert(ChildOf(a));
-        assert!(!world.entity(a).contains::<ChildOf>());
-        assert!(!world.entity(a).contains::<Children>());
+        world.entity_mut(a).insert(Rel(a));
+        assert!(!world.entity(a).contains::<Rel>());
+        assert!(!world.entity(a).contains::<RelTarget>());
     }
 
     #[test]
     fn relationship_with_missing_target_fails() {
-        use crate::hierarchy::{ChildOf, Children};
+        #[derive(Component)]
+        #[relationship(relationship_target = RelTarget)]
+        struct Rel(Entity);
+
+        #[derive(Component)]
+        #[relationship_target(relationship = Rel)]
+        struct RelTarget(Vec<Entity>);
 
         let mut world = World::new();
         let a = world.spawn_empty().id();
         world.despawn(a);
-        let b = world.spawn(ChildOf(a)).id();
-        assert!(!world.entity(b).contains::<ChildOf>());
-        assert!(!world.entity(b).contains::<Children>());
+        let b = world.spawn(Rel(a)).id();
+        assert!(!world.entity(b).contains::<Rel>());
+        assert!(!world.entity(b).contains::<RelTarget>());
     }
 }


### PR DESCRIPTION
# Objective

There was a bug in the default `Relationship::on_insert` implementation that caused it to not properly handle entities targeting themselves in relationships. The relationship component was properly removed, but it would go on to add itself to its own target component.

## Solution

Added a missing `return` and a couple of tests (`self_relationship_fails` failed on its second assert prior to this PR).

## Testing

See above.