### PR TITLE
Split PointerId into distinct id and PointerKind fields

### DIFF
--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -32,7 +32,6 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 
 # other
 crossbeam-channel = { version = "0.5", optional = true }
-uuid = { version = "1.13.1", features = ["v4"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -27,7 +27,7 @@ use bevy_window::{PrimaryWindow, WindowEvent, WindowRef};
 use tracing::debug;
 
 use crate::pointer::{
-    Location, PointerAction, PointerButton, PointerId, PointerInput, PointerLocation,
+    Location, PointerAction, PointerButton, PointerId, PointerInput, PointerKind, PointerLocation,
 };
 
 use crate::PickSet;
@@ -99,7 +99,7 @@ impl Plugin for PointerInputPlugin {
 
 /// Spawns the default mouse pointer.
 pub fn spawn_mouse_pointer(mut commands: Commands) {
-    commands.spawn(PointerId::Mouse);
+    commands.spawn(PointerId::MOUSE);
 }
 
 /// Sends mouse pointer events to be processed by the core plugin
@@ -126,7 +126,7 @@ pub fn mouse_pick_events(
                     position: event.position,
                 };
                 pointer_events.send(PointerInput::new(
-                    PointerId::Mouse,
+                    PointerId::MOUSE,
                     location,
                     PointerAction::Move {
                         delta: event.position - *cursor_last,
@@ -155,7 +155,7 @@ pub fn mouse_pick_events(
                     ButtonState::Pressed => PointerAction::Press(button),
                     ButtonState::Released => PointerAction::Release(button),
                 };
-                pointer_events.send(PointerInput::new(PointerId::Mouse, location, action));
+                pointer_events.send(PointerInput::new(PointerId::MOUSE, location, action));
             }
             WindowEvent::MouseWheel(event) => {
                 let MouseWheel { unit, x, y, window } = *event;
@@ -172,7 +172,7 @@ pub fn mouse_pick_events(
 
                 let action = PointerAction::Scroll { x, y, unit };
 
-                pointer_events.send(PointerInput::new(PointerId::Mouse, location, action));
+                pointer_events.send(PointerInput::new(PointerId::MOUSE, location, action));
             }
             _ => {}
         }
@@ -192,7 +192,10 @@ pub fn touch_pick_events(
 ) {
     for window_event in window_events.read() {
         if let WindowEvent::TouchInput(touch) = window_event {
-            let pointer = PointerId::Touch(touch.id);
+            let pointer = PointerId {
+                id: touch.id,
+                kind: PointerKind::Touch,
+            };
             let location = Location {
                 target: match RenderTarget::Window(WindowRef::Entity(touch.window))
                     .normalize(primary_window.get_single().ok())

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -17,7 +17,7 @@ use bevy::{
     math::{CompassOctant, FloatOrd},
     picking::{
         backend::HitData,
-        pointer::{Location, PointerId},
+        pointer::{Location, PointerId, PointerKind},
     },
     platform_support::collections::{HashMap, HashSet},
     prelude::*,
@@ -383,8 +383,10 @@ fn interact_with_focused_button(
             commands.trigger_targets(
                 Pointer::<Click> {
                     target: focused_entity,
-                    // We're pretending that we're a mouse
-                    pointer_id: PointerId::Mouse,
+                    pointer_id: PointerId {
+                        id: 0,
+                        kind: PointerKind::Virtual,
+                    },
                     // This field isn't used, so we're just setting it to a placeholder value
                     pointer_location: Location {
                         target: NormalizedRenderTarget::Image(


### PR DESCRIPTION
# Objective

As discussed in https://github.com/bevyengine/bevy/pull/17399, sending fake picking events (as you might want to do for clicking a focused element) is frustrating.

After discussing this with @aevyrie (notes [here](https://hackmd.io/swhNP8IYTmGqCOOkyfUFFA)), part of the problem here is that our `PointerId` type is questionably designed. There are several small problems with it:

1. Constructing Uuids is very annoying.
2. Storing the id inside of each variant, rather than splitting the ID apart from the variants encourages inconsistent design and makes matching harder.
3. The `Custom` variant has unclear semantics. When mocking inputs for tests, you almost always want to pretend to be a real mouse or touch (often at a level above this, sending raw input events). But when sending picking events for "click on the focused element", it's not clear what whether you should pretend to be a mouse, a custom input, or even a touch.

## Solution

1. Store the id of each pointer separately from the kind of pointer it is.
2. Standardize on a u64 identifier, and cut uuid from bevy_picking completely.
3. Add a `PointerKind::Virtual` variant with clear semantics for this sort of software-driven pointer that doesn't correspond to real hardware.

## Future work

It would be nice to support multiple mice at some point in the future (I've had creative coding users asking me for this). Unfortunately, while this PR ensures that bevy_picking could easily accommodate it, winit still assumes a single mouse (and keyboard).

Unsurprisingly, patching winit is outside of the scope of this PR.

## Testing

Existing tests pass. The picking examples seem to work fine, although I haven't tested them with touch inputs.

## Migration Guide

`PointerId` has been refactored for consistency. Check the `kind` field to see the `PointerKind` of the pointer, and read the `id` field to recover the unique identifier.

To construct a `PointerId::Mouse`, use the `PointerId::MOUSE` constant. If you were using `PointerId::Custom`, either use `PointerKind::Mouse` (if you were mocking inputs for tests) or use `PointerKind::Virtual` if you were emulating a gamepad-controlled pointer or mocking pointer events to interact with various objects.