### PR TITLE
gate get_tag behind ndef MESHLET_MESH_MATERIAL_PASS

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -133,6 +133,9 @@ fn get_visibility_range_dither_level(instance_index: u32, world_position: vec4<f
 }
 #endif
 
+
+#ifndef MESHLET_MESH_MATERIAL_PASS
 fn get_tag(instance_index: u32) -> u32 {
     return mesh[instance_index].tag;
 }
+#endif


### PR DESCRIPTION
# Objective

- Fixes #17797 

## Solution

- `mesh` in `bevy_pbr::mesh_bindings` is behind a `ifndef MESHLET_MESH_MATERIAL_PASS`. also gate `get_tag` which uses this `mesh`

## Testing

- Run the meshlet example
