### PR TITLE
Bump `typos` to 1.29.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.29.6
+        uses: crate-ci/typos@v1.29.7
       - name: Typos info
         if: failure()
         run: |

--- a/typos.toml
+++ b/typos.toml
@@ -13,7 +13,6 @@ LOD = "LOD"                             # Level of detail
 reparametrization = "reparametrization" # Mathematical term in curve context (reparameterize)
 reparametrize = "reparametrize"
 reparametrized = "reparametrized"
-implementors = "implementors"           # Can probably remove after next typos release. https://github.com/crate-ci/typos/issues/1226
 
 # Match a Whole Word - Case Sensitive
 [default.extend-identifiers]


### PR DESCRIPTION
# Objective

Alternative to #17894 that also cleans up the workaround from the previous version

## Solution

Bump version and remove entry from `typos` config
