### PR TITLE
Interactable hidden overflow

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -250,7 +250,7 @@ pub fn ui_focus_system(
             // Intersect with the calculated clip rect to find the bounds of the visible region of the node
             let visible_rect = node
                 .calculated_clip
-                .map(|clip| node_rect.intersect(clip.clip))
+                .map(|clip| node_rect.intersect(clip.interactable))
                 .unwrap_or(node_rect);
 
             let cursor_position = camera_cursor_positions.get(&camera_entity);

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -149,9 +149,9 @@ pub fn ui_picking(
         }
 
         // Intersect with the calculated clip rect to find the bounds of the visible region of the node
-        let visible_rect = node
+        let interactable_rect = node
             .calculated_clip
-            .map(|clip| node_rect.intersect(clip.clip))
+            .map(|clip| node_rect.intersect(clip.interactable))
             .unwrap_or(node_rect);
 
         let pointers_on_this_cam = pointer_pos_by_camera.get(&camera_entity);
@@ -162,7 +162,7 @@ pub fn ui_picking(
         for (pointer_id, cursor_position) in pointers_on_this_cam.iter().flat_map(|h| h.iter()) {
             let relative_cursor_position = (*cursor_position - node_rect.min) / node_rect.size();
 
-            if visible_rect
+            if interactable_rect
                 .normalize(node_rect)
                 .contains(relative_cursor_position)
                 && pick_rounded_rect(

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -317,7 +317,7 @@ pub fn extract_shadows(
                 transform: transform.compute_matrix() * Mat4::from_translation(offset.extend(0.)),
                 color: drop_shadow.color.into(),
                 bounds: shadow_size + 6. * blur_radius,
-                clip: clip.map(|clip| clip.clip),
+                clip: clip.map(|clip| clip.visible),
                 extracted_camera_entity,
                 radius,
                 blur_radius,

--- a/crates/bevy_ui/src/render/debug_overlay.rs
+++ b/crates/bevy_ui/src/render/debug_overlay.rs
@@ -96,7 +96,7 @@ pub fn extract_debug_overlay(
             },
             clip: maybe_clip
                 .filter(|_| !debug_options.show_clipped)
-                .map(|clip| clip.clip),
+                .map(|clip| clip.visible),
             image: AssetId::default(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -366,7 +366,7 @@ pub fn extract_uinode_background_colors(
                 min: Vec2::ZERO,
                 max: uinode.size,
             },
-            clip: clip.map(|clip| clip.clip),
+            clip: clip.map(|clip| clip.visible),
             image: AssetId::default(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {
@@ -450,7 +450,7 @@ pub fn extract_uinode_images(
             stack_index: uinode.stack_index,
             color: image.color.into(),
             rect,
-            clip: clip.map(|clip| clip.clip),
+            clip: clip.map(|clip| clip.visible),
             image: image.image.id(),
             extracted_camera_entity,
             item: ExtractedUiItem::Node {
@@ -519,7 +519,7 @@ pub fn extract_uinode_borders(
                         ..Default::default()
                     },
                     image,
-                    clip: maybe_clip.map(|clip| clip.clip),
+                    clip: maybe_clip.map(|clip| clip.visible),
                     extracted_camera_entity,
                     item: ExtractedUiItem::Node {
                         atlas_scaling: None,
@@ -552,7 +552,7 @@ pub fn extract_uinode_borders(
                     ..Default::default()
                 },
                 image,
-                clip: maybe_clip.map(|clip| clip.clip),
+                clip: maybe_clip.map(|clip| clip.visible),
                 extracted_camera_entity,
                 item: ExtractedUiItem::Node {
                     transform: global_transform.compute_matrix(),
@@ -785,7 +785,7 @@ pub fn extract_text_sections(
                     stack_index: uinode.stack_index,
                     color,
                     image: atlas_info.texture.id(),
-                    clip: clip.map(|clip| clip.clip),
+                    clip: clip.map(|clip| clip.visible),
                     extracted_camera_entity,
                     rect,
                     item: ExtractedUiItem::Glyphs { range: start..end },

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -409,7 +409,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
             },
             border: computed_node.border(),
             border_radius: computed_node.border_radius(),
-            clip: clip.map(|clip| clip.clip),
+            clip: clip.map(|clip| clip.visible),
             extracted_camera_entity,
             main_entity: entity.into(),
         });

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -318,7 +318,7 @@ pub fn extract_ui_texture_slices(
                 min: Vec2::ZERO,
                 max: uinode.size,
             },
-            clip: clip.map(|clip| clip.clip),
+            clip: clip.map(|clip| clip.visible),
             image: image.image.id(),
             extracted_camera_entity,
             image_scale_mode,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1093,6 +1093,11 @@ impl Overflow {
         self.x.is_visible() && self.y.is_visible()
     }
 
+    /// Overflow is interactable on both axes
+    pub const fn is_interactable(&self) -> bool {
+        self.x.is_interactable() && self.y.is_interactable()
+    }
+
     pub const fn scroll() -> Self {
         Self {
             x: OverflowAxis::Scroll,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1149,6 +1149,11 @@ impl OverflowAxis {
     pub const fn is_visible(&self) -> bool {
         matches!(self, Self::Visible)
     }
+
+    /// Overflow is interactable on this axis
+    pub const fn is_interactable(&self) -> bool {
+        matches!(self, Self::Visible | Self::Hidden)
+    }
 }
 
 impl Default for OverflowAxis {
@@ -2133,12 +2138,15 @@ impl Outline {
     }
 }
 
-/// The calculated clip of the node
-#[derive(Component, Default, Copy, Clone, Debug, Reflect)]
-#[reflect(Component, Default, Debug)]
+/// The calculated clip of the node.
+/// The two rects are intersected to find the visable area.
+#[derive(Component, Default, Copy, Clone, Debug, Reflect, PartialEq)]
+#[reflect(Component, Default, Debug, PartialEq)]
 pub struct CalculatedClip {
-    /// The rect of the clip
-    pub clip: Rect,
+    /// Content outside this `Rect` is not visable
+    pub visible: Rect,
+    /// Content outside this `Rect` is not interactable
+    pub interactable: Rect,
 }
 
 /// Indicates that this [`Node`] entity's front-to-back ordering is not controlled solely

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2144,13 +2144,14 @@ impl Outline {
 }
 
 /// The calculated clip of the node.
-/// The two rects are intersected to find the visable area.
+/// Split into two `Rect`s that can be intersected with the node's bounding rect
+/// to find it's visible and interactable areas.
 #[derive(Component, Default, Copy, Clone, Debug, Reflect, PartialEq)]
 #[reflect(Component, Default, Debug, PartialEq)]
 pub struct CalculatedClip {
-    /// Content outside this `Rect` is not visable
+    /// Content outside this `Rect` should not be visible
     pub visible: Rect,
-    /// Content outside this `Rect` is not interactable
+    /// Content outside this `Rect` should not be interactable
     pub interactable: Rect,
 }
 

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -40,6 +40,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 Overflow::hidden_x(),
                 Overflow::hidden_y(),
                 Overflow::hidden(),
+                Overflow {
+                    x: OverflowAxis::Hidden,
+                    y: OverflowAxis::Clip,
+                },
             ] {
                 parent
                     .spawn(Node {

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -26,6 +26,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 height: Val::Percent(100.),
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
+                flex_wrap: FlexWrap::Wrap,
                 ..Default::default()
             },
             BackgroundColor(ANTIQUE_WHITE.into()),
@@ -36,6 +37,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 Overflow::clip_x(),
                 Overflow::clip_y(),
                 Overflow::clip(),
+                Overflow::hidden_x(),
+                Overflow::hidden_y(),
+                Overflow::hidden(),
             ] {
                 parent
                     .spawn(Node {
@@ -84,11 +88,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         ..default()
                                     },
                                     Interaction::default(),
-                                    Outline {
-                                        width: Val::Px(2.),
-                                        offset: Val::Px(2.),
-                                        color: Color::NONE,
-                                    },
                                 ));
                             });
                     });
@@ -96,13 +95,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-fn update_outlines(mut outlines_query: Query<(&mut Outline, Ref<Interaction>)>) {
-    for (mut outline, interaction) in outlines_query.iter_mut() {
+fn update_outlines(mut interactions_query: Query<(&mut ImageNode, Ref<Interaction>)>) {
+    for (mut image_node, interaction) in interactions_query.iter_mut() {
         if interaction.is_changed() {
-            outline.color = match *interaction {
+            image_node.color = match *interaction {
                 Interaction::Pressed => RED.into(),
-                Interaction::Hovered => WHITE.into(),
-                Interaction::None => Color::NONE,
+                Interaction::Hovered => YELLOW.into(),
+                Interaction::None => Color::WHITE,
             };
         }
     }


### PR DESCRIPTION
# Objective

Enable interactions for areas of UI Node's made non-visible with `OverflowAxis::Hidden`.

## Solution

Replace `CalculatedClip`'s `clip` field into two new fields `visible` and `interactable`.

In `update_clipping` update and propagate both the `interactable` and `visible` fields.

Rendering intersects UI node rects with `CalculatedClip::visible` to find the visible area of the nodes.
Interaction intersects UI node rects with `CalculatedClip::interactable` to find the interactable area of the nodes.

## Showcase
Extended the `overflow` example to showcase the new behaviours:
```
cargo run --example overflow
```

<img width="773" alt="overflow" src="https://github.com/user-attachments/assets/1dbffcd3-3e53-424f-a79b-cadbc7166cd5" />

## Testing

The `overflow` example above can be used for testing.

You should see that with `OverflowAxis::Hidden` interactions are enabled for the non-visible sections of the image node buttons on that axis. The sections clipped with `OverflowAxis::Clip` should be non-interactive.

## Migration Guide
`CalculatedClip` `clip: Rect` field has been split into two new fields:
```
pub struct CalculatedClip {
    /// Content outside this `Rect` should not be visible
    pub visible: Rect,
    /// Content outside this `Rect` should not be interactable
    pub interactable: Rect,
}
```
These fields can be intersected with a Node's bounding rect to find it's visible and interactable areas respectively.