### PR TITLE
Split the labels in many_buttons

### DIFF
--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -289,6 +289,7 @@ fn spawn_button(
 
     if spawn_text {
         builder.with_children(|parent| {
+            // These labels are split to stress test multi-span text
             parent
                 .spawn((
                     Text(format!("{column}, ")),

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -289,14 +289,23 @@ fn spawn_button(
 
     if spawn_text {
         builder.with_children(|parent| {
-            parent.spawn((
-                Text(format!("{column}, {row}")),
-                TextFont {
-                    font_size: FONT_SIZE,
-                    ..default()
-                },
-                TextColor(Color::srgb(0.2, 0.2, 0.2)),
-            ));
+            parent
+                .spawn((
+                    Text(format!("{column}, ")),
+                    TextFont {
+                        font_size: FONT_SIZE,
+                        ..default()
+                    },
+                    TextColor(Color::srgb(0.5, 0.2, 0.2)),
+                ))
+                .with_child((
+                    TextSpan(format!("{row}")),
+                    TextFont {
+                        font_size: FONT_SIZE,
+                        ..default()
+                    },
+                    TextColor(Color::srgb(0.2, 0.2, 0.5)),
+                ));
         });
     }
 }


### PR DESCRIPTION
# Objective

Add some multi-span text to the `many_buttons` benchmark by splitting up each button label text into two different coloured text spans.
