### PR TITLE
Add `on_insert` hook to `Node` to warn if parent has `Text`

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -20,6 +20,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.16.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "bevy",
 ] }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -630,7 +630,7 @@ fn on_insert_node(world: DeferredWorld, ctx: HookContext) {
     };
 
     if let Some(_parent) = world.get::<Text>(childof.parent) {
-        error_once!("Found `Node` with `Text` as a component of parent entity. This is unsupported behaviour and will lead to unexpected results.");
+        error_once!("Found `Node` with `Text` as a component of parent entity. This is unsupported behavior and will lead to unexpected results.");
     }
 }
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -55,6 +55,8 @@ impl Default for TextNodeFlags {
 ///
 /// Note that [`Transform`](bevy_transform::components::Transform) on this entity is managed automatically by the UI layout system.
 ///
+/// This entity is intended to be a leaf node, and as such should not have children with `Node`
+/// components.
 ///
 /// ```
 /// # use bevy_asset::Handle;


### PR DESCRIPTION
# Objective

Add a warning when adding a `Node` as a child of an entity with a `Text` component, and some information in `Text` docs.

Closes #18015
Would close #17551 if it weren't already

## Solution

Use an `on_insert` component hook on `Node` to check the node's parent and emit a warning.

## Testing

<details>
  <summary>Click to view test code</summary>

```rust
use bevy::{input::common_conditions::input_just_pressed, prelude::*};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, (setup, setup_insert))
        .add_systems(
            Update,
            insert_test.run_if(input_just_pressed(MouseButton::Left)),
        )
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2d);
    commands
        .spawn(Text::new("Hello, bevy!"))
        .with_children(|cb| {
            cb.spawn(Node::default()); // Warning triggers here.
        });
}

fn setup_insert(mut commands: Commands) {
    commands
        .spawn(Text::new("Hello, bevy!"))
        .with_children(|cb| {
            cb.spawn_empty();
        });
}

fn insert_test(mut commands: Commands, q: Query<Entity, With<ChildOf>>) {
    for e in &q {
        commands.entity(e).insert(Node::default()); // Warning triggers here.
    }
}

```

</details>

---
