### PR TITLE
implement UniqueEntityArray

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -70,6 +70,10 @@ mod unique_slice;
 
 pub use unique_slice::*;
 
+mod unique_array;
+
+pub use unique_array::UniqueEntityArray;
+
 use crate::{
     archetype::{ArchetypeId, ArchetypeRow},
     change_detection::MaybeLocation,

--- a/crates/bevy_ecs/src/entity/unique_array.rs
+++ b/crates/bevy_ecs/src/entity/unique_array.rs
@@ -1,0 +1,471 @@
+use core::{
+    array,
+    borrow::{Borrow, BorrowMut},
+    fmt::Debug,
+    ops::{
+        Bound, Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive,
+        RangeTo, RangeToInclusive,
+    },
+    ptr,
+};
+
+use alloc::{
+    boxed::Box,
+    collections::{BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    rc::Rc,
+    sync::Arc,
+    vec::Vec,
+};
+
+use super::{unique_slice, TrustedEntityBorrow, UniqueEntityIter, UniqueEntitySlice};
+
+/// An array that contains only unique entities.
+///
+/// It can be obtained through certain methods on [`UniqueEntitySlice`],
+/// and some [`TryFrom`] implementations.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UniqueEntityArray<T: TrustedEntityBorrow, const N: usize>([T; N]);
+
+impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityArray<T, N> {
+    /// Constructs a `UniqueEntityArray` from a [`[T; N]`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `array` must contain only unique elements.
+    pub const unsafe fn from_array_unchecked(array: [T; N]) -> Self {
+        Self(array)
+    }
+
+    /// Constructs a `&UniqueEntityArray` from a [`&[T; N]`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `array` must contain only unique elements.
+    pub const unsafe fn from_array_ref_unchecked(array: &[T; N]) -> &Self {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { &*(ptr::from_ref(array).cast()) }
+    }
+
+    /// Constructs a `Box<UniqueEntityArray>` from a [`Box<[T; N]>`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `array` must contain only unique elements.
+    pub unsafe fn from_boxed_array_unchecked(array: Box<[T; N]>) -> Box<Self> {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { Box::from_raw(Box::into_raw(array).cast()) }
+    }
+
+    /// Casts `self` into the inner array.
+    pub fn into_boxed_inner(self: Box<Self>) -> Box<[T; N]> {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { Box::from_raw(Box::into_raw(self).cast()) }
+    }
+
+    /// Constructs a `Arc<UniqueEntityArray>` from a [`Arc<[T; N]>`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub unsafe fn from_arc_array_unchecked(slice: Arc<[T; N]>) -> Arc<Self> {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { Arc::from_raw(Arc::into_raw(slice).cast()) }
+    }
+
+    /// Casts `self` to the inner array.
+    pub fn into_arc_inner(self: Arc<Self>) -> Arc<[T; N]> {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { Arc::from_raw(Arc::into_raw(self).cast()) }
+    }
+
+    // Constructs a `Rc<UniqueEntityArray>` from a [`Rc<[T; N]>`] unsafely.
+    ///
+    /// # Safety
+    ///
+    /// `slice` must contain only unique elements.
+    pub unsafe fn from_rc_array_unchecked(slice: Rc<[T; N]>) -> Rc<Self> {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { Rc::from_raw(Rc::into_raw(slice).cast()) }
+    }
+
+    /// Casts `self` to the inner array.
+    pub fn into_rc_inner(self: Rc<Self>) -> Rc<[T; N]> {
+        // SAFETY: UniqueEntityArray is a transparent wrapper around [T; N].
+        unsafe { Rc::from_raw(Rc::into_raw(self).cast()) }
+    }
+
+    /// Return the inner array.
+    pub fn into_inner(self) -> [T; N] {
+        self.0
+    }
+
+    /// Returns a reference to the inner array.
+    pub fn as_inner(&self) -> &[T; N] {
+        &self.0
+    }
+
+    /// Returns a slice containing the entire array. Equivalent to `&s[..]`.
+    pub const fn as_slice(&self) -> &UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original array are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.as_slice()) }
+    }
+
+    /// Returns a mutable slice containing the entire array. Equivalent to
+    /// `&mut s[..]`.
+    pub fn as_mut_slice(&mut self) -> &mut UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original array are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.as_mut_slice()) }
+    }
+
+    /// Borrows each element and returns an array of references with the same
+    /// size as `self`.
+    ///
+    /// Equivalent to [`[T; N]::as_ref`](array::each_ref).
+    pub fn each_ref(&self) -> UniqueEntityArray<&T, N> {
+        UniqueEntityArray(self.0.each_ref())
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Deref for UniqueEntityArray<T, N> {
+    type Target = UniqueEntitySlice<T>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: All elements in the original array are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(&self.0) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> DerefMut for UniqueEntityArray<T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: All elements in the original array are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(&mut self.0) }
+    }
+}
+impl<T: TrustedEntityBorrow> Default for UniqueEntityArray<T, 0> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<'a, T: TrustedEntityBorrow, const N: usize> IntoIterator for &'a UniqueEntityArray<T, N> {
+    type Item = &'a T;
+
+    type IntoIter = unique_slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // SAFETY: All elements in the original array are unique.
+        unsafe { UniqueEntityIter::from_iterator_unchecked(self.0.iter()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IntoIterator for UniqueEntityArray<T, N> {
+    type Item = T;
+
+    type IntoIter = IntoIter<T, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // SAFETY: All elements in the original array are unique.
+        unsafe { UniqueEntityIter::from_iterator_unchecked(self.0.into_iter()) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> AsRef<UniqueEntitySlice<T>>
+    for UniqueEntityArray<T, N>
+{
+    fn as_ref(&self) -> &UniqueEntitySlice<T> {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> AsMut<UniqueEntitySlice<T>>
+    for UniqueEntityArray<T, N>
+{
+    fn as_mut(&mut self) -> &mut UniqueEntitySlice<T> {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Borrow<UniqueEntitySlice<T>>
+    for UniqueEntityArray<T, N>
+{
+    fn borrow(&self) -> &UniqueEntitySlice<T> {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> BorrowMut<UniqueEntitySlice<T>>
+    for UniqueEntityArray<T, N>
+{
+    fn borrow_mut(&mut self) -> &mut UniqueEntitySlice<T> {
+        self
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<(Bound<usize>, Bound<usize>)>
+    for UniqueEntityArray<T, N>
+{
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: (Bound<usize>, Bound<usize>)) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<Range<usize>> for UniqueEntityArray<T, N> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: Range<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFrom<usize>> for UniqueEntityArray<T, N> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeFrom<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFull> for UniqueEntityArray<T, N> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeFull) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeInclusive<usize>>
+    for UniqueEntityArray<T, N>
+{
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeInclusive<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeTo<usize>> for UniqueEntityArray<T, N> {
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeTo<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeToInclusive<usize>>
+    for UniqueEntityArray<T, N>
+{
+    type Output = UniqueEntitySlice<T>;
+    fn index(&self, key: RangeToInclusive<usize>) -> &Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.0.index(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> Index<usize> for UniqueEntityArray<T, N> {
+    type Output = T;
+    fn index(&self, key: usize) -> &T {
+        self.0.index(key)
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<(Bound<usize>, Bound<usize>)>
+    for UniqueEntityArray<T, N>
+{
+    fn index_mut(&mut self, key: (Bound<usize>, Bound<usize>)) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<Range<usize>> for UniqueEntityArray<T, N> {
+    fn index_mut(&mut self, key: Range<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFrom<usize>>
+    for UniqueEntityArray<T, N>
+{
+    fn index_mut(&mut self, key: RangeFrom<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFull> for UniqueEntityArray<T, N> {
+    fn index_mut(&mut self, key: RangeFull) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeInclusive<usize>>
+    for UniqueEntityArray<T, N>
+{
+    fn index_mut(&mut self, key: RangeInclusive<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeTo<usize>> for UniqueEntityArray<T, N> {
+    fn index_mut(&mut self, key: RangeTo<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeToInclusive<usize>>
+    for UniqueEntityArray<T, N>
+{
+    fn index_mut(&mut self, key: RangeToInclusive<usize>) -> &mut Self::Output {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&[T; 1]> for UniqueEntityArray<T, 1> {
+    fn from(value: &[T; 1]) -> Self {
+        Self(value.clone())
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&[T; 0]> for UniqueEntityArray<T, 0> {
+    fn from(value: &[T; 0]) -> Self {
+        Self(value.clone())
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&mut [T; 1]> for UniqueEntityArray<T, 1> {
+    fn from(value: &mut [T; 1]) -> Self {
+        Self(value.clone())
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone> From<&mut [T; 0]> for UniqueEntityArray<T, 0> {
+    fn from(value: &mut [T; 0]) -> Self {
+        Self(value.clone())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<[T; 1]> for UniqueEntityArray<T, 1> {
+    fn from(value: [T; 1]) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<[T; 0]> for UniqueEntityArray<T, 0> {
+    fn from(value: [T; 0]) -> Self {
+        Self(value)
+    }
+}
+
+// impl From<UniqueEntityArray> for Tuples from size 0-12
+
+impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<T, N>> for BTreeSet<T> {
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        BTreeSet::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<T, N>> for BinaryHeap<T> {
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        BinaryHeap::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for LinkedList<T> {
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        LinkedList::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for Vec<T> {
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        Vec::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for VecDeque<T> {
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        VecDeque::from(value.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<&UniqueEntitySlice<U>> for UniqueEntityArray<T, N>
+{
+    fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
+        self.0.eq(&other.as_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<UniqueEntitySlice<U>> for UniqueEntityArray<T, N>
+{
+    fn eq(&self, other: &UniqueEntitySlice<U>) -> bool {
+        self.0.eq(other.as_inner())
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntityArray<U, N>>
+    for Vec<T>
+{
+    fn eq(&self, other: &&UniqueEntityArray<U, N>) -> bool {
+        self.eq(&other.0)
+    }
+}
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntityArray<U, N>>
+    for VecDeque<T>
+{
+    fn eq(&self, other: &&UniqueEntityArray<U, N>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<&mut UniqueEntityArray<U, N>> for VecDeque<T>
+{
+    fn eq(&self, other: &&mut UniqueEntityArray<U, N>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntityArray<U, N>>
+    for Vec<T>
+{
+    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+        self.eq(&other.0)
+    }
+}
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntityArray<U, N>>
+    for VecDeque<T>
+{
+    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+pub type IntoIter<T, const N: usize> = UniqueEntityIter<array::IntoIter<T, N>>;
+
+impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityIter<array::IntoIter<T, N>> {
+    /// Returns an immutable slice of all elements that have not been yielded
+    /// yet.
+    ///
+    /// Equivalent to [`array::IntoIter::as_slice`].
+    pub fn as_slice(&self) -> &UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked(self.as_inner().as_slice()) }
+    }
+
+    /// Returns a mutable slice of all elements that have not been yielded yet.
+    ///
+    /// Equivalent to [`array::IntoIter::as_mut_slice`].
+    pub fn as_mut_slice(&mut self) -> &mut UniqueEntitySlice<T> {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.as_mut_inner().as_mut_slice()) }
+    }
+}

--- a/crates/bevy_ecs/src/entity/unique_array.rs
+++ b/crates/bevy_ecs/src/entity/unique_array.rs
@@ -363,7 +363,79 @@ impl<T: TrustedEntityBorrow> From<[T; 0]> for UniqueEntityArray<T, 0> {
     }
 }
 
-// impl From<UniqueEntityArray> for Tuples from size 0-12
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 1>> for (T,) {
+    fn from(array: UniqueEntityArray<T, 1>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 2>> for (T, T) {
+    fn from(array: UniqueEntityArray<T, 2>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 3>> for (T, T, T) {
+    fn from(array: UniqueEntityArray<T, 3>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 4>> for (T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 4>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 5>> for (T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 5>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 6>> for (T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 6>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 7>> for (T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 7>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 8>> for (T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 8>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 9>> for (T, T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 9>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 10>> for (T, T, T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 10>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 11>> for (T, T, T, T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<T, 11>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
+
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 12>>
+    for (T, T, T, T, T, T, T, T, T, T, T, T)
+{
+    fn from(array: UniqueEntityArray<T, 12>) -> Self {
+        Self::from(array.into_inner())
+    }
+}
 
 impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<T, N>> for BTreeSet<T> {
     fn from(value: UniqueEntityArray<T, N>) -> Self {

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -1,4 +1,5 @@
 use core::{
+    array::TryFromSliceError,
     borrow::Borrow,
     cmp::Ordering,
     fmt::Debug,
@@ -22,7 +23,7 @@ use alloc::{
 
 use super::{
     unique_vec, EntitySet, EntitySetIterator, FromEntitySetIterator, TrustedEntityBorrow,
-    UniqueEntityIter, UniqueEntityVec,
+    UniqueEntityArray, UniqueEntityIter, UniqueEntityVec,
 };
 
 /// A slice that contains only unique entities.
@@ -126,6 +127,64 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
         };
         // SAFETY: All elements in the original slice are unique.
         Some((last, unsafe { Self::from_slice_unchecked(rest) }))
+    }
+
+    /// Returns an array reference to the first `N` items in the slice.
+    ///
+    /// Equivalent to [`[T]::first_chunk`](slice::first_chunk).
+    pub const fn first_chunk<const N: usize>(&self) -> Option<&UniqueEntityArray<T, N>> {
+        let Some(chunk) = self.0.first_chunk() else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        Some(unsafe { UniqueEntityArray::from_array_ref_unchecked(chunk) })
+    }
+
+    /// Returns an array reference to the first `N` items in the slice and the remaining slice.
+    ///
+    /// Equivalent to [`[T]::split_first_chunk`](slice::split_first_chunk).
+    pub const fn split_first_chunk<const N: usize>(
+        &self,
+    ) -> Option<(&UniqueEntityArray<T, N>, &UniqueEntitySlice<T>)> {
+        let Some((chunk, rest)) = self.0.split_first_chunk() else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            Some((
+                UniqueEntityArray::from_array_ref_unchecked(chunk),
+                Self::from_slice_unchecked(rest),
+            ))
+        }
+    }
+
+    /// Returns an array reference to the last `N` items in the slice and the remaining slice.
+    ///
+    /// Equivalent to [`[T]::split_last_chunk`](slice::split_last_chunk).
+    pub const fn split_last_chunk<const N: usize>(
+        &self,
+    ) -> Option<(&UniqueEntitySlice<T>, &UniqueEntityArray<T, N>)> {
+        let Some((rest, chunk)) = self.0.split_last_chunk() else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        unsafe {
+            Some((
+                Self::from_slice_unchecked(rest),
+                UniqueEntityArray::from_array_ref_unchecked(chunk),
+            ))
+        }
+    }
+
+    /// Returns an array reference to the last `N` items in the slice.
+    ///
+    /// Equivalent to [`[T]::last_chunk`](slice::last_chunk).
+    pub const fn last_chunk<const N: usize>(&self) -> Option<&UniqueEntityArray<T, N>> {
+        let Some(chunk) = self.0.last_chunk() else {
+            return None;
+        };
+        // SAFETY: All elements in the original slice are unique.
+        Some(unsafe { UniqueEntityArray::from_array_ref_unchecked(chunk) })
     }
 
     /// Returns a reference to a subslice.
@@ -949,6 +1008,15 @@ impl<'a, T: TrustedEntityBorrow + Clone> From<&'a UniqueEntitySlice<T>>
     }
 }
 
+impl<T: TrustedEntityBorrow + Clone, const N: usize> From<UniqueEntityArray<T, N>>
+    for Box<UniqueEntitySlice<T>>
+{
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        // SAFETY: All elements in the original slice are unique.
+        unsafe { UniqueEntitySlice::from_boxed_slice_unchecked(Box::new(value.into_inner())) }
+    }
+}
+
 impl<'a, T: TrustedEntityBorrow + Clone> From<Cow<'a, UniqueEntitySlice<T>>>
     for Box<UniqueEntitySlice<T>>
 {
@@ -1134,6 +1202,30 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<[U; N]>
     }
 }
 
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<UniqueEntityArray<U, N>> for &UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<UniqueEntityArray<U, N>> for &mut UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<UniqueEntityArray<U, N>> for UniqueEntitySlice<T>
+{
+    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
 impl<T: TrustedEntityBorrow + PartialEq<U>, U> PartialEq<Vec<U>> for &UniqueEntitySlice<T> {
     fn eq(&self, other: &Vec<U>) -> bool {
         self.0.eq(other)
@@ -1158,6 +1250,38 @@ impl<T: TrustedEntityBorrow + Clone> ToOwned for UniqueEntitySlice<T> {
     fn to_owned(&self) -> Self::Owned {
         // SAFETY: All elements in the original slice are unique.
         unsafe { UniqueEntityVec::from_vec_unchecked(self.0.to_owned()) }
+    }
+}
+
+impl<'a, T: TrustedEntityBorrow + Copy, const N: usize> TryFrom<&'a UniqueEntitySlice<T>>
+    for &'a UniqueEntityArray<T, N>
+{
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &'a UniqueEntitySlice<T>) -> Result<Self, Self::Error> {
+        <&[T; N]>::try_from(&value.0).map(|array|
+                // SAFETY: All elements in the original slice are unique.
+                unsafe { UniqueEntityArray::from_array_ref_unchecked(array) })
+    }
+}
+
+impl<T: TrustedEntityBorrow + Copy, const N: usize> TryFrom<&UniqueEntitySlice<T>>
+    for UniqueEntityArray<T, N>
+{
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &UniqueEntitySlice<T>) -> Result<Self, Self::Error> {
+        <&Self>::try_from(value).copied()
+    }
+}
+
+impl<T: TrustedEntityBorrow + Copy, const N: usize> TryFrom<&mut UniqueEntitySlice<T>>
+    for UniqueEntityArray<T, N>
+{
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &mut UniqueEntitySlice<T>) -> Result<Self, Self::Error> {
+        <Self>::try_from(&*value)
     }
 }
 

--- a/crates/bevy_ecs/src/entity/unique_vec.rs
+++ b/crates/bevy_ecs/src/entity/unique_vec.rs
@@ -17,8 +17,8 @@ use alloc::{
 };
 
 use super::{
-    unique_slice, EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
-    UniqueEntitySlice,
+    unique_slice, EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityArray,
+    UniqueEntityIter, UniqueEntitySlice,
 };
 
 /// A `Vec` that contains only unique entities.
@@ -550,11 +550,27 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<&[U; N]
     }
 }
 
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<&UniqueEntityArray<U, N>> for UniqueEntityVec<T>
+{
+    fn eq(&self, other: &&UniqueEntityArray<U, N>) -> bool {
+        self.0.eq(&other.as_inner())
+    }
+}
+
 impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<&mut [U; N]>
     for UniqueEntityVec<T>
 {
     fn eq(&self, other: &&mut [U; N]) -> bool {
         self.0.eq(&**other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<&mut UniqueEntityArray<U, N>> for UniqueEntityVec<T>
+{
+    fn eq(&self, other: &&mut UniqueEntityArray<U, N>) -> bool {
+        self.0.eq(other.as_inner())
     }
 }
 
@@ -577,6 +593,14 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<[U; N]>
 {
     fn eq(&self, other: &[U; N]) -> bool {
         self.0.eq(other)
+    }
+}
+
+impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
+    PartialEq<UniqueEntityArray<U, N>> for UniqueEntityVec<T>
+{
+    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+        self.0.eq(other.as_inner())
     }
 }
 
@@ -683,6 +707,28 @@ impl<T: TrustedEntityBorrow> From<[T; 0]> for UniqueEntityVec<T> {
     }
 }
 
+impl<T: TrustedEntityBorrow + Clone, const N: usize> From<&UniqueEntityArray<T, N>>
+    for UniqueEntityVec<T>
+{
+    fn from(value: &UniqueEntityArray<T, N>) -> Self {
+        Self(Vec::from(value.as_inner().clone()))
+    }
+}
+
+impl<T: TrustedEntityBorrow + Clone, const N: usize> From<&mut UniqueEntityArray<T, N>>
+    for UniqueEntityVec<T>
+{
+    fn from(value: &mut UniqueEntityArray<T, N>) -> Self {
+        Self(Vec::from(value.as_inner().clone()))
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for UniqueEntityVec<T> {
+    fn from(value: UniqueEntityArray<T, N>) -> Self {
+        Self(Vec::from(value.into_inner()))
+    }
+}
+
 impl<T: TrustedEntityBorrow> From<UniqueEntityVec<T>> for Vec<T> {
     fn from(value: UniqueEntityVec<T>) -> Self {
         value.0
@@ -755,11 +801,39 @@ impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>> for Box
     }
 }
 
+impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>>
+    for Box<UniqueEntityArray<T, N>>
+{
+    type Error = UniqueEntityVec<T>;
+
+    fn try_from(value: UniqueEntityVec<T>) -> Result<Self, Self::Error> {
+        Box::try_from(value.0)
+            .map(|v|
+                // SAFETY: All elements in the original Vec are unique.
+                unsafe { UniqueEntityArray::from_boxed_array_unchecked(v) })
+            .map_err(UniqueEntityVec)
+    }
+}
+
 impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>> for [T; N] {
     type Error = UniqueEntityVec<T>;
 
     fn try_from(value: UniqueEntityVec<T>) -> Result<Self, Self::Error> {
         <[T; N] as TryFrom<Vec<T>>>::try_from(value.0).map_err(UniqueEntityVec)
+    }
+}
+
+impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>>
+    for UniqueEntityArray<T, N>
+{
+    type Error = UniqueEntityVec<T>;
+
+    fn try_from(value: UniqueEntityVec<T>) -> Result<Self, Self::Error> {
+        <[T; N] as TryFrom<Vec<T>>>::try_from(value.0)
+            .map(|v|
+            // SAFETY: All elements in the original Vec are unique.
+            unsafe { UniqueEntityArray::from_array_unchecked(v) })
+            .map_err(UniqueEntityVec)
     }
 }
 


### PR DESCRIPTION
# Objective

Continuation of #17589 and #16547.

`get_many` is last of the `many` methods with a missing `unique` counterpart.
It both takes and returns arrays, thus necessitates a matching `UniqueEntityArray` type! 
Plus, some slice methods involve returning arrays, which are currently missing from `UniqueEntitySlice`.

## Solution

Add the type, the related methods and trait impls.

Note that for this PR, we abstain from some methods/trait impls that create `&mut UniqueEntityArray`, because it can be successfully mem-swapped. This can potentially invalidate a larger slice, which is the same reason we punted on some mutable slice methods in #17589. We can follow-up on all of these together in a following PR.

The new `unique_array` module is not glob-exported, because the trait alias `unique_array::IntoIter` would conflict with `unique_vec::IntoIter`.
The solution for this is to make the various `unique_*` modules public, which I intend to do in yet another PR.
