### PR TITLE
impl `Eq`/`PartialEq` for `MeshMaterial{2|3}d`

### DIFF
--- a/crates/bevy_pbr/src/mesh_material.rs
+++ b/crates/bevy_pbr/src/mesh_material.rs
@@ -36,7 +36,7 @@ use derive_more::derive::From;
 ///     ));
 /// }
 /// ```
-#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
+#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, From)]
 #[reflect(Component, Default)]
 pub struct MeshMaterial3d<M: Material>(pub Handle<M>);
 
@@ -45,6 +45,14 @@ impl<M: Material> Default for MeshMaterial3d<M> {
         Self(Handle::default())
     }
 }
+
+impl<M: Material> PartialEq for MeshMaterial3d<M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<M: Material> Eq for MeshMaterial3d<M> {}
 
 impl<M: Material> From<MeshMaterial3d<M>> for AssetId<M> {
     fn from(material: MeshMaterial3d<M>) -> Self {

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -186,7 +186,7 @@ pub trait Material2d: AsBindGroup + Asset + Clone + Sized {
 /// ```
 ///
 /// [`MeshMaterial2d`]: crate::MeshMaterial2d
-#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, PartialEq, Eq, From)]
+#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, From)]
 #[reflect(Component, Default)]
 pub struct MeshMaterial2d<M: Material2d>(pub Handle<M>);
 
@@ -195,6 +195,14 @@ impl<M: Material2d> Default for MeshMaterial2d<M> {
         Self(Handle::default())
     }
 }
+
+impl<M: Material2d> PartialEq for MeshMaterial2d<M> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<M: Material2d> Eq for MeshMaterial2d<M> {}
 
 impl<M: Material2d> From<MeshMaterial2d<M>> for AssetId<M> {
     fn from(material: MeshMaterial2d<M>) -> Self {


### PR DESCRIPTION
# Objective

`Eq`/`PartialEq` are currently implemented for `MeshMaterial{2|3}d` only through the derive macro. Since we don't have perfect derive yet, the impls are only present for `M: Eq` and `M: PartialEq`. On the other hand, I want to be able to compare material components for my toy reactivity project.

## Solution

Switch to manual `Eq`/`PartialEq` impl.

## Testing

Boy I hope this didn't break anything!