### PR TITLE
Make `batch_and_prepare_binned_render_phase` only record information about the first batch in each batch set.

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1362,7 +1362,8 @@ pub fn batch_and_prepare_binned_render_phase<BPI, GFBD>(
                     match batch_set {
                         None => {
                             batch_set = Some(BinnedRenderPhaseBatchSet {
-                                batches: vec![batch],
+                                first_batch: batch,
+                                batch_count: 1,
                                 bin_key: bin_key.clone(),
                                 index: indirect_parameters_buffers
                                     .batch_set_count(batch_set_key.indexed())
@@ -1370,7 +1371,7 @@ pub fn batch_and_prepare_binned_render_phase<BPI, GFBD>(
                             });
                         }
                         Some(ref mut batch_set) => {
-                            batch_set.batches.push(batch);
+                            batch_set.batch_count += 1;
                         }
                     }
                 }
@@ -1498,7 +1499,8 @@ pub fn batch_and_prepare_binned_render_phase<BPI, GFBD>(
                         // However, custom render pipelines might do so, such as
                         // the `specialized_mesh_pipeline` example.
                         vec.push(BinnedRenderPhaseBatchSet {
-                            batches: vec![batch],
+                            first_batch: batch,
+                            batch_count: 1,
                             bin_key: key.1.clone(),
                             index: indirect_parameters_buffers.batch_set_count(key.0.indexed())
                                 as u32,


### PR DESCRIPTION
Data for the other batches is only accessed by the GPU, not the CPU, so it's a waste of time and memory to store information relating to those other batches.

On Bistro, this reduces time spent in
`batch_and_prepare_binned_render_phase` from 85.9 us to 61.2 us, a 40% speedup.

![Screenshot 2025-02-04 093315](https://github.com/user-attachments/assets/eb00db93-a260-44f9-9ae0-4e90b0697138)
