### PR TITLE
Fix issue with `define_label!` instantiation in a 3rd party crate

### DIFF
--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -180,7 +180,7 @@ macro_rules! define_label {
 
         impl $crate::intern::Internable for dyn $label_trait_name {
             fn leak(&self) -> &'static Self {
-                Box::leak(self.dyn_clone())
+                $crate::label::Box::leak(self.dyn_clone())
             }
 
             fn ref_eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
# Objective

Calling `define_label!` in a `no_std` 3rd party crate currently requires the user to import `Box` themselves due to a non-fully-specified reference to `Box`.

## Solution

Add a fully specified path for `Box` in the one location necessary, to match all of the other cases.