### PR TITLE
Add gram-schmidt fast approximation tangent generation algorithm

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -102,7 +102,7 @@ use bevy_platform_support::collections::HashMap;
 use bevy_app::prelude::*;
 use bevy_asset::AssetApp;
 use bevy_image::CompressedImageFormats;
-use bevy_mesh::{MeshVertexAttribute, TangentCalculationStrategy};
+use bevy_mesh::{MeshVertexAttribute, TangentAlgorithm};
 use bevy_render::renderer::RenderDevice;
 
 /// The glTF prelude.
@@ -119,8 +119,8 @@ pub use {assets::*, label::GltfAssetLabel, loader::*};
 #[derive(Default)]
 pub struct GltfPlugin {
     custom_vertex_attributes: HashMap<Box<str>, MeshVertexAttribute>,
-    /// The strategy to use when computing tangents for meshes without them.
-    pub tangent_calculation_strategy: TangentCalculationStrategy,
+    /// The algorithm to use when computing tangents for meshes without them.
+    pub tangent_calculation_algorithm: TangentAlgorithm,
 }
 
 impl GltfPlugin {
@@ -138,12 +138,12 @@ impl GltfPlugin {
         self
     }
 
-    /// The strategy to use when computing mesh tangents.
-    pub fn with_tangent_calculation_strategy(
+    /// The algorithm to use when computing mesh tangents.
+    pub fn with_tangent_calculation_algorithm(
         mut self,
-        tangent_strategy: TangentCalculationStrategy,
+        tangent_algorithm: TangentAlgorithm,
     ) -> Self {
-        self.tangent_calculation_strategy = tangent_strategy;
+        self.tangent_calculation_algorithm = tangent_algorithm;
         self
     }
 }
@@ -171,7 +171,7 @@ impl Plugin for GltfPlugin {
         app.register_asset_loader(GltfLoader {
             supported_compressed_formats,
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),
-            tangent_calculation_strategy: self.tangent_calculation_strategy,
+            tangent_calculation_algorithm: self.tangent_calculation_algorithm,
         });
     }
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -102,7 +102,7 @@ use bevy_platform_support::collections::HashMap;
 use bevy_app::prelude::*;
 use bevy_asset::AssetApp;
 use bevy_image::CompressedImageFormats;
-use bevy_mesh::{MeshVertexAttribute, TangentStrategy};
+use bevy_mesh::{MeshVertexAttribute, TangentCalculationStrategy};
 use bevy_render::renderer::RenderDevice;
 
 /// The glTF prelude.
@@ -119,8 +119,8 @@ pub use {assets::*, label::GltfAssetLabel, loader::*};
 #[derive(Default)]
 pub struct GltfPlugin {
     custom_vertex_attributes: HashMap<Box<str>, MeshVertexAttribute>,
-    /// The strategy to use when computing mesh tangents.
-    pub computed_tangent_strategy: TangentStrategy,
+    /// The strategy to use when computing tangents for meshes without them.
+    pub tangent_calculation_strategy: TangentCalculationStrategy,
 }
 
 impl GltfPlugin {
@@ -139,8 +139,11 @@ impl GltfPlugin {
     }
 
     /// The strategy to use when computing mesh tangents.
-    pub fn with_computed_tangent_strategy(mut self, tangent_strategy: TangentStrategy) -> Self {
-        self.computed_tangent_strategy = tangent_strategy;
+    pub fn with_tangent_calculation_strategy(
+        mut self,
+        tangent_strategy: TangentCalculationStrategy,
+    ) -> Self {
+        self.tangent_calculation_strategy = tangent_strategy;
         self
     }
 }
@@ -168,7 +171,7 @@ impl Plugin for GltfPlugin {
         app.register_asset_loader(GltfLoader {
             supported_compressed_formats,
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),
-            computed_tangent_strategy: self.computed_tangent_strategy,
+            tangent_calculation_strategy: self.tangent_calculation_strategy,
         });
     }
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -102,7 +102,7 @@ use bevy_platform_support::collections::HashMap;
 use bevy_app::prelude::*;
 use bevy_asset::AssetApp;
 use bevy_image::CompressedImageFormats;
-use bevy_mesh::MeshVertexAttribute;
+use bevy_mesh::{MeshVertexAttribute, TangentStrategy};
 use bevy_render::renderer::RenderDevice;
 
 /// The glTF prelude.
@@ -119,6 +119,8 @@ pub use {assets::*, label::GltfAssetLabel, loader::*};
 #[derive(Default)]
 pub struct GltfPlugin {
     custom_vertex_attributes: HashMap<Box<str>, MeshVertexAttribute>,
+    /// The strategy to use when computing mesh tangents.
+    pub computed_tangent_strategy: TangentStrategy,
 }
 
 impl GltfPlugin {
@@ -133,6 +135,12 @@ impl GltfPlugin {
         attribute: MeshVertexAttribute,
     ) -> Self {
         self.custom_vertex_attributes.insert(name.into(), attribute);
+        self
+    }
+
+    /// The strategy to use when computing mesh tangents.
+    pub fn with_computed_tangent_strategy(mut self, tangent_strategy: TangentStrategy) -> Self {
+        self.computed_tangent_strategy = tangent_strategy;
         self
     }
 }
@@ -160,6 +168,7 @@ impl Plugin for GltfPlugin {
         app.register_asset_loader(GltfLoader {
             supported_compressed_formats,
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),
+            computed_tangent_strategy: self.computed_tangent_strategy,
         });
     }
 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -28,8 +28,7 @@ use bevy_math::{Mat4, Vec3};
 use bevy_mesh::{
     morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-    Indices, Mesh, MeshVertexAttribute, PrimitiveTopology, TangentCalculationStrategy,
-    VertexAttributeValues,
+    Indices, Mesh, MeshVertexAttribute, PrimitiveTopology, TangentAlgorithm, VertexAttributeValues,
 };
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_pbr::UvChannel;
@@ -147,8 +146,8 @@ pub struct GltfLoader {
     /// See [this section of the glTF specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#meshes-overview)
     /// for additional details on custom attributes.
     pub custom_vertex_attributes: HashMap<Box<str>, MeshVertexAttribute>,
-    /// The strategy to use when computing mesh tangents.
-    pub tangent_calculation_strategy: TangentCalculationStrategy,
+    /// The algorithm to use when computing mesh tangents.
+    pub tangent_calculation_algorithm: TangentAlgorithm,
 }
 
 /// Specifies optional settings for processing gltfs at load time. By default, all recognized contents of
@@ -685,17 +684,17 @@ async fn load_gltf<'a, 'b, 'c>(
                 && needs_tangents(&primitive.material())
             {
                 tracing::debug!(
-                    "Missing vertex tangents for {}, computing them using the {:?} strategy. Consider using a tool such as Blender to pre-compute the tangents.",
-                    file_name, loader.tangent_calculation_strategy
+                    "Missing vertex tangents for {}, computing them using the {:?} algorithm. Consider using a tool such as Blender to pre-compute the tangents.",
+                    file_name, loader.tangent_calculation_algorithm
                 );
 
                 let generate_tangents_span = info_span!("compute_tangents", name = file_name);
 
                 generate_tangents_span.in_scope(|| {
-                    if let Err(err) = mesh.compute_tangents(loader.tangent_calculation_strategy) {
+                    if let Err(err) = mesh.compute_tangents(loader.tangent_calculation_algorithm) {
                         warn!(
                             "Failed to generate vertex tangents using {:?}: {}",
-                            loader.tangent_calculation_strategy, err
+                            loader.tangent_calculation_algorithm, err
                         );
                     }
                 });

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -28,7 +28,8 @@ use bevy_math::{Mat4, Vec3};
 use bevy_mesh::{
     morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
     skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-    Indices, Mesh, MeshVertexAttribute, PrimitiveTopology, TangentStrategy, VertexAttributeValues,
+    Indices, Mesh, MeshVertexAttribute, PrimitiveTopology, TangentCalculationStrategy,
+    VertexAttributeValues,
 };
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_pbr::UvChannel;
@@ -147,7 +148,7 @@ pub struct GltfLoader {
     /// for additional details on custom attributes.
     pub custom_vertex_attributes: HashMap<Box<str>, MeshVertexAttribute>,
     /// The strategy to use when computing mesh tangents.
-    pub computed_tangent_strategy: TangentStrategy,
+    pub tangent_calculation_strategy: TangentCalculationStrategy,
 }
 
 /// Specifies optional settings for processing gltfs at load time. By default, all recognized contents of
@@ -685,16 +686,16 @@ async fn load_gltf<'a, 'b, 'c>(
             {
                 tracing::debug!(
                     "Missing vertex tangents for {}, computing them using the {:?} strategy. Consider using a tool such as Blender to pre-compute the tangents.",
-                    file_name, loader.computed_tangent_strategy
+                    file_name, loader.tangent_calculation_strategy
                 );
 
                 let generate_tangents_span = info_span!("compute_tangents", name = file_name);
 
                 generate_tangents_span.in_scope(|| {
-                    if let Err(err) = mesh.compute_tangents(loader.computed_tangent_strategy) {
+                    if let Err(err) = mesh.compute_tangents(loader.tangent_calculation_strategy) {
                         warn!(
                             "Failed to generate vertex tangents using {:?}: {}",
-                            loader.computed_tangent_strategy, err
+                            loader.tangent_calculation_strategy, err
                         );
                     }
                 });

--- a/crates/bevy_mesh/src/gramschmidt.rs
+++ b/crates/bevy_mesh/src/gramschmidt.rs
@@ -136,14 +136,14 @@ pub(crate) fn generate_tangents_for_mesh(
 mod tests {
     use bevy_math::{primitives::*, Vec2, Vec3, Vec3A};
 
-    use crate::{Mesh, TangentCalculationStrategy};
+    use crate::{Mesh, TangentAlgorithm};
 
     // The tangents should be very close for simple shapes
     fn compare_tangents(mut mesh: Mesh) {
         let hq_tangents: Vec<[f32; 4]> = {
             mesh.remove_attribute(Mesh::ATTRIBUTE_TANGENT);
-            mesh.compute_tangents(TangentCalculationStrategy::HighQuality)
-                .expect("compute_tangents(HighQuality)");
+            mesh.compute_tangents(TangentAlgorithm::Mikktspace)
+                .expect("compute_tangents(Mikktspace)");
             mesh.attribute(Mesh::ATTRIBUTE_TANGENT)
                 .expect("hq_tangents.attribute(tangent)")
                 .as_float4()
@@ -153,8 +153,8 @@ mod tests {
 
         let fa_tangents: Vec<[f32; 4]> = {
             mesh.remove_attribute(Mesh::ATTRIBUTE_TANGENT);
-            mesh.compute_tangents(TangentCalculationStrategy::FastApproximation)
-                .expect("compute_tangents(FastApproximation)");
+            mesh.compute_tangents(TangentAlgorithm::GramSchmidt)
+                .expect("compute_tangents(GramSchmidt)");
             mesh.attribute(Mesh::ATTRIBUTE_TANGENT)
                 .expect("fa_tangents.attribute(tangent)")
                 .as_float4()

--- a/crates/bevy_mesh/src/gramschmidt.rs
+++ b/crates/bevy_mesh/src/gramschmidt.rs
@@ -1,0 +1,217 @@
+use super::{GenerateTangentsError, Mesh};
+use bevy_math::{Vec2, Vec3A, Vec4};
+use wgpu_types::{PrimitiveTopology, VertexFormat};
+
+struct TriangleIndexIter<'a, I>(&'a mut I);
+
+impl<'a, I> Iterator for TriangleIndexIter<'a, I>
+where
+    I: Iterator<Item = usize>,
+{
+    type Item = [usize; 3];
+    fn next(&mut self) -> Option<[usize; 3]> {
+        let i = &mut self.0;
+        match (i.next(), i.next(), i.next()) {
+            (Some(i1), Some(i2), Some(i3)) => Some([i1, i2, i3]),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) fn generate_tangents_for_mesh(
+    mesh: &Mesh,
+) -> Result<Vec<[f32; 4]>, GenerateTangentsError> {
+    let positions = mesh.attribute(Mesh::ATTRIBUTE_POSITION);
+    let normals = mesh.attribute(Mesh::ATTRIBUTE_NORMAL);
+    let uvs = mesh.attribute(Mesh::ATTRIBUTE_UV_0);
+    let indices = mesh.indices();
+    let primitive_topology = mesh.primitive_topology();
+
+    if primitive_topology != PrimitiveTopology::TriangleList {
+        return Err(GenerateTangentsError::UnsupportedTopology(
+            primitive_topology,
+        ));
+    }
+
+    match (positions, normals, uvs, indices) {
+        (None, _, _, _) => Err(GenerateTangentsError::MissingVertexAttribute(
+            Mesh::ATTRIBUTE_POSITION.name,
+        )),
+        (_, None, _, _) => Err(GenerateTangentsError::MissingVertexAttribute(
+            Mesh::ATTRIBUTE_NORMAL.name,
+        )),
+        (_, _, None, _) => Err(GenerateTangentsError::MissingVertexAttribute(
+            Mesh::ATTRIBUTE_UV_0.name,
+        )),
+        (_, _, _, None) => Err(GenerateTangentsError::MissingIndices),
+        (Some(positions), Some(normals), Some(uvs), Some(indices)) => {
+            let positions = positions.as_float3().ok_or(
+                GenerateTangentsError::InvalidVertexAttributeFormat(
+                    Mesh::ATTRIBUTE_POSITION.name,
+                    VertexFormat::Float32x3,
+                ),
+            )?;
+            let normals =
+                normals
+                    .as_float3()
+                    .ok_or(GenerateTangentsError::InvalidVertexAttributeFormat(
+                        Mesh::ATTRIBUTE_NORMAL.name,
+                        VertexFormat::Float32x3,
+                    ))?;
+            let uvs =
+                uvs.as_float2()
+                    .ok_or(GenerateTangentsError::InvalidVertexAttributeFormat(
+                        Mesh::ATTRIBUTE_UV_0.name,
+                        VertexFormat::Float32x2,
+                    ))?;
+            let vertex_count = positions.len();
+            let mut tangents = vec![Vec3A::ZERO; vertex_count];
+            let mut bi_tangents = vec![Vec3A::ZERO; vertex_count];
+
+            for [i1, i2, i3] in TriangleIndexIter(&mut indices.iter()) {
+                let v1 = Vec3A::from_array(positions[i1]);
+                let v2 = Vec3A::from_array(positions[i2]);
+                let v3 = Vec3A::from_array(positions[i3]);
+
+                let w1 = Vec2::from(uvs[i1]);
+                let w2 = Vec2::from(uvs[i2]);
+                let w3 = Vec2::from(uvs[i3]);
+
+                let delta_pos1 = v2 - v1;
+                let delta_pos2 = v3 - v1;
+
+                let delta_uv1 = w2 - w1;
+                let delta_uv2 = w3 - w1;
+
+                let determinant = delta_uv1.x * delta_uv2.y - delta_uv1.y * delta_uv2.x;
+
+                // check for degenerate triangles
+                if determinant.abs() > 1e-6 {
+                    let r = 1.0 / determinant;
+                    let tangent = (delta_pos1 * delta_uv2.y - delta_pos2 * delta_uv1.y) * r;
+                    let bi_tangent = (delta_pos2 * delta_uv1.x - delta_pos1 * delta_uv2.x) * r;
+
+                    tangents[i1] += tangent;
+                    tangents[i2] += tangent;
+                    tangents[i3] += tangent;
+
+                    bi_tangents[i1] += bi_tangent;
+                    bi_tangents[i2] += bi_tangent;
+                    bi_tangents[i3] += bi_tangent;
+                }
+            }
+
+            let mut result_tangents = Vec::with_capacity(vertex_count);
+
+            for i in 0..vertex_count {
+                let normal = Vec3A::from_array(normals[i]);
+                let tangent = tangents[i].normalize();
+                // Gram-Schmidt orthogonalization
+                let tangent = (tangent - normal * normal.dot(tangent)).normalize();
+                let bi_tangent = bi_tangents[i];
+                let handedness = if normal.cross(tangent).dot(bi_tangent) > 0.0 {
+                    1.0
+                } else {
+                    -1.0
+                };
+                // Both the gram-schmidt and mikktspace algorithms seem to assume left-handedness,
+                // so we flip the sign to correct for this. The extra multiplication here is
+                // negligible and it's done as a separate step to better document that it's
+                // a deviation from the general algorithm. The generated mikktspace tangents are
+                // also post processed to flip the sign.
+                let handedness = handedness * -1.0;
+                result_tangents
+                    .push(Vec4::new(tangent.x, tangent.y, tangent.z, handedness).to_array());
+            }
+
+            Ok(result_tangents)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_math::{primitives::*, Vec2, Vec3, Vec3A};
+
+    use crate::{Mesh, TangentStrategy};
+
+    // The tangents should be very close for simple shapes
+    fn compare_tangents(mut mesh: Mesh) {
+        let hq_tangents: Vec<[f32; 4]> = {
+            mesh.remove_attribute(Mesh::ATTRIBUTE_TANGENT);
+            mesh.compute_tangents(TangentStrategy::HighQuality)
+                .expect("compute_tangents(HighQuality)");
+            mesh.attribute(Mesh::ATTRIBUTE_TANGENT)
+                .expect("hq_tangents.attribute(tangent)")
+                .as_float4()
+                .expect("hq_tangents.as_float4")
+                .to_vec()
+        };
+
+        let fa_tangents: Vec<[f32; 4]> = {
+            mesh.remove_attribute(Mesh::ATTRIBUTE_TANGENT);
+            mesh.compute_tangents(TangentStrategy::FastApproximation)
+                .expect("compute_tangents(FastApproximation)");
+            mesh.attribute(Mesh::ATTRIBUTE_TANGENT)
+                .expect("fa_tangents.attribute(tangent)")
+                .as_float4()
+                .expect("fa_tangents.as_float4")
+                .to_vec()
+        };
+
+        for (hq, fa) in hq_tangents.iter().zip(fa_tangents.iter()) {
+            assert_eq!(hq[3], fa[3], "handedness");
+            let hq = Vec3A::from_slice(hq);
+            let fa = Vec3A::from_slice(fa);
+            let angle = hq.angle_between(fa);
+            let threshold = 15.0f32.to_radians();
+            assert!(
+                angle < threshold,
+                "tangents differ significantly: hq = {:?}, fa = {:?}, angle.to_degrees() = {}",
+                hq,
+                fa,
+                angle.to_degrees()
+            );
+        }
+    }
+
+    #[test]
+    fn cuboid() {
+        compare_tangents(Mesh::from(Cuboid::new(10.0, 10.0, 10.0)));
+    }
+
+    #[test]
+    fn capsule3d() {
+        compare_tangents(Mesh::from(Capsule3d::new(10.0, 10.0)));
+    }
+
+    #[test]
+    fn plane3d() {
+        compare_tangents(Mesh::from(Plane3d::new(Vec3::Y, Vec2::splat(10.0))));
+    }
+
+    #[test]
+    fn cylinder() {
+        compare_tangents(Mesh::from(Cylinder::new(10.0, 10.0)));
+    }
+
+    #[test]
+    fn torus() {
+        compare_tangents(Mesh::from(Torus::new(10.0, 100.0)));
+    }
+
+    #[test]
+    fn rhombus() {
+        compare_tangents(Mesh::from(Rhombus::new(10.0, 100.0)));
+    }
+
+    #[test]
+    fn tetrahedron() {
+        compare_tangents(Mesh::from(Tetrahedron::default()));
+    }
+
+    #[test]
+    fn cone() {
+        compare_tangents(Mesh::from(Cone::new(10.0, 100.0)));
+    }
+}

--- a/crates/bevy_mesh/src/gramschmidt.rs
+++ b/crates/bevy_mesh/src/gramschmidt.rs
@@ -133,13 +133,13 @@ pub(crate) fn generate_tangents_for_mesh(
 mod tests {
     use bevy_math::{primitives::*, Vec2, Vec3, Vec3A};
 
-    use crate::{Mesh, TangentStrategy};
+    use crate::{Mesh, TangentCalculationStrategy};
 
     // The tangents should be very close for simple shapes
     fn compare_tangents(mut mesh: Mesh) {
         let hq_tangents: Vec<[f32; 4]> = {
             mesh.remove_attribute(Mesh::ATTRIBUTE_TANGENT);
-            mesh.compute_tangents(TangentStrategy::HighQuality)
+            mesh.compute_tangents(TangentCalculationStrategy::HighQuality)
                 .expect("compute_tangents(HighQuality)");
             mesh.attribute(Mesh::ATTRIBUTE_TANGENT)
                 .expect("hq_tangents.attribute(tangent)")
@@ -150,7 +150,7 @@ mod tests {
 
         let fa_tangents: Vec<[f32; 4]> = {
             mesh.remove_attribute(Mesh::ATTRIBUTE_TANGENT);
-            mesh.compute_tangents(TangentStrategy::FastApproximation)
+            mesh.compute_tangents(TangentCalculationStrategy::FastApproximation)
                 .expect("compute_tangents(FastApproximation)");
             mesh.attribute(Mesh::ATTRIBUTE_TANGENT)
                 .expect("fa_tangents.attribute(tangent)")

--- a/crates/bevy_mesh/src/gramschmidt.rs
+++ b/crates/bevy_mesh/src/gramschmidt.rs
@@ -105,6 +105,10 @@ pub(crate) fn generate_tangents_for_mesh(
 
             for i in 0..vertex_count {
                 let normal = Vec3A::from_array(normals[i]);
+                // Assume that the normal has not been pre-normalized
+                let normal = normal.normalize_or_zero();
+                // Although it is not mathematically necessary to normalize the accumulated
+                // tangent, doing so may provide better numerical stability in extreme cases.
                 let tangent = tangents[i].normalize();
                 // Gram-Schmidt orthogonalization
                 let tangent = (tangent - normal * normal.dot(tangent)).normalize();

--- a/crates/bevy_mesh/src/gramschmidt.rs
+++ b/crates/bevy_mesh/src/gramschmidt.rs
@@ -1,5 +1,5 @@
 use super::{GenerateTangentsError, Mesh};
-use bevy_math::{Vec2, Vec3A, Vec4};
+use bevy_math::{Vec2, Vec3A};
 use wgpu_types::{PrimitiveTopology, VertexFormat};
 
 struct TriangleIndexIter<'a, I>(&'a mut I);
@@ -120,8 +120,7 @@ pub(crate) fn generate_tangents_for_mesh(
                 // a deviation from the general algorithm. The generated mikktspace tangents are
                 // also post processed to flip the sign.
                 let handedness = handedness * -1.0;
-                result_tangents
-                    .push(Vec4::new(tangent.x, tangent.y, tangent.z, handedness).to_array());
+                result_tangents.push([tangent.x, tangent.y, tangent.z, handedness]);
             }
 
             Ok(result_tangents)

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 extern crate core;
 
 mod conversions;
+mod gramschmidt;
 mod index;
 mod mesh;
 mod mikktspace;
@@ -14,7 +15,7 @@ mod vertex;
 use bitflags::bitflags;
 pub use index::*;
 pub use mesh::*;
-pub use mikktspace::*;
+use mikktspace::*;
 pub use primitives::*;
 pub use vertex::*;
 pub use wgpu_types::VertexFormat;

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -776,7 +776,7 @@ impl Mesh {
     /// Requires a [`PrimitiveTopology::TriangleList`] topology and the [`Mesh::ATTRIBUTE_POSITION`], [`Mesh::ATTRIBUTE_NORMAL`] and [`Mesh::ATTRIBUTE_UV_0`] attributes set.
     #[deprecated(since = "0.16.0", note = "use compute_tangents")]
     pub fn generate_tangents(&mut self) -> Result<(), GenerateTangentsError> {
-        self.compute_tangents(TangentStrategy::HighQuality)?;
+        self.compute_tangents(TangentCalculationStrategy::HighQuality)?;
         Ok(())
     }
 
@@ -784,14 +784,18 @@ impl Mesh {
     ///
     /// Sets the [`Mesh::ATTRIBUTE_TANGENT`] attribute if successful.
     ///
-    /// See [`TangentStrategy`] for mesh topology and attribute requirements.
+    /// See [`TangentCalculationStrategy`] for mesh topology and attribute requirements.
     pub fn compute_tangents(
         &mut self,
-        tangent_strategy: TangentStrategy,
+        strategy: TangentCalculationStrategy,
     ) -> Result<(), GenerateTangentsError> {
-        let tangents = match tangent_strategy {
-            TangentStrategy::HighQuality => mikktspace::generate_tangents_for_mesh(self)?,
-            TangentStrategy::FastApproximation => gramschmidt::generate_tangents_for_mesh(self)?,
+        let tangents = match strategy {
+            TangentCalculationStrategy::HighQuality => {
+                mikktspace::generate_tangents_for_mesh(self)?
+            }
+            TangentCalculationStrategy::FastApproximation => {
+                gramschmidt::generate_tangents_for_mesh(self)?
+            }
         };
         self.insert_attribute(Mesh::ATTRIBUTE_TANGENT, tangents);
         Ok(())
@@ -817,12 +821,12 @@ impl Mesh {
     ///
     /// (Alternatively, you can use [`Mesh::compute_tangents`] to mutate an existing mesh in-place)
     ///
-    /// See [`TangentStrategy`] for mesh topology and attribute requirements.
+    /// See [`TangentCalculationStrategy`] for mesh topology and attribute requirements.
     pub fn with_computed_tangents(
         mut self,
-        tangent_strategy: TangentStrategy,
+        strategy: TangentCalculationStrategy,
     ) -> Result<Mesh, GenerateTangentsError> {
-        self.compute_tangents(tangent_strategy)?;
+        self.compute_tangents(strategy)?;
         Ok(self)
     }
 
@@ -1272,7 +1276,7 @@ impl core::ops::Mul<Mesh> for Transform {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 /// The strategy to use when computing mesh tangents. Defaults to `HighQuality`.
-pub enum TangentStrategy {
+pub enum TangentCalculationStrategy {
     /// Uses the Morten S. Mikkelsen "mikktspace" algorithm. Produces potentially higher quality tangents, but much slower.
     ///
     /// Requires a [`PrimitiveTopology::TriangleList`] topology and the [`Mesh::ATTRIBUTE_POSITION`], [`Mesh::ATTRIBUTE_NORMAL`] and [`Mesh::ATTRIBUTE_UV_0`] attributes set.

--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -163,9 +163,10 @@ impl Mesh {
     pub const ATTRIBUTE_UV_1: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Uv_1", 3, VertexFormat::Float32x2);
 
-    /// The direction of the vertex tangent. Used for normal mapping.
-    /// Usually generated with [`generate_tangents`](Mesh::generate_tangents) or
-    /// [`with_generated_tangents`](Mesh::with_generated_tangents).
+    /// The direction of the vertex tangent, with the "handedness" (`1` or `-1`) in the `w` column.
+    /// Used for normal mapping. Usually generated with
+    /// [`compute_tangents`](Mesh::generate_tangents) or
+    /// [`with_computed_tangents`](Mesh::with_computed_tangents).
     ///
     /// The format of this attribute is [`VertexFormat::Float32x4`].
     pub const ATTRIBUTE_TANGENT: MeshVertexAttribute =

--- a/crates/bevy_mesh/src/mikktspace.rs
+++ b/crates/bevy_mesh/src/mikktspace.rs
@@ -1,6 +1,5 @@
-use super::{Indices, Mesh, VertexAttributeValues};
+use super::{GenerateTangentsError, Indices, Mesh, VertexAttributeValues};
 use bevy_math::Vec3;
-use thiserror::Error;
 use wgpu_types::{PrimitiveTopology, VertexFormat};
 
 struct MikktspaceGeometryHelper<'a> {
@@ -53,21 +52,6 @@ impl bevy_mikktspace::Geometry for MikktspaceGeometryHelper<'_> {
     }
 }
 
-#[derive(Error, Debug)]
-/// Failed to generate tangents for the mesh.
-pub enum GenerateTangentsError {
-    #[error("cannot generate tangents for {0:?}")]
-    UnsupportedTopology(PrimitiveTopology),
-    #[error("missing indices")]
-    MissingIndices,
-    #[error("missing vertex attributes '{0}'")]
-    MissingVertexAttribute(&'static str),
-    #[error("the '{0}' vertex attribute should have {1:?} format")]
-    InvalidVertexAttributeFormat(&'static str, VertexFormat),
-    #[error("mesh not suitable for tangent generation")]
-    MikktspaceError,
-}
-
 pub(crate) fn generate_tangents_for_mesh(
     mesh: &Mesh,
 ) -> Result<Vec<[f32; 4]>, GenerateTangentsError> {
@@ -115,7 +99,7 @@ pub(crate) fn generate_tangents_for_mesh(
     };
     let success = bevy_mikktspace::generate_tangents(&mut mikktspace_mesh);
     if !success {
-        return Err(GenerateTangentsError::MikktspaceError);
+        return Err(GenerateTangentsError::AlgorithmError);
     }
 
     // mikktspace seems to assume left-handedness so we can flip the sign to correct for this

--- a/crates/bevy_mesh/src/vertex.rs
+++ b/crates/bevy_mesh/src/vertex.rs
@@ -244,10 +244,26 @@ impl VertexAttributeValues {
         self.len() == 0
     }
 
+    /// Returns the values as float pairs if possible.
+    pub fn as_float2(&self) -> Option<&[[f32; 2]]> {
+        match self {
+            VertexAttributeValues::Float32x2(values) => Some(values),
+            _ => None,
+        }
+    }
+
     /// Returns the values as float triples if possible.
     pub fn as_float3(&self) -> Option<&[[f32; 3]]> {
         match self {
             VertexAttributeValues::Float32x3(values) => Some(values),
+            _ => None,
+        }
+    }
+
+    /// Returns the values as float quads if possible.
+    pub fn as_float4(&self) -> Option<&[[f32; 4]]> {
+        match self {
+            VertexAttributeValues::Float32x4(values) => Some(values),
             _ => None,
         }
     }

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -9,9 +9,7 @@ use bevy_math::{prelude::Rectangle, Quat, Vec2, Vec3};
 use bevy_reflect::{Reflect, TypePath};
 use bevy_render::{
     alpha::AlphaMode,
-    mesh::{
-        Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable, TangentCalculationStrategy,
-    },
+    mesh::{Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable, TangentAlgorithm},
     render_resource::{
         AsBindGroup, CompareFunction, RenderPipelineDescriptor, Shader,
         SpecializedMeshPipelineError,
@@ -44,7 +42,7 @@ impl Plugin for ForwardDecalPlugin {
                 .mesh()
                 .build()
                 .rotated_by(Quat::from_rotation_arc(Vec3::Z, Vec3::Y))
-                .with_computed_tangents(TangentCalculationStrategy::HighQuality)
+                .with_computed_tangents(TangentAlgorithm::Mikktspace)
                 .unwrap(),
         );
 

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -9,7 +9,9 @@ use bevy_math::{prelude::Rectangle, Quat, Vec2, Vec3};
 use bevy_reflect::{Reflect, TypePath};
 use bevy_render::{
     alpha::AlphaMode,
-    mesh::{Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable, TangentStrategy},
+    mesh::{
+        Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable, TangentCalculationStrategy,
+    },
     render_resource::{
         AsBindGroup, CompareFunction, RenderPipelineDescriptor, Shader,
         SpecializedMeshPipelineError,
@@ -42,7 +44,7 @@ impl Plugin for ForwardDecalPlugin {
                 .mesh()
                 .build()
                 .rotated_by(Quat::from_rotation_arc(Vec3::Z, Vec3::Y))
-                .with_computed_tangents(TangentStrategy::HighQuality)
+                .with_computed_tangents(TangentCalculationStrategy::HighQuality)
                 .unwrap(),
         );
 

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -9,7 +9,7 @@ use bevy_math::{prelude::Rectangle, Quat, Vec2, Vec3};
 use bevy_reflect::{Reflect, TypePath};
 use bevy_render::{
     alpha::AlphaMode,
-    mesh::{Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable},
+    mesh::{Mesh, Mesh3d, MeshBuilder, MeshVertexBufferLayoutRef, Meshable, TangentStrategy},
     render_resource::{
         AsBindGroup, CompareFunction, RenderPipelineDescriptor, Shader,
         SpecializedMeshPipelineError,
@@ -42,7 +42,7 @@ impl Plugin for ForwardDecalPlugin {
                 .mesh()
                 .build()
                 .rotated_by(Quat::from_rotation_arc(Vec3::Z, Vec3::Y))
-                .with_generated_tangents()
+                .with_computed_tangents(TangentStrategy::HighQuality)
                 .unwrap(),
         );
 

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -379,13 +379,13 @@ pub struct StandardMaterial {
     /// - Vertex normals
     ///
     /// Tangents do not have to be stored in your model,
-    /// they can be generated using the [`Mesh::generate_tangents`] or
-    /// [`Mesh::with_generated_tangents`] methods.
+    /// they can be generated using the [`Mesh::compute_tangents`] or
+    /// [`Mesh::with_computed_tangents`] methods.
     /// If your material has a normal map, but still renders as a flat surface,
     /// make sure your meshes have their tangents set.
     ///
-    /// [`Mesh::generate_tangents`]: bevy_render::mesh::Mesh::generate_tangents
-    /// [`Mesh::with_generated_tangents`]: bevy_render::mesh::Mesh::with_generated_tangents
+    /// [`Mesh::compute_tangents`]: bevy_render::mesh::Mesh::compute_tangents
+    /// [`Mesh::with_computed_tangents`]: bevy_render::mesh::Mesh::with_computed_tangents
     #[texture(9)]
     #[sampler(10)]
     #[dependency]

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -7,6 +7,7 @@ use bevy::{
     core_pipeline::Skybox,
     math::vec3,
     prelude::*,
+    render::mesh::TangentStrategy,
     time::Stopwatch,
 };
 
@@ -115,7 +116,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
         Mesh3d(
             asset_server.add(
                 Mesh::from(Sphere::new(0.1))
-                    .with_generated_tangents()
+                    .with_computed_tangents(TangentStrategy::HighQuality)
                     .unwrap(),
             ),
         ),

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -7,7 +7,7 @@ use bevy::{
     core_pipeline::Skybox,
     math::vec3,
     prelude::*,
-    render::mesh::TangentCalculationStrategy,
+    render::mesh::TangentAlgorithm,
     time::Stopwatch,
 };
 
@@ -116,7 +116,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
         Mesh3d(
             asset_server.add(
                 Mesh::from(Sphere::new(0.1))
-                    .with_computed_tangents(TangentCalculationStrategy::HighQuality)
+                    .with_computed_tangents(TangentAlgorithm::Mikktspace)
                     .unwrap(),
             ),
         ),

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -7,7 +7,7 @@ use bevy::{
     core_pipeline::Skybox,
     math::vec3,
     prelude::*,
-    render::mesh::TangentStrategy,
+    render::mesh::TangentCalculationStrategy,
     time::Stopwatch,
 };
 
@@ -116,7 +116,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
         Mesh3d(
             asset_server.add(
                 Mesh::from(Sphere::new(0.1))
-                    .with_computed_tangents(TangentStrategy::HighQuality)
+                    .with_computed_tangents(TangentCalculationStrategy::HighQuality)
                     .unwrap(),
             ),
         ),

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -25,6 +25,7 @@ use bevy::{
     image::ImageLoaderSettings,
     math::vec3,
     prelude::*,
+    render::mesh::TangentStrategy,
 };
 
 /// The size of each sphere.
@@ -83,7 +84,7 @@ fn create_sphere_mesh(meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
 
     let mut sphere_mesh = Sphere::new(1.0).mesh().build();
     sphere_mesh
-        .generate_tangents()
+        .compute_tangents(TangentStrategy::HighQuality)
         .expect("Failed to generate tangents");
     meshes.add(sphere_mesh)
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -25,7 +25,7 @@ use bevy::{
     image::ImageLoaderSettings,
     math::vec3,
     prelude::*,
-    render::mesh::TangentStrategy,
+    render::mesh::TangentCalculationStrategy,
 };
 
 /// The size of each sphere.
@@ -84,7 +84,7 @@ fn create_sphere_mesh(meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
 
     let mut sphere_mesh = Sphere::new(1.0).mesh().build();
     sphere_mesh
-        .compute_tangents(TangentStrategy::HighQuality)
+        .compute_tangents(TangentCalculationStrategy::HighQuality)
         .expect("Failed to generate tangents");
     meshes.add(sphere_mesh)
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -25,7 +25,7 @@ use bevy::{
     image::ImageLoaderSettings,
     math::vec3,
     prelude::*,
-    render::mesh::TangentCalculationStrategy,
+    render::mesh::TangentAlgorithm,
 };
 
 /// The size of each sphere.
@@ -84,7 +84,7 @@ fn create_sphere_mesh(meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
 
     let mut sphere_mesh = Sphere::new(1.0).mesh().build();
     sphere_mesh
-        .compute_tangents(TangentCalculationStrategy::HighQuality)
+        .compute_tangents(TangentAlgorithm::Mikktspace)
         .expect("Failed to generate tangents");
     meshes.add(sphere_mesh)
 }

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -12,6 +12,7 @@ use bevy::{
         NotShadowCaster, NotShadowReceiver, OpaqueRendererMethod,
     },
     prelude::*,
+    render::mesh::TangentStrategy,
 };
 
 fn main() {
@@ -233,7 +234,8 @@ fn setup_parallax(
 
     // NOTE: for normal maps and depth maps to work, the mesh
     // needs tangents generated.
-    cube.generate_tangents().unwrap();
+    cube.compute_tangents(TangentStrategy::FastApproximation)
+        .unwrap();
 
     let parallax_material = materials.add(StandardMaterial {
         perceptual_roughness: 0.4,

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -12,7 +12,7 @@ use bevy::{
         NotShadowCaster, NotShadowReceiver, OpaqueRendererMethod,
     },
     prelude::*,
-    render::mesh::TangentStrategy,
+    render::mesh::TangentCalculationStrategy,
 };
 
 fn main() {
@@ -234,7 +234,7 @@ fn setup_parallax(
 
     // NOTE: for normal maps and depth maps to work, the mesh
     // needs tangents generated.
-    cube.compute_tangents(TangentStrategy::FastApproximation)
+    cube.compute_tangents(TangentCalculationStrategy::FastApproximation)
         .unwrap();
 
     let parallax_material = materials.add(StandardMaterial {

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -12,7 +12,7 @@ use bevy::{
         NotShadowCaster, NotShadowReceiver, OpaqueRendererMethod,
     },
     prelude::*,
-    render::mesh::TangentCalculationStrategy,
+    render::mesh::TangentAlgorithm,
 };
 
 fn main() {
@@ -234,7 +234,7 @@ fn setup_parallax(
 
     // NOTE: for normal maps and depth maps to work, the mesh
     // needs tangents generated.
-    cube.compute_tangents(TangentCalculationStrategy::FastApproximation)
+    cube.compute_tangents(TangentAlgorithm::GramSchmidt)
         .unwrap();
 
     let parallax_material = materials.add(StandardMaterial {

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -3,7 +3,9 @@
 
 use std::fmt;
 
-use bevy::{image::ImageLoaderSettings, math::ops, prelude::*, render::mesh::TangentStrategy};
+use bevy::{
+    image::ImageLoaderSettings, math::ops, prelude::*, render::mesh::TangentCalculationStrategy,
+};
 
 fn main() {
     App::new()
@@ -267,7 +269,7 @@ fn setup(
                 // NOTE: for normal maps and depth maps to work, the mesh
                 // needs tangents generated.
                 Mesh::from(Cuboid::default())
-                    .with_computed_tangents(TangentStrategy::HighQuality)
+                    .with_computed_tangents(TangentCalculationStrategy::HighQuality)
                     .unwrap(),
             ),
         ),
@@ -277,7 +279,7 @@ fn setup(
 
     let background_cube = meshes.add(
         Mesh::from(Cuboid::new(40.0, 40.0, 40.0))
-            .with_computed_tangents(TangentStrategy::HighQuality)
+            .with_computed_tangents(TangentCalculationStrategy::HighQuality)
             .unwrap(),
     );
 

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -3,7 +3,7 @@
 
 use std::fmt;
 
-use bevy::{image::ImageLoaderSettings, math::ops, prelude::*};
+use bevy::{image::ImageLoaderSettings, math::ops, prelude::*, render::mesh::TangentStrategy};
 
 fn main() {
     App::new()
@@ -267,7 +267,7 @@ fn setup(
                 // NOTE: for normal maps and depth maps to work, the mesh
                 // needs tangents generated.
                 Mesh::from(Cuboid::default())
-                    .with_generated_tangents()
+                    .with_computed_tangents(TangentStrategy::HighQuality)
                     .unwrap(),
             ),
         ),
@@ -277,7 +277,7 @@ fn setup(
 
     let background_cube = meshes.add(
         Mesh::from(Cuboid::new(40.0, 40.0, 40.0))
-            .with_generated_tangents()
+            .with_computed_tangents(TangentStrategy::HighQuality)
             .unwrap(),
     );
 

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -3,9 +3,7 @@
 
 use std::fmt;
 
-use bevy::{
-    image::ImageLoaderSettings, math::ops, prelude::*, render::mesh::TangentCalculationStrategy,
-};
+use bevy::{image::ImageLoaderSettings, math::ops, prelude::*, render::mesh::TangentAlgorithm};
 
 fn main() {
     App::new()
@@ -269,7 +267,7 @@ fn setup(
                 // NOTE: for normal maps and depth maps to work, the mesh
                 // needs tangents generated.
                 Mesh::from(Cuboid::default())
-                    .with_computed_tangents(TangentCalculationStrategy::HighQuality)
+                    .with_computed_tangents(TangentAlgorithm::Mikktspace)
                     .unwrap(),
             ),
         ),
@@ -279,7 +277,7 @@ fn setup(
 
     let background_cube = meshes.add(
         Mesh::from(Cuboid::new(40.0, 40.0, 40.0))
-            .with_computed_tangents(TangentCalculationStrategy::HighQuality)
+            .with_computed_tangents(TangentAlgorithm::Mikktspace)
             .unwrap(),
     );
 

--- a/examples/3d/rotate_environment_map.rs
+++ b/examples/3d/rotate_environment_map.rs
@@ -7,7 +7,7 @@ use bevy::{
     core_pipeline::{tonemapping::Tonemapping::AcesFitted, Skybox},
     image::ImageLoaderSettings,
     prelude::*,
-    render::mesh::TangentStrategy,
+    render::mesh::TangentCalculationStrategy,
 };
 
 /// Entry point.
@@ -52,7 +52,7 @@ fn create_sphere_mesh(meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
 
     let mut sphere_mesh = Sphere::new(1.0).mesh().build();
     sphere_mesh
-        .compute_tangents(TangentStrategy::HighQuality)
+        .compute_tangents(TangentCalculationStrategy::HighQuality)
         .expect("Failed to generate tangents");
     meshes.add(sphere_mesh)
 }

--- a/examples/3d/rotate_environment_map.rs
+++ b/examples/3d/rotate_environment_map.rs
@@ -7,6 +7,7 @@ use bevy::{
     core_pipeline::{tonemapping::Tonemapping::AcesFitted, Skybox},
     image::ImageLoaderSettings,
     prelude::*,
+    render::mesh::TangentStrategy,
 };
 
 /// Entry point.
@@ -51,7 +52,7 @@ fn create_sphere_mesh(meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
 
     let mut sphere_mesh = Sphere::new(1.0).mesh().build();
     sphere_mesh
-        .generate_tangents()
+        .compute_tangents(TangentStrategy::HighQuality)
         .expect("Failed to generate tangents");
     meshes.add(sphere_mesh)
 }

--- a/examples/3d/rotate_environment_map.rs
+++ b/examples/3d/rotate_environment_map.rs
@@ -7,7 +7,7 @@ use bevy::{
     core_pipeline::{tonemapping::Tonemapping::AcesFitted, Skybox},
     image::ImageLoaderSettings,
     prelude::*,
-    render::mesh::TangentCalculationStrategy,
+    render::mesh::TangentAlgorithm,
 };
 
 /// Entry point.
@@ -52,7 +52,7 @@ fn create_sphere_mesh(meshes: &mut Assets<Mesh>) -> Handle<Mesh> {
 
     let mut sphere_mesh = Sphere::new(1.0).mesh().build();
     sphere_mesh
-        .compute_tangents(TangentCalculationStrategy::HighQuality)
+        .compute_tangents(TangentAlgorithm::Mikktspace)
         .expect("Failed to generate tangents");
     meshes.add(sphere_mesh)
 }

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -11,7 +11,7 @@ use bevy::ecs::{
 use bevy::math::sampling::UniformMeshSampler;
 use bevy::prelude::*;
 
-use bevy::render::mesh::TangentStrategy;
+use bevy::render::mesh::TangentCalculationStrategy;
 use rand::distributions::Distribution;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -96,7 +96,7 @@ fn setup(
 
     // Create a new sphere mesh:
     let mut sphere_mesh = Sphere::new(1.0).mesh().ico(7)?;
-    sphere_mesh.compute_tangents(TangentStrategy::HighQuality)?;
+    sphere_mesh.compute_tangents(TangentCalculationStrategy::HighQuality)?;
 
     // Spawn the mesh into the scene:
     let mut sphere = commands.spawn((

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -11,7 +11,7 @@ use bevy::ecs::{
 use bevy::math::sampling::UniformMeshSampler;
 use bevy::prelude::*;
 
-use bevy::render::mesh::TangentCalculationStrategy;
+use bevy::render::mesh::TangentAlgorithm;
 use rand::distributions::Distribution;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -96,7 +96,7 @@ fn setup(
 
     // Create a new sphere mesh:
     let mut sphere_mesh = Sphere::new(1.0).mesh().ico(7)?;
-    sphere_mesh.compute_tangents(TangentCalculationStrategy::HighQuality)?;
+    sphere_mesh.compute_tangents(TangentAlgorithm::Mikktspace)?;
 
     // Spawn the mesh into the scene:
     let mut sphere = commands.spawn((

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -11,6 +11,7 @@ use bevy::ecs::{
 use bevy::math::sampling::UniformMeshSampler;
 use bevy::prelude::*;
 
+use bevy::render::mesh::TangentStrategy;
 use rand::distributions::Distribution;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -95,7 +96,7 @@ fn setup(
 
     // Create a new sphere mesh:
     let mut sphere_mesh = Sphere::new(1.0).mesh().ico(7)?;
-    sphere_mesh.generate_tangents()?;
+    sphere_mesh.compute_tangents(TangentStrategy::HighQuality)?;
 
     // Spawn the mesh into the scene:
     let mut sphere = commands.spawn((


### PR DESCRIPTION
# Provide a fast alternative algorithm for tangent generation

Fixes: #17834
Related (maybe): #17877

## Solution

Add a new enum `TangentStrategy` that gives the user the option to select how tangents are generated. 

The GLTF loader now has a property to set which algorithm is used for models that are missing tangents.

The `FastApproximation` strategy is implemented with the Gram-Schmidt fast approximation technique. The `HighQuality` variant uses MikkTSpace.

## Testing

Unit tests have been added to assert that both tangent computation strategies produce similar tangents for simple shapes. I also tried to check several examples to verify that the visual results are acceptable with both algorithms. I wasn't able to tell any visible difference.

> How can other people (reviewers) test your changes? Is there anything specific they need to know?

I checked the `deferred_rendering`, `parallax_mapping`, and `anisotropy` examples. Suspiciously, when I produced intentionally invalid tangents, the deferred_rendering and parallax_mapping examples seemed to render fine. I didn't try the anisotropy example with intentionally invalid values. I'm curious if there is an unrelated bug in the shader where tangents are ignored (or the examples I tested somehow didn't leverage tangents). 

## Migration Guide

- `GenerateTangentsError::MikktspaceError` has been renamed `GenerateTangentsError::AlgorithmError`
- The `Mesh::generate_tangents` and `Mesh::with_generated_tangents` methods are now deprecated. They are replaced by `compute_tangents`  and `with_computed_tangents`, both of which accept a `TangentStrategy` parameter. The naming conventino of these methods now matches `compute_normals`.


