### PR TITLE
Improve `bevy_reflect` `no_std` support

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -29,7 +29,7 @@ bevy = ["smallvec", "smol_str"]
 debug = ["debug_stack"]
 
 ## When enabled, keeps track of the current serialization/deserialization context for better error messages
-debug_stack = []
+debug_stack = ["std"]
 
 # Integrations
 
@@ -46,7 +46,7 @@ smallvec = ["dep:smallvec"]
 uuid = ["dep:uuid"]
 
 ## Adds reflection support to `wgpu-types` types.
-wgpu-types = ["dep:wgpu-types", "std"]
+wgpu-types = ["dep:wgpu-types"]
 
 # Platform Compatibility
 
@@ -62,6 +62,7 @@ std = [
   "smol_str?/std",
   "uuid?/std",
   "bevy_platform_support/std",
+  "wgpu-types?/std",
 ]
 
 ## `critical-section` provides the building blocks for synchronization primitives
@@ -109,7 +110,7 @@ uuid = { version = "1.13.1", default-features = false, optional = true, features
   "serde",
 ] }
 variadics_please = "1.1"
-wgpu-types = { version = "24", features = ["serde"], optional = true }
+wgpu-types = { version = "24", features = ["serde"], optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.13.1", default-features = false, features = ["js"] }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -110,7 +110,9 @@ uuid = { version = "1.13.1", default-features = false, optional = true, features
   "serde",
 ] }
 variadics_please = "1.1"
-wgpu-types = { version = "24", features = ["serde"], optional = true, default-features = false }
+wgpu-types = { version = "24", features = [
+  "serde",
+], optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.13.1", default-features = false, features = ["js"] }

--- a/crates/bevy_reflect/src/func/registry.rs
+++ b/crates/bevy_reflect/src/func/registry.rs
@@ -1,8 +1,9 @@
 use alloc::borrow::Cow;
-use bevy_platform_support::collections::HashMap;
-use bevy_platform_support::sync::Arc;
+use bevy_platform_support::{
+    collections::HashMap,
+    sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
 use core::fmt::Debug;
-use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::func::{
     ArgList, DynamicFunction, FunctionRegistrationError, FunctionResult, IntoFunction,


### PR DESCRIPTION
# Objective

- Fixes #18051

## Solution

- Switched function registry to use `bevy_platform_support::sync` instead of `std::sync`
- Also documented that `debug_stack` (and transitively `debug`) require `std`
- Also removed `std` from `wgpu-types` since that crate is now `no_std` compatible

## Testing

- `cargo check -p bevy_reflect --no-default-features --features critical-section,documentation,glam,glam/libm,smallvec,wgpu-types,functions --target thumbv6m-none-eabi`

---

## Notes

With these changes, `bevy_reflect`'s feature support looks like this:

| Feature | `no_std` (Before) | `no_std` (After) | Notes |
| - | - | - | - |
| `default` | ❌ | ❌ | |
| `std` | ❌ | ❌ | |
| `documentation` | ✔️ | ✔️ | |
| `functions` | ❌ | ✔️ | |
| `critical-section` | ✔️ | ✔️ | |
| `bevy` | ✔️* | ✔️* | Partial due to `smol_str` |
| `debug` | ❌ | ❌ | |
| `debug_stack` | ❌ | ❌ | |
| `petgraph` | ❌ | ❌ | |
| `glam` | ✔️* | ✔️* | Requires enabling `glam/libm` |
| `smallvec` | ✔️ | ✔️ | |
| `uuid` | ✔️* | ✔️* | Requires setting up `getrandom` backend |
| `wgpu-types ` | ❌ | ✔️ | |
| `smol_str` | ✔️* | ✔️* | Partial due to `smol_str` not supporting `portable-atomic` |
