### PR TITLE
Update `typos` to 1.29.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.29.5
+        uses: crate-ci/typos@v1.29.6
       - name: Typos info
         if: failure()
         run: |

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -310,7 +310,7 @@ unsafe impl<I: EntitySetIterator> EntitySetIterator for iter::StepBy<I> {}
 /// Conversion from an `EntitySetIterator`.
 ///
 /// Some collections, while they can be constructed from plain iterators,
-/// benefit strongly from the additional uniqeness guarantee [`EntitySetIterator`] offers.
+/// benefit strongly from the additional uniqueness guarantee [`EntitySetIterator`] offers.
 /// Mirroring [`Iterator::collect`]/[`FromIterator::from_iter`], [`EntitySetIterator::collect_set`] and
 /// `FromEntitySetIterator::from_entity_set_iter` can be used for construction.
 ///

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -136,7 +136,7 @@ pub struct SGroup {
     pub iNrFaces: i32,
     pub pFaceIndices: *mut i32,
     pub iVertexRepresentative: i32,
-    pub bOrientPreservering: bool,
+    pub bOrientPreserving: bool,
 }
 
 impl SGroup {
@@ -145,7 +145,7 @@ impl SGroup {
             iNrFaces: 0,
             pFaceIndices: null_mut(),
             iVertexRepresentative: 0,
-            bOrientPreservering: false,
+            bOrientPreserving: false,
         }
     }
 }
@@ -576,11 +576,11 @@ unsafe fn GenerateTSpaces<I: Geometry>(
             if (*pTS_out).iCounter == 1i32 {
                 *pTS_out = AvgTSpace(pTS_out, &mut pSubGroupTspace[l]);
                 (*pTS_out).iCounter = 2i32;
-                (*pTS_out).bOrient = (*pGroup).bOrientPreservering
+                (*pTS_out).bOrient = (*pGroup).bOrientPreserving
             } else {
                 *pTS_out = pSubGroupTspace[l];
                 (*pTS_out).iCounter = 1i32;
-                (*pTS_out).bOrient = (*pGroup).bOrientPreservering
+                (*pTS_out).bOrient = (*pGroup).bOrientPreserving
             }
             i += 1
         }
@@ -838,7 +838,7 @@ unsafe fn Build4RuleGroups(
                 *fresh2 = ptr::from_mut(&mut *pGroups.offset(iNrActiveGroups as isize));
                 (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize])
                     .iVertexRepresentative = vert_index;
-                (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).bOrientPreservering =
+                (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).bOrientPreserving =
                     (*pTriInfos.offset(f as isize)).iFlag & 8i32 != 0i32;
                 (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).iNrFaces = 0i32;
                 let ref mut fresh3 =
@@ -927,7 +927,7 @@ unsafe fn AssignRecur(
             && (*pMyTriInfo).AssignedGroup[2usize].is_null()
         {
             (*pMyTriInfo).iFlag &= !8i32;
-            (*pMyTriInfo).iFlag |= if (*pGroup).bOrientPreservering {
+            (*pMyTriInfo).iFlag |= if (*pGroup).bOrientPreserving {
                 8i32
             } else {
                 0i32
@@ -939,7 +939,7 @@ unsafe fn AssignRecur(
     } else {
         false
     };
-    if bOrient != (*pGroup).bOrientPreservering {
+    if bOrient != (*pGroup).bOrientPreserving {
         return false;
     }
     AddTriToGroup(pGroup, iMyTriIndex);

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -241,7 +241,7 @@ fn bend_normal_for_anisotropy(lighting_input: ptr<function, lighting::LightingIn
     (*lighting_input).layers[LAYER_BASE].R = R;
 }
 
-#endif  // STANDARD_MATERIAL_ANISTROPY
+#endif  // STANDARD_MATERIAL_ANISOTROPY
 
 // NOTE: Correctly calculates the view vector depending on whether
 // the projection is orthographic or perspective.

--- a/crates/bevy_pbr/src/ssr/raymarch.wgsl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wgsl
@@ -286,7 +286,7 @@ struct DepthRayMarchResult {
     /// Range: `0..=1` as a lerp factor over `ray_start_cs..=ray_end_cs`.
     hit_t: f32,
 
-    /// UV correspindong to `hit_t`.
+    /// UV corresponding to `hit_t`.
     hit_uv: vec2<f32>,
 
     /// The distance that the hit point penetrates into the hit surface.

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -7,7 +7,7 @@
 //! allows you to express more complex interactions, like detecting when a touch input drags a UI
 //! element and drops it on a 3d mesh rendered to a different camera.
 //!
-//! Pointer events bubble up the entity hieararchy and can be used with observers, allowing you to
+//! Pointer events bubble up the entity hierarchy and can be used with observers, allowing you to
 //! succinctly express rich interaction behaviors by attaching pointer callbacks to entities:
 //!
 //! ```rust

--- a/crates/bevy_reflect/src/func/args/count.rs
+++ b/crates/bevy_reflect/src/func/args/count.rs
@@ -264,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn should_allow_removeting_nonexistent_count() {
+    fn should_allow_removing_nonexistent_count() {
         let mut count = ArgCount::default();
 
         assert_eq!(count.len(), 0);

--- a/crates/bevy_reflect/src/func/dynamic_function_internal.rs
+++ b/crates/bevy_reflect/src/func/dynamic_function_internal.rs
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn should_merge_overloaed_into_single() {
+    fn should_merge_overload_into_single() {
         let mut func_a = DynamicFunctionInternal {
             functions: vec!['a', 'b'],
             info: FunctionInfo::new(SignatureInfo::anonymous().with_arg::<i8>("arg0"))

--- a/typos.toml
+++ b/typos.toml
@@ -1,9 +1,9 @@
 [files]
 extend-exclude = [
-  "*.pbxproj",      # metadata file
-  "*.patch",        # Automatically generated files that should not be manually modified.
-  "*.bin",          # Binary files
-  ".git/",          # Version control files
+  "*.pbxproj", # metadata file
+  "*.patch",   # Automatically generated files that should not be manually modified.
+  "*.bin",     # Binary files
+  ".git/",     # Version control files
 ]
 ignore-hidden = false
 

--- a/typos.toml
+++ b/typos.toml
@@ -13,7 +13,7 @@ LOD = "LOD"                             # Level of detail
 reparametrization = "reparametrization" # Mathematical term in curve context (reparameterize)
 reparametrize = "reparametrize"
 reparametrized = "reparametrized"
-implementors = "implementors"           # https://github.com/crate-ci/typos/issues/1226
+implementors = "implementors"           # Can probably remove after next typos release. https://github.com/crate-ci/typos/issues/1226
 
 # Match a Whole Word - Case Sensitive
 [default.extend-identifiers]

--- a/typos.toml
+++ b/typos.toml
@@ -1,9 +1,9 @@
 [files]
 extend-exclude = [
-  "*.pbxproj", # metadata file
-  "*.patch",   # Automatically generated files that should not be manually modified.
-  "*.bin",     # Binary files
-  ".git/",     # Version control files
+  "*.pbxproj",      # metadata file
+  "*.patch",        # Automatically generated files that should not be manually modified.
+  "*.bin",          # Binary files
+  ".git/",          # Version control files
 ]
 ignore-hidden = false
 
@@ -13,6 +13,7 @@ LOD = "LOD"                             # Level of detail
 reparametrization = "reparametrization" # Mathematical term in curve context (reparameterize)
 reparametrize = "reparametrize"
 reparametrized = "reparametrized"
+implementors = "implementors"           # https://github.com/crate-ci/typos/issues/1226
 
 # Match a Whole Word - Case Sensitive
 [default.extend-identifiers]


### PR DESCRIPTION
# Objective

Update typos, fix new typos.

1.29.6 was just released to fix an [issue](https://github.com/crate-ci/typos/issues/1228) where January's corrections were not included in the binaries for the last release.

Reminder: typos can be tossed in the monthly [non-critical corrections issue](https://github.com/crate-ci/typos/issues/1221).

## Solution

I chose to allow `implementors`, because a good argument seems to be being made [here](https://github.com/crate-ci/typos/issues/1226) and there is now a PR to address that.

## Discussion

Should I exclude `bevy_mikktspace`?

At one point I think we had an informal policy of "don't mess with mikktspace until https://github.com/bevyengine/bevy/pull/9050 is merged" but it doesn't seem like that is likely to be merged any time soon.

I think these particular corrections in mikktspace are fine because
- The same typo mistake seems to have been fixed in that PR
- The entire file containing these corrections was deleted in that PR

## Typo of the Month

correspindong -> corresponding