### PR TITLE
update CI patch for EventWriter::send deprecation

### DIFF
--- a/tools/example-showcase/extra-window-resized-events.patch
+++ b/tools/example-showcase/extra-window-resized-events.patch
@@ -6,7 +6,7 @@ index df0aab42d..6e28a6e9c 100644
              }
          }
  
-+        window_resized.send(WindowResized {
++        window_resized.write(WindowResized {
 +            window,
 +            width: win.width(),
 +            height: win.height(),


### PR DESCRIPTION
# Objective

- EventWriter::send has been deprecated, but it was used by one of the CI patch

## Solution

- Use EventWriter::write instead
