### PR TITLE
Add `edit_material_on_gltf` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -921,6 +921,17 @@ category = "3D Rendering"
 wasm = true
 
 [[example]]
+name = "edit_material_on_gltf"
+path = "examples/3d/edit_material_on_gltf.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.edit_material_on_gltf]
+name = "Edit Gltf Material"
+description = "Showcases changing materials of a Gltf after Scene spawn"
+category = "3D Rendering"
+wasm = true
+
+[[example]]
 name = "lighting"
 path = "examples/3d/lighting.rs"
 doc-scrape-examples = true

--- a/examples/3d/edit_material_on_gltf.rs
+++ b/examples/3d/edit_material_on_gltf.rs
@@ -1,0 +1,89 @@
+//! Showcases how to change the material of a `Scene` spawned from a Gltf
+
+use bevy::{
+    app::{App, PluginGroup, Startup},
+    asset::{AssetServer, Assets},
+    audio::AudioPlugin,
+    color::{palettes, Color},
+    gltf::GltfAssetLabel,
+    math::{Dir3, Vec3},
+    pbr::{DirectionalLight, MeshMaterial3d, StandardMaterial},
+    prelude::{Camera3d, Children, Commands, Component, Query, Res, ResMut, Transform, Trigger},
+    scene::{SceneInstanceReady, SceneRoot},
+    DefaultPlugins,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.build().disable::<AudioPlugin>())
+        .add_systems(Startup, setup_scene)
+        .add_observer(change_material)
+        .run();
+}
+
+/// Overrides the color of the `StandardMaterial` of a mesh
+#[derive(Component)]
+struct ColorOverride(Color);
+
+fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0., 1., 2.5).looking_at(Vec3::new(0., 0.25, 0.), Dir3::Y),
+    ));
+
+    // Directional light
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform::from_xyz(0., 1., 0.25).looking_at(Vec3::ZERO, Dir3::Y),
+    ));
+
+    // Flight Helmets
+    commands.spawn((SceneRoot(asset_server.load(
+        GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
+    )),));
+    commands.spawn((
+        SceneRoot(
+            asset_server
+                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+        ),
+        Transform::from_xyz(-1.25, 0., 0.),
+        ColorOverride(palettes::tailwind::RED_300.into()),
+    ));
+    commands.spawn((
+        SceneRoot(
+            asset_server
+                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
+        ),
+        Transform::from_xyz(1.25, 0., 0.),
+        ColorOverride(palettes::tailwind::GREEN_300.into()),
+    ));
+}
+
+fn change_material(
+    trigger: Trigger<SceneInstanceReady>,
+    mut commands: Commands,
+    children: Query<&Children>,
+    color_override: Query<&ColorOverride>,
+    materials: Query<&MeshMaterial3d<StandardMaterial>>,
+    mut standard_materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let Ok(color_override) = color_override.get(trigger.target()) else {
+        return;
+    };
+
+    for child in children.iter_descendants(trigger.target()) {
+        if let Some(material) = materials
+            .get(child)
+            .ok()
+            .and_then(|id| standard_materials.get_mut(id.id()))
+        {
+            let mut new_material = material.clone();
+            new_material.base_color = color_override.0;
+
+            commands
+                .entity(child)
+                .insert(MeshMaterial3d(standard_materials.add(new_material)));
+        }
+    }
+}

--- a/examples/3d/edit_material_on_gltf.rs
+++ b/examples/3d/edit_material_on_gltf.rs
@@ -21,27 +21,26 @@ fn main() {
         .run();
 }
 
-/// Overrides the color of the `StandardMaterial` of a mesh
+/// This is added to a [`SceneRoot`] and will cause the [`StandardMaterial::base_color`] of all materials
 #[derive(Component)]
 struct ColorOverride(Color);
 
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // Camera
     commands.spawn((
         Camera3d::default(),
         Transform::from_xyz(0., 1., 2.5).looking_at(Vec3::new(0., 0.25, 0.), Dir3::Y),
     ));
 
-    // Directional light
     commands.spawn((
         DirectionalLight::default(),
         Transform::from_xyz(0., 1., 0.25).looking_at(Vec3::ZERO, Dir3::Y),
     ));
 
-    // Flight Helmets
-    commands.spawn((SceneRoot(asset_server.load(
+    // This model will keep its original material
+    commands.spawn(SceneRoot(asset_server.load(
         GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
-    )),));
+    )));
+    // This model will be tinted red
     commands.spawn((
         SceneRoot(
             asset_server
@@ -50,6 +49,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         Transform::from_xyz(-1.25, 0., 0.),
         ColorOverride(palettes::tailwind::RED_300.into()),
     ));
+    // This model will be tinted green
     commands.spawn((
         SceneRoot(
             asset_server
@@ -65,25 +65,30 @@ fn change_material(
     mut commands: Commands,
     children: Query<&Children>,
     color_override: Query<&ColorOverride>,
-    materials: Query<&MeshMaterial3d<StandardMaterial>>,
-    mut standard_materials: ResMut<Assets<StandardMaterial>>,
+    mesh_materials: Query<&MeshMaterial3d<StandardMaterial>>,
+    mut asset_materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // Get the `ColorOverride` of the entity, if it does not have a color override, skip
     let Ok(color_override) = color_override.get(trigger.target()) else {
         return;
     };
 
-    for child in children.iter_descendants(trigger.target()) {
-        if let Some(material) = materials
-            .get(child)
+    // Iterate over all children recursively
+    for descendants in children.iter_descendants(trigger.target()) {
+        // Get the material of the descendant
+        if let Some(material) = mesh_materials
+            .get(descendants)
             .ok()
-            .and_then(|id| standard_materials.get_mut(id.id()))
+            .and_then(|id| asset_materials.get_mut(id.id()))
         {
+            // Create a copy of the material and override base color
             let mut new_material = material.clone();
             new_material.base_color = color_override.0;
 
+            // Override `MeshMaterial3d` with new material
             commands
-                .entity(child)
-                .insert(MeshMaterial3d(standard_materials.add(new_material)));
+                .entity(descendants)
+                .insert(MeshMaterial3d(asset_materials.add(new_material)));
         }
     }
 }

--- a/examples/3d/edit_material_on_gltf.rs
+++ b/examples/3d/edit_material_on_gltf.rs
@@ -37,25 +37,20 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         Transform::from_xyz(0., 1., 0.25).looking_at(Vec3::ZERO, Dir3::Y),
     ));
 
+    // FlightHelmet handle
+    let flight_helmet = asset_server
+        .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"));
     // This model will keep its original materials
-    commands.spawn(SceneRoot(asset_server.load(
-        GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
-    )));
+    commands.spawn(SceneRoot(flight_helmet.clone()));
     // This model will be tinted red
     commands.spawn((
-        SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
-        ),
+        SceneRoot(flight_helmet.clone()),
         Transform::from_xyz(-1.25, 0., 0.),
         ColorOverride(palettes::tailwind::RED_300.into()),
     ));
     // This model will be tinted green
     commands.spawn((
-        SceneRoot(
-            asset_server
-                .load(GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf")),
-        ),
+        SceneRoot(flight_helmet),
         Transform::from_xyz(1.25, 0., 0.),
         ColorOverride(palettes::tailwind::GREEN_300.into()),
     ));
@@ -83,6 +78,9 @@ fn change_material(
             .and_then(|id| asset_materials.get_mut(id.id()))
         {
             // Create a copy of the material and override base color
+            // If you intend on creating multiple models with the same tint, it
+            // is best to cache the handle somewhere, as having multiple materials
+            // that are identical is expensive
             let mut new_material = material.clone();
             new_material.base_color = color_override.0;
 

--- a/examples/3d/edit_material_on_gltf.rs
+++ b/examples/3d/edit_material_on_gltf.rs
@@ -21,7 +21,8 @@ fn main() {
         .run();
 }
 
-/// This is added to a [`SceneRoot`] and will cause the [`StandardMaterial::base_color`] of all materials
+/// This is added to a [`SceneRoot`] and will cause the [`StandardMaterial::base_color`]
+/// of all materials to be overwritten
 #[derive(Component)]
 struct ColorOverride(Color);
 
@@ -36,7 +37,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         Transform::from_xyz(0., 1., 0.25).looking_at(Vec3::ZERO, Dir3::Y),
     ));
 
-    // This model will keep its original material
+    // This model will keep its original materials
     commands.spawn(SceneRoot(asset_server.load(
         GltfAssetLabel::Scene(0).from_asset("models/FlightHelmet/FlightHelmet.gltf"),
     )));

--- a/examples/README.md
+++ b/examples/README.md
@@ -150,6 +150,7 @@ Example | Description
 [Decal](../examples/3d/decal.rs) | Decal rendering
 [Deferred Rendering](../examples/3d/deferred_rendering.rs) | Renders meshes with both forward and deferred pipelines
 [Depth of field](../examples/3d/depth_of_field.rs) | Demonstrates depth of field
+[Edit Gltf Material](../examples/3d/edit_material_on_gltf.rs) | Showcases changing materials of a Gltf after Scene spawn
 [Fog](../examples/3d/fog.rs) | A scene showcasing the distance fog effect
 [Fog volumes](../examples/3d/fog_volumes.rs) | Demonstrates fog volumes
 [Generate Custom Mesh](../examples/3d/generate_custom_mesh.rs) | Simple showcase of how to generate a custom mesh with a custom texture


### PR DESCRIPTION
# Objective

Create a minimal example of how to modify the material from a `Gltf`. This is frequently asked about on the help channel of the discord.

## Solution

Create the example.

## Showcase

![image](https://github.com/user-attachments/assets/efeab96d-056d-4597-953b-80ee5162749c)