### PR TITLE
Fix incorrect doc about `GamepadAxis::RightZ`/`LeftZ`

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -635,16 +635,16 @@ pub enum GamepadAxis {
     LeftStickX,
     /// The vertical value of the left stick.
     LeftStickY,
-    /// The value of the left `Z` button.
+    /// Generally the throttle axis of a HOTAS setup.
+    /// Refer to [`GamepadButton::LeftTrigger2`] for the analog trigger on a gamepad controller.
     LeftZ,
-
     /// The horizontal value of the right stick.
     RightStickX,
     /// The vertical value of the right stick.
     RightStickY,
-    /// The value of the right `Z` button.
+    /// The yaw of the main joystick, not supported on common gamepads.
+    /// Refer to [`GamepadButton::RightTrigger2`] for the analog trigger on a gamepad controller.
     RightZ,
-
     /// Non-standard support for other axis types (i.e. HOTAS sliders, potentiometers, etc).
     Other(u8),
 }


### PR DESCRIPTION

# Objective

Documentation correction.

# Reasoning
The `GamepadAxis::RightZ` and `LeftZ` do not map to the trigger buttons on a gamepad. They are in fact for the twisting/yaw of a flight Joystick and throttle lever respectively. I confirmed this with two gamepads that has analog triggers (Logitech F710, 8bitdo ultimate BT controller) and a HOTAS joystick (Saitek X52).