### PR TITLE
Add `TypeRegistry::register_by_val`

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -169,6 +169,8 @@ impl TypeRegistry {
     ///
     /// See [`register`] for more details.
     ///
+    /// # Example
+    ///
     /// ```
     /// # use bevy_reflect::{Reflect, TypeRegistry};
     /// # use core::any::TypeId;

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -165,6 +165,41 @@ impl TypeRegistry {
         }
     }
 
+    /// Attempts to register the referenced type `T` if it has not yet been registered.
+    ///
+    /// See [`register`] for more details.
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, TypeRegistry};
+    /// # use core::any::TypeId;
+    /// #
+    /// # let mut type_registry = TypeRegistry::default();
+    /// #
+    /// #[derive(Reflect)]
+    /// struct Foo {
+    ///   bar: Bar,
+    /// }
+    ///
+    /// #[derive(Reflect)]
+    /// struct Bar;
+    ///
+    /// let foo = Foo { bar: Bar };
+    ///
+    /// // Equivalent to `type_registry.register::<Foo>()`
+    /// type_registry.register_by_val(&foo);
+    ///
+    /// assert!(type_registry.contains(TypeId::of::<Foo>()));
+    /// assert!(type_registry.contains(TypeId::of::<Bar>()));
+    /// ```
+    ///
+    /// [`register`]: Self::register
+    pub fn register_by_val<T>(&mut self, _: &T)
+    where
+        T: GetTypeRegistration,
+    {
+        self.register::<T>();
+    }
+
     /// Attempts to register the type described by `registration`.
     ///
     /// If the registration for the type already exists, it will not be registered again.


### PR DESCRIPTION
# Objective

It is impossible to register a type with `TypeRegistry::register` if the type is unnameable (in the current scope).

## Solution

Add `TypeRegistry::register_by_val` which mirrors std's `size_of_val` and friends.

## Testing

There's a doc test (unrelated but there seem to be some pre-existing broken doc links in `bevy_reflect`).