### PR TITLE
Use unchecked shaders for better performance

### DIFF
--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -76,6 +76,11 @@ impl RenderDevice {
         }
 
         #[cfg(not(feature = "spirv_shader_passthrough"))]
+        // SAFETY: we are interfacing with shader code, which may contain undefined behavior,
+        // such as indexing out of bounds.
+        // The checks required are prohibitively expensive and a poor default for game engines.
+        // TODO: split this method into safe and unsafe variants, and propagate the safety requirements from
+        // https://docs.rs/wgpu/latest/wgpu/struct.Device.html#method.create_shader_module_trusted to the unsafe form.
         unsafe {
             self.device
                 .create_shader_module_trusted(desc, wgpu::ShaderRuntimeChecks::unchecked())

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -64,11 +64,17 @@ impl RenderDevice {
                         })
                 }
             }
-            _ => self.device.create_shader_module(desc),
+            _ => unsafe {
+                self.device
+                    .create_shader_module_trusted(desc, wgpu::ShaderRuntimeChecks::unchecked())
+            },
         }
 
         #[cfg(not(feature = "spirv_shader_passthrough"))]
-        self.device.create_shader_module(desc)
+        unsafe {
+            self.device
+                .create_shader_module_trusted(desc, wgpu::ShaderRuntimeChecks::unchecked())
+        }
     }
 
     /// Check for resource cleanups and mapping callbacks.

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -64,6 +64,11 @@ impl RenderDevice {
                         })
                 }
             }
+            // SAFETY: we are interfacing with shader code, which may contain undefined behavior,
+            // such as indexing out of bounds.
+            // The checks required are prohibitively expensive and a poor default for game engines.
+            // TODO: split this method into safe and unsafe variants, and propagate the safety requirements from
+            // https://docs.rs/wgpu/latest/wgpu/struct.Device.html#method.create_shader_module_trusted to the unsafe form.
             _ => unsafe {
                 self.device
                     .create_shader_module_trusted(desc, wgpu::ShaderRuntimeChecks::unchecked())


### PR DESCRIPTION
# Objective
- Wgpu has some expensive code it injects into shaders to avoid the possibility of things like infinite loops. Generally our shaders are written by users who won't do this, so it just makes our shaders perform worse.

## Solution

- Turn off the checks.
  - We could try to conditionally keep them, but that complicates the code and 99.9% of users won't want this.

## Migration Guide

-  Bevy no longer turns on wgpu's runtime safety checks https://docs.rs/wgpu/latest/wgpu/struct.ShaderRuntimeChecks.html. If you were using Bevy with untrusted shaders, please file an issue.