### PR TITLE
don't run wasm examples on firefox

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -246,7 +246,7 @@ jobs:
           # start a webserver
           python3 -m http.server --directory examples/wasm &
 
-          xvfb-run cargo run -p build-wasm-example -- --browsers chromium --browsers firefox --frames 25 --test 2d_shapes lighting text_debug breakout
+          xvfb-run cargo run -p build-wasm-example -- --browsers chromium --frames 25 --test 2d_shapes lighting text_debug breakout
 
       - name: Save screenshots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Objective

- running wasm examples in CI currently timeout, this blocks merging PRs

## Solution

- Remove running wasm examples on Firefox
- Alternative to #17999

## Testing

run in a docker container: `docker run --rm -it ubuntu`
```
apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl git software-properties-common nodejs npm build-essential
add-apt-repository ppa:kisak/turtle -y && apt-get update && apt install --no-install-recommends -y xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
. "$HOME/.cargo/env"
rustup target install wasm32-unknown-unknown

curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
cargo binstall wasm-bindgen-cli -y


git clone https://github.com/bevyengine/bevy
cd bevy

cd .github/start-wasm-example
npm install
npx playwright install --with-deps
cd ../..

python3 -m http.server --directory examples/wasm &

xvfb-run cargo run -p build-wasm-example -- --browsers firefox --frames 25 --test 2d_shapes
```
This will timeout. if you replace `firefox` by `crhomium` it works fine