### PR TITLE
Reextract meshes when their material assets change.

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -651,7 +651,10 @@ pub const fn screen_space_specular_transmission_pipeline_key(
 /// [`crate::render::mesh::extract_meshes_for_gpu_building`] re-extracts a mesh
 /// is to mark its [`Mesh3d`] as changed, so that's what this system does.
 fn mark_meshes_as_changed_if_their_materials_changed<M>(
-    mut changed_meshes_query: Query<&mut Mesh3d, Changed<MeshMaterial3d<M>>>,
+    mut changed_meshes_query: Query<
+        &mut Mesh3d,
+        Or<(Changed<MeshMaterial3d<M>>, AssetChanged<MeshMaterial3d<M>>)>,
+    >,
 ) where
     M: Material,
 {


### PR DESCRIPTION
This commit makes the
`mark_meshes_as_changed_if_their_materials_changed` system use the new `AssetChanged<MeshMaterial3d>` query filter in addition to `Changed<MeshMaterial3d>`. This ensures that we update the `MeshInputUniform`, which contains the bindless material slot. Updating the `MeshInputUniform` fixes problems that occurred when the `MeshBindGroupAllocator` reallocated meshes in such a way as to change their bindless slot.

Closes #18102.