### PR TITLE
Remove unused `#[must_used]`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1417,7 +1417,6 @@ impl AppExit {
 }
 
 impl From<u8> for AppExit {
-    #[must_use]
     fn from(value: u8) -> Self {
         Self::from_code(value)
     }


### PR DESCRIPTION
# Objective

- Fixed CI compilation failure on Rust Nightly 1.87 due to [this PR](https://github.com/rust-lang/rust/pull/136923)

## Solution

- Removed unused `#[must_use]`

## Testing

- cargo +nightly check --target wasm32-unknown-unknown -Z build-std=std,panic_abort
