### PR TITLE
Weak handle migration

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -143,6 +143,7 @@ impl<T: Asset> Clone for Handle<T> {
 
 impl<A: Asset> Handle<A> {
     /// Create a new [`Handle::Weak`] with the given [`u128`] encoding of a [`Uuid`].
+    #[deprecated = "use the `weak_handle!` macro with a UUID string instead"]
     pub const fn weak_from_u128(value: u128) -> Self {
         Handle::Weak(AssetId::Uuid {
             uuid: Uuid::from_u128(value),

--- a/crates/bevy_core_pipeline/src/auto_exposure/pipeline.rs
+++ b/crates/bevy_core_pipeline/src/auto_exposure/pipeline.rs
@@ -1,7 +1,7 @@
 use super::compensation_curve::{
     AutoExposureCompensationCurve, AutoExposureCompensationCurveUniform,
 };
-use bevy_asset::prelude::*;
+use bevy_asset::{prelude::*, weak_handle};
 use bevy_ecs::prelude::*;
 use bevy_image::Image;
 use bevy_render::{
@@ -44,7 +44,8 @@ pub enum AutoExposurePass {
     Average,
 }
 
-pub const METERING_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(12987620402995522466);
+pub const METERING_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("05c84384-afa4-41d9-844e-e9cd5e7609af");
 
 pub const HISTOGRAM_BIN_COUNT: u64 = 64;
 

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -1,5 +1,5 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     render_resource::{
@@ -12,7 +12,7 @@ use bevy_render::{
 
 use crate::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
 
-pub const BLIT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2312396983770133547);
+pub const BLIT_SHADER_HANDLE: Handle<Shader> = weak_handle!("59be3075-c34e-43e7-bf24-c8fe21a0192e");
 
 /// Adds support for specialized "blit pipelines", which can be used to write one texture to another.
 pub struct BlitPlugin;

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     core_3d::graph::{Core3d, Node3d},
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_math::{ops, UVec2};
 use bevy_render::{
@@ -34,7 +34,7 @@ use upsampling_pipeline::{
     prepare_upsampling_pipeline, BloomUpsamplingPipeline, UpsamplingPipelineIds,
 };
 
-const BLOOM_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(929599476923908);
+const BLOOM_SHADER_HANDLE: Handle<Shader> = weak_handle!("c9190ddc-573b-4472-8b21-573cab502b73");
 
 const BLOOM_TEXTURE_FORMAT: TextureFormat = TextureFormat::Rg11b10Ufloat;
 

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_image::BevyDefault as _;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -96,7 +96,7 @@ impl ExtractComponent for ContrastAdaptiveSharpening {
 }
 
 const CONTRAST_ADAPTIVE_SHARPENING_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(6925381244141981602);
+    weak_handle!("ef83f0a5-51df-4b51-9ab7-b5fd1ae5a397");
 
 /// Adds Support for Contrast Adaptive Sharpening (CAS).
 pub struct CasPlugin;

--- a/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
+++ b/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
@@ -3,7 +3,7 @@ use crate::{
     prepass::{DeferredPrepass, ViewPrepassTextures},
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::prelude::*;
 use bevy_math::UVec2;
 use bevy_render::{
@@ -24,7 +24,7 @@ use bevy_render::{
 use super::DEFERRED_LIGHTING_PASS_ID_DEPTH_FORMAT;
 
 pub const COPY_DEFERRED_LIGHTING_ID_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(5230948520734987);
+    weak_handle!("70d91342-1c43-4b20-973f-aa6ce93aa617");
 pub struct CopyDeferredLightingIdPlugin;
 
 impl Plugin for CopyDeferredLightingIdPlugin {

--- a/crates/bevy_core_pipeline/src/dof/mod.rs
+++ b/crates/bevy_core_pipeline/src/dof/mod.rs
@@ -15,7 +15,7 @@
 //! [Depth of field]: https://en.wikipedia.org/wiki/Depth_of_field
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -69,7 +69,7 @@ use crate::{
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
 };
 
-const DOF_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2031861180739216043);
+const DOF_SHADER_HANDLE: Handle<Shader> = weak_handle!("c3580ddc-2cbc-4535-a02b-9a2959066b52");
 
 /// A plugin that adds support for the depth of field effect to Bevy.
 pub struct DepthOfFieldPlugin;

--- a/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
+++ b/crates/bevy_core_pipeline/src/experimental/mip_generation/mod.rs
@@ -8,7 +8,7 @@
 use core::array;
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -51,7 +51,7 @@ use crate::{
 
 /// Identifies the `downsample_depth.wgsl` shader.
 pub const DOWNSAMPLE_DEPTH_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(3876351454330663524);
+    weak_handle!("a09a149e-5922-4fa4-9170-3c1a13065364");
 
 /// The maximum number of mip levels that we can produce.
 ///

--- a/crates/bevy_core_pipeline/src/fullscreen_vertex_shader/mod.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_vertex_shader/mod.rs
@@ -1,7 +1,8 @@
-use bevy_asset::Handle;
+use bevy_asset::{weak_handle, Handle};
 use bevy_render::{prelude::Shader, render_resource::VertexState};
 
-pub const FULLSCREEN_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7837534426033940724);
+pub const FULLSCREEN_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("481fb759-d0b1-4175-8319-c439acde30a2");
 
 /// uses the [`FULLSCREEN_SHADER_HANDLE`] to output a
 /// ```wgsl

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::prelude::*;
 use bevy_image::BevyDefault as _;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -80,7 +80,7 @@ impl Default for Fxaa {
     }
 }
 
-const FXAA_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(4182761465141723543);
+const FXAA_SHADER_HANDLE: Handle<Shader> = weak_handle!("fc58c0a8-01c0-46e9-94cc-83a794bae7b0");
 
 /// Adds support for Fast Approximate Anti-Aliasing (FXAA)
 pub struct FxaaPlugin;

--- a/crates/bevy_core_pipeline/src/motion_blur/mod.rs
+++ b/crates/bevy_core_pipeline/src/motion_blur/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     prepass::{DepthPrepass, MotionVectorPrepass},
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::{
     component::{require, Component},
     query::With,
@@ -108,7 +108,7 @@ impl Default for MotionBlur {
 }
 
 pub const MOTION_BLUR_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(987457899187986082347921);
+    weak_handle!("d9ca74af-fa0a-4f11-b0f2-19613b618b93");
 
 /// Adds support for per-object motion blur to the app. See [`MotionBlur`] for details.
 pub struct MotionBlurPlugin;

--- a/crates/bevy_core_pipeline/src/oit/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/mod.rs
@@ -1,7 +1,7 @@
 //! Order Independent Transparency (OIT) for 3d rendering. See [`OrderIndependentTransparencyPlugin`] for more details.
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::{component::*, prelude::*};
 use bevy_math::UVec2;
 use bevy_platform_support::collections::HashSet;
@@ -34,7 +34,8 @@ use crate::core_3d::{
 pub mod resolve;
 
 /// Shader handle for the shader that draws the transparent meshes to the OIT layers buffer.
-pub const OIT_DRAW_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(4042527984320512);
+pub const OIT_DRAW_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("0cd3c764-39b8-437b-86b4-4e45635fc03d");
 
 /// Used to identify which camera will use OIT to render transparent meshes
 /// and to configure OIT.
@@ -73,7 +74,7 @@ impl Component for OrderIndependentTransparencySettings {
         Some(|world, context| {
             if let Some(value) = world.get::<OrderIndependentTransparencySettings>(context.entity) {
                 if value.layer_count > 32 {
-                    warn!("{}OrderIndependentTransparencySettings layer_count set to {} might be too high.", 
+                    warn!("{}OrderIndependentTransparencySettings layer_count set to {} might be too high.",
                         context.caller.map(|location|format!("{location}: ")).unwrap_or_default(),
                         value.layer_count
                     );

--- a/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
+++ b/crates/bevy_core_pipeline/src/oit/resolve/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     oit::OrderIndependentTransparencySettings,
 };
 use bevy_app::Plugin;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_derive::Deref;
 use bevy_ecs::{
     entity::{hash_map::EntityHashMap, hash_set::EntityHashSet},
@@ -27,7 +27,8 @@ use tracing::warn;
 use super::OitBuffers;
 
 /// Shader handle for the shader that sorts the OIT layers, blends the colors based on depth and renders them to the screen.
-pub const OIT_RESOLVE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7698420424769536);
+pub const OIT_RESOLVE_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("562d2917-eb06-444d-9ade-41de76b0f5ae");
 
 /// Contains the render node used to run the resolve pass.
 pub mod node;

--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -3,7 +3,7 @@
 //! Currently, this consists only of chromatic aberration.
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -47,17 +47,18 @@ use crate::{
 };
 
 /// The handle to the built-in postprocessing shader `post_process.wgsl`.
-const POST_PROCESSING_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(14675654334038973533);
+const POST_PROCESSING_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("5e8e627a-7531-484d-a988-9a38acb34e52");
 /// The handle to the chromatic aberration shader `chromatic_aberration.wgsl`.
 const CHROMATIC_ABERRATION_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(10969893303667163833);
+    weak_handle!("e598550e-71c3-4f5a-ba29-aebc3f88c7b5");
 
 /// The handle to the default chromatic aberration lookup texture.
 ///
 /// This is just a 3x1 image consisting of one red pixel, one green pixel, and
 /// one blue pixel, in that order.
 const DEFAULT_CHROMATIC_ABERRATION_LUT_HANDLE: Handle<Image> =
-    Handle::weak_from_u128(2199972955136579180);
+    weak_handle!("dc3e3307-40a1-49bb-be6d-e0634e8836b2");
 
 /// The default chromatic aberration intensity amount, in a fraction of the
 /// window size.

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -1,5 +1,5 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::{
     prelude::{Component, Entity},
     query::{QueryItem, With},
@@ -30,7 +30,7 @@ use prepass::{SkyboxPrepassPipeline, SKYBOX_PREPASS_SHADER_HANDLE};
 
 use crate::{core_3d::CORE_3D_DEPTH_FORMAT, prepass::PreviousViewUniforms};
 
-const SKYBOX_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(55594763423201);
+const SKYBOX_SHADER_HANDLE: Handle<Shader> = weak_handle!("a66cf9cc-cab8-47f8-ac32-db82fdc4f29b");
 
 pub mod prepass;
 

--- a/crates/bevy_core_pipeline/src/skybox/prepass.rs
+++ b/crates/bevy_core_pipeline/src/skybox/prepass.rs
@@ -1,6 +1,6 @@
 //! Adds motion vector support to skyboxes. See [`SkyboxPrepassPipeline`] for details.
 
-use bevy_asset::Handle;
+use bevy_asset::{weak_handle, Handle};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -30,7 +30,8 @@ use crate::{
     Skybox,
 };
 
-pub const SKYBOX_PREPASS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(376510055324461154);
+pub const SKYBOX_PREPASS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("7a292435-bfe6-4ed9-8d30-73bf7aa673b0");
 
 /// This pipeline writes motion vectors to the prepass for all [`Skybox`]es.
 ///

--- a/crates/bevy_core_pipeline/src/smaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/smaa/mod.rs
@@ -38,7 +38,7 @@ use crate::{
 use bevy_app::{App, Plugin};
 #[cfg(feature = "smaa_luts")]
 use bevy_asset::load_internal_binary_asset;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -81,11 +81,13 @@ use bevy_render::{
 use bevy_utils::prelude::default;
 
 /// The handle of the `smaa.wgsl` shader.
-const SMAA_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(12247928498010601081);
+const SMAA_SHADER_HANDLE: Handle<Shader> = weak_handle!("fdd9839f-1ab4-4e0d-88a0-240b67da2ddf");
 /// The handle of the area LUT, a KTX2 format texture that SMAA uses internally.
-const SMAA_AREA_LUT_TEXTURE_HANDLE: Handle<Image> = Handle::weak_from_u128(15283551734567401670);
+const SMAA_AREA_LUT_TEXTURE_HANDLE: Handle<Image> =
+    weak_handle!("569c4d67-c7fa-4958-b1af-0836023603c0");
 /// The handle of the search LUT, a KTX2 format texture that SMAA uses internally.
-const SMAA_SEARCH_LUT_TEXTURE_HANDLE: Handle<Image> = Handle::weak_from_u128(3187314362190283210);
+const SMAA_SEARCH_LUT_TEXTURE_HANDLE: Handle<Image> =
+    weak_handle!("43b97515-252e-4c8a-b9af-f2fc528a1c27");
 
 /// Adds support for subpixel morphological antialiasing, or SMAA.
 pub struct SmaaPlugin;

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     prepass::{DepthPrepass, MotionVectorPrepass, ViewPrepassTextures},
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_diagnostic::FrameCount;
 use bevy_ecs::{
     prelude::{require, Component, Entity, ReflectComponent},
@@ -40,7 +40,7 @@ use bevy_render::{
 };
 use tracing::warn;
 
-const TAA_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(656865235226276);
+const TAA_SHADER_HANDLE: Handle<Shader> = weak_handle!("fea20d50-86b6-4069-aa32-374346aec00c");
 
 /// Plugin for temporal anti-aliasing.
 ///

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -1,6 +1,6 @@
 use crate::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_image::{CompressedImageFormats, Image, ImageSampler, ImageType};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -27,13 +27,14 @@ mod node;
 use bevy_utils::default;
 pub use node::TonemappingNode;
 
-const TONEMAPPING_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(17015368199668024512);
+const TONEMAPPING_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("e239c010-c25c-42a1-b4e8-08818764d667");
 
 const TONEMAPPING_SHARED_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2499430578245347910);
+    weak_handle!("61dbc544-4b30-4ca9-83bd-4751b5cfb1b1");
 
 const TONEMAPPING_LUT_BINDINGS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(8392056472189465073);
+    weak_handle!("d50e3a70-c85e-4725-a81e-72fc83281145");
 
 /// 3D LUT (look up table) textures used for tonemapping
 #[derive(Resource, Clone, ExtractResource)]

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -76,7 +76,7 @@ pub mod prelude {
 }
 
 use bevy_app::{App, FixedFirst, FixedLast, Last, Plugin, RunFixedMainLoop};
-use bevy_asset::{Asset, AssetApp, AssetId, Assets, Handle};
+use bevy_asset::{weak_handle, Asset, AssetApp, AssetId, Assets, Handle};
 use bevy_ecs::{
     resource::Resource,
     schedule::{IntoSystemConfigs, SystemSet},
@@ -138,9 +138,10 @@ use gizmos::{GizmoStorage, Swap};
 use light::LightGizmoPlugin;
 
 #[cfg(feature = "bevy_render")]
-const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812689238026784);
+const LINE_SHADER_HANDLE: Handle<Shader> = weak_handle!("15dc5869-ad30-4664-b35a-4137cb8804a1");
 #[cfg(feature = "bevy_render")]
-const LINE_JOINT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(1162780797909187908);
+const LINE_JOINT_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("7b5bdda5-df81-4711-a6cf-e587700de6f2");
 
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
 ///

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -71,26 +71,23 @@ use self::{
 };
 
 mod shaders {
-    use bevy_asset::Handle;
+    use bevy_asset::{weak_handle, Handle};
     use bevy_render::render_resource::Shader;
 
-    pub const TYPES: Handle<Shader> = Handle::weak_from_u128(0xB4CA686B10FA592B508580CCC2F9558C);
-    pub const FUNCTIONS: Handle<Shader> =
-        Handle::weak_from_u128(0xD5524FD88BDC153FBF256B7F2C21906F);
+    pub const TYPES: Handle<Shader> = weak_handle!("ef7e147e-30a0-4513-bae3-ddde2a6c20c5");
+    pub const FUNCTIONS: Handle<Shader> = weak_handle!("7ff93872-2ee9-4598-9f88-68b02fef605f");
     pub const BRUNETON_FUNCTIONS: Handle<Shader> =
-        Handle::weak_from_u128(0x7E896F48B707555DD11985F9C1594459);
-    pub const BINDINGS: Handle<Shader> = Handle::weak_from_u128(0x140EFD89B5D4C8490AB895010DFC42FE);
+        weak_handle!("e2dccbb0-7322-444a-983b-e74d0a08bcda");
+    pub const BINDINGS: Handle<Shader> = weak_handle!("bcc55ce5-0fc4-451e-8393-1b9efd2612c4");
 
     pub const TRANSMITTANCE_LUT: Handle<Shader> =
-        Handle::weak_from_u128(0xEECBDEDFEED7F4EAFBD401BFAA5E0EFB);
+        weak_handle!("a4187282-8cb1-42d3-889c-cbbfb6044183");
     pub const MULTISCATTERING_LUT: Handle<Shader> =
-        Handle::weak_from_u128(0x65915B32C44B6287C0CCE1E70AF2936A);
-    pub const SKY_VIEW_LUT: Handle<Shader> =
-        Handle::weak_from_u128(0x54136D7E6FFCD45BE38399A4E5ED7186);
+        weak_handle!("bde3a71a-73e9-49fe-a379-a81940c67a1e");
+    pub const SKY_VIEW_LUT: Handle<Shader> = weak_handle!("f87e007a-bf4b-4f99-9ef0-ac21d369f0e5");
     pub const AERIAL_VIEW_LUT: Handle<Shader> =
-        Handle::weak_from_u128(0x6FDEC284AD356B78C3A4D8ED4CBA0BC5);
-    pub const RENDER_SKY: Handle<Shader> =
-        Handle::weak_from_u128(0x1951EB87C8A6129F0B541B1E4B3D4962);
+        weak_handle!("a3daf030-4b64-49ae-a6a7-354489597cbe");
+    pub const RENDER_SKY: Handle<Shader> = weak_handle!("09422f46-d0f7-41c1-be24-121c17d6e834");
 }
 
 #[doc(hidden)]

--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -17,7 +17,7 @@
 use core::{num::NonZero, ops::Deref};
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::{require, Component},
@@ -54,7 +54,7 @@ use crate::{
 
 /// The handle to the `clustered.wgsl` shader.
 pub(crate) const CLUSTERED_DECAL_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2881025580737984685);
+    weak_handle!("87929002-3509-42f1-8279-2d2765dd145c");
 
 /// The maximum number of decals that can be present in a view.
 ///

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -3,7 +3,7 @@ use crate::{
     MaterialPlugin, StandardMaterial,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Asset, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Asset, Assets, Handle};
 use bevy_ecs::component::{require, Component};
 use bevy_math::{prelude::Rectangle, Quat, Vec2, Vec3};
 use bevy_reflect::{Reflect, TypePath};
@@ -16,8 +16,10 @@ use bevy_render::{
     },
 };
 
-const FORWARD_DECAL_MESH_HANDLE: Handle<Mesh> = Handle::weak_from_u128(19376620402995522466);
-const FORWARD_DECAL_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(29376620402995522466);
+const FORWARD_DECAL_MESH_HANDLE: Handle<Mesh> =
+    weak_handle!("afa817f9-1869-4e0c-ac0d-d8cd1552d38a");
+const FORWARD_DECAL_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("f8dfbef4-d88b-42ae-9af4-d9661e9f1648");
 
 /// Plugin to render [`ForwardDecal`]s.
 pub struct ForwardDecalPlugin;

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     ViewLightsUniformOffset,
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     deferred::{
@@ -35,7 +35,7 @@ use bevy_render::{
 pub struct DeferredPbrLightingPlugin;
 
 pub const DEFERRED_LIGHTING_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2708011359337029741);
+    weak_handle!("f4295279-8890-4748-b654-ca4d2183df1c");
 
 pub const DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID: u8 = 1;
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -110,7 +110,7 @@ pub mod graph {
 
 use crate::{deferred::DeferredPbrLightingPlugin, graph::NodePbr};
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetApp, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetApp, Assets, Handle};
 use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
 use bevy_ecs::prelude::*;
 use bevy_image::Image;
@@ -130,30 +130,42 @@ use bevy_render::{
 
 use bevy_transform::TransformSystem;
 
-pub const PBR_TYPES_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(1708015359337029744);
-pub const PBR_BINDINGS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(5635987986427308186);
-pub const UTILS_HANDLE: Handle<Shader> = Handle::weak_from_u128(1900548483293416725);
-pub const CLUSTERED_FORWARD_HANDLE: Handle<Shader> = Handle::weak_from_u128(166852093121196815);
-pub const PBR_LIGHTING_HANDLE: Handle<Shader> = Handle::weak_from_u128(14170772752254856967);
-pub const PBR_TRANSMISSION_HANDLE: Handle<Shader> = Handle::weak_from_u128(77319684653223658032);
-pub const SHADOWS_HANDLE: Handle<Shader> = Handle::weak_from_u128(11350275143789590502);
-pub const SHADOW_SAMPLING_HANDLE: Handle<Shader> = Handle::weak_from_u128(3145627513789590502);
-pub const PBR_FRAGMENT_HANDLE: Handle<Shader> = Handle::weak_from_u128(2295049283805286543);
-pub const PBR_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(4805239651767701046);
-pub const PBR_PREPASS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(9407115064344201137);
-pub const PBR_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(16550102964439850292);
-pub const PBR_AMBIENT_HANDLE: Handle<Shader> = Handle::weak_from_u128(2441520459096337034);
+pub const PBR_TYPES_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("b0330585-2335-4268-9032-a6c4c2d932f6");
+pub const PBR_BINDINGS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("13834c18-c7ec-4c4b-bbbd-432c3ba4cace");
+pub const UTILS_HANDLE: Handle<Shader> = weak_handle!("0a32978f-2744-4608-98b6-4c3000a0638d");
+pub const CLUSTERED_FORWARD_HANDLE: Handle<Shader> =
+    weak_handle!("f8e3b4c6-60b7-4b23-8b2e-a6b27bb4ddce");
+pub const PBR_LIGHTING_HANDLE: Handle<Shader> =
+    weak_handle!("de0cf697-2876-49a0-aa0f-f015216f70c2");
+pub const PBR_TRANSMISSION_HANDLE: Handle<Shader> =
+    weak_handle!("22482185-36bb-4c16-9b93-a20e6d4a2725");
+pub const SHADOWS_HANDLE: Handle<Shader> = weak_handle!("ff758c5a-3927-4a15-94c3-3fbdfc362590");
+pub const SHADOW_SAMPLING_HANDLE: Handle<Shader> =
+    weak_handle!("f6bf5843-54bc-4e39-bd9d-56bfcd77b033");
+pub const PBR_FRAGMENT_HANDLE: Handle<Shader> =
+    weak_handle!("1bd3c10d-851b-400c-934a-db489d99cc50");
+pub const PBR_SHADER_HANDLE: Handle<Shader> = weak_handle!("0eba65ed-3e5b-4752-93ed-e8097e7b0c84");
+pub const PBR_PREPASS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("9afeaeab-7c45-43ce-b322-4b97799eaeb9");
+pub const PBR_FUNCTIONS_HANDLE: Handle<Shader> =
+    weak_handle!("815b8618-f557-4a96-91a5-a2fb7e249fb0");
+pub const PBR_AMBIENT_HANDLE: Handle<Shader> = weak_handle!("4a90b95b-112a-4a10-9145-7590d6f14260");
 pub const PARALLAX_MAPPING_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(17035894873630133905);
+    weak_handle!("6cf57d9f-222a-429a-bba4-55ba9586e1d4");
 pub const VIEW_TRANSFORMATIONS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2098345702398750291);
+    weak_handle!("ec047703-cde3-4876-94df-fed121544abb");
 pub const PBR_PREPASS_FUNCTIONS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(73204817249182637);
-pub const PBR_DEFERRED_TYPES_HANDLE: Handle<Shader> = Handle::weak_from_u128(3221241127431430599);
-pub const PBR_DEFERRED_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(72019026415438599);
-pub const RGB9E5_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(2659010996143919192);
+    weak_handle!("77b1bd3a-877c-4b2c-981b-b9c68d1b774a");
+pub const PBR_DEFERRED_TYPES_HANDLE: Handle<Shader> =
+    weak_handle!("43060da7-a717-4240-80a8-dbddd92bd25d");
+pub const PBR_DEFERRED_FUNCTIONS_HANDLE: Handle<Shader> =
+    weak_handle!("9dc46746-c51d-45e3-a321-6a50c3963420");
+pub const RGB9E5_FUNCTIONS_HANDLE: Handle<Shader> =
+    weak_handle!("90c19aa3-6a11-4252-8586-d9299352e94f");
 const MESHLET_VISIBILITY_BUFFER_RESOLVE_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2325134235233421);
+    weak_handle!("69187376-3dea-4d0f-b3f5-185bde63d6a2");
 
 pub const TONEMAPPING_LUT_TEXTURE_BINDING_INDEX: u32 = 26;
 pub const TONEMAPPING_LUT_SAMPLER_BINDING_INDEX: u32 = 27;

--- a/crates/bevy_pbr/src/light_probe/environment_map.rs
+++ b/crates/bevy_pbr/src/light_probe/environment_map.rs
@@ -44,7 +44,7 @@
 //!
 //! [several pre-filtered environment maps]: https://github.com/KhronosGroup/glTF-Sample-Environments
 
-use bevy_asset::{AssetId, Handle};
+use bevy_asset::{weak_handle, AssetId, Handle};
 use bevy_ecs::{
     component::Component, query::QueryItem, reflect::ReflectComponent, system::lifetimeless::Read,
 };
@@ -74,7 +74,7 @@ use super::{LightProbeComponent, RenderViewLightProbes};
 
 /// A handle to the environment map helper shader.
 pub const ENVIRONMENT_MAP_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(154476556247605696);
+    weak_handle!("d38c4ec4-e84c-468f-b485-bf44745db937");
 
 /// A pair of cubemap textures that represent the surroundings of a specific
 /// area in space.

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
@@ -146,7 +146,7 @@ use bevy_render::{
 use bevy_utils::default;
 use core::{num::NonZero, ops::Deref};
 
-use bevy_asset::{AssetId, Handle};
+use bevy_asset::{weak_handle, AssetId, Handle};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 use crate::{
@@ -157,7 +157,7 @@ use crate::{
 use super::LightProbeComponent;
 
 pub const IRRADIANCE_VOLUME_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(160299515939076705258408299184317675488);
+    weak_handle!("7fc7dcd8-3f90-4124-b093-be0e53e08205");
 
 /// On WebGL and WebGPU, we must disable irradiance volumes, as otherwise we can
 /// overflow the number of texture bindings when deferred rendering is in use

--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -1,7 +1,7 @@
 //! Light probes for baked global illumination.
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetId, Handle};
 use bevy_core_pipeline::core_3d::Camera3d;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
@@ -43,7 +43,8 @@ use crate::{
 
 use self::irradiance_volume::IrradianceVolume;
 
-pub const LIGHT_PROBE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(8954249792581071582);
+pub const LIGHT_PROBE_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("e80a2ae6-1c5a-4d9a-a852-d66ff0e6bf7f");
 
 pub mod environment_map;
 pub mod irradiance_volume;

--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -32,7 +32,7 @@
 //! [`bevy-baked-gi`]: https://github.com/pcwalton/bevy-baked-gi
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     component::Component,
@@ -68,7 +68,7 @@ use crate::{binding_arrays_are_usable, ExtractMeshesSet};
 
 /// The ID of the lightmap shader.
 pub const LIGHTMAP_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(285484768317531991932943596447919767152);
+    weak_handle!("fc28203f-f258-47f3-973c-ce7d1dd70e59");
 
 /// The number of lightmaps that we store in a single slab, if bindless textures
 /// are in use.

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -59,7 +59,7 @@ use self::{
 use crate::graph::NodePbr;
 use crate::PreviousGlobalTransform;
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, AssetApp, AssetId, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetApp, AssetId, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     prepass::{DeferredPrepass, MotionVectorPrepass, NormalPrepass},
@@ -86,9 +86,10 @@ use bevy_transform::components::Transform;
 use derive_more::From;
 use tracing::error;
 
-const MESHLET_BINDINGS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(1325134235233421);
+const MESHLET_BINDINGS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("d90ac78c-500f-48aa-b488-cc98eb3f6314");
 const MESHLET_MESH_MATERIAL_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(3325134235233421);
+    weak_handle!("db8d9001-6ca7-4d00-968a-d5f5b96b89c3");
 
 /// Provides a plugin for rendering large amounts of high-poly 3d meshes using an efficient GPU-driven method. See also [`MeshletMesh`].
 ///

--- a/crates/bevy_pbr/src/meshlet/pipelines.rs
+++ b/crates/bevy_pbr/src/meshlet/pipelines.rs
@@ -1,5 +1,5 @@
 use super::resource_manager::ResourceManager;
-use bevy_asset::Handle;
+use bevy_asset::{weak_handle, Handle};
 use bevy_core_pipeline::{
     core_3d::CORE_3D_DEPTH_FORMAT, experimental::mip_generation::DOWNSAMPLE_DEPTH_SHADER_HANDLE,
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
@@ -11,16 +11,17 @@ use bevy_ecs::{
 use bevy_render::render_resource::*;
 
 pub const MESHLET_FILL_CLUSTER_BUFFERS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(4325134235233421);
-pub const MESHLET_CULLING_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(5325134235233421);
+    weak_handle!("80ccea4a-8234-4ee0-af74-77b3cad503cf");
+pub const MESHLET_CULLING_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("d71c5879-97fa-49d1-943e-ed9162fe8adb");
 pub const MESHLET_VISIBILITY_BUFFER_SOFTWARE_RASTER_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(7325134235233421);
+    weak_handle!("68cc6826-8321-43d1-93d5-4f61f0456c13");
 pub const MESHLET_VISIBILITY_BUFFER_HARDWARE_RASTER_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(8325134235233421);
+    weak_handle!("4b4e3020-748f-4baf-b011-87d9d2a12796");
 pub const MESHLET_RESOLVE_RENDER_TARGETS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(9325134235233421);
+    weak_handle!("c218ce17-cf59-4268-8898-13ecf384f133");
 pub const MESHLET_REMAP_1D_TO_2D_DISPATCH_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(9425134235233421);
+    weak_handle!("f5b7edfc-2eac-4407-8f5c-1265d4d795c2");
 
 #[derive(Resource)]
 pub struct MeshletPipelines {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::{
 };
 pub use prepass_bindings::*;
 
-use bevy_asset::{load_internal_asset, AssetServer, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetServer, Handle};
 use bevy_core_pipeline::{
     core_3d::CORE_3D_DEPTH_FORMAT, deferred::*, prelude::Camera3d, prepass::*,
 };
@@ -64,14 +64,17 @@ use bevy_render::view::RenderVisibleEntities;
 use bevy_render::RenderSet::PrepareAssets;
 use core::{hash::Hash, marker::PhantomData};
 
-pub const PREPASS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(921124473254008983);
+pub const PREPASS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("ce810284-f1ae-4439-ab2e-0d6b204b6284");
 
 pub const PREPASS_BINDINGS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(5533152893177403494);
+    weak_handle!("3e83537e-ae17-489c-a18a-999bc9c1d252");
 
-pub const PREPASS_UTILS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(4603948296044544);
+pub const PREPASS_UTILS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("02e4643a-a14b-48eb-a339-0c47aeab0d7e");
 
-pub const PREPASS_IO_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(81212356509530944);
+pub const PREPASS_IO_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("1c065187-c99b-4b7c-ba59-c1575482d2c9");
 
 /// Sets up everything required to use the prepass pipeline.
 ///

--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -1,5 +1,5 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_color::{ColorToComponents, LinearRgba};
 use bevy_ecs::prelude::*;
 use bevy_math::{Vec3, Vec4};
@@ -127,7 +127,7 @@ pub struct ViewFogUniformOffset {
 }
 
 /// Handle for the fog WGSL Shader internal asset
-pub const FOG_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(4913569193382610166);
+pub const FOG_SHADER_HANDLE: Handle<Shader> = weak_handle!("e943f446-2856-471c-af5e-68dd276eec42");
 
 /// A plugin that consolidates fog extraction, preparation and related resources/assets
 pub struct FogPlugin;

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -9,7 +9,7 @@
 use core::num::{NonZero, NonZeroU64};
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     experimental::mip_generation::ViewDepthPyramid,
@@ -64,16 +64,16 @@ use super::ViewLightEntities;
 
 /// The handle to the `mesh_preprocess.wgsl` compute shader.
 pub const MESH_PREPROCESS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(16991728318640779533);
+    weak_handle!("c8579292-cf92-43b5-9c5a-ec5bd4e44d12");
 /// The handle to the `mesh_preprocess_types.wgsl` compute shader.
 pub const MESH_PREPROCESS_TYPES_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2720440370122465935);
+    weak_handle!("06f797ef-a106-4098-9a2e-20a73aa182e2");
 /// The handle to the `reset_indirect_batch_sets.wgsl` compute shader.
 pub const RESET_INDIRECT_BATCH_SETS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2602194133710559644);
+    weak_handle!("045fb176-58e2-4e76-b241-7688d761bb23");
 /// The handle to the `build_indirect_params.wgsl` compute shader.
 pub const BUILD_INDIRECT_PARAMS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(3711077208359699672);
+    weak_handle!("133b01f0-3eaf-4590-9ee9-f0cf91a00b71");
 
 /// The GPU workgroup size.
 const WORKGROUP_SIZE: usize = 64;

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -88,16 +88,21 @@ pub struct MeshRenderPlugin {
     pub use_gpu_instance_buffer_builder: bool,
 }
 
-pub const FORWARD_IO_HANDLE: Handle<Shader> = Handle::weak_from_u128(2645551199423808407);
-pub const MESH_VIEW_TYPES_HANDLE: Handle<Shader> = Handle::weak_from_u128(8140454348013264787);
-pub const MESH_VIEW_BINDINGS_HANDLE: Handle<Shader> = Handle::weak_from_u128(9076678235888822571);
-pub const MESH_TYPES_HANDLE: Handle<Shader> = Handle::weak_from_u128(2506024101911992377);
-pub const MESH_BINDINGS_HANDLE: Handle<Shader> = Handle::weak_from_u128(16831548636314682308);
-pub const MESH_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(6300874327833745635);
-pub const MESH_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(3252377289100772450);
-pub const SKINNING_HANDLE: Handle<Shader> = Handle::weak_from_u128(13215291596265391738);
-pub const MORPH_HANDLE: Handle<Shader> = Handle::weak_from_u128(970982813587607345);
-pub const OCCLUSION_CULLING_HANDLE: Handle<Shader> = Handle::weak_from_u128(285365001154292827);
+pub const FORWARD_IO_HANDLE: Handle<Shader> = weak_handle!("38111de1-6e35-4dbb-877b-7b6f9334baf6");
+pub const MESH_VIEW_TYPES_HANDLE: Handle<Shader> =
+    weak_handle!("979493db-4ae1-4003-b5c6-fcbb88b152a2");
+pub const MESH_VIEW_BINDINGS_HANDLE: Handle<Shader> =
+    weak_handle!("c6fe674b-4c21-4d4b-867a-352848da5337");
+pub const MESH_TYPES_HANDLE: Handle<Shader> = weak_handle!("a4a3fc2e-a57e-4083-a8ab-2840176927f2");
+pub const MESH_BINDINGS_HANDLE: Handle<Shader> =
+    weak_handle!("84e7f9e6-e566-4a61-914e-c568f5dabf49");
+pub const MESH_FUNCTIONS_HANDLE: Handle<Shader> =
+    weak_handle!("c46aa0f0-6c0c-4b3a-80bf-d8213c771f12");
+pub const MESH_SHADER_HANDLE: Handle<Shader> = weak_handle!("1a7bbae8-4b4f-48a7-b53b-e6822e56f321");
+pub const SKINNING_HANDLE: Handle<Shader> = weak_handle!("7474e812-2506-4cbf-9de3-fe07e5c6ff24");
+pub const MORPH_HANDLE: Handle<Shader> = weak_handle!("da30aac7-34cc-431d-a07f-15b1a783008c");
+pub const OCCLUSION_CULLING_HANDLE: Handle<Shader> =
+    weak_handle!("eaea07d9-7516-482c-aa42-6f8e9927e1f0");
 
 /// How many textures are allowed in the view bind group layout (`@group(0)`) before
 /// broader compatibility with WebGL and WebGPU is at risk, due to the minimum guaranteed

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -1,6 +1,6 @@
 use crate::NodePbr;
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     prelude::Camera3d,
@@ -39,10 +39,13 @@ use bevy_utils::prelude::default;
 use core::mem;
 use tracing::{error, warn};
 
-const PREPROCESS_DEPTH_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(102258915420479);
-const SSAO_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(253938746510568);
-const SPATIAL_DENOISE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(466162052558226);
-const SSAO_UTILS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(366465052568786);
+const PREPROCESS_DEPTH_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("b7f2cc3d-c935-4f5c-9ae2-43d6b0d5659a");
+const SSAO_SHADER_HANDLE: Handle<Shader> = weak_handle!("9ea355d7-37a2-4cc4-b4d1-5d8ab47b07f5");
+const SPATIAL_DENOISE_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("0f2764a0-b343-471b-b7ce-ef5d636f4fc3");
+const SSAO_UTILS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("da53c78d-f318-473e-bdff-b388bc50ada2");
 
 /// Plugin for screen space ambient occlusion.
 pub struct ScreenSpaceAmbientOcclusionPlugin;

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -1,7 +1,7 @@
 //! Screen space reflections implemented via raymarching.
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_core_pipeline::{
     core_3d::{
         graph::{Core3d, Node3d},
@@ -49,8 +49,8 @@ use crate::{
     ViewLightsUniformOffset,
 };
 
-const SSR_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(10438925299917978850);
-const RAYMARCH_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(8517409683450840946);
+const SSR_SHADER_HANDLE: Handle<Shader> = weak_handle!("0b559df2-0d61-4f53-bf62-aea16cf32787");
+const RAYMARCH_SHADER_HANDLE: Handle<Shader> = weak_handle!("798cc6fc-6072-4b6c-ab4f-83905fa4a19e");
 
 /// Enables screen-space reflections for a camera.
 ///

--- a/crates/bevy_pbr/src/volumetric_fog/render.rs
+++ b/crates/bevy_pbr/src/volumetric_fog/render.rs
@@ -2,7 +2,7 @@
 
 use core::array;
 
-use bevy_asset::{AssetId, Handle};
+use bevy_asset::{weak_handle, AssetId, Handle};
 use bevy_color::ColorToComponents as _;
 use bevy_core_pipeline::{
     core_3d::Camera3d,
@@ -78,21 +78,22 @@ bitflags! {
 }
 
 /// The volumetric fog shader.
-pub const VOLUMETRIC_FOG_HANDLE: Handle<Shader> = Handle::weak_from_u128(17400058287583986650);
+pub const VOLUMETRIC_FOG_HANDLE: Handle<Shader> =
+    weak_handle!("481f474c-2024-44bb-8f79-f7c05ced95ea");
 
 /// The plane mesh, which is used to render a fog volume that the camera is
 /// inside.
 ///
 /// This mesh is simply stretched to the size of the framebuffer, as when the
 /// camera is inside a fog volume it's essentially a full-screen effect.
-pub const PLANE_MESH: Handle<Mesh> = Handle::weak_from_u128(435245126479971076);
+pub const PLANE_MESH: Handle<Mesh> = weak_handle!("92523617-c708-4fd0-b42f-ceb4300c930b");
 
 /// The cube mesh, which is used to render a fog volume that the camera is
 /// outside.
 ///
 /// Note that only the front faces of this cuboid will be rasterized in
 /// hardware. The back faces will be calculated in the shader via raytracing.
-pub const CUBE_MESH: Handle<Mesh> = Handle::weak_from_u128(5023959819001661507);
+pub const CUBE_MESH: Handle<Mesh> = weak_handle!("4a1dd661-2d91-4377-a17a-a914e21e277e");
 
 /// The total number of bind group layouts.
 ///

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,6 +1,6 @@
 use crate::{Material, MaterialPipeline, MaterialPipelineKey, MaterialPlugin, MeshMaterial3d};
 use bevy_app::{Plugin, Startup, Update};
-use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Asset, AssetApp, Assets, Handle};
 use bevy_color::{Color, LinearRgba};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -11,7 +11,8 @@ use bevy_render::{
     render_resource::*,
 };
 
-pub const WIREFRAME_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(192598014480025766);
+pub const WIREFRAME_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("2646a633-f8e3-4380-87ae-b44d881abbce");
 
 /// A [`Plugin`] that draws wireframes.
 ///

--- a/crates/bevy_render/src/experimental/occlusion_culling/mod.rs
+++ b/crates/bevy_render/src/experimental/occlusion_culling/mod.rs
@@ -4,7 +4,7 @@
 //! Bevy.
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_ecs::{component::Component, prelude::ReflectComponent};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 
@@ -12,7 +12,7 @@ use crate::{extract_component::ExtractComponent, render_resource::Shader};
 
 /// The handle to the `mesh_preprocess_types.wgsl` compute shader.
 pub const MESH_PREPROCESS_TYPES_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2720440370122465935);
+    weak_handle!("7bf7bdb1-ec53-4417-987f-9ec36533287c");
 
 /// Enables GPU occlusion culling.
 ///

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -6,13 +6,14 @@ use crate::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_diagnostic::FrameCount;
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
 use bevy_time::Time;
 
-pub const GLOBALS_TYPE_HANDLE: Handle<Shader> = Handle::weak_from_u128(17924628719070609599);
+pub const GLOBALS_TYPE_HANDLE: Handle<Shader> =
+    weak_handle!("9e22a765-30ca-4070-9a4c-34ac08f1c0e7");
 
 pub struct GlobalsPlugin;
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -97,7 +97,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use bevy_app::{App, AppLabel, Plugin, SubApp};
-use bevy_asset::{load_internal_asset, AssetApp, AssetServer, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetApp, AssetServer, Handle};
 use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 use core::ops::{Deref, DerefMut};
 use std::sync::Mutex;
@@ -259,10 +259,11 @@ struct FutureRenderResources(Arc<Mutex<Option<RenderResources>>>);
 pub struct RenderApp;
 
 pub const INSTANCE_INDEX_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(10313207077636615845);
-pub const MATHS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(10665356303104593376);
+    weak_handle!("475c76aa-4afd-4a6b-9878-1fc1e2f41216");
+pub const MATHS_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("d94d70d4-746d-49c4-bfc3-27d63f2acda0");
 pub const COLOR_OPERATIONS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(1844674407370955161);
+    weak_handle!("33a80b2f-aaf7-4c86-b828-e7ae83b72f1a");
 
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderSet`] and creates the rendering sub-app.

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     render_asset::RenderAssetPlugin, renderer::RenderDevice, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{AssetApp, Assets, Handle};
+use bevy_asset::{weak_handle, AssetApp, Assets, Handle};
 use bevy_ecs::prelude::*;
 
 /// A handle to a 1 x 1 transparent white image.
@@ -27,7 +27,7 @@ use bevy_ecs::prelude::*;
 /// While that handle points to an opaque white 1 x 1 image, this handle points to a transparent 1 x 1 white image.
 // Number randomly selected by fair WolframAlpha query. Totally arbitrary.
 pub const TRANSPARENT_IMAGE_HANDLE: Handle<Image> =
-    Handle::weak_from_u128(154728948001857810431816125397303024160);
+    weak_handle!("d18ad97e-a322-4981-9505-44c59a4b5e46");
 
 // TODO: replace Texture names with Image names?
 /// Adds the [`Image`] as an asset and makes sure that they are extracted and prepared for the GPU.

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -1,7 +1,7 @@
 pub mod visibility;
 pub mod window;
 
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 pub use visibility::*;
 pub use window::*;
 
@@ -45,7 +45,7 @@ use wgpu::{
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 
-pub const VIEW_TYPE_HANDLE: Handle<Shader> = Handle::weak_from_u128(15421373904451797197);
+pub const VIEW_TYPE_HANDLE: Handle<Shader> = weak_handle!("7234423c-38bb-411c-acec-f67730f6db5b");
 
 /// The matrix that converts from the RGB to the LMS color space.
 ///

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use alloc::{borrow::Cow, sync::Arc};
 use bevy_app::{First, Plugin, Update};
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     entity::hash_map::EntityHashMap, event::event_update_system, prelude::*, system::SystemState,
@@ -392,7 +392,8 @@ fn prepare_screenshot_state(
 
 pub struct ScreenshotPlugin;
 
-const SCREENSHOT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(11918575842344596158);
+const SCREENSHOT_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("c31753d6-326a-47cb-a359-65c97a471fda");
 
 impl Plugin for ScreenshotPlugin {
     fn build(&self, app: &mut bevy_app::App) {

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -37,7 +37,7 @@ pub use sprite::*;
 pub use texture_slice::*;
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetEvents, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetEvents, Assets, Handle};
 use bevy_core_pipeline::core_2d::Transparent2d;
 use bevy_ecs::prelude::*;
 use bevy_image::{prelude::*, TextureAtlasPlugin};
@@ -74,9 +74,10 @@ impl Default for SpritePlugin {
     }
 }
 
-pub const SPRITE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2763343953151597127);
+pub const SPRITE_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("ed996613-54c0-49bd-81be-1c2d1a0d03c2");
 pub const SPRITE_VIEW_BINDINGS_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(8846920112458963210);
+    weak_handle!("43947210-8df6-459a-8f2a-12f350d174cc");
 
 /// System set for sprite rendering.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -1,6 +1,6 @@
 use crate::{AlphaMode2d, Material2d, Material2dPlugin};
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Asset, AssetApp, Assets, Handle};
 use bevy_color::{Alpha, Color, ColorToComponents, LinearRgba};
 use bevy_image::Image;
 use bevy_math::Vec4;
@@ -8,7 +8,7 @@ use bevy_reflect::prelude::*;
 use bevy_render::{render_asset::RenderAssets, render_resource::*, texture::GpuImage};
 
 pub const COLOR_MATERIAL_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(3253086872234592509);
+    weak_handle!("92e0e6e9-ed0b-4db3-89ab-5f65d3678250");
 
 #[derive(Default)]
 pub struct ColorMaterialPlugin;

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -1,5 +1,5 @@
 use bevy_app::Plugin;
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetId, Handle};
 
 use crate::{tonemapping_pipeline_key, Material2dBindGroupId};
 use bevy_core_pipeline::tonemapping::DebandDither;
@@ -55,13 +55,20 @@ use tracing::error;
 #[derive(Default)]
 pub struct Mesh2dRenderPlugin;
 
-pub const MESH2D_VERTEX_OUTPUT: Handle<Shader> = Handle::weak_from_u128(7646632476603252194);
-pub const MESH2D_VIEW_TYPES_HANDLE: Handle<Shader> = Handle::weak_from_u128(12677582416765805110);
-pub const MESH2D_VIEW_BINDINGS_HANDLE: Handle<Shader> = Handle::weak_from_u128(6901431444735842434);
-pub const MESH2D_TYPES_HANDLE: Handle<Shader> = Handle::weak_from_u128(8994673400261890424);
-pub const MESH2D_BINDINGS_HANDLE: Handle<Shader> = Handle::weak_from_u128(8983617858458862856);
-pub const MESH2D_FUNCTIONS_HANDLE: Handle<Shader> = Handle::weak_from_u128(4976379308250389413);
-pub const MESH2D_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2971387252468633715);
+pub const MESH2D_VERTEX_OUTPUT: Handle<Shader> =
+    weak_handle!("71e279c7-85a0-46ac-9a76-1586cbf506d0");
+pub const MESH2D_VIEW_TYPES_HANDLE: Handle<Shader> =
+    weak_handle!("01087b0d-91e9-46ac-8628-dfe19a7d4b83");
+pub const MESH2D_VIEW_BINDINGS_HANDLE: Handle<Shader> =
+    weak_handle!("fbdd8b80-503d-4688-bcec-db29ab4620b2");
+pub const MESH2D_TYPES_HANDLE: Handle<Shader> =
+    weak_handle!("199f2089-6e99-4348-9bb1-d82816640a7f");
+pub const MESH2D_BINDINGS_HANDLE: Handle<Shader> =
+    weak_handle!("a7bd44cc-0580-4427-9a00-721cf386b6e4");
+pub const MESH2D_FUNCTIONS_HANDLE: Handle<Shader> =
+    weak_handle!("0d08ff71-68c1-4017-83e2-bfc34d285c51");
+pub const MESH2D_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("91a7602b-df95-4ea3-9d97-076abcb69d91");
 
 impl Plugin for Mesh2dRenderPlugin {
     fn build(&self, app: &mut bevy_app::App) {

--- a/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite/src/mesh2d/wireframe2d.rs
@@ -1,6 +1,6 @@
 use crate::{Material2d, Material2dKey, Material2dPlugin, Mesh2d};
 use bevy_app::{Plugin, Startup, Update};
-use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, Asset, AssetApp, Assets, Handle};
 use bevy_color::{Color, LinearRgba};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -11,7 +11,8 @@ use bevy_render::{
 
 use super::MeshMaterial2d;
 
-pub const WIREFRAME_2D_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(6920362697190520314);
+pub const WIREFRAME_2D_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("3d8a3853-2927-4de2-9dc7-3971e7e40970");
 
 /// A [`Plugin`] that draws wireframes for 2D meshes.
 ///

--- a/crates/bevy_ui/src/render/box_shadow.rs
+++ b/crates/bevy_ui/src/render/box_shadow.rs
@@ -35,7 +35,8 @@ use bytemuck::{Pod, Zeroable};
 
 use super::{stack_z_offsets, UiCameraMap, UiCameraView, QUAD_INDICES, QUAD_VERTEX_POSITIONS};
 
-pub const BOX_SHADOW_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(17717747047134343426);
+pub const BOX_SHADOW_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("d2991ecd-134f-4f82-adf5-0fcc86f02227");
 
 /// A plugin that enables the rendering of box shadows.
 pub struct BoxShadowPlugin;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     Outline, ResolvedBorderRadius, TextShadow, UiAntiAlias, UiTargetCamera,
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};
+use bevy_asset::{load_internal_asset, weak_handle, AssetEvent, AssetId, Assets, Handle};
 use bevy_color::{Alpha, ColorToComponents, LinearRgba};
 use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
 use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
@@ -95,7 +95,7 @@ pub mod stack_z_offsets {
     pub const MATERIAL: f32 = 0.18267;
 }
 
-pub const UI_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(13012847047162779583);
+pub const UI_SHADER_HANDLE: Handle<Shader> = weak_handle!("7d190d05-545b-42f5-bd85-22a0da85b0f6");
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum RenderUiSystem {

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -27,9 +27,11 @@ use bevy_sprite::BorderRect;
 use bevy_transform::prelude::GlobalTransform;
 use bytemuck::{Pod, Zeroable};
 
-pub const UI_MATERIAL_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(10074188772096983955);
+pub const UI_MATERIAL_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("b5612b7b-aed5-41b4-a930-1d1588239fcd");
 
-const UI_VERTEX_OUTPUT_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(10123618247720234751);
+const UI_VERTEX_OUTPUT_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("1d97ca3e-eaa8-4bc5-a676-e8e9568c472e");
 
 /// Adds the necessary ECS resources and render logic to enable rendering entities using the given
 /// [`UiMaterial`] asset type (which includes [`UiMaterial`] types).

--- a/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_texture_slice_pipeline.rs
@@ -30,7 +30,8 @@ use binding_types::{sampler, texture_2d};
 use bytemuck::{Pod, Zeroable};
 use widget::ImageNode;
 
-pub const UI_SLICER_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(11156288772117983964);
+pub const UI_SLICER_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("10cd61e3-bbf7-47fa-91c8-16cbe806378c");
 
 pub struct UiTextureSlicerPlugin;
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -6,6 +6,7 @@
 //! [`Material2d`]: bevy::sprite::Material2d
 
 use bevy::{
+    asset::weak_handle,
     color::palettes::basic::YELLOW,
     core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT},
     math::{ops, FloatOrd},
@@ -285,7 +286,7 @@ pub struct ColoredMesh2dPlugin;
 
 /// Handle to the custom shader with a unique random ID
 pub const COLORED_MESH2D_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(13828845428412094821);
+    weak_handle!("f48b148f-7373-4638-9900-392b3b3ccc66");
 
 /// Our custom pipeline needs its own instance storage
 #[derive(Resource, Deref, DerefMut, Default)]


### PR DESCRIPTION
# Objective

- Make use of the new `weak_handle!` macro added in https://github.com/bevyengine/bevy/pull/17384

## Solution

- Migrate bevy from `Handle::weak_from_u128` to the new `weak_handle!` macro that takes a random UUID
- Deprecate `Handle::weak_from_u128`, since there are no remaining use cases that can't also be addressed by constructing the type manually

## Testing

- `cargo run -p ci -- test`

---

## Migration Guide

Replace `Handle::weak_from_u128` with `weak_handle!` and a random UUID.