### PR TITLE
Update `ChildOf` deprecation advice to match new layout

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -52,9 +52,9 @@ use log::warn;
 /// # use bevy_ecs::prelude::*;
 /// # let mut world = World::new();
 /// let root = world.spawn_empty().id();
-/// let child1 = world.spawn(ChildOf {parent: root}).id();
-/// let child2 = world.spawn(ChildOf {parent: root}).id();
-/// let grandchild = world.spawn(ChildOf {parent: child1}).id();
+/// let child1 = world.spawn(ChildOf { parent: root }).id();
+/// let child2 = world.spawn(ChildOf { parent: root }).id();
+/// let grandchild = world.spawn(ChildOf { parent: child1 }).id();
 ///
 /// assert_eq!(&**world.entity(root).get::<Children>().unwrap(), &[child1, child2]);
 /// assert_eq!(&**world.entity(child1).get::<Children>().unwrap(), &[grandchild]);
@@ -200,7 +200,10 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Inserts the [`ChildOf`] component with the given `parent` entity, if it exists.
-    #[deprecated(since = "0.16.0", note = "Use entity_mut.insert(ChildOf(entity))")]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Use entity_mut.insert(ChildOf { parent: entity })"
+    )]
     pub fn set_parent(&mut self, parent: Entity) -> &mut Self {
         self.insert(ChildOf { parent });
         self
@@ -246,7 +249,10 @@ impl<'a> EntityCommands<'a> {
     }
 
     /// Inserts the [`ChildOf`] component with the given `parent` entity, if it exists.
-    #[deprecated(since = "0.16.0", note = "Use entity_commands.insert(ChildOf(entity))")]
+    #[deprecated(
+        since = "0.16.0",
+        note = "Use entity_commands.insert(ChildOf { parent: entity })"
+    )]
     pub fn set_parent(&mut self, parent: Entity) -> &mut Self {
         self.insert(ChildOf { parent });
         self


### PR DESCRIPTION
https://github.com/bevyengine/bevy/pull/17905 replaced `ChildOf(entity)` with `ChildOf { parent: entity }`, but some deprecation advice was overlooked. Also corrected formatting in documentation.

## Testing

Added a `set_parent` to a random example. Confirmed that the deprecation warning shows and the advice can be pasted in.