### PR TITLE
Missing UI glpyhs fix

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -274,6 +274,7 @@ fn build_text_interop(app: &mut App) {
             widget::text_system
                 .in_set(UiSystem::PostLayout)
                 .after(bevy_text::remove_dropped_font_atlas_sets)
+                .before(bevy_asset::AssetEvents)
                 // Text2d and bevy_ui text are entirely on separate entities
                 .ambiguous_with(bevy_text::detect_text_needs_rerender::<bevy_text::Text2d>)
                 .ambiguous_with(bevy_text::update_text2d_layout)


### PR DESCRIPTION
# Objective

Fixes #17718

## Solution

Schedule `text_system` before `AssetEvents`.

I guess what was happening here is that glyphs weren't shown because `text_system` was running before `AssetEevents` and so `prepare_uinodes` never recieves the the asset modified event about the glyph texture atlas image.