### PR TITLE
Minor tidying in `font_atlas_debug`

### DIFF
--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -39,21 +39,23 @@ fn atlas_render_system(
     mut commands: Commands,
     mut state: ResMut<State>,
     font_atlas_sets: Res<FontAtlasSets>,
+    images: Res<Assets<Image>>,
 ) {
     if let Some(set) = font_atlas_sets.get(&state.handle) {
-        if let Some((_size, font_atlas)) = set.iter().next() {
+        if let Some((_size, font_atlases)) = set.iter().next() {
             let x_offset = state.atlas_count as f32;
-            if state.atlas_count == font_atlas.len() as u32 {
+            if state.atlas_count == font_atlases.len() as u32 {
                 return;
             }
-            let font_atlas = &font_atlas[state.atlas_count as usize];
+            let font_atlas = &font_atlases[state.atlas_count as usize];
+            let image = images.get(&font_atlas.texture).unwrap();
             state.atlas_count += 1;
             commands.spawn((
                 ImageNode::new(font_atlas.texture.clone()),
                 Node {
                     position_type: PositionType::Absolute,
                     top: Val::ZERO,
-                    left: Val::Px(512.0 * x_offset),
+                    left: Val::Px(image.width() as f32 * x_offset),
                     ..default()
                 },
             ));
@@ -67,16 +69,16 @@ fn text_update_system(
     mut query: Query<&mut Text>,
     mut seeded_rng: ResMut<SeededRng>,
 ) {
-    if state.timer.tick(time.delta()).finished() {
-        for mut text in &mut query {
-            let c = seeded_rng.gen::<u8>() as char;
-            let string = &mut **text;
-            if !string.contains(c) {
-                string.push(c);
-            }
-        }
+    if !state.timer.tick(time.delta()).just_finished() {
+        return;
+    }
 
-        state.timer.reset();
+    for mut text in &mut query {
+        let c = seeded_rng.gen::<u8>() as char;
+        let string = &mut **text;
+        if !string.contains(c) {
+            string.push(c);
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

Tidy up a few little things I noticed while working with this example

## Solution

- Fix manual resetting of a repeating timer
- Use atlas image size instead of hardcoded value. Atlases are always 512x512 right now, but hopefully not in the future.
- Pluralize a variable name for a variable holding a `Vec`