### PR TITLE
Fix `webgl2` feature gating affecting webgpu in `transmission` example

### DIFF
--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -35,7 +35,7 @@ use bevy::{
     },
 };
 
-#[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
+#[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
 use bevy::core_pipeline::experimental::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing};
 use rand::random;
 
@@ -55,7 +55,7 @@ fn main() {
     // *Note:* TAA is not _required_ for specular transmission, but
     // it _greatly enhances_ the look of the resulting blur effects.
     // Sadly, it's not available under WebGL.
-    #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
+    #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
     app.add_plugins(TemporalAntiAliasPlugin);
 
     app.run();
@@ -317,9 +317,9 @@ fn setup(
         },
         Tonemapping::TonyMcMapface,
         Exposure { ev100: 6.0 },
-        #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
+        #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
         Msaa::Off,
-        #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
+        #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
         TemporalAntiAliasing::default(),
         EnvironmentMapLight {
             intensity: 25.0,
@@ -471,7 +471,7 @@ fn example_control_system(
         camera.hdr = !camera.hdr;
     }
 
-    #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
+    #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
     if input.just_pressed(KeyCode::KeyD) {
         if depth_prepass.is_none() {
             commands.entity(camera_entity).insert(DepthPrepass);
@@ -480,7 +480,7 @@ fn example_control_system(
         }
     }
 
-    #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
+    #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
     if input.just_pressed(KeyCode::KeyT) {
         if temporal_jitter.is_none() {
             commands
@@ -572,7 +572,7 @@ fn example_control_system(
         state.perceptual_roughness,
         state.reflectance,
         if camera.hdr { "ON " } else { "OFF" },
-        if cfg!(any(not(feature = "webgl2"), not(target_arch = "wasm32"))) {
+        if cfg!(any(feature = "webgpu", not(target_arch = "wasm32"))) {
             if depth_prepass.is_some() {
                 "ON "
             } else {
@@ -581,7 +581,7 @@ fn example_control_system(
         } else {
             "N/A (WebGL)"
         },
-        if cfg!(any(not(feature = "webgl2"), not(target_arch = "wasm32"))) {
+        if cfg!(any(feature = "webgpu", not(target_arch = "wasm32"))) {
             if temporal_jitter.is_some() {
                 if depth_prepass.is_some() {
                     "ON "


### PR DESCRIPTION
# Objective

Fixes #18095

## Solution

Update the feature gates so that `Taa`, etc are added if
- Not on wasm
- OR using webgpu

## Testing

Check that `Taa` is disabled with appropriate messaging on webgl2
```
cargo run -p build-wasm-example -- --api webgl2 transmission && basic-http-server examples/wasm/
```

Check that `Taa` works on webgpu in chrome
```
cargo run -p build-wasm-example -- --api webgpu transmission && basic-http-server examples/wasm/
```

Check that `Taa` still works in a native build
```
cargo run -example transmission
```
