### PR TITLE
don't update mesa for wasm example run

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -219,13 +219,6 @@ jobs:
             target/
           key: ${{ runner.os }}-wasm-run-examples-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: install xvfb, llvmpipe and lavapipe
-        run: |
-          sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:kisak/turtle -y
-          sudo apt-get update
-          sudo apt install -y xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
-
       - name: Install wasm-bindgen
         run: cargo install --force wasm-bindgen-cli
 


### PR DESCRIPTION
# Objective

- running wasm examples in CI currently timeout, this blocks merging PRs

## Solution

- Don't update mesa but uses the version provided by the latest ubuntu
- Alternative to #17998

## Testing

run in a docker container: `docker run --rm -it ubuntu`
```
apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl git software-properties-common nodejs npm build-essential
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
. "$HOME/.cargo/env"
rustup target install wasm32-unknown-unknown

curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
cargo binstall wasm-bindgen-cli -y


git clone https://github.com/bevyengine/bevy
cd bevy

cd .github/start-wasm-example
npm install
npx playwright install --with-deps
cd ../..

python3 -m http.server --directory examples/wasm &

xvfb-run cargo run -p build-wasm-example -- --browsers firefox --frames 25 --test 2d_shapes
```