### PR TITLE
moved Debug from derive to impl_ptr in bevy_ptr

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -9,7 +9,7 @@
 
 use core::{
     cell::UnsafeCell,
-    fmt::{self, Formatter, Pointer},
+    fmt::{self, Debug, Formatter, Pointer},
     marker::PhantomData,
     mem::ManuallyDrop,
     num::NonZeroUsize,
@@ -159,7 +159,7 @@ impl<'a, T: ?Sized> From<&'a mut T> for ConstNonNull<T> {
 ///
 /// It may be helpful to think of this type as similar to `&'a dyn Any` but without
 /// the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct Ptr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a u8, A)>);
 
@@ -174,7 +174,6 @@ pub struct Ptr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a u8, A)>
 ///
 /// It may be helpful to think of this type as similar to `&'a mut dyn Any` but without
 /// the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct PtrMut<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut u8, A)>);
 
@@ -194,7 +193,6 @@ pub struct PtrMut<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut 
 ///
 /// It may be helpful to think of this type as similar to `&'a mut ManuallyDrop<dyn Any>` but
 /// without the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct OwningPtr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut u8, A)>);
 
@@ -263,6 +261,29 @@ macro_rules! impl_ptr {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 Pointer::fmt(&self.0, f)
+            }
+        }
+
+        impl Debug for $ptr<'_, Aligned> {
+            #[inline]
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                write! {
+                    f,
+                    "{}<Aligned>({:?})",
+                    stringify!($ptr),
+                    self.0
+                }
+            }
+        }
+        impl Debug for $ptr<'_, Unaligned> {
+            #[inline]
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                write! {
+                    f,
+                    "{}<Unaligned>({:?})",
+                    stringify!($ptr),
+                    self.0
+                }
             }
         }
     };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -267,23 +267,13 @@ macro_rules! impl_ptr {
         impl Debug for $ptr<'_, Aligned> {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                write! {
-                    f,
-                    "{}<Aligned>({:?})",
-                    stringify!($ptr),
-                    self.0
-                }
+                write!(f, "{}<Aligned>({:?})", stringify!($ptr), self.0)
             }
         }
         impl Debug for $ptr<'_, Unaligned> {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                write! {
-                    f,
-                    "{}<Unaligned>({:?})",
-                    stringify!($ptr),
-                    self.0
-                }
+                write!(f, "{}<Unaligned>({:?})", stringify!($ptr), self.0)
             }
         }
     };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -17,11 +17,11 @@ use core::{
 };
 
 /// Used as a type argument to [`Ptr`], [`PtrMut`] and [`OwningPtr`] to specify that the pointer is aligned.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Aligned;
 
 /// Used as a type argument to [`Ptr`], [`PtrMut`] and [`OwningPtr`] to specify that the pointer is not aligned.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Unaligned;
 
 /// Trait that is only implemented for [`Aligned`] and [`Unaligned`] to work around the lack of ability


### PR DESCRIPTION
# Objective

Fixes #17988

## Solution

Added two Debug impls to the `impl_ptr` macro - one for Aligned and one for Unaligned.

## Testing

No tests have been added. Would a test guaranteeing debug layout be appropriate?

---

## Showcase

The debug representation of a `Ptr<'_, Aligned>` follows. `PtrMut` and `OwningPtr` are similar.

`Ptr<Aligned>(0x0123456789ab)`