### PR TITLE
Fix meshlets when bindless disabled.

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -70,17 +70,16 @@ fn pbr_input_from_standard_material(
     in: VertexOutput,
     is_front: bool,
 ) -> pbr_types::PbrInput {
-#ifdef BINDLESS
 #ifdef MESHLET_MESH_MATERIAL_PASS
     let slot = in.material_bind_group_slot;
 #else   // MESHLET_MESH_MATERIAL_PASS
     let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
 #endif  // MESHLET_MESH_MATERIAL_PASS
+#ifdef BINDLESS
     let flags = pbr_bindings::material[slot].flags;
     let base_color = pbr_bindings::material[slot].base_color;
     let deferred_lighting_pass_id = pbr_bindings::material[slot].deferred_lighting_pass_id;
 #else   // BINDLESS
-    let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
     let flags = pbr_bindings::material.flags;
     let base_color = pbr_bindings::material.base_color;
     let deferred_lighting_pass_id = pbr_bindings::material.deferred_lighting_pass_id;


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/pull/16966 tried to fix a bug where `slot` wasn't passed to `parallaxed_uv` when not running under bindless, but failed to account for meshlets. This surfaces on macOS where bindless is disabled.

## Solution

Lift the slot variable out of the bindless condition so it's always available.