### PR TITLE
Decoupled naga for wgpu testing

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -9,20 +9,17 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-default = ["coupled_naga"]
-
-# Bevy users should _always_ leave this feature on.
+# Bevy users should _never_ turn this feature on.
 #
-# Bevy/wgpu developers can turn this feature off (see `default` above) to test a newer version of wgpu
-# without needing to also update naga_oil. Make sure to update both wgpu and wgpu-types.
+# Bevy/wgpu developers can turn this feature on to test a newer version of wgpu without needing to also update naga_oil.
 #
-# When turning this feature off, you can add the following to bevy/Cargo.toml, and then run `cargo update`:
+# When turning this feature on, you can add the following to bevy/Cargo.toml (not this file), and then run `cargo update`:
 # [patch.crates-io]
 # wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 # wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 # wgpu-hal = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 # wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
-coupled_naga = ["wgpu/naga-ir"]
+decoupled_naga = []
 
 # Texture formats (require more than just image support)
 basis-universal = ["bevy_image/basis-universal"]
@@ -92,6 +89,7 @@ wgpu = { version = "24", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
+  "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }
 naga = { version = "24", features = ["wgsl-in"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -13,8 +13,15 @@ default = ["coupled_naga"]
 
 # Bevy users should _always_ leave this feature on.
 #
-# Bevy/wgpu developers can turn this feature off to test a newer version of wgpu
+# Bevy/wgpu developers can turn this feature off (see `default` above) to test a newer version of wgpu
 # without needing to also update naga_oil. Make sure to update both wgpu and wgpu-types.
+#
+# When turning this feature off, you can add the following to bevy/Cargo.toml:
+# [patch.crates-io]
+# wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
+# wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
+# wgpu-hal = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
+# wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 coupled_naga = ["wgpu/naga-ir"]
 
 # Texture formats (require more than just image support)

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -9,6 +9,14 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+default = ["coupled_naga"]
+
+# Bevy users should _always_ leave this feature on.
+#
+# Bevy/wgpu developers can turn this feature off to test a newer version of wgpu
+# without needing to also update naga_oil. Make sure to update both wgpu and wgpu-types.
+coupled_naga = ["wgpu/naga-ir"]
+
 # Texture formats (require more than just image support)
 basis-universal = ["bevy_image/basis-universal"]
 dds = ["bevy_image/dds"]
@@ -77,7 +85,6 @@ wgpu = { version = "24", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
-  "naga-ir",
   "fragile-send-sync-non-atomic-wasm",
 ] }
 naga = { version = "24", features = ["wgsl-in"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -16,7 +16,7 @@ default = ["coupled_naga"]
 # Bevy/wgpu developers can turn this feature off (see `default` above) to test a newer version of wgpu
 # without needing to also update naga_oil. Make sure to update both wgpu and wgpu-types.
 #
-# When turning this feature off, you can add the following to bevy/Cargo.toml, and then `cargo update`:
+# When turning this feature off, you can add the following to bevy/Cargo.toml, and then run `cargo update`:
 # [patch.crates-io]
 # wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 # wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -16,7 +16,7 @@ default = ["coupled_naga"]
 # Bevy/wgpu developers can turn this feature off (see `default` above) to test a newer version of wgpu
 # without needing to also update naga_oil. Make sure to update both wgpu and wgpu-types.
 #
-# When turning this feature off, you can add the following to bevy/Cargo.toml:
+# When turning this feature off, you can add the following to bevy/Cargo.toml, and then `cargo update`:
 # [patch.crates-io]
 # wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }
 # wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "..." }

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -306,12 +306,12 @@ impl ShaderCache {
                             },
                         )?;
 
-                        #[cfg(feature = "coupled_naga")]
+                        #[cfg(not(feature = "decoupled_naga"))]
                         {
                             ShaderSource::Naga(Cow::Owned(naga))
                         }
 
-                        #[cfg(not(feature = "coupled_naga"))]
+                        #[cfg(feature = "decoupled_naga")]
                         {
                             let mut validator = naga::valid::Validator::new(
                                 naga::valid::ValidationFlags::all(),

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -314,7 +314,7 @@ impl ShaderCache {
                         #[cfg(not(feature = "coupled_naga"))]
                         {
                             let mut validator = naga::valid::Validator::new(
-                                naga::valid::ValidationFlags::empty(),
+                                naga::valid::ValidationFlags::all(),
                                 self.composer.capabilities,
                             );
                             let module_info = validator.validate(&naga).unwrap();


### PR DESCRIPTION
# Objective
- Allow bevy and wgpu developers to test newer versions of wgpu without having to update naga_oil.

## Solution

- Currently bevy feeds wgsl through naga_oil to get a naga::Module that it passes to wgpu.
- Added a way to pass wgsl through naga_oil, and then serialize the naga::Module back into a wgsl string to feed to wgpu, allowing wgpu to parse it using it's internal version of naga (and not the version of naga bevy_render/naga_oil is using).

## Testing
1. Run 3d_scene (it works)
2. Run 3d_scene with `--features bevy_render/decoupled_naga` (it still works)
3. Add the following patch to bevy/Cargo.toml, run cargo update, and compile again (it will fail)
```toml
[patch.crates-io]
wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "2764e7a39920e23928d300e8856a672f1952da63" }
wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "2764e7a39920e23928d300e8856a672f1952da63" }
wgpu-hal = { git = "https://github.com/gfx-rs/wgpu", rev = "2764e7a39920e23928d300e8856a672f1952da63" }
wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "2764e7a39920e23928d300e8856a672f1952da63" }
```
4. Fix errors and compile again (it will work, and you didn't have to touch naga_oil)