### PR TITLE
Deprecate panicking `.resource` methods

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -361,6 +361,10 @@ impl<'w> DeferredWorld<'w> {
     /// Use [`get_resource_mut`](DeferredWorld::get_resource_mut) instead if you want to handle this case.
     #[inline]
     #[track_caller]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_resource_mut` instead, which returns an `Option` instead of panicking."
+    )]
     pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
         match self.get_resource_mut() {
             Some(x) => x,
@@ -391,6 +395,10 @@ impl<'w> DeferredWorld<'w> {
     /// This function will panic if it isn't called from the same thread that the resource was inserted from.
     #[inline]
     #[track_caller]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_non_send_resource_mut` instead, which returns an `Option` instead of panicking."
+    )]
     pub fn non_send_resource_mut<R: 'static>(&mut self) -> Mut<'_, R> {
         match self.get_non_send_resource_mut() {
             Some(x) => x,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1328,6 +1328,10 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// Panics if the resource does not exist.
     /// Use [`get_resource`](EntityWorldMut::get_resource) instead if you want to handle this case.
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_resource` instead, which returns an `Option` instead of panicking."
+    )]
     #[inline]
     #[track_caller]
     pub fn resource<R: Resource>(&self) -> &R {
@@ -1345,6 +1349,10 @@ impl<'w> EntityWorldMut<'w> {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_resource_mut` instead, which returns an `Option` instead of panicking."
+    )]
     pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
         self.world.resource_mut::<R>()
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1850,6 +1850,10 @@ impl World {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_resource` instead, which returns an `Option` instead of panicking."
+    )]
     pub fn resource<R: Resource>(&self) -> &R {
         match self.get_resource() {
             Some(x) => x,
@@ -1874,6 +1878,10 @@ impl World {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_resource_ref` instead, which returns an `Option` instead of panicking."
+    )]
     pub fn resource_ref<R: Resource>(&self) -> Ref<R> {
         match self.get_resource_ref() {
             Some(x) => x,
@@ -1898,6 +1906,10 @@ impl World {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Please use `get_resource_mut` instead, which returns an `Option` instead of panicking."
+    )]
     pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
         match self.get_resource_mut() {
             Some(x) => x,


### PR DESCRIPTION
# Objective

This PR is a sibling to #18082, and almost all of the motivation there applies here. These methods are much more commonly used in commands, tests and exclusive systems though, and deserve their own judgement call.

Ultimately part of #14275.

## Solution

1. Deprecate all of the panicking resource methods I can find.

I'm less confident about this PR, and there's 796 warnings in my IDE, so I want to get consensus before burning time on migrating all of these.

TODO:

- [ ] fix deprecation warnings
- [ ] add docs?
- [] make `World::resource` and friends return a `Result` for nicer `?` ergonomics?

## Future Work

Move the non-panicking versions to the better names during the 0.17 cycle, just like in #18082.

## Migration Guide

`World::resource` and all related methods are now deprecated. Use `World::get_resource` and so on and handle the returned `Option`.