### PR TITLE
chore: update compile fail test stderr files

### DIFF
--- a/crates/bevy_ecs/compile_fail/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -1,20 +1,22 @@
-error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` is not satisfied
+error[E0277]: `bevy_ecs::query::Changed<Foo>` is not a valid `Query` filter based on archetype information
   --> tests/ui/query_exact_sized_iterator_safety.rs:7:28
    |
 7  |     is_exact_size_iterator(query.iter());
-   |     ---------------------- ^^^^^^^^^^^^ the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Changed<Foo>`, which is required by `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>: ExactSizeIterator`
+   |     ---------------------- ^^^^^^^^^^^^ invalid `Query` filter
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Changed<Foo>`
+   = note: an `ArchetypeFilter` typically uses a combination of `With<T>` and `Without<T>` statements
    = help: the following other types implement trait `ArchetypeFilter`:
-             With<T>
-             Without<T>
-             Or<()>
-             Or<(F0,)>
-             Or<(F0, F1)>
-             Or<(F0, F1, F2)>
-             Or<(F0, F1, F2, F3)>
-             Or<(F0, F1, F2, F3, F4)>
+             ()
+             (F,)
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+             (F0, F1, F2, F3, F4, F5)
+             (F0, F1, F2, F3, F4, F5, F6)
            and 26 others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
@@ -23,23 +25,25 @@ note: required by a bound in `is_exact_size_iterator`
 16 | fn is_exact_size_iterator<T: ExactSizeIterator>(_iter: T) {}
    |                              ^^^^^^^^^^^^^^^^^ required by this bound in `is_exact_size_iterator`
 
-error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is not satisfied
+error[E0277]: `bevy_ecs::query::Added<Foo>` is not a valid `Query` filter based on archetype information
   --> tests/ui/query_exact_sized_iterator_safety.rs:12:28
    |
 12 |     is_exact_size_iterator(query.iter());
-   |     ---------------------- ^^^^^^^^^^^^ the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Added<Foo>`, which is required by `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>: ExactSizeIterator`
+   |     ---------------------- ^^^^^^^^^^^^ invalid `Query` filter
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Added<Foo>`
+   = note: an `ArchetypeFilter` typically uses a combination of `With<T>` and `Without<T>` statements
    = help: the following other types implement trait `ArchetypeFilter`:
-             With<T>
-             Without<T>
-             Or<()>
-             Or<(F0,)>
-             Or<(F0, F1)>
-             Or<(F0, F1, F2)>
-             Or<(F0, F1, F2, F3)>
-             Or<(F0, F1, F2, F3, F4)>
+             ()
+             (F,)
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+             (F0, F1, F2, F3, F4, F5)
+             (F0, F1, F2, F3, F4, F5, F6)
            and 26 others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -2,20 +2,20 @@ error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
   --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:9:17
    |
 9  |     is_iterator(iter)
-   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`, which is required by `QueryCombinationIter<'_, '_, &mut A, (), _>: Iterator`
+   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`
    |     |
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
-             bevy_ecs::change_detection::Ref<'__w, T>
-             Has<T>
-             AnyOf<()>
-             AnyOf<(F0,)>
-             AnyOf<(F0, F1)>
-             AnyOf<(F0, F1, F2)>
-             AnyOf<(F0, F1, F2, F3)>
-             AnyOf<(F0, F1, F2, F3, F4)>
-           and 34 others
+             &Archetype
+             &T
+             ()
+             (F,)
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+           and 36 others
    = note: `ReadOnlyQueryData` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryCombinationIter<'_, '_, &mut A, (), _>` to implement `Iterator`
 note: required by a bound in `is_iterator`

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -2,20 +2,20 @@ error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
   --> tests/ui/query_iter_many_mut_iterator_safety.rs:9:17
    |
 9  |     is_iterator(iter)
-   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`, which is required by `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>: Iterator`
+   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`
    |     |
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
-             bevy_ecs::change_detection::Ref<'__w, T>
-             Has<T>
-             AnyOf<()>
-             AnyOf<(F0,)>
-             AnyOf<(F0, F1)>
-             AnyOf<(F0, F1, F2)>
-             AnyOf<(F0, F1, F2, F3)>
-             AnyOf<(F0, F1, F2, F3, F4)>
-           and 34 others
+             &Archetype
+             &T
+             ()
+             (F,)
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+           and 36 others
    = note: `ReadOnlyQueryData` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>` to implement `Iterator`
 note: required by a bound in `is_iterator`

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_lens_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_lens_lifetime_safety.stderr
@@ -1,5 +1,14 @@
 error[E0499]: cannot borrow `lens` as mutable more than once at a time
-  --> tests/ui\query_lens_lifetime_safety.rs:18:39
+  --> tests/ui/query_lens_lifetime_safety.rs:18:39
    |
 17 |             let mut data: Mut<Foo> = lens.query().get_inner(e).unwrap();
    |                                      ---- first mutable borrow occurs here
+18 |             let mut data2: Mut<Foo> = lens.query().get_inner(e).unwrap();
+   |                                       ^^^^ second mutable borrow occurs here
+19 |
+20 |             assert_eq!(&mut *data, &mut *data2); // oops UB
+   |                              ---- first borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0499`.

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_to_readonly.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_to_readonly.stderr
@@ -6,13 +6,13 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   |              |
   |              mutable borrow occurs here
   |              mutable borrow later used here
-9 |         for _ in query.to_readonly().iter() {}
+9 |         for _ in query.as_readonly().iter() {}
   |                  ^^^^^ immutable borrow occurs here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_to_readonly.rs:15:18
    |
-14 |     for _ in query.to_readonly().iter() {
+14 |     for _ in query.as_readonly().iter() {
    |              --------------------------
    |              |
    |              immutable borrow occurs here
@@ -26,7 +26,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 38 |         let mut mut_foo = query.single_mut();
    |                           ----- mutable borrow occurs here
 ...
-41 |         let readonly_query = query.to_readonly();
+41 |         let readonly_query = query.as_readonly();
    |                              ^^^^^ immutable borrow occurs here
 ...
 46 |         *mut_foo = Foo;
@@ -35,7 +35,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_to_readonly.rs:58:27
    |
-54 |         let readonly_query = query.to_readonly();
+54 |         let readonly_query = query.as_readonly();
    |                              ----- immutable borrow occurs here
 ...
 58 |         let mut mut_foo = query.single_mut();

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_param_derive_readonly.stderr
@@ -2,29 +2,29 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satis
    --> tests/ui/system_param_derive_readonly.rs:16:11
     |
 16  |     state.get(&world);
-    |           ^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`, which is required by `Mutable<'_, '_>: ReadOnlySystemParam`
+    |           ^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`
     |
     = help: the following other types implement trait `ReadOnlyQueryData`:
-              bevy_ecs::change_detection::Ref<'__w, T>
-              Has<T>
-              AnyOf<()>
-              AnyOf<(F0,)>
-              AnyOf<(F0, F1)>
-              AnyOf<(F0, F1, F2)>
-              AnyOf<(F0, F1, F2, F3)>
-              AnyOf<(F0, F1, F2, F3, F4)>
-            and 34 others
+              &Archetype
+              &T
+              ()
+              (F,)
+              (F0, F1)
+              (F0, F1, F2)
+              (F0, F1, F2, F3)
+              (F0, F1, F2, F3, F4)
+            and 36 others
     = note: `ReadOnlyQueryData` is implemented for `&'static Foo`, but not for `&'static mut Foo`
     = note: required for `bevy_ecs::system::Query<'_, '_, &'static mut Foo>` to implement `ReadOnlySystemParam`
     = note: 1 redundant requirement hidden
     = note: required for `Mutable<'_, '_>` to implement `ReadOnlySystemParam`
 note: required by a bound in `SystemState::<Param>::get`
-   --> $BEVY_ROOT/crates/bevy_ecs/src/system/function_system.rs:215:16
+   --> $BEVY_ROOT/bevy_ecs/src/system/function_system.rs:487:16
     |
-213 |     pub fn get<'w, 's>(&'s mut self, world: &'w World) -> SystemParamItem<'w, 's, Param>
+485 |     pub fn get<'w, 's>(&'s mut self, world: &'w World) -> SystemParamItem<'w, 's, Param>
     |            --- required by a bound in this associated function
-214 |     where
-215 |         Param: ReadOnlySystemParam,
+486 |     where
+487 |         Param: ReadOnlySystemParam,
     |                ^^^^^^^^^^^^^^^^^^^ required by this bound in `SystemState::<Param>::get`
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_sort_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_sort_lifetime_safety.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> tests/ui\system_query_iter_sort_lifetime_safety.rs:12:9
+  --> tests/ui/system_query_iter_sort_lifetime_safety.rs:12:9
    |
 9  |     let mut stored: Option<&A> = None;
    |         ---------- `stored` declared here, outside of the closure body
@@ -8,3 +8,7 @@ error[E0521]: borrowed data escapes outside of closure
 11 |         // Try to smuggle the lens item out of the closure.
 12 |         stored = Some(left);
    |         ^^^^^^^^^^^^^^^^^^^ `left` escapes the closure body here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/crates/bevy_ecs/compile_fail/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/world_query_derive.stderr
@@ -1,3 +1,21 @@
+error: invalid attribute, expected `mutable` or `derive`
+  --> tests/ui/world_query_derive.rs:14:14
+   |
+14 | #[query_data(mut)]
+   |              ^^^
+
+error: `mutable` does not take any arguments
+  --> tests/ui/world_query_derive.rs:21:14
+   |
+21 | #[query_data(mutable(foo))]
+   |              ^^^^^^^
+
+error: `derive` requires at least one argument
+  --> tests/ui/world_query_derive.rs:28:14
+   |
+28 | #[query_data(derive)]
+   |              ^^^^^^
+
 error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satisfied
   --> tests/ui/world_query_derive.rs:10:8
    |
@@ -5,15 +23,15 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satis
    |        ^^^^^^^^^^^^^^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
-             MutableUnmarked
-             MutableMarkedReadOnly
-             NestedMutableUnmarked
-             bevy_ecs::change_detection::Ref<'__w, T>
-             Has<T>
-             AnyOf<()>
-             AnyOf<(F0,)>
-             AnyOf<(F0, F1)>
-           and 37 others
+             &Archetype
+             &T
+             ()
+             (F,)
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+           and 39 others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:7:10
    |
@@ -22,28 +40,28 @@ note: required by a bound in `_::assert_readonly`
    = note: this error originates in the derive macro `QueryData` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MutableMarked: ReadOnlyQueryData` is not satisfied
-  --> tests/ui/world_query_derive.rs:22:8
+  --> tests/ui/world_query_derive.rs:43:8
    |
-22 |     a: MutableMarked,
+43 |     a: MutableMarked,
    |        ^^^^^^^^^^^^^ the trait `ReadOnlyQueryData` is not implemented for `MutableMarked`
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
-             MutableUnmarked
-             MutableMarkedReadOnly
-             NestedMutableUnmarked
-             bevy_ecs::change_detection::Ref<'__w, T>
-             Has<T>
-             AnyOf<()>
-             AnyOf<(F0,)>
-             AnyOf<(F0, F1)>
-           and 37 others
+             &Archetype
+             &T
+             ()
+             (F,)
+             (F0, F1)
+             (F0, F1, F2)
+             (F0, F1, F2, F3)
+             (F0, F1, F2, F3, F4)
+           and 39 others
 note: required by a bound in `_::assert_readonly`
-  --> tests/ui/world_query_derive.rs:19:10
+  --> tests/ui/world_query_derive.rs:40:10
    |
-19 | #[derive(QueryData)]
+40 | #[derive(QueryData)]
    |          ^^^^^^^^^ required by this bound in `assert_readonly`
    = note: this error originates in the derive macro `QueryData` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
I noticed this while working on #18017 . Some of the `stderr` compile_fail tests were updated while I generated the output for the new tests I introduced in the mentioned PR.

I'm on rust 1.85.0