### PR TITLE
Bump to `uuid` 1.13.1 and enable `js` on `wasm` targets

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -40,9 +40,12 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 either = "1.13"
 thread_local = "1"
-uuid = { version = "1.7", features = ["v4"] }
+uuid = { version = "1.13", features = ["v4"] }
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.13", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -40,12 +40,12 @@ thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 either = "1.13"
 thread_local = "1"
-uuid = { version = "1.13", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 smallvec = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.13", default-features = false, features = ["js"] }
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -49,7 +49,7 @@ ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-uuid = { version = "1.13", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -64,7 +64,7 @@ web-sys = { version = "0.3", features = [
 ] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-uuid = { version = "1.13", default-features = false, features = ["js"] }
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.4.0", optional = true }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -49,7 +49,7 @@ ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "1.13", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
@@ -64,6 +64,7 @@ web-sys = { version = "0.3", features = [
 ] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
+uuid = { version = "1.13", default-features = false, features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.4.0", optional = true }

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -32,8 +32,11 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 
 # other
 crossbeam-channel = { version = "0.5", optional = true }
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.13", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.13", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -32,11 +32,11 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 
 # other
 crossbeam-channel = { version = "0.5", optional = true }
-uuid = { version = "1.13", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.13", default-features = false, features = ["js"] }
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -111,7 +111,7 @@ petgraph = { version = "0.6", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", default-features = false, features = [
   "serde",
 ], optional = true }
-uuid = { version = "1.13", default-features = false, optional = true, features = [
+uuid = { version = "1.13.1", default-features = false, optional = true, features = [
   "v4",
   "serde",
 ] }
@@ -119,7 +119,7 @@ variadics_please = "1.1"
 wgpu-types = { version = "23", features = ["serde"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.13", default-features = false, features = ["js"] }
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -111,12 +111,15 @@ petgraph = { version = "0.6", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", default-features = false, features = [
   "serde",
 ], optional = true }
-uuid = { version = "1.0", default-features = false, optional = true, features = [
+uuid = { version = "1.13", default-features = false, optional = true, features = [
   "v4",
   "serde",
 ] }
 variadics_please = "1.1"
 wgpu-types = { version = "23", features = ["serde"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.13", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -23,10 +23,10 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-uuid = { version = "1.13", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.13", default-features = false, features = ["js"] }
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -23,7 +23,10 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.13", features = ["v4"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.13", default-features = false, features = ["js"] }
 
 [lints]
 workspace = true

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -35,9 +35,12 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.13", features = ["v4"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.13", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -35,12 +35,12 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-uuid = { version = "1.13", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-uuid = { version = "1.13", default-features = false, features = ["js"] }
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }


### PR DESCRIPTION
# Objective

- Fixes CI failure due to `uuid` 1.13 using the new version of `getrandom` which requires using a new API to work on Wasm.

## Solution

- Based on [`uuid` 1.13 release notes](https://github.com/uuid-rs/uuid/releases/tag/1.13.0) I've enabled the `js` feature on `wasm32`. This will need to be revisited once #17499 is up for review
- Updated minimum `uuid` version to 1.13.1, which fixes a separate issue with `target_feature = atomics` on `wasm`.

## Testing

- `cargo check --target wasm32-unknown-unknown`

