### PR TITLE
Use fully qualified syntax in assertions.

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -256,7 +256,7 @@ impl BlobArray {
         new_capacity: NonZeroUsize,
     ) {
         #[cfg(debug_assertions)]
-        debug_assert_eq!(self.capacity, current_capacity.into());
+        debug_assert_eq!(self.capacity, usize::from(current_capacity));
         if !self.is_zst() {
             // SAFETY: `new_capacity` can't overflow usize
             let new_layout =

--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -256,7 +256,7 @@ impl BlobArray {
         new_capacity: NonZeroUsize,
     ) {
         #[cfg(debug_assertions)]
-        debug_assert_eq!(self.capacity, usize::from(current_capacity));
+        debug_assert_eq!(self.capacity, current_capacity.get());
         if !self.is_zst() {
             // SAFETY: `new_capacity` can't overflow usize
             let new_layout =

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -87,7 +87,7 @@ impl<T> ThinArrayPtr<T> {
     /// - The caller should update their saved `capacity` value to reflect the fact that it was changed
     pub unsafe fn realloc(&mut self, current_capacity: NonZeroUsize, new_capacity: NonZeroUsize) {
         #[cfg(debug_assertions)]
-        assert_eq!(self.capacity, usize::from(current_capacity));
+        assert_eq!(self.capacity, current_capacity.get());
         self.set_capacity(new_capacity.get());
         if size_of::<T>() != 0 {
             let new_layout =

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -87,7 +87,7 @@ impl<T> ThinArrayPtr<T> {
     /// - The caller should update their saved `capacity` value to reflect the fact that it was changed
     pub unsafe fn realloc(&mut self, current_capacity: NonZeroUsize, new_capacity: NonZeroUsize) {
         #[cfg(debug_assertions)]
-        assert_eq!(self.capacity, current_capacity.into());
+        assert_eq!(self.capacity, usize::from(current_capacity));
         self.set_capacity(new_capacity.get());
         if size_of::<T>() != 0 {
             let new_layout =


### PR DESCRIPTION
# Objective

Fix #17924 

## Solution

Use fully qualified syntax (`usize::from` rather than `.into()`).

## Testing

Ran a build for the platform specified in the issue.