### PR TITLE
Auto sync point before exclusive system despite `*_ignore_deferred`

### DIFF
--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -89,10 +89,10 @@ impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
 
             for target in dependency_flattened.neighbors_directed(*node, Direction::Outgoing) {
                 let target_system = graph.systems[target.index()].get().unwrap();
-                let add_sync_on_edge = add_sync_after
-                    && !is_apply_deferred(target_system)
-                    && (target_system.is_exclusive()
-                        || !self.no_sync_edges.contains(&(*node, target)));
+                let add_sync_on_edge = target_system.is_exclusive()
+                    || (add_sync_after
+                        && !is_apply_deferred(target_system)
+                        && !self.no_sync_edges.contains(&(*node, target)));
 
                 let weight = if add_sync_on_edge { 1 } else { 0 };
 

--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -88,9 +88,11 @@ impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
             let add_sync_after = graph.systems[node.index()].get().unwrap().has_deferred();
 
             for target in dependency_flattened.neighbors_directed(*node, Direction::Outgoing) {
+                let target_system = graph.systems[target.index()].get().unwrap();
                 let add_sync_on_edge = add_sync_after
-                    && !is_apply_deferred(graph.systems[target.index()].get().unwrap())
-                    && !self.no_sync_edges.contains(&(*node, target));
+                    && !is_apply_deferred(target_system)
+                    && (target_system.is_exclusive()
+                        || !self.no_sync_edges.contains(&(*node, target)));
 
                 let weight = if add_sync_on_edge { 1 } else { 0 };
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2167,13 +2167,14 @@ mod tests {
         schedule.add_systems(
             (
                 |mut commands: Commands| commands.insert_resource(Resource1),
+                || (),
                 |world: &mut World| assert!(world.contains_resource::<Resource1>()),
             )
                 .chain_ignore_deferred(),
         );
         schedule.run(&mut world);
 
-        assert_eq!(schedule.executable.systems.len(), 3);
+        assert_eq!(schedule.executable.systems.len(), 4);
     }
 
     mod no_sync_edges {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2177,6 +2177,30 @@ mod tests {
         assert_eq!(schedule.executable.systems.len(), 4);
     }
 
+    fn insert_resource(mut commands: Commands) {
+        commands.insert_resource(Resource1);
+    }
+
+    fn another_with_deferred(_: Commands) {}
+
+    fn contains_resource(world: &mut World) {
+        assert!(world.contains_resource::<Resource1>());
+    }
+
+    #[test]
+    fn merges_sync_points_before_exclusive_system() {
+        let mut schedule = Schedule::default();
+        let mut world = World::default();
+        schedule.add_systems((
+            insert_resource.before_ignore_deferred(contains_resource),
+            another_with_deferred.before_ignore_deferred(contains_resource),
+            contains_resource,
+        ));
+        schedule.run(&mut world);
+
+        assert_eq!(schedule.executable.systems.len(), 4);
+    }
+
     mod no_sync_edges {
         use super::*;
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2160,6 +2160,22 @@ mod tests {
         assert_eq!(schedule.executable.systems.len(), 2);
     }
 
+    #[test]
+    fn adds_sync_point_before_exclusive_system_despite_ignore_deferred() {
+        let mut schedule = Schedule::default();
+        let mut world = World::default();
+        schedule.add_systems(
+            (
+                |mut commands: Commands| commands.insert_resource(Resource1),
+                |world: &mut World| assert!(world.contains_resource::<Resource1>()),
+            )
+                .chain_ignore_deferred(),
+        );
+        schedule.run(&mut world);
+
+        assert_eq!(schedule.executable.systems.len(), 3);
+    }
+
     mod no_sync_edges {
         use super::*;
 
@@ -2215,7 +2231,6 @@ mod tests {
                     .configure_sets(Sets::A.after_ignore_deferred(insert_resource));
             });
         }
-
         #[test]
         fn set_to_system_before() {
             check_no_sync_edges(|schedule| {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2231,6 +2231,7 @@ mod tests {
                     .configure_sets(Sets::A.after_ignore_deferred(insert_resource));
             });
         }
+
         #[test]
         fn set_to_system_before() {
             check_no_sync_edges(|schedule| {


### PR DESCRIPTION
# Objective

Fixes #17828

Exclusive systems are expected to see the effects of all precedent commands. This was previously not made sure of by the scheduler. This showed especially with `*_ignore_deferred` configurations.

## Solution

Every edge that leads to an exclusive system will contain a sync point that are combined into one if needed.

There needs to be no extra sync point after the exclusive system because it can only queue commands in the global commands queue and that is flushed already in the [`ExclusiveFunctionSystem::run`](https://github.com/bevyengine/bevy/blob/3c9e696faa961ac01cec5933dcb4d16e653a5ecf/crates/bevy_ecs/src/system/exclusive_function_system.rs#L131) implementation.


## Testing

See the new unit tests. 
I did not add mirrored tests of those in the `no_sync_edges` and `no_sync_chain` modules below the new test because I think these are enough. Though I can add more if desired.

## Migration Guide

I am not sure if this needs any. The API did not change and I can think up no scenario where someone would rely on absent sync points before exclusive systems.