### PR TITLE
Relationship(…Target) html trait tag

### DIFF
--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -16,6 +16,8 @@
         'ScheduleLabel',
         'SystemSet',
         'SystemParam',
+        'Relationship',
+        'RelationshipTarget'
     ];
 
     // Find all traits that are implemented by the current type.
@@ -138,7 +140,7 @@
     }
 
     .resource-tag {
-        --tag-color: oklch(50% 27% 130);
+        --tag-color: oklch(50% 27% 110);
     }
 
     .asset-tag {
@@ -161,5 +163,10 @@
 
     .systemparam-tag {
         --tag-color: oklch(50% 27% 200);
+    }
+
+    .relationship-tag,
+    .relationshiptarget-tag {
+        --tag-color: oklch(50% 27% 150);
     }
 </style>


### PR DESCRIPTION
# Objective

Fixes #18117

These are component subtraits, but unlike for `Event` (before that bound got removed) this still shows it as a component because it's actually used as such.

## Testing

```sh
 RUSTDOCFLAGS="--html-after-content docs-rs/trait-tags.html --cfg docsrs_dep" RUSTFLAGS="--cfg docsrs_dep" cargo doc --no-deps --package bevy_ecs
```

---

## Showcase

![Screenshot from 2025-03-03 17-31-24](https://github.com/user-attachments/assets/4b152b3f-f9c3-4ee6-a3d4-ad10f09040b6)
