### PR TITLE
Fix cloning entities with multiple `linked_spawn` relationships

### DIFF
--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -277,7 +277,7 @@ pub fn clone_relationship_target<T: RelationshipTarget>(
     if let Some(component) = context.read_source_component::<T>() {
         if context.is_recursive() && T::LINKED_SPAWN {
             for entity in component.iter() {
-                context.queue_entity_clone(entity);
+                context.queue_entity_clone_once(entity);
             }
         }
         context.write_target_component(T::with_capacity(component.len()));


### PR DESCRIPTION
# Objective
#17687 changed recursive cloning to queue cloning commands for entities in `linked_spawn` `RelationshipTarget`s. However, if there are multiple relationships with `linked_spawn` on the same entity, multiple clone commands will be queued for the same entity.

## Solution
Maintain a list of already cloned entities during one `clone_entity_mapped` call and skip as necessary.

## Testing
- Added a test when cloning entities with multiple `linked_spawn` relations.
