### PR TITLE
Add missing bindless imports in `pbr_prepass.wgsl`.

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -10,6 +10,8 @@
     mesh_view_bindings::view,
 }
 
+#import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d}
+
 #ifdef MESHLET_MESH_MATERIAL_PASS
 #import bevy_pbr::meshlet_visibility_buffer_resolve::resolve_vertex_output
 #endif


### PR DESCRIPTION
The bindless reform PR neglected to include these, causing the prepass shader to fail to compile in some circumstances.
