### PR TITLE
Fix rounding in steps easing function

### DIFF
--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -685,7 +685,7 @@ mod easing_functions {
 
     #[inline]
     pub(crate) fn steps(num_steps: usize, t: f32) -> f32 {
-        ops::round(t * num_steps as f32) / num_steps.max(1) as f32
+        ops::floor(t * num_steps as f32) / num_steps.max(1) as f32
     }
 
     #[inline]

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -1064,14 +1064,12 @@ mod tests {
         let curve = EasingCurve::new(start, end, EaseFunction::Steps(4));
         [
             (0.0, start),
-            (0.124, start),
-            (0.125, Vec2::new(0.25, 0.5)),
-            (0.374, Vec2::new(0.25, 0.5)),
-            (0.375, Vec2::new(0.5, 1.0)),
-            (0.624, Vec2::new(0.5, 1.0)),
-            (0.625, Vec2::new(0.75, 1.5)),
-            (0.874, Vec2::new(0.75, 1.5)),
-            (0.875, end),
+            (0.249, start),
+            (0.250, Vec2::new(0.25, 0.5)),
+            (0.499, Vec2::new(0.25, 0.5)),
+            (0.500, Vec2::new(0.5, 1.0)),
+            (0.749, Vec2::new(0.5, 1.0)),
+            (0.750, Vec2::new(0.75, 1.5)),
             (1.0, end),
         ]
         .into_iter()


### PR DESCRIPTION
# Objective

While working on #17742, I noticed that the `Steps` easing function looked a bit suspicious.

![image](https://github.com/user-attachments/assets/be8f07e4-2079-461f-8c23-56d4b689aed9)

Comparing to the options available in [css](https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/steps#description):

![image](https://github.com/user-attachments/assets/2c351519-c87f-483f-b5ff-63a9ee7b7b51)

It is "off the charts," so probably not what users are expecting.

## Solution

Use `floor` when rounding to match the default behavior (jump-end, top right) in css.

<img width="100" alt="image" src="https://github.com/user-attachments/assets/1ec46270-72f2-4227-87e4-03de881548ab" />


## Testing

I had to modify an existing test that was testing against the old behavior. This function and test were introduced in #14788 and I didn't see any discussion about the rounding there.

`cargo run --example easing_functions`

## Migration Guide

<!-- Note to editors: this should be adjusted if 17744 is addressed, and possibly combined with the notes from the PR that fixes it. -->

`EaseFunction::Steps` now behaves like css's default, "jump-end." If you were relying on the old behavior, we plan on providing it. See https://github.com/bevyengine/bevy/issues/17744.