### PR TITLE
Update picking docs to include position space

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -7,6 +7,11 @@
 //! to `true` and add a [`RayCastPickable`] component to the desired camera and target entities.
 //!
 //! To manually perform mesh ray casts independent of picking, use the [`MeshRayCast`] system parameter.
+//!
+//! ## Implementation Notes
+//!
+//! - The `position` reported in `HitData` is in world space. The `normal` is a vector pointing
+//! away from the face, it is not guaranteed to be normalized for scaled meshes.
 
 pub mod ray_cast;
 

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -11,7 +11,7 @@
 //! ## Implementation Notes
 //!
 //! - The `position` reported in `HitData` is in world space. The `normal` is a vector pointing
-//! away from the face, it is not guaranteed to be normalized for scaled meshes.
+//!   away from the face, it is not guaranteed to be normalized for scaled meshes.
 
 pub mod ray_cast;
 

--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -6,6 +6,10 @@
 //! window will be inserted as a pointer hit, listed behind all other pointer
 //! hits. This means that when the pointer isn't hovering any other entities,
 //! the picking events will be routed to the window.
+//!
+//! ## Implementation Notes
+//!
+//! - This backend does not provide `position` or `normal` in `HitData`.
 
 use core::f32;
 

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -1,6 +1,11 @@
 //! A [`bevy_picking`] backend for sprites. Works for simple sprites and sprite atlases. Works for
 //! sprites with arbitrary transforms. Picking is done based on sprite bounds, not visible pixels.
 //! This means a partially transparent sprite is pickable even in its transparent areas.
+//!
+//! ## Implementation Notes
+//!
+//! - The `position` reported in `HitData` in in world space, and the `normal` is a normalized
+//! vector provided by the target's `GlobalTransform::back()`.
 
 use crate::Sprite;
 use bevy_app::prelude::*;

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -5,7 +5,7 @@
 //! ## Implementation Notes
 //!
 //! - The `position` reported in `HitData` in in world space, and the `normal` is a normalized
-//! vector provided by the target's `GlobalTransform::back()`.
+//!   vector provided by the target's `GlobalTransform::back()`.
 
 use crate::Sprite;
 use bevy_app::prelude::*;

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -19,8 +19,8 @@
 //!   camera.
 //! - To correctly sort picks, the order of `bevy_ui` is set to be the camera order plus 0.5.
 //! - The `position` reported in `HitData` is normalized relative to the node, with `(0.,0.,0.)` at
-//! the top left and `(1., 1., 0.)` in the bottom right. Coordinates are relative to the entire
-//! node, not just the visible region. This backend does not provide a `normal`.
+//!   the top left and `(1., 1., 0.)` in the bottom right. Coordinates are relative to the entire
+//!   node, not just the visible region. This backend does not provide a `normal`.
 
 #![deny(missing_docs)]
 

--- a/crates/bevy_ui/src/picking_backend.rs
+++ b/crates/bevy_ui/src/picking_backend.rs
@@ -18,8 +18,9 @@
 //! - `bevy_ui` can render on any camera with a flag, it is special, and is not tied to a particular
 //!   camera.
 //! - To correctly sort picks, the order of `bevy_ui` is set to be the camera order plus 0.5.
-//! - The position reported in `HitData` is normalized relative to the node, with `(0.,0.,0.)` at the top
-//!   left and `(1., 1., 0.)` in the bottom right. Coordinates are relative to the entire node, not just the visible region.
+//! - The `position` reported in `HitData` is normalized relative to the node, with `(0.,0.,0.)` at
+//! the top left and `(1., 1., 0.)` in the bottom right. Coordinates are relative to the entire
+//! node, not just the visible region. This backend does not provide a `normal`.
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
# Objective

Add reference to reported position space in picking backend docs.

Fixes #17844 

## Solution

Add explanatory docs to the implementation notes of each picking backend.

## Testing

`cargo r -p ci -- doc-check` & `cargo r -p ci -- lints`