### PR TITLE
Incorporate OIT into MeshPipelineKey used by the LineGizmoPipeline

### DIFF
--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -7,6 +7,7 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_core_pipeline::{
     core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT},
+    oit::OrderIndependentTransparencySettings,
     prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
 };
 
@@ -301,6 +302,7 @@ fn queue_line_gizmos_3d(
             Has<DepthPrepass>,
             Has<MotionVectorPrepass>,
             Has<DeferredPrepass>,
+            Has<OrderIndependentTransparencySettings>,
         ),
     )>,
 ) {
@@ -314,7 +316,7 @@ fn queue_line_gizmos_3d(
         view,
         msaa,
         render_layers,
-        (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass),
+        (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass, oit),
     ) in &views
     {
         let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
@@ -341,6 +343,10 @@ fn queue_line_gizmos_3d(
 
         if deferred_prepass {
             view_key |= MeshPipelineKey::DEFERRED_PREPASS;
+        }
+
+        if oit {
+            view_key |= MeshPipelineKey::OIT_ENABLED;
         }
 
         for (entity, main_entity, config) in &line_gizmos {


### PR DESCRIPTION
# Objective

Fixes #17945 

## Solution

Check if the view being extracted has OIT enabled and incorporate the associated bit into the mesh pipeline key.

I basically have no idea what's going on in the renderer, so let me know if I missed something, which is extraordinarily possible.

## Testing

I modified the `order_independent_transparency` example to put everything on the default render layer and render a gizmo at the origin. Previously, this would cause the application to panic. 
