### PR TITLE
Use `RayMap` and `RenderLayers` in `bevy_sprite/picking_backend`

### DIFF
--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -146,10 +146,10 @@ fn sprite_picking(
             continue;
         };
 
-        if !camera
+        if camera
             .target
             .normalize(primary_window)
-            .is_some_and(|x| x == location.target)
+            .is_none_or(|x| x != location.target)
         {
             continue;
         }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,99 +1,11 @@
-//! blah
-use bevy::{
-    color::palettes::tailwind::CYAN_300,
-    prelude::*,
-    render::{camera::ScalingMode, view::RenderLayers},
-};
-// use bevy_inspector_egui::quick::WorldInspectorPlugin;
+//! A minimal example that outputs "hello world"
+
+use bevy::prelude::*;
 
 fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_systems(Startup, setup)
-        // .add_plugins(WorldInspectorPlugin::new())
-        .run();
+    App::new().add_systems(Update, hello_world_system).run();
 }
 
-/// Set up a simple 3D scene
-fn setup(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-) {
-    commands
-        .spawn((
-            Mesh2d(meshes.add(RegularPolygon::new(100.0, 6)).clone()),
-            MeshMaterial2d(materials.add(Color::srgb(0.3, 0.5, 0.3)).clone()),
-            Transform::from_xyz(100.0, 100., 1.0),
-            RenderLayers::from_layers(&[1]),
-            Sprite::sized(Vec2::new(100., 100.)),
-        ))
-        .observe(on_hover)
-        .observe(on_out);
-
-    commands
-        .spawn((
-            Mesh2d(meshes.add(RegularPolygon::new(50., 5))),
-            MeshMaterial2d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
-            Transform::from_xyz(-100.0, 0.5, 2.0),
-            RenderLayers::from_layers(&[0]),
-            Sprite::sized(Vec2::new(50., 50.)),
-        ))
-        .observe(on_hover)
-        .observe(on_out);
-
-    // Main Camera
-    let mut projection = OrthographicProjection::default_2d();
-    projection.scaling_mode = ScalingMode::FixedHorizontal {
-        viewport_width: 300.,
-    };
-    commands.spawn((
-        Camera2d,
-        Transform::from_xyz(-2.0, 2.5, 5.0),
-        Projection::from(projection),
-        Camera {
-            order: 0,
-            ..default()
-        },
-        RenderLayers::from_layers(&[0]),
-    ));
-
-    // Overlay camera
-    let mut projection = OrthographicProjection::default_2d();
-    projection.scaling_mode = ScalingMode::WindowSize;
-    commands.spawn((
-        Camera2d,
-        Camera {
-            order: 1,
-            ..default()
-        },
-        Projection::from(projection),
-        RenderLayers::from_layers(&[1]),
-        Transform::from_xyz(-2.0, 2.5, 10.0),
-    ));
-}
-
-fn on_hover(
-    hover: Trigger<Pointer<Over>>,
-    mut mesh: Query<&MeshMaterial2d<ColorMaterial>>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-) {
-    if let Ok(material) = mesh.get_mut(hover.target) {
-        info!("found material");
-        if let Some(material) = materials.get_mut(material) {
-            material.color = Color::WHITE;
-        }
-    }
-}
-fn on_out(
-    hover: Trigger<Pointer<Out>>,
-    mut mesh: Query<&MeshMaterial2d<ColorMaterial>>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-) {
-    info!("observiing");
-    if let Ok(material) = mesh.get_mut(hover.target) {
-        if let Some(material) = materials.get_mut(material) {
-            material.color = Color::from(CYAN_300);
-        }
-    }
+fn hello_world_system() {
+    println!("hello world");
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,11 +1,99 @@
-//! A minimal example that outputs "hello world"
-
-use bevy::prelude::*;
+//! blah
+use bevy::{
+    color::palettes::tailwind::CYAN_300,
+    prelude::*,
+    render::{camera::ScalingMode, view::RenderLayers},
+};
+// use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 fn main() {
-    App::new().add_systems(Update, hello_world_system).run();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        // .add_plugins(WorldInspectorPlugin::new())
+        .run();
 }
 
-fn hello_world_system() {
-    println!("hello world");
+/// Set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    commands
+        .spawn((
+            Mesh2d(meshes.add(RegularPolygon::new(100.0, 6)).clone()),
+            MeshMaterial2d(materials.add(Color::srgb(0.3, 0.5, 0.3)).clone()),
+            Transform::from_xyz(100.0, 100., 1.0),
+            RenderLayers::from_layers(&[1]),
+            Sprite::sized(Vec2::new(100., 100.)),
+        ))
+        .observe(on_hover)
+        .observe(on_out);
+
+    commands
+        .spawn((
+            Mesh2d(meshes.add(RegularPolygon::new(50., 5))),
+            MeshMaterial2d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+            Transform::from_xyz(-100.0, 0.5, 2.0),
+            RenderLayers::from_layers(&[0]),
+            Sprite::sized(Vec2::new(50., 50.)),
+        ))
+        .observe(on_hover)
+        .observe(on_out);
+
+    // Main Camera
+    let mut projection = OrthographicProjection::default_2d();
+    projection.scaling_mode = ScalingMode::FixedHorizontal {
+        viewport_width: 300.,
+    };
+    commands.spawn((
+        Camera2d,
+        Transform::from_xyz(-2.0, 2.5, 5.0),
+        Projection::from(projection),
+        Camera {
+            order: 0,
+            ..default()
+        },
+        RenderLayers::from_layers(&[0]),
+    ));
+
+    // Overlay camera
+    let mut projection = OrthographicProjection::default_2d();
+    projection.scaling_mode = ScalingMode::WindowSize;
+    commands.spawn((
+        Camera2d,
+        Camera {
+            order: 1,
+            ..default()
+        },
+        Projection::from(projection),
+        RenderLayers::from_layers(&[1]),
+        Transform::from_xyz(-2.0, 2.5, 10.0),
+    ));
+}
+
+fn on_hover(
+    hover: Trigger<Pointer<Over>>,
+    mut mesh: Query<&MeshMaterial2d<ColorMaterial>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    if let Ok(material) = mesh.get_mut(hover.target) {
+        info!("found material");
+        if let Some(material) = materials.get_mut(material) {
+            material.color = Color::WHITE;
+        }
+    }
+}
+fn on_out(
+    hover: Trigger<Pointer<Out>>,
+    mut mesh: Query<&MeshMaterial2d<ColorMaterial>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    info!("observiing");
+    if let Ok(material) = mesh.get_mut(hover.target) {
+        if let Some(material) = materials.get_mut(material) {
+            material.color = Color::from(CYAN_300);
+        }
+    }
 }


### PR DESCRIPTION
# Objective

Fixes #18005

Utilize `RayMap` in sprite picking in order to get picking working with differing viewport scaling. Adds `RenderLayers` to the sprite query for layer-exclusive picking control.

## Solution

Small rewrite of the loops in `bevy_sprite/picking_backend.rs`. Implementing either `RayMap` or `RenderLayers` on their own didn't have the correct results, so both solutions are rolled into one PR.

## Testing

CI & an updated version of the reproduction repo in the original issue, along with the `sprite_picking` example. 

--- 
