### PR TITLE
Text cursor

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -49,7 +49,7 @@ pub mod prelude {
     #[cfg(feature = "bevy_ui_debug")]
     pub use crate::render::UiDebugOptions;
     #[doc(hidden)]
-    pub use crate::widget::{Text, TextUiReader, TextUiWriter};
+    pub use crate::widget::{Text, TextCursor, TextCursorWidth, TextUiReader, TextUiWriter};
     #[doc(hidden)]
     pub use {
         crate::{

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -397,3 +397,32 @@ pub fn text_system(
         }
     }
 }
+
+/// Add to a [`Text`] entity to draw a cursor for a block of text.
+#[derive(Component, Copy, Clone, Debug, Default, PartialEq)]
+pub struct TextCursor {
+    /// Index of the glyph where the cursor will be drawn.
+    /// If the index is out of bounds the cursor isn't shown.
+    pub index: usize,
+    /// Color of the cursor
+    pub color: Color,
+    /// Width of the cursor
+    pub width: TextCursorWidth,
+    /// Corner radius in logical pixels
+    pub radius: f32,
+}
+
+/// Width of a text cursor
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TextCursorWidth {
+    /// Cover whole glyph
+    All,
+    /// Width of cursor in logical pixels
+    Px(f32),
+}
+
+impl Default for TextCursorWidth {
+    fn default() -> Self {
+        Self::Px(4.)
+    }
+}

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -4,9 +4,10 @@
 //! in the bottom right. For text within a scene, please see the text2d example.
 
 use bevy::{
-    color::palettes::css::GOLD,
+    color::palettes::css::{GOLD, RED},
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
+    ui::widget::{TextCursor, TextCursorWidth},
 };
 
 fn main() {
@@ -38,7 +39,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             font_size: 67.0,
             ..default()
         },
-        TextShadow::default(),
+        TextCursor {
+            index: 5,
+            color: Color::WHITE,
+            width: TextCursorWidth::Px(4.),
+            radius: 1.,
+        },
         // Set the justification of the Text
         TextLayout::new_with_justify(JustifyText::Center),
         // Set the style of the Node itself.


### PR DESCRIPTION
# Objective

Draw a text cursor for a block of text.

## Solution

New `TextCursor` component. Add it to a `Text` entity and a cursor will be drawn above the glyph at the given index of the text block.

`extract_text_sections` handles the rendering.

This only draws a cursor. Movement, blink, focus, etc need to be handled by the user.

## Testing

Added a cursor to the `text` example, run with: 

```
cargo run --example text
```

---

## Showcase

![cursor](https://github.com/user-attachments/assets/d3c096ae-35f9-4a09-852e-b949d6822e05)
