### PR TITLE
Add links to the types on the documentation of `GltfAssetLabel`

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -492,13 +492,13 @@ pub struct GltfMaterialName(pub String);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GltfAssetLabel {
-    /// `Scene{}`: glTF Scene as a Bevy `Scene`
+    /// `Scene{}`: glTF Scene as a Bevy [`Scene`]
     Scene(usize),
-    /// `Node{}`: glTF Node as a `GltfNode`
+    /// `Node{}`: glTF Node as a [`GltfNode`]
     Node(usize),
-    /// `Mesh{}`: glTF Mesh as a `GltfMesh`
+    /// `Mesh{}`: glTF Mesh as a [`GltfMesh`]
     Mesh(usize),
-    /// `Mesh{}/Primitive{}`: glTF Primitive as a Bevy `Mesh`
+    /// `Mesh{}/Primitive{}`: glTF Primitive as a Bevy [`Mesh`]
     Primitive {
         /// Index of the mesh for this primitive
         mesh: usize,
@@ -506,28 +506,29 @@ pub enum GltfAssetLabel {
         primitive: usize,
     },
     /// `Mesh{}/Primitive{}/MorphTargets`: Morph target animation data for a glTF Primitive
+    /// as a Bevy [`Image`](bevy_image::prelude::Image)
     MorphTarget {
         /// Index of the mesh for this primitive
         mesh: usize,
         /// Index of this primitive in its parent mesh
         primitive: usize,
     },
-    /// `Texture{}`: glTF Texture as a Bevy `Image`
+    /// `Texture{}`: glTF Texture as a Bevy [`Image`](bevy_image::prelude::Image)
     Texture(usize),
-    /// `Material{}`: glTF Material as a Bevy `StandardMaterial`
+    /// `Material{}`: glTF Material as a Bevy [`StandardMaterial`]
     Material {
         /// Index of this material
         index: usize,
         /// Used to set the [`Face`](bevy_render::render_resource::Face) of the material, useful if it is used with negative scale
         is_scale_inverted: bool,
     },
-    /// `DefaultMaterial`: as above, if the glTF file contains a default material with no index
+    /// `DefaultMaterial`: glTF's default Material as a Bevy [`StandardMaterial`]
     DefaultMaterial,
-    /// `Animation{}`: glTF Animation as Bevy `AnimationClip`
+    /// `Animation{}`: glTF Animation as Bevy [`AnimationClip`]
     Animation(usize),
-    /// `Skin{}`: glTF mesh skin as `GltfSkin`
+    /// `Skin{}`: glTF mesh skin as [`GltfSkin`]
     Skin(usize),
-    /// `Skin{}/InverseBindMatrices`: glTF mesh skin matrices as Bevy `SkinnedMeshInverseBindposes`
+    /// `Skin{}/InverseBindMatrices`: glTF mesh skin matrices as Bevy [`SkinnedMeshInverseBindposes`]
     InverseBindMatrices(usize),
 }
 


### PR DESCRIPTION
# Objective

Allow quick jump to definition of types of GlTFs labeled assets.

## Solution

Add links to the types refered on the docs of `GltfAssetLabel`

## Testing

Ran `cargo run -p ci`
