### PR TITLE
Compile fail stderr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           # Compile fail tests need std sources for the errors to display correctly
-          components: rust-std
+          components: rust-src
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests
@@ -66,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt, clippy, rust-src
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -126,6 +126,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          # Compile fail tests need std sources for the errors to display correctly
+          components: rust-src
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Compile fail tests need std sources for the errors to display correctly
+          components: rust-std
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests

--- a/crates/bevy_derive/compile_fail/tests/deref_derive/invalid_attribute_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_derive/invalid_attribute_fail.stderr
@@ -1,14 +1,13 @@
 error: unexpected token in attribute
- --> tests/deref_derive/invalid_attribute_fail.rs:8:12
-  |
-8 |     #[deref()] String
-  |            ^
+  --> tests/deref_derive/invalid_attribute_fail.rs:LL:CC
+   |
+LL |     #[deref()] String
+   |            ^
 
 error: unexpected token in attribute
-  --> tests/deref_derive/invalid_attribute_fail.rs:15:12
+  --> tests/deref_derive/invalid_attribute_fail.rs:LL:CC
    |
-15 |     #[deref()]
+LL |     #[deref()]
    |            ^
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_derive/invalid_item_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_derive/invalid_item_fail.stderr
@@ -1,18 +1,17 @@
 error: Deref cannot be derived on field-less structs
- --> tests/deref_derive/invalid_item_fail.rs:3:10
-  |
-3 | #[derive(Deref)]
-  |          ^^^^^
-  |
+  --> tests/deref_derive/invalid_item_fail.rs:LL:CC
+   |
+LL | #[derive(Deref)]
+   |          ^^^^^
+   |
   = note: this error originates in the derive macro `Deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Deref can only be derived on structs
- --> tests/deref_derive/invalid_item_fail.rs:7:10
-  |
-7 | #[derive(Deref)]
-  |          ^^^^^
-  |
+  --> tests/deref_derive/invalid_item_fail.rs:LL:CC
+   |
+LL | #[derive(Deref)]
+   |          ^^^^^
+   |
   = note: this error originates in the derive macro `Deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_derive/missing_attribute_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_derive/missing_attribute_fail.stderr
@@ -1,18 +1,17 @@
 error: deriving Deref on multi-field structs requires one field to have the `#[deref]` attribute
- --> tests/deref_derive/missing_attribute_fail.rs:3:10
-  |
-3 | #[derive(Deref)]
-  |          ^^^^^
-  |
+  --> tests/deref_derive/missing_attribute_fail.rs:LL:CC
+   |
+LL | #[derive(Deref)]
+   |          ^^^^^
+   |
   = note: this error originates in the derive macro `Deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: deriving Deref on multi-field structs requires one field to have the `#[deref]` attribute
- --> tests/deref_derive/missing_attribute_fail.rs:7:10
-  |
-7 | #[derive(Deref)]
-  |          ^^^^^
-  |
+  --> tests/deref_derive/missing_attribute_fail.rs:LL:CC
+   |
+LL | #[derive(Deref)]
+   |          ^^^^^
+   |
   = note: this error originates in the derive macro `Deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_derive/multiple_attributes_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_derive/multiple_attributes_fail.stderr
@@ -1,14 +1,13 @@
 error: `#[deref]` attribute can only be used on a single field
- --> tests/deref_derive/multiple_attributes_fail.rs:6:5
-  |
-6 |     #[deref] String
-  |     ^^^^^^^^
+  --> tests/deref_derive/multiple_attributes_fail.rs:LL:CC
+   |
+LL |     #[deref] String
+   |     ^^^^^^^^
 
 error: `#[deref]` attribute can only be used on a single field
-  --> tests/deref_derive/multiple_attributes_fail.rs:14:5
+  --> tests/deref_derive/multiple_attributes_fail.rs:LL:CC
    |
-14 |     #[deref]
+LL |     #[deref]
    |     ^^^^^^^^
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_mut_derive/invalid_attribute_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_mut_derive/invalid_attribute_fail.stderr
@@ -1,14 +1,13 @@
 error: unexpected token in attribute
- --> tests/deref_mut_derive/invalid_attribute_fail.rs:9:12
-  |
-9 |     #[deref()] String
-  |            ^
+  --> tests/deref_mut_derive/invalid_attribute_fail.rs:LL:CC
+   |
+LL |     #[deref()] String
+   |            ^
 
 error: unexpected token in attribute
-  --> tests/deref_mut_derive/invalid_attribute_fail.rs:24:12
+  --> tests/deref_mut_derive/invalid_attribute_fail.rs:LL:CC
    |
-24 |     #[deref()]
+LL |     #[deref()]
    |            ^
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_mut_derive/invalid_item_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_mut_derive/invalid_item_fail.stderr
@@ -1,18 +1,17 @@
 error: DerefMut cannot be derived on field-less structs
- --> tests/deref_mut_derive/invalid_item_fail.rs:3:10
-  |
-3 | #[derive(DerefMut)]
-  |          ^^^^^^^^
-  |
+  --> tests/deref_mut_derive/invalid_item_fail.rs:LL:CC
+   |
+LL | #[derive(DerefMut)]
+   |          ^^^^^^^^
+   |
   = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: DerefMut can only be derived on structs
- --> tests/deref_mut_derive/invalid_item_fail.rs:7:10
-  |
-7 | #[derive(DerefMut)]
-  |          ^^^^^^^^
-  |
+  --> tests/deref_mut_derive/invalid_item_fail.rs:LL:CC
+   |
+LL | #[derive(DerefMut)]
+   |          ^^^^^^^^
+   |
   = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_mut_derive/mismatched_target_type_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_mut_derive/mismatched_target_type_fail.stderr
@@ -1,20 +1,20 @@
 error[E0308]: mismatched types
- --> tests/deref_mut_derive/mismatched_target_type_fail.rs:4:10
-  |
-4 | #[derive(DerefMut)]
-  |          ^^^^^^^^
-  |          |
-  |          expected `&mut String`, found `&mut usize`
-  |          expected `&mut String` because of return type
-  |
+  --> tests/deref_mut_derive/mismatched_target_type_fail.rs:LL:CC
+   |
+LL | #[derive(DerefMut)]
+   |          ^^^^^^^^
+   |          |
+   |          expected `&mut String`, found `&mut usize`
+   |          expected `&mut String` because of return type
+   |
   = note: expected mutable reference `&mut String`
              found mutable reference `&mut usize`
   = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/deref_mut_derive/mismatched_target_type_fail.rs:16:10
+  --> tests/deref_mut_derive/mismatched_target_type_fail.rs:LL:CC
    |
-16 | #[derive(DerefMut)]
+LL | #[derive(DerefMut)]
    |          ^^^^^^^^
    |          |
    |          expected `&mut String`, found `&mut usize`

--- a/crates/bevy_derive/compile_fail/tests/deref_mut_derive/missing_attribute_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_mut_derive/missing_attribute_fail.stderr
@@ -1,18 +1,17 @@
 error: deriving DerefMut on multi-field structs requires one field to have the `#[deref]` attribute
- --> tests/deref_mut_derive/missing_attribute_fail.rs:4:10
-  |
-4 | #[derive(DerefMut)]
-  |          ^^^^^^^^
-  |
+  --> tests/deref_mut_derive/missing_attribute_fail.rs:LL:CC
+   |
+LL | #[derive(DerefMut)]
+   |          ^^^^^^^^
+   |
   = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: deriving DerefMut on multi-field structs requires one field to have the `#[deref]` attribute
-  --> tests/deref_mut_derive/missing_attribute_fail.rs:16:10
+  --> tests/deref_mut_derive/missing_attribute_fail.rs:LL:CC
    |
-16 | #[derive(DerefMut)]
+LL | #[derive(DerefMut)]
    |          ^^^^^^^^
    |
    = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_derive/compile_fail/tests/deref_mut_derive/missing_deref_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_mut_derive/missing_deref_fail.stderr
@@ -1,39 +1,39 @@
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
-   --> tests/deref_mut_derive/missing_deref_fail.rs:10:8
-    |
-10  | struct TupleStruct(usize, #[deref] String);
-    |        ^^^^^^^^^^^ the trait `Deref` is not implemented for `TupleStruct`
-    |
+  --> tests/deref_mut_derive/missing_deref_fail.rs:LL:CC
+   |
+LL | struct TupleStruct(usize, #[deref] String);
+   |        ^^^^^^^^^^^ the trait `Deref` is not implemented for `TupleStruct`
+   |
 note: required by a bound in `DerefMut`
-   --> $RUSTUP_HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust/library/core/src/ops/deref.rs:264:21
-    |
-264 | pub trait DerefMut: Deref {
-    |                     ^^^^^ required by this bound in `DerefMut`
+  --> RUSTLIB/core/src/ops/deref.rs:LL:CC
+   |
+LL | pub trait DerefMut: ~const Deref {
+   |                     ^^^^^^^^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
- --> tests/deref_mut_derive/missing_deref_fail.rs:7:10
-  |
-7 | #[derive(DerefMut)]
-  |          ^^^^^^^^ the trait `Deref` is not implemented for `TupleStruct`
-  |
+  --> tests/deref_mut_derive/missing_deref_fail.rs:LL:CC
+   |
+LL | #[derive(DerefMut)]
+   |          ^^^^^^^^ the trait `Deref` is not implemented for `TupleStruct`
+   |
   = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
-   --> tests/deref_mut_derive/missing_deref_fail.rs:15:8
-    |
-15  | struct Struct {
-    |        ^^^^^^ the trait `Deref` is not implemented for `Struct`
-    |
+  --> tests/deref_mut_derive/missing_deref_fail.rs:LL:CC
+   |
+LL | struct Struct {
+   |        ^^^^^^ the trait `Deref` is not implemented for `Struct`
+   |
 note: required by a bound in `DerefMut`
-   --> $RUSTUP_HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust/library/core/src/ops/deref.rs:264:21
-    |
-264 | pub trait DerefMut: Deref {
-    |                     ^^^^^ required by this bound in `DerefMut`
+  --> RUSTLIB/core/src/ops/deref.rs:LL:CC
+   |
+LL | pub trait DerefMut: ~const Deref {
+   |                     ^^^^^^^^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
-  --> tests/deref_mut_derive/missing_deref_fail.rs:13:10
+  --> tests/deref_mut_derive/missing_deref_fail.rs:LL:CC
    |
-13 | #[derive(DerefMut)]
+LL | #[derive(DerefMut)]
    |          ^^^^^^^^ the trait `Deref` is not implemented for `Struct`
    |
    = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/bevy_derive/compile_fail/tests/deref_mut_derive/multiple_attributes_fail.stderr
+++ b/crates/bevy_derive/compile_fail/tests/deref_mut_derive/multiple_attributes_fail.stderr
@@ -1,14 +1,13 @@
 error: `#[deref]` attribute can only be used on a single field
- --> tests/deref_mut_derive/multiple_attributes_fail.rs:7:5
-  |
-7 |     #[deref] String
-  |     ^^^^^^^^
+  --> tests/deref_mut_derive/multiple_attributes_fail.rs:LL:CC
+   |
+LL |     #[deref] String
+   |     ^^^^^^^^
 
 error: `#[deref]` attribute can only be used on a single field
-  --> tests/deref_mut_derive/multiple_attributes_fail.rs:23:5
+  --> tests/deref_mut_derive/multiple_attributes_fail.rs:LL:CC
    |
-23 |     #[deref]
+LL |     #[deref]
    |     ^^^^^^^^
 
 error: aborting due to 2 previous errors
-

--- a/crates/bevy_ecs/compile_fail/tests/ui/entity_ref_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/entity_ref_mut_lifetime_safety.stderr
@@ -1,81 +1,81 @@
 error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as immutable
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:17:26
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-16 |         let gotten: &A = e_mut.get::<A>().unwrap();
+LL |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ----- immutable borrow occurs here
-17 |         let gotten2: A = e_mut.take::<A>().unwrap();
+LL |         let gotten2: A = e_mut.take::<A>().unwrap();
    |                          ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-18 |
-19 |         assert_eq!(gotten, &gotten2); // oops UB
+LL |
+LL |         assert_eq!(gotten, &gotten2); // oops UB
    |         ---------------------------- immutable borrow later used here
 
 error[E0499]: cannot borrow `e_mut` as mutable more than once at a time
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:26:30
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-25 |         let mut gotten: Mut<A> = e_mut.get_mut::<A>().unwrap();
+LL |         let mut gotten: Mut<A> = e_mut.get_mut::<A>().unwrap();
    |                                  ----- first mutable borrow occurs here
-26 |         let mut gotten2: A = e_mut.take::<A>().unwrap();
+LL |         let mut gotten2: A = e_mut.take::<A>().unwrap();
    |                              ^^^^^ second mutable borrow occurs here
-27 |
-28 |         assert_eq!(&mut *gotten, &mut gotten2); // oops UB
+LL |
+LL |         assert_eq!(&mut *gotten, &mut gotten2); // oops UB
    |                          ------ first borrow later used here
 
 error[E0505]: cannot move out of `e_mut` because it is borrowed
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:35:9
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-13 |     let mut e_mut = world.entity_mut(e);
+LL |     let mut e_mut = world.entity_mut(e);
    |         --------- binding `e_mut` declared here
 ...
-34 |         let gotten: &A = e_mut.get::<A>().unwrap();
+LL |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ----- borrow of `e_mut` occurs here
-35 |         e_mut.despawn();
+LL |         e_mut.despawn();
    |         ^^^^^ move out of `e_mut` occurs here
-36 |
-37 |         assert_eq!(gotten, &A(Box::new(14_usize))); // oops UB
+LL |
+LL |         assert_eq!(gotten, &A(Box::new(14_usize))); // oops UB
    |         ------------------------------------------ borrow later used here
 
 error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as immutable
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:45:34
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-44 |         let gotten: &A = e_mut.get::<A>().unwrap();
+LL |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ----- immutable borrow occurs here
-45 |         let gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
+LL |         let gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
    |                                  ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-46 |
-47 |         assert_eq!(gotten, &*gotten_mut); // oops UB
+LL |
+LL |         assert_eq!(gotten, &*gotten_mut); // oops UB
    |         -------------------------------- immutable borrow later used here
 
 error[E0502]: cannot borrow `e_mut` as immutable because it is also borrowed as mutable
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:52:26
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-51 |         let gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
+LL |         let gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
    |                                  ----- mutable borrow occurs here
-52 |         let gotten: &A = e_mut.get::<A>().unwrap();
+LL |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ^^^^^ immutable borrow occurs here
-53 |
-54 |         assert_eq!(gotten, &*gotten_mut); // oops UB
+LL |
+LL |         assert_eq!(gotten, &*gotten_mut); // oops UB
    |                              ---------- mutable borrow later used here
 
 error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as immutable
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:59:9
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-58 |         let gotten: &A = e_mut.get::<A>().unwrap();
+LL |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ----- immutable borrow occurs here
-59 |         e_mut.insert::<B>(B);
+LL |         e_mut.insert::<B>(B);
    |         ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-60 |
-61 |         assert_eq!(gotten, &A(Box::new(16_usize))); // oops UB
+LL |
+LL |         assert_eq!(gotten, &A(Box::new(16_usize))); // oops UB
    |         ------------------------------------------ immutable borrow later used here
 
 error[E0499]: cannot borrow `e_mut` as mutable more than once at a time
-  --> tests/ui/entity_ref_mut_lifetime_safety.rs:67:9
+  --> tests/ui/entity_ref_mut_lifetime_safety.rs:LL:CC
    |
-66 |         let mut gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
+LL |         let mut gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
    |                                      ----- first mutable borrow occurs here
-67 |         e_mut.insert::<B>(B);
+LL |         e_mut.insert::<B>(B);
    |         ^^^^^ second mutable borrow occurs here
-68 |
-69 |         assert_eq!(&mut *gotten_mut, &mut A(Box::new(16_usize))); // oops UB
+LL |
+LL |         assert_eq!(&mut *gotten_mut, &mut A(Box::new(16_usize))); // oops UB
    |                          ---------- first borrow later used here
 
 error: aborting due to 7 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `bevy_ecs::query::Changed<Foo>` is not a valid `Query` filter based on archetype information
-  --> tests/ui/query_exact_sized_iterator_safety.rs:7:28
+  --> tests/ui/query_exact_sized_iterator_safety.rs:LL:CC
    |
-7  |     is_exact_size_iterator(query.iter());
+LL |     is_exact_size_iterator(query.iter());
    |     ---------------------- ^^^^^^^^^^^^ invalid `Query` filter
    |     |
    |     required by a bound introduced by this call
@@ -20,15 +20,15 @@ error[E0277]: `bevy_ecs::query::Changed<Foo>` is not a valid `Query` filter base
            and 26 others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
-  --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
+  --> tests/ui/query_exact_sized_iterator_safety.rs:LL:CC
    |
-16 | fn is_exact_size_iterator<T: ExactSizeIterator>(_iter: T) {}
+LL | fn is_exact_size_iterator<T: ExactSizeIterator>(_iter: T) {}
    |                              ^^^^^^^^^^^^^^^^^ required by this bound in `is_exact_size_iterator`
 
 error[E0277]: `bevy_ecs::query::Added<Foo>` is not a valid `Query` filter based on archetype information
-  --> tests/ui/query_exact_sized_iterator_safety.rs:12:28
+  --> tests/ui/query_exact_sized_iterator_safety.rs:LL:CC
    |
-12 |     is_exact_size_iterator(query.iter());
+LL |     is_exact_size_iterator(query.iter());
    |     ---------------------- ^^^^^^^^^^^^ invalid `Query` filter
    |     |
    |     required by a bound introduced by this call
@@ -47,9 +47,9 @@ error[E0277]: `bevy_ecs::query::Added<Foo>` is not a valid `Query` filter based 
            and 26 others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
-  --> tests/ui/query_exact_sized_iterator_safety.rs:16:30
+  --> tests/ui/query_exact_sized_iterator_safety.rs:LL:CC
    |
-16 | fn is_exact_size_iterator<T: ExactSizeIterator>(_iter: T) {}
+LL | fn is_exact_size_iterator<T: ExactSizeIterator>(_iter: T) {}
    |                              ^^^^^^^^^^^^^^^^^ required by this bound in `is_exact_size_iterator`
 
 error: aborting due to 2 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
-  --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:9:17
+  --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:LL:CC
    |
-9  |     is_iterator(iter)
+LL |     is_iterator(iter)
    |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`
    |     |
    |     required by a bound introduced by this call
@@ -19,9 +19,9 @@ error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
    = note: `ReadOnlyQueryData` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryCombinationIter<'_, '_, &mut A, (), _>` to implement `Iterator`
 note: required by a bound in `is_iterator`
-  --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:13:19
+  --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:LL:CC
    |
-13 | fn is_iterator<T: Iterator>(_iter: T) {}
+LL | fn is_iterator<T: Iterator>(_iter: T) {}
    |                   ^^^^^^^^ required by this bound in `is_iterator`
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
-  --> tests/ui/query_iter_many_mut_iterator_safety.rs:9:17
+  --> tests/ui/query_iter_many_mut_iterator_safety.rs:LL:CC
    |
-9  |     is_iterator(iter)
+LL |     is_iterator(iter)
    |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`
    |     |
    |     required by a bound introduced by this call
@@ -19,9 +19,9 @@ error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
    = note: `ReadOnlyQueryData` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>` to implement `Iterator`
 note: required by a bound in `is_iterator`
-  --> tests/ui/query_iter_many_mut_iterator_safety.rs:13:19
+  --> tests/ui/query_iter_many_mut_iterator_safety.rs:LL:CC
    |
-13 | fn is_iterator<T: Iterator>(_iter: T) {}
+LL | fn is_iterator<T: Iterator>(_iter: T) {}
    |                   ^^^^^^^^ required by this bound in `is_iterator`
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_lens_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_lens_lifetime_safety.stderr
@@ -1,12 +1,12 @@
 error[E0499]: cannot borrow `lens` as mutable more than once at a time
-  --> tests/ui/query_lens_lifetime_safety.rs:18:39
+  --> tests/ui/query_lens_lifetime_safety.rs:LL:CC
    |
-17 |             let mut data: Mut<Foo> = lens.query().get_inner(e).unwrap();
+LL |             let mut data: Mut<Foo> = lens.query().get_inner(e).unwrap();
    |                                      ---- first mutable borrow occurs here
-18 |             let mut data2: Mut<Foo> = lens.query().get_inner(e).unwrap();
+LL |             let mut data2: Mut<Foo> = lens.query().get_inner(e).unwrap();
    |                                       ^^^^ second mutable borrow occurs here
-19 |
-20 |             assert_eq!(&mut *data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(&mut *data, &mut *data2); // oops UB
    |                              ---- first borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_lifetime_safety.stderr
@@ -1,111 +1,111 @@
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_lifetime_safety.rs:17:39
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-16 |             let data: &Foo = query.get(e).unwrap();
+LL |             let data: &Foo = query.get(e).unwrap();
    |                              ----- immutable borrow occurs here
-17 |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
+LL |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
    |                                       ^^^^^^^^^^^^^^^^ mutable borrow occurs here
-18 |
-19 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |             ----------------------------- immutable borrow later used here
 
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_lifetime_safety.rs:24:30
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-23 |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
+LL |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
    |                                       ----- mutable borrow occurs here
-24 |             let data: &Foo = query.get(e).unwrap();
+LL |             let data: &Foo = query.get(e).unwrap();
    |                              ^^^^^ immutable borrow occurs here
-25 |
-26 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_lifetime_safety.rs:31:39
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-30 |             let data: &Foo = query.single();
+LL |             let data: &Foo = query.single();
    |                              ----- immutable borrow occurs here
-31 |             let mut data2: Mut<Foo> = query.single_mut();
+LL |             let mut data2: Mut<Foo> = query.single_mut();
    |                                       ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-32 |
-33 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |             ----------------------------- immutable borrow later used here
 
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_lifetime_safety.rs:38:30
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-37 |             let mut data2: Mut<Foo> = query.single_mut();
+LL |             let mut data2: Mut<Foo> = query.single_mut();
    |                                       ----- mutable borrow occurs here
-38 |             let data: &Foo = query.single();
+LL |             let data: &Foo = query.single();
    |                              ^^^^^ immutable borrow occurs here
-39 |
-40 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_lifetime_safety.rs:45:39
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-44 |             let data: &Foo = query.get_single().unwrap();
+LL |             let data: &Foo = query.get_single().unwrap();
    |                              ----- immutable borrow occurs here
-45 |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
+LL |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
    |                                       ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-46 |
-47 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |             ----------------------------- immutable borrow later used here
 
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_lifetime_safety.rs:52:30
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-51 |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
+LL |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
    |                                       ----- mutable borrow occurs here
-52 |             let data: &Foo = query.get_single().unwrap();
+LL |             let data: &Foo = query.get_single().unwrap();
    |                              ^^^^^ immutable borrow occurs here
-53 |
-54 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_lifetime_safety.rs:59:39
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-58 |             let data: &Foo = query.iter().next().unwrap();
+LL |             let data: &Foo = query.iter().next().unwrap();
    |                              ----- immutable borrow occurs here
-59 |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
+LL |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
    |                                       ^^^^^^^^^^^^^^^^ mutable borrow occurs here
-60 |
-61 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |             ----------------------------- immutable borrow later used here
 
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_lifetime_safety.rs:66:30
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-65 |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
+LL |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
    |                                       ----- mutable borrow occurs here
-66 |             let data: &Foo = query.iter().next().unwrap();
+LL |             let data: &Foo = query.iter().next().unwrap();
    |                              ^^^^^ immutable borrow occurs here
-67 |
-68 |             assert_eq!(data, &mut *data2); // oops UB
+LL |
+LL |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_lifetime_safety.rs:75:13
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-74 |             query.iter().for_each(|data| opt_data = Some(data));
+LL |             query.iter().for_each(|data| opt_data = Some(data));
    |             ----- immutable borrow occurs here
-75 |             query.iter_mut().for_each(|data| opt_data_2 = Some(data));
+LL |             query.iter_mut().for_each(|data| opt_data_2 = Some(data));
    |             ^^^^^^^^^^^^^^^^ mutable borrow occurs here
-76 |
-77 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
+LL |
+LL |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
    |                        -------- immutable borrow later used here
 
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_lifetime_safety.rs:84:13
+  --> tests/ui/query_lifetime_safety.rs:LL:CC
    |
-83 |             query.iter_mut().for_each(|data| opt_data_2 = Some(data));
+LL |             query.iter_mut().for_each(|data| opt_data_2 = Some(data));
    |             ----- mutable borrow occurs here
-84 |             query.iter().for_each(|data| opt_data = Some(data));
+LL |             query.iter().for_each(|data| opt_data = Some(data));
    |             ^^^^^ immutable borrow occurs here
-85 |
-86 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
+LL |
+LL |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
    |                                                 ---------- mutable borrow later used here
 
 error: aborting due to 10 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_to_readonly.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_to_readonly.stderr
@@ -1,47 +1,47 @@
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
- --> tests/ui/query_to_readonly.rs:9:18
-  |
-8 |     for _ in query.iter_mut() {
-  |              ----------------
-  |              |
-  |              mutable borrow occurs here
-  |              mutable borrow later used here
-9 |         for _ in query.as_readonly().iter() {}
-  |                  ^^^^^ immutable borrow occurs here
+  --> tests/ui/query_to_readonly.rs:LL:CC
+   |
+LL |     for _ in query.iter_mut() {
+   |              ----------------
+   |              |
+   |              mutable borrow occurs here
+   |              mutable borrow later used here
+LL |         for _ in query.as_readonly().iter() {}
+   |                  ^^^^^ immutable borrow occurs here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_to_readonly.rs:15:18
+  --> tests/ui/query_to_readonly.rs:LL:CC
    |
-14 |     for _ in query.as_readonly().iter() {
+LL |     for _ in query.as_readonly().iter() {
    |              --------------------------
    |              |
    |              immutable borrow occurs here
    |              immutable borrow later used here
-15 |         for _ in query.iter_mut() {}
+LL |         for _ in query.iter_mut() {}
    |                  ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_to_readonly.rs:41:30
+  --> tests/ui/query_to_readonly.rs:LL:CC
    |
-38 |         let mut mut_foo = query.single_mut();
+LL |         let mut mut_foo = query.single_mut();
    |                           ----- mutable borrow occurs here
 ...
-41 |         let readonly_query = query.as_readonly();
+LL |         let readonly_query = query.as_readonly();
    |                              ^^^^^ immutable borrow occurs here
 ...
-46 |         *mut_foo = Foo;
+LL |         *mut_foo = Foo;
    |          ------- mutable borrow later used here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_to_readonly.rs:58:27
+  --> tests/ui/query_to_readonly.rs:LL:CC
    |
-54 |         let readonly_query = query.as_readonly();
+LL |         let readonly_query = query.as_readonly();
    |                              ----- immutable borrow occurs here
 ...
-58 |         let mut mut_foo = query.single_mut();
+LL |         let mut mut_foo = query.single_mut();
    |                           ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
-61 |         println!("{ref_foo:?}");
+LL |         println!("{ref_foo:?}");
    |                   ----------- immutable borrow later used here
 
 error: aborting due to 4 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/query_transmute_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/query_transmute_safety.stderr
@@ -1,23 +1,23 @@
 error[E0499]: cannot borrow `query` as mutable more than once at a time
-  --> tests/ui/query_transmute_safety.rs:19:26
+  --> tests/ui/query_transmute_safety.rs:LL:CC
    |
-18 |         let mut lens_a = query.transmute_lens::<&mut Foo>();
+LL |         let mut lens_a = query.transmute_lens::<&mut Foo>();
    |                          ----- first mutable borrow occurs here
-19 |         let mut lens_b = query.transmute_lens::<&mut Foo>();
+LL |         let mut lens_b = query.transmute_lens::<&mut Foo>();
    |                          ^^^^^ second mutable borrow occurs here
 ...
-22 |         let mut query_a = lens_a.query();
+LL |         let mut query_a = lens_a.query();
    |                           ------ first borrow later used here
 
 error[E0499]: cannot borrow `lens` as mutable more than once at a time
-  --> tests/ui/query_transmute_safety.rs:34:27
+  --> tests/ui/query_transmute_safety.rs:LL:CC
    |
-33 |         let mut query_a = lens.query();
+LL |         let mut query_a = lens.query();
    |                           ---- first mutable borrow occurs here
-34 |         let mut query_b = lens.query();
+LL |         let mut query_b = lens.query();
    |                           ^^^^ second mutable borrow occurs here
 ...
-37 |         let a = query_a.single_mut();
+LL |         let a = query_a.single_mut();
    |                 ------- first borrow later used here
 
 error: aborting due to 2 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_param_derive_readonly.stderr
@@ -1,9 +1,9 @@
 error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satisfied
-   --> tests/ui/system_param_derive_readonly.rs:16:11
-    |
-16  |     state.get(&world);
-    |           ^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`
-    |
+  --> tests/ui/system_param_derive_readonly.rs:LL:CC
+   |
+LL |     state.get(&world);
+   |           ^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`
+   |
     = help: the following other types implement trait `ReadOnlyQueryData`:
               &Archetype
               &T
@@ -19,13 +19,13 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satis
     = note: 1 redundant requirement hidden
     = note: required for `Mutable<'_, '_>` to implement `ReadOnlySystemParam`
 note: required by a bound in `SystemState::<Param>::get`
-   --> $BEVY_ROOT/bevy_ecs/src/system/function_system.rs:487:16
-    |
-485 |     pub fn get<'w, 's>(&'s mut self, world: &'w World) -> SystemParamItem<'w, 's, Param>
-    |            --- required by a bound in this associated function
-486 |     where
-487 |         Param: ReadOnlySystemParam,
-    |                ^^^^^^^^^^^^^^^^^^^ required by this bound in `SystemState::<Param>::get`
+  --> BEVY_ROOT/bevy_ecs/src/system/function_system.rs:LL:CC
+   |
+LL |     pub fn get<'w, 's>(&'s mut self, world: &'w World) -> SystemParamItem<'w, 's, Param>
+   |            --- required by a bound in this associated function
+LL |     where
+LL |         Param: ReadOnlySystemParam,
+   |                ^^^^^^^^^^^^^^^^^^^ required by this bound in `SystemState::<Param>::get`
 
 error: aborting due to 1 previous error
 

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_get_lifetime_safety.stderr
@@ -1,12 +1,12 @@
 error[E0499]: cannot borrow `query` as mutable more than once at a time
-  --> tests/ui/system_query_get_lifetime_safety.rs:8:14
+  --> tests/ui/system_query_get_lifetime_safety.rs:LL:CC
    |
-7  |     let a1 = query.get_mut(e).unwrap();
+LL |     let a1 = query.get_mut(e).unwrap();
    |              ----- first mutable borrow occurs here
-8  |     let a2 = query.get_mut(e).unwrap();
+LL |     let a2 = query.get_mut(e).unwrap();
    |              ^^^^^ second mutable borrow occurs here
-9  |
-10 |     println!("{} {}", a1.0, a2.0);
+LL |
+LL |     println!("{} {}", a1.0, a2.0);
    |                       -- first borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_get_many_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_get_many_lifetime_safety.stderr
@@ -1,12 +1,12 @@
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/system_query_get_many_lifetime_safety.rs:8:14
+  --> tests/ui/system_query_get_many_lifetime_safety.rs:LL:CC
    |
-7  |     let a1 = query.get_many([e, e]).unwrap();
+LL |     let a1 = query.get_many([e, e]).unwrap();
    |              ----- immutable borrow occurs here
-8  |     let a2 = query.get_mut(e).unwrap();
+LL |     let a2 = query.get_mut(e).unwrap();
    |              ^^^^^^^^^^^^^^^^ mutable borrow occurs here
-9  |
-10 |     println!("{} {}", a1[0].0, a2.0);
+LL |
+LL |     println!("{} {}", a1[0].0, a2.0);
    |                       ----- immutable borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_get_many_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_get_many_mut_lifetime_safety.stderr
@@ -1,12 +1,12 @@
 error[E0499]: cannot borrow `query` as mutable more than once at a time
-  --> tests/ui/system_query_get_many_mut_lifetime_safety.rs:8:14
+  --> tests/ui/system_query_get_many_mut_lifetime_safety.rs:LL:CC
    |
-7  |     let a1 = query.get_many_mut([e, e]).unwrap();
+LL |     let a1 = query.get_many_mut([e, e]).unwrap();
    |              ----- first mutable borrow occurs here
-8  |     let a2 = query.get_mut(e).unwrap();
+LL |     let a2 = query.get_mut(e).unwrap();
    |              ^^^^^ second mutable borrow occurs here
-9  |
-10 |     println!("{} {}", a1[0].0, a2.0);
+LL |
+LL |     println!("{} {}", a1[0].0, a2.0);
    |                       ----- first borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_lifetime_safety.stderr
@@ -1,13 +1,13 @@
 error[E0499]: cannot borrow `query` as mutable more than once at a time
-  --> tests/ui/system_query_iter_lifetime_safety.rs:10:21
+  --> tests/ui/system_query_iter_lifetime_safety.rs:LL:CC
    |
-7  |     let mut iter = query.iter_mut();
+LL |     let mut iter = query.iter_mut();
    |                    ----- first mutable borrow occurs here
 ...
-10 |     let mut iter2 = query.iter_mut();
+LL |     let mut iter2 = query.iter_mut();
    |                     ^^^^^ second mutable borrow occurs here
 ...
-14 |     println!("{}", a.0);
+LL |     println!("{}", a.0);
    |                    --- first borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_many_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_many_mut_lifetime_safety.stderr
@@ -1,9 +1,9 @@
 error[E0499]: cannot borrow `iter` as mutable more than once at a time
-  --> tests/ui/system_query_iter_many_mut_lifetime_safety.rs:10:25
+  --> tests/ui/system_query_iter_many_mut_lifetime_safety.rs:LL:CC
    |
-10 |     while let Some(a) = iter.fetch_next() {
+LL |     while let Some(a) = iter.fetch_next() {
    |                         ^^^^ `iter` was mutably borrowed here in the previous iteration of the loop
-11 |         results.push(a);
+LL |         results.push(a);
    |         ------- first borrow used here, in later iteration of loop
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_sort_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_iter_sort_lifetime_safety.stderr
@@ -1,12 +1,12 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> tests/ui/system_query_iter_sort_lifetime_safety.rs:12:9
+  --> tests/ui/system_query_iter_sort_lifetime_safety.rs:LL:CC
    |
-9  |     let mut stored: Option<&A> = None;
+LL |     let mut stored: Option<&A> = None;
    |         ---------- `stored` declared here, outside of the closure body
-10 |     let mut sorted = iter.sort_by::<&A>(|left, _right| {
+LL |     let mut sorted = iter.sort_by::<&A>(|left, _right| {
    |                                          ---- `left` is a reference that is only valid in the closure body
-11 |         // Try to smuggle the lens item out of the closure.
-12 |         stored = Some(left);
+LL |         // Try to smuggle the lens item out of the closure.
+LL |         stored = Some(left);
    |         ^^^^^^^^^^^^^^^^^^^ `left` escapes the closure body here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_set_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_set_get_lifetime_safety.stderr
@@ -1,25 +1,25 @@
 error[E0499]: cannot borrow `queries` as mutable more than once at a time
-  --> tests/ui/system_query_set_get_lifetime_safety.rs:10:14
+  --> tests/ui/system_query_set_get_lifetime_safety.rs:LL:CC
    |
-7  |     let mut q2 = queries.p0();
+LL |     let mut q2 = queries.p0();
    |                  ------- first mutable borrow occurs here
 ...
-10 |     let q1 = queries.p1();
+LL |     let q1 = queries.p1();
    |              ^^^^^^^ second mutable borrow occurs here
 ...
-15 |     b.0 = a.0
+LL |     b.0 = a.0
    |     - first borrow later used here
 
 error[E0499]: cannot borrow `queries` as mutable more than once at a time
-  --> tests/ui/system_query_set_get_lifetime_safety.rs:22:18
+  --> tests/ui/system_query_set_get_lifetime_safety.rs:LL:CC
    |
-19 |     let q1 = queries.p1();
+LL |     let q1 = queries.p1();
    |              ------- first mutable borrow occurs here
 ...
-22 |     let mut q2 = queries.p0();
+LL |     let mut q2 = queries.p0();
    |                  ^^^^^^^ second mutable borrow occurs here
 ...
-27 |     b.0 = a.0
+LL |     b.0 = a.0
    |           --- first borrow later used here
 
 error: aborting due to 2 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_query_set_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_query_set_iter_lifetime_safety.stderr
@@ -1,25 +1,25 @@
 error[E0499]: cannot borrow `queries` as mutable more than once at a time
-  --> tests/ui/system_query_set_iter_lifetime_safety.rs:11:14
+  --> tests/ui/system_query_set_iter_lifetime_safety.rs:LL:CC
    |
-7  |     let mut q2 = queries.p0();
+LL |     let mut q2 = queries.p0();
    |                  ------- first mutable borrow occurs here
 ...
-11 |     let q1 = queries.p1();
+LL |     let q1 = queries.p1();
    |              ^^^^^^^ second mutable borrow occurs here
 ...
-16 |     b.0 = a.0
+LL |     b.0 = a.0
    |     - first borrow later used here
 
 error[E0499]: cannot borrow `queries` as mutable more than once at a time
-  --> tests/ui/system_query_set_iter_lifetime_safety.rs:24:18
+  --> tests/ui/system_query_set_iter_lifetime_safety.rs:LL:CC
    |
-20 |     let q1 = queries.p1();
+LL |     let q1 = queries.p1();
    |              ------- first mutable borrow occurs here
 ...
-24 |     let mut q2 = queries.p0();
+LL |     let mut q2 = queries.p0();
    |                  ^^^^^^^ second mutable borrow occurs here
 ...
-29 |     b.0 = a.0;
+LL |     b.0 = a.0;
    |           --- first borrow later used here
 
 error: aborting due to 2 previous errors

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_state_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_state_get_lifetime_safety.stderr
@@ -1,13 +1,13 @@
 error[E0502]: cannot borrow `*world` as mutable because it is also borrowed as immutable
-  --> tests/ui/system_state_get_lifetime_safety.rs:20:22
+  --> tests/ui/system_state_get_lifetime_safety.rs:LL:CC
    |
-17 |         let q1 = self.state_r.get(&world);
+LL |         let q1 = self.state_r.get(&world);
    |                                   ------ immutable borrow occurs here
 ...
-20 |         let mut q2 = self.state_w.get_mut(world);
+LL |         let mut q2 = self.state_w.get_mut(world);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
-24 |         println!("{}", a1.0);
+LL |         println!("{}", a1.0);
    |                        ---- immutable borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_state_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_state_iter_lifetime_safety.stderr
@@ -1,13 +1,13 @@
 error[E0502]: cannot borrow `*world` as mutable because it is also borrowed as immutable
-  --> tests/ui/system_state_iter_lifetime_safety.rs:20:22
+  --> tests/ui/system_state_iter_lifetime_safety.rs:LL:CC
    |
-17 |         let q1 = self.state_r.get(&world);
+LL |         let q1 = self.state_r.get(&world);
    |                                   ------ immutable borrow occurs here
 ...
-20 |         let mut q2 = self.state_w.get_mut(world);
+LL |         let mut q2 = self.state_w.get_mut(world);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
-24 |         println!("{}", a1.0);
+LL |         println!("{}", a1.0);
    |                        ---- immutable borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/system_state_iter_mut_overlap_safety.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/system_state_iter_mut_overlap_safety.stderr
@@ -1,13 +1,13 @@
 error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/system_state_iter_mut_overlap_safety.rs:18:13
+  --> tests/ui/system_state_iter_mut_overlap_safety.rs:LL:CC
    |
-15 |         let mut_vec = query.iter_mut().collect::<Vec<bevy_ecs::prelude::Mut<A>>>();
+LL |         let mut_vec = query.iter_mut().collect::<Vec<bevy_ecs::prelude::Mut<A>>>();
    |                       ----- mutable borrow occurs here
 ...
-18 |             query.iter().collect::<Vec<&A>>(),
+LL |             query.iter().collect::<Vec<&A>>(),
    |             ^^^^^ immutable borrow occurs here
 ...
-24 |             mut_vec.iter().map(|m| **m).collect::<Vec<A>>(),
+LL |             mut_vec.iter().map(|m| **m).collect::<Vec<A>>(),
    |             ------- mutable borrow later used here
 
 error: aborting due to 1 previous error

--- a/crates/bevy_ecs/compile_fail/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/world_query_derive.stderr
@@ -1,25 +1,25 @@
 error: invalid attribute, expected `mutable` or `derive`
-  --> tests/ui/world_query_derive.rs:14:14
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-14 | #[query_data(mut)]
+LL | #[query_data(mut)]
    |              ^^^
 
 error: `mutable` does not take any arguments
-  --> tests/ui/world_query_derive.rs:21:14
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-21 | #[query_data(mutable(foo))]
+LL | #[query_data(mutable(foo))]
    |              ^^^^^^^
 
 error: `derive` requires at least one argument
-  --> tests/ui/world_query_derive.rs:28:14
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-28 | #[query_data(derive)]
+LL | #[query_data(derive)]
    |              ^^^^^^
 
 error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satisfied
-  --> tests/ui/world_query_derive.rs:10:8
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-10 |     a: &'static mut Foo,
+LL |     a: &'static mut Foo,
    |        ^^^^^^^^^^^^^^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
@@ -33,16 +33,16 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satis
              (F0, F1, F2, F3, F4)
            and 39 others
 note: required by a bound in `_::assert_readonly`
-  --> tests/ui/world_query_derive.rs:7:10
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-7  | #[derive(QueryData)]
+LL | #[derive(QueryData)]
    |          ^^^^^^^^^ required by this bound in `assert_readonly`
    = note: this error originates in the derive macro `QueryData` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MutableMarked: ReadOnlyQueryData` is not satisfied
-  --> tests/ui/world_query_derive.rs:43:8
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-43 |     a: MutableMarked,
+LL |     a: MutableMarked,
    |        ^^^^^^^^^^^^^ the trait `ReadOnlyQueryData` is not implemented for `MutableMarked`
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
@@ -56,9 +56,9 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyQueryData` is not satisfie
              (F0, F1, F2, F3, F4)
            and 39 others
 note: required by a bound in `_::assert_readonly`
-  --> tests/ui/world_query_derive.rs:40:10
+  --> tests/ui/world_query_derive.rs:LL:CC
    |
-40 | #[derive(QueryData)]
+LL | #[derive(QueryData)]
    |          ^^^^^^^^^ required by this bound in `assert_readonly`
    = note: this error originates in the derive macro `QueryData` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/crates/bevy_reflect/compile_fail/tests/into_function/arguments_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/into_function/arguments_fail.stderr
@@ -1,0 +1,45 @@
+error[E0599]: the method `into_function` exists for fn item `fn(i32, ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ...) {too_many_arguments}`, but its trait bounds were not satisfied
+  --> tests/into_function/arguments_fail.rs:LL:CC
+   |
+LL |     let _ = too_many_arguments.into_function();
+   |                                ^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   |
+   = note: the full type name has been written to 'BEVY_ROOT/bevy_reflect/compile_fail/target/ui/0/tests/into_function/long-type.sr''
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: the following trait bounds were not satisfied:
+           `fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: ReflectFn<'_, _>`
+           which is required by `fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: IntoFunction<'_, (_, _)>`
+           `fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: TypedFunction<_>`
+           which is required by `fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: IntoFunction<'_, (_, _)>`
+           `&fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: ReflectFn<'_, _>`
+           which is required by `&fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: IntoFunction<'_, (_, _)>`
+           `&fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: TypedFunction<_>`
+           which is required by `&fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: IntoFunction<'_, (_, _)>`
+           `&mut fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: ReflectFn<'_, _>`
+           which is required by `&mut fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: IntoFunction<'_, (_, _)>`
+           `&mut fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: TypedFunction<_>`
+           which is required by `&mut fn(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) {too_many_arguments}: IntoFunction<'_, (_, _)>`
+
+error[E0599]: the method `into_function` exists for fn item `fn(Foo) {argument_not_reflect}`, but its trait bounds were not satisfied
+  --> tests/into_function/arguments_fail.rs:LL:CC
+   |
+LL |     let _ = argument_not_reflect.into_function();
+   |                                  ^^^^^^^^^^^^^ method cannot be called on `fn(Foo) {argument_not_reflect}` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `fn(Foo) {argument_not_reflect}: ReflectFn<'_, _>`
+           which is required by `fn(Foo) {argument_not_reflect}: IntoFunction<'_, (_, _)>`
+           `fn(Foo) {argument_not_reflect}: TypedFunction<_>`
+           which is required by `fn(Foo) {argument_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&fn(Foo) {argument_not_reflect}: ReflectFn<'_, _>`
+           which is required by `&fn(Foo) {argument_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&fn(Foo) {argument_not_reflect}: TypedFunction<_>`
+           which is required by `&fn(Foo) {argument_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&mut fn(Foo) {argument_not_reflect}: ReflectFn<'_, _>`
+           which is required by `&mut fn(Foo) {argument_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&mut fn(Foo) {argument_not_reflect}: TypedFunction<_>`
+           which is required by `&mut fn(Foo) {argument_not_reflect}: IntoFunction<'_, (_, _)>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/crates/bevy_reflect/compile_fail/tests/into_function/closure_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/into_function/closure_fail.stderr
@@ -1,0 +1,18 @@
+error[E0597]: `value` does not live long enough
+  --> tests/into_function/closure_fail.rs:LL:CC
+   |
+LL |     let value = String::from("Hello, World!");
+   |         ----- binding `value` declared here
+LL |     let closure_capture_reference = || println!("{}", value);
+   |                                     --                ^^^^^ borrowed value does not live long enough
+   |                                     |
+   |                                     value captured here
+...
+LL |     let _: DynamicFunction<'static> = closure_capture_reference.into_function();
+   |            ------------------------ type annotation requires that `value` is borrowed for `'static`
+LL | }
+   | - `value` dropped here while still borrowed
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/crates/bevy_reflect/compile_fail/tests/into_function/return_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/into_function/return_fail.stderr
@@ -1,0 +1,39 @@
+error[E0599]: the method `into_function` exists for fn item `fn() -> Foo {return_not_reflect}`, but its trait bounds were not satisfied
+  --> tests/into_function/return_fail.rs:LL:CC
+   |
+LL |     let _ = return_not_reflect.into_function();
+   |                                ^^^^^^^^^^^^^ method cannot be called on `fn() -> Foo {return_not_reflect}` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `fn() -> Foo {return_not_reflect}: ReflectFn<'_, _>`
+           which is required by `fn() -> Foo {return_not_reflect}: IntoFunction<'_, (_, _)>`
+           `fn() -> Foo {return_not_reflect}: TypedFunction<_>`
+           which is required by `fn() -> Foo {return_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&fn() -> Foo {return_not_reflect}: ReflectFn<'_, _>`
+           which is required by `&fn() -> Foo {return_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&fn() -> Foo {return_not_reflect}: TypedFunction<_>`
+           which is required by `&fn() -> Foo {return_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&mut fn() -> Foo {return_not_reflect}: ReflectFn<'_, _>`
+           which is required by `&mut fn() -> Foo {return_not_reflect}: IntoFunction<'_, (_, _)>`
+           `&mut fn() -> Foo {return_not_reflect}: TypedFunction<_>`
+           which is required by `&mut fn() -> Foo {return_not_reflect}: IntoFunction<'_, (_, _)>`
+
+error[E0599]: the method `into_function` exists for fn item `fn(&String, &String) -> &String {return_with_invalid_lifetime}`, but its trait bounds were not satisfied
+  --> tests/into_function/return_fail.rs:LL:CC
+   |
+LL |     let _ = return_with_invalid_lifetime.into_function();
+   |                                          ^^^^^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
+   |
+   = note: the full type name has been written to 'BEVY_ROOT/bevy_reflect/compile_fail/target/ui/0/tests/into_function/long-type.sr''
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: the following trait bounds were not satisfied:
+           `for<'a, 'b> fn(&'a std::string::String, &'b std::string::String) -> &'b std::string::String {return_with_invalid_lifetime}: ReflectFn<'_, _>`
+           which is required by `for<'a, 'b> fn(&'a std::string::String, &'b std::string::String) -> &'b std::string::String {return_with_invalid_lifetime}: IntoFunction<'_, (_, _)>`
+           `&for<'a, 'b> fn(&'a std::string::String, &'b std::string::String) -> &'b std::string::String {return_with_invalid_lifetime}: ReflectFn<'_, _>`
+           which is required by `&for<'a, 'b> fn(&'a std::string::String, &'b std::string::String) -> &'b std::string::String {return_with_invalid_lifetime}: IntoFunction<'_, (_, _)>`
+           `&mut for<'a, 'b> fn(&'a std::string::String, &'b std::string::String) -> &'b std::string::String {return_with_invalid_lifetime}: ReflectFn<'_, _>`
+           which is required by `&mut for<'a, 'b> fn(&'a std::string::String, &'b std::string::String) -> &'b std::string::String {return_with_invalid_lifetime}: IntoFunction<'_, (_, _)>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/custom_where_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/custom_where_fail.stderr
@@ -1,8 +1,7 @@
 error: expected `:`
-  --> tests/reflect_derive/custom_where_fail.rs:15:44
+  --> tests/reflect_derive/custom_where_fail.rs:LL:CC
    |
-15 | #[reflect(where T: std::fmt::Debug, MyTrait)]
-   |                                            ^
+LL | #[reflect(where T: core::fmt::Debug, MyTrait)]
+   |                                             ^
 
 error: aborting due to 1 previous error
-

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/from_reflect_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/from_reflect_fail.stderr
@@ -1,19 +1,19 @@
 error: `from_reflect` already set to false
- --> tests/reflect_derive/from_reflect_fail.rs:6:26
-  |
-6 | #[reflect(from_reflect = true)]
-  |                          ^^^^
+  --> tests/reflect_derive/from_reflect_fail.rs:LL:CC
+   |
+LL | #[reflect(from_reflect = true)]
+   |                          ^^^^
 
 error: `from_reflect` already set to true
-  --> tests/reflect_derive/from_reflect_fail.rs:15:26
+  --> tests/reflect_derive/from_reflect_fail.rs:LL:CC
    |
-15 | #[reflect(from_reflect = false)]
+LL | #[reflect(from_reflect = false)]
    |                          ^^^^^
 
 error[E0119]: conflicting implementations of trait `FromReflect` for type `Baz`
-  --> tests/reflect_derive/from_reflect_fail.rs:22:19
+  --> tests/reflect_derive/from_reflect_fail.rs:LL:CC
    |
-22 | #[derive(Reflect, FromReflect)]
+LL | #[derive(Reflect, FromReflect)]
    |          -------  ^^^^^^^^^^^ conflicting implementation for `Baz`
    |          |
    |          first implementation here

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/generics_fail.stderr
@@ -1,58 +1,86 @@
-error[E0277]: `NoReflect` can not be reflected
-   --> tests/reflect_derive/generics_fail.rs:18:21
-    |
-18  |     foo.get_field::<NoReflect>("a").unwrap();
-    |         ---------   ^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
-    |         |
-    |         required by a bound introduced by this call
-    |
-    = note: Try using `#[derive(Reflect)]`
+error[E0277]: `NoReflect` does not implement `Reflect` so cannot be fully reflected
+  --> tests/reflect_derive/generics_fail.rs:LL:CC
+   |
+LL |     foo.get_field::<NoReflect>("a").unwrap();
+   |         ---------   ^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
+   |         |
+   |         required by a bound introduced by this call
+   |
+    = note: consider annotating `NoReflect` with `#[derive(Reflect)]`
     = help: the following other types implement trait `Reflect`:
-              bool
-              char
-              isize
-              i8
-              i16
-              i32
-              i64
-              i128
-            and 74 others
+              &'static Location<'static>
+              &'static Path
+              &'static str
+              ()
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+            and 80 others
 note: required by a bound in `bevy_reflect::GetField::get_field`
-   --> $BEVY_ROOT/crates/bevy_reflect/src/struct_trait.rs:244:21
-    |
-244 |     fn get_field<T: Reflect>(&self, name: &str) -> Option<&T>;
-    |                     ^^^^^^^ required by this bound in `GetField::get_field`
+  --> BEVY_ROOT/bevy_reflect/src/struct_trait.rs:LL:CC
+   |
+LL |     fn get_field<T: Reflect>(&self, name: &str) -> Option<&T>;
+   |                     ^^^^^^^ required by this bound in `GetField::get_field`
 
-error[E0277]: `NoReflect` does not provide type registration information
-  --> tests/reflect_derive/generics_fail.rs:14:36
+error[E0277]: `NoReflect` does not implement `Typed` so cannot provide static type information
+  --> tests/reflect_derive/generics_fail.rs:LL:CC
    |
-14 |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid Type
+LL |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Typed` is not implemented for `NoReflect`
    |
-   = help: the trait `GetTypeRegistration` is not implemented for `NoReflect`, which is required by `Foo<NoReflect>: bevy_reflect::Struct`
-   = note: Try using `#[derive(Reflect)]`
-   = help: the following other types implement trait `GetTypeRegistration`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and 67 others
-   = note: required for `NoReflect` to implement `RegisterForReflection`
+   = note: consider annotating `NoReflect` with `#[derive(Reflect)]`
+   = help: the following other types implement trait `Typed`:
+             &'static Location<'static>
+             &'static Path
+             &'static str
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+           and 81 others
+   = note: required for `NoReflect` to implement `MaybeTyped`
 note: required for `Foo<NoReflect>` to implement `bevy_reflect::Struct`
-  --> tests/reflect_derive/generics_fail.rs:3:10
+  --> tests/reflect_derive/generics_fail.rs:LL:CC
    |
-3  | #[derive(Reflect)]
+LL | #[derive(Reflect)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-4  | #[reflect(from_reflect = false)]
-5  | struct Foo<T> {
+LL | #[reflect(from_reflect = false)]
+LL | struct Foo<T> {
    |        ^^^^^^
    = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn bevy_reflect::Struct + 'static)>`
    = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error[E0277]: `NoReflect` does not implement `GetTypeRegistration` so cannot provide type registration information
+  --> tests/reflect_derive/generics_fail.rs:LL:CC
+   |
+LL |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GetTypeRegistration` is not implemented for `NoReflect`
+   |
+   = note: consider annotating `NoReflect` with `#[derive(Reflect)]`
+   = help: the following other types implement trait `GetTypeRegistration`:
+             &'static Location<'static>
+             &'static Path
+             &'static str
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+           and 80 others
+   = note: required for `NoReflect` to implement `RegisterForReflection`
+note: required for `Foo<NoReflect>` to implement `bevy_reflect::Struct`
+  --> tests/reflect_derive/generics_fail.rs:LL:CC
+   |
+LL | #[derive(Reflect)]
+   |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+LL | #[reflect(from_reflect = false)]
+LL | struct Foo<T> {
+   |        ^^^^^^
+   = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn bevy_reflect::Struct + 'static)>`
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/crates/bevy_reflect/compile_fail/tests/reflect_derive/lifetimes_pass.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_derive/lifetimes_pass.stderr
@@ -1,13 +1,12 @@
 warning: field `value` is never read
- --> tests/reflect_derive/lifetimes_pass.rs:8:5
-  |
-6 | struct Foo<'a: 'static> {
-  |        --- field in this struct
-7 |     #[reflect(ignore)]
-8 |     value: &'a str,
-  |     ^^^^^
-  |
+  --> tests/reflect_derive/lifetimes_pass.rs:LL:CC
+   |
+LL | struct Foo<'a: 'static> {
+   |        --- field in this struct
+LL |     #[reflect(ignore)]
+LL |     value: &'a str,
+   |     ^^^^^
+   |
   = note: `#[warn(dead_code)]` on by default
 
 warning: 1 warning emitted
-

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/incorrect_wrapper_fail.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `MyFoo: ReflectRemote` is not satisfied
+  --> tests/reflect_remote/incorrect_wrapper_fail.rs:LL:CC
+   |
+LL |     #[reflect(remote = MyFoo)]
+   |                        ^^^^^ the trait `ReflectRemote` is not implemented for `MyFoo`
+
+error[E0277]: the trait bound `MyFoo: ReflectRemote` is not satisfied
+  --> tests/reflect_remote/incorrect_wrapper_fail.rs:LL:CC
+   |
+LL | #[derive(Reflect)]
+   |          ^^^^^^^ the trait `ReflectRemote` is not implemented for `MyFoo`
+   |
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/invalid_definition_fail.stderr
@@ -1,0 +1,116 @@
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `bool`
+   |
+   = note: `?` operator cannot convert from `bool` to `u32`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ----------------------------------------------
+   |     |
+   |     expected due to the type of this binding
+   |     in this procedural macro expansion
+...
+LL |         pub value: bool,
+   |                    ^^^^ expected `u32`, found `bool`
+   |
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `bool`
+   |
+   = note: `?` operator cannot convert from `bool` to `u32`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ----------------------------------------------
+   |     |
+   |     expected due to the type of this binding
+   |     in this procedural macro expansion
+...
+LL |         pub bool,
+   |             ^^^^ expected `u32`, found `bool`
+   |
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0026]: variant `enums::external_crate::TheirStruct::Unit` does not have a field named `0`
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variant `enums::external_crate::TheirStruct::Unit` does not have this field
+   |
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0559]: variant `enums::external_crate::TheirStruct::Unit` has no field named `0`
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `enums::external_crate::TheirStruct::Unit` does not have this field
+   |
+   = note: all struct fields are already assigned
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `bool`
+   |
+   = note: `?` operator cannot convert from `bool` to `u32`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `String`
+   |
+   = note: `?` operator cannot convert from `std::string::String` to `usize`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |       #[reflect_remote(external_crate::TheirStruct)]
+   |       ----------------------------------------------
+   |       |
+   |  _____in this procedural macro expansion
+   | |
+...  |
+LL | |         Tuple(bool),
+   | |               ^^^-
+   | |_______________|__|
+   |                 |  expected due to the type of this binding
+   |                 expected `u32`, found `bool`
+   |
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/invalid_definition_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirStruct)]
+   |     ---------------------------------------------- in this procedural macro expansion
+...
+LL |         Struct { value: String },
+   |                         ^^^^^^
+   |                         |
+   |                         expected `usize`, found `String`
+   |                         expected due to the type of this binding
+   |
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0026, E0308, E0559.
+For more information about an error, try `rustc --explain E0026`.

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/macro_order_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/macro_order_fail.stderr
@@ -1,0 +1,23 @@
+error[E0609]: no field `value` on type `&MyType`
+  --> tests/reflect_remote/macro_order_fail.rs:LL:CC
+   |
+LL |     pub value: String,
+   |         ^^^^^ unknown field
+   |
+help: one of the expressions' fields has a field of the same name
+   |
+LL |     pub 0.value: String,
+   |         ++
+
+error[E0560]: struct `MyType` has no field named `value`
+  --> tests/reflect_remote/macro_order_fail.rs:LL:CC
+   |
+LL | struct MyType {
+   |        ------ `MyType` defined here
+LL |     pub value: String,
+   |     ^^^^^^^^^^^^^^^^^ field does not exist
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0560, E0609.
+For more information about an error, try `rustc --explain E0560`.

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/nested_fail.stderr
@@ -1,0 +1,245 @@
+error[E0277]: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PartialReflect` is not implemented for `TheirInner<T>`
+   |
+   = note: consider annotating `TheirInner<T>` with `#[derive(Reflect)]`
+   = help: the following other types implement trait `PartialReflect`:
+             &'static Location<'static>
+             &'static Path
+             &'static str
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+           and 90 others
+   = note: required for the cast from `&TheirInner<T>` to `&dyn PartialReflect`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PartialReflect` is not implemented for `TheirInner<T>`
+   |
+   = note: consider annotating `TheirInner<T>` with `#[derive(Reflect)]`
+   = help: the following other types implement trait `PartialReflect`:
+             &'static Location<'static>
+             &'static Path
+             &'static str
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+           and 90 others
+   = note: required for the cast from `&mut TheirInner<T>` to `&mut (dyn PartialReflect + 'static)`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `TheirInner<T>` does not implement `PartialReflect` so cannot be introspected
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PartialReflect` is not implemented for `TheirInner<T>`
+   |
+   = note: consider annotating `TheirInner<T>` with `#[derive(Reflect)]`
+   = help: the following other types implement trait `PartialReflect`:
+             &'static Location<'static>
+             &'static Path
+             &'static str
+             ()
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+           and 90 others
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `TheirInner<T>` does not implement `TypePath` so cannot provide dynamic type path information
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypePath` is not implemented for `TheirInner<T>`
+   |
+    = note: consider annotating `TheirInner<T>` with `#[derive(Reflect)]` or `#[derive(TypePath)]`
+    = help: the following other types implement trait `TypePath`:
+              &'static Location<'static>
+              &'static T
+              &'static mut T
+              ()
+              (P,)
+              (P1, P0)
+              (P1, P2, P0)
+              (P1, P2, P3, P0)
+            and 103 others
+    = note: required for `TheirInner<T>` to implement `DynamicTypePath`
+note: required by a bound in `clone_value`
+  --> BEVY_ROOT/bevy_reflect/src/reflect.rs:LL:CC
+   |
+LL | pub trait PartialReflect: DynamicTypePath + Send + Sync
+   |                           ^^^^^^^^^^^^^^^ required by this bound in `PartialReflect::clone_value`
+...
+LL |     fn clone_value(&self) -> Box<dyn PartialReflect>;
+   |        ----------- required by a bound in this associated function
+    = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `TheirInner<T>`, found `MyInner<T>`
+   |
+   = note: `?` operator cannot convert from `incorrect_inner_type::MyInner<T>` to `TheirInner<T>`
+   = note: expected struct `TheirInner<T>`
+              found struct `incorrect_inner_type::MyInner<T>`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     -------------------------------------------------------
+   |     |
+   |     expected due to the type of this binding
+   |     in this procedural macro expansion
+...
+LL |         pub inner: MyInner<T>,
+   |                    ^^^^^^^ expected `TheirInner<T>`, found `MyInner<T>`
+   |
+   = note: expected struct `TheirInner<T>`
+              found struct `incorrect_inner_type::MyInner<T>`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected `&TheirOuter<T>`, found `&TheirInner<T>`
+   |     arguments to this function are incorrect
+   |
+   = note: expected reference `&TheirOuter<T>`
+              found reference `&TheirInner<T>`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper(remote: &Self::Remote) -> &Self;
+   |        ^^^^^^^^^^
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected `&mut TheirOuter<T>`, found `&mut TheirInner<T>`
+   |     arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut TheirOuter<T>`
+              found mutable reference `&mut TheirInner<T>`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper_mut(remote: &mut Self::Remote) -> &mut Self;
+   |        ^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ------------------------------------------------------- in this procedural macro expansion
+...
+LL |         #[reflect(remote = MyOuter<T>)]
+   |                            ^^^^^^^
+   |                            |
+   |                            expected `TheirOuter<T>`, found `TheirInner<T>`
+   |                            expected due to this
+   |
+   = note: expected struct `TheirOuter<T>`
+              found struct `TheirInner<T>`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected `&TheirInner<bool>`, found `&TheirInner<T>`
+   |     arguments to this function are incorrect
+...
+LL |     struct MyOuter<T: FromReflect + GetTypeRegistration> {
+   |                    - found this type parameter
+   |
+   = note: expected reference `&TheirInner<bool>`
+              found reference `&TheirInner<T>`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper(remote: &Self::Remote) -> &Self;
+   |        ^^^^^^^^^^
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected `&mut TheirInner<bool>`, found `&mut TheirInner<T>`
+   |     arguments to this function are incorrect
+...
+LL |     struct MyOuter<T: FromReflect + GetTypeRegistration> {
+   |                    - found this type parameter
+   |
+   = note: expected mutable reference `&mut TheirInner<bool>`
+              found mutable reference `&mut TheirInner<T>`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper_mut(remote: &mut Self::Remote) -> &mut Self;
+   |        ^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `TheirInner<T>`, found `TheirInner<bool>`
+...
+LL |     struct MyOuter<T: FromReflect + GetTypeRegistration> {
+   |                    - expected this type parameter
+   |
+   = note: `?` operator cannot convert from `TheirInner<bool>` to `TheirInner<T>`
+   = note: expected struct `TheirInner<T>`
+              found struct `TheirInner<bool>`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/nested_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(super::external_crate::TheirOuter<T>)]
+   |     -------------------------------------------------------
+   |     |
+   |     expected due to the type of this binding
+   |     in this procedural macro expansion
+...
+LL |     struct MyOuter<T: FromReflect + GetTypeRegistration> {
+   |                    - expected this type parameter
+...
+LL |         pub inner: super::external_crate::TheirInner<bool>,
+   |                    ^^^^^ expected `TheirInner<T>`, found `TheirInner<bool>`
+   |
+   = note: expected struct `TheirInner<T>`
+              found struct `TheirInner<bool>`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 13 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.stderr
+++ b/crates/bevy_reflect/compile_fail/tests/reflect_remote/type_mismatch_fail.stderr
@@ -1,0 +1,193 @@
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^
+   |              |
+   |              expected `&TheirBar`, found `&TheirFoo`
+   |              arguments to this function are incorrect
+   |
+   = note: expected reference `&structs::external_crate::TheirBar`
+              found reference `&structs::external_crate::TheirFoo`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper(remote: &Self::Remote) -> &Self;
+   |        ^^^^^^^^^^
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^
+   |              |
+   |              expected `&mut TheirBar`, found `&mut TheirFoo`
+   |              arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut structs::external_crate::TheirBar`
+              found mutable reference `&mut structs::external_crate::TheirFoo`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper_mut(remote: &mut Self::Remote) -> &mut Self;
+   |        ^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ------- in this derive macro expansion
+...
+LL |         #[reflect(remote = MyBar)]
+   |                            ^^^^^
+   |                            |
+   |                            expected `TheirBar`, found `TheirFoo`
+   |                            expected due to this
+   |
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^
+   |              |
+   |              expected `&TheirBar`, found `&TheirFoo`
+   |              arguments to this function are incorrect
+   |
+   = note: expected reference `&tuple_structs::external_crate::TheirBar`
+              found reference `&tuple_structs::external_crate::TheirFoo`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper(remote: &Self::Remote) -> &Self;
+   |        ^^^^^^^^^^
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^
+   |              |
+   |              expected `&mut TheirBar`, found `&mut TheirFoo`
+   |              arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut tuple_structs::external_crate::TheirBar`
+              found mutable reference `&mut tuple_structs::external_crate::TheirFoo`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper_mut(remote: &mut Self::Remote) -> &mut Self;
+   |        ^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ------- in this derive macro expansion
+...
+LL |         #[reflect(remote = MyBar)] external_crate::TheirFoo,
+   |                            ^^^^^
+   |                            |
+   |                            expected `TheirBar`, found `TheirFoo`
+   |                            expected due to this
+   |
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: `?` operator has incompatible types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[reflect_remote(external_crate::TheirBar)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
+   |
+   = note: `?` operator cannot convert from `u32` to `i32`
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
+   |
+LL |     #[reflect_remote(external_crate::TheirBar)].try_into().unwrap()
+   |                                                ++++++++++++++++++++
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |       #[reflect_remote(external_crate::TheirBar)]
+   |       -------------------------------------------
+   |       |
+   |  _____in this procedural macro expansion
+   | |
+LL | |
+LL | |     enum MyBar {
+LL | |         // Reason: Should use `i32`
+LL | |         Value(u32),
+   | |               ^^-
+   | |_______________|_|
+   |                 | expected due to the type of this binding
+   |                 expected `i32`, found `u32`
+   |
+   = note: this error originates in the attribute macro `reflect_remote` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^
+   |              |
+   |              expected `&TheirBar`, found `&TheirFoo`
+   |              arguments to this function are incorrect
+   |
+   = note: expected reference `&enums::external_crate::TheirBar`
+              found reference `&enums::external_crate::TheirFoo`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper(remote: &Self::Remote) -> &Self;
+   |        ^^^^^^^^^^
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^
+   |              |
+   |              expected `&mut TheirBar`, found `&mut TheirFoo`
+   |              arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut enums::external_crate::TheirBar`
+              found mutable reference `&mut enums::external_crate::TheirFoo`
+note: associated function defined here
+  --> BEVY_ROOT/bevy_reflect/src/remote.rs:LL:CC
+   |
+LL |     fn as_wrapper_mut(remote: &mut Self::Remote) -> &mut Self;
+   |        ^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ^^^^^^^ expected `TheirFoo`, found `TheirBar`
+   |
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/reflect_remote/type_mismatch_fail.rs:LL:CC
+   |
+LL |     #[derive(Reflect)]
+   |              ------- in this derive macro expansion
+...
+LL |             #[reflect(remote = MyBar)] external_crate::TheirFoo,
+   |                                ^^^^^
+   |                                |
+   |                                expected `TheirBar`, found `TheirFoo`
+   |                                expected due to this
+   |
+   = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -18,7 +18,7 @@ impl Prepare for CompileFailCommand {
 
         // Macro Compile Fail Tests
         // Run tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_macros_compile_fail_tests/README.md
+        // - See crates/bevy_derive/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
                 cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast}"),
@@ -29,7 +29,7 @@ impl Prepare for CompileFailCommand {
 
         // ECS Compile Fail Tests
         // Run UI tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_ecs_compile_fail_tests/README.md
+        // - See crates/bevy_ec/compile_fail/README.md
         commands.push(
             PreparedCommand::new::<Self>(
                 cmd!(sh, "cargo test --target-dir ../../../target {no_fail_fast}"),

--- a/tools/ci/src/commands/compile_fail.rs
+++ b/tools/ci/src/commands/compile_fail.rs
@@ -49,6 +49,15 @@ impl Prepare for CompileFailCommand {
             .with_subdir("crates/bevy_reflect/compile_fail"),
         );
 
+        // Compile fail utils Compile Fail Tests
+        commands.push(
+            PreparedCommand::new::<Self>(
+                cmd!(sh, "cargo test --target-dir ../../target {no_fail_fast}"),
+                "Compiler errors of the Compile fail utils compile fail tests seem to be different than expected! Check locally and compare rust versions.",
+            )
+            .with_subdir("tools/compile_fail_utils")
+        );
+
         commands
     }
 }

--- a/tools/compile_fail_utils/Cargo.toml
+++ b/tools/compile_fail_utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-ui_test = "0.23.0"
+ui_test = "0.29.0"
 
 [[test]]
 name = "example"

--- a/tools/compile_fail_utils/src/lib.rs
+++ b/tools/compile_fail_utils/src/lib.rs
@@ -62,12 +62,23 @@ fn basic_config(root_dir: impl Into<PathBuf>, args: &Args) -> ui_test::Result<Co
         r"[^ \n`]*/(?:rust[^/]*|checkout|[0-9a-fA-F]*)/library/",
         "RUSTLIB/",
     );
+    config.stderr_filter(
+        r"[^ \n`]*\/registry(?:\/[a-zA-Z0-9\.-]+)+\/([a-zA-Z0-9_-]+[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z]*)",
+        "CARGO_REGISTRY/$1",
+    );
     // Replace long type file names since they contain random numbers
     config.stderr_filter(r"[\p{L}\p{N}_]+\.long-type-\d+\.txt", "long-type.sr'");
     // The number of spaces in diagnostics isn't consistent across platforms
     config.stderr_filter(r"\n +-->", "\n  -->");
     config.stderr_filter(r"\n\d+ +\|", "\nLL |");
     config.stderr_filter(r"\n +\|", "\n   |");
+    // Normalize line endings
+    config.stderr_filter(r"\r\n", "\n");
+    config.stderr_filter(r"\r", "\n");
+    // Some tests output 2 newlines at the end.
+    config.stderr_filter(r"\n\n$", "\n");
+    // I don't know at this point..
+    config.stderr_filter(r"^[\n ]", "");
 
     let bevy_root = "..";
 

--- a/tools/compile_fail_utils/tests/example_tests/basic_test.stderr
+++ b/tools/compile_fail_utils/tests/example_tests/basic_test.stderr
@@ -1,37 +1,37 @@
 error[E0382]: borrow of moved value: `x`
-  --> tests/example_tests/basic_test.rs:13:15
+  --> tests/example_tests/basic_test.rs:LL:CC
    |
-7  |     let x = String::new();
+LL |     let x = String::new();
    |         - move occurs because `x` has type `String`, which does not implement the `Copy` trait
-8  |     // Help diagnostics need to be annotated
-9  |     let y = x;
+LL |     // Help diagnostics need to be annotated
+LL |     let y = x;
    |             - value moved here
 ...
-13 |     println!("{x}");
+LL |     println!("{x}");
    |               ^^^ value borrowed here after move
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
-9  |     let y = x.clone();
+LL |     let y = x.clone();
    |              ++++++++
 
 error[E0382]: borrow of moved value: `x`
-  --> tests/example_tests/basic_test.rs:22:15
+  --> tests/example_tests/basic_test.rs:LL:CC
    |
-16 |     let x = String::new();
+LL |     let x = String::new();
    |         - move occurs because `x` has type `String`, which does not implement the `Copy` trait
 ...
-19 |     let y = x;
+LL |     let y = x;
    |             - value moved here
 ...
-22 |     println!("{x}");
+LL |     println!("{x}");
    |               ^^^ value borrowed here after move
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
-19 |     let y = x.clone();
+LL |     let y = x.clone();
    |              ++++++++
 
 error: aborting due to 2 previous errors

--- a/tools/compile_fail_utils/tests/example_tests/import.stderr
+++ b/tools/compile_fail_utils/tests/example_tests/import.stderr
@@ -1,19 +1,23 @@
 error[E0599]: no function or associated item named `this_function_does_not_exist` found for struct `Config` in the current scope
-   --> tests/example_tests/import.rs:5:21
-    |
-5   |     let _ = Config::this_function_does_not_exist();
-    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `Config`
-    |
+  --> tests/example_tests/import.rs:LL:CC
+   |
+LL |     let _ = Config::this_function_does_not_exist();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `Config`
+   |
 note: if you're trying to build a new `Config` consider using one of the following associated functions:
+      Config::dummy
       Config::rustc
       Config::cargo
-   --> $RUSTUP_HOME/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ui_test-0.23.0/src/config.rs:70:5
-    |
-70  |     pub fn rustc(root_dir: impl Into<PathBuf>) -> Self {
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> CARGO_REGISTRY/ui_test-0.29.1/src/config.rs:LL:CC
+   |
+LL |     pub fn dummy() -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 ...
-221 |     pub fn cargo(root_dir: impl Into<PathBuf>) -> Self {
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub fn rustc(root_dir: impl Into<PathBuf>) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     pub fn cargo(root_dir: impl Into<PathBuf>) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tools/compile_fail_utils/tests/example_tests/pass_test.stderr
+++ b/tools/compile_fail_utils/tests/example_tests/pass_test.stderr
@@ -1,10 +1,9 @@
 warning: function `correct_borrowing` is never used
- --> tests/example_tests/pass_test.rs:4:4
-  |
-4 | fn correct_borrowing() {
-  |    ^^^^^^^^^^^^^^^^^
-  |
+  --> tests/example_tests/pass_test.rs:LL:CC
+   |
+LL | fn correct_borrowing() {
+   |    ^^^^^^^^^^^^^^^^^
+   |
   = note: `#[warn(dead_code)]` on by default
 
 warning: 1 warning emitted
-


### PR DESCRIPTION
# Objective

CI compile fail tests currently don't check stderr output. See https://github.com/bevyengine/bevy/pull/18056#issuecomment-2686241448

Supercedes #18056 

## Solution

- Update `compile_fail_utils` to use the newest `ui_test`
- Borrow some [regexes from miri](https://github.com/rust-lang/rust/blob/96cfc75584359ae7ad11cc45968059f29e7b44b7/src/tools/miri/tests/ui.rs#L248).
- Enable checking and bless compile fail .stderr files.

## Testing

Ran the updated tests.
I suggest you check some of the changed .stderr files. Look for any private filesystem information in paths.
