### PR TITLE
Primitive 3d custom tangents

### DIFF
--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -237,6 +237,35 @@ impl Mesh {
             .insert(attribute.id, MeshAttributeData { attribute, values });
     }
 
+    /// Sets the data for a vertex attribute (position, normal, etc.) if not empty.
+    /// The name will often be one of the associated constants such
+    /// as [`Mesh::ATTRIBUTE_POSITION`].
+    ///
+    /// `Aabb` of entities with modified mesh are not updated automatically.
+    ///
+    /// # Panics
+    /// Panics when the format of the values does not match the attribute's format.
+    #[inline]
+    pub fn insert_attribute_if_not_empty(
+        &mut self,
+        attribute: MeshVertexAttribute,
+        values: impl Into<VertexAttributeValues>,
+    ) {
+        let values = values.into();
+        if !values.is_empty() {
+            let values_format = VertexFormat::from(&values);
+            if values_format != attribute.format {
+                panic!(
+                "Failed to insert attribute. Invalid attribute format for {}. Given format is {values_format:?} but expected {:?}",
+                attribute.name, attribute.format
+            );
+            }
+
+            self.attributes
+                .insert(attribute.id, MeshAttributeData { attribute, values });
+        }
+    }
+
     /// Consumes the mesh and returns a mesh with data set for a vertex attribute (position, normal, etc.).
     /// The name will often be one of the associated constants such as [`Mesh::ATTRIBUTE_POSITION`].
     ///
@@ -254,6 +283,27 @@ impl Mesh {
         values: impl Into<VertexAttributeValues>,
     ) -> Self {
         self.insert_attribute(attribute, values);
+        self
+    }
+
+    /// Consumes the mesh and returns a mesh with data set for a vertex attribute (position, normal, etc.)
+    /// if it is not empty.
+    /// The name will often be one of the associated constants such as [`Mesh::ATTRIBUTE_POSITION`].
+    ///
+    /// (Alternatively, you can use [`Mesh::insert_attribute`] to mutate an existing mesh in-place)
+    ///
+    /// `Aabb` of entities with modified mesh are not updated automatically.
+    ///
+    /// # Panics
+    /// Panics when the format of the values does not match the attribute's format.
+    #[must_use]
+    #[inline]
+    pub fn with_inserted_attribute_if_not_empty(
+        mut self,
+        attribute: MeshVertexAttribute,
+        values: impl Into<VertexAttributeValues>,
+    ) -> Self {
+        self.insert_attribute_if_not_empty(attribute, values);
         self
     }
 

--- a/crates/bevy_mesh/src/primitives/dim3/mod.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/mod.rs
@@ -19,3 +19,13 @@ pub use sphere::*;
 pub use tetrahedron::*;
 pub use torus::*;
 pub use triangle3d::*;
+
+use bevy_math::{Dir3, Vec3};
+
+fn calculate_tangents_around_axis(normals: &[[f32; 3]], tangent_axis: &Dir3) -> Vec<[f32; 4]> {
+    normals
+        .iter()
+        .map(|normal| Vec3::from_array(*normal))
+        .map(|normal| tangent_axis.cross(normal).extend(1.).to_array())
+        .collect()
+}

--- a/crates/bevy_mesh/src/primitives/dim3/sphere.rs
+++ b/crates/bevy_mesh/src/primitives/dim3/sphere.rs
@@ -1,6 +1,6 @@
 use crate::{Indices, Mesh, MeshBuilder, Meshable, PrimitiveTopology};
 use bevy_asset::RenderAssetUsages;
-use bevy_math::{ops, primitives::Sphere, Dir3, Vec3};
+use bevy_math::{ops, primitives::Sphere, Dir3};
 use bevy_reflect::prelude::*;
 use core::f32::consts::PI;
 use hexasphere::shapes::IcoSphere;
@@ -162,7 +162,7 @@ impl SphereMeshBuilder {
         let indices = Indices::U32(indices);
 
         let tangent = if let Some(tangent_axis) = self.tangent_axis {
-            Self::calculate_tangents(normals.as_slice(), &tangent_axis)
+            super::calculate_tangents_around_axis(normals.as_slice(), &tangent_axis)
         } else {
             vec![]
         };
@@ -238,7 +238,7 @@ impl SphereMeshBuilder {
         }
 
         let tangents = if let Some(tangent_axis) = self.tangent_axis {
-            Self::calculate_tangents(normals.as_slice(), &tangent_axis)
+            super::calculate_tangents_around_axis(normals.as_slice(), &tangent_axis)
         } else {
             vec![]
         };
@@ -252,14 +252,6 @@ impl SphereMeshBuilder {
         .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
         .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)
         .with_inserted_attribute_if_not_empty(Mesh::ATTRIBUTE_TANGENT, tangents)
-    }
-
-    fn calculate_tangents(normals: &[[f32; 3]], tangent_axis: &Dir3) -> Vec<[f32; 4]> {
-        normals
-            .iter()
-            .map(|normal| Vec3::from_array(*normal))
-            .map(|normal| tangent_axis.cross(normal).extend(1.).to_array())
-            .collect()
     }
 }
 


### PR DESCRIPTION
# Objective

Anisotropy requires tangents, and the current method of building tangents depends on UVs, which causes seams on most of the primitive shapes. But most of the primitive shapes have simple methods of calculating tangents that do not require the UVs.

## Solution

Create custom calculation of the tangent for some of the 3d primitives.

## Testing

Add custom primitives to the `anisotropy` example.

## Showcase

Sphere with custom tangent calculation in the `anisotropy` example
[Screencast_20250205_110935.webm](https://github.com/user-attachments/assets/9cc8daf9-7201-4a40-96e3-a4f7663d32a3)

## Migration Guide

This PR requires #17690
