### PR TITLE
Assert a minimum thread count for `TaskPoolOptions`

### DIFF
--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -159,6 +159,7 @@ impl Default for TaskPoolOptions {
 impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
     pub fn with_num_threads(thread_count: usize) -> Self {
+        assert!(thread_count > 2);
         TaskPoolOptions {
             min_total_threads: thread_count,
             max_total_threads: thread_count,

--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -159,7 +159,7 @@ impl Default for TaskPoolOptions {
 impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
     pub fn with_num_threads(thread_count: usize) -> Self {
-        assert!(thread_count > 2);
+        assert!(thread_count > 2, "Default task pool policies requires at least 3 threads");
         TaskPoolOptions {
             min_total_threads: thread_count,
             max_total_threads: thread_count,

--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -12,7 +12,7 @@ use alloc::string::ToString;
 use bevy_platform_support::sync::Arc;
 use bevy_tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder};
 use core::{fmt::Debug, marker::PhantomData};
-use log::trace;
+use log::{trace, warn};
 
 #[cfg(not(target_arch = "wasm32"))]
 use {crate::Last, bevy_ecs::prelude::NonSend};
@@ -159,14 +159,13 @@ impl Default for TaskPoolOptions {
 impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
     ///
-    /// # Panics
-    ///
-    /// Values below 3 are not supported by Bevy (IO, Async and Compute pools each need at least one thread), and will panic.
+    /// Warns for values below 3 as three minimum are needed for the default pool assignments (IO, Async and Compute pools each need at least one thread).
     pub fn with_num_threads(thread_count: usize) -> Self {
-        assert!(
-            thread_count > 2,
-            "The default TaskPoolOptions thread assignment policies require a minimum of one thread each for the IO, Async, and Compute pools. Please specify a thread_count of at least 3."
-        );
+        if thread_count < 3 {
+            warn!(
+                "The default TaskPoolOptions thread assignment policies require a minimum of one thread each for the IO, Async, and Compute pools. Three threads will be assigned."
+            );
+        }
         TaskPoolOptions {
             min_total_threads: thread_count,
             max_total_threads: thread_count,

--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -161,7 +161,7 @@ impl TaskPoolOptions {
     pub fn with_num_threads(thread_count: usize) -> Self {
         assert!(
             thread_count > 2,
-            "Default task pool policies require at least 3 threads"
+            "The default TaskPoolOptions thread assignment policies require a minimum of one thread each for the IO, Async, and Compute pools. Please specify a thread_count of at least 3."
         );
         TaskPoolOptions {
             min_total_threads: thread_count,

--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -159,7 +159,10 @@ impl Default for TaskPoolOptions {
 impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
     pub fn with_num_threads(thread_count: usize) -> Self {
-        assert!(thread_count > 2, "Default task pool policies require at least 3 threads");
+        assert!(
+            thread_count > 2,
+            "Default task pool policies require at least 3 threads"
+        );
         TaskPoolOptions {
             min_total_threads: thread_count,
             max_total_threads: thread_count,

--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -158,6 +158,10 @@ impl Default for TaskPoolOptions {
 
 impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
+    ///
+    /// # Panics
+    ///
+    /// Values below 3 are not supported by Bevy (IO, Async and Compute pools each need at least one thread), and will panic.
     pub fn with_num_threads(thread_count: usize) -> Self {
         assert!(
             thread_count > 2,

--- a/crates/bevy_app/src/task_pool_plugin.rs
+++ b/crates/bevy_app/src/task_pool_plugin.rs
@@ -159,7 +159,7 @@ impl Default for TaskPoolOptions {
 impl TaskPoolOptions {
     /// Create a configuration that forces using the given number of threads.
     pub fn with_num_threads(thread_count: usize) -> Self {
-        assert!(thread_count > 2, "Default task pool policies requires at least 3 threads");
+        assert!(thread_count > 2, "Default task pool policies require at least 3 threads");
         TaskPoolOptions {
             min_total_threads: thread_count,
             max_total_threads: thread_count,


### PR DESCRIPTION
# Objective

 TaskPool policies assign one thread per group, so three threads are assigned at minimum. Adds an assertion for a minimum thread count for `TaskPoolOptions`. Passing 0, 1 or 2 for thread count has no real effect.

## Testing

- Module tests pass

