### PR TITLE
Fix invisible window creation on Windows

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -435,8 +435,12 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 // https://github.com/bevyengine/bevy/issues/17488
                 #[cfg(target_os = "windows")]
                 {
-                    self.redraw_requested = true;
-                    self.redraw_requested(_event_loop);
+                    // Have the startup behavior run in about_to_wait, which prevents issues with
+                    // invisible window creation. https://github.com/bevyengine/bevy/issues/18027
+                    if self.startup_forced_updates == 0 {
+                        self.redraw_requested = true;
+                        self.redraw_requested(_event_loop);
+                    }
                 }
             }
             _ => {}
@@ -480,6 +484,15 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
         //       The monitor sync logic likely belongs in monitor event handlers and not here.
         #[cfg(not(target_os = "windows"))]
         self.redraw_requested(event_loop);
+
+        // Have the startup behavior run in about_to_wait, which prevents issues with
+        // invisible window creation. https://github.com/bevyengine/bevy/issues/18027
+        #[cfg(target_os = "windows")]
+        {
+            if self.startup_forced_updates > 0 {
+                self.redraw_requested(event_loop);
+            }
+        }
     }
 
     fn suspended(&mut self, _event_loop: &ActiveEventLoop) {

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -489,7 +489,9 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
         // invisible window creation. https://github.com/bevyengine/bevy/issues/18027
         #[cfg(target_os = "windows")]
         {
-            if self.startup_forced_updates > 0 {
+            let winit_windows = self.world().non_send_resource::<WinitWindows>();
+            let headless = winit_windows.windows.is_empty();
+            if self.startup_forced_updates > 0 || headless {
                 self.redraw_requested(event_loop);
             }
         }

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -491,7 +491,11 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
         {
             let winit_windows = self.world().non_send_resource::<WinitWindows>();
             let headless = winit_windows.windows.is_empty();
-            if self.startup_forced_updates > 0 || headless {
+            let all_invisible = winit_windows
+                .windows
+                .iter()
+                .all(|(_, w)| !w.is_visible().unwrap_or(false));
+            if self.startup_forced_updates > 0 || headless || all_invisible {
                 self.redraw_requested(event_loop);
             }
         }


### PR DESCRIPTION
# Objective

Fixes #18027 

## Solution

Run `redraw_requested` logic in `about_to_wait` on Windows during initial application startup and when in headless mode

## Testing

- Ran `cargo run --example window_settings` to demonstrate invisible window creation worked again and fixes #18027
- Ran `cargo run --example eased_motion` to demonstrate no regression with the fix for #17488 

Ran all additional `window` examples. 

Notes:

- The `transparent_window` was not transparent but this appears to have been broken prior to #18004.  See: #7544