### PR TITLE
fix generics for relationships

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -3,7 +3,14 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, ToTokens};
 use std::collections::HashSet;
 use syn::{
-    parenthesized, parse::Parse, parse_macro_input, parse_quote, punctuated::Punctuated, spanned::Spanned, token::{Comma, Paren}, Data, DataStruct, DeriveInput, ExprClosure, ExprPath, Field, Fields, Ident, Index, LitStr, Member, Path, Result, Token, Type, Visibility
+    parenthesized,
+    parse::Parse,
+    parse_macro_input, parse_quote,
+    punctuated::Punctuated,
+    spanned::Spanned,
+    token::{Comma, Paren},
+    Data, DataStruct, DeriveInput, ExprClosure, ExprPath, Field, Fields, Ident, Index, LitStr,
+    Member, Path, Result, Token, Type, Visibility,
 };
 
 pub fn derive_event(input: TokenStream) -> TokenStream {

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -644,7 +644,7 @@ impl Parse for RelationshipTarget {
             }
         }
 
-        let relationship = relationship_ident.ok_or_else(|| syn::Error::new(input.span(), "RelationshipTarget derive must specify a relationship via #[relationship_target(relationship = X)"))?;
+        let relationship = relationship_type.ok_or_else(|| syn::Error::new(input.span(), "RelationshipTarget derive must specify a relationship via #[relationship_target(relationship = X)"))?;
         Ok(RelationshipTarget {
             relationship,
             linked_spawn: linked_spawn_exists,

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -620,7 +620,7 @@ impl Parse for Relationship {
 
 impl Parse for RelationshipTarget {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
-        let mut relationship_ident: Option<Type> = None;
+        let mut relationship_type: Option<Type> = None;
         let mut linked_spawn_exists = false;
         syn::custom_keyword!(relationship);
         syn::custom_keyword!(linked_spawn);
@@ -629,7 +629,7 @@ impl Parse for RelationshipTarget {
             if input.peek(relationship) {
                 input.parse::<relationship>()?;
                 input.parse::<Token![=]>()?;
-                relationship_ident = Some(input.parse()?);
+                relationship_type = Some(input.parse()?);
             } else if input.peek(linked_spawn) {
                 input.parse::<linked_spawn>()?;
                 linked_spawn_exists = true;

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -3,14 +3,7 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, ToTokens};
 use std::collections::HashSet;
 use syn::{
-    parenthesized,
-    parse::Parse,
-    parse_macro_input, parse_quote,
-    punctuated::Punctuated,
-    spanned::Spanned,
-    token::{Comma, Paren},
-    Data, DataStruct, DeriveInput, ExprClosure, ExprPath, Field, Fields, Ident, Index, LitStr,
-    Member, Path, Result, Token, Visibility,
+    parenthesized, parse::Parse, parse_macro_input, parse_quote, punctuated::Punctuated, spanned::Spanned, token::{Comma, Paren}, Data, DataStruct, DeriveInput, ExprClosure, ExprPath, Field, Fields, Ident, Index, LitStr, Member, Path, Result, Token, Type, Visibility
 };
 
 pub fn derive_event(input: TokenStream) -> TokenStream {
@@ -474,11 +467,11 @@ enum RequireFunc {
 }
 
 struct Relationship {
-    relationship_target: Ident,
+    relationship_target: Type,
 }
 
 struct RelationshipTarget {
-    relationship: Ident,
+    relationship: Type,
     linked_spawn: bool,
 }
 
@@ -613,14 +606,14 @@ impl Parse for Relationship {
         input.parse::<relationship_target>()?;
         input.parse::<Token![=]>()?;
         Ok(Relationship {
-            relationship_target: input.parse::<Ident>()?,
+            relationship_target: input.parse::<Type>()?,
         })
     }
 }
 
 impl Parse for RelationshipTarget {
     fn parse(input: syn::parse::ParseStream) -> Result<Self> {
-        let mut relationship_ident = None;
+        let mut relationship_ident: Option<Type> = None;
         let mut linked_spawn_exists = false;
         syn::custom_keyword!(relationship);
         syn::custom_keyword!(linked_spawn);
@@ -629,7 +622,7 @@ impl Parse for RelationshipTarget {
             if input.peek(relationship) {
                 input.parse::<relationship>()?;
                 input.parse::<Token![=]>()?;
-                relationship_ident = Some(input.parse::<Ident>()?);
+                relationship_ident = Some(input.parse()?);
             } else if input.peek(linked_spawn) {
                 input.parse::<linked_spawn>()?;
                 linked_spawn_exists = true;


### PR DESCRIPTION
# Objective
Allow Relationship to be derived for structs with generics.

fixes #18133
## Solution

"X" inside #[relationship_target(relationship = X)]  was previously parsed as Idents, 
now they are parsed as syn::Type

## Testing

```rust
#[derive(Component)]
#[relationship(relationship_target = Attachments<T>)]
pub struct AttachedTo<T: Send + Sync + 'static> {
    #[relationship]
    pub entity: Entity,
    pub marker: PhantomData<T>,
}

#[derive(Component)]
#[relationship_target(relationship = AttachedTo<T>)]
pub struct Attachments<T: Send + Sync + 'static> {
    #[relationship]
    entities: Vec<Entity>,
    pub marker: PhantomData<T>,
}
```
This now compiles!