### PR TITLE
implement par_iter_many and par_iter_many_unique

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2433,7 +2433,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
     }
 
     // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
-    // QueryIter, QueryIterationCursor, QuerySortedIter, QueryManyIter, QuerySortedManyIter, QueryCombinationIter, QueryState::par_fold_init_unchecked_manual
+    // QueryIter, QueryIterationCursor, QuerySortedIter, QueryManyIter, QuerySortedManyIter, QueryCombinationIter,
+    // QueryState::par_fold_init_unchecked_manual, QueryState::par_many_fold_init_unchecked_manual,
+    // QueryState::par_many_unique_fold_init_unchecked_manual
     /// # Safety
     /// `tables` and `archetypes` must belong to the same world that the [`QueryIterationCursor`]
     /// was initialized for.

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -59,12 +59,12 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     /// fn system(query: Query<&T>){
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
-    ///     query.par_iter().for_each_init(|| queue.borrow_local_mut(),|local_queue,item| {
+    ///     query.par_iter().for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
     ///         **local_queue += 1;
     ///      });
     ///     
     ///     // collect value from every thread
-    ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
+    ///     let entity_count = queue.iter().copied().sum();
     /// }
     /// ```
     ///
@@ -202,6 +202,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     /// ```
     /// use bevy_utils::Parallel;
     /// use crate::{bevy_ecs::prelude::{Component, Res, Resource, Entity}, bevy_ecs::system::Query};
+    /// # use core::slice;
     /// use bevy_platform_support::prelude::Vec;
     /// # fn some_expensive_operation(item: T) -> usize {
     /// #     0
@@ -211,9 +212,9 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     /// struct T;
     ///
     /// #[derive(Resource)]
-    /// struct V(Vec<Entity>)
+    /// struct V(Vec<Entity>);
     ///
-    /// impl<'a> IntoIterator for &V {
+    /// impl<'a> IntoIterator for &'a V {
     /// // ...
     /// #   type Item = &'a Entity;
     /// #   type IntoIter = slice::Iter<'a, Entity>;
@@ -231,7 +232,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     ///     });
     ///     
     ///     // collect value from every thread
-    ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
+    ///     let final_value = queue.iter().copied().sum();
     /// }
     /// ```
     ///
@@ -368,7 +369,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///
     /// ```
     /// use bevy_utils::Parallel;
-    /// use crate::{bevy_ecs::prelude::{Component, Res, Entity}, bevy_ecs::{entity::UniqueEntityVec, system::Query}};
+    /// use crate::{bevy_ecs::prelude::{Component, Res, Resource, Entity}, bevy_ecs::{entity::UniqueEntityVec, system::Query}};
+    /// # use core::slice;
     /// # fn some_expensive_operation(item: T) -> usize {
     /// #     0
     /// # }
@@ -377,9 +379,9 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     /// struct T;
     ///
     /// #[derive(Resource)]
-    /// struct V(UniqueEntityVec<Entity>)
+    /// struct V(UniqueEntityVec<Entity>);
     ///
-    /// impl<'a> IntoIterator for &V {
+    /// impl<'a> IntoIterator for &'a V {
     /// // ...
     /// #   type Item = &'a Entity;
     /// #   type IntoIter = UniqueEntityVec<slice::Iter<'a, Entity>>;
@@ -397,7 +399,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///     });
     ///     
     ///     // collect value from every thread
-    ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
+    ///     let final_value = queue.iter().copied().sum();
     /// }
     /// ```
     ///

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -201,15 +201,29 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     ///
     /// ```
     /// use bevy_utils::Parallel;
-    /// use crate::{bevy_ecs::prelude::{Component, Res, Entity}, bevy_ecs::system::Query};
-    /// use std::collections::Vec;
+    /// use crate::{bevy_ecs::prelude::{Component, Res, Resource, Entity}, bevy_ecs::system::Query};
+    /// use bevy_platform_support::prelude::Vec;
     /// # fn some_expensive_operation(item: T) -> usize {
     /// #     0
     /// # }
     ///
     /// #[derive(Component)]
     /// struct T;
-    /// fn system(query: Query<&T>, entities: Res<Vec<Entity>>){
+    ///
+    /// #[derive(Resource)]
+    /// struct V(Vec<Entity>)
+    ///
+    /// impl<'a> IntoIterator for &V {
+    /// // ...
+    /// #   type Item = &'a Entity;
+    /// #   type IntoIter = slice::Iter<'a, Entity>;
+    /// #
+    /// #    fn into_iter(self) -> Self::IntoIter {
+    /// #        self.0.iter()
+    /// #    }
+    /// }
+    ///
+    /// fn system(query: Query<&T>, entities: Res<V>){
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
     ///     query.par_iter_many(entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
@@ -361,7 +375,21 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///
     /// #[derive(Component)]
     /// struct T;
-    /// fn system(query: Query<&T>, entities: Res<UniqueEntityVec<Entity>>){
+    ///
+    /// #[derive(Resource)]
+    /// struct V(UniqueEntityVec<Entity>)
+    ///
+    /// impl<'a> IntoIterator for &V {
+    /// // ...
+    /// #   type Item = &'a Entity;
+    /// #   type IntoIter = UniqueEntityVec<slice::Iter<'a, Entity>>;
+    /// #
+    /// #    fn into_iter(self) -> Self::IntoIter {
+    /// #        self.0.iter()
+    /// #    }
+    /// }
+    ///
+    /// fn system(query: Query<&T>, entities: Res<V>){
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
     ///     query.par_iter_many_unique(entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -202,7 +202,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     /// ```
     /// use bevy_utils::Parallel;
     /// use crate::{bevy_ecs::prelude::{Component, Res, Entity}, bevy_ecs::system::Query};
-    /// use alloc::collections::Vec;
+    /// use std::collections::Vec;
     /// # fn some_expensive_operation(item: T) -> usize {
     /// #     0
     /// # }
@@ -361,7 +361,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///
     /// #[derive(Component)]
     /// struct T;
-    /// fn system(query: Query<&T>, entities: Res<UniqueEntityVec>){
+    /// fn system(query: Query<&T>, entities: Res<UniqueEntityVec<Entity>>){
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
     ///     query.par_iter_many_unique(entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -1,8 +1,13 @@
 use crate::{
-    batching::BatchingStrategy, component::Tick, world::unsafe_world_cell::UnsafeWorldCell,
+    batching::BatchingStrategy,
+    component::Tick,
+    entity::{EntityBorrow, TrustedEntityBorrow, UniqueEntityVec},
+    world::unsafe_world_cell::UnsafeWorldCell,
 };
 
-use super::{QueryData, QueryFilter, QueryItem, QueryState};
+use super::{QueryData, QueryFilter, QueryItem, QueryState, ReadOnlyQueryData};
+
+use alloc::vec::Vec;
 
 /// A parallel iterator over query results of a [`Query`](crate::system::Query).
 ///
@@ -144,5 +149,292 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
         };
         self.batching_strategy
             .calc_batch_size(max_items, thread_count)
+    }
+}
+
+/// A parallel iterator over the unique query items generated from an [`Entity`] list.
+///
+/// This struct is created by the [`Query::par_iter_many`] method.
+///
+/// [`Query::par_iter_many`]: crate::system::Query::par_iter_many
+pub struct QueryParManyIter<'w, 's, D: QueryData, F: QueryFilter, E: EntityBorrow> {
+    pub(crate) world: UnsafeWorldCell<'w>,
+    pub(crate) state: &'s QueryState<D, F>,
+    pub(crate) entity_list: Vec<E>,
+    pub(crate) last_run: Tick,
+    pub(crate) this_run: Tick,
+    pub(crate) batching_strategy: BatchingStrategy,
+}
+
+impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
+    QueryParManyIter<'w, 's, D, F, E>
+{
+    /// Changes the batching strategy used when iterating.
+    ///
+    /// For more information on how this affects the resultant iteration, see
+    /// [`BatchingStrategy`].
+    pub fn batching_strategy(mut self, strategy: BatchingStrategy) -> Self {
+        self.batching_strategy = strategy;
+        self
+    }
+
+    /// Runs `func` on each query result in parallel.
+    ///
+    /// # Panics
+    /// If the [`ComputeTaskPool`] is not initialized. If using this from a query that is being
+    /// initialized and run from the ECS scheduler, this should never panic.
+    ///
+    /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
+    #[inline]
+    pub fn for_each<FN: Fn(QueryItem<'w, D>) + Send + Sync + Clone>(self, func: FN) {
+        self.for_each_init(|| {}, |_, item| func(item));
+    }
+
+    /// Runs `func` on each query result in parallel on a value returned by `init`.
+    ///
+    /// `init` may be called multiple times per thread, and the values returned may be discarded between tasks on any given thread.
+    /// Callers should avoid using this function as if it were a parallel version
+    /// of [`Iterator::fold`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bevy_utils::Parallel;
+    /// use crate::{bevy_ecs::prelude::Component, bevy_ecs::system::Query};
+    /// #[derive(Component)]
+    /// struct T;
+    /// fn system(query: Query<&T>){
+    ///     let mut queue: Parallel<usize> = Parallel::default();
+    ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
+    ///     query.par_iter().for_each_init(|| queue.borrow_local_mut(),|local_queue,item| {
+    ///         **local_queue += 1;
+    ///      });
+    ///     
+    ///     // collect value from every thread
+    ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
+    /// }
+    /// ```
+    ///
+    /// # Panics
+    /// If the [`ComputeTaskPool`] is not initialized. If using this from a query that is being
+    /// initialized and run from the ECS scheduler, this should never panic.
+    ///
+    /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
+    #[inline]
+    pub fn for_each_init<FN, INIT, T>(self, init: INIT, func: FN)
+    where
+        FN: Fn(&mut T, QueryItem<'w, D>) + Send + Sync + Clone,
+        INIT: Fn() -> T + Sync + Send + Clone,
+    {
+        let func = |mut init, item| {
+            func(&mut init, item);
+            init
+        };
+        #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+        {
+            let init = init();
+            // SAFETY:
+            // This method can only be called once per instance of QueryParIter,
+            // which ensures that mutable queries cannot be executed multiple times at once.
+            // Mutable instances of QueryParIter can only be created via an exclusive borrow of a
+            // Query or a World, which ensures that multiple aliasing QueryParIters cannot exist
+            // at the same time.
+            unsafe {
+                self.state
+                    .iter_many_unchecked_manual(
+                        &self.entity_list,
+                        self.world,
+                        self.last_run,
+                        self.this_run,
+                    )
+                    .fold(init, func);
+            }
+        }
+        #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+        {
+            let thread_count = bevy_tasks::ComputeTaskPool::get().thread_num();
+            if thread_count <= 1 {
+                let init = init();
+                // SAFETY: See the safety comment above.
+                unsafe {
+                    self.state
+                        .iter_many_unchecked_manual(
+                            &self.entity_list,
+                            self.world,
+                            self.last_run,
+                            self.this_run,
+                        )
+                        .fold(init, func);
+                }
+            } else {
+                // Need a batch size of at least 1.
+                let batch_size = self.get_batch_size(thread_count).max(1);
+                // SAFETY: See the safety comment above.
+                unsafe {
+                    self.state.par_many_fold_init_unchecked_manual(
+                        init,
+                        self.world,
+                        &self.entity_list,
+                        batch_size,
+                        func,
+                        self.last_run,
+                        self.this_run,
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    fn get_batch_size(&self, thread_count: usize) -> usize {
+        self.batching_strategy
+            .calc_batch_size(|| self.entity_list.len(), thread_count)
+    }
+}
+
+/// A parallel iterator over the unique query items generated from an [`EntitySet`].
+///
+/// This struct is created by the [`Query::par_iter_many_unique`] and [`Query::par_iter_many_unique_mut`] methods.
+///
+/// [`Query::par_iter_many_unique`]: crate::system::Query::par_iter_many_unique
+/// [`Query::par_iter_many_unique_mut`]: crate::system::Query::par_iter_many_unique_mut
+pub struct QueryParManyUniqueIter<
+    'w,
+    's,
+    D: QueryData,
+    F: QueryFilter,
+    E: TrustedEntityBorrow + Sync,
+> {
+    pub(crate) world: UnsafeWorldCell<'w>,
+    pub(crate) state: &'s QueryState<D, F>,
+    pub(crate) entity_list: UniqueEntityVec<E>,
+    pub(crate) last_run: Tick,
+    pub(crate) this_run: Tick,
+    pub(crate) batching_strategy: BatchingStrategy,
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
+    QueryParManyUniqueIter<'w, 's, D, F, E>
+{
+    /// Changes the batching strategy used when iterating.
+    ///
+    /// For more information on how this affects the resultant iteration, see
+    /// [`BatchingStrategy`].
+    pub fn batching_strategy(mut self, strategy: BatchingStrategy) -> Self {
+        self.batching_strategy = strategy;
+        self
+    }
+
+    /// Runs `func` on each query result in parallel.
+    ///
+    /// # Panics
+    /// If the [`ComputeTaskPool`] is not initialized. If using this from a query that is being
+    /// initialized and run from the ECS scheduler, this should never panic.
+    ///
+    /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
+    #[inline]
+    pub fn for_each<FN: Fn(QueryItem<'w, D>) + Send + Sync + Clone>(self, func: FN) {
+        self.for_each_init(|| {}, |_, item| func(item));
+    }
+
+    /// Runs `func` on each query result in parallel on a value returned by `init`.
+    ///
+    /// `init` may be called multiple times per thread, and the values returned may be discarded between tasks on any given thread.
+    /// Callers should avoid using this function as if it were a parallel version
+    /// of [`Iterator::fold`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use bevy_utils::Parallel;
+    /// use crate::{bevy_ecs::prelude::Component, bevy_ecs::system::Query};
+    /// #[derive(Component)]
+    /// struct T;
+    /// fn system(query: Query<&T>){
+    ///     let mut queue: Parallel<usize> = Parallel::default();
+    ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
+    ///     query.par_iter().for_each_init(|| queue.borrow_local_mut(),|local_queue,item| {
+    ///         **local_queue += 1;
+    ///      });
+    ///     
+    ///     // collect value from every thread
+    ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
+    /// }
+    /// ```
+    ///
+    /// # Panics
+    /// If the [`ComputeTaskPool`] is not initialized. If using this from a query that is being
+    /// initialized and run from the ECS scheduler, this should never panic.
+    ///
+    /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
+    #[inline]
+    pub fn for_each_init<FN, INIT, T>(self, init: INIT, func: FN)
+    where
+        FN: Fn(&mut T, QueryItem<'w, D>) + Send + Sync + Clone,
+        INIT: Fn() -> T + Sync + Send + Clone,
+    {
+        let func = |mut init, item| {
+            func(&mut init, item);
+            init
+        };
+        #[cfg(any(target_arch = "wasm32", not(feature = "multi_threaded")))]
+        {
+            let init = init();
+            // SAFETY:
+            // This method can only be called once per instance of QueryParIter,
+            // which ensures that mutable queries cannot be executed multiple times at once.
+            // Mutable instances of QueryParIter can only be created via an exclusive borrow of a
+            // Query or a World, which ensures that multiple aliasing QueryParIters cannot exist
+            // at the same time.
+            unsafe {
+                self.state
+                    .iter_many_unique_unchecked_manual(
+                        self.entity_list,
+                        self.world,
+                        self.last_run,
+                        self.this_run,
+                    )
+                    .fold(init, func);
+            }
+        }
+        #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+        {
+            let thread_count = bevy_tasks::ComputeTaskPool::get().thread_num();
+            if thread_count <= 1 {
+                let init = init();
+                // SAFETY: See the safety comment above.
+                unsafe {
+                    self.state
+                        .iter_many_unique_unchecked_manual(
+                            self.entity_list,
+                            self.world,
+                            self.last_run,
+                            self.this_run,
+                        )
+                        .fold(init, func);
+                }
+            } else {
+                // Need a batch size of at least 1.
+                let batch_size = self.get_batch_size(thread_count).max(1);
+                // SAFETY: See the safety comment above.
+                unsafe {
+                    self.state.par_many_unique_fold_init_unchecked_manual(
+                        init,
+                        self.world,
+                        &self.entity_list,
+                        batch_size,
+                        func,
+                        self.last_run,
+                        self.this_run,
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    fn get_batch_size(&self, thread_count: usize) -> usize {
+        self.batching_strategy
+            .calc_batch_size(|| self.entity_list.len(), thread_count)
     }
 }

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -64,7 +64,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     ///      });
     ///     
     ///     // collect value from every thread
-    ///     let entity_count = queue.iter().copied().sum();
+    ///     let entity_count = queue.iter_mut().copied().sum();
     /// }
     /// ```
     ///
@@ -232,7 +232,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     ///     });
     ///     
     ///     // collect value from every thread
-    ///     let final_value = queue.iter().copied().sum();
+    ///     let final_value = queue.iter_mut().copied().sum();
     /// }
     /// ```
     ///
@@ -399,7 +399,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///     });
     ///     
     ///     // collect value from every thread
-    ///     let final_value = queue.iter().copied().sum();
+    ///     let final_value = queue.iter_mut().copied().sum();
     /// }
     /// ```
     ///

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -64,7 +64,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     ///      });
     ///     
     ///     // collect value from every thread
-    ///     let entity_count = queue.iter_mut().copied().sum();
+    ///     let entity_count: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
     /// ```
     ///
@@ -204,7 +204,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     /// use crate::{bevy_ecs::prelude::{Component, Res, Resource, Entity}, bevy_ecs::system::Query};
     /// # use core::slice;
     /// use bevy_platform_support::prelude::Vec;
-    /// # fn some_expensive_operation(item: T) -> usize {
+    /// # fn some_expensive_operation(_item: &T) -> usize {
     /// #     0
     /// # }
     ///
@@ -227,12 +227,12 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
     /// fn system(query: Query<&T>, entities: Res<V>){
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
-    ///     query.par_iter_many(entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
+    ///     query.par_iter_many(&entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
     ///         **local_queue += some_expensive_operation(item);
     ///     });
     ///     
     ///     // collect value from every thread
-    ///     let final_value = queue.iter_mut().copied().sum();
+    ///     let final_value: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
     /// ```
     ///
@@ -369,9 +369,10 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///
     /// ```
     /// use bevy_utils::Parallel;
-    /// use crate::{bevy_ecs::prelude::{Component, Res, Resource, Entity}, bevy_ecs::{entity::UniqueEntityVec, system::Query}};
+    /// use crate::{bevy_ecs::{prelude::{Component, Res, Resource, Entity}, entity::UniqueEntityVec, system::Query}};
     /// # use core::slice;
-    /// # fn some_expensive_operation(item: T) -> usize {
+    /// # use crate::bevy_ecs::entity::UniqueEntityIter;
+    /// # fn some_expensive_operation(_item: &T) -> usize {
     /// #     0
     /// # }
     ///
@@ -384,7 +385,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     /// impl<'a> IntoIterator for &'a V {
     /// // ...
     /// #   type Item = &'a Entity;
-    /// #   type IntoIter = UniqueEntityVec<slice::Iter<'a, Entity>>;
+    /// #   type IntoIter = UniqueEntityIter<slice::Iter<'a, Entity>>;
     /// #
     /// #    fn into_iter(self) -> Self::IntoIter {
     /// #        self.0.iter()
@@ -394,12 +395,12 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     /// fn system(query: Query<&T>, entities: Res<V>){
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
-    ///     query.par_iter_many_unique(entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
+    ///     query.par_iter_many_unique(&entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
     ///         **local_queue += some_expensive_operation(item);
     ///     });
     ///     
     ///     // collect value from every thread
-    ///     let final_value = queue.iter_mut().copied().sum();
+    ///     let final_value: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
     /// ```
     ///

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -156,6 +156,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
 ///
 /// This struct is created by the [`Query::par_iter_many`] method.
 ///
+/// [`Entity`]: crate::entity::Entity
 /// [`Query::par_iter_many`]: crate::system::Query::par_iter_many
 pub struct QueryParManyIter<'w, 's, D: QueryData, F: QueryFilter, E: EntityBorrow> {
     pub(crate) world: UnsafeWorldCell<'w>,
@@ -296,6 +297,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
 ///
 /// This struct is created by the [`Query::par_iter_many_unique`] and [`Query::par_iter_many_unique_mut`] methods.
 ///
+/// [`EntitySet`]: crate::entity::EntitySet
 /// [`Query::par_iter_many_unique`]: crate::system::Query::par_iter_many_unique
 /// [`Query::par_iter_many_unique_mut`]: crate::system::Query::par_iter_many_unique_mut
 pub struct QueryParManyUniqueIter<

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1791,7 +1791,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         INIT: Fn() -> T + Sync + Send + Clone,
     {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
-        // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
+        // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual,
+        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
         use arrayvec::ArrayVec;
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
@@ -1904,6 +1905,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
+        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
             let chunks = entity_list.chunks_exact(batch_size);
@@ -1963,7 +1965,8 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
         E: EntityBorrow + Sync,
     {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
-        // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
+        // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter, QueryState::par_fold_init_unchecked_manual
+        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
             let chunks = entity_list.chunks_exact(batch_size);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1918,7 +1918,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                     let accum = init_accum();
                     self.iter_many_unique_unchecked_manual(batch, world, last_run, this_run)
                         .fold(accum, &mut func);
-                })
+                });
             }
 
             #[cfg(feature = "trace")]
@@ -1978,7 +1978,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
                     let accum = init_accum();
                     self.iter_many_unchecked_manual(batch, world, last_run, this_run)
                         .fold(accum, &mut func);
-                })
+                });
             }
 
             #[cfg(feature = "trace")]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1906,10 +1906,10 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
-            let len = entity_list.len();
-            let rem = len - len % batch_size;
+            let chunks = entity_list.chunks_exact(batch_size);
+            let remainder = chunks.remainder();
 
-            for batch in entity_list.chunks_exact(batch_size) {
+            for batch in chunks {
                 let mut func = func.clone();
                 let init_accum = init_accum.clone();
                 scope.spawn(async move {
@@ -1924,7 +1924,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             #[cfg(feature = "trace")]
             let _span = self.par_iter_span.enter();
             let accum = init_accum();
-            self.iter_many_unique_unchecked_manual(&entity_list[rem..], world, last_run, this_run)
+            self.iter_many_unique_unchecked_manual(remainder, world, last_run, this_run)
                 .fold(accum, &mut func);
         });
     }
@@ -1966,10 +1966,10 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
-            let len = entity_list.len();
-            let rem = len - len % batch_size;
+            let chunks = entity_list.chunks_exact(batch_size);
+            let remainder = chunks.remainder();
 
-            for batch in entity_list.chunks_exact(batch_size) {
+            for batch in chunks {
                 let mut func = func.clone();
                 let init_accum = init_accum.clone();
                 scope.spawn(async move {
@@ -1984,7 +1984,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
             #[cfg(feature = "trace")]
             let _span = self.par_iter_span.enter();
             let accum = init_accum();
-            self.iter_many_unchecked_manual(&entity_list[rem..], world, last_run, this_run)
+            self.iter_many_unchecked_manual(remainder, world, last_run, this_run)
                 .fold(accum, &mut func);
         });
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -14,6 +14,9 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, World, WorldId},
 };
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+use crate::entity::{TrustedEntityBorrow, UniqueEntitySlice};
+
 use alloc::vec::Vec;
 use core::{fmt, mem::MaybeUninit, ptr};
 use fixedbitset::FixedBitSet;
@@ -23,7 +26,7 @@ use tracing::Span;
 
 use super::{
     NopWorldQuery, QueryBuilder, QueryData, QueryEntityError, QueryFilter, QueryManyIter,
-    QueryManyUniqueIter, QuerySingleError, ROQueryItem,
+    QueryManyUniqueIter, QuerySingleError, ROQueryItem, ReadOnlyQueryData,
 };
 
 /// An ID for either a table or an archetype. Used for Query iteration.
@@ -1868,6 +1871,126 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         });
     }
 
+    /// Runs `func` on each query result in parallel for the given [`EntitySet`],
+    /// where the last change and the current change tick are given. This is faster than the
+    /// equivalent `iter_many_unique()` method, but cannot be chained like a normal [`Iterator`].
+    ///
+    /// # Panics
+    /// The [`ComputeTaskPool`] is not initialized. If using this from a query that is being
+    /// initialized and run from the ECS scheduler, this should never panic.
+    ///
+    /// # Safety
+    ///
+    /// This does not check for mutable query correctness. To be safe, make sure mutable queries
+    /// have unique access to the components they query.
+    /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
+    /// with a mismatched [`WorldId`] is unsound.
+    ///
+    /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    pub(crate) unsafe fn par_many_unique_fold_init_unchecked_manual<'w, T, FN, INIT, E>(
+        &self,
+        init_accum: INIT,
+        world: UnsafeWorldCell<'w>,
+        entity_list: &UniqueEntitySlice<E>,
+        batch_size: usize,
+        mut func: FN,
+        last_run: Tick,
+        this_run: Tick,
+    ) where
+        FN: Fn(T, D::Item<'w>) -> T + Send + Sync + Clone,
+        INIT: Fn() -> T + Sync + Send + Clone,
+        E: TrustedEntityBorrow + Sync,
+    {
+        // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
+        // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
+
+        bevy_tasks::ComputeTaskPool::get().scope(|scope| {
+            let len = entity_list.len();
+            let rem = len - len % batch_size;
+
+            for batch in entity_list.chunks_exact(batch_size) {
+                let mut func = func.clone();
+                let init_accum = init_accum.clone();
+                scope.spawn(async move {
+                    #[cfg(feature = "trace")]
+                    let _span = self.par_many_iter_span.enter();
+                    let accum = init_accum();
+                    self.iter_many_unique_unchecked_manual(batch, world, last_run, this_run)
+                        .fold(accum, &mut func);
+                })
+            }
+
+            #[cfg(feature = "trace")]
+            let _span = self.par_many_iter_span.enter();
+            let accum = init_accum();
+            self.iter_many_unique_unchecked_manual(&entity_list[rem..], world, last_run, this_run)
+                .fold(accum, &mut func);
+        });
+    }
+}
+
+impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
+    /// Runs `func` on each read-only query result in parallel for the given [`Entity`] list,
+    /// where the last change and the current change tick are given. This is faster than the equivalent
+    /// `iter_many()` method, but cannot be chained like a normal [`Iterator`].
+    ///
+    /// # Panics
+    /// The [`ComputeTaskPool`] is not initialized. If using this from a query that is being
+    /// initialized and run from the ECS scheduler, this should never panic.
+    ///
+    /// # Safety
+    ///
+    /// This does not check for mutable query correctness. To be safe, make sure mutable queries
+    /// have unique access to the components they query.
+    /// This does not validate that `world.id()` matches `self.world_id`. Calling this on a `world`
+    /// with a mismatched [`WorldId`] is unsound.
+    ///
+    /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
+    pub(crate) unsafe fn par_many_fold_init_unchecked_manual<'w, T, FN, INIT, E>(
+        &self,
+        init_accum: INIT,
+        world: UnsafeWorldCell<'w>,
+        entity_list: &[E],
+        batch_size: usize,
+        mut func: FN,
+        last_run: Tick,
+        this_run: Tick,
+    ) where
+        FN: Fn(T, D::Item<'w>) -> T + Send + Sync + Clone,
+        INIT: Fn() -> T + Sync + Send + Clone,
+        E: EntityBorrow + Sync,
+    {
+        // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
+        // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
+
+        bevy_tasks::ComputeTaskPool::get().scope(|scope| {
+            let len = entity_list.len();
+            let rem = len - len % batch_size;
+
+            for batch in entity_list.chunks_exact(batch_size) {
+                let mut func = func.clone();
+                let init_accum = init_accum.clone();
+                scope.spawn(async move {
+                    #[cfg(feature = "trace")]
+                    let _span = self.par_many_iter_span.enter();
+                    let accum = init_accum();
+                    self.iter_many_unchecked_manual(batch, world, last_run, this_run)
+                        .fold(accum, &mut func);
+                })
+            }
+
+            #[cfg(feature = "trace")]
+            let _span = self.par_many_iter_span.enter();
+            let accum = init_accum();
+            self.iter_many_unchecked_manual(&entity_list[rem..], world, last_run, this_run)
+                .fold(accum, &mut func);
+        });
+    }
+}
+
+impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns a single immutable query result when there is exactly one entity matching
     /// the query.
     ///

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1914,7 +1914,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                 let init_accum = init_accum.clone();
                 scope.spawn(async move {
                     #[cfg(feature = "trace")]
-                    let _span = self.par_many_iter_span.enter();
+                    let _span = self.par_iter_span.enter();
                     let accum = init_accum();
                     self.iter_many_unique_unchecked_manual(batch, world, last_run, this_run)
                         .fold(accum, &mut func);
@@ -1922,7 +1922,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             }
 
             #[cfg(feature = "trace")]
-            let _span = self.par_many_iter_span.enter();
+            let _span = self.par_iter_span.enter();
             let accum = init_accum();
             self.iter_many_unique_unchecked_manual(&entity_list[rem..], world, last_run, this_run)
                 .fold(accum, &mut func);
@@ -1974,7 +1974,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
                 let init_accum = init_accum.clone();
                 scope.spawn(async move {
                     #[cfg(feature = "trace")]
-                    let _span = self.par_many_iter_span.enter();
+                    let _span = self.par_iter_span.enter();
                     let accum = init_accum();
                     self.iter_many_unchecked_manual(batch, world, last_run, this_run)
                         .fold(accum, &mut func);
@@ -1982,7 +1982,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
             }
 
             #[cfg(feature = "trace")]
-            let _span = self.par_many_iter_span.enter();
+            let _span = self.par_iter_span.enter();
             let accum = init_accum();
             self.iter_many_unchecked_manual(&entity_list[rem..], world, last_run, this_run)
                 .fold(accum, &mut func);

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1089,7 +1089,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// If the `multithreaded` feature is disabled, iterating with this operates identically to [`Iterator::for_each`]
     /// on [`QueryManyIter`].
     ///
-    /// This can only be called for read-only queries, there is no `par_iter_many_mut` equivalent.
+    /// This can only be called for read-only queries. To avoid potential aliasing, there is no `par_iter_many_mut` equivalent.
     /// See [`par_iter_many_unique_mut`] for an alternative using [`EntitySet`].
     ///
     /// Note that you must use the `for_each` method to iterate over the

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1095,6 +1095,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Note that you must use the `for_each` method to iterate over the
     /// results, see [`par_iter_mut`] for an example.
     ///
+    /// [`Entity`]: crate::entity::Entity
     /// [`par_iter_many_unique_mut`]: Self::par_iter_many_unique_mut
     /// [`par_iter_mut`]: Self::par_iter_mut
     #[inline]
@@ -1124,6 +1125,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Note that you must use the `for_each` method to iterate over the
     /// results, see [`par_iter_mut`] for an example.
     ///
+    /// [`EntitySet`]: crate::entity::EntitySet
     /// [`par_iter_many_unique_mut`]: Self::par_iter_many_unique_mut
     /// [`par_iter_mut`]: Self::par_iter_mut
     #[inline]
@@ -1153,6 +1155,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Note that you must use the `for_each` method to iterate over the
     /// results, see [`par_iter_mut`] for an example.
     ///
+    /// [`EntitySet`]: crate::entity::EntitySet
     /// [`par_iter_many_unique`]: Self::par_iter_many_unique
     /// [`par_iter_mut`]: Self::par_iter_mut
     #[inline]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1095,7 +1095,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Note that you must use the `for_each` method to iterate over the
     /// results, see [`par_iter_mut`] for an example.
     ///
-    /// [`Entity`]: crate::entity::Entity
     /// [`par_iter_many_unique_mut`]: Self::par_iter_many_unique_mut
     /// [`par_iter_mut`]: Self::par_iter_mut
     #[inline]
@@ -1125,7 +1124,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Note that you must use the `for_each` method to iterate over the
     /// results, see [`par_iter_mut`] for an example.
     ///
-    /// [`EntitySet`]: crate::entity::EntitySet
     /// [`par_iter_many_unique_mut`]: Self::par_iter_many_unique_mut
     /// [`par_iter_mut`]: Self::par_iter_mut
     #[inline]
@@ -1155,7 +1153,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Note that you must use the `for_each` method to iterate over the
     /// results, see [`par_iter_mut`] for an example.
     ///
-    /// [`EntitySet`]: crate::entity::EntitySet
     /// [`par_iter_many_unique`]: Self::par_iter_many_unique
     /// [`par_iter_mut`]: Self::par_iter_mut
     #[inline]


### PR DESCRIPTION
# Objective

Continuation of #16547.

We do not yet have parallel versions of `par_iter_many` and `par_iter_many_unique`. It is currently very painful to try and use parallel iteration over entity lists. Even if a list is not long, each operation might still be very expensive, and worth parallelizing.
Plus, it has been requested several times!

## Solution

Once again, we implement what we lack!

These parallel iterators collect their input entity list into a `Vec`/`UniqueEntityVec`, then chunk that over the available threads, inspired by the original `par_iter`.  

Since no order guarantee is given to the caller, we could sort the input list according to `EntityLocation`, but that would likely only be worth it for very large entity lists.

There is some duplication which could likely be improved, but I'd like to leave that for a follow-up.

## Testing

The doc tests on `for_each_init` of `QueryParManyIter` and `QueryParManyUniqueIter`.
