### PR TITLE
Benches for wave spawning

### DIFF
--- a/benches/benches/bevy_ecs/world/mod.rs
+++ b/benches/benches/bevy_ecs/world/mod.rs
@@ -3,6 +3,7 @@ mod despawn;
 mod despawn_recursive;
 mod entity_hash;
 mod spawn;
+mod waves;
 mod world_get;
 
 use commands::*;

--- a/benches/benches/bevy_ecs/world/mod.rs
+++ b/benches/benches/bevy_ecs/world/mod.rs
@@ -36,4 +36,5 @@ criterion_group!(
     query_get_many::<5>,
     query_get_many::<10>,
     entity_set_build_and_lookup,
+    waves::world_wave_spawn,
 );

--- a/benches/benches/bevy_ecs/world/waves.rs
+++ b/benches/benches/bevy_ecs/world/waves.rs
@@ -1,0 +1,54 @@
+use bevy_ecs::prelude::*;
+use criterion::Criterion;
+
+#[derive(Component, Default)]
+struct EmptyComponent;
+
+#[derive(Component, Default)]
+struct LargeComponent([u64; 32]);
+
+const WAVES: &[WaveBench] = &[
+    WaveBench {
+        waves: 1,
+        entities: 100_000,
+    },
+    WaveBench {
+        waves: 16,
+        entities: 100_000,
+    },
+];
+
+struct WaveBench {
+    waves: u8,
+    entities: u32,
+}
+
+pub fn world_spawn(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("spawn_waves");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(16));
+
+    for bench in WAVES {
+        group.bench_function(
+            format!(
+                "{0}_waves_of_{1} `EmptyComponent` spawn_batch",
+                bench.waves, bench.entities
+            ),
+            |bencher| {
+                let mut world = World::default();
+                bencher.iter(|| {
+                    let mut entities = Vec::with_capacity(bench.entities as usize);
+                    for _ in 0..(bench.waves - 1) {
+                        entities
+                            .extend(world.spawn_batch((0..bench.entities).map(|_| EmptyComponent)));
+                        for entity in entities.drain(..) {
+                            world.despawn(entity);
+                        }
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/world/waves.rs
+++ b/benches/benches/bevy_ecs/world/waves.rs
@@ -13,6 +13,10 @@ const WAVES: &[WaveBench] = &[
         entities: 100_000,
     },
     WaveBench {
+        waves: 2,
+        entities: 100_000,
+    },
+    WaveBench {
         waves: 16,
         entities: 100_000,
     },

--- a/benches/benches/bevy_ecs/world/waves.rs
+++ b/benches/benches/bevy_ecs/world/waves.rs
@@ -31,8 +31,8 @@ macro_rules! expand_benches {
                 $bench.waves, $bench.entities, $bench_name
             ),
             |bencher| {
-                let mut world = World::default();
                 bencher.iter(|| {
+                    let mut world = World::default();
                     let mut entities = Vec::with_capacity($bench.entities as usize);
                     for _ in 0..($bench.waves - 1) {
                         entities
@@ -53,8 +53,8 @@ macro_rules! expand_benches {
                 $bench.waves, $bench.entities, $bench_name
             ),
             |bencher| {
-                let mut world = World::default();
                 bencher.iter(|| {
+                    let mut world = World::default();
                     let entities = world
                         .spawn_batch((0..$bench.entities).map(|_| <$component>::default()))
                         .collect::<Vec<_>>();

--- a/benches/benches/bevy_ecs/world/waves.rs
+++ b/benches/benches/bevy_ecs/world/waves.rs
@@ -38,7 +38,7 @@ macro_rules! expand_benches {
                 bencher.iter(|| {
                     let mut world = World::default();
                     let mut entities = Vec::with_capacity($bench.entities as usize);
-                    for _ in 0..($bench.waves - 1) {
+                    for _ in 0..$bench.waves {
                         entities
                             .extend(world.spawn_batch(
                                 (0..$bench.entities).map(|_| <$component>::default()),


### PR DESCRIPTION
# Objective

Establish benchmarks for waves of entity spawning as discussed in #18054. This does not include (for now) wave insertions, as mere insertions don't affect entity allocation.

## Solution

Add benchmarks for permutations of entity count, wave count, component size, and batch spawning function.

The benchmarks do not show much difference in the component size variance, so I would be happy to remove that and decrease complexity if desired.

## Showcase

Yikes! Here are the results on M2 MAX:

![Screenshot 2025-02-26 at 4 11 41 PM](https://github.com/user-attachments/assets/0fac948a-b751-447a-a168-3017f3a8514f)
(Ignore the regressions and improvements. That's from testing the benches.)

Here, I only ran the `EmptyComponent` benches.

With only one wave, `spawn_batch` and `insert_or_spawn_batch` both run in roughly 3ms because there are no shenanigans in `Entities` regarding allocation.

So if one wave takes 3ms, 2 waves should take 6ms, right? Nope! `spawn_batch` on 2 waves takes 6ms, but `insert_or_spawn_batch` with the infamous `alloc_at_without_replacement` takes **760ms!!**. That's a little more than 6.

Running 16 waves was taking too long, but I'll leave it running for a bit so we can get a number. I would estimate ~11 seconds (700ms per wave on average) for `insert_or_spawn_batch`. This implies that the relationship isn't quite linear since the above 2 waves was also 700ms. But this could be memory allocator shenanigans too.

**EDIT:** It did end up being ~11.5 seconds. 

