### PR TITLE
`Query::get_many` should not check for duplicates

### DIFF
--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -439,6 +439,18 @@ mod tests {
     }
 
     #[test]
+    fn get_many_only_mut_checks_duplicates() {
+        let mut world = World::new();
+        let id = world.spawn(A(10)).id();
+        let mut query_state = world.query::<&mut A>();
+        let mut query = query_state.query_mut(&mut world);
+        let result = query.get_many([id, id]);
+        assert_eq!(result, Ok([&A(10), &A(10)]));
+        let mut_result = query.get_many_mut([id, id]);
+        assert!(mut_result.is_err());
+    }
+
+    #[test]
     fn multi_storage_query() {
         let mut world = World::new();
 


### PR DESCRIPTION
# Objective

Restore the behavior of `Query::get_many` prior to #15858.  

When passed duplicate `Entity`s, `get_many` is supposed to return results for all of them, since read-only queries don't alias.  However, #15858 merged the implementation with `get_many_mut` and caused it to return `QueryEntityError::AliasedMutability`.  

## Solution

Introduce a new `Query::get_many_readonly` method that consumes the `Query` like `get_many_inner`, but that is constrained to `D: ReadOnlyQueryData` so that it can skip the aliasing check.  Implement `Query::get_many` in terms of that new method.  Add a test, and a comment explaining why it doesn't match the pattern of the other `&self` methods.  