### PR TITLE
Allow `bevy_reflect` and `wgpu-types` features in `no_std` for `bevy_color`

### DIFF
--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -13,9 +13,7 @@ rust-version = "1.85.0"
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev", default-features = false, features = [
   "curve",
 ] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
-  "bevy",
-], optional = true }
+bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, optional = true }
 bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1.0", features = [
   "derive",
@@ -27,13 +25,20 @@ encase = { version = "0.10", default-features = false, optional = true }
 
 [features]
 default = ["std", "bevy_reflect", "encase"]
-std = ["alloc", "bevy_math/std", "serde?/std"]
+std = [
+  "alloc",
+  "bevy_math/std",
+  "serde?/std",
+  "wgpu-types?/std",
+  "bevy_reflect?/std",
+]
 alloc = ["bevy_math/alloc", "serde?/alloc"]
 serialize = ["serde", "bevy_math/serialize"]
-bevy_reflect = ["dep:bevy_reflect", "std"]
-wgpu-types = ["dep:wgpu-types", "std"]
+bevy_reflect = ["dep:bevy_reflect"]
+wgpu-types = ["dep:wgpu-types"]
 encase = ["dep:encase", "std"]
 libm = ["bevy_math/libm"]
+critical-section = ["bevy_reflect?/critical-section"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- Improve feature parity in `no_std` for `bevy_color`

## Solution

- Allowed `bevy_reflect` in `no_std` now that it has full support
- Allowed `wgpu-types` in `no_std` now version 24 has full support
- Added `critical-section` feature to make standalone usage in `no_std` easier

## Testing

- `cargo check -p bevy_color --no-default-features --features libm,bevy_reflect,critical-section,serialize,alloc,wgpu-types --target thumbv6m-none-eabi`

---

## Notes

With these changes, `bevy_color`'s feature support looks like this:

| Feature | `no_std` (Before) | `no_std` (After) | Notes |
| - | - | - | - |
| `default` | ❌ | ❌ | |
| `std` | ❌ | ❌ | |
| `alloc` | ✔️ | ✔️ | |
| `serialize` | ✔️ | ✔️ | |
| `bevy_reflect` | ❌ | ✔️ | |
| `wgpu-types` | ❌ | ✔️ | |
| `encase` | ❌ | ❌ | |
| `libm` | ✔️ | ✔️ | |
| `critical-section` | ➖ | ✔️ | |