### PR TITLE
Add tonemapping switch to bloom 2d example

### DIFF
--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -16,12 +16,14 @@ fn main() {
         .run();
 }
 
+/// Resource to allow cycling through available Tonemapping algorithms
 #[derive(Resource)]
 struct Tonemapper {
     tonemapper: Tonemapping,
 }
 
 impl Tonemapper {
+    /// Modifies resources tonemapping algorithm for the next one and returns it
     fn next(&mut self) -> Tonemapping {
         let next = match self.tonemapper {
             Tonemapping::None => Tonemapping::AcesFitted,

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -79,10 +79,10 @@ fn update_bloom_settings(
     keycode: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
 ) {
-    let bloom = camera.into_inner();
+    let (camera_entity, tonemapping, bloom) = camera.into_inner();
 
     match bloom {
-        (entity, _, Some(mut bloom)) => {
+        Some(mut bloom) => {
             text.0 = "Bloom (Toggle: Space)\n".to_string();
             text.push_str(&format!("(Q/A) Intensity: {}\n", bloom.intensity));
             text.push_str(&format!(
@@ -112,7 +112,7 @@ fn update_bloom_settings(
             text.push_str(&format!("(I/K) Horizontal Scale: {}\n", bloom.scale.x));
 
             if keycode.just_pressed(KeyCode::Space) {
-                commands.entity(entity).remove::<Bloom>();
+                commands.entity(camera_entity).remove::<Bloom>();
             }
 
             let dt = time.delta_secs();
@@ -182,24 +182,26 @@ fn update_bloom_settings(
             bloom.scale.x = bloom.scale.x.clamp(0.0, 16.0);
         }
 
-        (entity, _, None) => {
+        None => {
             text.0 = "Bloom: Off (Toggle: Space)\n".to_string();
 
             if keycode.just_pressed(KeyCode::Space) {
-                commands.entity(entity).insert(Bloom::default());
+                commands.entity(camera_entity).insert(Bloom::default());
             }
         }
     }
 
-    text.push_str(&format!("(O) Tonemapper: {:?}\n", bloom.1));
+    text.push_str(&format!("(O) Tonemapping: {:?}\n", tonemapping));
     if keycode.just_pressed(KeyCode::KeyO) {
-        commands.entity(bloom.0).insert(next_tonemap(bloom.1));
+        commands
+            .entity(camera_entity)
+            .insert(next_tonemap(tonemapping));
     }
 }
 
 /// Get the next Tonemapping algorithm
-fn next_tonemap(tonemap: &Tonemapping) -> Tonemapping {
-    match tonemap {
+fn next_tonemap(tonemapping: &Tonemapping) -> Tonemapping {
+    match tonemapping {
         Tonemapping::None => Tonemapping::AcesFitted,
         Tonemapping::AcesFitted => Tonemapping::AgX,
         Tonemapping::AgX => Tonemapping::BlenderFilmic,

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -197,7 +197,7 @@ fn update_bloom_settings(
     }
 }
 
-/// Modifies resources tonemapping algorithm for the next one and returns it
+/// Get the next Tonemapping algorithm
 fn next_tonemap(tonemap: &Tonemapping) -> Tonemapping {
     match tonemap {
         Tonemapping::None => Tonemapping::AcesFitted,

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -139,7 +139,6 @@ fn update_bloom_settings(
                 bloom.prefilter.threshold_softness
             ));
             text.push_str(&format!("(I/K) Horizontal Scale: {}\n", bloom.scale.x));
-            text.push_str(&format!("(O) Tonemapper: {:?}\n", tonemapper.tonemapper));
 
             if keycode.just_pressed(KeyCode::Space) {
                 commands.entity(entity).remove::<Bloom>();
@@ -210,18 +209,19 @@ fn update_bloom_settings(
                 bloom.scale.x += dt * 2.0;
             }
             bloom.scale.x = bloom.scale.x.clamp(0.0, 16.0);
-
-            if keycode.just_pressed(KeyCode::KeyO) {
-                commands.entity(entity).insert(tonemapper.next());
-            }
         }
 
         (entity, None) => {
-            text.0 = "Bloom: Off (Toggle: Space)".to_string();
+            text.0 = "Bloom: Off (Toggle: Space)\n".to_string();
 
             if keycode.just_pressed(KeyCode::Space) {
                 commands.entity(entity).insert(Bloom::default());
             }
         }
+    }
+
+    text.push_str(&format!("(O) Tonemapper: {:?}\n", tonemapper.tonemapper));
+    if keycode.just_pressed(KeyCode::KeyO) {
+        commands.entity(bloom.0).insert(tonemapper.next());
     }
 }


### PR DESCRIPTION
# Objective

Allow switching through available Tonemapping algorithms on `bloom_2d` example to compare between them

## Solution

Add a resource to `bloom_2d` that holds current tonemapping algorithm, a method to get the next one, and a check of key press to make the switch

## Testing

Ran `bloom_2d` example with modified code

## Showcase

https://github.com/user-attachments/assets/920b2d6a-b237-4b19-be9d-9b651b4dc913
Note: Sprite flashing is already described in #17763 

