### PR TITLE
Add a Sphere to `anisotropy` example

### DIFF
--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -112,20 +112,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
 
 /// Spawns the help text.
 fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
-    let help_text = app_status.create_help_text();
-    commands
-        .spawn((Node {
+    commands.spawn((
+        app_status.create_help_text(),
+        Node {
             position_type: PositionType::Absolute,
-            flex_direction: FlexDirection::Column,
             bottom: Val::Px(12.0),
             left: Val::Px(12.0),
             ..default()
-        },))
-        .with_children(|parent| {
-            for text in help_text {
-                parent.spawn(Node::default()).with_child(text);
-            }
-        });
+        },
+    ));
 }
 
 /// For each material, creates a version with the anisotropy removed.
@@ -278,8 +273,8 @@ fn handle_input(
 
 /// A system that updates the help text based on the current app status.
 fn update_help_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
-    for (mut text_node, text) in text_query.iter_mut().zip(app_status.create_help_text()) {
-        *text_node = text;
+    for mut text in text_query.iter_mut() {
+        *text = app_status.create_help_text();
     }
 }
 
@@ -324,7 +319,7 @@ fn spawn_point_light(commands: &mut Commands) {
 
 impl AppStatus {
     /// Creates the help text as appropriate for the current app status.
-    fn create_help_text(&self) -> Vec<Text> {
+    fn create_help_text(&self) -> Text {
         // Choose the appropriate help text for the anisotropy toggle.
         let material_variant_help_text = if self.anisotropy_enabled {
             "Press Enter to disable anisotropy"
@@ -347,11 +342,11 @@ impl AppStatus {
         };
 
         // Build the `Text` object.
-        vec![
-            material_variant_help_text.into(),
-            light_help_text.into(),
-            mesh_help_text.into(),
-        ]
+        format!(
+            "{}\n{}\n{}",
+            material_variant_help_text, light_help_text, mesh_help_text,
+        )
+        .into()
     }
 }
 

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -1,5 +1,7 @@
 //! Demonstrates anisotropy with the glTF sample barn lamp model.
 
+use std::fmt::Display;
+
 use bevy::{
     color::palettes::{self, css::WHITE},
     core_pipeline::Skybox,
@@ -62,6 +64,16 @@ impl Scene {
             Self::BarnLamp => Self::Sphere,
             Self::Sphere => Self::BarnLamp,
         }
+    }
+}
+
+impl Display for Scene {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let scene_name = match self {
+            Self::BarnLamp => "Barn Lamp",
+            Self::Sphere => "Sphere",
+        };
+        write!(f, "{scene_name}")
     }
 }
 
@@ -337,11 +349,8 @@ impl AppStatus {
             LightMode::EnvironmentMap => "Press Space to switch to a directional light",
         };
 
-        // Choose the appropriate help text for the light toggle.
-        let mesh_help_text = match self.visible_scene {
-            Scene::BarnLamp => "Press Q to change to Sphere",
-            Scene::Sphere => "Press Q to change to Barn Lamp",
-        };
+        // Choose the appropriate help text for the scene selector.
+        let mesh_help_text = format!("Press Q to change to {}", self.visible_scene.next());
 
         // Build the `Text` object.
         format!(

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -261,16 +261,10 @@ fn handle_input(
         }
     }
 
-    let visibility_index = if keyboard.just_pressed(KeyCode::KeyQ) {
-        Some(app_status.visible_scene.next())
-    } else {
-        None
-    };
-
-    if let Some(index) = visibility_index {
-        app_status.visible_scene = index;
+    if keyboard.just_pressed(KeyCode::KeyQ) {
+        app_status.visible_scene = app_status.visible_scene.next();
         for (mut visibility, scene) in scenes.iter_mut() {
-            let new_vis = if *scene == index {
+            let new_vis = if *scene == app_status.visible_scene {
                 Visibility::Inherited
             } else {
                 Visibility::Hidden


### PR DESCRIPTION
# Objective

Add a mesh with a more regular shape to visualize the anisotropy effect.

## Solution

Add a `Sphere` to the scene.

## Testing

Ran `anisotropy` example

## Showcase

![image](https://github.com/user-attachments/assets/9bf20c61-5626-49fc-bc4a-c8e2f2309a8a)

![image](https://github.com/user-attachments/assets/649a32ad-a260-44b1-ad73-b7a660a110a3)

Note: defects are already mentioned on #16179