### PR TITLE
make bevy math publishable

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -36,9 +36,7 @@ approx = "0.5"
 rand = "0.8"
 rand_chacha = "0.3"
 # Enable the approx feature when testing.
-bevy_math = { path = ".", version = "0.16.0-dev", default-features = false, features = [
-  "approx",
-] }
+bevy_math = { path = ".", default-features = false, features = ["approx"] }
 glam = { version = "0.29", default-features = false, features = ["approx"] }
 
 [features]

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -662,6 +662,7 @@ impl EaseFunction {
 }
 
 #[cfg(test)]
+#[cfg(feature = "approx")]
 mod tests {
     use crate::{Vec2, Vec3, Vec3A};
     use approx::assert_abs_diff_eq;

--- a/crates/bevy_math/src/curve/sample_curves.rs
+++ b/crates/bevy_math/src/curve/sample_curves.rs
@@ -4,6 +4,7 @@ use super::cores::{EvenCore, EvenCoreError, UnevenCore, UnevenCoreError};
 use super::{Curve, Interval};
 
 use crate::StableInterpolate;
+#[cfg(feature = "bevy_reflect")]
 use alloc::format;
 use core::any::type_name;
 use core::fmt::{self, Debug};

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -198,9 +198,11 @@ impl Dir2 {
     /// let dir2 = Dir2::Y;
     ///
     /// let result1 = dir1.slerp(dir2, 1.0 / 3.0);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(result1, Dir2::from_xy(0.75_f32.sqrt(), 0.5).unwrap());
     ///
     /// let result2 = dir1.slerp(dir2, 0.5);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(result2, Dir2::from_xy(0.5_f32.sqrt(), 0.5_f32.sqrt()).unwrap());
     /// ```
     #[inline]
@@ -457,6 +459,7 @@ impl Dir3 {
     /// let dir2 = Dir3::Y;
     ///
     /// let result1 = dir1.slerp(dir2, 1.0 / 3.0);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(
     ///     result1,
     ///     Dir3::from_xyz(0.75_f32.sqrt(), 0.5, 0.0).unwrap(),
@@ -464,6 +467,7 @@ impl Dir3 {
     /// );
     ///
     /// let result2 = dir1.slerp(dir2, 0.5);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(result2, Dir3::from_xyz(0.5_f32.sqrt(), 0.5_f32.sqrt(), 0.0).unwrap());
     /// ```
     #[inline]
@@ -716,6 +720,7 @@ impl Dir3A {
     /// let dir2 = Dir3A::Y;
     ///
     /// let result1 = dir1.slerp(dir2, 1.0 / 3.0);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(
     ///     result1,
     ///     Dir3A::from_xyz(0.75_f32.sqrt(), 0.5, 0.0).unwrap(),
@@ -723,6 +728,7 @@ impl Dir3A {
     /// );
     ///
     /// let result2 = dir1.slerp(dir2, 0.5);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(result2, Dir3A::from_xyz(0.5_f32.sqrt(), 0.5_f32.sqrt(), 0.0).unwrap());
     /// ```
     #[inline]
@@ -850,6 +856,7 @@ impl approx::UlpsEq for Dir3A {
 }
 
 #[cfg(test)]
+#[cfg(feature = "approx")]
 mod tests {
     use crate::ops;
 

--- a/crates/bevy_math/src/isometry.rs
+++ b/crates/bevy_math/src/isometry.rs
@@ -589,6 +589,7 @@ impl UlpsEq for Isometry3d {
 }
 
 #[cfg(test)]
+#[cfg(feature = "approx")]
 mod tests {
     use super::*;
     use crate::{vec2, vec3, vec3a};

--- a/crates/bevy_math/src/rotation2d.rs
+++ b/crates/bevy_math/src/rotation2d.rs
@@ -30,9 +30,11 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// assert_eq!(rotation2.as_radians(), PI / 4.0);
 ///
 /// // "Add" rotations together using `*`
+/// #[cfg(feature = "approx")]
 /// assert_relative_eq!(rotation1 * rotation2, Rot2::degrees(135.0));
 ///
 /// // Rotate vectors
+/// #[cfg(feature = "approx")]
 /// assert_relative_eq!(rotation1 * Vec2::X, Vec2::Y);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -116,9 +118,11 @@ impl Rot2 {
     ///
     /// let rot1 = Rot2::radians(3.0 * FRAC_PI_2);
     /// let rot2 = Rot2::radians(-FRAC_PI_2);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(rot1, rot2);
     ///
     /// let rot3 = Rot2::radians(PI);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(rot1 * rot1, rot3);
     /// ```
     #[inline]
@@ -141,9 +145,11 @@ impl Rot2 {
     ///
     /// let rot1 = Rot2::degrees(270.0);
     /// let rot2 = Rot2::degrees(-90.0);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(rot1, rot2);
     ///
     /// let rot3 = Rot2::degrees(180.0);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(rot1 * rot1, rot3);
     /// ```
     #[inline]
@@ -165,9 +171,11 @@ impl Rot2 {
     ///
     /// let rot1 = Rot2::turn_fraction(0.75);
     /// let rot2 = Rot2::turn_fraction(-0.25);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(rot1, rot2);
     ///
     /// let rot3 = Rot2::turn_fraction(0.5);
+    /// #[cfg(feature = "approx")]
     /// assert_relative_eq!(rot1 * rot1, rot3);
     /// ```
     #[inline]

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,9 @@ deny = [
   { name = "glam", deny-multiple-versions = true },
   { name = "raw-window-handle", deny-multiple-versions = true },
 ]
+skip = [
+  { name = "bevy_math", reason = "bevy_math has a path dev dependency on itself without a version" },
+]
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
# Objective

- bevy_math fails to publish because of the self dev-dependency
- it's used to enable the `approx` feature in tests

## Solution

- Don't specify a version in the dev-dependency. dependencies without a version are ignored by cargo when publishing
- Gate all the tests that depend on the `approx` feature so that it doesn't fail to compile when not enabled
- Also gate an import that wasn't used without `bevy_reflect`

## Testing

- with at least cargo 1.84: `cargo package -p bevy_math`
- `cd target/package/bevy_math_* && cargo test`