### PR TITLE
Allow users to register their own disabling components / default query filters

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1034,6 +1034,12 @@ impl App {
             .try_register_required_components_with::<T, R>(constructor)
     }
 
+    /// Registers a component type as "disabling",
+    /// using [default query filters](bevy_ecs::entity_disabling::DefaultQueryFilters) to exclude entities with the component from queries.
+    pub fn register_disabling_component<C: Component>(&mut self) {
+        self.world_mut().register_disabling_component::<C>();
+    }
+
     /// Returns a reference to the main [`SubApp`]'s [`World`]. This is the same as calling
     /// [`app.main().world()`].
     ///

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1036,6 +1036,11 @@ impl App {
 
     /// Registers a component type as "disabling",
     /// using [default query filters](bevy_ecs::entity_disabling::DefaultQueryFilters) to exclude entities with the component from queries.
+    ///
+    /// # Warning
+    ///
+    /// As discussed in the [module docs](bevy_ecs::entity_disabling), this can have performance implications,
+    /// as well as create interoperability issues, and should be used with caution.
     pub fn register_disabling_component<C: Component>(&mut self) {
         self.world_mut().register_disabling_component::<C>();
     }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -103,7 +103,9 @@ portable-atomic = [
 
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.16.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, optional = true }
+bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
+  "smallvec",
+], default-features = false, optional = true }
 bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false, optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false, features = [
   "alloc",

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -87,7 +87,7 @@ use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
 /// not its children or other entities that reference it.
 /// To disable an entire tree of entities, use [`EntityCommands::insert_recursive`](crate::prelude::EntityCommands::insert_recursive).
 ///
-/// Every [`World`](crate::prelude::World) has a default query filter that excludes entities with this component,
+/// Every [`World`] has a default query filter that excludes entities with this component,
 /// registered in the [`DefaultQueryFilters`] resource.
 /// See [the module docs] for more info.
 ///

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -1,5 +1,10 @@
 //! Disabled entities do not show up in queries unless the query explicitly mentions them.
 //!
+//! Entities which are disabled in this way are not removed from the [`World`],
+//! and their relationships remain intact.
+//! In many cases, you may want to disable entire trees of entities at once,
+//! using [`EntityCommands::insert_recursive`](crate::prelude::EntityCommands::insert_recursive).
+//!
 //! While Bevy ships with a built-in [`Disabled`] component, you can also create your own
 //! disabling components, which will operate in the same way but can have distinct semantics.
 //!
@@ -74,6 +79,13 @@ use smallvec::SmallVec;
 use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
 
 /// A marker component for disabled entities.
+///
+/// Semantically, this component is used to mark entities that are temporarily disabled (typically for gameplay reasons),
+/// but will likely be re-enabled at some point.
+///
+/// Like all disabling components, this only disables the entity itself,
+/// not its children or other entities that reference it.
+/// To disable an entire tree of entities, use [`EntityCommands::insert_recursive`](crate::prelude::EntityCommands::insert_recursive).
 ///
 /// Every [`World`](crate::prelude::World) has a default query filter that excludes entities with this component,
 /// registered in the [`DefaultQueryFilters`] resource.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -179,13 +179,13 @@ impl DefaultQueryFilters {
     }
 
     /// Get an iterator over all of the components which disable entities when present.
-    pub fn disabling_ids(&self) -> impl Iterator<Item = &ComponentId> {
-        self.disabling.iter()
+    pub fn disabling_ids(&self) -> impl Iterator<Item = ComponentId> + use<'_> {
+        self.disabling.iter().copied()
     }
 
     /// Modifies the provided [`FilteredAccess`] to include the filters from this [`DefaultQueryFilters`].
     pub(super) fn modify_access(&self, component_access: &mut FilteredAccess<ComponentId>) {
-        for &component_id in self.disabling_ids() {
+        for component_id in self.disabling_ids() {
             if !component_access.contains(component_id) {
                 component_access.and_without(component_id);
             }
@@ -195,7 +195,7 @@ impl DefaultQueryFilters {
     pub(super) fn is_dense(&self, components: &Components) -> bool {
         self.disabling_ids().all(|component_id| {
             components
-                .get_info(*component_id)
+                .get_info(component_id)
                 .is_some_and(|info| info.storage_type() == StorageType::Table)
         })
     }

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -45,8 +45,13 @@ use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
 /// A marker component for disabled entities. See [the module docs] for more info.
 ///
 /// [the module docs]: crate::entity_disabling
-#[derive(Component)]
-#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
+#[derive(Component, Clone, Debug)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Component),
+    reflect(Debug)
+)]
 pub struct Disabled;
 
 /// The default filters for all queries, these are used to globally exclude entities from queries.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -3,7 +3,31 @@
 //! While Bevy ships with a built-in [`Disabled`] component, you can also create your own
 //! disabling components, which will operate in the same way but can have distinct semantics.
 //!
-//! ## Defining your own disabling components
+//! ```
+//! use bevy_ecs::prelude::*;
+//!
+//! // Our custom disabling component!
+//! #[derive(Component, Clone)]
+//! struct Prefab;
+//!
+//! #[derive(Component)]
+//! struct A;
+//!
+//! let mut world = World::new();
+//! world.register_disabling_component::<Prefab>();
+//! world.spawn((A, Prefab));
+//! world.spawn((A,));
+//! world.spawn((A,));
+//!
+//! let mut normal_query = world.query::<&A>();
+//! assert_eq!(2, normal_query.iter(&world).count());
+//!
+//! let mut prefab_query = world.query_filtered::<&A, With<Prefab>>();
+//! assert_eq!(1, prefab_query.iter(&world).count());
+//!
+//! let mut maybe_prefab_query = world.query::<(&A, Has<Prefab>)>();
+//! assert_eq!(3, maybe_prefab_query.iter(&world).count());
+//! ```
 //!
 //! ## Default query filters
 //!

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -117,6 +117,10 @@ pub struct Disabled;
 /// and clearly communicate their presence in any libraries you publish.
 #[derive(Resource, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[expect(
+    clippy::new_without_default,
+    reason = "We cannot implement both Default and FromWorld due to the blanket impl for FromWorld"
+)]
 pub struct DefaultQueryFilters {
     // We only expect a few components per application to act as disabling components, so we use a SmallVec here
     // to avoid heap allocation in most cases.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -137,7 +137,7 @@ pub struct DefaultQueryFilters {
 
 impl FromWorld for DefaultQueryFilters {
     fn from_world(world: &mut World) -> Self {
-        let mut filters = DefaultQueryFilters::new();
+        let mut filters = DefaultQueryFilters::empty();
         let disabled_component_id = world.register_component::<Disabled>();
         filters.register_disabling_component(disabled_component_id);
         filters
@@ -149,12 +149,8 @@ impl DefaultQueryFilters {
     ///
     /// This is provided as an escape hatch; in most cases you should initialize this using [`FromWorld`],
     /// which is automatically called when creating a new [`World`].
-    #[expect(
-        clippy::new_without_default,
-        reason = "We cannot implement both Default and FromWorld due to the blanket impl for FromWorld"
-    )]
     #[must_use]
-    pub fn new() -> Self {
+    pub fn empty() -> Self {
         DefaultQueryFilters {
             disabling: SmallVec::new(),
         }
@@ -213,7 +209,7 @@ mod tests {
 
     #[test]
     fn filters_modify_access() {
-        let mut filters = DefaultQueryFilters::new();
+        let mut filters = DefaultQueryFilters::empty();
         filters.register_disabling_component(ComponentId::new(1));
 
         // A component access with an unrelated component

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -67,7 +67,7 @@ use crate::{
     query::FilteredAccess,
 };
 use bevy_ecs_macros::{Component, Resource};
-use bevy_platform_support::collections::HashSet;
+use smallvec::SmallVec;
 
 #[cfg(feature = "bevy_reflect")]
 use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
@@ -111,7 +111,9 @@ pub struct Disabled;
 #[derive(Resource, Default, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct DefaultQueryFilters {
-    disabling: HashSet<ComponentId>,
+    // We only expect a few components per application to act as disabling components, so we use a SmallVec here
+    // to avoid heap allocation in most cases.
+    disabling: SmallVec<[ComponentId; 4]>,
 }
 
 impl DefaultQueryFilters {
@@ -126,7 +128,7 @@ impl DefaultQueryFilters {
     /// As discussed in the [module docs](crate::entity_disabling), this can have performance implications,
     /// as well as create interoperability issues, and should be used with caution.
     pub fn register_disabling_component(&mut self, component_id: ComponentId) {
-        self.disabling.insert(component_id);
+        self.disabling.push(component_id);
     }
 
     /// Get an iterator over all currently enabled filter components.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -120,6 +120,8 @@ impl DefaultQueryFilters {
     /// Adds this [`ComponentId`] to the set of [`DefaultQueryFilters`],
     /// causing entities with this component to be excluded from queries.
     ///
+    /// This method is idempotent, and will not add the same component multiple times.
+    ///
     /// # Warning
     ///
     /// This method should only be called before the app starts, as it will not affect queries
@@ -128,7 +130,9 @@ impl DefaultQueryFilters {
     /// As discussed in the [module docs](crate::entity_disabling), this can have performance implications,
     /// as well as create interoperability issues, and should be used with caution.
     pub fn register_disabling_component(&mut self, component_id: ComponentId) {
-        self.disabling.push(component_id);
+        if !self.disabling.contains(&component_id) {
+            self.disabling.push(component_id);
+        }
     }
 
     /// Get an iterator over all of the components which disable entities when present.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -1,14 +1,26 @@
-//! Types for entity disabling.
-//!
 //! Disabled entities do not show up in queries unless the query explicitly mentions them.
 //!
-//! If for example we have `Disabled` as an entity disabling component, when you add `Disabled`
-//! to an entity, the entity will only be visible to queries with a filter like
-//! [`With`]`<Disabled>` or query data like [`Has`]`<Disabled>`.
+//! While Bevy ships with a built-in [`Disabled`] component, you can also create your own
+//! disabling components, which will operate in the same way but can have distinct semantics.
 //!
-//! ### Note
+//! ## Defining your own disabling components
 //!
-//! Currently only queries for which the cache is built after enabling a filter will have entities
+//! ## Default query filters
+//!
+//! In Bevy, entity disabling is implemented through the construction of a global "default query filter".
+//! Queries which do not explicitly mention the disabled component will not include entities with that component.
+//! If an entity has multiple disabling components, it will only be included in queries that mention all of them.
+//!
+//! For example, `Query<&Position>` will not include entities with the [`Disabled`] component,
+//! even if they have a `Position` component,
+//! but `Query<&Position, With<Disabled>>` or `Query<(&Position, Has<Disabled>)>` will see them.
+//!
+//! Entities with disabling components are still present in the [`World`] and can be accessed directly,
+//! using methods on [`World`] or [`Commands`](crate::prelude::Commands).
+//!
+//! ### Warning
+//!
+//! Currently, only queries for which the cache is built after enabling a default query filter will have entities
 //! with those components filtered. As a result, they should generally only be modified before the
 //! app starts.
 //!

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -131,7 +131,7 @@ impl DefaultQueryFilters {
         self.disabling.push(component_id);
     }
 
-    /// Get an iterator over all currently enabled filter components.
+    /// Get an iterator over all of the components which disable entities when present.
     pub fn disabling_ids(&self) -> impl Iterator<Item = &ComponentId> {
         self.disabling.iter()
     }

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -117,10 +117,6 @@ pub struct Disabled;
 /// and clearly communicate their presence in any libraries you publish.
 #[derive(Resource, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
-#[expect(
-    clippy::new_without_default,
-    reason = "We cannot implement both Default and FromWorld due to the blanket impl for FromWorld"
-)]
 pub struct DefaultQueryFilters {
     // We only expect a few components per application to act as disabling components, so we use a SmallVec here
     // to avoid heap allocation in most cases.
@@ -141,6 +137,10 @@ impl DefaultQueryFilters {
     ///
     /// This is provided as an escape hatch; in most cases you should initialize this using [`FromWorld`],
     /// which is automatically called when creating a new [`World`].
+    #[expect(
+        clippy::new_without_default,
+        reason = "We cannot implement both Default and FromWorld due to the blanket impl for FromWorld"
+    )]
     #[must_use]
     pub fn new() -> Self {
         DefaultQueryFilters {

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -43,7 +43,11 @@ use bevy_platform_support::collections::HashSet;
 #[cfg(feature = "bevy_reflect")]
 use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
 
-/// A marker component for disabled entities. See [the module docs] for more info.
+/// A marker component for disabled entities.
+///
+/// Every [`World`](crate::prelude::World) has a default query filter that excludes entities with this component,
+/// registered in the [`DefaultQueryFilters`] resource.
+/// See [the module docs] for more info.
 ///
 /// [the module docs]: crate::entity_disabling
 #[derive(Component, Clone, Debug)]
@@ -53,6 +57,7 @@ use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
     reflect(Component),
     reflect(Debug)
 )]
+// This component is registered as a disabling component during World::bootstrap
 pub struct Disabled;
 
 /// Default query filters work by excluding entities with certain components from most queries.

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -75,7 +75,7 @@ impl DefaultQueryFilters {
         self.disabling.iter()
     }
 
-    pub(super) fn apply(&self, component_access: &mut FilteredAccess<ComponentId>) {
+    pub(super) fn modify_access(&self, component_access: &mut FilteredAccess<ComponentId>) {
         for &component_id in self.disabling_ids() {
             if !component_access.contains(component_id) {
                 component_access.and_without(component_id);
@@ -99,7 +99,7 @@ mod tests {
     use alloc::{vec, vec::Vec};
 
     #[test]
-    fn test_apply_filters() {
+    fn filters_modify_access() {
         let mut filters = DefaultQueryFilters::default();
         filters.register_disabling_component(ComponentId::new(1));
 
@@ -110,7 +110,7 @@ mod tests {
             .add_component_read(ComponentId::new(2));
 
         let mut applied_access = component_access.clone();
-        filters.apply(&mut applied_access);
+        filters.modify_access(&mut applied_access);
         assert_eq!(0, applied_access.with_filters().count());
         assert_eq!(
             vec![ComponentId::new(1)],
@@ -121,7 +121,7 @@ mod tests {
         component_access.and_with(ComponentId::new(4));
 
         let mut applied_access = component_access.clone();
-        filters.apply(&mut applied_access);
+        filters.modify_access(&mut applied_access);
         assert_eq!(
             vec![ComponentId::new(4)],
             applied_access.with_filters().collect::<Vec<_>>()
@@ -136,7 +136,7 @@ mod tests {
         component_access.and_with(ComponentId::new(1));
 
         let mut applied_access = component_access.clone();
-        filters.apply(&mut applied_access);
+        filters.modify_access(&mut applied_access);
         assert_eq!(
             vec![ComponentId::new(1), ComponentId::new(4)],
             applied_access.with_filters().collect::<Vec<_>>()
@@ -150,7 +150,7 @@ mod tests {
             .add_archetypal(ComponentId::new(1));
 
         let mut applied_access = component_access.clone();
-        filters.apply(&mut applied_access);
+        filters.modify_access(&mut applied_access);
         assert_eq!(
             vec![ComponentId::new(4)],
             applied_access.with_filters().collect::<Vec<_>>()

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -42,7 +42,7 @@
 //! Entities with disabling components are still present in the [`World`] and can be accessed directly,
 //! using methods on [`World`] or [`Commands`](crate::prelude::Commands).
 //!
-//! ### Warning
+//! ### Warnings
 //!
 //! Currently, only queries for which the cache is built after enabling a default query filter will have entities
 //! with those components filtered. As a result, they should generally only be modified before the
@@ -51,6 +51,11 @@
 //! Because filters are applied to all queries they can have performance implication for
 //! the enire [`World`], especially when they cause queries to mix sparse and table components.
 //! See [`Query` performance] for more info.
+//!
+//! Custom disabling components can cause significant interoperability issues within the ecosystem,
+//! as users must be aware of each disabling component in use.
+//! Libraries should think carefully about whether they need to use a new disabling component,
+//! and clearly communicate their presence to their users to avoid the new for library compatibility flags.
 //!
 //! [`With`]: crate::prelude::With
 //! [`Has`]: crate::prelude::Has
@@ -91,6 +96,18 @@ pub struct Disabled;
 /// and if it does not, adds a [`Without`](crate::prelude::Without) filter for that component to the query.
 ///
 /// See the [module docs](crate::entity_disabling) for more info.
+///
+///
+/// # Warning
+///
+/// Default query filters are a global setting that affects all queries in the [`World`],
+/// and incur a small performance cost for each query.
+///
+/// They can cause significant interoperability issues within the ecosystem,
+/// as users must be aware of each disabling component in use.
+///
+/// Think carefully about whether you need to use a new disabling component,
+/// and clearly communicate their presence in any libraries you publish.
 #[derive(Resource, Default, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct DefaultQueryFilters {
@@ -105,6 +122,9 @@ impl DefaultQueryFilters {
     ///
     /// This method should only be called before the app starts, as it will not affect queries
     /// initialized before it is called.
+    ///
+    /// As discussed in the [module docs](crate::entity_disabling), this can have performance implications,
+    /// as well as create interoperability issues, and should be used with caution.
     pub fn register_disabling_component(&mut self, component_id: ComponentId) {
         self.disabling.insert(component_id);
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2454,7 +2454,7 @@ mod tests {
         world.spawn((B(0), C(0)));
         world.spawn(C(0));
 
-        let mut df = DefaultQueryFilters::default();
+        let mut df = DefaultQueryFilters::new();
         df.register_disabling_component(world.register_component::<C>());
         world.insert_resource(df);
 
@@ -2494,7 +2494,7 @@ mod tests {
         assert!(query.is_dense);
         assert_eq!(3, query.iter(&world).count());
 
-        let mut df = DefaultQueryFilters::default();
+        let mut df = DefaultQueryFilters::new();
         df.register_disabling_component(world.register_component::<Sparse>());
         world.insert_resource(df);
 
@@ -2504,7 +2504,7 @@ mod tests {
         assert!(!query.is_dense);
         assert_eq!(1, query.iter(&world).count());
 
-        let mut df = DefaultQueryFilters::default();
+        let mut df = DefaultQueryFilters::new();
         df.register_disabling_component(world.register_component::<Table>());
         world.insert_resource(df);
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -258,7 +258,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         let mut is_dense = D::IS_DENSE && F::IS_DENSE;
 
         if let Some(default_filters) = world.get_resource::<DefaultQueryFilters>() {
-            default_filters.apply(&mut component_access);
+            default_filters.modify_access(&mut component_access);
             is_dense &= default_filters.is_dense(world.components());
         }
 
@@ -293,7 +293,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         let mut is_dense = builder.is_dense();
 
         if let Some(default_filters) = builder.world().get_resource::<DefaultQueryFilters>() {
-            default_filters.apply(&mut component_access);
+            default_filters.modify_access(&mut component_access);
             is_dense &= default_filters.is_dense(builder.world().components());
         }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2455,7 +2455,7 @@ mod tests {
         world.spawn(C(0));
 
         let mut df = DefaultQueryFilters::default();
-        df.set_disabled(world.register_component::<C>());
+        df.register_disabling_component(world.register_component::<C>());
         world.insert_resource(df);
 
         // Without<C> only matches the first entity
@@ -2495,7 +2495,7 @@ mod tests {
         assert_eq!(3, query.iter(&world).count());
 
         let mut df = DefaultQueryFilters::default();
-        df.set_disabled(world.register_component::<Sparse>());
+        df.register_disabling_component(world.register_component::<Sparse>());
         world.insert_resource(df);
 
         let mut query = QueryState::<()>::new(&mut world);
@@ -2505,7 +2505,7 @@ mod tests {
         assert_eq!(1, query.iter(&world).count());
 
         let mut df = DefaultQueryFilters::default();
-        df.set_disabled(world.register_component::<Table>());
+        df.register_disabling_component(world.register_component::<Table>());
         world.insert_resource(df);
 
         let mut query = QueryState::<()>::new(&mut world);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2454,7 +2454,7 @@ mod tests {
         world.spawn((B(0), C(0)));
         world.spawn(C(0));
 
-        let mut df = DefaultQueryFilters::new();
+        let mut df = DefaultQueryFilters::empty();
         df.register_disabling_component(world.register_component::<C>());
         world.insert_resource(df);
 
@@ -2494,7 +2494,7 @@ mod tests {
         assert!(query.is_dense);
         assert_eq!(3, query.iter(&world).count());
 
-        let mut df = DefaultQueryFilters::new();
+        let mut df = DefaultQueryFilters::empty();
         df.register_disabling_component(world.register_component::<Sparse>());
         world.insert_resource(df);
 
@@ -2504,7 +2504,7 @@ mod tests {
         assert!(!query.is_dense);
         assert_eq!(1, query.iter(&world).count());
 
-        let mut df = DefaultQueryFilters::new();
+        let mut df = DefaultQueryFilters::empty();
         df.register_disabling_component(world.register_component::<Table>());
         world.insert_resource(df);
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -253,6 +253,14 @@ impl World {
         self.components.register_component::<T>()
     }
 
+    /// Registers a component type as "disabling",
+    /// using [default query filters](DefaultQueryFilters) to exclude entities with the component from queries.
+    pub fn register_disabling_component<C: Component>(&mut self) {
+        let component_id = self.register_component::<C>();
+        let mut dqf = self.resource_mut::<DefaultQueryFilters>();
+        dqf.register_disabling_component(component_id);
+    }
+
     /// Returns a mutable reference to the [`ComponentHooks`] for a [`Component`] type.
     ///
     /// Will panic if `T` exists in any archetypes.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -161,7 +161,7 @@ impl World {
 
         let disabled = self.register_component::<Disabled>();
         let mut filters = DefaultQueryFilters::default();
-        filters.set_disabled(disabled);
+        filters.register_disabling_component(disabled);
         self.insert_resource(filters);
     }
     /// Creates a new empty [`World`].

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         Components, Mutable, RequiredComponents, RequiredComponentsError, Tick,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
-    entity_disabling::{DefaultQueryFilters, Disabled},
+    entity_disabling::DefaultQueryFilters,
     event::{Event, EventId, Events, SendBatchIds},
     observer::Observers,
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
@@ -159,10 +159,8 @@ impl World {
         let on_despawn = OnDespawn::register_component_id(self);
         assert_eq!(ON_DESPAWN, on_despawn);
 
-        let disabled = self.register_component::<Disabled>();
-        let mut filters = DefaultQueryFilters::default();
-        filters.register_disabling_component(disabled);
-        self.insert_resource(filters);
+        // This sets up `Disabled` as a disabling component, via the FromWorld impl
+        self.init_resource::<DefaultQueryFilters>();
     }
     /// Creates a new empty [`World`].
     ///

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -351,6 +351,7 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// [`deny_resource`]: Self::deny_resource
     #[must_use]
     pub fn extract_resources(mut self) -> Self {
+        // Don't extract the DefaultQueryFilters resource
         let original_world_dqf_id = self
             .original_world
             .components()


### PR DESCRIPTION
# Objective

Currently, default query filters, as added in #13120 / #17514 are hardcoded to only use a single query filter.

This is limiting, as multiple distinct disabling components can serve important distinct roles. I ran into this limitation when experimenting with a workflow for prefabs, which don't represent the same state as "an entity which is temporarily nonfunctional".

## Solution

1. Change `DefaultQueryFilters` to store a SmallVec of ComponentId, rather than an Option.
2. Expose methods on `DefaultQueryFilters`, `World` and `App` to actually configure this.
3. While we're here, improve the docs, write some tests, make use of FromWorld and make some method names more descriptive.

## Follow-up

I'm not convinced that supporting sparse set disabling components is useful, given the hit to iteration performance and runtime checks incurred. That's disjoint from this PR though, so I'm not doing it here. The existing warnings are fine for now.

## Testing

I've added both a doc test and an mid-level unit test to verify that this works!