### PR TITLE
`Node::transform` field

### DIFF
--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -448,6 +448,8 @@ impl RepeatedGridTrack {
 
 #[cfg(test)]
 mod tests {
+    use bevy_transform::components::Transform;
+
     use super::*;
 
     #[test]
@@ -522,6 +524,7 @@ mod tests {
             ],
             grid_column: GridPlacement::start(4),
             grid_row: GridPlacement::span(3),
+            transform: Transform::IDENTITY,
         };
         let viewport_values = LayoutContext::new(1.0, bevy_math::Vec2::new(800., 600.));
         let taffy_style = from_node(&node, &viewport_values, false);

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -288,9 +288,8 @@ with UI components as a child of an entity without UI components, your UI layout
                 .max(0.);
             }
 
-            if transform.translation.truncate() != node_center {
-                transform.translation = node_center.extend(0.);
-            }
+            transform
+                .set_if_neq(style.transform * Transform::from_translation(node_center.extend(0.)));
 
             let scroll_position: Vec2 = maybe_scroll_position
                 .map(|scroll_pos| {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -331,7 +331,6 @@ impl From<Vec2> for ScrollPosition {
     ScrollPosition,
     Transform,
     Visibility,
-    VisibilityClass,
     ZIndex
 )]
 #[reflect(Component, Default, PartialEq, Debug)]

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -7,7 +7,6 @@ use bevy_reflect::prelude::*;
 use bevy_render::{
     camera::{Camera, RenderTarget},
     view::Visibility,
-    view::VisibilityClass,
 };
 use bevy_sprite::BorderRect;
 use bevy_transform::components::Transform;

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -618,6 +618,9 @@ pub struct Node {
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column>
     pub grid_column: GridPlacement,
+
+    /// Rotate, scale, skew, or translate the node and its content.
+    pub transform: Transform,
 }
 
 impl Node {
@@ -661,6 +664,7 @@ impl Node {
         grid_auto_columns: Vec::new(),
         grid_column: GridPlacement::DEFAULT,
         grid_row: GridPlacement::DEFAULT,
+        transform: Transform::IDENTITY,
     };
 }
 


### PR DESCRIPTION
# Objective

Animating UI elements by modifying the Transform component of UI nodes doesn't work very well because ui_layout_system overwrites the translations each frame. The overflow_debug example uses a horrible hack where it copies the transform into the position that'll likely cause a panic if any users naively copy it.

## Solution

* Add a `transform` field to `Node`.
* In layout updates apply the layout position translation to the transform field and then `set_if_neq` it to the node entitie's `Transform` component. 

The difference with this from my other five or so UI transform PRs is that this one still uses regular transform propagation to update the GlobalTransform`s.

## Testing

Reviewers can look at the `overflow_debug` example, which is the only current UI example that modifies the transform.

