### PR TITLE
Disable sprite picking in bevymark

### DIFF
--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -14,7 +14,7 @@ use bevy::{
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat},
     },
-    sprite::AlphaMode2d,
+    sprite::{AlphaMode2d, SpritePlugin},
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
@@ -132,16 +132,18 @@ fn main() {
 
     App::new()
         .add_plugins((
-            DefaultPlugins.set(WindowPlugin {
-                primary_window: Some(Window {
-                    title: "BevyMark".into(),
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
-                    present_mode: PresentMode::AutoNoVsync,
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "BevyMark".into(),
+                        resolution: WindowResolution::new(1920.0, 1080.0)
+                            .with_scale_factor_override(1.0),
+                        present_mode: PresentMode::AutoNoVsync,
+                        ..default()
+                    }),
                     ..default()
-                }),
-                ..default()
-            }),
+                })
+                .set(SpritePlugin { add_picking: false }),
             FrameTimeDiagnosticsPlugin::default(),
             LogDiagnosticsPlugin::default(),
         ))


### PR DESCRIPTION
# Objective

- Don't waste CPU cycles in a benchmark

## Solution

- Don't add the picking plugin

## Testing

- Tracy
