### PR TITLE
Bump Rust tracy client version

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -30,8 +30,8 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 
 # Tracy dependency compatibility table:
 # https://github.com/nagisa/rust_tracy_client
-tracing-tracy = { version = "0.11.0", optional = true }
-tracy-client = { version = "0.17.0", optional = true }
+tracing-tracy = { version = "0.11.4", optional = true }
+tracy-client = { version = "0.18.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.3.0"


### PR DESCRIPTION
# Objective

- Fix the tracy debugger working with the latest version of bevy.
- Broken experience for users of the latest version of the tracy profiler.

![image](https://github.com/user-attachments/assets/03a5937f-0bcb-438b-95dc-c904f76eb203)


## Solution

- Bump the dependencies of tracy and recompile , works well with the latest tracy version. 
- Used the matrix available at https://github.com/nagisa/rust_tracy_client

## Testing

- Tested changes using the tracy GUI client and running a few examples with `--features "trace_tracy"`

---

## Showcase

Screenshot shows tracy profiler v0.11.1

<img width="1651" alt="Screenshot 2025-02-14 at 6 57 10 PM" src="https://github.com/user-attachments/assets/835575a6-db44-4abb-ac68-18a23e937c19" />
