### PR TITLE
deps: bump notify-debouncer-full to remove unmaintained crate

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -67,7 +67,7 @@ js-sys = "0.3"
 uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-notify-debouncer-full = { version = "0.4.0", optional = true }
+notify-debouncer-full = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }

--- a/deny.toml
+++ b/deny.toml
@@ -3,10 +3,7 @@ all-features = true
 
 [advisories]
 version = 2
-ignore = [
-  # TODO: #16477 - Delete this once notify-types has been bumped.
-  "RUSTSEC-2024-0384",
-]
+ignore = []
 
 [licenses]
 version = 2


### PR DESCRIPTION
# Objective

Fix #16477.

## Solution
- Remove temporary silence introduced in #16763 
- bump version of `notify-debouncer-full` to remove transitive dependency on `instant` crate.