### PR TITLE
Split out the `IndirectParametersMetadata` into CPU-populated and GPU-populated buffers.

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -105,6 +105,7 @@ pub mod graph {
         EarlyPrepassBuildIndirectParameters,
         LatePrepassBuildIndirectParameters,
         MainBuildIndirectParameters,
+        ClearIndirectParametersMetadata,
     }
 }
 

--- a/crates/bevy_pbr/src/render/build_indirect_params.wgsl
+++ b/crates/bevy_pbr/src/render/build_indirect_params.wgsl
@@ -12,7 +12,8 @@
     IndirectBatchSet,
     IndirectParametersIndexed,
     IndirectParametersNonIndexed,
-    IndirectParametersMetadata,
+    IndirectParametersCpuMetadata,
+    IndirectParametersGpuMetadata,
     MeshInput
 }
 
@@ -22,26 +23,30 @@
 // Data that we use to generate the indirect parameters.
 //
 // The `mesh_preprocess.wgsl` shader emits these.
-@group(0) @binding(1) var<storage> indirect_parameters_metadata: array<IndirectParametersMetadata>;
+@group(0) @binding(1) var<storage> indirect_parameters_cpu_metadata:
+    array<IndirectParametersCpuMetadata>;
+
+@group(0) @binding(2) var<storage> indirect_parameters_gpu_metadata:
+    array<IndirectParametersGpuMetadata>;
 
 // Information about each batch set.
 //
 // A *batch set* is a set of meshes that might be multi-drawn together.
-@group(0) @binding(2) var<storage, read_write> indirect_batch_sets: array<IndirectBatchSet>;
+@group(0) @binding(3) var<storage, read_write> indirect_batch_sets: array<IndirectBatchSet>;
 
 #ifdef INDEXED
 // The buffer of indirect draw parameters that we generate, and that the GPU
 // reads to issue the draws.
 //
 // This buffer is for indexed meshes.
-@group(0) @binding(3) var<storage, read_write> indirect_parameters:
+@group(0) @binding(4) var<storage, read_write> indirect_parameters:
     array<IndirectParametersIndexed>;
 #else   // INDEXED
 // The buffer of indirect draw parameters that we generate, and that the GPU
 // reads to issue the draws.
 //
 // This buffer is for non-indexed meshes.
-@group(0) @binding(3) var<storage, read_write> indirect_parameters:
+@group(0) @binding(4) var<storage, read_write> indirect_parameters:
     array<IndirectParametersNonIndexed>;
 #endif  // INDEXED
 
@@ -51,20 +56,21 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // Figure out our instance index (i.e. batch index). If this thread doesn't
     // correspond to any index, bail.
     let instance_index = global_invocation_id.x;
-    if (instance_index >= arrayLength(&indirect_parameters_metadata)) {
+    if (instance_index >= arrayLength(&indirect_parameters_cpu_metadata)) {
         return;
     }
 
     // Unpack the metadata for this batch.
-    let mesh_index = indirect_parameters_metadata[instance_index].mesh_index;
-    let base_output_index = indirect_parameters_metadata[instance_index].base_output_index;
-    let batch_set_index = indirect_parameters_metadata[instance_index].batch_set_index;
+    let base_output_index = indirect_parameters_cpu_metadata[instance_index].base_output_index;
+    let batch_set_index = indirect_parameters_cpu_metadata[instance_index].batch_set_index;
+    let mesh_index = indirect_parameters_gpu_metadata[instance_index].mesh_index;
 
     // If we aren't using `multi_draw_indirect_count`, we have a 1:1 fixed
     // assignment of batches to slots in the indirect parameters buffer, so we
     // can just use the instance index as the index of our indirect parameters.
-    let early_instance_count = indirect_parameters_metadata[instance_index].early_instance_count;
-    let late_instance_count = indirect_parameters_metadata[instance_index].late_instance_count;
+    let early_instance_count =
+        indirect_parameters_gpu_metadata[instance_index].early_instance_count;
+    let late_instance_count = indirect_parameters_gpu_metadata[instance_index].late_instance_count;
 
     // If in the early phase, we draw only the early meshes. If in the late
     // phase, we draw only the late meshes. If in the main phase, draw all the

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -150,7 +150,7 @@ pub struct LateGpuPreprocessNode {
 ///
 /// This node runs a compute shader on the output of the
 /// [`EarlyGpuPreprocessNode`] in order to transform the
-/// [`IndirectParametersMetadata`] into properly-formatted
+/// [`IndirectParametersGpuMetadata`] into properly-formatted
 /// [`IndirectParametersIndexed`] and [`IndirectParametersNonIndexed`].
 pub struct EarlyPrepassBuildIndirectParametersNode {
     view_query: QueryState<
@@ -170,7 +170,7 @@ pub struct EarlyPrepassBuildIndirectParametersNode {
 ///
 /// This node runs a compute shader on the output of the
 /// [`LateGpuPreprocessNode`] in order to transform the
-/// [`IndirectParametersMetadata`] into properly-formatted
+/// [`IndirectParametersGpuMetadata`] into properly-formatted
 /// [`IndirectParametersIndexed`] and [`IndirectParametersNonIndexed`].
 pub struct LatePrepassBuildIndirectParametersNode {
     view_query: QueryState<
@@ -191,7 +191,7 @@ pub struct LatePrepassBuildIndirectParametersNode {
 ///
 /// This node runs a compute shader on the output of the
 /// [`EarlyGpuPreprocessNode`] and [`LateGpuPreprocessNode`] in order to
-/// transform the [`IndirectParametersMetadata`] into properly-formatted
+/// transform the [`IndirectParametersGpuMetadata`] into properly-formatted
 /// [`IndirectParametersIndexed`] and [`IndirectParametersNonIndexed`].
 pub struct MainBuildIndirectParametersNode {
     view_query: QueryState<

--- a/crates/bevy_pbr/src/render/gpu_preprocess.rs
+++ b/crates/bevy_pbr/src/render/gpu_preprocess.rs
@@ -29,12 +29,14 @@ use bevy_ecs::{
     system::{lifetimeless::Read, Commands, Query, Res, ResMut},
     world::{FromWorld, World},
 };
-use bevy_render::batching::gpu_preprocessing::UntypedPhaseIndirectParametersBuffers;
+use bevy_render::batching::gpu_preprocessing::{
+    IndirectParametersGpuMetadata, UntypedPhaseIndirectParametersBuffers,
+};
 use bevy_render::{
     batching::gpu_preprocessing::{
         BatchedInstanceBuffers, GpuOcclusionCullingWorkItemBuffers, GpuPreprocessingSupport,
-        IndirectBatchSet, IndirectParametersBuffers, IndirectParametersIndexed,
-        IndirectParametersMetadata, IndirectParametersNonIndexed,
+        IndirectBatchSet, IndirectParametersBuffers, IndirectParametersCpuMetadata,
+        IndirectParametersIndexed, IndirectParametersNonIndexed,
         LatePreprocessWorkItemIndirectParameters, PreprocessWorkItem, PreprocessWorkItemBuffers,
         UntypedPhaseBatchedInstanceBuffers,
     },
@@ -91,6 +93,12 @@ pub struct GpuMeshPreprocessPlugin {
     /// the platform doesn't support those.
     pub use_gpu_instance_buffer_builder: bool,
 }
+
+/// The render node that clears out the GPU-side indirect metadata buffers.
+///
+/// This is only used when indirect drawing is enabled.
+#[derive(Default)]
+pub struct ClearIndirectParametersMetadataNode;
 
 /// The render node for the first mesh preprocessing pass.
 ///
@@ -494,6 +502,10 @@ impl Plugin for GpuMeshPreprocessPlugin {
                     write_mesh_culling_data_buffer.in_set(RenderSet::PrepareResourcesFlush),
                 ),
             )
+            .add_render_graph_node::<ClearIndirectParametersMetadataNode>(
+                Core3d,
+                NodePbr::ClearIndirectParametersMetadata
+            )
             .add_render_graph_node::<EarlyGpuPreprocessNode>(Core3d, NodePbr::EarlyGpuPreprocess)
             .add_render_graph_node::<LateGpuPreprocessNode>(Core3d, NodePbr::LateGpuPreprocess)
             .add_render_graph_node::<EarlyPrepassBuildIndirectParametersNode>(
@@ -511,6 +523,7 @@ impl Plugin for GpuMeshPreprocessPlugin {
             .add_render_graph_edges(
                 Core3d,
                 (
+                    NodePbr::ClearIndirectParametersMetadata,
                     NodePbr::EarlyGpuPreprocess,
                     NodePbr::EarlyPrepassBuildIndirectParameters,
                     Node3d::EarlyPrepass,
@@ -530,6 +543,53 @@ impl Plugin for GpuMeshPreprocessPlugin {
                 NodePbr::MainBuildIndirectParameters,
                 Node3d::DeferredPrepass,
             );
+    }
+}
+
+impl Node for ClearIndirectParametersMetadataNode {
+    fn run<'w>(
+        &self,
+        _: &mut RenderGraphContext,
+        render_context: &mut RenderContext<'w>,
+        world: &'w World,
+    ) -> Result<(), NodeRunError> {
+        let Some(indirect_parameters_buffers) = world.get_resource::<IndirectParametersBuffers>()
+        else {
+            return Ok(());
+        };
+
+        // Clear out each indexed and non-indexed GPU-side buffer.
+        for phase_indirect_parameters_buffers in indirect_parameters_buffers.values() {
+            if let Some(indexed_gpu_metadata_buffer) = phase_indirect_parameters_buffers
+                .indexed
+                .gpu_metadata_buffer()
+            {
+                render_context.command_encoder().clear_buffer(
+                    indexed_gpu_metadata_buffer,
+                    0,
+                    Some(
+                        phase_indirect_parameters_buffers.indexed.batch_count() as u64
+                            * size_of::<IndirectParametersGpuMetadata>() as u64,
+                    ),
+                );
+            }
+
+            if let Some(non_indexed_gpu_metadata_buffer) = phase_indirect_parameters_buffers
+                .non_indexed
+                .gpu_metadata_buffer()
+            {
+                render_context.command_encoder().clear_buffer(
+                    non_indexed_gpu_metadata_buffer,
+                    0,
+                    Some(
+                        phase_indirect_parameters_buffers.non_indexed.batch_count() as u64
+                            * size_of::<IndirectParametersGpuMetadata>() as u64,
+                    ),
+                );
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -1085,7 +1145,8 @@ fn run_build_indirect_parameters_node(
             compute_pass.set_pipeline(build_indexed_indirect_params_pipeline);
             compute_pass.set_bind_group(0, build_indirect_indexed_params_bind_group, &[]);
             let workgroup_count = phase_indirect_parameters_buffers
-                .indexed_batch_count()
+                .indexed
+                .batch_count()
                 .div_ceil(WORKGROUP_SIZE);
             if workgroup_count > 0 {
                 compute_pass.dispatch_workgroups(workgroup_count as u32, 1, 1);
@@ -1112,7 +1173,8 @@ fn run_build_indirect_parameters_node(
             compute_pass.set_pipeline(build_non_indexed_indirect_params_pipeline);
             compute_pass.set_bind_group(0, build_indirect_non_indexed_params_bind_group, &[]);
             let workgroup_count = phase_indirect_parameters_buffers
-                .non_indexed_batch_count()
+                .non_indexed
+                .batch_count()
                 .div_ceil(WORKGROUP_SIZE);
             if workgroup_count > 0 {
                 compute_pass.dispatch_workgroups(workgroup_count as u32, 1, 1);
@@ -1366,7 +1428,7 @@ fn preprocess_direct_bind_group_layout_entries() -> DynamicBindGroupLayoutEntrie
     )
 }
 
-// Returns the first 3 bind group layout entries shared between all invocations
+// Returns the first 4 bind group layout entries shared between all invocations
 // of the indirect parameters building shader.
 fn build_indirect_params_bind_group_layout_entries() -> DynamicBindGroupLayoutEntries {
     DynamicBindGroupLayoutEntries::new_with_indices(
@@ -1375,9 +1437,13 @@ fn build_indirect_params_bind_group_layout_entries() -> DynamicBindGroupLayoutEn
             (0, storage_buffer_read_only::<MeshInputUniform>(false)),
             (
                 1,
-                storage_buffer_read_only::<IndirectParametersMetadata>(false),
+                storage_buffer_read_only::<IndirectParametersCpuMetadata>(false),
             ),
-            (2, storage_buffer::<IndirectBatchSet>(false)),
+            (
+                2,
+                storage_buffer_read_only::<IndirectParametersGpuMetadata>(false),
+            ),
+            (3, storage_buffer::<IndirectBatchSet>(false)),
         ),
     )
 }
@@ -1388,14 +1454,21 @@ fn gpu_culling_bind_group_layout_entries() -> DynamicBindGroupLayoutEntries {
     // GPU culling bind group parameters are a superset of those in the CPU
     // culling (direct) shader.
     preprocess_direct_bind_group_layout_entries().extend_with_indices((
-        // `indirect_parameters`
+        // `indirect_parameters_cpu_metadata`
         (
             7,
-            storage_buffer::<IndirectParametersMetadata>(/* has_dynamic_offset= */ false),
+            storage_buffer_read_only::<IndirectParametersCpuMetadata>(
+                /* has_dynamic_offset= */ false,
+            ),
+        ),
+        // `indirect_parameters_gpu_metadata`
+        (
+            8,
+            storage_buffer::<IndirectParametersGpuMetadata>(/* has_dynamic_offset= */ false),
         ),
         // `mesh_culling_data`
         (
-            8,
+            9,
             storage_buffer_read_only::<MeshCullingData>(/* has_dynamic_offset= */ false),
         ),
         // `view`
@@ -1935,13 +2008,18 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
 
         match (
             self.phase_indirect_parameters_buffers
-                .indexed_metadata_buffer(),
+                .indexed
+                .cpu_metadata_buffer(),
+            self.phase_indirect_parameters_buffers
+                .indexed
+                .gpu_metadata_buffer(),
             indexed_work_item_buffer.buffer(),
             late_indexed_work_item_buffer.buffer(),
             self.late_indexed_indirect_parameters_buffer.buffer(),
         ) {
             (
-                Some(indexed_metadata_buffer),
+                Some(indexed_cpu_metadata_buffer),
+                Some(indexed_gpu_metadata_buffer),
                 Some(indexed_work_item_gpu_buffer),
                 Some(late_indexed_work_item_gpu_buffer),
                 Some(late_indexed_indirect_parameters_buffer),
@@ -1974,8 +2052,9 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                                 }),
                             ),
                             (6, self.data_buffer.as_entire_binding()),
-                            (7, indexed_metadata_buffer.as_entire_binding()),
-                            (8, mesh_culling_data_buffer.as_entire_binding()),
+                            (7, indexed_cpu_metadata_buffer.as_entire_binding()),
+                            (8, indexed_gpu_metadata_buffer.as_entire_binding()),
+                            (9, mesh_culling_data_buffer.as_entire_binding()),
                             (0, view_uniforms_binding.clone()),
                             (10, &view_depth_pyramid.all_mips),
                             (
@@ -2027,13 +2106,18 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
 
         match (
             self.phase_indirect_parameters_buffers
-                .non_indexed_metadata_buffer(),
+                .non_indexed
+                .cpu_metadata_buffer(),
+            self.phase_indirect_parameters_buffers
+                .non_indexed
+                .gpu_metadata_buffer(),
             non_indexed_work_item_buffer.buffer(),
             late_non_indexed_work_item_buffer.buffer(),
             self.late_non_indexed_indirect_parameters_buffer.buffer(),
         ) {
             (
-                Some(non_indexed_metadata_buffer),
+                Some(non_indexed_cpu_metadata_buffer),
+                Some(non_indexed_gpu_metadata_buffer),
                 Some(non_indexed_work_item_gpu_buffer),
                 Some(late_non_indexed_work_item_buffer),
                 Some(late_non_indexed_indirect_parameters_buffer),
@@ -2066,8 +2150,9 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                                 }),
                             ),
                             (6, self.data_buffer.as_entire_binding()),
-                            (7, non_indexed_metadata_buffer.as_entire_binding()),
-                            (8, mesh_culling_data_buffer.as_entire_binding()),
+                            (7, non_indexed_cpu_metadata_buffer.as_entire_binding()),
+                            (8, non_indexed_gpu_metadata_buffer.as_entire_binding()),
+                            (9, mesh_culling_data_buffer.as_entire_binding()),
                             (0, view_uniforms_binding.clone()),
                             (10, &view_depth_pyramid.all_mips),
                             (
@@ -2118,12 +2203,17 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
 
         match (
             self.phase_indirect_parameters_buffers
-                .indexed_metadata_buffer(),
+                .indexed
+                .cpu_metadata_buffer(),
+            self.phase_indirect_parameters_buffers
+                .indexed
+                .gpu_metadata_buffer(),
             late_indexed_work_item_buffer.buffer(),
             self.late_indexed_indirect_parameters_buffer.buffer(),
         ) {
             (
-                Some(indexed_metadata_buffer),
+                Some(indexed_cpu_metadata_buffer),
+                Some(indexed_gpu_metadata_buffer),
                 Some(late_indexed_work_item_gpu_buffer),
                 Some(late_indexed_indirect_parameters_buffer),
             ) => {
@@ -2155,8 +2245,9 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                                 }),
                             ),
                             (6, self.data_buffer.as_entire_binding()),
-                            (7, indexed_metadata_buffer.as_entire_binding()),
-                            (8, mesh_culling_data_buffer.as_entire_binding()),
+                            (7, indexed_cpu_metadata_buffer.as_entire_binding()),
+                            (8, indexed_gpu_metadata_buffer.as_entire_binding()),
+                            (9, mesh_culling_data_buffer.as_entire_binding()),
                             (0, view_uniforms_binding.clone()),
                             (10, &view_depth_pyramid.all_mips),
                             (
@@ -2199,12 +2290,17 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
 
         match (
             self.phase_indirect_parameters_buffers
-                .non_indexed_metadata_buffer(),
+                .non_indexed
+                .cpu_metadata_buffer(),
+            self.phase_indirect_parameters_buffers
+                .non_indexed
+                .gpu_metadata_buffer(),
             late_non_indexed_work_item_buffer.buffer(),
             self.late_non_indexed_indirect_parameters_buffer.buffer(),
         ) {
             (
-                Some(non_indexed_metadata_buffer),
+                Some(non_indexed_cpu_metadata_buffer),
+                Some(non_indexed_gpu_metadata_buffer),
                 Some(non_indexed_work_item_gpu_buffer),
                 Some(late_non_indexed_indirect_parameters_buffer),
             ) => {
@@ -2236,8 +2332,9 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                                 }),
                             ),
                             (6, self.data_buffer.as_entire_binding()),
-                            (7, non_indexed_metadata_buffer.as_entire_binding()),
-                            (8, mesh_culling_data_buffer.as_entire_binding()),
+                            (7, non_indexed_cpu_metadata_buffer.as_entire_binding()),
+                            (8, non_indexed_gpu_metadata_buffer.as_entire_binding()),
+                            (9, mesh_culling_data_buffer.as_entire_binding()),
                             (0, view_uniforms_binding.clone()),
                             (10, &view_depth_pyramid.all_mips),
                             (
@@ -2293,10 +2390,18 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
 
         match (
             self.phase_indirect_parameters_buffers
-                .indexed_metadata_buffer(),
+                .indexed
+                .cpu_metadata_buffer(),
+            self.phase_indirect_parameters_buffers
+                .indexed
+                .gpu_metadata_buffer(),
             indexed_work_item_buffer.buffer(),
         ) {
-            (Some(indexed_metadata_buffer), Some(indexed_work_item_gpu_buffer)) => {
+            (
+                Some(indexed_cpu_metadata_buffer),
+                Some(indexed_gpu_metadata_buffer),
+                Some(indexed_work_item_gpu_buffer),
+            ) => {
                 // Don't use `as_entire_binding()` here; the shader reads the array
                 // length and the underlying buffer may be longer than the actual size
                 // of the vector.
@@ -2325,8 +2430,9 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                                 }),
                             ),
                             (6, self.data_buffer.as_entire_binding()),
-                            (7, indexed_metadata_buffer.as_entire_binding()),
-                            (8, mesh_culling_data_buffer.as_entire_binding()),
+                            (7, indexed_cpu_metadata_buffer.as_entire_binding()),
+                            (8, indexed_gpu_metadata_buffer.as_entire_binding()),
+                            (9, mesh_culling_data_buffer.as_entire_binding()),
                             (0, view_uniforms_binding.clone()),
                         )),
                     ),
@@ -2347,10 +2453,18 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
 
         match (
             self.phase_indirect_parameters_buffers
-                .non_indexed_metadata_buffer(),
+                .non_indexed
+                .cpu_metadata_buffer(),
+            self.phase_indirect_parameters_buffers
+                .non_indexed
+                .gpu_metadata_buffer(),
             non_indexed_work_item_buffer.buffer(),
         ) {
-            (Some(non_indexed_metadata_buffer), Some(non_indexed_work_item_gpu_buffer)) => {
+            (
+                Some(non_indexed_cpu_metadata_buffer),
+                Some(non_indexed_gpu_metadata_buffer),
+                Some(non_indexed_work_item_gpu_buffer),
+            ) => {
                 // Don't use `as_entire_binding()` here; the shader reads the array
                 // length and the underlying buffer may be longer than the actual size
                 // of the vector.
@@ -2379,8 +2493,9 @@ impl<'a> PreprocessBindGroupBuilder<'a> {
                                 }),
                             ),
                             (6, self.data_buffer.as_entire_binding()),
-                            (7, non_indexed_metadata_buffer.as_entire_binding()),
-                            (8, mesh_culling_data_buffer.as_entire_binding()),
+                            (7, non_indexed_cpu_metadata_buffer.as_entire_binding()),
+                            (8, non_indexed_gpu_metadata_buffer.as_entire_binding()),
+                            (9, mesh_culling_data_buffer.as_entire_binding()),
                             (0, view_uniforms_binding.clone()),
                         )),
                     ),
@@ -2407,9 +2522,10 @@ fn create_build_indirect_parameters_bind_groups(
         build_indirect_parameters_bind_groups.insert(
             *phase_type_id,
             PhaseBuildIndirectParametersBindGroups {
-                reset_indexed_indirect_batch_sets: match (
-                    phase_indirect_parameters_buffer.indexed_batch_sets_buffer(),
-                ) {
+                reset_indexed_indirect_batch_sets: match (phase_indirect_parameters_buffer
+                    .indexed
+                    .batch_sets_buffer(),)
+                {
                     (Some(indexed_batch_sets_buffer),) => Some(
                         render_device.create_bind_group(
                             "reset_indexed_indirect_batch_sets_bind_group",
@@ -2427,9 +2543,10 @@ fn create_build_indirect_parameters_bind_groups(
                     _ => None,
                 },
 
-                reset_non_indexed_indirect_batch_sets: match (
-                    phase_indirect_parameters_buffer.non_indexed_batch_sets_buffer(),
-                ) {
+                reset_non_indexed_indirect_batch_sets: match (phase_indirect_parameters_buffer
+                    .non_indexed
+                    .batch_sets_buffer(),)
+                {
                     (Some(non_indexed_batch_sets_buffer),) => Some(
                         render_device.create_bind_group(
                             "reset_non_indexed_indirect_batch_sets_bind_group",
@@ -2448,12 +2565,18 @@ fn create_build_indirect_parameters_bind_groups(
                 },
 
                 build_indexed_indirect: match (
-                    phase_indirect_parameters_buffer.indexed_metadata_buffer(),
-                    phase_indirect_parameters_buffer.indexed_data_buffer(),
-                    phase_indirect_parameters_buffer.indexed_batch_sets_buffer(),
+                    phase_indirect_parameters_buffer
+                        .indexed
+                        .cpu_metadata_buffer(),
+                    phase_indirect_parameters_buffer
+                        .indexed
+                        .gpu_metadata_buffer(),
+                    phase_indirect_parameters_buffer.indexed.data_buffer(),
+                    phase_indirect_parameters_buffer.indexed.batch_sets_buffer(),
                 ) {
                     (
-                        Some(indexed_indirect_parameters_metadata_buffer),
+                        Some(indexed_indirect_parameters_cpu_metadata_buffer),
+                        Some(indexed_indirect_parameters_gpu_metadata_buffer),
                         Some(indexed_indirect_parameters_data_buffer),
                         Some(indexed_batch_sets_buffer),
                     ) => Some(
@@ -2469,12 +2592,21 @@ fn create_build_indirect_parameters_bind_groups(
                                 // Don't use `as_entire_binding` here; the shader reads
                                 // the length and `RawBufferVec` overallocates.
                                 BufferBinding {
-                                    buffer: indexed_indirect_parameters_metadata_buffer,
+                                    buffer: indexed_indirect_parameters_cpu_metadata_buffer,
                                     offset: 0,
                                     size: NonZeroU64::new(
-                                        phase_indirect_parameters_buffer.indexed_batch_count()
+                                        phase_indirect_parameters_buffer.indexed.batch_count()
                                             as u64
-                                            * size_of::<IndirectParametersMetadata>() as u64,
+                                            * size_of::<IndirectParametersCpuMetadata>() as u64,
+                                    ),
+                                },
+                                BufferBinding {
+                                    buffer: indexed_indirect_parameters_gpu_metadata_buffer,
+                                    offset: 0,
+                                    size: NonZeroU64::new(
+                                        phase_indirect_parameters_buffer.indexed.batch_count()
+                                            as u64
+                                            * size_of::<IndirectParametersGpuMetadata>() as u64,
                                     ),
                                 },
                                 indexed_batch_sets_buffer.as_entire_binding(),
@@ -2486,12 +2618,20 @@ fn create_build_indirect_parameters_bind_groups(
                 },
 
                 build_non_indexed_indirect: match (
-                    phase_indirect_parameters_buffer.non_indexed_metadata_buffer(),
-                    phase_indirect_parameters_buffer.non_indexed_data_buffer(),
-                    phase_indirect_parameters_buffer.non_indexed_batch_sets_buffer(),
+                    phase_indirect_parameters_buffer
+                        .non_indexed
+                        .cpu_metadata_buffer(),
+                    phase_indirect_parameters_buffer
+                        .non_indexed
+                        .gpu_metadata_buffer(),
+                    phase_indirect_parameters_buffer.non_indexed.data_buffer(),
+                    phase_indirect_parameters_buffer
+                        .non_indexed
+                        .batch_sets_buffer(),
                 ) {
                     (
-                        Some(non_indexed_indirect_parameters_metadata_buffer),
+                        Some(non_indexed_indirect_parameters_cpu_metadata_buffer),
+                        Some(non_indexed_indirect_parameters_gpu_metadata_buffer),
                         Some(non_indexed_indirect_parameters_data_buffer),
                         Some(non_indexed_batch_sets_buffer),
                     ) => Some(
@@ -2507,12 +2647,21 @@ fn create_build_indirect_parameters_bind_groups(
                                 // Don't use `as_entire_binding` here; the shader reads
                                 // the length and `RawBufferVec` overallocates.
                                 BufferBinding {
-                                    buffer: non_indexed_indirect_parameters_metadata_buffer,
+                                    buffer: non_indexed_indirect_parameters_cpu_metadata_buffer,
                                     offset: 0,
                                     size: NonZeroU64::new(
-                                        phase_indirect_parameters_buffer.non_indexed_batch_count()
+                                        phase_indirect_parameters_buffer.non_indexed.batch_count()
                                             as u64
-                                            * size_of::<IndirectParametersMetadata>() as u64,
+                                            * size_of::<IndirectParametersCpuMetadata>() as u64,
+                                    ),
+                                },
+                                BufferBinding {
+                                    buffer: non_indexed_indirect_parameters_gpu_metadata_buffer,
+                                    offset: 0,
+                                    size: NonZeroU64::new(
+                                        phase_indirect_parameters_buffer.non_indexed.batch_count()
+                                            as u64
+                                            * size_of::<IndirectParametersGpuMetadata>() as u64,
                                     ),
                                 },
                                 non_indexed_batch_sets_buffer.as_entire_binding(),

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -14,7 +14,9 @@
 // are known as *early mesh preprocessing* and *late mesh preprocessing*
 // respectively.
 
-#import bevy_pbr::mesh_preprocess_types::{IndirectParametersMetadata, MeshInput}
+#import bevy_pbr::mesh_preprocess_types::{
+    IndirectParametersCpuMetadata, IndirectParametersGpuMetadata, MeshInput
+}
 #import bevy_pbr::mesh_types::{Mesh, MESH_FLAGS_NO_FRUSTUM_CULLING_BIT}
 #import bevy_pbr::mesh_view_bindings::view
 #import bevy_pbr::occlusion_culling
@@ -90,15 +92,18 @@ struct PushConstants {
 
 #ifdef INDIRECT
 // The array of indirect parameters for drawcalls.
-@group(0) @binding(7) var<storage, read_write> indirect_parameters_metadata:
-    array<IndirectParametersMetadata>;
+@group(0) @binding(7) var<storage> indirect_parameters_cpu_metadata:
+    array<IndirectParametersCpuMetadata>;
+
+@group(0) @binding(8) var<storage, read_write> indirect_parameters_gpu_metadata:
+    array<IndirectParametersGpuMetadata>;
 #endif
 
 #ifdef FRUSTUM_CULLING
 // Data needed to cull the meshes.
 //
 // At the moment, this consists only of AABBs.
-@group(0) @binding(8) var<storage> mesh_culling_data: array<MeshCullingData>;
+@group(0) @binding(9) var<storage> mesh_culling_data: array<MeshCullingData>;
 #endif  // FRUSTUM_CULLING
 
 #ifdef OCCLUSION_CULLING
@@ -172,6 +177,16 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     let input_index = work_items[instance_index].input_index;
 #ifdef INDIRECT
     let indirect_parameters_index = work_items[instance_index].output_or_indirect_parameters_index;
+
+    // If we're the first mesh instance in this batch, write the index of our
+    // `MeshInput` into the appropriate slot so that the indirect parameters
+    // building shader can access it.
+#ifndef LATE_PHASE
+    if (instance_index == 0u || work_items[instance_index - 1].output_or_indirect_parameters_index != indirect_parameters_index) {
+        indirect_parameters_gpu_metadata[indirect_parameters_index].mesh_index = input_index;
+    }
+#endif  // LATE_PHASE
+
 #else   // INDIRECT
     let mesh_output_index = work_items[instance_index].output_or_indirect_parameters_index;
 #endif  // INDIRECT
@@ -315,18 +330,21 @@ fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
     // parameters. Otherwise, this index was directly supplied to us.
 #ifdef INDIRECT
 #ifdef LATE_PHASE
-    let batch_output_index =
-        atomicLoad(&indirect_parameters_metadata[indirect_parameters_index].early_instance_count) +
-        atomicAdd(&indirect_parameters_metadata[indirect_parameters_index].late_instance_count, 1u);
+    let batch_output_index = atomicLoad(
+        &indirect_parameters_gpu_metadata[indirect_parameters_index].early_instance_count
+    ) + atomicAdd(
+        &indirect_parameters_gpu_metadata[indirect_parameters_index].late_instance_count,
+        1u
+    );
 #else   // LATE_PHASE
     let batch_output_index = atomicAdd(
-        &indirect_parameters_metadata[indirect_parameters_index].early_instance_count,
+        &indirect_parameters_gpu_metadata[indirect_parameters_index].early_instance_count,
         1u
     );
 #endif  // LATE_PHASE
 
     let mesh_output_index =
-        indirect_parameters_metadata[indirect_parameters_index].base_output_index +
+        indirect_parameters_cpu_metadata[indirect_parameters_index].base_output_index +
         batch_output_index;
 
 #endif  // INDIRECT

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -624,10 +624,10 @@ pub struct PreprocessWorkItem {
     pub input_index: u32,
 
     /// In direct mode, the index of the mesh uniform; in indirect mode, the
-    /// index of the [`IndirectParametersMetadata`].
+    /// index of the [`IndirectParametersGpuMetadata`].
     ///
     /// In indirect mode, this is the index of the
-    /// [`IndirectParametersMetadata`] in the
+    /// [`IndirectParametersGpuMetadata`] in the
     /// `IndirectParametersBuffers::indexed_metadata` or
     /// `IndirectParametersBuffers::non_indexed_metadata`.
     pub output_or_indirect_parameters_index: u32,
@@ -690,8 +690,8 @@ pub struct IndirectParametersCpuMetadata {
     ///
     /// A *batch set* is a set of meshes that may be multi-drawn together.
     /// Multiple batches (and therefore multiple instances of
-    /// [`IndirectParametersMetadata`] structures) can be part of the same batch
-    /// set.
+    /// [`IndirectParametersGpuMetadata`] structures) can be part of the same
+    /// batch set.
     pub batch_set_index: u32,
 }
 
@@ -761,7 +761,7 @@ pub struct IndirectBatchSet {
 /// (`multi_draw_indirect`, `multi_draw_indirect_count`) use to draw the scene.
 ///
 /// In addition to the indirect draw buffers themselves, this structure contains
-/// the buffers that store [`IndirectParametersMetadata`], which are the
+/// the buffers that store [`IndirectParametersGpuMetadata`], which are the
 /// structures that culling writes to so that the indirect parameter building
 /// pass can determine how many meshes are actually to be drawn.
 ///

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -9,8 +9,8 @@ use nonmax::NonMaxU32;
 
 use crate::{
     render_phase::{
-        BinnedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, InputUniformIndex,
-        PhaseItemExtraIndex, SortedPhaseItem, SortedRenderPhase, ViewBinnedRenderPhases,
+        BinnedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItemExtraIndex,
+        SortedPhaseItem, SortedRenderPhase, ViewBinnedRenderPhases,
     },
     render_resource::{CachedRenderPipelineId, GpuArrayBufferable},
     sync_world::MainEntity,
@@ -154,9 +154,6 @@ pub trait GetFullBatchData: GetBatchData {
     /// This is only used if GPU culling is enabled (which requires GPU
     /// preprocessing).
     ///
-    /// * `mesh_index` describes the index of the first mesh instance in this
-    ///   batch in the `MeshInputUniform` buffer.
-    ///
     /// * `indexed` is true if the mesh is indexed or false if it's non-indexed.
     ///
     /// * `base_output_index` is the index of the first mesh instance in this
@@ -172,7 +169,6 @@ pub trait GetFullBatchData: GetBatchData {
     /// * `indirect_parameters_offset` is the index in that buffer at which to
     ///   write the metadata.
     fn write_batch_indirect_parameters_metadata(
-        mesh_index: InputUniformIndex,
         indexed: bool,
         base_output_index: u32,
         batch_set_index: Option<NonMaxU32>,

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -148,8 +148,9 @@ pub trait GetFullBatchData: GetBatchData {
         query_item: MainEntity,
     ) -> Option<NonMaxU32>;
 
-    /// Writes the [`gpu_preprocessing::IndirectParametersMetadata`] necessary
-    /// to draw this batch into the given metadata buffer at the given index.
+    /// Writes the [`gpu_preprocessing::IndirectParametersGpuMetadata`]
+    /// necessary to draw this batch into the given metadata buffer at the given
+    /// index.
     ///
     /// This is only used if GPU culling is enabled (which requires GPU
     /// preprocessing).

--- a/crates/bevy_render/src/experimental/occlusion_culling/mesh_preprocess_types.wgsl
+++ b/crates/bevy_render/src/experimental/occlusion_culling/mesh_preprocess_types.wgsl
@@ -47,17 +47,20 @@ struct IndirectParametersNonIndexed {
     first_instance: u32,
 }
 
-struct IndirectParametersMetadata {
-    mesh_index: u32,
+struct IndirectParametersCpuMetadata {
     base_output_index: u32,
     batch_set_index: u32,
+}
+
+struct IndirectParametersGpuMetadata {
+    mesh_index: u32,
 #ifdef WRITE_INDIRECT_PARAMETERS_METADATA
     early_instance_count: atomic<u32>,
     late_instance_count: atomic<u32>,
-#else
+#else   // WRITE_INDIRECT_PARAMETERS_METADATA
     early_instance_count: u32,
     late_instance_count: u32,
-#endif
+#endif  // WRITE_INDIRECT_PARAMETERS_METADATA
 }
 
 struct IndirectBatchSet {

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -451,8 +451,14 @@ where
 
     /// Reserves space for one more element in the buffer and returns its index.
     pub fn add(&mut self) -> usize {
+        self.add_multiple(1)
+    }
+
+    /// Reserves space for the given number of elements in the buffer and
+    /// returns the index of the first one.
+    pub fn add_multiple(&mut self, count: usize) -> usize {
         let index = self.len;
-        self.len += 1;
+        self.len += count;
         index
     }
 

--- a/examples/3d/occlusion_culling.rs
+++ b/examples/3d/occlusion_culling.rs
@@ -450,8 +450,10 @@ impl render_graph::Node for ReadbackIndirectParametersNode {
             Some(indirect_parameters_staging_data_buffer),
             Some(indirect_parameters_staging_batch_sets_buffer),
         ) = (
-            phase_indirect_parameters_buffers.indexed_data_buffer(),
-            phase_indirect_parameters_buffers.indexed_batch_sets_buffer(),
+            phase_indirect_parameters_buffers.indexed.data_buffer(),
+            phase_indirect_parameters_buffers
+                .indexed
+                .batch_sets_buffer(),
             indirect_parameters_mapping_buffers.data.as_ref(),
             indirect_parameters_mapping_buffers.batch_sets.as_ref(),
         )
@@ -501,8 +503,10 @@ fn create_indirect_parameters_staging_buffers(
 
     // Fetch the indirect parameters buffers that we're going to copy from.
     let (Some(indexed_data_buffer), Some(indexed_batch_set_buffer)) = (
-        phase_indirect_parameters_buffers.indexed_data_buffer(),
-        phase_indirect_parameters_buffers.indexed_batch_sets_buffer(),
+        phase_indirect_parameters_buffers.indexed.data_buffer(),
+        phase_indirect_parameters_buffers
+            .indexed
+            .batch_sets_buffer(),
     ) else {
         return;
     };

--- a/examples/shader/custom_render_phase.rs
+++ b/examples/shader/custom_render_phase.rs
@@ -28,7 +28,7 @@ use bevy::{
     render::{
         batching::{
             gpu_preprocessing::{
-                batch_and_prepare_sorted_render_phase, IndirectParametersMetadata,
+                batch_and_prepare_sorted_render_phase, IndirectParametersCpuMetadata,
                 UntypedPhaseIndirectParametersBuffers,
             },
             GetBatchData, GetFullBatchData,
@@ -42,8 +42,8 @@ use bevy::{
         },
         render_phase::{
             sort_phase_system, AddRenderCommand, CachedRenderPipelinePhaseItem, DrawFunctionId,
-            DrawFunctions, InputUniformIndex, PhaseItem, PhaseItemExtraIndex, SetItemPipeline,
-            SortedPhaseItem, ViewSortedRenderPhases,
+            DrawFunctions, PhaseItem, PhaseItemExtraIndex, SetItemPipeline, SortedPhaseItem,
+            ViewSortedRenderPhases,
         },
         render_resource::{
             CachedRenderPipelineId, ColorTargetState, ColorWrites, Face, FragmentState, FrontFace,
@@ -432,7 +432,6 @@ impl GetFullBatchData for StencilPipeline {
     }
 
     fn write_batch_indirect_parameters_metadata(
-        mesh_index: InputUniformIndex,
         indexed: bool,
         base_output_index: u32,
         batch_set_index: Option<NonMaxU32>,
@@ -442,23 +441,22 @@ impl GetFullBatchData for StencilPipeline {
         // Note that `IndirectParameters` covers both of these structures, even
         // though they actually have distinct layouts. See the comment above that
         // type for more information.
-        let indirect_parameters = IndirectParametersMetadata {
-            mesh_index: *mesh_index,
+        let indirect_parameters = IndirectParametersCpuMetadata {
             base_output_index,
             batch_set_index: match batch_set_index {
                 None => !0,
                 Some(batch_set_index) => u32::from(batch_set_index),
             },
-            early_instance_count: 0,
-            late_instance_count: 0,
         };
 
         if indexed {
             indirect_parameters_buffers
-                .set_indexed(indirect_parameters_offset, indirect_parameters);
+                .indexed
+                .set(indirect_parameters_offset, indirect_parameters);
         } else {
             indirect_parameters_buffers
-                .set_non_indexed(indirect_parameters_offset, indirect_parameters);
+                .non_indexed
+                .set(indirect_parameters_offset, indirect_parameters);
         }
     }
 


### PR DESCRIPTION
The GPU can fill out many of the fields in `IndirectParametersMetadata` using information it already has:

* `early_instance_count` and `late_instance_count` are always initialized to zero.

* `mesh_index` is already present in the work item buffer as the `input_index` of the first work item in each batch.

This patch moves these fields to a separate buffer, the *GPU indirect parameters metadata* buffer. That way, it avoids having to write them on CPU during `batch_and_prepare_binned_render_phase`. This effectively reduces the number of bits that that function must write per mesh from 160 to 64 (in addition to the 64 bits per mesh *instance*).

Additionally, this PR refactors `UntypedPhaseIndirectParametersBuffers` to add another layer, `MeshClassIndirectParametersBuffers`, which allows abstracting over the buffers corresponding indexed and non-indexed meshes. This patch doesn't make much use of this abstraction, but forthcoming patches will, and it's overall a cleaner approach.

This didn't seem to have much of an effect by itself on `batch_and_prepare_binned_render_phase` time, but subsequent PRs dependent on this PR yield roughly a 2× speedup.