### PR TITLE
Add AnnularSector primitive shape

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1017,6 +1017,116 @@ impl Measured2d for Annulus {
     }
 }
 
+/// A sector of an [`Annulus`] defined by a half angle.
+/// The sector middle is at `Vec2::Y`, extending by `half_angle` radians on either side.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, PartialEq, Default)
+)]
+#[cfg_attr(
+    all(feature = "serialize", feature = "bevy_reflect"),
+    reflect(Serialize, Deserialize)
+)]
+pub struct AnnularSector {
+    /// The annulus that the sector is taken from.
+    pub annulus: Annulus,
+    /// The half angle of the sector.
+    pub half_angle: f32,
+}
+impl Primitive2d for AnnularSector {}
+
+impl Default for AnnularSector {
+    /// Returns a sector of the default [`Annulus`] with a half angle of 1.0.
+    fn default() -> Self {
+        Self {
+            annulus: Annulus::default(),
+            half_angle: 1.0,
+        }
+    }
+}
+
+impl AnnularSector {
+    /// Create a new [`AnnularSector`] from the radii of the inner and outer circle, and the half angle.
+    /// It is created starting from `Vec2::Y`, extending by `half_angle` radians on either side.
+    #[inline(always)]
+    pub const fn new(inner_radius: f32, outer_radius: f32, half_angle: f32) -> Self {
+        Self {
+            annulus: Annulus::new(inner_radius, outer_radius),
+            half_angle,
+        }
+    }
+
+    /// Get the diameter of the outer circle.
+    #[inline(always)]
+    pub fn diameter(&self) -> f32 {
+        self.annulus.diameter()
+    }
+
+    /// Get the thickness of the annulus.
+    #[inline(always)]
+    pub fn thickness(&self) -> f32 {
+        self.annulus.thickness()
+    }
+
+    /// If `point` lies inside the annular sector, it is returned as-is.
+    /// Otherwise the closest point on the perimeter of the shape is returned.
+    #[inline(always)]
+    pub fn closest_point(&self, point: Vec2) -> Vec2 {
+        let distance_squared = point.length_squared();
+        let angle = ops::abs(point.angle_to(Vec2::Y));
+
+        if angle > self.half_angle {
+            // Project the point onto the nearest boundary of the sector
+            let clamped_angle = ops::copysign(self.half_angle, point.x);
+            let dir_to_point = Vec2::from_angle(clamped_angle);
+            if distance_squared > self.annulus.outer_circle.radius.squared() {
+                return self.annulus.outer_circle.radius * dir_to_point;
+            } else if distance_squared < self.annulus.inner_circle.radius.squared() {
+                return self.annulus.inner_circle.radius * dir_to_point;
+            }
+            return point;
+        }
+
+        if self.annulus.inner_circle.radius.squared() <= distance_squared {
+            if distance_squared <= self.annulus.outer_circle.radius.squared() {
+                // The point is inside the annular sector.
+                point
+            } else {
+                // The point is outside the annular sector and closer to the outer perimeter.
+                let dir_to_point = point / ops::sqrt(distance_squared);
+                self.annulus.outer_circle.radius * dir_to_point
+            }
+        } else {
+            // The point is outside the annular sector and closer to the inner perimeter.
+            let dir_to_point = point / ops::sqrt(distance_squared);
+            self.annulus.inner_circle.radius * dir_to_point
+        }
+    }
+}
+
+impl Measured2d for AnnularSector {
+    /// Get the area of the annular sector.
+    #[inline(always)]
+    fn area(&self) -> f32 {
+        self.half_angle
+            * (self.annulus.outer_circle.radius.squared()
+                - self.annulus.inner_circle.radius.squared())
+    }
+
+    /// Get the perimeter or circumference of the annular sector.
+    #[inline(always)]
+    #[doc(alias = "circumference")]
+    fn perimeter(&self) -> f32 {
+        let arc_length_outer = 2.0 * self.half_angle * self.annulus.outer_circle.radius;
+        let arc_length_inner = 2.0 * self.half_angle * self.annulus.inner_circle.radius;
+        let radial_edges = 2.0 * self.annulus.thickness();
+        arc_length_outer + arc_length_inner + radial_edges
+    }
+}
+
 /// A rhombus primitive, also known as a diamond shape.
 /// A four sided polygon, centered on the origin, where opposite sides are parallel but without
 /// requiring right angles.

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -20,7 +20,7 @@ fn main() {
     app.run();
 }
 
-const X_EXTENT: f32 = 900.;
+const X_EXTENT: f32 = 600.;
 
 fn setup(
     mut commands: Commands,
@@ -35,6 +35,7 @@ fn setup(
         meshes.add(CircularSegment::new(50.0, 1.25)),
         meshes.add(Ellipse::new(25.0, 50.0)),
         meshes.add(Annulus::new(25.0, 50.0)),
+        meshes.add(AnnularSector::new(25.0, 50.0, 1.0)),
         meshes.add(Capsule2d::new(25.0, 50.0)),
         meshes.add(Rhombus::new(75.0, 100.0)),
         meshes.add(Rectangle::new(50.0, 100.0)),
@@ -46,18 +47,23 @@ fn setup(
         )),
     ];
     let num_shapes = shapes.len();
+    let shapes_per_row = (num_shapes as f32 / 2.0).ceil() as usize;
 
     for (i, shape) in shapes.into_iter().enumerate() {
         // Distribute colors evenly across the rainbow.
         let color = Color::hsl(360. * i as f32 / num_shapes as f32, 0.95, 0.7);
 
+        let row = i / shapes_per_row;
+        let col = i % shapes_per_row;
+
         commands.spawn((
             Mesh2d(shape),
             MeshMaterial2d(materials.add(color)),
             Transform::from_xyz(
-                // Distribute shapes from -X_EXTENT/2 to +X_EXTENT/2.
-                -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
-                0.0,
+                // Distribute shapes from -X_EXTENT/2 to +X_EXTENT/2 in each row.
+                -X_EXTENT / 2. + col as f32 / (shapes_per_row - 1) as f32 * X_EXTENT,
+                // Position the rows 120 units apart vertically.
+                60.0 - row as f32 * 120.0,
                 0.0,
             ),
         ));

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -71,6 +71,7 @@ fn setup(
         meshes.add(Extrusion::new(Rectangle::default(), 1.)),
         meshes.add(Extrusion::new(Capsule2d::default(), 1.)),
         meshes.add(Extrusion::new(Annulus::default(), 1.)),
+        meshes.add(Extrusion::new(AnnularSector::default(), 1.)),
         meshes.add(Extrusion::new(Circle::default(), 1.)),
         meshes.add(Extrusion::new(Ellipse::default(), 1.)),
         meshes.add(Extrusion::new(RegularPolygon::default(), 1.)),


### PR DESCRIPTION
Adds an `AnnularSector` primitive 2d shape.

<small>(a pie-slice of an annulus, which is the 2d-donut)</small>

## Solution

- Based on the existing Annulus, to which i added a `half_angle` defined and oriented the same way as `CircularSector`.

## Testing

- Visually inspected the 2d shape and the extruded mesh
- Added it to the `2d_shapes` and `3d_shapes` examples to inspect it.
- Modified the 2d_shapes example to display shapes in two rows, since it was getting crowded.
- TODO: I've not verified if `AnnularSector::closest_point` is correct, is there an example that visualizes this?

---

## Showcase

**2d_shapes example**
<img width="823" alt="Screenshot 2025-02-18 at 21 59 42" src="https://github.com/user-attachments/assets/cb123d66-e750-4a5c-8607-830dffd40ca8" />

**3d_shapes example**
<img width="368" alt="annular sector extrusion 3d_shapes" src="https://github.com/user-attachments/assets/aa49cd04-8efd-43c9-aab4-bd6e3c0075a4" />

**gratuitous screenshot**
<img width="833" alt="Screenshot 2025-02-18 at 21 05 52" src="https://github.com/user-attachments/assets/58b8bc5f-e1fb-4e4a-8123-8c7beb238f96" />

