### PR TITLE
Add get_ref_with_ticks

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -23,6 +23,7 @@ use crate::{
     },
 };
 use alloc::vec::Vec;
+use bevy_ecs::component::Tick;
 use bevy_platform_support::collections::{HashMap, HashSet};
 use bevy_ptr::{OwningPtr, Ptr};
 #[cfg(feature = "track_location")]
@@ -35,7 +36,6 @@ use core::{
     mem::MaybeUninit,
 };
 use thiserror::Error;
-use bevy_ecs::component::Tick;
 
 /// A read-only reference to a particular [`Entity`] and all of its components.
 ///
@@ -152,7 +152,11 @@ impl<'w> EntityRef<'w> {
     /// Usually `get_ref` should be used because the correct change ticks will be set by the scheduler,
     /// but for some advanced users it can be useful to have more control over the change ticks.
     #[inline]
-    pub fn get_ref_with_ticks<T: Component>(&self, last_run: Tick, this_run: Tick) -> Option<Ref<'w, T>> {
+    pub fn get_ref_with_ticks<T: Component>(
+        &self,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Option<Ref<'w, T>> {
         // SAFETY: We have read-only access to all components of this entity.
         unsafe { self.cell.get_ref_with_ticks::<T>(last_run, this_run) }
     }
@@ -593,7 +597,11 @@ impl<'w> EntityMut<'w> {
     /// Usually `get_ref` should be used because the correct change ticks will be set by the scheduler,
     /// but for some advanced users it can be useful to have more control over the change ticks.
     #[inline]
-    pub fn get_ref_with_ticks<T: Component>(&self, last_run: Tick, this_run: Tick) -> Option<Ref<'_, T>> {
+    pub fn get_ref_with_ticks<T: Component>(
+        &self,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Option<Ref<'_, T>> {
         self.as_readonly().get_ref_with_ticks(last_run, this_run)
     }
 
@@ -1262,7 +1270,11 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// If the entity has been despawned while this `EntityWorldMut` is still alive.
     #[inline]
-    pub fn get_ref_with_ticks<T: Component>(&self, last_run: Tick, this_run: Tick) -> Option<Ref<'_, T>> {
+    pub fn get_ref_with_ticks<T: Component>(
+        &self,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Option<Ref<'_, T>> {
         self.as_readonly().get_ref_with_ticks(last_run, this_run)
     }
 
@@ -3320,7 +3332,11 @@ impl<'w> FilteredEntityRef<'w> {
     /// Usually `get_ref` should be used because the correct change ticks will be set by the scheduler,
     /// but for some advanced users it can be useful to have more control over the change ticks.
     #[inline]
-    pub fn get_ref_with_ticks<T: Component>(&self, last_run: Tick, this_run: Tick) -> Option<Ref<'w, T>> {
+    pub fn get_ref_with_ticks<T: Component>(
+        &self,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Option<Ref<'w, T>> {
         let id = self.entity.world().components().get_id(TypeId::of::<T>())?;
         self.access
             .has_component_read(id)
@@ -3655,7 +3671,11 @@ impl<'w> FilteredEntityMut<'w> {
     /// Usually `get_ref` should be used because the correct change ticks will be set by the scheduler,
     /// but for some advanced users it can be useful to have more control over the change ticks.
     #[inline]
-    pub fn get_ref_with_ticks<T: Component>(&self, last_run: Tick, this_run: Tick) -> Option<Ref<'_, T>> {
+    pub fn get_ref_with_ticks<T: Component>(
+        &self,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Option<Ref<'_, T>> {
         self.as_readonly().get_ref_with_ticks(last_run, this_run)
     }
 

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -801,7 +801,11 @@ impl<'w> UnsafeEntityCell<'w> {
     /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
-    pub unsafe fn get_ref_with_ticks<T: Component>(self, last_run: Tick, this_run: Tick) -> Option<Ref<'w, T>> {
+    pub unsafe fn get_ref_with_ticks<T: Component>(
+        self,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> Option<Ref<'w, T>> {
         let component_id = self.world.components().get_id(TypeId::of::<T>())?;
 
         // SAFETY:
@@ -816,16 +820,15 @@ impl<'w> UnsafeEntityCell<'w> {
                 self.entity,
                 self.location,
             )
-                .map(|(value, cells, _caller)| Ref {
-                    // SAFETY: returned component is of type T
-                    value: value.deref::<T>(),
-                    ticks: Ticks::from_tick_cells(cells, last_run, this_run),
-                    #[cfg(feature = "track_location")]
-                    changed_by: _caller.deref(),
-                })
+            .map(|(value, cells, _caller)| Ref {
+                // SAFETY: returned component is of type T
+                value: value.deref::<T>(),
+                ticks: Ticks::from_tick_cells(cells, last_run, this_run),
+                #[cfg(feature = "track_location")]
+                changed_by: _caller.deref(),
+            })
         }
     }
-
 
     /// Retrieves the change ticks for the given component. This can be useful for implementing change
     /// detection in custom runtimes.


### PR DESCRIPTION
# Objective

Alternative to https://github.com/bevyengine/bevy/pull/17716

It's currently not possible to create a `Ref` and provide/modify the `last_run/this_run` ticks inside the Ref.
The `last_run/this_run` are usually set to the correct values by the scheduler, but not always, see https://github.com/bevyengine/bevy/issues/13735

Note that it's also not possible to build your own `Ref` manually because with the `track_location` feature you need to get a `&'static Location` which is not easily accessible.

One option would be to expose methods on `Ref` to override the existing `last_run/this_run` ticks; this is another solution.

Note that for completeness we would want to add the same methods to `get_mut`.


This PR provides extra functions to get a Ref with custom `last_run/this_run` ticks.

I do believe that https://github.com/bevyengine/bevy/pull/17716 is easier and has more code reuse