### PR TITLE
Fix `dds` feature enabling `bevy_gltf`

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -33,7 +33,7 @@ dds = [
   "bevy_image/dds",
   "bevy_render/dds",
   "bevy_core_pipeline/dds",
-  "bevy_gltf/dds",
+  "bevy_gltf?/dds",
 ]
 exr = ["bevy_image/exr", "bevy_render/exr"]
 hdr = ["bevy_image/hdr", "bevy_render/hdr"]


### PR DESCRIPTION
# Objective

Fixes #17022

## Solution

Only enable `bevy_gltf/dds` if `bevy_gltf` is already enabled.

## Testing

Tested with empty project

```toml
[dependencies]
bevy = { version = "0.16.0-dev", path = "../bevy", default-features = false, features = [
    "dds",
] }
```

### Before

```
 cargo tree --depth 1 -i bevy_gltf
bevy_gltf v0.16.0-dev (/Users/robparrett/src/bevy/crates/bevy_gltf)
└── bevy_internal v0.16.0-dev (/Users/robparrett/src/bevy/crates/bevy_internal)
```

### After

```
 cargo tree --depth 1 -i bevy_gltf
warning: nothing to print.

To find dependencies that require specific target platforms, try to use option `--target all` first, and then narrow your search scope accordingly.
```