### PR TITLE
Update smol_str requirement from 0.2 to 0.3

### DIFF
--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -86,7 +86,7 @@ serde = { version = "1", features = [
 ], default-features = false, optional = true }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-smol_str = { version = "0.2", default-features = false, optional = true }
+smol_str = { version = "0.3", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 
 [lints]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -108,7 +108,7 @@ glam = { version = "0.29", default-features = false, features = [
   "serde",
 ], optional = true }
 petgraph = { version = "0.6", features = ["serde-1"], optional = true }
-smol_str = { version = "0.2.0", default-features = false, features = [
+smol_str = { version = "0.3.2", default-features = false, features = [
   "serde",
 ], optional = true }
 uuid = { version = "1.13.1", default-features = false, optional = true, features = [

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -69,7 +69,7 @@ serde = { version = "1.0", features = [
 raw-window-handle = { version = "0.6", features = [
   "alloc",
 ], default-features = false }
-smol_str = { version = "0.2", default-features = false }
+smol_str = { version = "0.3", default-features = false }
 log = { version = "0.4", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
# Objective

- Closes #15113.

## Solution

Updates the requirements on [smol_str](https://github.com/rust-analyzer/smol_str) to permit the latest version.
- [Changelog](https://github.com/rust-analyzer/smol_str/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-analyzer/smol_str/compare/v0.2.0...v0.3.1)

## Testing

- Ran `cargo check` locally. Still blocked by `winit` as far as I can tell, but I wanted to have this properly rebased in anticipation.