### PR TITLE
Add checked methods to add vertex attributes to mesh only if values is not empty

### DIFF
--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -237,6 +237,35 @@ impl Mesh {
             .insert(attribute.id, MeshAttributeData { attribute, values });
     }
 
+    /// Sets the data for a vertex attribute (position, normal, etc.) if not empty.
+    /// The name will often be one of the associated constants such
+    /// as [`Mesh::ATTRIBUTE_POSITION`].
+    ///
+    /// `Aabb` of entities with modified mesh are not updated automatically.
+    ///
+    /// # Panics
+    /// Panics when the format of the values does not match the attribute's format.
+    #[inline]
+    pub fn insert_attribute_if_not_empty(
+        &mut self,
+        attribute: MeshVertexAttribute,
+        values: impl Into<VertexAttributeValues>,
+    ) {
+        let values = values.into();
+        if !values.is_empty() {
+            let values_format = VertexFormat::from(&values);
+            if values_format != attribute.format {
+                panic!(
+                "Failed to insert attribute. Invalid attribute format for {}. Given format is {values_format:?} but expected {:?}",
+                attribute.name, attribute.format
+            );
+            }
+
+            self.attributes
+                .insert(attribute.id, MeshAttributeData { attribute, values });
+        }
+    }
+
     /// Consumes the mesh and returns a mesh with data set for a vertex attribute (position, normal, etc.).
     /// The name will often be one of the associated constants such as [`Mesh::ATTRIBUTE_POSITION`].
     ///
@@ -254,6 +283,27 @@ impl Mesh {
         values: impl Into<VertexAttributeValues>,
     ) -> Self {
         self.insert_attribute(attribute, values);
+        self
+    }
+
+    /// Consumes the mesh and returns a mesh with data set for a vertex attribute (position, normal, etc.)
+    /// if it is not empty.
+    /// The name will often be one of the associated constants such as [`Mesh::ATTRIBUTE_POSITION`].
+    ///
+    /// (Alternatively, you can use [`Mesh::insert_attribute`] to mutate an existing mesh in-place)
+    ///
+    /// `Aabb` of entities with modified mesh are not updated automatically.
+    ///
+    /// # Panics
+    /// Panics when the format of the values does not match the attribute's format.
+    #[must_use]
+    #[inline]
+    pub fn with_inserted_attribute_if_not_empty(
+        mut self,
+        attribute: MeshVertexAttribute,
+        values: impl Into<VertexAttributeValues>,
+    ) -> Self {
+        self.insert_attribute_if_not_empty(attribute, values);
         self
     }
 


### PR DESCRIPTION
# Objective

When creating a custom mesh, there might be an attribute that is optional, that way you would need to store the `Mesh` in a variable, insert the required attributes, then check if the optional attribute exists or not, and insert if it does. With this checked methods you can use with the builder patterns

## Solution

Create methods `insert_attribute_if_not_empty` and `with_inserted_attribute_if_not_empty` (names are tentative).

## Testing

Used in a modification to `SphereMeshBuilder` (PR #17691)

## Showcase

Before
```rust
        let mut mesh = Mesh::new(
            PrimitiveTopology::TriangleList,
            RenderAssetUsages::default(),
        )
        .with_inserted_indices(indices)
        .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, points)
        .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
        .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs);

         if optional_attribute {
                 let optional_attribute = generate_optional_attribute();
                 mesh.insert_attribute(OPTIONAL_ATTRIBUTE, optional_attribute);
        }

       mesh
```

After
```rust
let optional_attribute = if optional_attribute {
          generate_optional_attribute()
} else {
    vec![]
};

Mesh::new(
    PrimitiveTopology::TriangleList,
    RenderAssetUsages::default(),
)
.with_inserted_indices(indices)
.with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, points)
.with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
.with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
.with_inserted_attribute_if_not_empty(OPTIONAL_ATTRIBUTE, optional_attribue)
```
