### PR TITLE
Use `target_abi = "sim"` instead of `ios_simulator` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -457,9 +457,6 @@ meshlet = ["bevy_internal/meshlet"]
 # Enables processing meshes into meshlet meshes for bevy_pbr
 meshlet_processor = ["bevy_internal/meshlet_processor"]
 
-# Enable support for the ios_simulator by downgrading some rendering capabilities
-ios_simulator = ["bevy_internal/ios_simulator"]
-
 # Enable built in global state machines
 bevy_state = ["bevy_internal/bevy_state"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -249,9 +249,6 @@ bevy_ui_picking_backend = ["bevy_picking", "bevy_ui/bevy_ui_picking_backend"]
 # Provides a UI debug overlay
 bevy_ui_debug = ["bevy_ui?/bevy_ui_debug"]
 
-# Enable support for the ios_simulator by downgrading some rendering capabilities
-ios_simulator = ["bevy_pbr?/ios_simulator", "bevy_render?/ios_simulator"]
-
 # Enable built in global state machines
 bevy_state = ["dep:bevy_state"]
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -18,7 +18,6 @@ experimental_pbr_pcss = []
 pbr_specular_textures = []
 shader_format_glsl = ["bevy_render/shader_format_glsl"]
 trace = ["bevy_render/trace"]
-ios_simulator = ["bevy_render/ios_simulator"]
 # Enables the meshlet renderer for dense high-poly scenes (experimental)
 meshlet = ["dep:lz4_flex", "dep:range-alloc", "dep:half", "dep:bevy_tasks"]
 # Enables processing meshes into meshlet meshes

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1062,7 +1062,7 @@ pub fn prepare_lights(
                 // NOTE: iOS Simulator is missing CubeArray support so we use Cube instead.
                 // See https://github.com/bevyengine/bevy/pull/12052 - remove if support is added.
                 #[cfg(all(
-                    not(feature = "ios_simulator"),
+                    not(target_abi = "sim"),
                     any(
                         not(feature = "webgl"),
                         not(target_arch = "wasm32"),
@@ -1071,7 +1071,7 @@ pub fn prepare_lights(
                 ))]
                 dimension: Some(TextureViewDimension::CubeArray),
                 #[cfg(any(
-                    feature = "ios_simulator",
+                    target_abi = "sim",
                     all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))
                 ))]
                 dimension: Some(TextureViewDimension::Cube),

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -216,7 +216,7 @@ fn layout_entries(
             (
                 2,
                 #[cfg(all(
-                    not(feature = "ios_simulator"),
+                    not(target_abi = "sim"),
                     any(
                         not(feature = "webgl"),
                         not(target_arch = "wasm32"),
@@ -225,7 +225,7 @@ fn layout_entries(
                 ))]
                 texture_cube_array(TextureSampleType::Depth),
                 #[cfg(any(
-                    feature = "ios_simulator",
+                    target_abi = "sim",
                     all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))
                 ))]
                 texture_cube(TextureSampleType::Depth),

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -29,7 +29,6 @@ tracing-tracy = []
 ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
-ios_simulator = []
 detailed_trace = []
 
 [dependencies]

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -251,7 +251,7 @@ impl ShaderCache {
                     shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
                 }
 
-                if cfg!(feature = "ios_simulator") {
+                if cfg!(target_abi = "sim") {
                     shader_defs.push("NO_CUBE_ARRAY_TEXTURES_SUPPORT".into());
                 }
 

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -278,11 +278,11 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         device: &RenderDevice,
         queue: &'a RenderQueue,
     ) -> Option<DynamicUniformBufferWriter<'a, T>> {
-        let alignment = if cfg!(feature = "ios_simulator") {
+        let alignment = if cfg!(target_abi = "sim") {
             // On iOS simulator on silicon macs, metal validation check that the host OS alignment
             // is respected, but the device reports the correct value for iOS, which is smaller.
             // Use the larger value.
-            // See https://github.com/bevyengine/bevy/pull/10178 - remove if it's not needed anymore.
+            // See https://github.com/gfx-rs/wgpu/issues/7057 - remove if it's not needed anymore.
             AlignmentValue::new(256)
         } else {
             AlignmentValue::new(device.limits().min_uniform_buffer_offset_alignment as u64)

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -79,7 +79,6 @@ The default feature set enables most of the expected features of a game engine, 
 |gif|GIF image format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
 |ico|ICO image format support|
-|ios_simulator|Enable support for the ios_simulator by downgrading some rendering capabilities|
 |jpeg|JPEG image format support|
 |meshlet|Enables the meshlet renderer for dense high-poly scenes (experimental)|
 |meshlet_processor|Enables processing meshes into meshlet meshes for bevy_pbr|

--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -14,8 +14,5 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies]
 bevy = { path = "../../" }
 
-[target.aarch64-apple-ios-sim.dependencies]
-bevy = { path = "../../", features = ["ios_simulator"] }
-
 [lints]
 workspace = true

--- a/examples/mobile/android_basic/Cargo.toml
+++ b/examples/mobile/android_basic/Cargo.toml
@@ -45,9 +45,6 @@ bevy = { path = "../../", default-features = false, features = [
   "zstd",
 ] }
 
-[target.aarch64-apple-ios-sim.dependencies]
-bevy = { path = "../../", features = ["ios_simulator"] }
-
 [package.metadata.android]
 package = "org.bevyengine.example"
 apk_name = "bevyexample"


### PR DESCRIPTION
## Objective

Get rid of a redundant Cargo feature flag.

## Solution

Use the built-in `target_abi = "sim"` instead of a custom Cargo feature flag, which is set for the iOS (and visionOS and tvOS) simulator. This has been stable since Rust 1.78.

In the future, some of this may become redundant if Wgpu implements proper supper for the iOS Simulator:
https://github.com/gfx-rs/wgpu/issues/7057

CC @mockersf who implemented [the original fix](https://github.com/bevyengine/bevy/pull/10178).

## Testing

- Open mobile example in Xcode.
- Launch the simulator.
- See that no errors are emitted.
- Remove the code cfg-guarded behind `target_abi = "sim"`.
- See that an error now happens.

(I haven't actually performed these steps on the latest `main`, because I'm hitting an unrelated error (EDIT: It was https://github.com/bevyengine/bevy/pull/17637). But tested it on 0.15.0).

---

## Migration Guide

> If you're using a project that builds upon the mobile example, remove the `ios_simulator` feature from your `Cargo.toml` (Bevy now handles this internally).
