### PR TITLE
Prevent last_trigger_id from overflowing

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -671,7 +671,9 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn increment_trigger_id(self) {
         self.assert_allows_mutable_access();
         // SAFETY: Caller ensure there are no outstanding references
-        unsafe { (*self.ptr).last_trigger_id += 1 }
+        unsafe {
+            (*self.ptr).last_trigger_id = (*self.ptr).last_trigger_id.wrapping_add(1);
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

This prevents overflowing the `last_trigger_id` property that leads to a panic in debug mode.

```bash
panicked at C:\XXX\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_ecs-0.15.2\src\world\unsafe_world_cell.rs:630:18:
attempt to add with overflow
Encountered a panic when applying buffers for system `bevy_sprite::calculate_bounds_2d`!
Encountered a panic in system `bevy_ecs::schedule::executor::apply_deferred`!
```

## Solution

As this value is only used for detecting a change, we can wrap when it reaches max value.

## Testing

This can be verified by running `cargo run --example observers`
