### PR TITLE
`TaskPool`: Prefer task completion over executing new tasks

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -478,7 +478,7 @@ impl TaskPool {
                     .is_ok();
             }
         };
-        execute_forever.or(get_results).await
+        get_results.or(execute_forever).await
     }
 
     #[inline]
@@ -497,7 +497,7 @@ impl TaskPool {
                 let _result = AssertUnwindSafe(tick_forever).catch_unwind().await.is_ok();
             }
         };
-        execute_forever.or(get_results).await
+        get_results.or(execute_forever).await
     }
 
     #[inline]
@@ -519,7 +519,7 @@ impl TaskPool {
                     .is_ok();
             }
         };
-        execute_forever.or(get_results).await
+        get_results.or(execute_forever).await
     }
 
     #[inline]
@@ -537,7 +537,7 @@ impl TaskPool {
                 let _result = AssertUnwindSafe(tick_forever).catch_unwind().await.is_ok();
             }
         };
-        execute_forever.or(get_results).await
+        get_results.or(execute_forever).await
     }
 
     /// Spawns a static future onto the thread pool. The returned [`Task`] is a


### PR DESCRIPTION
# Objective

- Systems that use the task pool, either explicitly or implicitly using parallel queries, will often end up executing tasks from different systems.
- This can cause random tasks to block the main or render schedule at random, adding frame variance and increasing frame times when CPU bound.
- This profile is a common occurrence on `main`. `propagate_parent_transforms` takes more than twice as long as it should, blocking the main schedule for that time, because it uses `task pool.scope`, which has decided to execute tasks from the render schedule on the main schedule.
![image](https://github.com/user-attachments/assets/c363be40-82ce-451e-ba29-3eb4ee367e0b)


## Solution

- In task pool scope execution, prefer to check if the current task is complete instead of ticking the executor to find new work.

## Testing

- Ran the scene viewer with tracy to look for images like the one in the objective section.
- Things look much, much better, and I could not find any occurrences: 
![image](https://github.com/user-attachments/assets/18b79394-1a7c-49c1-820a-f5207e81bbac)
![image](https://github.com/user-attachments/assets/e7d4831d-66c3-41c1-ae2c-a624724c9965)

