### PR TITLE
Move implementations of `Query` methods from `QueryState` to `Query`.

### DIFF
--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -17,7 +17,7 @@ pub enum QueryEntityError<'w> {
     NoSuchEntity(Entity, EntityDoesNotExistDetails),
     /// The [`Entity`] was requested mutably more than once.
     ///
-    /// See [`QueryState::get_many_mut`](crate::query::QueryState::get_many_mut) for an example.
+    /// See [`Query::get_many_mut`](crate::system::Query::get_many_mut) for an example.
     AliasedMutability(Entity),
 }
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -849,6 +849,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
         // SAFETY:
         // `self.world` has permission to access the required components.
         // The original query iter has not been iterated on, so no items are aliased from it.
+        // `QueryIter::new` ensures `world` is the same one used to initialize `query_state`.
         let query_lens = unsafe { query_lens_state.query_unchecked_manual(world) }.into_iter();
         let mut keyed_query: Vec<_> = query_lens
             .map(|(key, entity)| (key, NeutralOrd(entity)))
@@ -1683,6 +1684,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityBorrow>>
         // SAFETY:
         // `self.world` has permission to access the required components.
         // The original query iter has not been iterated on, so no items are aliased from it.
+        // `QueryIter::new` ensures `world` is the same one used to initialize `query_state`.
         let query_lens = unsafe { query_lens_state.query_unchecked_manual(world) }
             .iter_many_inner(self.entity_iter);
         let mut keyed_query: Vec<_> = query_lens

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -264,12 +264,8 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
             // at the same time.
             unsafe {
                 self.state
-                    .iter_many_unchecked_manual(
-                        &self.entity_list,
-                        self.world,
-                        self.last_run,
-                        self.this_run,
-                    )
+                    .query_unchecked_manual_with_ticks(self.world, self.last_run, self.this_run)
+                    .iter_many_inner(&self.entity_list)
                     .fold(init, func);
             }
         }
@@ -281,12 +277,8 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityBorrow + Sync>
                 // SAFETY: See the safety comment above.
                 unsafe {
                     self.state
-                        .iter_many_unchecked_manual(
-                            &self.entity_list,
-                            self.world,
-                            self.last_run,
-                            self.this_run,
-                        )
+                        .query_unchecked_manual_with_ticks(self.world, self.last_run, self.this_run)
+                        .iter_many_inner(&self.entity_list)
                         .fold(init, func);
                 }
             } else {
@@ -432,12 +424,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
             // at the same time.
             unsafe {
                 self.state
-                    .iter_many_unique_unchecked_manual(
-                        self.entity_list,
-                        self.world,
-                        self.last_run,
-                        self.this_run,
-                    )
+                    .query_unchecked_manual_with_ticks(self.world, self.last_run, self.this_run)
+                    .iter_many_unique_inner(self.entity_list)
                     .fold(init, func);
             }
         }
@@ -449,12 +437,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
                 // SAFETY: See the safety comment above.
                 unsafe {
                     self.state
-                        .iter_many_unique_unchecked_manual(
-                            self.entity_list,
-                            self.world,
-                            self.last_run,
-                            self.this_run,
-                        )
+                        .query_unchecked_manual_with_ticks(self.world, self.last_run, self.this_run)
+                        .iter_many_unique_inner(self.entity_list)
                         .fold(init, func);
                 }
             } else {

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -89,7 +89,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
             // at the same time.
             unsafe {
                 self.state
-                    .iter_unchecked_manual(self.world, self.last_run, self.this_run)
+                    .query_unchecked_manual_with_ticks(self.world, self.last_run, self.this_run)
+                    .into_iter()
                     .fold(init, func);
             }
         }
@@ -101,7 +102,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
                 // SAFETY: See the safety comment above.
                 unsafe {
                     self.state
-                        .iter_unchecked_manual(self.world, self.last_run, self.this_run)
+                        .query_unchecked_manual_with_ticks(self.world, self.last_run, self.this_run)
+                        .into_iter()
                         .fold(init, func);
                 }
             } else {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1496,7 +1496,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                     let _span = self.par_iter_span.enter();
                     let accum = init_accum();
                     self.query_unchecked_manual_with_ticks(world, last_run, this_run)
-                        .iter_many_unique(batch)
+                        .iter_many_unique_inner(batch)
                         .fold(accum, &mut func);
                 });
             }
@@ -1505,7 +1505,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             let _span = self.par_iter_span.enter();
             let accum = init_accum();
             self.query_unchecked_manual_with_ticks(world, last_run, this_run)
-                .iter_many_unique(remainder)
+                .iter_many_unique_inner(remainder)
                 .fold(accum, &mut func);
         });
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1552,51 +1552,8 @@ impl<D: QueryData, F: QueryFilter> From<QueryBuilder<'_, D, F>> for QueryState<D
 mod tests {
     use crate::{
         component::Component, entity_disabling::DefaultQueryFilters, prelude::*,
-        query::QueryEntityError, world::FilteredEntityRef,
+        world::FilteredEntityRef,
     };
-    use alloc::vec::Vec;
-
-    #[test]
-    fn get_many_unchecked_manual_uniqueness() {
-        let mut world = World::new();
-
-        let entities: Vec<Entity> = (0..10).map(|_| world.spawn_empty().id()).collect();
-
-        let mut query_state = world.query::<Entity>();
-
-        // It's best to test get_many_inner directly, as it is shared
-        // We don't care about aliased mutability for the read-only equivalent
-
-        // SAFETY: Query does not access world data.
-        assert!(query_state
-            .query_mut(&mut world)
-            .get_many_inner::<10>(entities.clone().try_into().unwrap())
-            .is_ok());
-
-        assert_eq!(
-            query_state
-                .query_mut(&mut world)
-                .get_many_inner([entities[0], entities[0]])
-                .unwrap_err(),
-            QueryEntityError::AliasedMutability(entities[0])
-        );
-
-        assert_eq!(
-            query_state
-                .query_mut(&mut world)
-                .get_many_inner([entities[0], entities[1], entities[0]])
-                .unwrap_err(),
-            QueryEntityError::AliasedMutability(entities[0])
-        );
-
-        assert_eq!(
-            query_state
-                .query_mut(&mut world)
-                .get_many_inner([entities[9], entities[9]])
-                .unwrap_err(),
-            QueryEntityError::AliasedMutability(entities[9])
-        );
-    }
 
     #[test]
     #[should_panic]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1495,7 +1495,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                     #[cfg(feature = "trace")]
                     let _span = self.par_iter_span.enter();
                     let accum = init_accum();
-                    self.iter_many_unique_unchecked_manual(batch, world, last_run, this_run)
+                    self.query_unchecked_manual_with_ticks(world, last_run, this_run)
+                        .iter_many_unique(batch)
                         .fold(accum, &mut func);
                 });
             }
@@ -1503,7 +1504,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
             #[cfg(feature = "trace")]
             let _span = self.par_iter_span.enter();
             let accum = init_accum();
-            self.iter_many_unique_unchecked_manual(remainder, world, last_run, this_run)
+            self.query_unchecked_manual_with_ticks(world, last_run, this_run)
+                .iter_many_unique(remainder)
                 .fold(accum, &mut func);
         });
     }
@@ -1556,7 +1558,8 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
                     #[cfg(feature = "trace")]
                     let _span = self.par_iter_span.enter();
                     let accum = init_accum();
-                    self.iter_many_unchecked_manual(batch, world, last_run, this_run)
+                    self.query_unchecked_manual_with_ticks(world, last_run, this_run)
+                        .iter_many_inner(batch)
                         .fold(accum, &mut func);
                 });
             }
@@ -1564,7 +1567,8 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
             #[cfg(feature = "trace")]
             let _span = self.par_iter_span.enter();
             let accum = init_accum();
-            self.iter_many_unchecked_manual(remainder, world, last_run, this_run)
+            self.query_unchecked_manual_with_ticks(world, last_run, this_run)
+                .iter_many_inner(remainder)
                 .fold(accum, &mut func);
         });
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -2481,3 +2481,51 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Populated<'w, 's, D, F> {
         self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{prelude::*, query::QueryEntityError};
+    use alloc::vec::Vec;
+
+    #[test]
+    fn get_many_uniqueness() {
+        let mut world = World::new();
+
+        let entities: Vec<Entity> = (0..10).map(|_| world.spawn_empty().id()).collect();
+
+        let mut query_state = world.query::<Entity>();
+
+        // It's best to test get_many_inner directly, as it is shared
+        // We don't care about aliased mutability for the read-only equivalent
+
+        // SAFETY: Query does not access world data.
+        assert!(query_state
+            .query_mut(&mut world)
+            .get_many_inner::<10>(entities.clone().try_into().unwrap())
+            .is_ok());
+
+        assert_eq!(
+            query_state
+                .query_mut(&mut world)
+                .get_many_inner([entities[0], entities[0]])
+                .unwrap_err(),
+            QueryEntityError::AliasedMutability(entities[0])
+        );
+
+        assert_eq!(
+            query_state
+                .query_mut(&mut world)
+                .get_many_inner([entities[0], entities[1], entities[0]])
+                .unwrap_err(),
+            QueryEntityError::AliasedMutability(entities[0])
+        );
+
+        assert_eq!(
+            query_state
+                .query_mut(&mut world)
+                .get_many_inner([entities[9], entities[9]])
+                .unwrap_err(),
+            QueryEntityError::AliasedMutability(entities[9])
+        );
+    }
+}

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -3,14 +3,15 @@ use crate::{
     component::Tick,
     entity::{Entity, EntityBorrow, EntitySet},
     query::{
-        QueryCombinationIter, QueryData, QueryEntityError, QueryFilter, QueryIter, QueryManyIter,
-        QueryManyUniqueIter, QueryParIter, QuerySingleError, QueryState, ROQueryItem,
-        ReadOnlyQueryData,
+        DebugCheckedUnwrap, NopWorldQuery, QueryCombinationIter, QueryData, QueryEntityError,
+        QueryFilter, QueryIter, QueryManyIter, QueryManyUniqueIter, QueryParIter, QuerySingleError,
+        QueryState, ROQueryItem, ReadOnlyQueryData,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 use core::{
     marker::PhantomData,
+    mem::MaybeUninit,
     ops::{Deref, DerefMut},
 };
 
@@ -439,6 +440,15 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         unsafe { self.reborrow_unsafe() }.into_readonly()
     }
 
+    /// Returns another `Query` from this does not return any data, which can be faster.
+    fn as_nop(&self) -> Query<'w, 's, NopWorldQuery<D>, F> {
+        let new_state = self.state.as_nop();
+        // SAFETY:
+        // - This is memory safe because it performs no access.
+        // - The world matches because it was the same one used to construct self.
+        unsafe { Query::new(self.world, new_state, self.last_run, self.this_run) }
+    }
+
     /// Returns another `Query` from this that fetches the read-only version of the query items.
     ///
     /// For example, `Query<(&mut D1, &D2, &mut D3), With<F>>` will become `Query<(&D1, &D2, &D3), With<F>>`.
@@ -498,6 +508,24 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// - [`reborrow`](Self::reborrow) for the safe versions.
     pub unsafe fn reborrow_unsafe(&self) -> Query<'_, 's, D, F> {
+        // SAFETY:
+        // - This is memory safe because the caller ensures that there are no conflicting references.
+        // - The world matches because it was the same one used to construct self.
+        unsafe { self.copy_unsafe() }
+    }
+
+    /// Returns a new `Query` copying the access from this one.
+    /// The current query will still be usable while the new one exists, but must not be used in a way that violates aliasing.
+    ///
+    /// # Safety
+    ///
+    /// This function makes it possible to violate Rust's aliasing guarantees.
+    /// You must make sure this call does not result in a mutable or shared reference to a component with a mutable reference.
+    ///
+    /// # See also
+    ///
+    /// - [`reborrow_unsafe`](Self::reborrow_unsafe) for a safer version that constrains the returned `'w` lifetime to the length of the borrow.
+    unsafe fn copy_unsafe(&self) -> Query<'w, 's, D, F> {
         // SAFETY:
         // - This is memory safe because the caller ensures that there are no conflicting references.
         // - The world matches because it was the same one used to construct self.
@@ -653,10 +681,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     #[inline]
     pub fn iter_combinations_inner<const K: usize>(self) -> QueryCombinationIter<'w, 's, D, F, K> {
         // SAFETY: `self.world` has permission to access the required components.
-        unsafe {
-            self.state
-                .iter_combinations_unchecked_manual(self.world, self.last_run, self.this_run)
-        }
+        unsafe { QueryCombinationIter::new(self.world, self.state, self.last_run, self.this_run) }
     }
 
     /// Returns an [`Iterator`] over the read-only query items generated from an [`Entity`] list.
@@ -766,9 +791,10 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ) -> QueryManyIter<'w, 's, D, F, EntityList::IntoIter> {
         // SAFETY: `self.world` has permission to access the required components.
         unsafe {
-            self.state.iter_many_unchecked_manual(
-                entities,
+            QueryManyIter::new(
                 self.world,
+                self.state,
+                entities,
                 self.last_run,
                 self.this_run,
             )
@@ -822,22 +848,13 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// # See also
     ///
     /// - [`iter_many_unique_mut`](Self::iter_many_unique_mut) to get mutable query items.
+    /// - [`iter_many_unique_inner`](Self::iter_many_unique_inner) to get with the actual "inner" world lifetime.
     #[inline]
     pub fn iter_many_unique<EntityList: EntitySet>(
         &self,
         entities: EntityList,
     ) -> QueryManyUniqueIter<'_, 's, D::ReadOnly, F, EntityList::IntoIter> {
-        // SAFETY:
-        // - `self.world` has permission to access the required components.
-        // - The query is read-only, so it can be aliased even if it was originally mutable.
-        unsafe {
-            self.state.as_readonly().iter_many_unique_unchecked_manual(
-                entities,
-                self.world,
-                self.last_run,
-                self.this_run,
-            )
-        }
+        self.as_readonly().iter_many_unique_inner(entities)
     }
 
     /// Returns an iterator over the unique query items generated from an [`EntitySet`].
@@ -883,16 +900,76 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// }
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
+    /// # See also
+    ///
+    /// - [`iter_many_unique`](Self::iter_many_unique) to get read-only query items.
+    /// - [`iter_many_unique_inner`](Self::iter_many_unique_inner) to get with the actual "inner" world lifetime.
     #[inline]
     pub fn iter_many_unique_mut<EntityList: EntitySet>(
         &mut self,
         entities: EntityList,
     ) -> QueryManyUniqueIter<'_, 's, D, F, EntityList::IntoIter> {
+        self.reborrow().iter_many_unique_inner(entities)
+    }
+
+    /// Returns an iterator over the unique query items generated from an [`EntitySet`].
+    /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
+    ///
+    /// Items are returned in the order of the list of entities. Entities that don't match the query are skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, entity::{EntitySet, UniqueEntityIter}};
+    /// # use core::slice;
+    /// #[derive(Component)]
+    /// struct Counter {
+    ///     value: i32
+    /// }
+    ///
+    /// // `Friends` ensures that it only lists unique entities.
+    /// #[derive(Component)]
+    /// struct Friends {
+    ///     unique_list: Vec<Entity>,
+    /// }
+    ///
+    /// impl<'a> IntoIterator for &'a Friends {
+    ///     type Item = &'a Entity;
+    ///     type IntoIter = UniqueEntityIter<slice::Iter<'a, Entity>>;
+    ///
+    ///     fn into_iter(self) -> Self::IntoIter {
+    ///         // SAFETY: `Friends` ensures that it unique_list contains only unique entities.
+    ///         unsafe { UniqueEntityIter::from_iterator_unchecked(self.unique_list.iter()) }
+    ///     }
+    /// }
+    ///
+    /// fn system(
+    ///     friends_query: Query<&Friends>,
+    ///     mut counter_query: Query<&mut Counter>,
+    /// ) {
+    ///     let friends = friends_query.single();
+    ///     for mut counter in counter_query.iter_many_unique_inner(friends) {
+    ///         println!("Friend's counter: {:?}", counter.value);
+    ///         counter.value += 1;
+    ///     }
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    /// # See also
+    ///
+    /// - [`iter_many_unique`](Self::iter_many_unique) to get read-only query items.
+    /// - [`iter_many_unique_mut`](Self::iter_many_unique_mut) to get mutable query items.
+    #[inline]
+    pub fn iter_many_unique_inner<EntityList: EntitySet>(
+        self,
+        entities: EntityList,
+    ) -> QueryManyUniqueIter<'w, 's, D, F, EntityList::IntoIter> {
         // SAFETY: `self.world` has permission to access the required components.
         unsafe {
-            self.state.iter_many_unique_unchecked_manual(
-                entities,
+            QueryManyUniqueIter::new(
                 self.world,
+                self.state,
+                entities,
                 self.last_run,
                 self.this_run,
             )
@@ -972,22 +1049,15 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// # See also
     ///
-    /// - [`iter_many_mut`](Self::iter_many_mut) to safely access the query items.
+    /// - [`iter_many_unique`](Self::iter_many_unique) to get read-only query items.
+    /// - [`iter_many_unique_mut`](Self::iter_many_unique_mut) to get mutable query items.
+    /// - [`iter_many_unique_inner`](Self::iter_many_unique_inner) to get with the actual "inner" world lifetime.
     pub unsafe fn iter_many_unique_unsafe<EntityList: EntitySet>(
         &self,
         entities: EntityList,
     ) -> QueryManyUniqueIter<'_, 's, D, F, EntityList::IntoIter> {
-        // SAFETY:
-        // - `self.world` has permission to access the required components.
-        // - The caller ensures that this operation will not result in any aliased mutable accesses.
-        unsafe {
-            self.state.iter_many_unique_unchecked_manual(
-                entities,
-                self.world,
-                self.last_run,
-                self.this_run,
-            )
-        }
+        // SAFETY: The caller promises that this will not result in multiple mutable references.
+        unsafe { self.reborrow_unsafe() }.iter_many_unique_inner(entities)
     }
 
     /// Returns a parallel iterator over the query results for the given [`World`].
@@ -1126,6 +1196,39 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is returned instead.
     /// The elements of the array do not need to be unique, unlike `get_many_mut`.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// use bevy_ecs::query::QueryEntityError;
+    ///
+    /// #[derive(Component, PartialEq, Debug)]
+    /// struct A(usize);
+    ///
+    /// let mut world = World::new();
+    /// let entity_vec: Vec<Entity> = (0..3).map(|i| world.spawn(A(i)).id()).collect();
+    /// let entities: [Entity; 3] = entity_vec.try_into().unwrap();
+    ///
+    /// world.spawn(A(73));
+    ///
+    /// let mut query_state = world.query::<&A>();
+    /// let query = query_state.query(&world);
+    ///
+    /// let component_values = query.get_many(entities).unwrap();
+    ///
+    /// assert_eq!(component_values, [&A(0), &A(1), &A(2)]);
+    ///
+    /// let wrong_entity = Entity::from_raw(365);
+    ///
+    /// assert_eq!(
+    ///     match query.get_many([wrong_entity]).unwrap_err() {
+    ///         QueryEntityError::NoSuchEntity(entity, _) => entity,
+    ///         _ => panic!(),
+    ///     },
+    ///     wrong_entity
+    /// );
+    /// ```
+    ///
     /// # See also
     ///
     /// - [`get_many_mut`](Self::get_many_mut) to get mutable query items.
@@ -1239,8 +1342,55 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         // SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
-            self.state
-                .get_unchecked_manual(self.world, entity, self.last_run, self.this_run)
+            let location =
+                self.world
+                    .entities()
+                    .get(entity)
+                    .ok_or(QueryEntityError::NoSuchEntity(
+                        entity,
+                        self.world
+                            .entities()
+                            .entity_does_not_exist_error_details(entity),
+                    ))?;
+            if !self
+                .state
+                .matched_archetypes
+                .contains(location.archetype_id.index())
+            {
+                return Err(QueryEntityError::QueryDoesNotMatch(entity, self.world));
+            }
+            let archetype = self
+                .world
+                .archetypes()
+                .get(location.archetype_id)
+                .debug_checked_unwrap();
+            let mut fetch = D::init_fetch(
+                self.world,
+                &self.state.fetch_state,
+                self.last_run,
+                self.this_run,
+            );
+            let mut filter = F::init_fetch(
+                self.world,
+                &self.state.filter_state,
+                self.last_run,
+                self.this_run,
+            );
+
+            let table = self
+                .world
+                .storages()
+                .tables
+                .get(location.table_id)
+                .debug_checked_unwrap();
+            D::set_archetype(&mut fetch, &self.state.fetch_state, archetype, table);
+            F::set_archetype(&mut filter, &self.state.filter_state, archetype, table);
+
+            if F::filter_fetch(&mut filter, entity, location.table_row) {
+                Ok(D::fetch(&mut fetch, entity, location.table_row))
+            } else {
+                Err(QueryEntityError::QueryDoesNotMatch(entity, self.world))
+            }
         }
     }
 
@@ -1249,6 +1399,65 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// The returned query items are in the same order as the input.
     /// In case of a nonexisting entity, duplicate entities or mismatched component, a [`QueryEntityError`] is returned instead.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// use bevy_ecs::query::QueryEntityError;
+    ///
+    /// #[derive(Component, PartialEq, Debug)]
+    /// struct A(usize);
+    ///
+    /// let mut world = World::new();
+    ///
+    /// let entities: Vec<Entity> = (0..3).map(|i| world.spawn(A(i)).id()).collect();
+    /// let entities: [Entity; 3] = entities.try_into().unwrap();
+    ///
+    /// world.spawn(A(73));
+    /// let wrong_entity = Entity::from_raw(57);
+    /// let invalid_entity = world.spawn_empty().id();
+    ///
+    ///
+    /// let mut query_state = world.query::<&mut A>();
+    /// let mut query = query_state.query_mut(&mut world);
+    ///
+    /// let mut mutable_component_values = query.get_many_mut(entities).unwrap();
+    ///
+    /// for mut a in &mut mutable_component_values {
+    ///     a.0 += 5;
+    /// }
+    ///
+    /// let component_values = query.get_many(entities).unwrap();
+    ///
+    /// assert_eq!(component_values, [&A(5), &A(6), &A(7)]);
+    ///
+    /// assert_eq!(
+    ///     match query
+    ///         .get_many_mut([wrong_entity])
+    ///         .unwrap_err()
+    ///     {
+    ///         QueryEntityError::NoSuchEntity(entity, _) => entity,
+    ///         _ => panic!(),
+    ///     },
+    ///     wrong_entity
+    /// );
+    /// assert_eq!(
+    ///     match query
+    ///         .get_many_mut([invalid_entity])
+    ///         .unwrap_err()
+    ///     {
+    ///         QueryEntityError::QueryDoesNotMatch(entity, _) => entity,
+    ///         _ => panic!(),
+    ///     },
+    ///     invalid_entity
+    /// );
+    /// assert_eq!(
+    ///     query
+    ///         .get_many_mut([entities[0], entities[0]])
+    ///         .unwrap_err(),
+    ///     QueryEntityError::AliasedMutability(entities[0])
+    /// );
+    /// ```
     /// # See also
     ///
     /// - [`get_many`](Self::get_many) to get read-only query items without checking for duplicate entities.
@@ -1278,11 +1487,17 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         self,
         entities: [Entity; N],
     ) -> Result<[D::Item<'w>; N], QueryEntityError<'w>> {
-        // SAFETY: scheduler ensures safe Query world access
-        unsafe {
-            self.state
-                .get_many_unchecked_manual(self.world, entities, self.last_run, self.this_run)
+        // Verify that all entities are unique
+        for i in 0..N {
+            for j in 0..i {
+                if entities[i] == entities[j] {
+                    return Err(QueryEntityError::AliasedMutability(entities[i]));
+                }
+            }
         }
+
+        // SAFETY: All entities are unique, so the results don't alias.
+        unsafe { self.get_many_impl(entities) }
     }
 
     /// Returns the query items for the given array of [`Entity`].
@@ -1304,11 +1519,31 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     where
         D: ReadOnlyQueryData,
     {
-        // SAFETY: scheduler ensures safe Query world access
-        unsafe {
-            self.state
-                .get_many_read_only_manual(self.world, entities, self.last_run, self.this_run)
+        // SAFETY: The query results are read-only, so they don't conflict if there are duplicate entities.
+        unsafe { self.get_many_impl(entities) }
+    }
+
+    /// Returns the query items for the given array of [`Entity`].
+    /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the query data returned for the entities does not conflict,
+    /// either because they are all unique or because the data is read-only.
+    unsafe fn get_many_impl<const N: usize>(
+        self,
+        entities: [Entity; N],
+    ) -> Result<[D::Item<'w>; N], QueryEntityError<'w>> {
+        let mut values = [(); N].map(|_| MaybeUninit::uninit());
+
+        for (value, entity) in core::iter::zip(&mut values, entities) {
+            // SAFETY: The caller asserts that the results don't alias
+            let item = unsafe { self.copy_unsafe() }.get_inner(entity)?;
+            *value = MaybeUninit::new(item);
         }
+
+        // SAFETY: Each value has been fully initialized.
+        Ok(values.map(|x| unsafe { x.assume_init() }))
     }
 
     /// Returns the query items for the given array of [`Entity`].
@@ -1519,6 +1754,40 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Returns a single query item when there is exactly one entity matching the query.
     /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
     ///
+    /// # Panics
+    ///
+    /// This method panics if the number of query items is **not** exactly one.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// # #[derive(Component)]
+    /// # struct Player;
+    /// # #[derive(Component)]
+    /// # struct Health(u32);
+    /// #
+    /// fn regenerate_player_health_system(query: Query<&mut Health, With<Player>>) {
+    ///     let mut health = query.single_inner();
+    ///     health.0 += 1;
+    /// }
+    /// # bevy_ecs::system::assert_is_system(regenerate_player_health_system);
+    /// ```
+    ///
+    /// # See also
+    ///
+    /// - [`get_single_inner`](Self::get_single_inner) for the non-panicking version.
+    /// - [`single`](Self::single) to get the read-only query item.
+    /// - [`single_mut`](Self::single_mut) to get the mutable query item.
+    #[track_caller]
+    pub fn single_inner(self) -> D::Item<'w> {
+        self.get_single_inner().unwrap()
+    }
+
+    /// Returns a single query item when there is exactly one entity matching the query.
+    /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
+    ///
     /// If the number of query items is not exactly one, a [`QuerySingleError`] is returned instead.
     ///
     /// # Example
@@ -1542,14 +1811,19 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// - [`get_single`](Self::get_single) to get the read-only query item.
     /// - [`get_single_mut`](Self::get_single_mut) to get the mutable query item.
+    /// - [`single_inner`](Self::single_inner) for the panicking version.
     #[inline]
     pub fn get_single_inner(self) -> Result<D::Item<'w>, QuerySingleError> {
-        // SAFETY:
-        // the query ensures mutable access to the components it accesses, and the query
-        // is uniquely borrowed
-        unsafe {
-            self.state
-                .get_single_unchecked_manual(self.world, self.last_run, self.this_run)
+        let mut query = self.into_iter();
+        let first = query.next();
+        let extra = query.next().is_some();
+
+        match (first, extra) {
+            (Some(r), false) => Ok(r),
+            (None, _) => Err(QuerySingleError::NoEntities(core::any::type_name::<Self>())),
+            (Some(_), _) => Err(QuerySingleError::MultipleEntities(core::any::type_name::<
+                Self,
+            >())),
         }
     }
 
@@ -1583,14 +1857,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// [`Changed`]: crate::query::Changed
     #[inline]
     pub fn is_empty(&self) -> bool {
-        // SAFETY:
-        // - `self.world` has permission to read any data required by the WorldQuery.
-        // - `&self` ensures that no one currently has write access.
-        // - `self.world` matches `self.state`.
-        unsafe {
-            self.state
-                .is_empty_unsafe_world_cell(self.world, self.last_run, self.this_run)
-        }
+        self.as_nop().iter().next().is_none()
     }
 
     /// Returns `true` if the given [`Entity`] matches the query.
@@ -1619,13 +1886,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// ```
     #[inline]
     pub fn contains(&self, entity: Entity) -> bool {
-        // SAFETY: NopFetch does not access any members while &self ensures no one has exclusive access
-        unsafe {
-            self.state
-                .as_nop()
-                .get_unchecked_manual(self.world, entity, self.last_run, self.this_run)
-                .is_ok()
-        }
+        self.as_nop().get(entity).is_ok()
     }
 
     /// Returns a [`QueryLens`] that can be used to get a query with a more general fetch.
@@ -2060,10 +2321,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> IntoIterator for Query<'w, 's, D, F> 
         // - `self.world` has permission to access the required components.
         // - We consume the query, so mutable queries cannot alias.
         //   Read-only queries are `Copy`, but may alias themselves.
-        unsafe {
-            self.state
-                .iter_unchecked_manual(self.world, self.last_run, self.this_run)
-        }
+        unsafe { QueryIter::new(self.world, self.state, self.last_run, self.this_run) }
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -333,6 +333,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         // SAFETY: We have registered all of the query's world accesses,
         // so the caller ensures that `world` has permission to access any
         // world data that the query needs.
+        // The caller ensures the world matches the one used in init_state.
         unsafe { state.query_unchecked_manual_with_ticks(world, system_meta.last_run, change_tick) }
     }
 }
@@ -401,8 +402,8 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam fo
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        state.validate_world(world.id());
         // SAFETY: State ensures that the components it accesses are not accessible somewhere elsewhere.
+        // The caller ensures the world matches the one used in init_state.
         let query = unsafe {
             state.query_unchecked_manual_with_ticks(world, system_meta.last_run, change_tick)
         };
@@ -421,9 +422,9 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam fo
         system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> bool {
-        state.validate_world(world.id());
         // SAFETY: State ensures that the components it accesses are not mutably accessible elsewhere
         // and the query is read only.
+        // The caller ensures the world matches the one used in init_state.
         let query = unsafe {
             state.query_unchecked_manual_with_ticks(
                 world,
@@ -469,6 +470,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     ) -> Self::Item<'w, 's> {
         state.validate_world(world.id());
         // SAFETY: State ensures that the components it accesses are not accessible elsewhere.
+        // The caller ensures the world matches the one used in init_state.
         let query = unsafe {
             state.query_unchecked_manual_with_ticks(world, system_meta.last_run, change_tick)
         };
@@ -488,9 +490,9 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> bool {
-        state.validate_world(world.id());
         // SAFETY: State ensures that the components it accesses are not mutably accessible elsewhere
         // and the query is read only.
+        // The caller ensures the world matches the one used in init_state.
         let query = unsafe {
             state.query_unchecked_manual_with_ticks(
                 world,
@@ -558,10 +560,9 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         system_meta: &SystemMeta,
         world: UnsafeWorldCell,
     ) -> bool {
-        state.validate_world(world.id());
         // SAFETY:
         // - We have read-only access to the components accessed by query.
-        // - The world has been validated.
+        // - The caller ensures the world matches the one used in init_state.
         let query = unsafe {
             state.query_unchecked_manual_with_ticks(
                 world,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -562,9 +562,14 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         // SAFETY:
         // - We have read-only access to the components accessed by query.
         // - The world has been validated.
-        !unsafe {
-            state.is_empty_unsafe_world_cell(world, system_meta.last_run, world.change_tick())
-        }
+        let query = unsafe {
+            state.query_unchecked_manual_with_ticks(
+                world,
+                system_meta.last_run,
+                world.change_tick(),
+            )
+        };
+        !query.is_empty()
     }
 }
 


### PR DESCRIPTION
# Objective

Simplify the API surface by removing duplicated functionality between `Query` and `QueryState`.  

Reduce the amount of `unsafe` code required in `QueryState`.  

This is a follow-up to #15858.

## Solution

Move implementations of `Query` methods from `QueryState` to `Query`.  Instead of the original methods being on `QueryState`, with `Query` methods calling them by passing the individual parameters, the original methods are now on `Query`, with `QueryState` methods calling them by constructing a `Query`.  

This also adds two `_inner` methods that were missed in #15858: `iter_many_unique_inner` and `single_inner`.

One goal here is to be able to deprecate and eventually remove many of the methods on `QueryState`, reducing the overall API surface.  (I expected to do that in this PR, but this change was large enough on its own!)  Now that the `QueryState` methods each consist of a simple expression like `self.query(world).get_inner(entity)`, a future PR can deprecate some or all of them with simple migration instructions.  

The other goal is to reduce the amount of `unsafe` code.  The current implementation of a read-only method like `QueryState::get` directly calls the `unsafe fn get_unchecked_manual` and needs to repeat the proof that `&World` has enough access.  With this change, `QueryState::get` is entirely safe code, with the proof that `&World` has enough access done by the `query()` method and shared across all read-only operations.  

## Future Work

The next step will be to mark the `QueryState` methods as `#[deprecated]` and migrate callers to the methods on `Query`.  