### PR TITLE
Add `TypePath::crate_version`

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -144,7 +144,7 @@ macro_rules! embedded_path {
     }};
 
     ($source_path: expr, $path_str: expr) => {{
-        let crate_name = env!("CARGO_CRATE_NAME");
+        let crate_name = option_env!("CARGO_CRATE_NAME").unwrap_or("");
         $crate::io::embedded::_embedded_asset_path(
             crate_name,
             $source_path.as_ref(),

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -144,7 +144,7 @@ macro_rules! embedded_path {
     }};
 
     ($source_path: expr, $path_str: expr) => {{
-        let crate_name = module_path!().split(':').next().unwrap();
+        let crate_name = env!("CARGO_CRATE_NAME");
         $crate::io::embedded::_embedded_asset_path(
             crate_name,
             $source_path.as_ref(),

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -144,7 +144,7 @@ macro_rules! embedded_path {
     }};
 
     ($source_path: expr, $path_str: expr) => {{
-        let crate_name = option_env!("CARGO_PKG_NAME").unwrap_or("");
+        let crate_name = ::core::option_env!("CARGO_PKG_NAME").unwrap_or("");
         $crate::io::embedded::_embedded_asset_path(
             crate_name,
             $source_path.as_ref(),

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -144,7 +144,7 @@ macro_rules! embedded_path {
     }};
 
     ($source_path: expr, $path_str: expr) => {{
-        let crate_name = option_env!("CARGO_CRATE_NAME").unwrap_or("");
+        let crate_name = option_env!("CARGO_PKG_NAME").unwrap_or("");
         $crate::io::embedded::_embedded_asset_path(
             crate_name,
             $source_path.as_ref(),

--- a/crates/bevy_math/src/curve/adaptors.rs
+++ b/crates/bevy_math/src/curve/adaptors.rs
@@ -19,6 +19,7 @@ use {
 mod paths {
     pub(super) const THIS_MODULE: &str = "bevy_math::curve::adaptors";
     pub(super) const THIS_CRATE: &str = "bevy_math";
+    pub(super) const THIS_CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 }
 
 #[expect(unused, reason = "imported just for doc links")]
@@ -143,6 +144,10 @@ where
         Some(paths::THIS_CRATE)
     }
 
+    fn crate_version() -> Option<&'static str> {
+        Some(paths::THIS_CRATE_VERSION)
+    }
+
     fn module_path() -> Option<&'static str> {
         Some(paths::THIS_MODULE)
     }
@@ -253,6 +258,10 @@ where
         Some(paths::THIS_CRATE)
     }
 
+    fn crate_version() -> Option<&'static str> {
+        Some(paths::THIS_CRATE_VERSION)
+    }
+
     fn module_path() -> Option<&'static str> {
         Some(paths::THIS_MODULE)
     }
@@ -346,6 +355,10 @@ where
 
     fn crate_name() -> Option<&'static str> {
         Some(paths::THIS_CRATE)
+    }
+
+    fn crate_version() -> Option<&'static str> {
+        Some(paths::THIS_CRATE_VERSION)
     }
 
     fn module_path() -> Option<&'static str> {

--- a/crates/bevy_math/src/curve/sample_curves.rs
+++ b/crates/bevy_math/src/curve/sample_curves.rs
@@ -16,6 +16,7 @@ use bevy_reflect::{utility::GenericTypePathCell, Reflect, TypePath};
 mod paths {
     pub(super) const THIS_MODULE: &str = "bevy_math::curve::sample_curves";
     pub(super) const THIS_CRATE: &str = "bevy_math";
+    pub(super) const THIS_CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 }
 
 /// A curve that is defined by explicit neighbor interpolation over a set of evenly-spaced samples.
@@ -78,6 +79,10 @@ where
 
     fn crate_name() -> Option<&'static str> {
         Some(paths::THIS_CRATE)
+    }
+
+    fn crate_version() -> Option<&'static str> {
+        Some(paths::THIS_CRATE_VERSION)
     }
 
     fn module_path() -> Option<&'static str> {
@@ -238,6 +243,10 @@ where
 
     fn crate_name() -> Option<&'static str> {
         Some(paths::THIS_CRATE)
+    }
+
+    fn crate_version() -> Option<&'static str> {
+        Some(paths::THIS_CRATE_VERSION)
     }
 
     fn module_path() -> Option<&'static str> {

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -1018,7 +1018,7 @@ impl<'a> ReflectTypePath<'a> {
 
         match self {
             Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
-                option_env!("CARGO_PKG_NAME").unwrap_or("")
+                ::core::option_env!("CARGO_PKG_NAME").unwrap_or("")
             })),
             Self::External { .. } => unreachable!(),
             _ => None,
@@ -1042,7 +1042,7 @@ impl<'a> ReflectTypePath<'a> {
 
         match self {
             Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
-                option_env!("CARGO_PKG_VERSION").unwrap_or("")
+                ::core::option_env!("CARGO_PKG_VERSION").unwrap_or("")
             })),
             Self::External { .. } => unreachable!(),
             _ => None,

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -884,8 +884,8 @@ pub(crate) enum ReflectTypePath<'a> {
     ///
     /// May have a separate alias path used for the `TypePath` implementation.
     ///
-    /// Module and crate are found with [`module_path!()`](module_path),
-    /// if there is no custom path specified.
+    /// Module is found with [`module_path!()`](module_path), and crate/version info
+    /// provided by cargo via [`env!()`](env) when there is no custom path specified.
     Internal {
         ident: &'a Ident,
         custom_path: Option<Path>,
@@ -1003,7 +1003,7 @@ impl<'a> ReflectTypePath<'a> {
     ///
     /// Returns [`None`] if the type is [primitive] or [anonymous].
     ///
-    /// For non-customized [internal] paths this is created from [`module_path`].
+    /// For non-customized [internal] paths this is created from `env!("CARGO_CRATE_NAME")`.
     ///
     /// For `Option<PhantomData>`, this is `"core"`.
     ///
@@ -1018,10 +1018,31 @@ impl<'a> ReflectTypePath<'a> {
 
         match self {
             Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
-                ::core::module_path!()
-                    .split(':')
-                    .next()
-                    .unwrap()
+                env!("CARGO_CRATE_NAME")
+            })),
+            Self::External { .. } => unreachable!(),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`StringExpr`] representing the version of the type's crate.
+    ///
+    /// Returns [`None`] if the type is [primitive] or [anonymous].
+    ///
+    /// For non-customized [internal] paths this is created from `env!("CARGO_PKG_VERSION")`.
+    ///
+    /// [primitive]: ReflectTypePath::Primitive
+    /// [anonymous]: ReflectTypePath::Anonymous
+    /// [internal]: ReflectTypePath::Internal
+    pub fn crate_version(&self) -> Option<StringExpr> {
+        if let Some(path) = self.get_path() {
+            let crate_name = &path.segments.first().unwrap().ident;
+            return Some(StringExpr::from(crate_name));
+        }
+
+        match self {
+            Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
+                env!("CARGO_PKG_VERSION")
             })),
             Self::External { .. } => unreachable!(),
             _ => None,

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -1018,7 +1018,7 @@ impl<'a> ReflectTypePath<'a> {
 
         match self {
             Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
-                env!("CARGO_CRATE_NAME")
+                option_env!("CARGO_CRATE_NAME").unwrap_or("")
             })),
             Self::External { .. } => unreachable!(),
             _ => None,
@@ -1042,7 +1042,7 @@ impl<'a> ReflectTypePath<'a> {
 
         match self {
             Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
-                env!("CARGO_PKG_VERSION")
+                option_env!("CARGO_PKG_VERSION").unwrap_or("")
             })),
             Self::External { .. } => unreachable!(),
             _ => None,

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -1003,7 +1003,7 @@ impl<'a> ReflectTypePath<'a> {
     ///
     /// Returns [`None`] if the type is [primitive] or [anonymous].
     ///
-    /// For non-customized [internal] paths this is created from `env!("CARGO_CRATE_NAME")`.
+    /// For non-customized [internal] paths this is created from `env!("CARGO_PKG_NAME")`.
     ///
     /// For `Option<PhantomData>`, this is `"core"`.
     ///
@@ -1018,7 +1018,7 @@ impl<'a> ReflectTypePath<'a> {
 
         match self {
             Self::Internal { .. } => Some(StringExpr::Borrowed(quote! {
-                option_env!("CARGO_CRATE_NAME").unwrap_or("")
+                option_env!("CARGO_PKG_NAME").unwrap_or("")
             })),
             Self::External { .. } => unreachable!(),
             _ => None,

--- a/crates/bevy_reflect/derive/src/impls/typed.rs
+++ b/crates/bevy_reflect/derive/src/impls/typed.rs
@@ -84,6 +84,7 @@ pub(crate) fn impl_type_path(meta: &ReflectMeta) -> TokenStream {
     let type_ident = wrap_in_option(type_path.type_ident().map(StringExpr::into_borrowed));
     let module_path = wrap_in_option(type_path.module_path().map(StringExpr::into_borrowed));
     let crate_name = wrap_in_option(type_path.crate_name().map(StringExpr::into_borrowed));
+    let crate_version = wrap_in_option(type_path.crate_version().map(StringExpr::into_borrowed));
 
     let primitive_assert = if let ReflectTypePath::Primitive(_) = type_path {
         Some(quote! {
@@ -127,6 +128,10 @@ pub(crate) fn impl_type_path(meta: &ReflectMeta) -> TokenStream {
 
                 fn crate_name() -> Option<&'static str> {
                     #crate_name
+                }
+
+                fn crate_version() -> Option<&'static str> {
+                    #crate_version
                 }
 
                 fn module_path() -> Option<&'static str> {

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -31,6 +31,10 @@ mod tests {
             assert_eq!(MyEnum::module_path(), info.type_path_table().module_path());
             assert_eq!(MyEnum::crate_name(), info.type_path_table().crate_name());
             assert_eq!(
+                MyEnum::crate_version(),
+                info.type_path_table().crate_version()
+            );
+            assert_eq!(
                 MyEnum::short_type_path(),
                 info.type_path_table().short_path()
             );

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2448,6 +2448,10 @@ bevy_reflect::tests::Test {
                 Some("bevy_reflect")
             }
 
+            fn crate_version() -> Option<&'static str> {
+                Some("0.0.0")
+            }
+
             fn module_path() -> Option<&'static str> {
                 Some("bevy_reflect::tests")
             }

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -422,6 +422,11 @@ impl Type {
         self.type_path_table.crate_name()
     }
 
+    /// See [`TypePath::crate_version`].
+    pub fn crate_version(&self) -> Option<&'static str> {
+        self.type_path_table.crate_version()
+    }
+
     /// See [`TypePath::module_path`].
     pub fn module_path(&self) -> Option<&'static str> {
         self.type_path_table.module_path()

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -220,6 +220,10 @@ impl<T: TypedProperty> Default for NonGenericTypeCell<T> {
 ///     fn crate_name() -> Option<&'static str> {
 ///         Some("my_crate")
 ///     }
+///
+///     fn crate_version() -> Option<&'static str> {
+///         Some("0.0.0")
+///     }
 /// }
 /// ```
 /// [`impl_type_path`]: crate::impl_type_path


### PR DESCRIPTION
# Objective

For the purposes of modding or scripting, it becomes valuable to know not just from what crate a type is originating from, but also the version of that crate.

If we imagine a fairly simple example, like a game (v0.2.0) and separate level editor (v0.1.0) compiled with two slightly different versions of bevy. They communicate with each other using brp. Suppose a modder opens the editor and tries to move an object in the game by altering it's Transform. As long as bevy reflect is able to deserialize the message on the game's side, there won't be an issue. But if there is a version mismatch between bevy_transform in the game and in the editor that results in a deserialization error, nothing will move and instead they will see a vague error in the game's logs.

Adding this version info opens up the possibility of adding valuable context to serialization errors (for example that a type is from bevy_transform 0.1.0 but remote version is from bevy_transform 0.2.0).

In my wip bevy modding framework, this version information would be useful to differentiate the types used by different mods and determine which mods are incompatible/outdated compared to others.

## Solution

This pr adds this version info to reflected types.

## Testing

- Compiles fine on nightly and stable

## Migration guide

- Manual implementers of `TypePath` should eventually implement `crate_version()`. However, their code will continue to compile due to the default trait implementation that returns a `None`.