### PR TITLE
Don't reallocate work item buffers every frame.

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -4,7 +4,7 @@ use core::any::TypeId;
 
 use bevy_app::{App, Plugin};
 use bevy_ecs::{
-    entity::{hash_map::EntityHashMap, Entity},
+    entity::Entity,
     query::{Has, With},
     resource::Resource,
     schedule::IntoSystemConfigs as _,
@@ -13,7 +13,7 @@ use bevy_ecs::{
 };
 use bevy_encase_derive::ShaderType;
 use bevy_math::UVec4;
-use bevy_platform_support::collections::hash_map::Entry;
+use bevy_platform_support::collections::{hash_map::Entry, HashMap, HashSet};
 use bevy_utils::{default, TypeIdMap};
 use bytemuck::{Pod, Zeroable};
 use nonmax::NonMaxU32;
@@ -30,7 +30,7 @@ use crate::{
     },
     render_resource::{Buffer, BufferVec, GpuArrayBufferable, RawBufferVec, UninitBufferVec},
     renderer::{RenderAdapter, RenderDevice, RenderQueue},
-    view::{ExtractedView, NoIndirectDrawing},
+    view::{ExtractedView, NoIndirectDrawing, RetainedViewEntity},
     Render, RenderApp, RenderSet,
 };
 
@@ -157,7 +157,7 @@ where
     /// corresponds to each instance.
     ///
     /// This is keyed off each view. Each view has a separate buffer.
-    pub work_item_buffers: EntityHashMap<TypeIdMap<PreprocessWorkItemBuffers>>,
+    pub work_item_buffers: HashMap<RetainedViewEntity, TypeIdMap<PreprocessWorkItemBuffers>>,
 
     /// The uniform data inputs for the current frame.
     ///
@@ -409,8 +409,8 @@ impl Default for LatePreprocessWorkItemIndirectParameters {
 /// You may need to call this function if you're implementing your own custom
 /// render phases. See the `specialized_mesh_pipeline` example.
 pub fn get_or_create_work_item_buffer<'a, I>(
-    work_item_buffers: &'a mut EntityHashMap<TypeIdMap<PreprocessWorkItemBuffers>>,
-    view: Entity,
+    work_item_buffers: &'a mut HashMap<RetainedViewEntity, TypeIdMap<PreprocessWorkItemBuffers>>,
+    view: RetainedViewEntity,
     no_indirect_drawing: bool,
     gpu_occlusion_culling: bool,
     late_indexed_indirect_parameters_buffer: &'_ mut RawBufferVec<
@@ -489,6 +489,28 @@ impl PreprocessWorkItemBuffers {
                     } else {
                         gpu_occlusion_culling.late_non_indexed.add();
                     }
+                }
+            }
+        }
+    }
+
+    /// Clears out the GPU work item buffers in preparation for a new frame.
+    pub fn clear(&mut self) {
+        match *self {
+            PreprocessWorkItemBuffers::Direct(ref mut buffer) => {
+                buffer.clear();
+            }
+            PreprocessWorkItemBuffers::Indirect {
+                indexed: ref mut indexed_buffer,
+                non_indexed: ref mut non_indexed_buffer,
+                ref mut gpu_occlusion_culling,
+            } => {
+                indexed_buffer.clear();
+                non_indexed_buffer.clear();
+
+                if let Some(ref mut gpu_occlusion_culling) = *gpu_occlusion_culling {
+                    gpu_occlusion_culling.late_indexed.clear();
+                    gpu_occlusion_culling.late_non_indexed.clear();
                 }
             }
         }
@@ -942,7 +964,7 @@ where
     pub fn new() -> Self {
         BatchedInstanceBuffers {
             data_buffer: UninitBufferVec::new(BufferUsages::STORAGE),
-            work_item_buffers: EntityHashMap::default(),
+            work_item_buffers: HashMap::default(),
             current_input_buffer: InstanceInputUniformBuffer::new(),
             previous_input_buffer: InstanceInputUniformBuffer::new(),
             late_indexed_indirect_parameters_buffer: RawBufferVec::new(
@@ -968,7 +990,14 @@ where
         self.data_buffer.clear();
         self.late_indexed_indirect_parameters_buffer.clear();
         self.late_non_indexed_indirect_parameters_buffer.clear();
-        self.work_item_buffers.clear();
+
+        // Clear each individual set of buffers, but don't depopulate the hash
+        // table. We want to avoid reallocating these vectors every frame.
+        for view_work_item_buffers in self.work_item_buffers.values_mut() {
+            for phase_work_item_buffers in view_work_item_buffers.values_mut() {
+                phase_work_item_buffers.clear();
+            }
+        }
     }
 }
 
@@ -1074,13 +1103,17 @@ pub fn delete_old_work_item_buffers<GFBD>(
     mut gpu_batched_instance_buffers: ResMut<
         BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,
     >,
-    extracted_views: Query<Entity, With<ExtractedView>>,
+    extracted_views: Query<&ExtractedView>,
 ) where
     GFBD: GetFullBatchData,
 {
+    let retained_view_entities: HashSet<_> = extracted_views
+        .iter()
+        .map(|extracted_view| extracted_view.retained_view_entity)
+        .collect();
     gpu_batched_instance_buffers
         .work_item_buffers
-        .retain(|entity, _| extracted_views.contains(*entity));
+        .retain(|retained_view_entity, _| retained_view_entities.contains(retained_view_entity));
 }
 
 /// Batch the items in a sorted render phase, when GPU instance buffer building
@@ -1091,7 +1124,6 @@ pub fn batch_and_prepare_sorted_render_phase<I, GFBD>(
     mut indirect_parameters_buffers: ResMut<IndirectParametersBuffers>,
     mut sorted_render_phases: ResMut<ViewSortedRenderPhases<I>>,
     mut views: Query<(
-        Entity,
         &ExtractedView,
         Has<NoIndirectDrawing>,
         Has<OcclusionCulling>,
@@ -1110,7 +1142,7 @@ pub fn batch_and_prepare_sorted_render_phase<I, GFBD>(
         ..
     } = gpu_array_buffer.into_inner();
 
-    for (view, extracted_view, no_indirect_drawing, gpu_occlusion_culling) in &mut views {
+    for (extracted_view, no_indirect_drawing, gpu_occlusion_culling) in &mut views {
         let Some(phase) = sorted_render_phases.get_mut(&extracted_view.retained_view_entity) else {
             continue;
         };
@@ -1118,7 +1150,7 @@ pub fn batch_and_prepare_sorted_render_phase<I, GFBD>(
         // Create the work item buffer if necessary.
         let work_item_buffer = get_or_create_work_item_buffer::<I>(
             work_item_buffers,
-            view,
+            extracted_view.retained_view_entity,
             no_indirect_drawing,
             gpu_occlusion_culling,
             late_indexed_indirect_parameters_buffer,
@@ -1248,7 +1280,6 @@ pub fn batch_and_prepare_binned_render_phase<BPI, GFBD>(
     mut binned_render_phases: ResMut<ViewBinnedRenderPhases<BPI>>,
     mut views: Query<
         (
-            Entity,
             &ExtractedView,
             Has<NoIndirectDrawing>,
             Has<OcclusionCulling>,
@@ -1270,7 +1301,7 @@ pub fn batch_and_prepare_binned_render_phase<BPI, GFBD>(
         ..
     } = gpu_array_buffer.into_inner();
 
-    for (view, extracted_view, no_indirect_drawing, gpu_occlusion_culling) in &mut views {
+    for (extracted_view, no_indirect_drawing, gpu_occlusion_culling) in &mut views {
         let Some(phase) = binned_render_phases.get_mut(&extracted_view.retained_view_entity) else {
             continue;
         };
@@ -1279,7 +1310,7 @@ pub fn batch_and_prepare_binned_render_phase<BPI, GFBD>(
         // used this frame.
         let work_item_buffer = get_or_create_work_item_buffer::<BPI>(
             work_item_buffers,
-            view,
+            extracted_view.retained_view_entity,
             no_indirect_drawing,
             gpu_occlusion_culling,
             late_indexed_indirect_parameters_buffer,

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -4,7 +4,6 @@ use core::any::TypeId;
 
 use bevy_app::{App, Plugin};
 use bevy_ecs::{
-    entity::Entity,
     query::{Has, With},
     resource::Resource,
     schedule::IntoSystemConfigs as _,

--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -280,7 +280,6 @@ fn queue_custom_mesh_pipeline(
     ),
     mut specialized_mesh_pipelines: ResMut<SpecializedMeshPipelines<CustomMeshPipeline>>,
     views: Query<(
-        Entity,
         &RenderVisibleEntities,
         &ExtractedView,
         &Msaa,
@@ -318,14 +317,8 @@ fn queue_custom_mesh_pipeline(
     // Render phases are per-view, so we need to iterate over all views so that
     // the entity appears in them. (In this example, we have only one view, but
     // it's good practice to loop over all views anyway.)
-    for (
-        view_entity,
-        view_visible_entities,
-        view,
-        msaa,
-        no_indirect_drawing,
-        gpu_occlusion_culling,
-    ) in views.iter()
+    for (view_visible_entities, view, msaa, no_indirect_drawing, gpu_occlusion_culling) in
+        views.iter()
     {
         let Some(opaque_phase) = opaque_render_phases.get_mut(&view.retained_view_entity) else {
             continue;
@@ -336,7 +329,7 @@ fn queue_custom_mesh_pipeline(
         // enabled.
         let work_item_buffer = gpu_preprocessing::get_or_create_work_item_buffer::<Opaque3d>(
             work_item_buffers,
-            view_entity,
+            view.retained_view_entity,
             no_indirect_drawing,
             gpu_occlusion_culling,
             late_indexed_indirect_parameters_buffer,


### PR DESCRIPTION
We were calling `clear()` on the work item buffer table, which caused us to deallocate all the CPU side buffers. This patch changes the logic to instead just clear the buffers individually, but leave their backing stores. This has two consequences:

1. To effectively retain work item buffers from frame to frame, we need to key them off `RetainedViewEntity` values and not the render world `Entity`, which is transient. This PR changes those buffers accordingly.

2. We need to clean up work item buffers that belong to views that went away. Amusingly enough, we actually have a system, `delete_old_work_item_buffers`, that tries to do this already, but it wasn't doing anything because the `clear_batched_gpu_instance_buffers` system already handled that. This patch actually makes the `delete_old_work_item_buffers` system useful, by removing the clearing behavior from `clear_batched_gpu_instance_buffers` and instead making `delete_old_work_item_buffers` delete buffers corresponding to nonexistent views.

On Bistro, this PR improves the performance of
`batch_and_prepare_binned_render_phase` from 61.2 us to 47.8 us, a 28% speedup.

![Screenshot 2025-02-04 135542](https://github.com/user-attachments/assets/b0ecb551-f6c8-4677-8e4e-e39aa28115a3)
