### PR TITLE
Fix failing proc macros when depending on bevy through dev and normal dependencies.

### DIFF
--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-cargo-manifest-proc-macros = "0.3.3"
+cargo-manifest-proc-macros = "0.3.4"
 
 [lints]
 workspace = true

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -48,8 +48,7 @@ impl BevyManifest {
     /// Returns the path for the crate with the given name.
     pub fn get_path(&self, name: &str) -> syn::Path {
         self.maybe_get_path(name)
-            //.expect("Failed to get path for crate")
-            .unwrap_or_else(|_err| Self::parse_str(name))
+            .expect("Failed to get path for crate")
     }
 
     /// Attempt to parse the provided [path](str) as a [syntax tree node](syn::parse::Parse)

--- a/tests-integration/simple-ecs-test/Cargo.toml
+++ b/tests-integration/simple-ecs-test/Cargo.toml
@@ -2,5 +2,10 @@
 name = "simple-ecs-test"
 edition = "2021"
 
+# We depend on bevy in both normal and dev dependencies to verify that the proc macros still work.
+
 [dependencies]
+bevy = { path = "../../" }
+
+[dev-dependencies]
 bevy = { path = "../../" }


### PR DESCRIPTION
This is a follow up fix for #17330 and fixes #17780.
There was a logic error in the ambiguity detection of `cargo-manifest-proc-macros`.
`cargo-manifest-proc-macros` now has a test for this case to prevent the issue in the future.

I also opted to hard fail if the `cargo-manifest-proc-macros` crate fails. That way the error is more obvious and easier to fix and diagnose.

## Testing

- The reproducer: https://github.com/bevyengine/bevy_editor_prototypes/pull/178 works for me using these fixes.