### PR TITLE
`BorderRadius` comment fix

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2428,7 +2428,8 @@ impl BorderRadius {
         self
     }
 
-    /// Compute the logical border radius for a single corner from the given values
+    /// Resolve the border radius for a single corner from the given context values.
+    /// Returns the radius of the corner in physical pixels.
     pub fn resolve_single_corner(
         radius: Val,
         node_size: Vec2,
@@ -2447,6 +2448,8 @@ impl BorderRadius {
         .clamp(0., 0.5 * node_size.min_element())
     }
 
+    /// Resolve the border radii for the corners from the given context values.
+    /// Returns the radii of the each corner in physical pixels.
     pub fn resolve(
         &self,
         node_size: Vec2,


### PR DESCRIPTION

# Objective

The doc comment for `BorderRadius::resolve_single_corner` returns a value in physical pixels but the doc comments implies it returns a logical value. 