### PR TITLE
BRP resource methods

### DIFF
--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -18,8 +18,8 @@ use bevy_platform_support::collections::HashMap;
 use bevy_reflect::{
     prelude::ReflectDefault,
     serde::{ReflectSerializer, TypedReflectDeserializer, TypedReflectSerializer},
-    GetPath as _, NamedField, OpaqueInfo, PartialReflect, ReflectDeserialize, ReflectFromPtr,
-    ReflectSerialize, TypeInfo, TypeRegistration, TypeRegistry, VariantInfo,
+    GetPath as _, NamedField, OpaqueInfo, PartialReflect, ReflectDeserialize, ReflectSerialize,
+    TypeInfo, TypeRegistration, TypeRegistry, VariantInfo,
 };
 use serde::{de::DeserializeSeed as _, Deserialize, Serialize};
 use serde_json::{json, Map, Value};

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -425,6 +425,18 @@ impl Default for RemotePlugin {
                 builtin_methods::process_remote_list_request,
             )
             .with_method(
+                builtin_methods::BRP_LIST_RESOURCES_METHOD,
+                builtin_methods::process_remote_resources_list_request,
+            )
+            .with_method(
+                builtin_methods::BRP_GET_RESOURCE_METHOD,
+                builtin_methods::process_remote_get_resources_list_request,
+            )
+            .with_method(
+                builtin_methods::BRP_MUTATE_RESOURCE_METHOD,
+                builtin_methods::process_remote_mutate_resource_request,
+            )
+            .with_method(
                 builtin_methods::BRP_REGISTRY_SCHEMA_METHOD,
                 builtin_methods::export_registry_types,
             )


### PR DESCRIPTION
# Objective

BRP has no way to interact with Resources, this is a first step to change that.

## Solution

- Add methods to:
  - list resources
  - get content of the resource
  - mutate a resource

## Testing

Tested the commands by running the BRP sample( `cargo run --example server --features="bevy_remote"`) and with these curl commands:
```
curl -X POST -d '{ "jsonrpc": "2.0", "id": 1, "method": "bevy/resources/list"}' 127.0.0.1:15702 | jq .
```
```
curl -X POST -d '{ "jsonrpc": "2.0", "id": 1, "method": "bevy/resources/get", "params": "bevy_picking::PickingPlugin" }' 127.0.0.1:15702 | jq .
```

```
curl -X POST -d '{ "jsonrpc": "2.0", "id": 1, "method": "bevy/resources/mutate", "params": {"resource": "bevy_picking::PickingPlugin", "path":"is_enabled", "value": false} }' 127.0.0.1:15702 | jq .
```
