### PR TITLE
Fix 1x1 dds textures being interpreted as 1-dimensional

### DIFF
--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -66,10 +66,13 @@ pub fn dds_buffer_to_image(
     image.texture_descriptor.format = texture_format;
     image.texture_descriptor.dimension = if dds.get_depth() > 1 {
         TextureDimension::D3
-    } else if image.is_compressed() || dds.get_height() > 1 {
-        TextureDimension::D2
-    } else {
+    } else if ((dds.get_width() > 1 || dds.get_height() > 1)
+        && !(dds.get_width() > 1 && dds.get_height() > 1))
+        && !image.is_compressed()
+    {
         TextureDimension::D1
+    } else {
+        TextureDimension::D2
     };
     if is_cubemap {
         let dimension = if image.texture_descriptor.size.depth_or_array_layers > 6 {

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -66,6 +66,7 @@ pub fn dds_buffer_to_image(
     image.texture_descriptor.format = texture_format;
     image.texture_descriptor.dimension = if dds.get_depth() > 1 {
         TextureDimension::D3
+    // 1x1 textures should generally be interpreted as solid 2D
     } else if ((dds.get_width() > 1 || dds.get_height() > 1)
         && !(dds.get_width() > 1 && dds.get_height() > 1))
         && !image.is_compressed()


### PR DESCRIPTION
# Objective

Fixes #8615

## Solution

Bevy currently interprets 1x1 dds textures as 1-dimensional. I think it might be more common for game engines to assume two dimensions in this ambiguous case. [citation needed]

I reworked the dimension choosing logic to only use 1d if there's a dimension > 1, and assume 2d otherwise. I kept the assumption that compressed textures are probably 2d.

## Testing

Modified `sprite.rs` to use `Tex_0012_0.dds` from the linked issue.
