### PR TITLE
Fix mesh tangent attribute matching in mesh transform operations

### DIFF
--- a/crates/bevy_mesh/src/mesh.rs
+++ b/crates/bevy_mesh/src/mesh.rs
@@ -909,13 +909,16 @@ impl Mesh {
             });
         }
 
-        if let Some(VertexAttributeValues::Float32x3(tangents)) =
+        if let Some(VertexAttributeValues::Float32x4(tangents)) =
             self.attribute_mut(Mesh::ATTRIBUTE_TANGENT)
         {
             // Transform tangents, taking into account non-uniform scaling and rotation
             tangents.iter_mut().for_each(|tangent| {
+                let handedness = tangent[3];
                 let scaled_tangent = Vec3::from_slice(tangent) * transform.scale;
-                *tangent = (transform.rotation * scaled_tangent.normalize_or_zero()).to_array();
+                *tangent = (transform.rotation * scaled_tangent.normalize_or_zero())
+                    .extend(handedness)
+                    .to_array();
             });
         }
     }
@@ -981,12 +984,15 @@ impl Mesh {
             });
         }
 
-        if let Some(VertexAttributeValues::Float32x3(tangents)) =
+        if let Some(VertexAttributeValues::Float32x4(tangents)) =
             self.attribute_mut(Mesh::ATTRIBUTE_TANGENT)
         {
             // Transform tangents
             tangents.iter_mut().for_each(|tangent| {
-                *tangent = (rotation * Vec3::from_slice(tangent).normalize_or_zero()).to_array();
+                let handedness = tangent[3];
+                *tangent = (rotation * Vec3::from_slice(tangent).normalize_or_zero())
+                    .extend(handedness)
+                    .to_array();
             });
         }
     }
@@ -1033,13 +1039,17 @@ impl Mesh {
             });
         }
 
-        if let Some(VertexAttributeValues::Float32x3(tangents)) =
+        if let Some(VertexAttributeValues::Float32x4(tangents)) =
             self.attribute_mut(Mesh::ATTRIBUTE_TANGENT)
         {
             // Transform tangents, taking into account non-uniform scaling
             tangents.iter_mut().for_each(|tangent| {
+                let handedness = tangent[3];
                 let scaled_tangent = Vec3::from_slice(tangent) * scale;
-                *tangent = scaled_tangent.normalize_or_zero().to_array();
+                *tangent = scaled_tangent
+                    .normalize_or_zero()
+                    .extend(handedness)
+                    .to_array();
             });
         }
     }


### PR DESCRIPTION
Fixes #17170

# Objective

Tangents are not currently transformed as described in #17170. I came across this while working on #17989 and it seemed like low hanging fruit. 
