### PR TITLE
Add `NodeImageMode` to the UI prelude

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -56,7 +56,7 @@ pub mod prelude {
             geometry::*,
             ui_material::*,
             ui_node::*,
-            widget::{Button, ImageNode, Label},
+            widget::{Button, ImageNode, Label, NodeImageMode},
             Interaction, MaterialNode, UiMaterialPlugin, UiScale,
         },
         // `bevy_sprite` re-exports for texture slicing


### PR DESCRIPTION
# Objective

Add `NodeImageMode` to `bevy_ui::prelude`.
