### PR TITLE
Combine `output_index` and `indirect_parameters_index` into one field in `PreprocessWorkItem`.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -43,11 +43,10 @@ struct PreprocessWorkItem {
     // The index of the `MeshInput` in the `current_input` buffer that we read
     // from.
     input_index: u32,
-    // The index of the `Mesh` in `output` that we write to.
-    output_index: u32,
-    // The index of the `IndirectParameters` in `indirect_parameters` that we
-    // write to.
-    indirect_parameters_index: u32,
+    // In direct mode, the index of the `Mesh` in `output` that we write to. In
+    // indirect mode, the index of the `IndirectParameters` in
+    // `indirect_parameters` that we write to.
+    output_or_indirect_parameters_index: u32,
 }
 
 // The parameters for the indirect compute dispatch for the late mesh
@@ -171,8 +170,11 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
     // Unpack the work item.
     let input_index = work_items[instance_index].input_index;
-    let output_index = work_items[instance_index].output_index;
-    let indirect_parameters_index = work_items[instance_index].indirect_parameters_index;
+#ifdef INDIRECT
+    let indirect_parameters_index = work_items[instance_index].output_or_indirect_parameters_index;
+#else   // INDIRECT
+    let mesh_output_index = work_items[instance_index].output_or_indirect_parameters_index;
+#endif  // INDIRECT
 
     // Unpack the input matrix.
     let world_from_local_affine_transpose = current_input[input_index].world_from_local;
@@ -289,8 +291,7 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
 
         // Enqueue a work item for the late prepass phase.
         late_preprocess_work_items[output_work_item_index].input_index = input_index;
-        late_preprocess_work_items[output_work_item_index].output_index = output_index;
-        late_preprocess_work_items[output_work_item_index].indirect_parameters_index =
+        late_preprocess_work_items[output_work_item_index].output_or_indirect_parameters_index =
             indirect_parameters_index;
 #endif  // EARLY_PHASE
         // This mesh is culled. Skip it.
@@ -328,8 +329,6 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
         indirect_parameters_metadata[indirect_parameters_index].base_output_index +
         batch_output_index;
 
-#else   // INDIRECT
-    let mesh_output_index = output_index;
 #endif  // INDIRECT
 
     // Write the output.

--- a/examples/shader/specialized_mesh_pipeline.rs
+++ b/examples/shader/specialized_mesh_pipeline.rs
@@ -438,8 +438,11 @@ fn queue_custom_mesh_pipeline(
                 mesh.indexed(),
                 PreprocessWorkItem {
                     input_index: input_index.into(),
-                    output_index,
-                    indirect_parameters_index: mesh_info.indirect_parameters_index,
+                    output_or_indirect_parameters_index: if no_indirect_drawing {
+                        output_index
+                    } else {
+                        mesh_info.indirect_parameters_index
+                    },
                 },
             );
         }


### PR DESCRIPTION
The `output_index` field is only used in direct mode, and the `indirect_parameters_index` field is only used in indirect mode. Consequently, we can combine them into a single field, reducing the size of `PreprocessWorkItem`, which
`batch_and_prepare_{binned,sorted}_render_phase` must construct every frame for every mesh instance, from 96 bits to 64 bits.