### PR TITLE
added additional easing functions

### DIFF
--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -432,7 +432,7 @@ pub enum EaseFunction {
     ///
     #[doc = include_str!("../../images/easefunction/Steps.svg")]
     Steps(usize),
-    /// `n` steps connecting the start and the end. A jump is included at the start 
+    /// `n` steps connecting the start and the end. A jump is included at the start
     ///
     #[doc = include_str!("../../images/easefunction/Steps.svg")]
     StepsStart(usize),

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -432,6 +432,18 @@ pub enum EaseFunction {
     ///
     #[doc = include_str!("../../images/easefunction/Steps.svg")]
     Steps(usize),
+    /// `n` steps connecting the start and the end. A jump is included at the start 
+    ///
+    #[doc = include_str!("../../images/easefunction/Steps.svg")]
+    StepsStart(usize),
+    /// `n` steps connecting the start and the end. A jump is included at the end
+    ///
+    #[doc = include_str!("../../images/easefunction/Steps.svg")]
+    StepsEnd(usize),
+    /// `n` steps connecting the start and the end. A jump is included at the beginning and end
+    ///
+    #[doc = include_str!("../../images/easefunction/Steps.svg")]
+    StepsBoth(usize),
 
     /// `f(omega,t) = 1 - (1 - t)²(2sin(omega * t) / omega + cos(omega * t))`, parametrized by `omega`
     ///
@@ -685,7 +697,19 @@ mod easing_functions {
 
     #[inline]
     pub(crate) fn steps(num_steps: usize, t: f32) -> f32 {
+        (ops::floor(t * num_steps as f32) / (num_steps - 1).max(1) as f32).min(1.)
+    }
+    #[inline]
+    pub(crate) fn steps_start(num_steps: usize, t: f32) -> f32 {
+        ((ops::floor(t * num_steps as f32) + 1.) / num_steps.max(1) as f32).min(1.)
+    }
+    #[inline]
+    pub(crate) fn steps_end(num_steps: usize, t: f32) -> f32 {
         ops::floor(t * num_steps as f32) / num_steps.max(1) as f32
+    }
+    #[inline]
+    pub(crate) fn steps_both(num_steps: usize, t: f32) -> f32 {
+        ((ops::floor(t * num_steps as f32) + 1.) / (num_steps + 1).max(1) as f32).min(1.)
     }
 
     #[inline]
@@ -735,6 +759,9 @@ impl EaseFunction {
             EaseFunction::BounceOut => easing_functions::bounce_out(t),
             EaseFunction::BounceInOut => easing_functions::bounce_in_out(t),
             EaseFunction::Steps(num_steps) => easing_functions::steps(*num_steps, t),
+            EaseFunction::StepsStart(num_steps) => easing_functions::steps_start(*num_steps, t),
+            EaseFunction::StepsEnd(num_steps) => easing_functions::steps_end(*num_steps, t),
+            EaseFunction::StepsBoth(num_steps) => easing_functions::steps_both(*num_steps, t),
             EaseFunction::Elastic(omega) => easing_functions::elastic(*omega, t),
         }
     }

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -1059,9 +1059,72 @@ mod tests {
     #[test]
     fn easing_curves_step() {
         let start = Vec2::ZERO;
-        let end = Vec2::new(1.0, 2.0);
+        let end = Vec2::new(3.0, 3.0);
 
         let curve = EasingCurve::new(start, end, EaseFunction::Steps(4));
+        [
+            (0.0, start),
+            (0.249, start),
+            (0.250, Vec2::new(1., 1.)),
+            (0.499, Vec2::new(1., 1.)),
+            (0.500, Vec2::new(2., 2.)),
+            (0.749, Vec2::new(2., 2.)),
+            (0.750, end),
+            (1.0, end),
+        ]
+        .into_iter()
+        .for_each(|(t, x)| {
+            assert!(curve.sample_unchecked(t).abs_diff_eq(x, f32::EPSILON));
+        });
+    }
+    #[test]
+    fn easing_curves_step_start() {
+        let start = Vec2::ZERO;
+        let end = Vec2::new(1.0, 2.0);
+
+        let curve = EasingCurve::new(start, end, EaseFunction::StepsStart(4));
+        [
+            (0.0, Vec2::new(0.25, 0.5)),
+            (0.249, Vec2::new(0.25, 0.5)),
+            (0.250, Vec2::new(0.5, 1.0)),
+            (0.499, Vec2::new(0.5, 1.0)),
+            (0.500, Vec2::new(0.75, 1.5)),
+            (0.749, Vec2::new(0.75, 1.5)),
+            (0.750, end),
+            (1.0, end),
+        ]
+        .into_iter()
+        .for_each(|(t, x)| {
+            assert!(curve.sample_unchecked(t).abs_diff_eq(x, f32::EPSILON));
+        });
+    }
+    #[test]
+    fn easing_curves_step_end() {
+        let start = Vec2::ZERO;
+        let end = Vec2::new(5., 5.);
+
+        let curve = EasingCurve::new(start, end, EaseFunction::StepsBoth(4));
+        [
+            (0.0, Vec2::new(1.,1.)),
+            (0.249, Vec2::new(1.,1.)),
+            (0.250, Vec2::new(2., 2.)),
+            (0.499, Vec2::new(2., 2.)),
+            (0.500, Vec2::new(3., 3.)),
+            (0.749, Vec2::new(3., 3.)),
+            (0.750, Vec2::new(4., 4.)),
+            (1.0, end),
+        ]
+        .into_iter()
+        .for_each(|(t, x)| {
+            assert!(curve.sample_unchecked(t).abs_diff_eq(x, f32::EPSILON));
+        });
+    }
+    #[test]
+    fn easing_curves_step_both() {
+        let start = Vec2::ZERO;
+        let end = Vec2::new(1.0, 2.0);
+
+        let curve = EasingCurve::new(start, end, EaseFunction::StepsEnd(4));
         [
             (0.0, start),
             (0.249, start),

--- a/crates/bevy_math/src/curve/mod.rs
+++ b/crates/bevy_math/src/curve/mod.rs
@@ -1105,8 +1105,8 @@ mod tests {
 
         let curve = EasingCurve::new(start, end, EaseFunction::StepsBoth(4));
         [
-            (0.0, Vec2::new(1.,1.)),
-            (0.249, Vec2::new(1.,1.)),
+            (0.0, Vec2::new(1., 1.)),
+            (0.249, Vec2::new(1., 1.)),
             (0.250, Vec2::new(2., 2.)),
             (0.499, Vec2::new(2., 2.)),
             (0.500, Vec2::new(3., 3.)),

--- a/examples/animation/easing_functions.rs
+++ b/examples/animation/easing_functions.rs
@@ -69,6 +69,9 @@ fn setup(mut commands: Commands) {
         // "Other" row
         EaseFunction::Linear,
         EaseFunction::Steps(4),
+        EaseFunction::StepsStart(4),
+        EaseFunction::StepsEnd(4),
+        EaseFunction::StepsBoth(4),
         EaseFunction::Elastic(50.0),
     ]
     .chunks(COLS);

--- a/tools/build-easefunction-graphs/src/main.rs
+++ b/tools/build-easefunction-graphs/src/main.rs
@@ -56,6 +56,9 @@ fn main() {
         EaseFunction::BounceInOut,
         EaseFunction::Linear,
         EaseFunction::Steps(4),
+        EaseFunction::StepsStart(4),
+        EaseFunction::StepsEnd(4),
+        EaseFunction::StepsBoth(4),
         EaseFunction::Elastic(50.0),
     ] {
         let curve = EasingCurve::new(0.0, 1.0, function);


### PR DESCRIPTION
# Objective

Fixes #17744 



## Solution

This updated adds three additional easing functions to support the full set of functions available in CSS
https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function/steps#description

Three new `EaseFunction`s were added, and the original `EaseFunction::Steps` was modified.

I thought it made the most sense to have `Steps` be equivalent to `jump-none`, and added additional functions for the remaining options. `StepsStart` for `jump-start`, and so on. The original `Steps` function is now `StepsEnd`, which may be a problem .

## Testing

I updated the `EaseFunction`s example to include the three new functions, and successfully tested the code locally. 

---

## Showcase

![Screenshot from 2025-02-10 11-26-56](https://github.com/user-attachments/assets/847842c1-ddd0-448a-a1f6-fc24e5d4623d)


## Migration Guide

Calls to `EaseFunction::Steps` would need to be updated to `EaseFunction::StepsEnd` to display the same behavior
