### PR TITLE
feat(ecs): configurable error handling for fallible systems

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -13,13 +13,13 @@ use bevy_ecs::{
     event::{event_update_system, EventCursor},
     intern::Interned,
     prelude::*,
+    result::Error,
     schedule::{ScheduleBuildSettings, ScheduleLabel},
-    system::{IntoObserverSystem, SystemId, SystemInput},
+    system::{IntoObserverSystem, ScheduleSystem, SystemId, SystemInput},
 };
 use bevy_platform_support::collections::HashMap;
 use core::{fmt::Debug, num::NonZero, panic::AssertUnwindSafe};
 use log::debug;
-use thiserror::Error;
 
 #[cfg(feature = "trace")]
 use tracing::info_span;
@@ -44,7 +44,7 @@ pub use bevy_ecs::label::DynEq;
 /// A shorthand for `Interned<dyn AppLabel>`.
 pub type InternedAppLabel = Interned<dyn AppLabel>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum AppError {
     #[error("duplicate plugin {plugin_name:?}")]
     DuplicatePlugin { plugin_name: String },
@@ -1260,6 +1260,16 @@ impl App {
         S2: IntoSystemSet<M2>,
     {
         self.main_mut().ignore_ambiguity(schedule, a, b);
+        self
+    }
+
+    /// Set the global system error handler to use for systems that return a
+    /// [`Result`](crate::result::Result).
+    pub fn set_systems_error_handler(
+        &mut self,
+        error_handler: fn(Error, &ScheduleSystem),
+    ) -> &mut Self {
+        self.main_mut().set_systems_error_handler(error_handler);
         self
     }
 

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{
     event::EventRegistry,
     prelude::*,
     schedule::{InternedScheduleLabel, ScheduleBuildSettings, ScheduleLabel},
-    system::{SystemId, SystemInput},
+    system::{ScheduleSystem, SystemId, SystemInput},
 };
 use bevy_platform_support::collections::{HashMap, HashSet};
 use core::fmt::Debug;
@@ -332,6 +332,21 @@ impl SubApp {
 
         schedules.ignore_ambiguity(schedule, a, b);
 
+        self
+    }
+
+    /// Set the global error handler to use for systems that return a
+    /// [`Result`](crate::result::Result).
+    pub fn set_systems_error_handler(
+        &mut self,
+        error_handler: fn(Error, &ScheduleSystem),
+    ) -> &mut Self {
+        let mut schedules = self
+            .world_mut()
+            .remove_resource::<Schedules>()
+            .unwrap_or_default();
+        schedules.error_handler = error_handler;
+        self.world_mut().insert_resource(schedules);
         self
     }
 

--- a/crates/bevy_ecs/src/result.rs
+++ b/crates/bevy_ecs/src/result.rs
@@ -7,3 +7,8 @@ pub type Error = Box<dyn core::error::Error + Send + Sync + 'static>;
 
 /// A result type for use in fallible systems.
 pub type Result<T = (), E = Error> = core::result::Result<T, E>;
+
+pub(crate) fn default_error_handler(error: Error, system: &crate::system::ScheduleSystem) {
+    let name = system.name();
+    panic!("Encountered an error in system `{name}`: {error:?}",);
+}

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     component::{ComponentId, Tick},
     prelude::{IntoSystemSet, SystemSet},
     query::Access,
-    result::Result,
+    result::{Error, Result},
     schedule::{BoxedCondition, InternedSystemSet, NodeId, SystemTypeSet},
     system::{ScheduleSystem, System, SystemIn},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
@@ -33,6 +33,7 @@ pub(super) trait SystemExecutor: Send + Sync {
         schedule: &mut SystemSchedule,
         world: &mut World,
         skip_systems: Option<&FixedBitSet>,
+        error_handler: fn(Error, &ScheduleSystem),
     );
     fn set_apply_final_deferred(&mut self, value: bool);
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -17,6 +17,7 @@ use crate::{
     archetype::ArchetypeComponentId,
     prelude::Resource,
     query::Access,
+    result::{Error, Result},
     schedule::{is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule},
     system::ScheduleSystem,
     world::{unsafe_world_cell::UnsafeWorldCell, World},
@@ -133,6 +134,7 @@ pub struct ExecutorState {
 struct Context<'scope, 'env, 'sys> {
     environment: &'env Environment<'env, 'sys>,
     scope: &'scope Scope<'scope, 'env, ()>,
+    error_handler: fn(Error, &ScheduleSystem),
 }
 
 impl Default for MultiThreadedExecutor {
@@ -183,6 +185,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         schedule: &mut SystemSchedule,
         world: &mut World,
         _skip_systems: Option<&FixedBitSet>,
+        error_handler: fn(Error, &ScheduleSystem),
     ) {
         let state = self.state.get_mut().unwrap();
         // reset counts
@@ -222,7 +225,11 @@ impl SystemExecutor for MultiThreadedExecutor {
             false,
             thread_executor,
             |scope| {
-                let context = Context { environment, scope };
+                let context = Context {
+                    environment,
+                    scope,
+                    error_handler,
+                };
 
                 // The first tick won't need to process finished systems, but we still need to run the loop in
                 // tick_executor() in case a system completes while the first tick still holds the mutex.
@@ -603,17 +610,12 @@ impl ExecutorState {
                 // access the world data used by the system.
                 // - `update_archetype_component_access` has been called.
                 unsafe {
-                    // TODO: implement an error-handling API instead of panicking.
                     if let Err(err) = __rust_begin_short_backtrace::run_unsafe(
                         system,
                         context.environment.world_cell,
                     ) {
-                        panic!(
-                            "Encountered an error in system `{}`: {:?}",
-                            &*system.name(),
-                            err
-                        );
-                    };
+                        (context.error_handler)(err, &system);
+                    }
                 };
             }));
             context.system_completed(system_index, res, system);
@@ -657,14 +659,9 @@ impl ExecutorState {
                 // that no other systems currently have access to the world.
                 let world = unsafe { context.environment.world_cell.world_mut() };
                 let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    // TODO: implement an error-handling API instead of panicking.
                     if let Err(err) = __rust_begin_short_backtrace::run(system, world) {
-                        panic!(
-                            "Encountered an error in system `{}`: {:?}",
-                            &*system.name(),
-                            err
-                        );
-                    };
+                        (context.error_handler)(err, &system);
+                    }
                 }));
                 context.system_completed(system_index, res, system);
             };

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -8,9 +8,11 @@ use tracing::info_span;
 use std::eprintln;
 
 use crate::{
+    result::Error,
     schedule::{
         executor::is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule,
     },
+    system::ScheduleSystem,
     world::World,
 };
 
@@ -43,6 +45,7 @@ impl SystemExecutor for SimpleExecutor {
         schedule: &mut SystemSchedule,
         world: &mut World,
         _skip_systems: Option<&FixedBitSet>,
+        error_handler: fn(Error, &ScheduleSystem),
     ) {
         // If stepping is enabled, make sure we skip those systems that should
         // not be run.
@@ -104,13 +107,8 @@ impl SystemExecutor for SimpleExecutor {
             }
 
             let f = AssertUnwindSafe(|| {
-                // TODO: implement an error-handling API instead of panicking.
                 if let Err(err) = __rust_begin_short_backtrace::run(system, world) {
-                    panic!(
-                        "Encountered an error in system `{}`: {:?}",
-                        &*system.name(),
-                        err
-                    );
+                    error_handler(err, &system);
                 }
             });
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -45,10 +45,10 @@ use crate::{
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     removal_detection::RemovedComponentEvents,
     resource::Resource,
-    result::Result,
+    result,
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
-    system::Commands,
+    system::{Commands, ScheduleSystem},
     world::{
         command_queue::RawCommandQueue,
         error::{EntityFetchError, TryDespawnError, TryInsertBatchError, TryRunScheduleError},
@@ -3665,6 +3665,18 @@ impl World {
         let mut schedules = self.remove_resource::<Schedules>().unwrap_or_default();
         schedules.allow_ambiguous_resource::<T>(self);
         self.insert_resource(schedules);
+    }
+
+    /// Set the error handler to use for systems that return a [`Result`](crate::result::Result) in
+    /// a specific schedule.
+    pub fn set_schedule_error_handler(
+        &mut self,
+        label: impl ScheduleLabel,
+        error_handler: fn(result::Error, &ScheduleSystem),
+    ) -> Result<(), TryRunScheduleError> {
+        self.try_schedule_scope(label, |_, schedule| {
+            schedule.set_error_handler(error_handler);
+        })
     }
 }
 


### PR DESCRIPTION
You can now configure error handlers for fallible systems. These can be configured on several levels:

- Globally via `App::set_systems_error_handler`
- Per-schedule via `Schedule::set_error_handler`
- Per-system via a piped system (this is existing functionality)

The "fallible_systems" example demonstrates the new functionality.

This builds on top of #17731, #16589, #17051.