### PR TITLE
Add an example demonstrating how to use default query filtering and entity cloning to create a prefab system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2085,6 +2085,17 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "prefabs"
+path = "examples/ecs/prefabs.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.prefabs]
+name = "Prefabs"
+description = "Demonstrates how to load, store and clone template entity collections"
+category = "ECS (Entity Component System)"
+wasm = false
+
+[[example]]
 name = "relationships"
 path = "examples/ecs/relationships.rs"
 doc-scrape-examples = true

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -34,7 +34,7 @@ use {crate::reflect::ReflectComponent, bevy_reflect::Reflect};
 /// A marker component for disabled entities. See [the module docs] for more info.
 ///
 /// [the module docs]: crate::entity_disabling
-#[derive(Component)]
+#[derive(Component, Debug, Clone, Copy)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Component))]
 pub struct Disabled;
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -320,6 +320,7 @@ Example | Description
 [Observers](../examples/ecs/observers.rs) | Demonstrates observers that react to events (both built-in life-cycle events and custom events)
 [One Shot Systems](../examples/ecs/one_shot_systems.rs) | Shows how to flexibly run systems without scheduling them
 [Parallel Query](../examples/ecs/parallel_query.rs) | Illustrates parallel queries with `ParallelIterator`
+[Prefabs](../examples/ecs/prefabs.rs) | Demonstrates how to load, store and clone template entity collections
 [Relationships](../examples/ecs/relationships.rs) | Define and work with custom relationships between entities
 [Removal Detection](../examples/ecs/removal_detection.rs) | Query for entities that had a specific component removed earlier in the current frame
 [Run Conditions](../examples/ecs/run_conditions.rs) | Run systems only when one or multiple conditions are met

--- a/examples/ecs/prefabs.rs
+++ b/examples/ecs/prefabs.rs
@@ -38,7 +38,7 @@ fn setup_scene(
 ) {
     // Circular floor to display our models on
     commands.spawn((
-        Mesh3d(meshes.add(Circle::new(4.0))),
+        Mesh3d(meshes.add(Circle::new(100.0))),
         MeshMaterial3d(materials.add(Color::WHITE)),
         Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
     ));
@@ -48,12 +48,12 @@ fn setup_scene(
             shadows_enabled: true,
             ..default()
         },
-        Transform::from_xyz(4.0, 8.0, 4.0),
+        Transform::from_xyz(100.0, 200.0, 200.0),
     ));
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Transform::from_xyz(100.0, 100.0, 150.0).looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
     ));
 
     // Load in our test scene that we're storing as a prefab
@@ -65,9 +65,9 @@ fn setup_scene(
 // allowing us to modify the scene as we please.
 fn respond_to_scene_loaded(trigger: Trigger<SceneInstanceReady>, mut commands: Commands) {
     let scene_root_entity = trigger.target();
+    // Scenes are typically composed of multiple entities, so we need to
+    // modify all entities in the scene to disable the scene.
     commands
         .entity(scene_root_entity)
-        // Scenes are generally composed of multiple entities,
-        // so we need to make any changes to the scene as a whole.
         .insert_recursive::<Children>(Disabled);
 }

--- a/examples/ecs/prefabs.rs
+++ b/examples/ecs/prefabs.rs
@@ -1,0 +1,63 @@
+//! Generating a collection of "prefab" entities can be faster and cleaner than
+//! loading them from assets each time or working entirely in code.
+//!
+//! Rather than providing an opinonated prefab system, Bevy provides a flexible
+//! set of tools that can be used to create and modify your solution.
+//!
+//! The core workflow is pretty straightforward:
+//!
+//! 1. Load asssets from disk.
+//! 2. Create prefab entities from those assets.
+//! 3. Make sure that these prefab entities aren't accidentally modified using default query filters.
+//! 4. Clone these entities (and their children) out from the prefab when you need to spawn an instance of them.
+//!
+//! This solution can be easily adapted to meet the needs of your own asset loading workflows,
+//! and variants of prefabs (e.g. enemy variants) can readily be constructed ahead of time and stored for easy access.
+//!
+//! Be mindful of memory usage when defining prefabs; while they won't be seen by game logic,
+//! the components and assets that they use will still be loaded into memory (although asset data is shared between instances).
+//! Loading and unloading assets dynamically (e.g. per level) is an important strategy to manage memory usage.
+
+use bevy::prelude::*;
+
+#[derive(States, Debug, PartialEq, Eq, Clone, Copy, Hash)]
+enum AssetLoadingState {
+    Loading,
+    Loaded,
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup_scene)
+        .add_systems(OnEnter(AssetLoadingState::Loading), load_models)
+        .run();
+}
+
+fn setup_scene(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Circular floor to display our models on
+    commands.spawn((
+        Mesh3d(meshes.add(Circle::new(4.0))),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+    ));
+    // Light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // Camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+fn load_models() {}

--- a/examples/ecs/prefabs.rs
+++ b/examples/ecs/prefabs.rs
@@ -18,6 +18,8 @@
 //! the components and assets that they use will still be loaded into memory (although asset data is shared between instances).
 //! Loading and unloading assets dynamically (e.g. per level) is an important strategy to manage memory usage.
 
+use std::f32::consts::PI;
+
 use bevy::platform_support::collections::HashMap;
 use bevy::{ecs::entity_disabling::Disabled, prelude::*, scene::SceneInstanceReady};
 
@@ -110,7 +112,13 @@ fn spawn_prefab_on_mouse_click(
         .entity(fresh_clone)
         .remove_recursive::<Children, Disabled>();
     // Overwrite the position of the prefab entity with the new value we want to spawn it at
-    commands
-        .entity(fresh_clone)
-        .insert(Transform::from_translation(*click_position));
+    // and give it a random rotation.
+    let random_angle = PI * 2.0 * rand::random::<f32>();
+
+    commands.entity(fresh_clone).insert(
+        Transform::from_translation(*click_position)
+            .with_rotation(Quat::from_rotation_y(random_angle)),
+    );
+
+    println!("Spawned a prefab at {:?}", click_position);
 }

--- a/examples/ecs/prefabs.rs
+++ b/examples/ecs/prefabs.rs
@@ -93,7 +93,7 @@ fn respond_to_scene_loaded(
 }
 
 fn spawn_prefab_on_mouse_click(
-    trigger: Trigger<Pointer<Click>>,
+    mut trigger: Trigger<Pointer<Click>>,
     prefabs: Res<Prefabs>,
     mut commands: Commands,
 ) {
@@ -120,5 +120,7 @@ fn spawn_prefab_on_mouse_click(
             .with_rotation(Quat::from_rotation_y(random_angle)),
     );
 
-    println!("Spawned a prefab at {:?}", click_position);
+    // We've already handled this event;
+    // so we don't want it to propagate any further.
+    trigger.propagate(false);
 }

--- a/examples/ecs/prefabs.rs
+++ b/examples/ecs/prefabs.rs
@@ -36,9 +36,9 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Circular floor to display our models on
+    // Large floor plane to display our models on
     commands.spawn((
-        Mesh3d(meshes.add(Circle::new(100.0))),
+        Mesh3d(meshes.add(Rectangle::new(500.0, 500.0))),
         MeshMaterial3d(materials.add(Color::WHITE)),
         Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
     ));
@@ -53,7 +53,7 @@ fn setup_scene(
     // Camera
     commands.spawn((
         Camera3d::default(),
-        Transform::from_xyz(100.0, 100.0, 150.0).looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
+        Transform::from_xyz(100.0, 400.0, 100.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 
     // Load in our test scene that we're storing as a prefab


### PR DESCRIPTION
# Objective

Bevy users have long wished for tools for working with a "prefab"-style workflows: #10949, #3877, #2565, #1446...

The core idea is pretty simple: define an "object" (made up of some collection of entities) that we can save, instantiated, into the world, and then clone and modify them as needed.

## Solution

Instead of creating a first-class solution, I've instead chosen to add an example demonstrating how this pattern can be achieved quite simply with a combination of default query filters and recursive entity cloning.

This is useful for teaching users how to create their own prefab-flavored solution, and gives us time to iterate on the ideal solution.

Long-term, I think that Bevy would be well-served by making a first party prefab workflow, complete with a standardized state-powered asset loading solution. It's nice to be able to teach this pattern directly to new users, and more importantly, it allows us to view and building tooling around prefabs for e.g. a GUI-based level editor.

But Bevy itself is a poor place to prove out the architectural details for this: we aren't actually testing it in a large game project, and so the solution isn't subject to the appropriate pressures. Once the community has developed a robust solution, we should upstream it (likely as a standalone crate) and update this example!

## To do

This PR is not yet complete!

Before it's merged, we need to:

- [ ] merge https://github.com/bevyengine/bevy/pull/17768
- [ ] figure out why foxes flicker in and out of existence when spawning

It might also be nice to:

- [ ] add instruction text
- [ ] load more than one model, and actually make use of that hash map
- [ ] define and use an asset loading state (please discuss!)
- [ ] somehow extract the asset path from the SceneInstanceReady event and cache that

Like always, feel free to PR to my branch if you want to fix these.

## Testing

`cargo run --example prefabs`

## Showcase

![image](https://github.com/user-attachments/assets/a8394e3e-8ad8-4712-b9ac-d1bbb2d5afe6)
