### PR TITLE
comment on PR when example job finds changes

### DIFF
--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -81,27 +81,28 @@ jobs:
     name: Comment on PR
     runs-on: ubuntu-latest
     needs: [make-macos-screenshots-available, compare-macos-screenshots]
-    if: ${{ needs.compare-macos-screenshots.result == 'failure' }}
+    if: ${{ always() && needs.compare-macos-screenshots.result == 'failure' }}
     steps:
+      - uses: actions/checkout@v4
       - name: "Check if PR already has label"
         id: check-label
         env:
-          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number.result }}
+          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ `gh api --jq '.labels.[].name' /repos/bevyengine/bevy/pulls/${{ PR }}` =~ "S-Rendering-Change" ]]
+          if [[ `gh api --jq '.labels.[].name' /repos/bevyengine/bevy/pulls/$PR` =~ "S-Rendering-Change" ]]
           then
             echo "result=true" >> $GITHUB_OUTPUT
           else
             echo "result=false" >> $GITHUB_OUTPUT
           fi
       - name: "Comment on PR"
-        if: ${{ steps.check-label.result == 'false' }}
+        if: ${{ steps.check-label.outputs.result == 'false' }}
         env:
           PROJECT: B04F67C0-C054-4A6F-92EC-F599FEC2FD1D
-          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number.result }}
+          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LF=$'\n'
-          COMMENT_BODY="Your PR introduce a rendering change. ${LF}You can review it at https://pixel-eagle.com/project/${{ PROJECT }}?filter=PR-${{ PR }} ${LF} ${LF}If it's expected, add the label S-Rendering-Change."
-          gh issue comment ${{ PR }} --body "$COMMENT_BODY"
+          COMMENT_BODY="Your PR introduce a rendering change. ${LF}You can review it at https://pixel-eagle.com/project/$PROJECT?filter=PR-$PR ${LF} ${LF}If it's expected, add the label S-Rendering-Change."
+          gh issue comment $PR --body "$COMMENT_BODY"

--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -104,5 +104,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LF=$'\n'
-          COMMENT_BODY="Your PR introduce a rendering change. ${LF}You can review it at https://pixel-eagle.com/project/$PROJECT?filter=PR-$PR ${LF} ${LF}If it's expected, add the label S-Rendering-Change."
+          COMMENT_BODY="Your PR caused a change in the graphical output of an example or rendering test. This might be intentional, but it could also mean that something broke! ${LF}You can review it at https://pixel-eagle.com/project/$PROJECT?filter=PR-$PR ${LF} ${LF}If it's expected, please add the S-Deliberate-Rendering-Change label."
           gh issue comment $PR --body "$COMMENT_BODY"

--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       branch-name: ${{ steps.branch-name.outputs.result }}
+      pr-number: ${{ steps.pr-number.outputs.result }}
     steps:
       - name: "Download artifact"
         id: find-artifact
@@ -59,11 +60,11 @@ jobs:
       - name: branch name
         id: branch-name
         run: |
-          if [ -f PR ]; then
-            echo "result=PR-$(cat PR)-${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
-          else
-            echo "result=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
-          fi
+          echo "result=PR-$(cat PR)-${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+      - name: PR number
+        id: pr-number
+        run: |
+          echo "result=$(cat PR)" >> $GITHUB_OUTPUT
 
   compare-macos-screenshots:
     name: Compare macOS screenshots
@@ -75,3 +76,32 @@ jobs:
       artifact: screenshots-macos
       os: macos
     secrets: inherit
+
+  comment-on-pr:
+    name: Comment on PR
+    runs-on: ubuntu-latest
+    needs: [make-macos-screenshots-available, compare-macos-screenshots]
+    if: ${{ needs.compare-macos-screenshots.result == 'failure' }}
+    steps:
+      - name: "Check if PR already has label"
+        id: check-label
+        env:
+          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number.result }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ `gh api --jq '.labels.[].name' /repos/bevyengine/bevy/pulls/${{ PR }}` =~ "S-Rendering-Change" ]]
+          then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+      - name: "Comment on PR"
+        if: ${{ steps.check-label.result == 'false' }}
+        env:
+          PROJECT: B04F67C0-C054-4A6F-92EC-F599FEC2FD1D
+          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number.result }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LF=$'\n'
+          COMMENT_BODY="Your PR introduce a rendering change. ${LF}You can review it at https://pixel-eagle.com/project/${{ PROJECT }}?filter=PR-${{ PR }} ${LF} ${LF}If it's expected, add the label S-Rendering-Change."
+          gh issue comment ${{ PR }} --body "$COMMENT_BODY"


### PR DESCRIPTION
# Objective

- Comment on PR when getting a rendering change

## Solution

- When something changes in the rendering check CI, add a comment on the PR to check the results
- Suggest adding the label `S-Deliberate-Rendering-Change` if it's expected
- Don't comment if the label is already present
