### PR TITLE
Remove the id from `PointerId::Touch`

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -549,6 +549,7 @@ pub fn pointer_events(
         pointer_id,
         location,
         action,
+        ..
     } in input_events.read().cloned()
     {
         match action {

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -20,7 +20,7 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::Vec2;
-use bevy_platform_support::collections::{HashMap, HashSet};
+use bevy_platform_support::collections::HashMap;
 use bevy_reflect::prelude::*;
 use bevy_render::camera::RenderTarget;
 use bevy_window::{PrimaryWindow, WindowEvent, WindowRef};
@@ -87,10 +87,6 @@ impl Plugin for PointerInputPlugin {
                 )
                     .chain()
                     .in_set(PickSet::Input),
-            )
-            .add_systems(
-                Last,
-                deactivate_touch_pointers.run_if(PointerInputPlugin::is_touch_enabled),
             )
             .register_type::<Self>()
             .register_type::<PointerInputPlugin>();
@@ -185,14 +181,13 @@ pub fn touch_pick_events(
     mut window_events: EventReader<WindowEvent>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     // Locals
-    mut touch_cache: Local<HashMap<u64, TouchInput>>,
+    mut touch_cache: Local<HashMap<u64, (TouchInput, Entity)>>,
     // Output
     mut commands: Commands,
     mut pointer_events: EventWriter<PointerInput>,
 ) {
     for window_event in window_events.read() {
         if let WindowEvent::TouchInput(touch) = window_event {
-            let pointer = PointerId::Touch(touch.id);
             let location = Location {
                 target: match RenderTarget::Window(WindowRef::Entity(touch.window))
                     .normalize(primary_window.get_single().ok())
@@ -202,78 +197,34 @@ pub fn touch_pick_events(
                 },
                 position: touch.position,
             };
-            match touch.phase {
-                TouchPhase::Started => {
-                    debug!("Spawning pointer {:?}", pointer);
-                    commands.spawn((pointer, PointerLocation::new(location.clone())));
+            let pointer_id = PointerId::Touch;
+            let (start, pointer_entity) = *touch_cache.entry(touch.id).or_insert_with(|| {
+                let pointer_entity = commands
+                    .spawn((pointer_id, PointerLocation::new(location.clone())))
+                    .id();
+                debug!("Spawning touch pointer {:?}", pointer_entity);
+                (*touch, pointer_entity)
+            });
 
-                    pointer_events.send(PointerInput::new(
-                        pointer,
-                        location,
-                        PointerAction::Press(PointerButton::Primary),
-                    ));
+            pointer_events.send(PointerInput::new_with_entity(
+                pointer_id,
+                pointer_entity,
+                location,
+                match touch.phase {
+                    TouchPhase::Started => PointerAction::Press(PointerButton::Primary),
+                    TouchPhase::Moved => PointerAction::Move {
+                        delta: touch.position - start.position,
+                    },
+                    TouchPhase::Ended => PointerAction::Release(PointerButton::Primary),
+                    TouchPhase::Canceled => PointerAction::Cancel,
+                },
+            ));
 
-                    touch_cache.insert(touch.id, *touch);
-                }
-                TouchPhase::Moved => {
-                    // Send a move event only if it isn't the same as the last one
-                    if let Some(last_touch) = touch_cache.get(&touch.id) {
-                        if last_touch == touch {
-                            continue;
-                        }
-                        pointer_events.send(PointerInput::new(
-                            pointer,
-                            location,
-                            PointerAction::Move {
-                                delta: touch.position - last_touch.position,
-                            },
-                        ));
-                    }
-                    touch_cache.insert(touch.id, *touch);
-                }
-                TouchPhase::Ended => {
-                    pointer_events.send(PointerInput::new(
-                        pointer,
-                        location,
-                        PointerAction::Release(PointerButton::Primary),
-                    ));
-                    touch_cache.remove(&touch.id);
-                }
-                TouchPhase::Canceled => {
-                    pointer_events.send(PointerInput::new(
-                        pointer,
-                        location,
-                        PointerAction::Cancel,
-                    ));
-                    touch_cache.remove(&touch.id);
-                }
+            if matches!(touch.phase, TouchPhase::Ended | TouchPhase::Canceled) {
+                touch_cache.remove(&touch.id);
+                debug!("Despawning {:?} pointer {:?}", pointer_id, pointer_entity);
+                commands.entity(pointer_entity).despawn();
             }
         }
-    }
-}
-
-/// Deactivates unused touch pointers.
-///
-/// Because each new touch gets assigned a new ID, we need to remove the pointers associated with
-/// touches that are no longer active.
-pub fn deactivate_touch_pointers(
-    mut commands: Commands,
-    mut despawn_list: Local<HashSet<(Entity, PointerId)>>,
-    pointers: Query<(Entity, &PointerId)>,
-    mut touches: EventReader<TouchInput>,
-) {
-    for touch in touches.read() {
-        if let TouchPhase::Ended | TouchPhase::Canceled = touch.phase {
-            for (entity, pointer) in &pointers {
-                if pointer.get_touch_id() == Some(touch.id) {
-                    despawn_list.insert((entity, *pointer));
-                }
-            }
-        }
-    }
-    // A hash set is used to prevent despawning the same entity twice.
-    for (entity, pointer) in despawn_list.drain() {
-        debug!("Despawning pointer {:?}", pointer);
-        commands.entity(entity).despawn();
     }
 }

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -200,16 +200,15 @@ pub fn touch_pick_events(
 
             match touch.phase {
                 TouchPhase::Started => {
-                    let (_, pointer) = *touch_cache.entry(touch.id).or_insert_with(|| {
-                        let pointer = commands
-                            .spawn((PointerId::Touch, PointerLocation::new(location.clone())))
-                            .id();
-                        debug!(
-                            "Spawning touch finger: {:?}, pointer:{:?}",
-                            touch.id, pointer
-                        );
-                        (*touch, pointer)
-                    });
+                    let pointer = commands
+                        .spawn((PointerId::Touch, PointerLocation::new(location.clone())))
+                        .id();
+                    touch_cache.insert(touch.id, (*touch, pointer));
+
+                    debug!(
+                        "Spawned touch, finger: {:?}, pointer:{:?}",
+                        touch.id, pointer
+                    );
 
                     pointer_events.send(PointerInput::new_with_entity(
                         PointerId::Touch,
@@ -237,7 +236,7 @@ pub fn touch_pick_events(
                 TouchPhase::Ended => {
                     if let Some((last_touch, pointer)) = touch_cache.remove(&touch.id) {
                         debug!(
-                            "Despawning touch finger {:?}, entity {:?}",
+                            "Despawning touch, finger {:?}, entity {:?}",
                             last_touch.id, pointer
                         );
                         commands.entity(pointer).despawn();
@@ -253,7 +252,7 @@ pub fn touch_pick_events(
                 TouchPhase::Canceled => {
                     if let Some((last_touch, pointer)) = touch_cache.remove(&touch.id) {
                         debug!(
-                            "Despawning touch finger {:?}, entity {:?}",
+                            "Despawning touch, finger {:?}, entity {:?}",
                             last_touch.id, pointer
                         );
                         commands.entity(pointer).despawn();

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -234,10 +234,10 @@ pub fn touch_pick_events(
                     }
                 }
                 TouchPhase::Ended => {
-                    if let Some((last_touch, pointer)) = touch_cache.remove(&touch.id) {
+                    if let Some((_, pointer)) = touch_cache.remove(&touch.id) {
                         debug!(
                             "Despawning touch, finger {:?}, entity {:?}",
-                            last_touch.id, pointer
+                            touch.id, pointer
                         );
                         commands.entity(pointer).despawn();
 
@@ -250,10 +250,10 @@ pub fn touch_pick_events(
                     }
                 }
                 TouchPhase::Canceled => {
-                    if let Some((last_touch, pointer)) = touch_cache.remove(&touch.id) {
+                    if let Some((_, pointer)) = touch_cache.remove(&touch.id) {
                         debug!(
                             "Despawning touch, finger {:?}, entity {:?}",
-                            last_touch.id, pointer
+                            touch.id, pointer
                         );
                         commands.entity(pointer).despawn();
 

--- a/crates/bevy_picking/src/input.rs
+++ b/crates/bevy_picking/src/input.rs
@@ -197,17 +197,16 @@ pub fn touch_pick_events(
                 },
                 position: touch.position,
             };
-            let pointer_id = PointerId::Touch;
             let (start, pointer_entity) = *touch_cache.entry(touch.id).or_insert_with(|| {
                 let pointer_entity = commands
-                    .spawn((pointer_id, PointerLocation::new(location.clone())))
+                    .spawn((PointerId::Touch, PointerLocation::new(location.clone())))
                     .id();
                 debug!("Spawning touch pointer {:?}", pointer_entity);
                 (*touch, pointer_entity)
             });
 
             pointer_events.send(PointerInput::new_with_entity(
-                pointer_id,
+                PointerId::Touch,
                 pointer_entity,
                 location,
                 match touch.phase {
@@ -222,7 +221,7 @@ pub fn touch_pick_events(
 
             if matches!(touch.phase, TouchPhase::Ended | TouchPhase::Canceled) {
                 touch_cache.remove(&touch.id);
-                debug!("Despawning {:?} pointer {:?}", pointer_id, pointer_entity);
+                debug!("Despawning touch pointer {:?}", pointer_entity);
                 commands.entity(pointer_entity).despawn();
             }
         }

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -33,8 +33,8 @@ pub enum PointerId {
     /// The mouse pointer.
     #[default]
     Mouse,
-    /// A touch input, usually numbered by window touch events from `winit`.
-    Touch(u64),
+    /// A touch input.
+    Touch,
     /// A custom, uniquely identified pointer. Useful for mocking inputs or implementing a software
     /// controlled cursor.
     #[reflect(ignore)]
@@ -44,7 +44,7 @@ pub enum PointerId {
 impl PointerId {
     /// Returns true if the pointer is a touch input.
     pub fn is_touch(&self) -> bool {
-        matches!(self, PointerId::Touch(_))
+        matches!(self, PointerId::Touch)
     }
     /// Returns true if the pointer is the mouse.
     pub fn is_mouse(&self) -> bool {
@@ -53,14 +53,6 @@ impl PointerId {
     /// Returns true if the pointer is a custom input.
     pub fn is_custom(&self) -> bool {
         matches!(self, PointerId::Custom(_))
-    }
-    /// Returns the touch id if the pointer is a touch input.
-    pub fn get_touch_id(&self) -> Option<u64> {
-        if let PointerId::Touch(id) = self {
-            Some(*id)
-        } else {
-            None
-        }
     }
 }
 
@@ -270,6 +262,8 @@ pub enum PointerAction {
 pub struct PointerInput {
     /// The id of the pointer.
     pub pointer_id: PointerId,
+    /// The pointer entity
+    pub pointer_entity: Option<Entity>,
     /// The location of the pointer. For [`PointerAction::Move`], this is the location after the movement.
     pub location: Location,
     /// The action that the event describes.
@@ -283,6 +277,24 @@ impl PointerInput {
     pub fn new(pointer_id: PointerId, location: Location, action: PointerAction) -> PointerInput {
         PointerInput {
             pointer_id,
+            pointer_entity: None,
+            location,
+            action,
+        }
+    }
+
+    /// Creates a new pointer input event.
+    ///
+    /// Note that `location` refers to the position of the pointer *after* the event occurred.
+    pub fn new_with_entity(
+        pointer_id: PointerId,
+        pointer_entity: Entity,
+        location: Location,
+        action: PointerAction,
+    ) -> PointerInput {
+        PointerInput {
+            pointer_id,
+            pointer_entity: Some(pointer_entity),
             location,
             action,
         }


### PR DESCRIPTION
# Objective

Instead of storing winit's `u64` finger id for touches on the pointer entity in its `PointerId` component, just use the pointer entity itself to represent the touch within Bevy.

Related #17808

## Solution

* Changed `touch_pick_event` so its local `touch_cache` hashmap also tracks the entity id of touch pointers as well as the intial touch states.
* Removed the `deactivate_touch_pointers` system. Instead `touch_pick_event` despawns the corresponding touch pointer entity when a touch ends or is cancelled.
* Added a `pointer_entity: Option<Entity>` field to the `PointerInput` event. This is used to match events to the correct pointer for inputs that support multiple pointers.  For touch it would be used to distinguish between touches for multi-touch. 

Made `pointer_entity` optional so that this PR doesn't have to touch any of the other pointer event systems but it would probably make sense to require it (if this PR is adopted).

## Testing

Works when running the bevy examples in chrome with touch enabled in dev tools.