### PR TITLE
Split `Component::register_component_hooks` into individual methods

### DIFF
--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -69,8 +69,8 @@ impl Component for OrderIndependentTransparencySettings {
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
     type Mutability = Mutable;
 
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|world, context| {
+    fn on_add() -> Option<ComponentHook> {
+        Some(|world, context| {
             if let Some(value) = world.get::<OrderIndependentTransparencySettings>(context.entity) {
                 if value.layer_count > 32 {
                     warn!("{}OrderIndependentTransparencySettings layer_count set to {} might be too high.", 
@@ -79,7 +79,7 @@ impl Component for OrderIndependentTransparencySettings {
                     );
                 }
             }
-        });
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/observer/entity_observer.rs
+++ b/crates/bevy_ecs/src/observer/entity_observer.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::{
-        Component, ComponentCloneHandler, ComponentHooks, HookContext, Mutable, StorageType,
+        Component, ComponentCloneHandler, ComponentHook, HookContext, Mutable, StorageType,
     },
     entity::{ComponentCloneCtx, Entity, EntityCloneBuilder},
     observer::ObserverState,
@@ -16,8 +16,8 @@ impl Component for ObservedBy {
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
     type Mutability = Mutable;
 
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_remove(|mut world, HookContext { entity, .. }| {
+    fn on_remove() -> Option<ComponentHook> {
+        Some(|mut world, HookContext { entity, .. }| {
             let observed_by = {
                 let mut component = world.get_mut::<ObservedBy>(entity).unwrap();
                 core::mem::take(&mut component.0)
@@ -42,7 +42,7 @@ impl Component for ObservedBy {
                     world.commands().entity(e).despawn();
                 }
             }
-        });
+        })
     }
 
     fn get_component_clone_handler() -> ComponentCloneHandler {

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use core::any::Any;
 
 use crate::{
-    component::{ComponentHook, ComponentHooks, ComponentId, HookContext, Mutable, StorageType},
+    component::{ComponentHook, ComponentId, HookContext, Mutable, StorageType},
     observer::{ObserverDescriptor, ObserverTrigger},
     prelude::*,
     query::DebugCheckedUnwrap,
@@ -65,13 +65,16 @@ impl Component for ObserverState {
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
     type Mutability = Mutable;
 
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|mut world, HookContext { entity, .. }| {
+    fn on_add() -> Option<ComponentHook> {
+        Some(|mut world, HookContext { entity, .. }| {
             world.commands().queue(move |world: &mut World| {
                 world.register_observer(entity);
             });
-        });
-        hooks.on_remove(|mut world, HookContext { entity, .. }| {
+        })
+    }
+
+    fn on_remove() -> Option<ComponentHook> {
+        Some(|mut world, HookContext { entity, .. }| {
             let descriptor = core::mem::take(
                 &mut world
                     .entity_mut(entity)
@@ -83,7 +86,7 @@ impl Component for ObserverState {
             world.commands().queue(move |world: &mut World| {
                 world.unregister_observer(entity, descriptor);
             });
-        });
+        })
     }
 }
 
@@ -322,14 +325,14 @@ impl Observer {
 impl Component for Observer {
     const STORAGE_TYPE: StorageType = StorageType::SparseSet;
     type Mutability = Mutable;
-    fn register_component_hooks(hooks: &mut ComponentHooks) {
-        hooks.on_add(|world, context| {
+    fn on_add() -> Option<ComponentHook> {
+        Some(|world, context| {
             let Some(observe) = world.get::<Self>(context.entity) else {
                 return;
             };
             let hook = observe.hook_on_add;
             hook(world, context);
-        });
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -392,7 +392,7 @@ fn observer_system_runner<E: Event, B: Bundle, S: ObserverSystem<E, B>>(
     }
 }
 
-/// A [`ComponentHook`] used by [`Observer`] to handle its [`on-add`](`ComponentHooks::on_add`).
+/// A [`ComponentHook`] used by [`Observer`] to handle its [`on-add`](`crate::component::ComponentHooks::on_add`).
 ///
 /// This function exists separate from [`Observer`] to allow [`Observer`] to have its type parameters
 /// erased.

--- a/examples/ecs/component_hooks.rs
+++ b/examples/ecs/component_hooks.rs
@@ -14,7 +14,7 @@
 //!     between components (like hierarchies or parent-child links) and need to maintain correctness.
 
 use bevy::{
-    ecs::component::{ComponentHooks, HookContext, Mutable, StorageType},
+    ecs::component::{ComponentHook, HookContext, Mutable, StorageType},
     prelude::*,
 };
 use std::collections::HashMap;
@@ -33,9 +33,11 @@ impl Component for MyComponent {
     type Mutability = Mutable;
 
     /// Hooks can also be registered during component initialization by
-    /// implementing `register_component_hooks`
-    fn register_component_hooks(_hooks: &mut ComponentHooks) {
-        // Register hooks...
+    /// implementing the associated method
+    fn on_add() -> Option<ComponentHook> {
+        // We don't have an `on_add` hook so we'll just return None.
+        // Note that this is the default behavior when not implementing a hook.
+        None
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #17411

## Solution

- Deprecated `Component::register_component_hooks`
- Added individual methods for each hook which return `None` if the hook is unused.

## Testing

- CI

---

## Migration Guide

`Component::register_component_hooks` is now deprecated and will be removed in a future release. When implementing `Component` manually, also implement the respective hook methods on `Component`.

```rust
// Before
impl Component for Foo {
    // snip
    fn register_component_hooks(hooks: &mut ComponentHooks) {
            hooks.on_add(foo_on_add);
    }
}

// After
impl Component for Foo {
    // snip
    fn on_add() -> Option<ComponentHook> {
            Some(foo_on_add)
    }
}
```

## Notes

I've chosen to deprecate `Component::register_component_hooks` rather than outright remove it to ease the migration guide. While it is in a state of deprecation, it must be used by `Components::register_component_internal` to ensure users who haven't migrated to the new hook definition scheme aren't left behind. For users of the new scheme, a default implementation of `Component::register_component_hooks` is provided which forwards the new individual hook implementations.

Personally, I think this is a cleaner API to work with, and would allow the documentation for hooks to exist on the respective `Component` methods (e.g., documentation for `OnAdd` can exist on `Component::on_add`). Ideally, `Component::on_add` would be the hook itself rather than a getter for the hook, but it is the only way to early-out for a no-op hook, which is important for performance.

## Migration Guide

`Component::register_component_hooks` has been deprecated. If you are manually implementing the `Component` trait and registering hooks there, use the individual methods such as `on_add` instead for increased clarity.