### PR TITLE
fix test for .iter().sort() to include data to sort

### DIFF
--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2602,10 +2602,16 @@ mod tests {
     #[test]
     fn query_iter_sorts() {
         let mut world = World::new();
+        for i in 0..100 {
+            world.spawn(A(i as f32));
+            world.spawn((A(i as f32), Sparse(i)));
+            world.spawn(Sparse(i));
+        }
 
         let mut query = world.query::<Entity>();
 
         let sort = query.iter(&world).sort::<Entity>().collect::<Vec<_>>();
+        assert_eq!(sort.len(), 300);
 
         let sort_unstable = query
             .iter(&world)


### PR DESCRIPTION
The test case `query_iter_sorts` was doing lots of comparisons to ensure that various query arrays were sorted, but the arrays were all empty.

This PR spawns some entities so that the entity lists to compare not empty, and sorting can actually be tested for correctness.