### PR TITLE
Fix label name for Deliberate-Rendering-Change CI

### DIFF
--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -90,7 +90,7 @@ jobs:
           PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ `gh api --jq '.labels.[].name' /repos/bevyengine/bevy/pulls/$PR` =~ "S-Rendering-Change" ]]
+          if [[ `gh api --jq '.labels.[].name' /repos/bevyengine/bevy/pulls/$PR` =~ "M-Deliberate-Rendering-Change" ]]
           then
             echo "result=true" >> $GITHUB_OUTPUT
           else
@@ -104,5 +104,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LF=$'\n'
-          COMMENT_BODY="Your PR caused a change in the graphical output of an example or rendering test. This might be intentional, but it could also mean that something broke! ${LF}You can review it at https://pixel-eagle.com/project/$PROJECT?filter=PR-$PR ${LF} ${LF}If it's expected, please add the S-Deliberate-Rendering-Change label."
+          COMMENT_BODY="Your PR caused a change in the graphical output of an example or rendering test. This might be intentional, but it could also mean that something broke! ${LF}You can review it at https://pixel-eagle.com/project/$PROJECT?filter=PR-$PR ${LF} ${LF}If it's expected, please add the M-Deliberate-Rendering-Change label."
           gh issue comment $PR --body "$COMMENT_BODY"


### PR DESCRIPTION
# Objective

The label added in #18064 is the wrong color! It should be an `M-` (meta) label, not an `S-` (status) label!

## Solution

- Rename the label in the comment that gets left to `M-Deliberate-Rendering-Change`
- Also make the job check for the right label 🤦🏽‍♀️ 

Once this is approved and ready to merge, I'll rename the label on Github to match.
