### PR TITLE
Move `Item` and `fetch` to `QueryData` from `WorldQuery` 

### DIFF
--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     archetype::Archetype,
     component::{ComponentId, Tick},
     prelude::{Entity, Resource, World},
-    query::{FilteredAccess, QueryFilter, QueryItem, ReadFetch, WorldQuery},
+    query::{FilteredAccess, QueryData, QueryFilter, ReadFetch, WorldQuery},
     storage::{Table, TableRow},
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -151,12 +151,9 @@ pub struct AssetChangedState<A: AsAssetId> {
 #[expect(unsafe_code, reason = "WorldQuery is an unsafe trait.")]
 /// SAFETY: `ROQueryFetch<Self>` is the same as `QueryFetch<Self>`
 unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
-    type Item<'w> = ();
     type Fetch<'w> = AssetChangedFetch<'w, A>;
 
     type State = AssetChangedState<A>;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(_: QueryItem<'wlong, Self>) -> QueryItem<'wshort, Self> {}
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -227,8 +224,6 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
             }
         }
     }
-
-    unsafe fn fetch<'w>(_: &mut Self::Fetch<'w>, _: Entity, _: TableRow) -> Self::Item<'w> {}
 
     #[inline]
     fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {

--- a/crates/bevy_ecs/macros/src/query_filter.rs
+++ b/crates/bevy_ecs/macros/src/query_filter.rs
@@ -4,10 +4,7 @@ use proc_macro2::{Ident, Span};
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, parse_quote, Data, DataStruct, DeriveInput, Index};
 
-use crate::{
-    bevy_ecs_path,
-    world_query::{item_struct, world_query_impl},
-};
+use crate::{bevy_ecs_path, world_query::world_query_impl};
 
 mod field_attr_keywords {
     syn::custom_keyword!(ignore);
@@ -32,8 +29,6 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
         user_generics_with_world.split_for_impl();
 
     let struct_name = ast.ident;
-
-    let item_struct_name = Ident::new(&format!("{struct_name}Item"), Span::call_site());
 
     let fetch_struct_name = Ident::new(&format!("{struct_name}Fetch"), Span::call_site());
     let fetch_struct_name = ensure_no_collision(fetch_struct_name, tokens.clone());
@@ -81,35 +76,14 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
         field_types.push(quote!(#field_ty));
     }
 
-    let derive_macro_call = quote!();
-
-    let item_struct = item_struct(
-        &path,
-        fields,
-        &derive_macro_call,
-        &struct_name,
-        &visibility,
-        &item_struct_name,
-        &field_types,
-        &user_impl_generics_with_world,
-        &field_attrs,
-        &field_visibilities,
-        &field_idents,
-        &user_ty_generics,
-        &user_ty_generics_with_world,
-        user_where_clauses_with_world,
-    );
-
     let world_query_impl = world_query_impl(
         &path,
         &struct_name,
         &visibility,
-        &item_struct_name,
         &fetch_struct_name,
         &field_types,
         &user_impl_generics,
         &user_impl_generics_with_world,
-        &field_idents,
         &user_ty_generics,
         &user_ty_generics_with_world,
         &named_field_idents,
@@ -142,8 +116,6 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(quote! {
-        #item_struct
-
         const _: () = {
             #[doc(hidden)]
             #[doc = concat!(

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -34,14 +34,14 @@ pub(crate) fn item_struct(
             #derive_macro_call
             #item_attrs
             #visibility struct #item_struct_name #user_impl_generics_with_world #user_where_clauses_with_world {
-                #(#(#field_attrs)* #field_visibilities #field_idents: <#field_types as #path::query::WorldQuery>::Item<'__w>,)*
+                #(#(#field_attrs)* #field_visibilities #field_idents: <#field_types as #path::query::QueryData>::Item<'__w>,)*
             }
         },
         Fields::Unnamed(_) => quote! {
             #derive_macro_call
             #item_attrs
             #visibility struct #item_struct_name #user_impl_generics_with_world #user_where_clauses_with_world(
-                #( #field_visibilities <#field_types as #path::query::WorldQuery>::Item<'__w>, )*
+                #( #field_visibilities <#field_types as #path::query::QueryData>::Item<'__w>, )*
             );
         },
         Fields::Unit => quote! {
@@ -55,12 +55,10 @@ pub(crate) fn world_query_impl(
     path: &syn::Path,
     struct_name: &Ident,
     visibility: &Visibility,
-    item_struct_name: &Ident,
     fetch_struct_name: &Ident,
     field_types: &Vec<proc_macro2::TokenStream>,
     user_impl_generics: &ImplGenerics,
     user_impl_generics_with_world: &ImplGenerics,
-    field_idents: &Vec<proc_macro2::TokenStream>,
     user_ty_generics: &TypeGenerics,
     user_ty_generics_with_world: &TypeGenerics,
     named_field_idents: &Vec<Ident>,
@@ -98,19 +96,8 @@ pub(crate) fn world_query_impl(
         unsafe impl #user_impl_generics #path::query::WorldQuery
             for #struct_name #user_ty_generics #user_where_clauses {
 
-            type Item<'__w> = #item_struct_name #user_ty_generics_with_world;
             type Fetch<'__w> = #fetch_struct_name #user_ty_generics_with_world;
             type State = #state_struct_name #user_ty_generics;
-
-            fn shrink<'__wlong: '__wshort, '__wshort>(
-                item: <#struct_name #user_ty_generics as #path::query::WorldQuery>::Item<'__wlong>
-            ) -> <#struct_name #user_ty_generics as #path::query::WorldQuery>::Item<'__wshort> {
-                #item_struct_name {
-                    #(
-                        #field_idents: <#field_types>::shrink(item.#field_idents),
-                    )*
-                }
-            }
 
             fn shrink_fetch<'__wlong: '__wshort, '__wshort>(
                 fetch: <#struct_name #user_ty_generics as #path::query::WorldQuery>::Fetch<'__wlong>
@@ -163,18 +150,6 @@ pub(crate) fn world_query_impl(
                 _table: &'__w #path::storage::Table
             ) {
                 #(<#field_types>::set_table(&mut _fetch.#named_field_idents, &_state.#named_field_idents, _table);)*
-            }
-
-            /// SAFETY: we call `fetch` for each member that implements `Fetch`.
-            #[inline(always)]
-            unsafe fn fetch<'__w>(
-                _fetch: &mut <Self as #path::query::WorldQuery>::Fetch<'__w>,
-                _entity: #path::entity::Entity,
-                _table_row: #path::storage::TableRow,
-            ) -> <Self as #path::query::WorldQuery>::Item<'__w> {
-                Self::Item {
-                    #(#field_idents: <#field_types>::fetch(&mut _fetch.#named_field_idents, _entity, _table_row),)*
-                }
             }
 
             fn update_component_access(state: &Self::State, _access: &mut #path::query::FilteredAccess<#path::component::ComponentId>) {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -278,6 +278,38 @@ use variadics_please::all_tuples;
 pub unsafe trait QueryData: WorldQuery {
     /// The read-only variant of this [`QueryData`], which satisfies the [`ReadOnlyQueryData`] trait.
     type ReadOnly: ReadOnlyQueryData<State = <Self as WorldQuery>::State>;
+
+    /// The item returned by this [`WorldQuery`]
+    /// For `QueryData` this will be the data retrieved by the query,
+    /// and is visible to the end user when calling e.g. `Query<Self>::get`.
+    ///
+    /// For `QueryFilter` this will be either `()`, or a `bool` indicating whether the entity should be included
+    /// or a tuple of such things.
+    /// Archetypal query filters (like `With`) set this to `()`,
+    /// as the filtering is done by selecting the archetypes to iterate over via [`WorldQuery::matches_component_set`],
+    /// while non-archetypal query filters (like `Changed`) set this to a `bool` and evaluate the filter for each entity,
+    /// after the set of possible archetypes has been narrowed down.
+    type Item<'a>;
+
+    /// This function manually implements subtyping for the query items.
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort>;
+
+    /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
+    /// or for the given `entity` in the current [`Archetype`]. This must always be called after
+    /// [`WorldQuery::set_table`] with a `table_row` in the range of the current [`Table`] or after
+    /// [`WorldQuery::set_archetype`]  with an `entity` in the current archetype.
+    /// Accesses components registered in [`WorldQuery::update_component_access`].
+    ///
+    /// # Safety
+    ///
+    /// - Must always be called _after_ [`WorldQuery::set_table`] or [`WorldQuery::set_archetype`]. `entity` and
+    ///   `table_row` must be in the range of the current table and archetype.
+    /// - There must not be simultaneous conflicting component access registered in `update_component_access`.
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w>;
 }
 
 /// A [`QueryData`] that is read only.
@@ -288,7 +320,7 @@ pub unsafe trait QueryData: WorldQuery {
 pub unsafe trait ReadOnlyQueryData: QueryData<ReadOnly = Self> {}
 
 /// The item type returned when a [`WorldQuery`] is iterated over
-pub type QueryItem<'w, Q> = <Q as WorldQuery>::Item<'w>;
+pub type QueryItem<'w, Q> = <Q as QueryData>::Item<'w>;
 /// The read-only variant of the item type returned when a [`QueryData`] is iterated over immutably
 pub type ROQueryItem<'w, D> = QueryItem<'w, <D as QueryData>::ReadOnly>;
 
@@ -296,13 +328,8 @@ pub type ROQueryItem<'w, D> = QueryItem<'w, <D as QueryData>::ReadOnly>;
 /// `update_component_access` and `update_archetype_component_access` do nothing.
 /// This is sound because `fetch` does not access components.
 unsafe impl WorldQuery for Entity {
-    type Item<'w> = Entity;
     type Fetch<'w> = ();
     type State = ();
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(_: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {}
 
@@ -329,15 +356,6 @@ unsafe impl WorldQuery for Entity {
     unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        _fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        entity
-    }
-
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &mut World) {}
@@ -357,6 +375,21 @@ unsafe impl WorldQuery for Entity {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for Entity {
     type ReadOnly = Self;
+
+    type Item<'w> = Entity;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        entity
+    }
 }
 
 /// SAFETY: access is read only
@@ -366,13 +399,8 @@ unsafe impl ReadOnlyQueryData for Entity {}
 /// `update_component_access` and `update_archetype_component_access` do nothing.
 /// This is sound because `fetch` does not access components.
 unsafe impl WorldQuery for EntityLocation {
-    type Item<'w> = EntityLocation;
     type Fetch<'w> = &'w Entities;
     type State = ();
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -404,16 +432,6 @@ unsafe impl WorldQuery for EntityLocation {
     unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        // SAFETY: `fetch` must be called with an entity that exists in the world
-        unsafe { fetch.get(entity).debug_checked_unwrap() }
-    }
-
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &mut World) {}
@@ -433,6 +451,21 @@ unsafe impl WorldQuery for EntityLocation {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for EntityLocation {
     type ReadOnly = Self;
+    type Item<'w> = EntityLocation;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: `fetch` must be called with an entity that exists in the world
+        unsafe { fetch.get(entity).debug_checked_unwrap() }
+    }
 }
 
 /// SAFETY: access is read only
@@ -443,13 +476,8 @@ unsafe impl ReadOnlyQueryData for EntityLocation {}
 /// This is sound because `update_component_access` and `update_archetype_component_access` set read access for all components and panic when appropriate.
 /// Filters are unchanged.
 unsafe impl<'a> WorldQuery for EntityRef<'a> {
-    type Item<'w> = EntityRef<'w>;
     type Fetch<'w> = UnsafeWorldCell<'w>;
     type State = ();
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -477,18 +505,6 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
 
     #[inline]
     unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
-    }
-
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        world: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        // SAFETY: `fetch` must be called with an entity that exists in the world
-        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
-        // SAFETY: Read-only access to every component has been registered.
-        unsafe { EntityRef::new(cell) }
     }
 
     fn update_component_access(_state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
@@ -516,6 +532,23 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'a> QueryData for EntityRef<'a> {
     type ReadOnly = Self;
+    type Item<'w> = EntityRef<'w>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        world: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: `fetch` must be called with an entity that exists in the world
+        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
+        // SAFETY: Read-only access to every component has been registered.
+        unsafe { EntityRef::new(cell) }
+    }
 }
 
 /// SAFETY: access is read only
@@ -523,13 +556,8 @@ unsafe impl ReadOnlyQueryData for EntityRef<'_> {}
 
 /// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
 unsafe impl<'a> WorldQuery for EntityMut<'a> {
-    type Item<'w> = EntityMut<'w>;
     type Fetch<'w> = UnsafeWorldCell<'w>;
     type State = ();
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -559,18 +587,6 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        world: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        // SAFETY: `fetch` must be called with an entity that exists in the world
-        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
-        // SAFETY: mutable access to every component has been registered.
-        unsafe { EntityMut::new(cell) }
-    }
-
     fn update_component_access(_state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
         assert!(
             !access.access().has_any_component_read(),
@@ -596,17 +612,29 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
 /// SAFETY: access of `EntityRef` is a subset of `EntityMut`
 unsafe impl<'a> QueryData for EntityMut<'a> {
     type ReadOnly = EntityRef<'a>;
+    type Item<'w> = EntityMut<'w>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        world: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: `fetch` must be called with an entity that exists in the world
+        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
+        // SAFETY: mutable access to every component has been registered.
+        unsafe { EntityMut::new(cell) }
+    }
 }
 
 /// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
 unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
     type Fetch<'w> = (UnsafeWorldCell<'w>, Access<ComponentId>);
-    type Item<'w> = FilteredEntityRef<'w>;
     type State = FilteredAccess<ComponentId>;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -646,18 +674,6 @@ unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
         state.access_mut().clear_writes();
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        (world, access): &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        // SAFETY: `fetch` must be called with an entity that exists in the world
-        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
-        // SAFETY: mutable access to every component has been registered.
-        unsafe { FilteredEntityRef::new(cell, access.clone()) }
-    }
-
     fn update_component_access(
         state: &Self::State,
         filtered_access: &mut FilteredAccess<ComponentId>,
@@ -688,6 +704,23 @@ unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'a> QueryData for FilteredEntityRef<'a> {
     type ReadOnly = Self;
+    type Item<'w> = FilteredEntityRef<'w>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        (world, access): &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: `fetch` must be called with an entity that exists in the world
+        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
+        // SAFETY: mutable access to every component has been registered.
+        unsafe { FilteredEntityRef::new(cell, access.clone()) }
+    }
 }
 
 /// SAFETY: Access is read-only.
@@ -696,12 +729,7 @@ unsafe impl ReadOnlyQueryData for FilteredEntityRef<'_> {}
 /// SAFETY: The accesses of `Self::ReadOnly` are a subset of the accesses of `Self`
 unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
     type Fetch<'w> = (UnsafeWorldCell<'w>, Access<ComponentId>);
-    type Item<'w> = FilteredEntityMut<'w>;
     type State = FilteredAccess<ComponentId>;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -740,18 +768,6 @@ unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
         state.clone_from(access);
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        (world, access): &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        // SAFETY: `fetch` must be called with an entity that exists in the world
-        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
-        // SAFETY: mutable access to every component has been registered.
-        unsafe { FilteredEntityMut::new(cell, access.clone()) }
-    }
-
     fn update_component_access(
         state: &Self::State,
         filtered_access: &mut FilteredAccess<ComponentId>,
@@ -782,6 +798,23 @@ unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
 /// SAFETY: access of `FilteredEntityRef` is a subset of `FilteredEntityMut`
 unsafe impl<'a> QueryData for FilteredEntityMut<'a> {
     type ReadOnly = FilteredEntityRef<'a>;
+    type Item<'w> = FilteredEntityMut<'w>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        (world, access): &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        // SAFETY: `fetch` must be called with an entity that exists in the world
+        let cell = unsafe { world.get_entity(entity).debug_checked_unwrap() };
+        // SAFETY: mutable access to every component has been registered.
+        unsafe { FilteredEntityMut::new(cell, access.clone()) }
+    }
 }
 
 /// SAFETY: `EntityRefExcept` guards access to all components in the bundle `B`
@@ -792,12 +825,7 @@ where
     B: Bundle,
 {
     type Fetch<'w> = UnsafeWorldCell<'w>;
-    type Item<'w> = EntityRefExcept<'w, B>;
     type State = SmallVec<[ComponentId; 4]>;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -823,15 +851,6 @@ where
     }
 
     unsafe fn set_table<'w>(_: &mut Self::Fetch<'w>, _: &Self::State, _: &'w Table) {}
-
-    unsafe fn fetch<'w>(
-        world: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _: TableRow,
-    ) -> Self::Item<'w> {
-        let cell = world.get_entity(entity).unwrap();
-        EntityRefExcept::new(cell)
-    }
 
     fn update_component_access(
         state: &Self::State,
@@ -877,6 +896,20 @@ where
     B: Bundle,
 {
     type ReadOnly = Self;
+    type Item<'w> = EntityRefExcept<'w, B>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    unsafe fn fetch<'w>(
+        world: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _: TableRow,
+    ) -> Self::Item<'w> {
+        let cell = world.get_entity(entity).unwrap();
+        EntityRefExcept::new(cell)
+    }
 }
 
 /// SAFETY: `EntityRefExcept` enforces read-only access to its contained
@@ -891,12 +924,7 @@ where
     B: Bundle,
 {
     type Fetch<'w> = UnsafeWorldCell<'w>;
-    type Item<'w> = EntityMutExcept<'w, B>;
     type State = SmallVec<[ComponentId; 4]>;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -922,15 +950,6 @@ where
     }
 
     unsafe fn set_table<'w>(_: &mut Self::Fetch<'w>, _: &Self::State, _: &'w Table) {}
-
-    unsafe fn fetch<'w>(
-        world: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _: TableRow,
-    ) -> Self::Item<'w> {
-        let cell = world.get_entity(entity).unwrap();
-        EntityMutExcept::new(cell)
-    }
 
     fn update_component_access(
         state: &Self::State,
@@ -977,19 +996,28 @@ where
     B: Bundle,
 {
     type ReadOnly = EntityRefExcept<'a, B>;
+    type Item<'w> = EntityMutExcept<'w, B>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    unsafe fn fetch<'w>(
+        world: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _: TableRow,
+    ) -> Self::Item<'w> {
+        let cell = world.get_entity(entity).unwrap();
+        EntityMutExcept::new(cell)
+    }
 }
 
 /// SAFETY:
 /// `update_component_access` and `update_archetype_component_access` do nothing.
 /// This is sound because `fetch` does not access components.
 unsafe impl WorldQuery for &Archetype {
-    type Item<'w> = &'w Archetype;
     type Fetch<'w> = (&'w Entities, &'w Archetypes);
     type State = ();
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -1021,19 +1049,6 @@ unsafe impl WorldQuery for &Archetype {
     unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        let (entities, archetypes) = *fetch;
-        // SAFETY: `fetch` must be called with an entity that exists in the world
-        let location = unsafe { entities.get(entity).debug_checked_unwrap() };
-        // SAFETY: The assigned archetype for a living entity must always be valid.
-        unsafe { archetypes.get(location.archetype_id).debug_checked_unwrap() }
-    }
-
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &mut World) {}
@@ -1053,6 +1068,24 @@ unsafe impl WorldQuery for &Archetype {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for &Archetype {
     type ReadOnly = Self;
+    type Item<'w> = &'w Archetype;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        let (entities, archetypes) = *fetch;
+        // SAFETY: `fetch` must be called with an entity that exists in the world
+        let location = unsafe { entities.get(entity).debug_checked_unwrap() };
+        // SAFETY: The assigned archetype for a living entity must always be valid.
+        unsafe { archetypes.get(location.archetype_id).debug_checked_unwrap() }
+    }
 }
 
 /// SAFETY: access is read only
@@ -1082,13 +1115,8 @@ impl<T: Component> Copy for ReadFetch<'_, T> {}
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<T: Component> WorldQuery for &T {
-    type Item<'w> = &'w T;
     type Fetch<'w> = ReadFetch<'w, T>;
     type State = ComponentId;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: &'wlong T) -> &'wshort T {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -1159,28 +1187,6 @@ unsafe impl<T: Component> WorldQuery for &T {
         unsafe { fetch.components.set_table(table_data) };
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        table_row: TableRow,
-    ) -> Self::Item<'w> {
-        fetch.components.extract(
-            |table| {
-                // SAFETY: set_table was previously called
-                let table = unsafe { table.debug_checked_unwrap() };
-                // SAFETY: Caller ensures `table_row` is in range.
-                let item = unsafe { table.get(table_row.as_usize()) };
-                item.deref()
-            },
-            |sparse_set| {
-                // SAFETY: Caller ensures `entity` is in range.
-                let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
-                item.deref()
-            },
-        )
-    }
-
     fn update_component_access(
         &component_id: &ComponentId,
         access: &mut FilteredAccess<ComponentId>,
@@ -1212,6 +1218,33 @@ unsafe impl<T: Component> WorldQuery for &T {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<T: Component> QueryData for &T {
     type ReadOnly = Self;
+    type Item<'w> = &'w T;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: &'wlong T) -> &'wshort T {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w> {
+        fetch.components.extract(
+            |table| {
+                // SAFETY: set_table was previously called
+                let table = unsafe { table.debug_checked_unwrap() };
+                // SAFETY: Caller ensures `table_row` is in range.
+                let item = unsafe { table.get(table_row.as_usize()) };
+                item.deref()
+            },
+            |sparse_set| {
+                // SAFETY: Caller ensures `entity` is in range.
+                let item = unsafe { sparse_set.get(entity).debug_checked_unwrap() };
+                item.deref()
+            },
+        )
+    }
 }
 
 /// SAFETY: access is read only
@@ -1248,13 +1281,8 @@ impl<T: Component> Copy for RefFetch<'_, T> {}
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
-    type Item<'w> = Ref<'w, T>;
     type Fetch<'w> = RefFetch<'w, T>;
     type State = ComponentId;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Ref<'wlong, T>) -> Ref<'wshort, T> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -1331,6 +1359,43 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         unsafe { fetch.components.set_table(table_data) };
     }
 
+    fn update_component_access(
+        &component_id: &ComponentId,
+        access: &mut FilteredAccess<ComponentId>,
+    ) {
+        assert!(
+            !access.access().has_component_write(component_id),
+            "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
+            core::any::type_name::<T>(),
+        );
+        access.add_component_read(component_id);
+    }
+
+    fn init_state(world: &mut World) -> ComponentId {
+        world.register_component::<T>()
+    }
+
+    fn get_state(components: &Components) -> Option<Self::State> {
+        components.component_id::<T>()
+    }
+
+    fn matches_component_set(
+        &state: &ComponentId,
+        set_contains_id: &impl Fn(ComponentId) -> bool,
+    ) -> bool {
+        set_contains_id(state)
+    }
+}
+
+/// SAFETY: `Self` is the same as `Self::ReadOnly`
+unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {
+    type ReadOnly = Self;
+    type Item<'w> = Ref<'w, T>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Ref<'wlong, T>) -> Ref<'wshort, T> {
+        item
+    }
+
     #[inline(always)]
     unsafe fn fetch<'w>(
         fetch: &mut Self::Fetch<'w>,
@@ -1379,38 +1444,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
             },
         )
     }
-
-    fn update_component_access(
-        &component_id: &ComponentId,
-        access: &mut FilteredAccess<ComponentId>,
-    ) {
-        assert!(
-            !access.access().has_component_write(component_id),
-            "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
-            core::any::type_name::<T>(),
-        );
-        access.add_component_read(component_id);
-    }
-
-    fn init_state(world: &mut World) -> ComponentId {
-        world.register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
-    }
-
-    fn matches_component_set(
-        &state: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
-    ) -> bool {
-        set_contains_id(state)
-    }
-}
-
-/// SAFETY: `Self` is the same as `Self::ReadOnly`
-unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {
-    type ReadOnly = Self;
 }
 
 /// SAFETY: access is read only
@@ -1447,13 +1480,8 @@ impl<T: Component> Copy for WriteFetch<'_, T> {}
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
-    type Item<'w> = Mut<'w, T>;
     type Fetch<'w> = WriteFetch<'w, T>;
     type State = ComponentId;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Mut<'wlong, T>) -> Mut<'wshort, T> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -1530,6 +1558,43 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         unsafe { fetch.components.set_table(table_data) };
     }
 
+    fn update_component_access(
+        &component_id: &ComponentId,
+        access: &mut FilteredAccess<ComponentId>,
+    ) {
+        assert!(
+            !access.access().has_component_read(component_id),
+            "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
+            core::any::type_name::<T>(),
+        );
+        access.add_component_write(component_id);
+    }
+
+    fn init_state(world: &mut World) -> ComponentId {
+        world.register_component::<T>()
+    }
+
+    fn get_state(components: &Components) -> Option<Self::State> {
+        components.component_id::<T>()
+    }
+
+    fn matches_component_set(
+        &state: &ComponentId,
+        set_contains_id: &impl Fn(ComponentId) -> bool,
+    ) -> bool {
+        set_contains_id(state)
+    }
+}
+
+/// SAFETY: access of `&T` is a subset of `&mut T`
+unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T {
+    type ReadOnly = &'__w T;
+    type Item<'w> = Mut<'w, T>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Mut<'wlong, T>) -> Mut<'wshort, T> {
+        item
+    }
+
     #[inline(always)]
     unsafe fn fetch<'w>(
         fetch: &mut Self::Fetch<'w>,
@@ -1578,38 +1643,6 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
             },
         )
     }
-
-    fn update_component_access(
-        &component_id: &ComponentId,
-        access: &mut FilteredAccess<ComponentId>,
-    ) {
-        assert!(
-            !access.access().has_component_read(component_id),
-            "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
-            core::any::type_name::<T>(),
-        );
-        access.add_component_write(component_id);
-    }
-
-    fn init_state(world: &mut World) -> ComponentId {
-        world.register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
-    }
-
-    fn matches_component_set(
-        &state: &ComponentId,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
-    ) -> bool {
-        set_contains_id(state)
-    }
-}
-
-/// SAFETY: access of `&T` is a subset of `&mut T`
-unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T {
-    type ReadOnly = &'__w T;
 }
 
 /// When `Mut<T>` is used in a query, it will be converted to `Ref<T>` when transformed into its read-only form, providing access to change detection methods.
@@ -1622,14 +1655,8 @@ unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T 
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.
 unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
-    type Item<'w> = Mut<'w, T>;
     type Fetch<'w> = WriteFetch<'w, T>;
     type State = ComponentId;
-
-    // Forwarded to `&mut T`
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Mut<'wlong, T>) -> Mut<'wshort, T> {
-        <&mut T as WorldQuery>::shrink(item)
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -1664,18 +1691,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
     // Forwarded to `&mut T`
     unsafe fn set_table<'w>(fetch: &mut WriteFetch<'w, T>, state: &ComponentId, table: &'w Table) {
         <&mut T as WorldQuery>::set_table(fetch, state, table);
-    }
-
-    #[inline(always)]
-    // Forwarded to `&mut T`
-    unsafe fn fetch<'w>(
-        // Rust complains about lifetime bounds not matching the trait if I directly use `WriteFetch<'w, T>` right here.
-        // But it complains nowhere else in the entire trait implementation.
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        table_row: TableRow,
-    ) -> Mut<'w, T> {
-        <&mut T as WorldQuery>::fetch(fetch, entity, table_row)
     }
 
     // NOT forwarded to `&mut T`
@@ -1713,8 +1728,26 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
 }
 
 // SAFETY: access of `Ref<T>` is a subset of `Mut<T>`
-unsafe impl<'__w, T: Component> QueryData for Mut<'__w, T> {
+unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for Mut<'__w, T> {
     type ReadOnly = Ref<'__w, T>;
+    type Item<'w> = Mut<'w, T>;
+
+    // Forwarded to `&mut T`
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Mut<'wlong, T>) -> Mut<'wshort, T> {
+        <&mut T as QueryData>::shrink(item)
+    }
+
+    #[inline(always)]
+    // Forwarded to `&mut T`
+    unsafe fn fetch<'w>(
+        // Rust complains about lifetime bounds not matching the trait if I directly use `WriteFetch<'w, T>` right here.
+        // But it complains nowhere else in the entire trait implementation.
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Mut<'w, T> {
+        <&mut T as QueryData>::fetch(fetch, entity, table_row)
+    }
 }
 
 #[doc(hidden)]
@@ -1737,13 +1770,8 @@ impl<T: WorldQuery> Clone for OptionFetch<'_, T> {
 /// This is sound because `update_component_access` and `update_archetype_component_access` add the same accesses as `T`.
 /// Filters are unchanged.
 unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
-    type Item<'w> = Option<T::Item<'w>>;
     type Fetch<'w> = OptionFetch<'w, T>;
     type State = T::State;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item.map(T::shrink)
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         OptionFetch {
@@ -1795,18 +1823,6 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
         }
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        entity: Entity,
-        table_row: TableRow,
-    ) -> Self::Item<'w> {
-        fetch
-            .matches
-            // SAFETY: The invariants are upheld by the caller.
-            .then(|| unsafe { T::fetch(&mut fetch.fetch, entity, table_row) })
-    }
-
     fn update_component_access(state: &T::State, access: &mut FilteredAccess<ComponentId>) {
         // FilteredAccess::add_[write,read] adds the component to the `with` filter.
         // Those methods are called on `access` in `T::update_component_access`.
@@ -1841,6 +1857,23 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
 // SAFETY: defers to soundness of `T: WorldQuery` impl
 unsafe impl<T: QueryData> QueryData for Option<T> {
     type ReadOnly = Option<T::ReadOnly>;
+    type Item<'w> = Option<T::Item<'w>>;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item.map(T::shrink)
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        entity: Entity,
+        table_row: TableRow,
+    ) -> Self::Item<'w> {
+        fetch
+            .matches
+            // SAFETY: The invariants are upheld by the caller.
+            .then(|| unsafe { T::fetch(&mut fetch.fetch, entity, table_row) })
+    }
 }
 
 /// SAFETY: [`OptionFetch`] is read only because `T` is read only
@@ -1921,13 +1954,8 @@ impl<T> core::fmt::Debug for Has<T> {
 /// `update_component_access` and `update_archetype_component_access` do nothing.
 /// This is sound because `fetch` does not access components.
 unsafe impl<T: Component> WorldQuery for Has<T> {
-    type Item<'w> = bool;
     type Fetch<'w> = bool;
     type State = ComponentId;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-        item
-    }
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
         fetch
@@ -1965,15 +1993,6 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
         *fetch = table.has_column(*state);
     }
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        fetch: &mut Self::Fetch<'w>,
-        _entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-        *fetch
-    }
-
     fn update_component_access(
         &component_id: &Self::State,
         access: &mut FilteredAccess<ComponentId>,
@@ -2001,6 +2020,20 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<T: Component> QueryData for Has<T> {
     type ReadOnly = Self;
+    type Item<'w> = bool;
+
+    fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+        item
+    }
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        fetch: &mut Self::Fetch<'w>,
+        _entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+        *fetch
+    }
 }
 
 /// SAFETY: [`Has`] is read only
@@ -2015,10 +2048,45 @@ pub struct AnyOf<T>(PhantomData<T>);
 
 macro_rules! impl_tuple_query_data {
     ($(#[$meta:meta])* $(($name: ident, $state: ident)),*) => {
+        #[expect(
+            clippy::allow_attributes,
+            reason = "This is a tuple-related macro; as such the lints below may not always apply."
+        )]
+        #[allow(
+            non_snake_case,
+            reason = "The names of some variables are provided by the macro's caller, not by us."
+        )]
+        #[allow(
+            unused_variables,
+            reason = "Zero-length tuples won't use any of the parameters."
+        )]
+        #[allow(
+            clippy::unused_unit,
+            reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
+        )]
         $(#[$meta])*
         // SAFETY: defers to soundness `$name: WorldQuery` impl
         unsafe impl<$($name: QueryData),*> QueryData for ($($name,)*) {
             type ReadOnly = ($($name::ReadOnly,)*);
+            type Item<'w> = ($($name::Item<'w>,)*);
+
+            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+                let ($($name,)*) = item;
+                ($(
+                    $name::shrink($name),
+                )*)
+            }
+
+            #[inline(always)]
+            unsafe fn fetch<'w>(
+                fetch: &mut Self::Fetch<'w>,
+                entity: Entity,
+                table_row: TableRow
+            ) -> Self::Item<'w> {
+                let ($($name,)*) = fetch;
+                // SAFETY: The invariants are upheld by the caller.
+                ($(unsafe { $name::fetch($name, entity, table_row) },)*)
+            }
         }
 
         $(#[$meta])*
@@ -2054,15 +2122,8 @@ macro_rules! impl_anytuple_fetch {
         /// This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
         unsafe impl<$($name: WorldQuery),*> WorldQuery for AnyOf<($($name,)*)> {
             type Fetch<'w> = ($(($name::Fetch<'w>, bool),)*);
-            type Item<'w> = ($(Option<$name::Item<'w>>,)*);
             type State = ($($name::State,)*);
 
-            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-                let ($($name,)*) = item;
-                ($(
-                    $name.map($name::shrink),
-                )*)
-            }
             fn shrink_fetch<'wlong: 'wshort, 'wshort>(fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
                 let ($($name,)*) = fetch;
                 ($(
@@ -2073,7 +2134,7 @@ macro_rules! impl_anytuple_fetch {
             #[inline]
             unsafe fn init_fetch<'w>(_world: UnsafeWorldCell<'w>, state: &Self::State, _last_run: Tick, _this_run: Tick) -> Self::Fetch<'w> {
                 let ($($name,)*) = state;
-                 // SAFETY: The invariants are upheld by the caller.
+                // SAFETY: The invariants are upheld by the caller.
                 ($(( unsafe { $name::init_fetch(_world, $name, _last_run, _this_run) }, false),)*)
             }
 
@@ -2091,7 +2152,7 @@ macro_rules! impl_anytuple_fetch {
                 $(
                     $name.1 = $name::matches_component_set($state, &|id| _archetype.contains(id));
                     if $name.1 {
-                         // SAFETY: The invariants are upheld by the caller.
+                        // SAFETY: The invariants are upheld by the caller.
                         unsafe { $name::set_archetype(&mut $name.0, $state, _archetype, _table); }
                     }
                 )*
@@ -2104,23 +2165,10 @@ macro_rules! impl_anytuple_fetch {
                 $(
                     $name.1 = $name::matches_component_set($state, &|id| _table.has_column(id));
                     if $name.1 {
-                         // SAFETY: The invariants are required to be upheld by the caller.
+                        // SAFETY: The invariants are required to be upheld by the caller.
                         unsafe { $name::set_table(&mut $name.0, $state, _table); }
                     }
                 )*
-            }
-
-            #[inline(always)]
-            unsafe fn fetch<'w>(
-                _fetch: &mut Self::Fetch<'w>,
-                _entity: Entity,
-                _table_row: TableRow
-            ) -> Self::Item<'w> {
-                let ($($name,)*) = _fetch;
-                ($(
-                    // SAFETY: The invariants are required to be upheld by the caller.
-                    $name.1.then(|| unsafe { $name::fetch(&mut $name.0, _entity, _table_row) }),
-                )*)
             }
 
             fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
@@ -2162,10 +2210,47 @@ macro_rules! impl_anytuple_fetch {
             }
         }
 
+        #[expect(
+            clippy::allow_attributes,
+            reason = "This is a tuple-related macro; as such the lints below may not always apply."
+        )]
+        #[allow(
+            non_snake_case,
+            reason = "The names of some variables are provided by the macro's caller, not by us."
+        )]
+        #[allow(
+            unused_variables,
+            reason = "Zero-length tuples won't use any of the parameters."
+        )]
+        #[allow(
+            clippy::unused_unit,
+            reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
+        )]
         $(#[$meta])*
         // SAFETY: defers to soundness of `$name: WorldQuery` impl
         unsafe impl<$($name: QueryData),*> QueryData for AnyOf<($($name,)*)> {
             type ReadOnly = AnyOf<($($name::ReadOnly,)*)>;
+            type Item<'w> = ($(Option<$name::Item<'w>>,)*);
+
+            fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+                let ($($name,)*) = item;
+                ($(
+                    $name.map($name::shrink),
+                )*)
+            }
+
+            #[inline(always)]
+            unsafe fn fetch<'w>(
+                _fetch: &mut Self::Fetch<'w>,
+                _entity: Entity,
+                _table_row: TableRow
+            ) -> Self::Item<'w> {
+                let ($($name,)*) = _fetch;
+                ($(
+                    // SAFETY: The invariants are required to be upheld by the caller.
+                    $name.1.then(|| unsafe { $name::fetch(&mut $name.0, _entity, _table_row) }),
+                )*)
+            }
         }
 
         $(#[$meta])*
@@ -2200,11 +2285,8 @@ pub(crate) struct NopWorldQuery<D: QueryData>(PhantomData<D>);
 /// `update_component_access` and `update_archetype_component_access` do nothing.
 /// This is sound because `fetch` does not access components.
 unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
-    type Item<'w> = ();
     type Fetch<'w> = ();
     type State = D::State;
-
-    fn shrink<'wlong: 'wshort, 'wshort>(_: ()) {}
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(_: ()) {}
 
@@ -2231,14 +2313,6 @@ unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
     #[inline(always)]
     unsafe fn set_table<'w>(_fetch: &mut (), _state: &D::State, _table: &Table) {}
 
-    #[inline(always)]
-    unsafe fn fetch<'w>(
-        _fetch: &mut Self::Fetch<'w>,
-        _entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-    }
-
     fn update_component_access(_state: &D::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(world: &mut World) -> Self::State {
@@ -2260,6 +2334,17 @@ unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
 /// SAFETY: `Self::ReadOnly` is `Self`
 unsafe impl<D: QueryData> QueryData for NopWorldQuery<D> {
     type ReadOnly = Self;
+    type Item<'w> = ();
+
+    fn shrink<'wlong: 'wshort, 'wshort>(_: ()) {}
+
+    #[inline(always)]
+    unsafe fn fetch<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+    }
 }
 
 /// SAFETY: `NopFetch` never accesses any data
@@ -2269,12 +2354,9 @@ unsafe impl<D: QueryData> ReadOnlyQueryData for NopWorldQuery<D> {}
 /// `update_component_access` and `update_archetype_component_access` do nothing.
 /// This is sound because `fetch` does not access components.
 unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
-    type Item<'a> = ();
     type Fetch<'a> = ();
 
     type State = ();
-
-    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
     fn shrink_fetch<'wlong: 'wshort, 'wshort>(_fetch: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {
     }
@@ -2302,13 +2384,6 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
     }
 
-    unsafe fn fetch<'w>(
-        _fetch: &mut Self::Fetch<'w>,
-        _entity: Entity,
-        _table_row: TableRow,
-    ) -> Self::Item<'w> {
-    }
-
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &mut World) -> Self::State {}
@@ -2328,6 +2403,16 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
 /// SAFETY: `Self::ReadOnly` is `Self`
 unsafe impl<T: ?Sized> QueryData for PhantomData<T> {
     type ReadOnly = Self;
+    type Item<'a> = ();
+
+    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
+
+    unsafe fn fetch<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+    }
 }
 
 /// SAFETY: `PhantomData` never accesses any world data.

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -294,7 +294,7 @@ pub unsafe trait QueryData: WorldQuery {
     /// This function manually implements subtyping for the query items.
     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort>;
 
-    /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
+    /// Fetch [`Self::Item`](`QueryData::Item`) for either the given `entity` in the current [`Table`],
     /// or for the given `entity` in the current [`Archetype`]. This must always be called after
     /// [`WorldQuery::set_table`] with a `table_row` in the range of the current [`Table`] or after
     /// [`WorldQuery::set_archetype`]  with an `entity` in the current archetype.

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -280,15 +280,8 @@ pub unsafe trait QueryData: WorldQuery {
     type ReadOnly: ReadOnlyQueryData<State = <Self as WorldQuery>::State>;
 
     /// The item returned by this [`WorldQuery`]
-    /// For `QueryData` this will be the data retrieved by the query,
+    /// This will be the data retrieved by the query,
     /// and is visible to the end user when calling e.g. `Query<Self>::get`.
-    ///
-    /// For `QueryFilter` this will be either `()`, or a `bool` indicating whether the entity should be included
-    /// or a tuple of such things.
-    /// Archetypal query filters (like `With`) set this to `()`,
-    /// as the filtering is done by selecting the archetypes to iterate over via [`WorldQuery::matches_component_set`],
-    /// while non-archetypal query filters (like `Changed`) set this to a `bool` and evaluate the filter for each entity,
-    /// after the set of possible archetypes has been narrowed down.
     type Item<'a>;
 
     /// This function manually implements subtyping for the query items.

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -140,7 +140,7 @@ pub struct With<T>(PhantomData<T>);
 
 /// SAFETY:
 /// `update_component_access` does not add any accesses.
-/// This is sound because `fetch` does not access any components.
+/// This is sound because [`Query_filter::filter_fetch`] does not access any components.
 /// `update_component_access` adds a `With` filter for `T`.
 /// This is sound because `matches_component_set` returns whether the set contains the component.
 unsafe impl<T: Component> WorldQuery for With<T> {
@@ -240,7 +240,7 @@ pub struct Without<T>(PhantomData<T>);
 
 /// SAFETY:
 /// `update_component_access` does not add any accesses.
-/// This is sound because `fetch` does not access any components.
+/// This is sound because [`Query_filter::filter_fetch`] does not access any components.
 /// `update_component_access` adds a `Without` filter for `T`.
 /// This is sound because `matches_component_set` returns whether the set does not contain the component.
 unsafe impl<T: Component> WorldQuery for Without<T> {
@@ -379,7 +379,7 @@ macro_rules! impl_or_query_filter {
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
         /// SAFETY:
-        /// `fetch` accesses are a subset of the subqueries' accesses
+        /// [`Query_filter::filter_fetch`] accesses are a subset of the subqueries' accesses
         /// This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
         /// `update_component_access` replace the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
         /// This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.
@@ -647,7 +647,7 @@ impl<T: Component> Clone for AddedFetch<'_, T> {
 }
 
 /// SAFETY:
-/// `fetch` accesses a single component in a readonly way.
+/// [`QueryFilter::filter_fetch`] accesses a single component in a readonly way.
 /// This is sound because `update_component_access` adds read access for that component and panics when appropriate.
 /// `update_component_access` adds a `With` filter for a component.
 /// This is sound because `matches_component_set` returns whether the set contains that component.

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -140,7 +140,7 @@ pub struct With<T>(PhantomData<T>);
 
 /// SAFETY:
 /// `update_component_access` does not add any accesses.
-/// This is sound because [`Query_filter::filter_fetch`] does not access any components.
+/// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
 /// `update_component_access` adds a `With` filter for `T`.
 /// This is sound because `matches_component_set` returns whether the set contains the component.
 unsafe impl<T: Component> WorldQuery for With<T> {
@@ -240,7 +240,7 @@ pub struct Without<T>(PhantomData<T>);
 
 /// SAFETY:
 /// `update_component_access` does not add any accesses.
-/// This is sound because [`Query_filter::filter_fetch`] does not access any components.
+/// This is sound because [`QueryFilter::filter_fetch`] does not access any components.
 /// `update_component_access` adds a `Without` filter for `T`.
 /// This is sound because `matches_component_set` returns whether the set does not contain the component.
 unsafe impl<T: Component> WorldQuery for Without<T> {
@@ -379,7 +379,7 @@ macro_rules! impl_or_query_filter {
             reason = "Zero-length tuples will generate some function bodies equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
         )]
         /// SAFETY:
-        /// [`Query_filter::filter_fetch`] accesses are a subset of the subqueries' accesses
+        /// [`QueryFilter::filter_fetch`] accesses are a subset of the subqueries' accesses
         /// This is sound because `update_component_access` adds accesses according to the implementations of all the subqueries.
         /// `update_component_access` replace the filters with a disjunction where every element is a conjunction of the previous filters and the filters of one of the subqueries.
         /// This is sound because `matches_component_set` returns a disjunction of the results of the subqueries' implementations.

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -66,7 +66,6 @@ use variadics_please::all_tuples;
 /// # bevy_ecs::system::assert_is_system(my_system);
 /// ```
 ///
-/// [`fetch`]: Self::fetch
 /// [`matches_component_set`]: Self::matches_component_set
 /// [`Query`]: crate::system::Query
 /// [`State`]: Self::State
@@ -97,7 +96,7 @@ pub unsafe trait QueryFilter: WorldQuery {
     /// ones that are compatible with the Filter's access.
     ///
     /// Implementors of this method will generally either have a trivial `true` body (required for archetypal filters),
-    /// or call [`WorldQuery::fetch`] to access the raw data needed to make the final decision on filter inclusion.
+    /// or access the necessary data within this function to make the final decision on filter inclusion.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -809,11 +809,8 @@ mod tests {
     /// `update_component_access` adds resource read access for `R`.
     /// `update_archetype_component_access` does nothing, as this accesses no components.
     unsafe impl WorldQuery for ReadsRData {
-        type Item<'w> = ();
         type Fetch<'w> = ();
         type State = ComponentId;
-
-        fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
         fn shrink_fetch<'wlong: 'wshort, 'wshort>(_: Self::Fetch<'wlong>) -> Self::Fetch<'wshort> {}
 
@@ -842,14 +839,6 @@ mod tests {
             _state: &Self::State,
             _table: &'w Table,
         ) {
-        }
-
-        #[inline(always)]
-        unsafe fn fetch<'w>(
-            _fetch: &mut Self::Fetch<'w>,
-            _entity: Entity,
-            _table_row: TableRow,
-        ) -> Self::Item<'w> {
         }
 
         fn update_component_access(
@@ -882,6 +871,17 @@ mod tests {
     /// SAFETY: `Self` is the same as `Self::ReadOnly`
     unsafe impl QueryData for ReadsRData {
         type ReadOnly = Self;
+        type Item<'w> = ();
+
+        fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
+
+        #[inline(always)]
+        unsafe fn fetch<'w>(
+            _fetch: &mut Self::Fetch<'w>,
+            _entity: Entity,
+            _table_row: TableRow,
+        ) -> Self::Item<'w> {
+        }
     }
 
     /// SAFETY: access is read only

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -13,11 +13,11 @@ use variadics_please::all_tuples;
 /// # Safety
 ///
 /// Implementor must ensure that
-/// [`update_component_access`], [`matches_component_set`], [`QueryData::fetch`] and [`init_fetch`]
+/// [`update_component_access`], [`matches_component_set`], [`QueryData::fetch`], [`QueryFilter::filter_fetch`] and [`init_fetch`]
 /// obey the following:
 ///
 /// - For each component mutably accessed by [`QueryData::fetch`], [`update_component_access`] should add write access unless read or write access has already been added, in which case it should panic.
-/// - For each component readonly accessed by [`QueryData::fetch`], [`update_component_access`] should add read access unless write access has already been added, in which case it should panic.
+/// - For each component readonly accessed by [`QueryData::fetch`] or [`QueryFilter::filter_fetch`], [`update_component_access`] should add read access unless write access has already been added, in which case it should panic.
 /// - If `fetch` mutably accesses the same component twice, [`update_component_access`] should panic.
 /// - [`update_component_access`] may not add a `Without` filter for a component unless [`matches_component_set`] always returns `false` when the component set contains that component.
 /// - [`update_component_access`] may not add a `With` filter for a component unless [`matches_component_set`] always returns `false` when the component set doesn't contain that component.
@@ -31,6 +31,7 @@ use variadics_please::all_tuples;
 /// When implementing [`update_component_access`], note that `add_read` and `add_write` both also add a `With` filter, whereas `extend_access` does not change the filters.
 ///
 /// [`QueryData::fetch`]: crate::query::QueryData::fetch
+/// [`QueryFilter::filter_fetch`]: crate::query::QueryFilter::filter_fetch
 /// [`init_fetch`]: Self::init_fetch
 /// [`matches_component_set`]: Self::matches_component_set
 /// [`Query`]: crate::system::Query

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -13,11 +13,11 @@ use variadics_please::all_tuples;
 /// # Safety
 ///
 /// Implementor must ensure that
-/// [`update_component_access`], [`matches_component_set`], [`fetch`] and [`init_fetch`]
+/// [`update_component_access`], [`matches_component_set`], [`QueryData::fetch`] and [`init_fetch`]
 /// obey the following:
 ///
-/// - For each component mutably accessed by [`fetch`], [`update_component_access`] should add write access unless read or write access has already been added, in which case it should panic.
-/// - For each component readonly accessed by [`fetch`], [`update_component_access`] should add read access unless write access has already been added, in which case it should panic.
+/// - For each component mutably accessed by [`QueryData::fetch`], [`update_component_access`] should add write access unless read or write access has already been added, in which case it should panic.
+/// - For each component readonly accessed by [`QueryData::fetch`], [`update_component_access`] should add read access unless write access has already been added, in which case it should panic.
 /// - If `fetch` mutably accesses the same component twice, [`update_component_access`] should panic.
 /// - [`update_component_access`] may not add a `Without` filter for a component unless [`matches_component_set`] always returns `false` when the component set contains that component.
 /// - [`update_component_access`] may not add a `With` filter for a component unless [`matches_component_set`] always returns `false` when the component set doesn't contain that component.
@@ -30,7 +30,7 @@ use variadics_please::all_tuples;
 ///
 /// When implementing [`update_component_access`], note that `add_read` and `add_write` both also add a `With` filter, whereas `extend_access` does not change the filters.
 ///
-/// [`fetch`]: Self::fetch
+/// [`QueryData::fetch`]: crate::query::QueryData::fetch
 /// [`init_fetch`]: Self::init_fetch
 /// [`matches_component_set`]: Self::matches_component_set
 /// [`Query`]: crate::system::Query
@@ -38,7 +38,7 @@ use variadics_please::all_tuples;
 /// [`QueryData`]: crate::query::QueryData
 /// [`QueryFilter`]: crate::query::QueryFilter
 pub unsafe trait WorldQuery {
-    /// Per archetype/table state retrieved by this [`WorldQuery`] to compute [`Self::Item`](WorldQuery::Item) for each entity.
+    /// Per archetype/table state retrieved by this [`WorldQuery`] to compute [`Self::Item`](crate::query::QueryData::Item) for each entity.
     type Fetch<'a>: Clone;
 
     /// State used to construct a [`Self::Fetch`](WorldQuery::Fetch). This will be cached inside [`QueryState`](crate::query::QueryState),
@@ -71,8 +71,8 @@ pub unsafe trait WorldQuery {
     ///
     /// This is used to select a more efficient "table iterator"
     /// for "dense" queries. If this returns true, [`WorldQuery::set_table`] must be used before
-    /// [`WorldQuery::fetch`] can be called for iterators. If this returns false,
-    /// [`WorldQuery::set_archetype`] must be used before [`WorldQuery::fetch`] can be called for
+    /// [`QueryData::fetch`](crate::query::QueryData::fetch) can be called for iterators. If this returns false,
+    /// [`WorldQuery::set_archetype`] must be used before [`QueryData::fetch`](crate::query::QueryData::fetch) can be called for
     /// iterators.
     const IS_DENSE: bool;
 

--- a/crates/bevy_ecs/src/relationship/relationship_query.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_query.rs
@@ -1,6 +1,6 @@
 use crate::{
     entity::Entity,
-    query::{QueryData, QueryFilter, WorldQuery},
+    query::{QueryData, QueryFilter},
     relationship::{Relationship, RelationshipTarget},
     system::Query,
 };
@@ -14,7 +14,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// target entity of that relationship.
     pub fn related<R: Relationship>(&'w self, entity: Entity) -> Option<Entity>
     where
-        <D as QueryData>::ReadOnly: WorldQuery<Item<'w> = &'w R>,
+        <D as QueryData>::ReadOnly: QueryData<Item<'w> = &'w R>,
     {
         self.get(entity).map(R::get).ok()
     }
@@ -26,7 +26,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entity: Entity,
     ) -> impl Iterator<Item = Entity> + 'w
     where
-        <D as QueryData>::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+        <D as QueryData>::ReadOnly: QueryData<Item<'w> = &'w S>,
     {
         self.get(entity)
             .into_iter()
@@ -42,7 +42,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// If your relationship is not a tree (like Bevy's hierarchy), be sure to stop if you encounter a duplicate entity.
     pub fn root_ancestor<R: Relationship>(&'w self, entity: Entity) -> Entity
     where
-        <D as QueryData>::ReadOnly: WorldQuery<Item<'w> = &'w R>,
+        <D as QueryData>::ReadOnly: QueryData<Item<'w> = &'w R>,
     {
         // Recursively search up the tree until we're out of parents
         match self.get(entity) {
@@ -62,7 +62,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entity: Entity,
     ) -> impl Iterator<Item = Entity> + 'w
     where
-        <D as QueryData>::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+        <D as QueryData>::ReadOnly: QueryData<Item<'w> = &'w S>,
         SourceIter<'w, S>: DoubleEndedIterator,
     {
         self.iter_descendants_depth_first(entity).filter(|entity| {
@@ -80,7 +80,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entity: Entity,
     ) -> impl Iterator<Item = Entity> + 'w
     where
-        D::ReadOnly: WorldQuery<Item<'w> = (Option<&'w R>, Option<&'w R::RelationshipTarget>)>,
+        D::ReadOnly: QueryData<Item<'w> = (Option<&'w R>, Option<&'w R::RelationshipTarget>)>,
     {
         self.get(entity)
             .ok()
@@ -103,7 +103,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entity: Entity,
     ) -> DescendantIter<'w, 's, D, F, S>
     where
-        D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+        D::ReadOnly: QueryData<Item<'w> = &'w S>,
     {
         DescendantIter::new(self, entity)
     }
@@ -120,7 +120,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entity: Entity,
     ) -> DescendantDepthFirstIter<'w, 's, D, F, S>
     where
-        D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+        D::ReadOnly: QueryData<Item<'w> = &'w S>,
         SourceIter<'w, S>: DoubleEndedIterator,
     {
         DescendantDepthFirstIter::new(self, entity)
@@ -137,7 +137,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         entity: Entity,
     ) -> AncestorIter<'w, 's, D, F, R>
     where
-        D::ReadOnly: WorldQuery<Item<'w> = &'w R>,
+        D::ReadOnly: QueryData<Item<'w> = &'w R>,
     {
         AncestorIter::new(self, entity)
     }
@@ -148,7 +148,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 /// Traverses the hierarchy breadth-first.
 pub struct DescendantIter<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+    D::ReadOnly: QueryData<Item<'w> = &'w S>,
 {
     children_query: &'w Query<'w, 's, D, F>,
     vecdeque: VecDeque<Entity>,
@@ -156,7 +156,7 @@ where
 
 impl<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget> DescendantIter<'w, 's, D, F, S>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+    D::ReadOnly: QueryData<Item<'w> = &'w S>,
 {
     /// Returns a new [`DescendantIter`].
     pub fn new(children_query: &'w Query<'w, 's, D, F>, entity: Entity) -> Self {
@@ -174,7 +174,7 @@ where
 impl<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget> Iterator
     for DescendantIter<'w, 's, D, F, S>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+    D::ReadOnly: QueryData<Item<'w> = &'w S>,
 {
     type Item = Entity;
 
@@ -194,7 +194,7 @@ where
 /// Traverses the hierarchy depth-first.
 pub struct DescendantDepthFirstIter<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+    D::ReadOnly: QueryData<Item<'w> = &'w S>,
 {
     children_query: &'w Query<'w, 's, D, F>,
     stack: SmallVec<[Entity; 8]>,
@@ -203,7 +203,7 @@ where
 impl<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget>
     DescendantDepthFirstIter<'w, 's, D, F, S>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+    D::ReadOnly: QueryData<Item<'w> = &'w S>,
     SourceIter<'w, S>: DoubleEndedIterator,
 {
     /// Returns a new [`DescendantDepthFirstIter`].
@@ -220,7 +220,7 @@ where
 impl<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget> Iterator
     for DescendantDepthFirstIter<'w, 's, D, F, S>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w S>,
+    D::ReadOnly: QueryData<Item<'w> = &'w S>,
     SourceIter<'w, S>: DoubleEndedIterator,
 {
     type Item = Entity;
@@ -239,7 +239,7 @@ where
 /// An [`Iterator`] of [`Entity`]s over the ancestors of an [`Entity`].
 pub struct AncestorIter<'w, 's, D: QueryData, F: QueryFilter, R: Relationship>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w R>,
+    D::ReadOnly: QueryData<Item<'w> = &'w R>,
 {
     parent_query: &'w Query<'w, 's, D, F>,
     next: Option<Entity>,
@@ -247,7 +247,7 @@ where
 
 impl<'w, 's, D: QueryData, F: QueryFilter, R: Relationship> AncestorIter<'w, 's, D, F, R>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w R>,
+    D::ReadOnly: QueryData<Item<'w> = &'w R>,
 {
     /// Returns a new [`AncestorIter`].
     pub fn new(parent_query: &'w Query<'w, 's, D, F>, entity: Entity) -> Self {
@@ -261,7 +261,7 @@ where
 impl<'w, 's, D: QueryData, F: QueryFilter, R: Relationship> Iterator
     for AncestorIter<'w, 's, D, F, R>
 where
-    D::ReadOnly: WorldQuery<Item<'w> = &'w R>,
+    D::ReadOnly: QueryData<Item<'w> = &'w R>,
 {
     type Item = Entity;
 

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -285,13 +285,8 @@ mod render_entities_world_query_impls {
     /// SAFETY: defers completely to `&RenderEntity` implementation,
     /// and then only modifies the output safely.
     unsafe impl WorldQuery for RenderEntity {
-        type Item<'w> = Entity;
         type Fetch<'w> = <&'static RenderEntity as WorldQuery>::Fetch<'w>;
         type State = <&'static RenderEntity as WorldQuery>::State;
-
-        fn shrink<'wlong: 'wshort, 'wshort>(item: Entity) -> Entity {
-            item
-        }
 
         fn shrink_fetch<'wlong: 'wshort, 'wshort>(
             fetch: Self::Fetch<'wlong>,
@@ -337,18 +332,6 @@ mod render_entities_world_query_impls {
             unsafe { <&RenderEntity as WorldQuery>::set_table(fetch, &component_id, table) }
         }
 
-        #[inline(always)]
-        unsafe fn fetch<'w>(
-            fetch: &mut Self::Fetch<'w>,
-            entity: Entity,
-            table_row: TableRow,
-        ) -> Self::Item<'w> {
-            // SAFETY: defers to the `&T` implementation, with T set to `RenderEntity`.
-            let component =
-                unsafe { <&RenderEntity as WorldQuery>::fetch(fetch, entity, table_row) };
-            component.id()
-        }
-
         fn update_component_access(
             &component_id: &ComponentId,
             access: &mut FilteredAccess<ComponentId>,
@@ -376,6 +359,23 @@ mod render_entities_world_query_impls {
     // Self::ReadOnly matches exactly the same archetypes/tables as Self.
     unsafe impl QueryData for RenderEntity {
         type ReadOnly = RenderEntity;
+        type Item<'w> = Entity;
+
+        fn shrink<'wlong: 'wshort, 'wshort>(item: Entity) -> Entity {
+            item
+        }
+
+        #[inline(always)]
+        unsafe fn fetch<'w>(
+            fetch: &mut Self::Fetch<'w>,
+            entity: Entity,
+            table_row: TableRow,
+        ) -> Self::Item<'w> {
+            // SAFETY: defers to the `&T` implementation, with T set to `RenderEntity`.
+            let component =
+                unsafe { <&RenderEntity as QueryData>::fetch(fetch, entity, table_row) };
+            component.id()
+        }
     }
 
     // SAFETY: the underlying `Entity` is copied, and no mutable access is provided.
@@ -384,13 +384,8 @@ mod render_entities_world_query_impls {
     /// SAFETY: defers completely to `&RenderEntity` implementation,
     /// and then only modifies the output safely.
     unsafe impl WorldQuery for MainEntity {
-        type Item<'w> = Entity;
         type Fetch<'w> = <&'static MainEntity as WorldQuery>::Fetch<'w>;
         type State = <&'static MainEntity as WorldQuery>::State;
-
-        fn shrink<'wlong: 'wshort, 'wshort>(item: Entity) -> Entity {
-            item
-        }
 
         fn shrink_fetch<'wlong: 'wshort, 'wshort>(
             fetch: Self::Fetch<'wlong>,
@@ -436,17 +431,6 @@ mod render_entities_world_query_impls {
             unsafe { <&MainEntity as WorldQuery>::set_table(fetch, &component_id, table) }
         }
 
-        #[inline(always)]
-        unsafe fn fetch<'w>(
-            fetch: &mut Self::Fetch<'w>,
-            entity: Entity,
-            table_row: TableRow,
-        ) -> Self::Item<'w> {
-            // SAFETY: defers to the `&T` implementation, with T set to `MainEntity`.
-            let component = unsafe { <&MainEntity as WorldQuery>::fetch(fetch, entity, table_row) };
-            component.id()
-        }
-
         fn update_component_access(
             &component_id: &ComponentId,
             access: &mut FilteredAccess<ComponentId>,
@@ -474,6 +458,22 @@ mod render_entities_world_query_impls {
     // Self::ReadOnly matches exactly the same archetypes/tables as Self.
     unsafe impl QueryData for MainEntity {
         type ReadOnly = MainEntity;
+        type Item<'w> = Entity;
+
+        fn shrink<'wlong: 'wshort, 'wshort>(item: Entity) -> Entity {
+            item
+        }
+
+        #[inline(always)]
+        unsafe fn fetch<'w>(
+            fetch: &mut Self::Fetch<'w>,
+            entity: Entity,
+            table_row: TableRow,
+        ) -> Self::Item<'w> {
+            // SAFETY: defers to the `&T` implementation, with T set to `MainEntity`.
+            let component = unsafe { <&MainEntity as QueryData>::fetch(fetch, entity, table_row) };
+            component.id()
+        }
     }
 
     // SAFETY: the underlying `Entity` is copied, and no mutable access is provided.


### PR DESCRIPTION
# Objective

Fixes #17662

## Solution

Moved `Item` and `fetch` from `WorldQuery` to `QueryData`, and adjusted their implementations accordingly.

Currently, documentation related to `fetch` is written under `WorldQuery`. It would be more appropriate to move it to the `QueryData` documentation for clarity.

I am not very experienced with making contributions. If there are any mistakes or areas for improvement, I would appreciate any suggestions you may have.

## Migration Guide

The `WorldQuery::Item` type and `WorldQuery::fetch` method have been moved to `QueryData`, as they were not useful for `QueryFilter` types.
