### PR TITLE
Make CursorGrabMode a State

### DIFF
--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -60,6 +60,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-featu
 ], optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false }
+bevy_state = { path = "../bevy_state", version = "0.16.0-dev", default-features = false }
 
 # other
 serde = { version = "1.0", features = [

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,4 +1,5 @@
 use alloc::{borrow::ToOwned, string::String};
+use bevy_state::state::States;
 use core::num::NonZero;
 
 use bevy_ecs::{
@@ -1031,7 +1032,7 @@ impl From<DVec2> for WindowResolution {
 /// - **`iOS/Android`** don't have cursors.
 ///
 /// Since `Windows` and `macOS` have different [`CursorGrabMode`] support, we first try to set the grab mode that was asked for. If it doesn't work then use the alternate grab mode.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, States, Hash, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),


### PR DESCRIPTION
# Objective

Keeping various systems from running when the window isn't viewed/holding the mouse such as player movement requires needless extra steps.

## Solution

Makes it so that users can use cursor grab mode as a state to control system runs.
