### PR TITLE
Removes compile_fail glob pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ members = [
   "crates/*",
   # Several crates with macros have "compile fail" tests nested inside them, also known as UI
   # tests, that verify diagnostic output does not accidentally change.
-  "crates/*/compile_fail",
+  # TODO: Use a glob pattern once they are fixed in `dependabot-core`
+  # TODO: See https://github.com/bevyengine/bevy/issues/17876 for context.
+  "crates/bevy_derive/compile_fail",
+  "crates/bevy_ecs/compile_fail",
+  "crates/bevy_reflect/compile_fail",
   # Examples of compiling Bevy for mobile platforms.
   "examples/mobile",
   # Benchmarks


### PR DESCRIPTION
# Objective

- Attempts to fix #17876.

## Solution

- Reverted some changes that added a glob pattern to match all `compile_fail` crates. This should enable Dependabot to create PRs again.
- Added a TODO comment to not forget that this glob matching failure should also be fixed in the Dependabot repo.