### PR TITLE
Unrequire `VisibilityClass` from  `Node`

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -331,7 +331,6 @@ impl From<Vec2> for ScrollPosition {
     ScrollPosition,
     Transform,
     Visibility,
-    VisibilityClass,
     ZIndex
 )]
 #[reflect(Component, Default, PartialEq, Debug)]


### PR DESCRIPTION
# Objective

The UI doesn't use `ViewVisibility` so it doesn't do anything.

## Solution

Remove it.