### PR TITLE
Fix false positive GPU frustum culling

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wgsl
@@ -136,9 +136,9 @@ fn view_frustum_intersects_obb(
         let relative_radius = dot(
             abs(
                 vec3(
-                    dot(plane_normal, world_from_local[0]),
-                    dot(plane_normal, world_from_local[1]),
-                    dot(plane_normal, world_from_local[2]),
+                    dot(plane_normal.xyz, world_from_local[0].xyz),
+                    dot(plane_normal.xyz, world_from_local[1].xyz),
+                    dot(plane_normal.xyz, world_from_local[2].xyz),
                 )
             ),
             aabb_half_extents


### PR DESCRIPTION
# Objective

Fix incorrect mesh culling where objects (particularly directional shadows) were being incorrectly culled during the early preprocessing phase. The issue manifested specifically on Apple M1 GPUs but not on newer devices like the M4. The bug was in the `view_frustum_intersects_obb` function, where including the w component (plane distance) in the dot product calculations led to false positive culling results. This caused objects to be incorrectly culled before shadow casting could begin.

## Issue Details
The problem of missing shadows is reproducible on Apple M1 GPUs as of this commit (bisected):

```
00722b8d0 Make indirect drawing opt-out instead of opt-in, enabling multidraw by default. (#16757)
```

and as recent as this commit:

```
c818c9214 Add option to animate materials in many_cubes (#17927)
```

- The frustum culling calculation incorrectly included the w component (plane distance) when transforming basis vectors
- The relative radius calculation should only consider directional transformation (xyz), not positional information (w)
- This caused false positive culling specifically on M1 devices likely due to different device-specific floating-point behavior
- When objects were incorrectly culled, `early_instance_count` never incremented, leading to missing geometry in the shadow pass

## Testing

- Tested on M1 and M4 devices to verify the fix
- Verified shadows and geometry render correctly on both platforms
- Confirmed the solution matches the existing Rust implementation's behavior for calculating the relative radius: https://github.com/bevyengine/bevy/blob/c818c92143e56ef3b51836af423319a5a61b15ad/crates/bevy_render/src/primitives/mod.rs#L77-L87
- The fix resolves a mathematical error in the frustum culling calculation while maintaining correct culling behavior across all platforms.

---

## Showcase

`c818c9214`
<img width="1284" alt="c818c9214" src="https://github.com/user-attachments/assets/fe1c7ea9-b13d-422e-b12d-f1cd74475213" />

`mate-h/frustum-cull-fix`
<img width="1283" alt="frustum-cull-fix" src="https://github.com/user-attachments/assets/8a9ccb2a-64b6-4d5e-a17d-ac4798da5b51" />
