### PR TITLE
Inheritable Render Layers

### DIFF
--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 };
 use bevy_image::BevyDefault as _;
 use bevy_math::FloatOrd;
-use bevy_render::sync_world::MainEntity;
+use bevy_render::{sync_world::MainEntity, view::ComputedVisibleLayers};
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
@@ -24,7 +24,7 @@ use bevy_render::{
         ViewSortedRenderPhases,
     },
     render_resource::*,
-    view::{ExtractedView, Msaa, RenderLayers, ViewTarget},
+    view::{ExtractedView, Msaa, ViewTarget},
     Render, RenderApp, RenderSet,
 };
 use bevy_sprite::{Mesh2dPipeline, Mesh2dPipelineKey, SetMesh2dViewBindGroup};
@@ -297,7 +297,7 @@ fn queue_line_gizmos_2d(
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    mut views: Query<(&ExtractedView, &Msaa, Option<&RenderLayers>)>,
+    mut views: Query<(&ExtractedView, &Msaa, Option<&ComputedVisibleLayers>)>,
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo2d>().unwrap();
     let draw_function_strip = draw_functions
@@ -376,7 +376,7 @@ fn queue_line_joint_gizmos_2d(
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    mut views: Query<(&ExtractedView, &Msaa, Option<&RenderLayers>)>,
+    mut views: Query<(&ExtractedView, &Msaa, Option<&ComputedVisibleLayers>)>,
 ) {
     let draw_function = draw_functions
         .read()

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
 };
 use bevy_image::BevyDefault as _;
 use bevy_math::FloatOrd;
-use bevy_render::{sync_world::MainEntity, view::ComputedVisibleLayers};
+use bevy_render::{sync_world::MainEntity, view::InheritedVisibleLayers};
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
@@ -297,7 +297,7 @@ fn queue_line_gizmos_2d(
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    mut views: Query<(&ExtractedView, &Msaa, Option<&ComputedVisibleLayers>)>,
+    mut views: Query<(&ExtractedView, &Msaa, Option<&InheritedVisibleLayers>)>,
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo2d>().unwrap();
     let draw_function_strip = draw_functions
@@ -376,7 +376,7 @@ fn queue_line_joint_gizmos_2d(
     line_gizmos: Query<(Entity, &MainEntity, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<GpuLineGizmo>>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
-    mut views: Query<(&ExtractedView, &Msaa, Option<&ComputedVisibleLayers>)>,
+    mut views: Query<(&ExtractedView, &Msaa, Option<&InheritedVisibleLayers>)>,
 ) {
     let draw_function = draw_functions
         .read()

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -20,7 +20,7 @@ use bevy_ecs::{
 };
 use bevy_image::BevyDefault as _;
 use bevy_pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
-use bevy_render::sync_world::MainEntity;
+use bevy_render::{sync_world::MainEntity, view::ComputedVisibleLayers};
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
@@ -28,7 +28,7 @@ use bevy_render::{
         ViewSortedRenderPhases,
     },
     render_resource::*,
-    view::{ExtractedView, Msaa, RenderLayers, ViewTarget},
+    view::{ExtractedView, Msaa, ViewTarget},
     Render, RenderApp, RenderSet,
 };
 use tracing::error;
@@ -295,7 +295,7 @@ fn queue_line_gizmos_3d(
     views: Query<(
         &ExtractedView,
         &Msaa,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         (
             Has<NormalPrepass>,
             Has<DepthPrepass>,
@@ -410,7 +410,7 @@ fn queue_line_joint_gizmos_3d(
     views: Query<(
         &ExtractedView,
         &Msaa,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         (
             Has<NormalPrepass>,
             Has<DepthPrepass>,

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -20,7 +20,7 @@ use bevy_ecs::{
 };
 use bevy_image::BevyDefault as _;
 use bevy_pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};
-use bevy_render::{sync_world::MainEntity, view::ComputedVisibleLayers};
+use bevy_render::{sync_world::MainEntity, view::InheritedVisibleLayers};
 use bevy_render::{
     render_asset::{prepare_assets, RenderAssets},
     render_phase::{
@@ -295,7 +295,7 @@ fn queue_line_gizmos_3d(
     views: Query<(
         &ExtractedView,
         &Msaa,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         (
             Has<NormalPrepass>,
             Has<DepthPrepass>,
@@ -410,7 +410,7 @@ fn queue_line_joint_gizmos_3d(
     views: Query<(
         &ExtractedView,
         &Msaa,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         (
             Has<NormalPrepass>,
             Has<DepthPrepass>,

--- a/crates/bevy_gizmos/src/retained.rs
+++ b/crates/bevy_gizmos/src/retained.rs
@@ -17,7 +17,7 @@ use {
         entity::Entity,
         system::{Commands, Local, Query},
     },
-    bevy_render::{view::RenderLayers, Extract},
+    bevy_render::{view::ComputedVisibleLayers, Extract},
     bevy_transform::components::GlobalTransform,
 };
 
@@ -102,7 +102,7 @@ pub struct Gizmo {
 pub(crate) fn extract_linegizmos(
     mut commands: Commands,
     mut previous_len: Local<usize>,
-    query: Extract<Query<(Entity, &Gizmo, &GlobalTransform, Option<&RenderLayers>)>>,
+    query: Extract<Query<(Entity, &Gizmo, &GlobalTransform, Option<&ComputedVisibleLayers>)>>,
 ) {
     use bevy_math::Affine3;
     use bevy_render::sync_world::{MainEntity, TemporaryRenderEntity};
@@ -151,7 +151,7 @@ pub(crate) fn extract_linegizmos(
                 line_perspective: gizmo.line_config.perspective,
                 line_style: gizmo.line_config.style,
                 line_joints: gizmo.line_config.joints,
-                render_layers: render_layers.cloned().unwrap_or_default(),
+                render_layers: render_layers.cloned().unwrap_or_default().0,
                 handle: gizmo.handle.clone_weak(),
             },
             MainEntity::from(entity),

--- a/crates/bevy_gizmos/src/retained.rs
+++ b/crates/bevy_gizmos/src/retained.rs
@@ -17,7 +17,7 @@ use {
         entity::Entity,
         system::{Commands, Local, Query},
     },
-    bevy_render::{view::ComputedVisibleLayers, Extract},
+    bevy_render::{view::InheritedVisibleLayers, Extract},
     bevy_transform::components::GlobalTransform,
 };
 
@@ -102,7 +102,7 @@ pub struct Gizmo {
 pub(crate) fn extract_linegizmos(
     mut commands: Commands,
     mut previous_len: Local<usize>,
-    query: Extract<Query<(Entity, &Gizmo, &GlobalTransform, Option<&ComputedVisibleLayers>)>>,
+    query: Extract<Query<(Entity, &Gizmo, &GlobalTransform, Option<&InheritedVisibleLayers>)>>,
 ) {
     use bevy_math::Affine3;
     use bevy_render::sync_world::{MainEntity, TemporaryRenderEntity};

--- a/crates/bevy_pbr/src/cluster/assign.rs
+++ b/crates/bevy_pbr/src/cluster/assign.rs
@@ -14,7 +14,7 @@ use bevy_render::{
     primitives::{Aabb, Frustum, HalfSpace, Sphere},
     render_resource::BufferBindingType,
     renderer::{RenderAdapter, RenderDevice},
-    view::{ComputedVisibleLayers, RenderLayers, ViewVisibility},
+    view::{InheritedVisibleLayers, RenderLayers, ViewVisibility},
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::prelude::default;
@@ -142,7 +142,6 @@ impl ClusterableObjectType {
     }
 }
 
-// TODO GRACE: make sure ordering is good!
 // NOTE: Run this before update_point_light_frusta!
 pub(crate) fn assign_objects_to_clusters(
     mut commands: Commands,
@@ -154,14 +153,14 @@ pub(crate) fn assign_objects_to_clusters(
         &Frustum,
         &ClusterConfig,
         &mut Clusters,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         Option<&mut VisibleClusterableObjects>,
     )>,
     point_lights_query: Query<(
         Entity,
         &GlobalTransform,
         &PointLight,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         Option<&VolumetricLight>,
         &ViewVisibility,
     )>,
@@ -169,7 +168,7 @@ pub(crate) fn assign_objects_to_clusters(
         Entity,
         &GlobalTransform,
         &SpotLight,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         Option<&VolumetricLight>,
         &ViewVisibility,
     )>,

--- a/crates/bevy_pbr/src/cluster/assign.rs
+++ b/crates/bevy_pbr/src/cluster/assign.rs
@@ -14,7 +14,7 @@ use bevy_render::{
     primitives::{Aabb, Frustum, HalfSpace, Sphere},
     render_resource::BufferBindingType,
     renderer::{RenderAdapter, RenderDevice},
-    view::{RenderLayers, ViewVisibility},
+    view::{ComputedVisibleLayers, RenderLayers, ViewVisibility},
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::prelude::default;
@@ -142,6 +142,7 @@ impl ClusterableObjectType {
     }
 }
 
+// TODO GRACE: make sure ordering is good!
 // NOTE: Run this before update_point_light_frusta!
 pub(crate) fn assign_objects_to_clusters(
     mut commands: Commands,
@@ -153,14 +154,14 @@ pub(crate) fn assign_objects_to_clusters(
         &Frustum,
         &ClusterConfig,
         &mut Clusters,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         Option<&mut VisibleClusterableObjects>,
     )>,
     point_lights_query: Query<(
         Entity,
         &GlobalTransform,
         &PointLight,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         Option<&VolumetricLight>,
         &ViewVisibility,
     )>,
@@ -168,7 +169,7 @@ pub(crate) fn assign_objects_to_clusters(
         Entity,
         &GlobalTransform,
         &SpotLight,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         Option<&VolumetricLight>,
         &ViewVisibility,
     )>,
@@ -203,7 +204,7 @@ pub(crate) fn assign_objects_to_clusters(
                             shadows_enabled: point_light.shadows_enabled,
                             volumetric: volumetric.is_some(),
                         },
-                        render_layers: maybe_layers.unwrap_or_default().clone(),
+                        render_layers: maybe_layers.unwrap_or_default().0.clone(),
                     }
                 },
             ),
@@ -223,7 +224,7 @@ pub(crate) fn assign_objects_to_clusters(
                             shadows_enabled: spot_light.shadows_enabled,
                             volumetric: volumetric.is_some(),
                         },
-                        render_layers: maybe_layers.unwrap_or_default().clone(),
+                        render_layers: maybe_layers.unwrap_or_default().0.clone(),
                     }
                 },
             ),

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -13,7 +13,7 @@ use bevy_render::{
     mesh::Mesh3d,
     primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, Sphere},
     view::{
-        ComputedVisibleLayers, InheritedVisibility, NoFrustumCulling, PreviousVisibleEntities, ViewVisibility, VisibilityClass, VisibilityRange, VisibleEntityRanges
+        InheritedVisibleLayers, InheritedVisibility, NoFrustumCulling, PreviousVisibleEntities, ViewVisibility, VisibilityClass, VisibilityRange, VisibleEntityRanges
     },
 };
 use bevy_transform::components::{GlobalTransform, Transform};
@@ -666,7 +666,7 @@ pub fn check_dir_light_mesh_visibility(
             &DirectionalLight,
             &CascadesFrusta,
             &mut CascadesVisibleEntities,
-            Option<&ComputedVisibleLayers>,
+            Option<&InheritedVisibleLayers>,
             &ViewVisibility,
         ),
         Without<SpotLight>,
@@ -675,7 +675,7 @@ pub fn check_dir_light_mesh_visibility(
         (
             Entity,
             &InheritedVisibility,
-            Option<&ComputedVisibleLayers>,
+            Option<&InheritedVisibleLayers>,
             Option<&Aabb>,
             Option<&GlobalTransform>,
             Has<VisibilityRange>,
@@ -840,21 +840,21 @@ pub fn check_point_light_mesh_visibility(
         &GlobalTransform,
         &CubemapFrusta,
         &mut CubemapVisibleEntities,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
     )>,
     mut spot_lights: Query<(
         &SpotLight,
         &GlobalTransform,
         &Frustum,
         &mut VisibleMeshEntities,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
     )>,
     mut visible_entity_query: Query<
         (
             Entity,
             &InheritedVisibility,
             &mut ViewVisibility,
-            Option<&ComputedVisibleLayers>,
+            Option<&InheritedVisibleLayers>,
             Option<&Aabb>,
             Option<&GlobalTransform>,
             Has<VisibilityRange>,

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -13,8 +13,7 @@ use bevy_render::{
     mesh::Mesh3d,
     primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, Sphere},
     view::{
-        InheritedVisibility, NoFrustumCulling, PreviousVisibleEntities, RenderLayers,
-        ViewVisibility, VisibilityClass, VisibilityRange, VisibleEntityRanges,
+        ComputedVisibleLayers, InheritedVisibility, NoFrustumCulling, PreviousVisibleEntities, ViewVisibility, VisibilityClass, VisibilityRange, VisibleEntityRanges
     },
 };
 use bevy_transform::components::{GlobalTransform, Transform};
@@ -667,7 +666,7 @@ pub fn check_dir_light_mesh_visibility(
             &DirectionalLight,
             &CascadesFrusta,
             &mut CascadesVisibleEntities,
-            Option<&RenderLayers>,
+            Option<&ComputedVisibleLayers>,
             &ViewVisibility,
         ),
         Without<SpotLight>,
@@ -676,7 +675,7 @@ pub fn check_dir_light_mesh_visibility(
         (
             Entity,
             &InheritedVisibility,
-            Option<&RenderLayers>,
+            Option<&ComputedVisibleLayers>,
             Option<&Aabb>,
             Option<&GlobalTransform>,
             Has<VisibilityRange>,
@@ -841,21 +840,21 @@ pub fn check_point_light_mesh_visibility(
         &GlobalTransform,
         &CubemapFrusta,
         &mut CubemapVisibleEntities,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
     )>,
     mut spot_lights: Query<(
         &SpotLight,
         &GlobalTransform,
         &Frustum,
         &mut VisibleMeshEntities,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
     )>,
     mut visible_entity_query: Query<
         (
             Entity,
             &InheritedVisibility,
             &mut ViewVisibility,
-            Option<&RenderLayers>,
+            Option<&ComputedVisibleLayers>,
             Option<&Aabb>,
             Option<&GlobalTransform>,
             Has<VisibilityRange>,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -19,6 +19,7 @@ use bevy_render::experimental::occlusion_culling::{
     OcclusionCulling, OcclusionCullingSubview, OcclusionCullingSubviewEntities,
 };
 use bevy_render::sync_world::MainEntityHashMap;
+use bevy_render::view::ComputedVisibleLayers;
 use bevy_render::{
     batching::gpu_preprocessing::{GpuPreprocessingMode, GpuPreprocessingSupport},
     camera::SortedCameras,
@@ -257,7 +258,7 @@ pub fn extract_lights(
                 &CascadesFrusta,
                 &GlobalTransform,
                 &ViewVisibility,
-                Option<&RenderLayers>,
+                Option<&ComputedVisibleLayers>,
                 Option<&VolumetricLight>,
                 Has<OcclusionCulling>,
             ),
@@ -489,7 +490,7 @@ pub fn extract_lights(
                     cascade_shadow_config: cascade_config.clone(),
                     cascades: extracted_cascades,
                     frusta: extracted_frusta,
-                    render_layers: maybe_layers.unwrap_or_default().clone(),
+                    render_layers: maybe_layers.unwrap_or_default().0.clone(),
                     occlusion_culling,
                 },
                 RenderCascadesVisibleEntities {
@@ -727,7 +728,7 @@ pub fn prepare_lights(
             MainEntity,
             &ExtractedView,
             &ExtractedClusterConfig,
-            Option<&RenderLayers>,
+            Option<&ComputedVisibleLayers>,
             Has<NoIndirectDrawing>,
             Option<&AmbientLight>,
         ),

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -19,7 +19,7 @@ use bevy_render::experimental::occlusion_culling::{
     OcclusionCulling, OcclusionCullingSubview, OcclusionCullingSubviewEntities,
 };
 use bevy_render::sync_world::MainEntityHashMap;
-use bevy_render::view::ComputedVisibleLayers;
+use bevy_render::view::InheritedVisibleLayers;
 use bevy_render::{
     batching::gpu_preprocessing::{GpuPreprocessingMode, GpuPreprocessingSupport},
     camera::SortedCameras,
@@ -258,7 +258,7 @@ pub fn extract_lights(
                 &CascadesFrusta,
                 &GlobalTransform,
                 &ViewVisibility,
-                Option<&ComputedVisibleLayers>,
+                Option<&InheritedVisibleLayers>,
                 Option<&VolumetricLight>,
                 Has<OcclusionCulling>,
             ),
@@ -728,7 +728,7 @@ pub fn prepare_lights(
             MainEntity,
             &ExtractedView,
             &ExtractedClusterConfig,
-            Option<&ComputedVisibleLayers>,
+            Option<&InheritedVisibleLayers>,
             Has<NoIndirectDrawing>,
             Option<&AmbientLight>,
         ),

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
-use bevy_render::{prelude::*, view::RenderLayers};
+use bevy_render::{prelude::*, view::ComputedVisibleLayers};
 use ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastVisibility, SimplifiedMesh};
 
 /// Runtime settings for the [`MeshPickingPlugin`].
@@ -72,14 +72,15 @@ impl Plugin for MeshPickingPlugin {
     }
 }
 
+// TODO GRACE: make sure that this system is ordered appropriately to new systemss
 /// Casts rays into the scene using [`MeshPickingSettings`] and sends [`PointerHits`] events.
 pub fn update_hits(
     backend_settings: Res<MeshPickingSettings>,
     ray_map: Res<RayMap>,
-    picking_cameras: Query<(&Camera, Option<&RayCastPickable>, Option<&RenderLayers>)>,
+    picking_cameras: Query<(&Camera, Option<&RayCastPickable>, Option<&ComputedVisibleLayers>)>,
     pickables: Query<&Pickable>,
     marked_targets: Query<&RayCastPickable>,
-    layers: Query<&RenderLayers>,
+    layers: Query<&ComputedVisibleLayers>,
     mut ray_cast: MeshRayCast,
     mut output: EventWriter<PointerHits>,
 ) {
@@ -100,7 +101,7 @@ pub fn update_hits(
                     !backend_settings.require_markers || marked_targets.get(entity).is_ok();
 
                 // Other entities missing render layers are on the default layer 0
-                let entity_layers = layers.get(entity).cloned().unwrap_or_default();
+                let entity_layers = layers.get(entity).cloned().unwrap_or_default().0;
                 let render_layers_match = cam_layers.intersects(&entity_layers);
 
                 let is_pickable = pickables.get(entity).ok().is_none_or(|p| p.is_hoverable);

--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
-use bevy_render::{prelude::*, view::ComputedVisibleLayers};
+use bevy_render::{prelude::*, view::InheritedVisibleLayers};
 use ray_cast::{MeshRayCast, MeshRayCastSettings, RayCastVisibility, SimplifiedMesh};
 
 /// Runtime settings for the [`MeshPickingPlugin`].
@@ -72,15 +72,14 @@ impl Plugin for MeshPickingPlugin {
     }
 }
 
-// TODO GRACE: make sure that this system is ordered appropriately to new systemss
 /// Casts rays into the scene using [`MeshPickingSettings`] and sends [`PointerHits`] events.
 pub fn update_hits(
     backend_settings: Res<MeshPickingSettings>,
     ray_map: Res<RayMap>,
-    picking_cameras: Query<(&Camera, Option<&RayCastPickable>, Option<&ComputedVisibleLayers>)>,
+    picking_cameras: Query<(&Camera, Option<&RayCastPickable>, Option<&InheritedVisibleLayers>)>,
     pickables: Query<&Pickable>,
     marked_targets: Query<&RayCastPickable>,
-    layers: Query<&ComputedVisibleLayers>,
+    layers: Query<&InheritedVisibleLayers>,
     mut ray_cast: MeshRayCast,
     mut output: EventWriter<PointerHits>,
 ) {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -13,7 +13,7 @@ use crate::{
     sync_world::{RenderEntity, SyncToRenderWorld},
     texture::GpuImage,
     view::{
-        ColorGrading, ComputedVisibleLayers, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing, RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset, Visibility, VisibleEntities
+        ColorGrading, InheritedVisibleLayers, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing, RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset, Visibility, VisibleEntities, VisibleLayers
     },
     Extract,
 };
@@ -1041,7 +1041,6 @@ pub struct ExtractedCamera {
     pub hdr: bool,
 }
 
-// TODO GRACE: order appropriately(?)
 pub fn extract_cameras(
     mut commands: Commands,
     query: Extract<
@@ -1056,7 +1055,7 @@ pub fn extract_cameras(
             Option<&ColorGrading>,
             Option<&Exposure>,
             Option<&TemporalJitter>,
-            Option<&ComputedVisibleLayers>,
+            Option<&InheritedVisibleLayers>,
             Option<&Projection>,
             Has<NoIndirectDrawing>,
         )>,
@@ -1088,8 +1087,8 @@ pub fn extract_cameras(
                 ExtractedView,
                 RenderVisibleEntities,
                 TemporalJitter,
-                // TODO GRACE: what is this code supposed to do?
-                // RenderLayers,
+                VisibleLayers,
+                InheritedVisibleLayers,
                 Projection,
                 NoIndirectDrawing,
                 ViewUniformOffset,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -13,8 +13,7 @@ use crate::{
     sync_world::{RenderEntity, SyncToRenderWorld},
     texture::GpuImage,
     view::{
-        ColorGrading, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing, RenderLayers,
-        RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset, Visibility, VisibleEntities,
+        ColorGrading, ComputedVisibleLayers, ExtractedView, ExtractedWindows, Msaa, NoIndirectDrawing, RenderVisibleEntities, RetainedViewEntity, ViewUniformOffset, Visibility, VisibleEntities
     },
     Extract,
 };
@@ -1042,6 +1041,7 @@ pub struct ExtractedCamera {
     pub hdr: bool,
 }
 
+// TODO GRACE: order appropriately(?)
 pub fn extract_cameras(
     mut commands: Commands,
     query: Extract<
@@ -1056,7 +1056,7 @@ pub fn extract_cameras(
             Option<&ColorGrading>,
             Option<&Exposure>,
             Option<&TemporalJitter>,
-            Option<&RenderLayers>,
+            Option<&ComputedVisibleLayers>,
             Option<&Projection>,
             Has<NoIndirectDrawing>,
         )>,
@@ -1088,7 +1088,8 @@ pub fn extract_cameras(
                 ExtractedView,
                 RenderVisibleEntities,
                 TemporalJitter,
-                RenderLayers,
+                // TODO GRACE: what is this code supposed to do?
+                // RenderLayers,
                 Projection,
                 NoIndirectDrawing,
                 ViewUniformOffset,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -108,6 +108,8 @@ impl Plugin for ViewPlugin {
             .register_type::<Msaa>()
             .register_type::<NoFrustumCulling>()
             .register_type::<RenderLayers>()
+            .register_type::<VisibleLayers>()
+            .register_type::<ComputedVisibleLayers>()
             .register_type::<Visibility>()
             .register_type::<VisibleEntities>()
             .register_type::<ColorGrading>()

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -109,7 +109,7 @@ impl Plugin for ViewPlugin {
             .register_type::<NoFrustumCulling>()
             .register_type::<RenderLayers>()
             .register_type::<VisibleLayers>()
-            .register_type::<ComputedVisibleLayers>()
+            .register_type::<InheritedVisibleLayers>()
             .register_type::<Visibility>()
             .register_type::<VisibleEntities>()
             .register_type::<ColorGrading>()

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 /// `Visibility` to set the values of each entity's [`InheritedVisibility`] component.
 #[derive(Component, Clone, Copy, Reflect, Debug, PartialEq, Eq, Default)]
 #[reflect(Component, Default, Debug, PartialEq)]
-#[require(InheritedVisibility, ViewVisibility)]
+#[require(InheritedVisibility, ViewVisibility, VisibleLayers)]
 pub enum Visibility {
     /// An entity with `Visibility::Inherited` will inherit the Visibility of its [`ChildOf`] target.
     ///
@@ -315,7 +315,7 @@ pub enum VisibilitySystems {
     CalculateBounds,
     /// Label for [`update_frusta`] in [`CameraProjectionPlugin`](crate::camera::CameraProjectionPlugin).
     UpdateFrusta,
-    /// Label for the system propagating the [`InheritedVisibility`] in a
+    /// Label for the systems propagating [`InheritedVisibility`] and [`InheritedVisibleLayers`] in the
     /// [`ChildOf`] / [`Children`] hierarchy.
     VisibilityPropagate,
     /// Label for the [`check_visibility`] system updating [`ViewVisibility`]
@@ -489,7 +489,6 @@ fn reset_view_visibility(
     });
 }
 
-// TODO GRACE: make sure this system is consistently ordered to new systems
 /// System updating the visibility of entities each frame.
 ///
 /// The system is part of the [`VisibilitySystems::CheckVisibility`] set. Each
@@ -504,7 +503,7 @@ pub fn check_visibility(
         Entity,
         &mut VisibleEntities,
         &Frustum,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         &Camera,
         Has<NoCpuCulling>,
     )>,
@@ -513,7 +512,7 @@ pub fn check_visibility(
         &InheritedVisibility,
         &mut ViewVisibility,
         &VisibilityClass,
-        Option<&ComputedVisibleLayers>,
+        Option<&InheritedVisibleLayers>,
         Option<&Aabb>,
         &GlobalTransform,
         Has<NoFrustumCulling>,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -353,7 +353,7 @@ impl Plugin for VisibilityPlugin {
                 PostUpdate,
                 (
                     calculate_bounds.in_set(CalculateBounds),
-                    (visibility_propagate_system, reset_view_visibility)
+                    (visibility_propagate_system, visible_layers_propagate_system, reset_view_visibility)
                         .in_set(VisibilityPropagate),
                     check_visibility.in_set(CheckVisibility),
                     mark_newly_hidden_entities_invisible.in_set(MarkNewlyHiddenEntitiesInvisible),
@@ -489,6 +489,7 @@ fn reset_view_visibility(
     });
 }
 
+// TODO GRACE: make sure this system is consistently ordered to new systems
 /// System updating the visibility of entities each frame.
 ///
 /// The system is part of the [`VisibilitySystems::CheckVisibility`] set. Each
@@ -503,7 +504,7 @@ pub fn check_visibility(
         Entity,
         &mut VisibleEntities,
         &Frustum,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         &Camera,
         Has<NoCpuCulling>,
     )>,
@@ -512,7 +513,7 @@ pub fn check_visibility(
         &InheritedVisibility,
         &mut ViewVisibility,
         &VisibilityClass,
-        Option<&RenderLayers>,
+        Option<&ComputedVisibleLayers>,
         Option<&Aabb>,
         &GlobalTransform,
         Has<NoFrustumCulling>,

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -350,18 +350,18 @@ fn propagate_recursive(
 ) -> Result<(), ()> {
     // Get the visible_layer components for the current entity.
     // If the entity does not have the required components, just return early.
-    let (visibility, mut inherited_visibility) = visible_layer_query.get_mut(entity).map_err(drop)?;
+    let (visible_layers, mut inherited_visible_layers) = visible_layer_query.get_mut(entity).map_err(drop)?;
 
-    let render_layers = match visibility {
+    let render_layers = match visible_layers {
         VisibleLayers::Override(layers) => layers.clone(),
         VisibleLayers::Inherited => parent_render_layers.clone()
     };
 
-    if inherited_visibility.0 != render_layers {
-        inherited_visibility.0 = render_layers;
-        let new_render_layers = inherited_visibility.0.clone();
+    if inherited_visible_layers.0 != render_layers {
+        inherited_visible_layers.0 = render_layers;
+        let new_render_layers = inherited_visible_layers.0.clone();
 
-        for &child in children_query.into_iter().flatten() {
+        for &child in children_query.get(entity).ok().into_iter().flatten() {
             let _ = propagate_recursive(&new_render_layers, child, &mut visible_layer_query, &children_query);
         }
     }

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -8,7 +8,7 @@ use bevy::{
         render_resource::{
             Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
         },
-        view::RenderLayers,
+        view::VisibleLayers,
     },
     window::WindowResized,
 };
@@ -21,10 +21,10 @@ const RES_HEIGHT: u32 = 90;
 
 /// Default render layers for pixel-perfect rendering.
 /// You can skip adding this component, as this is the default.
-const PIXEL_PERFECT_LAYERS: RenderLayers = RenderLayers::layer(0);
+const PIXEL_PERFECT_LAYERS: VisibleLayers = VisibleLayers::layer(0);
 
 /// Render layers for high-resolution rendering.
-const HIGH_RES_LAYERS: RenderLayers = RenderLayers::layer(1);
+const HIGH_RES_LAYERS: VisibleLayers = VisibleLayers::layer(1);
 
 fn main() {
     App::new()

--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -7,7 +7,7 @@ use bevy::{
     color::palettes::css::{BLUE, GREEN, RED},
     core_pipeline::oit::OrderIndependentTransparencySettings,
     prelude::*,
-    render::view::RenderLayers,
+    render::view::VisibleLayers,
 };
 
 fn main() {
@@ -30,7 +30,7 @@ fn setup(
         Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
         // Add this component to this camera to render transparent meshes using OIT
         OrderIndependentTransparencySettings::default(),
-        RenderLayers::layer(1),
+        VisibleLayers::layer(1),
         // Msaa currently doesn't work with OIT
         Msaa::Off,
     ));
@@ -42,7 +42,7 @@ fn setup(
             ..default()
         },
         Transform::from_xyz(4.0, 8.0, 4.0),
-        RenderLayers::layer(1),
+        VisibleLayers::layer(1),
     ));
 
     // spawn help text
@@ -55,7 +55,7 @@ fn setup(
                 left: Val::Px(12.0),
                 ..default()
             },
-            RenderLayers::layer(1),
+            VisibleLayers::layer(1),
         ))
         .with_children(|p| {
             p.spawn(TextSpan::new("Press T to toggle OIT\n"));
@@ -135,7 +135,7 @@ fn spawn_spheres(
 
     let alpha = 0.25;
 
-    let render_layers = RenderLayers::layer(1);
+    let render_layers = VisibleLayers::layer(1);
 
     commands.spawn((
         Mesh3d(sphere_handle.clone()),
@@ -181,7 +181,7 @@ fn spawn_occlusion_test(
     let cube_handle = meshes.add(Cuboid::from_size(Vec3::ONE).mesh());
     let cube_material = materials.add(Color::srgb(0.8, 0.7, 0.6));
 
-    let render_layers = RenderLayers::layer(1);
+    let render_layers = VisibleLayers::layer(1);
 
     // front
     let x = -2.5;

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -7,7 +7,7 @@ use bevy::{
     render::{
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat, TextureUsages},
-        view::RenderLayers,
+        view::{VisibleLayers, RenderLayers},
     },
 };
 
@@ -62,7 +62,7 @@ fn setup(
     });
 
     // This specifies the layer used for the first pass, which will be attached to the first pass camera and cube.
-    let first_pass_layer = RenderLayers::layer(1);
+    let first_pass_layer = VisibleLayers::layer(1);
 
     // The cube that will be rendered to the texture.
     commands.spawn((
@@ -80,7 +80,7 @@ fn setup(
     commands.spawn((
         PointLight::default(),
         Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-        RenderLayers::layer(0).with(1),
+        VisibleLayers::Override(RenderLayers::layer(0).with(1)),
     ));
 
     commands.spawn((

--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -46,7 +46,7 @@ use std::f32::consts::FRAC_PI_2;
 
 use bevy::{
     color::palettes::tailwind, input::mouse::AccumulatedMouseMotion, pbr::NotShadowCaster,
-    prelude::*, render::view::RenderLayers,
+    prelude::*, render::view::VisibleLayers,
 };
 
 fn main() {
@@ -134,7 +134,7 @@ fn spawn_view_model(
                     ..default()
                 }),
                 // Only render objects belonging to the view model.
-                RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
+                VisibleLayers::layer(VIEW_MODEL_RENDER_LAYER),
             ));
 
             // Spawn the player's right arm.
@@ -143,7 +143,7 @@ fn spawn_view_model(
                 MeshMaterial3d(arm_material),
                 Transform::from_xyz(0.2, -0.1, -0.25),
                 // Ensure the arm is only rendered by the view model camera.
-                RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
+                VisibleLayers::layer(VIEW_MODEL_RENDER_LAYER),
                 // The arm is free-floating, so shadows would look weird.
                 NotShadowCaster,
             ));
@@ -186,7 +186,7 @@ fn spawn_lights(mut commands: Commands) {
         },
         Transform::from_xyz(-2.0, 4.0, -0.75),
         // The light source illuminates both the world model and the view model.
-        RenderLayers::from_layers(&[DEFAULT_RENDER_LAYER, VIEW_MODEL_RENDER_LAYER]),
+        VisibleLayers::from_layers(&[DEFAULT_RENDER_LAYER, VIEW_MODEL_RENDER_LAYER]),
     ));
 }
 


### PR DESCRIPTION
# Objective

Implements #12461. 

## Solution

Makes `RenderLayers` no longer a component, adds components `VisibleLayers` and `InheritedVisibleLayers` that work as you'd expect, and `VisibleLayers` is now required by `Visibility`.

## Testing

These changes work on all of the examples that used to use `RenderLayers` as a component: `pixel_grid_snap`, `first_person_view_model`, `order_independent_transparency`, and `render_to_texture`.  I have yet to do any benchmarking. It also seems to work in the more hierarchical example I put in showcase.

---

## Showcase

Users can now add `VisibleLayers` to a root component of a mesh, and it will inherit down the tree!

<details>
  <summary>Click to view showcase</summary>

```rust
use std::f32::consts::PI;

use bevy::prelude::*;
use bevy_render::view::VisibleLayers;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, input)
        .run();
}

#[derive(Component)]
struct Box;

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn((Transform::default(), Visibility::default(), VisibleLayers::layer(1), Name::new("Root"))).with_children(|parent| {

        parent.spawn((
            Name::new("Camera3d"),
            Camera3d::default(),
            Transform::from_xyz(4.0, 4.0, 12.0).looking_at(Vec3::new(0.0, 0.0, 0.5), Vec3::Y),
        ));
    
        parent.spawn((
            Name::new("DirectionalLight"),
            Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
            DirectionalLight::default(),
        ));

        parent.spawn((
            Name::new("Box"),
            Transform::default(), 
            Visibility::default(),
            Box
        )).with_child((
            Name::new("BoxScene"),
            SceneRoot(asset_server.load(
                GltfAssetLabel::Scene(0).from_asset("models/GltfPrimitives/gltf_primitives.glb"),
                
            ))
        ));
    });
}

fn input(mut query: Single<&mut VisibleLayers, With<Box>>, input: Res<ButtonInput<KeyCode>>) {
    if input.just_pressed(KeyCode::KeyA) {
        **query = VisibleLayers::Inherited;
    }
    if input.just_pressed(KeyCode::KeyS) {
        **query = VisibleLayers::layer(0);
    }
    if input.just_pressed(KeyCode::KeyD) {
        **query = VisibleLayers::layer(1);
    }
}
```

</details>

## Migration Guide

- Replace uses of `RenderLayers` as a component with `VisibleLayers`.
