### PR TITLE
changed marker struct to const generic parameter

### DIFF
--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -3,7 +3,7 @@ use crate::{
     world::{DeferredWorld, World},
 };
 use alloc::{boxed::Box, vec::Vec};
-use bevy_ptr::{OwningPtr, Unaligned};
+use bevy_ptr::{OwningPtr, UNALIGNED};
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
@@ -20,7 +20,7 @@ struct CommandMeta {
     ///
     /// Advances `cursor` by the size of `T` in bytes.
     consume_command_and_get_size:
-        unsafe fn(value: OwningPtr<Unaligned>, world: Option<NonNull<World>>, cursor: &mut usize),
+        unsafe fn(value: OwningPtr<UNALIGNED>, world: Option<NonNull<World>>, cursor: &mut usize),
 }
 
 /// Densely and efficiently stores a queue of heterogenous types implementing [`Command`].
@@ -249,7 +249,7 @@ impl RawCommandQueue {
             // guarantees that nothing stored in the buffer will get observed after this function ends.
             // `cmd` points to a valid address of a stored command, so it must be non-null.
             let cmd = unsafe {
-                OwningPtr::<Unaligned>::new(NonNull::new_unchecked(
+                OwningPtr::<UNALIGNED>::new(NonNull::new_unchecked(
                     self.bytes.as_mut().as_mut_ptr().add(local_cursor).cast(),
                 ))
             };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -16,9 +16,9 @@ use core::{
     ptr::{self, NonNull},
 };
 
-/// Constant for use with the const generic in [`Ptr`], [`PtrMut`], and [`OwningPtr`]
+/// Used as a const generic in [`Ptr`], [`PtrMut`], and [`OwningPtr`] to specify that the pointer is aligned.
 pub const ALIGNED: bool = true;
-/// Constant for use with the const generic in [`Ptr`], [`PtrMut`], and [`OwningPtr`]
+/// Used as a const generic in [`Ptr`], [`PtrMut`], and [`OwningPtr`] to specify that the pointer is unaligned.
 pub const UNALIGNED: bool = false;
 
 /// A newtype around [`NonNull`] that only allows conversion to read-only borrows or pointers.
@@ -205,8 +205,8 @@ macro_rules! impl_ptr {
             ///
             /// # Safety
             /// - The offset cannot make the existing ptr null, or take it out of bounds for its allocation.
-            /// - If the `A` type parameter is [`Aligned`] then the offset must not make the resulting pointer
-            ///   be unaligned for the pointee type.
+            /// - If the `IS_ALIGNED` const generic parameter is [`ALIGNED`] then the offset must not make the resulting
+            ///   pointer be unaligned for the pointee type.
             /// - The value pointed by the resulting pointer must outlive the lifetime of this pointer.
             ///
             /// [ptr_offset]: https://doc.rust-lang.org/std/primitive.pointer.html#method.offset
@@ -227,7 +227,7 @@ macro_rules! impl_ptr {
             ///
             /// # Safety
             /// - The offset cannot make the existing ptr null, or take it out of bounds for its allocation.
-            /// - If the `A` type parameter is [`Aligned`] then the offset must not make the resulting pointer
+            /// - If the `IS_ALIGNED` const generic parameter is [`ALIGNED`] then the offset must not make the resulting pointer
             ///   be unaligned for the pointee type.
             /// - The value pointed by the resulting pointer must outlive the lifetime of this pointer.
             ///
@@ -276,7 +276,7 @@ impl<'a, const IS_ALIGNED: bool> Ptr<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `inner` must point to valid value of whatever the pointee type is.
-    /// - If the `A` type parameter is [`Aligned`] then `inner` must be sufficiently aligned for the pointee type.
+    /// - If the `IS_ALIGNED` const generic parameter is [`ALIGNED`] then `inner` must be sufficiently aligned for the pointee type.
     /// - `inner` must have correct provenance to allow reads of the pointee type.
     /// - The lifetime `'a` must be constrained such that this [`Ptr`] will stay valid and nothing
     ///   can mutate the pointee while this [`Ptr`] is live except through an [`UnsafeCell`].
@@ -300,7 +300,7 @@ impl<'a, const IS_ALIGNED: bool> Ptr<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `T` must be the erased pointee type for this [`Ptr`].
-    /// - If the type parameter `A` is [`Unaligned`] then this pointer must be sufficiently aligned
+    /// - If the const generic parameter `IS_ALIGNED` is [`UNALIGNED`] then this pointer must be sufficiently aligned
     ///   for the pointee type `T`.
     #[inline]
     pub unsafe fn deref<T>(self) -> &'a T {
@@ -333,7 +333,7 @@ impl<'a, const IS_ALIGNED: bool> PtrMut<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `inner` must point to valid value of whatever the pointee type is.
-    /// - If the `A` type parameter is [`Aligned`] then `inner` must be sufficiently aligned for the pointee type.
+    /// - If the `IS_ALIGNED` const generic parameter is [`ALIGNED`] then `inner` must be sufficiently aligned for the pointee type.
     /// - `inner` must have correct provenance to allow read and writes of the pointee type.
     /// - The lifetime `'a` must be constrained such that this [`PtrMut`] will stay valid and nothing
     ///   else can read or mutate the pointee while this [`PtrMut`] is live.
@@ -355,7 +355,7 @@ impl<'a, const IS_ALIGNED: bool> PtrMut<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `T` must be the erased pointee type for this [`PtrMut`].
-    /// - If the type parameter `A` is [`Unaligned`] then this pointer must be sufficiently aligned
+    /// - If the const generic parameter `IS_ALIGNED` is [`UNALIGNED`] then this pointer must be sufficiently aligned
     ///   for the pointee type `T`.
     #[inline]
     pub unsafe fn deref_mut<T>(self) -> &'a mut T {
@@ -424,7 +424,7 @@ impl<'a, const IS_ALIGNED: bool> OwningPtr<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `inner` must point to valid value of whatever the pointee type is.
-    /// - If the `A` type parameter is [`Aligned`] then `inner` must be sufficiently aligned for the pointee type.
+    /// - If the `IS_ALIGNED` const generic parameter is [`ALIGNED`] then `inner` must be sufficiently aligned for the pointee type.
     /// - `inner` must have correct provenance to allow read and writes of the pointee type.
     /// - The lifetime `'a` must be constrained such that this [`OwningPtr`] will stay valid and nothing
     ///   else can read or mutate the pointee while this [`OwningPtr`] is live.
@@ -437,7 +437,7 @@ impl<'a, const IS_ALIGNED: bool> OwningPtr<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `T` must be the erased pointee type for this [`OwningPtr`].
-    /// - If the type parameter `A` is [`Unaligned`] then this pointer must be sufficiently aligned
+    /// - If the const generic parameter `IS_ALIGNED` is [`UNALIGNED`] then this pointer must be sufficiently aligned
     ///   for the pointee type `T`.
     #[inline]
     pub unsafe fn read<T>(self) -> T {
@@ -450,7 +450,7 @@ impl<'a, const IS_ALIGNED: bool> OwningPtr<'a, IS_ALIGNED> {
     ///
     /// # Safety
     /// - `T` must be the erased pointee type for this [`OwningPtr`].
-    /// - If the type parameter `A` is [`Unaligned`] then this pointer must be sufficiently aligned
+    /// - If the const generic parameter `IS_ALIGNED` is [`UNALIGNED`] then this pointer must be sufficiently aligned
     ///   for the pointee type `T`.
     #[inline]
     pub unsafe fn drop_as<T>(self) {

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -9,7 +9,7 @@
 
 use core::{
     cell::UnsafeCell,
-    fmt::{self, Formatter, Pointer},
+    fmt::{self, Debug, Formatter, Pointer},
     marker::PhantomData,
     mem::ManuallyDrop,
     num::NonZeroUsize,
@@ -159,7 +159,7 @@ impl<'a, T: ?Sized> From<&'a mut T> for ConstNonNull<T> {
 ///
 /// It may be helpful to think of this type as similar to `&'a dyn Any` but without
 /// the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct Ptr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a u8, A)>);
 
@@ -174,7 +174,6 @@ pub struct Ptr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a u8, A)>
 ///
 /// It may be helpful to think of this type as similar to `&'a mut dyn Any` but without
 /// the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct PtrMut<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut u8, A)>);
 
@@ -194,7 +193,6 @@ pub struct PtrMut<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut 
 ///
 /// It may be helpful to think of this type as similar to `&'a mut ManuallyDrop<dyn Any>` but
 /// without the metadata and able to point to data that does not correspond to a Rust type.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct OwningPtr<'a, A: IsAligned = Aligned>(NonNull<u8>, PhantomData<(&'a mut u8, A)>);
 
@@ -263,6 +261,29 @@ macro_rules! impl_ptr {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 Pointer::fmt(&self.0, f)
+            }
+        }
+
+        impl Debug for $ptr<'_, Aligned> {
+            #[inline]
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                write! {
+                    f,
+                    "{}<Aligned>({:?})",
+                    stringify!($ptr),
+                    self.0
+                }
+            }
+        }
+        impl Debug for $ptr<'_, Unaligned> {
+            #[inline]
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                write! {
+                    f,
+                    "{}<Unaligned>({:?})",
+                    stringify!($ptr),
+                    self.0
+                }
             }
         }
     };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -267,23 +267,13 @@ macro_rules! impl_ptr {
         impl Debug for $ptr<'_, Aligned> {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                write! {
-                    f,
-                    "{}<Aligned>({:?})",
-                    stringify!($ptr),
-                    self.0
-                }
+                write!(f, "{}<Aligned>({:?})", stringify!($ptr), self.0)
             }
         }
         impl Debug for $ptr<'_, Unaligned> {
             #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                write! {
-                    f,
-                    "{}<Unaligned>({:?})",
-                    stringify!($ptr),
-                    self.0
-                }
+                write!(f, "{}<Unaligned>({:?})", stringify!($ptr), self.0)
             }
         }
     };

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -17,11 +17,11 @@ use core::{
 };
 
 /// Used as a type argument to [`Ptr`], [`PtrMut`] and [`OwningPtr`] to specify that the pointer is aligned.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Aligned;
 
 /// Used as a type argument to [`Ptr`], [`PtrMut`] and [`OwningPtr`] to specify that the pointer is not aligned.
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Unaligned;
 
 /// Trait that is only implemented for [`Aligned`] and [`Unaligned`] to work around the lack of ability

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -17,7 +17,7 @@ use bevy::{
         world::FilteredEntityMut,
     },
     prelude::*,
-    ptr::{Aligned, OwningPtr},
+    ptr::{ALIGNED, OwningPtr},
 };
 
 const PROMPT: &str = "
@@ -196,7 +196,7 @@ fn main() {
 
 // Constructs `OwningPtr` for each item in `components`
 // By sharing the lifetime of `components` with the resulting ptrs we ensure we don't drop the data before use
-fn to_owning_ptrs(components: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
+fn to_owning_ptrs(components: &mut [Vec<u64>]) -> Vec<OwningPtr<ALIGNED>> {
     components
         .iter_mut()
         .map(|data| {


### PR DESCRIPTION
# Objective

Fixes #18085.

## Solution

Implementation as described in issue:

- Replaced `Aligned` and `Unaligned` structs with `ALIGNED` and `UNALIGNED` constants
- Changed `A: IsAligned = Aligned` to `const IS_ALIGNED: bool = ALIGNED` in `Ptr`, `PtrMut` and `OwningPtr`

## Testing

- Changes have not been tested, aside from ensuring that `cargo check --workspace --all-targets` does not error

---


## Migration Guide

- Replace all uses of `bevy_ptr::Aligned` and `bevy_ptr::Unaligned` in the context of `Ptr`, `PtrMut` and `OwningPtr` with `ALIGNED` and `UNALIGNED`, respectively.
- Replace generic type parameters using the now removed `IsAligned` trait with a const generic parameter of type bool.