### PR TITLE
Make sprite picking opt-in

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -89,7 +89,7 @@ fn sprite_picking(
         Entity,
         &Sprite,
         &GlobalTransform,
-        Option<&Pickable>,
+        &Pickable,
         &ViewVisibility,
     )>,
     mut output: EventWriter<PointerHits>,
@@ -97,7 +97,7 @@ fn sprite_picking(
     let mut sorted_sprites: Vec<_> = sprite_query
         .iter()
         .filter_map(|(entity, sprite, transform, pickable, vis)| {
-            let marker_requirement = !settings.require_markers || pickable.is_some();
+            let marker_requirement = !settings.require_markers;
             if !transform.affine().is_nan() && vis.get() && marker_requirement {
                 Some((entity, sprite, transform, pickable))
             } else {
@@ -214,8 +214,7 @@ fn sprite_picking(
                     }
                 };
 
-                blocked = cursor_in_valid_pixels_of_sprite
-                    && pickable.is_none_or(|p| p.should_block_lower);
+                blocked = cursor_in_valid_pixels_of_sprite && pickable.should_block_lower;
 
                 cursor_in_valid_pixels_of_sprite.then(|| {
                     let hit_pos_world =

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -60,6 +60,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     .spawn((
                         Sprite::from_color(Color::BLACK, sprite_size),
                         Transform::from_xyz(i * len - len, j * len - len, -1.0),
+                        Pickable::default(),
                     ))
                     .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 1.0)))
                     .observe(recolor_on::<Pointer<Out>>(Color::BLACK))
@@ -79,6 +80,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         Transform::from_xyz(i * len - len, j * len - len, 0.0)
                             .with_scale(Vec3::splat(1.0 + (i - 1.0) * 0.2))
                             .with_rotation(Quat::from_rotation_z((j - 1.0) * 0.2)),
+                        Pickable::default(),
                     ))
                     .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 0.0)))
                     .observe(recolor_on::<Pointer<Out>>(Color::srgb(1.0, 0.0, 0.0)))
@@ -140,6 +142,7 @@ fn setup_atlas(
             Transform::from_xyz(300.0, 0.0, 0.0).with_scale(Vec3::splat(6.0)),
             animation_indices,
             AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
+            Pickable::default(),
         ))
         .observe(recolor_on::<Pointer<Over>>(Color::srgb(0.0, 1.0, 1.0)))
         .observe(recolor_on::<Pointer<Out>>(Color::srgb(1.0, 1.0, 1.0)))


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/17108
See https://github.com/bevyengine/bevy/issues/17108#issuecomment-2653020889

## Solution

- Make the query match `&Pickable` instead `Option<&Pickable>`

## Testing

- Run the `sprite_picking` example and everything still work


## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- Sprite picking are now opt-in, make sure you insert `Pickable` component when using sprite picking.
```diff
-commands.spawn(Sprite: {..} );
+commands.spawn((Sprite: {..}, Pickable::default());
```
