### PR TITLE
Improve compile/typecheck performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -504,14 +504,14 @@ flate2 = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bytemuck = "1.7"
-bevy_render = { path = "crates/bevy_render", version = "0.16.0-dev", default-features = false }
+bevy_render = { path = "crates/bevy_render", version = "0.16.0-dev" }
 # The following explicit dependencies are needed for proc macros to work inside of examples as they are part of the bevy crate itself.
-bevy_ecs = { path = "crates/bevy_ecs", version = "0.16.0-dev", default-features = false }
-bevy_state = { path = "crates/bevy_state", version = "0.16.0-dev", default-features = false }
-bevy_asset = { path = "crates/bevy_asset", version = "0.16.0-dev", default-features = false }
-bevy_reflect = { path = "crates/bevy_reflect", version = "0.16.0-dev", default-features = false }
-bevy_image = { path = "crates/bevy_image", version = "0.16.0-dev", default-features = false }
-bevy_gizmos = { path = "crates/bevy_gizmos", version = "0.16.0-dev", default-features = false }
+bevy_ecs = { path = "crates/bevy_ecs", version = "0.16.0-dev" }
+bevy_state = { path = "crates/bevy_state", version = "0.16.0-dev" }
+bevy_asset = { path = "crates/bevy_asset", version = "0.16.0-dev" }
+bevy_reflect = { path = "crates/bevy_reflect", version = "0.16.0-dev" }
+bevy_image = { path = "crates/bevy_image", version = "0.16.0-dev" }
+bevy_gizmos = { path = "crates/bevy_gizmos", version = "0.16.0-dev" }
 # Needed to poll Task examples
 futures-lite = "2.0.1"
 async-std = "1.13"


### PR DESCRIPTION
# Objective

~#18103~ (or at least significantly improves the situation)

## Solution

Removed `default-features = false` from the `bevy_*`  `[dev-dependencies]`. 

## Testing

`cargo check` and rust-analayzer are now significantly faster.