### PR TITLE
Fix error in scene example

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -7,10 +7,7 @@
   entities: {
     4294967296: (
       components: {
-        "bevy_ecs::name::Name": (
-          hash: 17588334858059901562,
-          name: "joe",
-        ),
+        "bevy_ecs::name::Name": "name",
         "bevy_transform::components::global_transform::GlobalTransform": ((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)),
         "bevy_transform::components::transform::Transform": (
           translation: (0.0, 0.0, 0.0),

--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -7,7 +7,7 @@
   entities: {
     4294967296: (
       components: {
-        "bevy_ecs::name::Name": "name",
+        "bevy_ecs::name::Name": "joe",
         "bevy_transform::components::global_transform::GlobalTransform": ((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)),
         "bevy_transform::components::transform::Transform": (
           translation: (0.0, 0.0, 0.0),


### PR DESCRIPTION
# Objective

After #16894, this example started logging errors:

```
ERROR bevy_asset::server: Failed to load asset 'scenes/load_scene_example.scn.ron' with asset loader 'bevy_scene::scene_loader::SceneLoader': Could not parse RON: 10:33: Expected string
```

Fixes #17798, this is the only actionable/unreported issue in there as far as I can tell.

## Solution

Update the serialized scene with the expected format for `Name`

## Testing

`cargo run --example scene`

## Discussion

This example breaks very often and we don't always catch it. It might be nice to have this scene either

1. produce visual output so that it can be checked
2. panic if the scene fails to load (check for LoadState::Failed)

Either of those would make the failures visible in [the example report](https://thebevyflock.github.io/bevy-example-runner/). Not sure which method would best suit the example.