### PR TITLE
Allowed creating uninitialized images (for use as storage textures)

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -465,7 +465,7 @@ pub fn lut_placeholder() -> Image {
     let format = TextureFormat::Rgba8Unorm;
     let data = vec![255, 0, 255, 255];
     Image {
-        data,
+        data: Some(data),
         texture_descriptor: TextureDescriptor {
             size: Extent3d {
                 width: 1,

--- a/crates/bevy_image/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_image/src/dynamic_texture_atlas_builder.rs
@@ -2,6 +2,7 @@ use crate::{Image, TextureAtlasLayout, TextureFormatPixelInfo as _};
 use bevy_asset::RenderAssetUsages;
 use bevy_math::{URect, UVec2};
 use guillotiere::{size2, Allocation, AtlasAllocator};
+use tracing::error;
 
 /// Helper utility to update [`TextureAtlasLayout`] on the fly.
 ///
@@ -80,8 +81,15 @@ impl DynamicTextureAtlasBuilder {
             let end = begin + rect_width * format_size;
             let texture_begin = texture_y * rect_width * format_size;
             let texture_end = texture_begin + rect_width * format_size;
-            atlas_texture.data[begin..end]
-                .copy_from_slice(&texture.data[texture_begin..texture_end]);
+            let Some(ref mut atlas_data) = atlas_texture.data else {
+                error!("Atlas texture has no texture data");
+                return;
+            };
+            let Some(ref data) = texture.data else {
+                error!("Source texture provided has no texture data");
+                return;
+            };
+            atlas_data[begin..end].copy_from_slice(&data[texture_begin..texture_end]);
         }
     }
 }

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -806,6 +806,7 @@ impl Image {
         let mut image = Image::default_uninit();
         image.texture_descriptor.format = format;
         image.texture_descriptor.dimension = dimension;
+        image.texture_descriptor.size = size;
         image.asset_usage = asset_usage;
 
         let byte_len = format.pixel_size() * size.volume();

--- a/crates/bevy_image/src/image_texture_conversion.rs
+++ b/crates/bevy_image/src/image_texture_conversion.rs
@@ -170,22 +170,26 @@ impl Image {
     ///
     /// To convert [`Image`] to a different format see: [`Image::convert`].
     pub fn try_into_dynamic(self) -> Result<DynamicImage, IntoDynamicImageError> {
+        let width = self.width();
+        let height = self.height();
+        let Some(data) = self.data else {
+            return Err(IntoDynamicImageError::UninitializedImage);
+        };
         match self.texture_descriptor.format {
-            TextureFormat::R8Unorm => ImageBuffer::from_raw(self.width(), self.height(), self.data)
-                .map(DynamicImage::ImageLuma8),
+            TextureFormat::R8Unorm => {
+                ImageBuffer::from_raw(width, height, data).map(DynamicImage::ImageLuma8)
+            }
             TextureFormat::Rg8Unorm => {
-                ImageBuffer::from_raw(self.width(), self.height(), self.data)
-                    .map(DynamicImage::ImageLumaA8)
+                ImageBuffer::from_raw(width, height, data).map(DynamicImage::ImageLumaA8)
             }
             TextureFormat::Rgba8UnormSrgb => {
-                ImageBuffer::from_raw(self.width(), self.height(), self.data)
-                    .map(DynamicImage::ImageRgba8)
+                ImageBuffer::from_raw(width, height, data).map(DynamicImage::ImageRgba8)
             }
             // This format is commonly used as the format for the swapchain texture
             // This conversion is added here to support screenshots
             TextureFormat::Bgra8UnormSrgb | TextureFormat::Bgra8Unorm => {
-                ImageBuffer::from_raw(self.width(), self.height(), {
-                    let mut data = self.data;
+                ImageBuffer::from_raw(width, height, {
+                    let mut data = data;
                     for bgra in data.chunks_exact_mut(4) {
                         bgra.swap(0, 2);
                     }
@@ -213,6 +217,10 @@ pub enum IntoDynamicImageError {
     /// Encountered an unknown error during conversion.
     #[error("Failed to convert into {0:?}.")]
     UnknownConversionError(TextureFormat),
+
+    /// Tried to convert an image that has no texture data
+    #[error("Image has no texture data")]
+    UninitializedImage,
 }
 
 #[cfg(test)]

--- a/crates/bevy_image/src/ktx2.rs
+++ b/crates/bevy_image/src/ktx2.rs
@@ -266,7 +266,7 @@ pub fn ktx2_buffer_to_image(
     // error cases have been handled
     let mut image = Image::default();
     image.texture_descriptor.format = texture_format;
-    image.data = wgpu_data.into_iter().flatten().collect::<Vec<_>>();
+    image.data = Some(wgpu_data.into_iter().flatten().collect::<Vec<_>>());
     image.texture_descriptor.size = Extent3d {
         width,
         height,

--- a/crates/bevy_image/src/texture_atlas_builder.rs
+++ b/crates/bevy_image/src/texture_atlas_builder.rs
@@ -118,8 +118,15 @@ impl<'a> TextureAtlasBuilder<'a> {
             let end = begin + rect_width * format_size;
             let texture_begin = texture_y * rect_width * format_size;
             let texture_end = texture_begin + rect_width * format_size;
-            atlas_texture.data[begin..end]
-                .copy_from_slice(&texture.data[texture_begin..texture_end]);
+            let Some(ref mut atlas_data) = atlas_texture.data else {
+                error!("Atlas texture has no texture data");
+                return;
+            };
+            let Some(ref data) = texture.data else {
+                error!("Source texture provided has no texture data");
+                return;
+            };
+            atlas_data[begin..end].copy_from_slice(&data[texture_begin..texture_end]);
         }
     }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1732,7 +1732,7 @@ impl FromWorld for MeshPipeline {
             let format_size = image.texture_descriptor.format.pixel_size();
             render_queue.write_texture(
                 texture.as_image_copy(),
-                &image.data,
+                image.data.as_ref().unwrap(),
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(image.width() * format_size as u32),

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -114,7 +114,7 @@ fn fallback_image_new(
             render_queue,
             &image.texture_descriptor,
             TextureDataOrder::default(),
-            &image.data,
+            &image.data.unwrap(),
         )
     } else {
         render_device.create_texture(&image.texture_descriptor)

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     resource::Resource,
     system::SystemParam,
 };
-use bevy_image::{BevyDefault, Image, ImageSampler, TextureFormatPixelInfo};
+use bevy_image::{BevyDefault, Image, ImageSampler};
 use bevy_platform_support::collections::HashMap;
 
 /// A [`RenderApp`](crate::RenderApp) resource that contains the default "fallback image",
@@ -89,16 +89,15 @@ fn fallback_image_new(
 
     let image_dimension = dimension.compatible_texture_dimension();
     let mut image = if create_texture_with_data {
-        let data = vec![value; format.pixel_size()];
         Image::new_fill(
             extents,
             image_dimension,
-            &data,
+            &[value],
             format,
             RenderAssetUsages::RENDER_WORLD,
         )
     } else {
-        let mut image = Image::default();
+        let mut image = Image::default_uninit();
         image.texture_descriptor.dimension = TextureDimension::D2;
         image.texture_descriptor.size = extents;
         image.texture_descriptor.format = format;

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -359,7 +359,7 @@ impl FromWorld for Mesh2dPipeline {
             let format_size = image.texture_descriptor.format.pixel_size();
             render_queue.write_texture(
                 texture.as_image_copy(),
-                &image.data,
+                image.data.as_ref().unwrap(),
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(image.width() * format_size as u32),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -102,7 +102,7 @@ impl FromWorld for SpritePipeline {
             let format_size = image.texture_descriptor.format.pixel_size();
             render_queue.write_texture(
                 texture.as_image_copy(),
-                &image.data,
+                image.data.as_ref().unwrap(),
                 ImageDataLayout {
                     offset: 0,
                     bytes_per_row: Some(image.width() * format_size as u32),

--- a/crates/bevy_winit/src/custom_cursor.rs
+++ b/crates/bevy_winit/src/custom_cursor.rs
@@ -145,18 +145,16 @@ pub(crate) fn extract_rgba_pixels(image: &Image) -> Option<Vec<u8>> {
         | TextureFormat::Rgba8UnormSrgb
         | TextureFormat::Rgba8Snorm
         | TextureFormat::Rgba8Uint
-        | TextureFormat::Rgba8Sint => Some(image.data.clone()),
-        TextureFormat::Rgba32Float => Some(
-            image
-                .data
-                .chunks(4)
+        | TextureFormat::Rgba8Sint => Some(image.data.clone()?),
+        TextureFormat::Rgba32Float => image.data.as_ref().map(|data| {
+            data.chunks(4)
                 .map(|chunk| {
                     let chunk = chunk.try_into().unwrap();
                     let num = bytemuck::cast_ref::<[u8; 4], f32>(chunk);
                     ops::round(num.clamp(0.0, 1.0) * 255.0) as u8
                 })
-                .collect(),
-        ),
+                .collect()
+        }),
         _ => None,
     }
 }

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -499,15 +499,17 @@ fn update(
                         * img_bytes.texture_descriptor.format.pixel_size();
                     let aligned_row_bytes = RenderDevice::align_copy_bytes_per_row(row_bytes);
                     if row_bytes == aligned_row_bytes {
-                        img_bytes.data.clone_from(&image_data);
+                        img_bytes.data.as_mut().unwrap().clone_from(&image_data);
                     } else {
                         // shrink data to original image size
-                        img_bytes.data = image_data
-                            .chunks(aligned_row_bytes)
-                            .take(img_bytes.height() as usize)
-                            .flat_map(|row| &row[..row_bytes.min(row.len())])
-                            .cloned()
-                            .collect();
+                        img_bytes.data = Some(
+                            image_data
+                                .chunks(aligned_row_bytes)
+                                .take(img_bytes.height() as usize)
+                                .flat_map(|row| &row[..row_bytes.min(row.len())])
+                                .cloned()
+                                .collect(),
+                        );
                     }
 
                     // Create RGBA Image Buffer

--- a/examples/asset/alter_sprite.rs
+++ b/examples/asset/alter_sprite.rs
@@ -127,7 +127,7 @@ fn alter_asset(mut images: ResMut<Assets<Image>>, left_bird: Single<&Sprite, Wit
         return;
     };
 
-    for pixel in &mut image.data {
+    for pixel in image.data.as_mut().unwrap() {
         // Directly modify the asset data, which will affect all users of this asset. By
         // contrast, mutating the handle (as we did above) affects only one copy. In this case,
         // we'll just invert the colors, by way of demonstration. Notice that both uses of the

--- a/examples/shader/gpu_readback.rs
+++ b/examples/shader/gpu_readback.rs
@@ -86,10 +86,11 @@ fn setup(
         height: 1,
         ..default()
     };
-    let mut image = Image::new_fill(
+    // We create an uninitialized image since this texture will only be used for getting data out
+    // of the compute shader, not getting data in, so there's no reason for it to exist on the CPU
+    let mut image = Image::new_uninit(
         size,
         TextureDimension::D2,
-        &[0, 0, 0, 0],
         TextureFormat::R32Uint,
         RenderAssetUsages::RENDER_WORLD,
     );


### PR DESCRIPTION
# Objective
https://github.com/bevyengine/bevy/issues/17746
## Solution
- Change `Image.data` from being a `Vec<u8>` to a `Option<Vec<u8>>`
- Added functions to help with creating images
## Testing

- Did you test these changes? If so, how?
All current tests pass
Tested a variety of existing examples to make sure they don't crash (they don't)
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Linux x86 64-bit NixOS 
---
## Migration Guide
Code that directly access `Image` data will now need to use unwrap or handle the case where no data is provided.
Behaviour of new_fill slightly changed, but not in a way that is likely to affect anything. It no longer panics and will fill the whole texture instead of leaving black pixels if the data provided is not a nice factor of the size of the image.