### PR TITLE
Add `LeafNode` to forbid adding `Node` children to certain `Node`s

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -198,6 +198,7 @@ impl Plugin for UiPlugin {
         app.add_systems(
             PostUpdate,
             (
+                validate_leaf_nodes.before(TransformSystem::TransformPropagate),
                 update_ui_context_system.in_set(UiSystem::Prepare),
                 ui_layout_system_config,
                 ui_stack_system

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1,7 +1,7 @@
 use crate::{FocusPolicy, UiRect, Val};
 use bevy_color::Color;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{prelude::*, system::SystemParam};
+use bevy_ecs::{component::HookContext, prelude::*, system::SystemParam, world::DeferredWorld};
 use bevy_math::{vec4, Rect, UVec2, Vec2, Vec4Swizzles};
 use bevy_reflect::prelude::*;
 use bevy_render::{
@@ -672,12 +672,19 @@ impl Default for Node {
     }
 }
 
-/// Marker struct for `Node`s that should not have `Node`s as children.
+/// Marker struct for `Node`s that can't have `Node`s as children.
+/// If you need to have a `Node` with a relationship to a `LeafNode`, look into using a parent
+/// entity and having the two `Node`s as siblings.
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, Default, Debug)]
+#[component(on_remove=on_remove_leaf_node)]
 pub struct LeafNode;
 
-/// Keeps `LeafNode` entities from having `Node` entities as children.
+fn on_remove_leaf_node(_world: DeferredWorld, ctx: HookContext) {
+    warn!("Removing `LeafNode` from {}. This will allow you to add child `Node`s but will result in unexpected behavior.", ctx.entity);
+}
+
+/// Prevents `LeafNode` entities from having `Node` entities as children.
 pub fn validate_leaf_nodes(
     mut commands: Commands,
     children: Query<&Children>,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -672,6 +672,28 @@ impl Default for Node {
     }
 }
 
+/// Marker struct for `Node`s that should not have `Node`s as children.
+#[derive(Component, Debug, Default, Clone, Reflect)]
+#[reflect(Component, Default, Debug)]
+pub struct LeafNode;
+
+/// Keeps `LeafNode` entities from having `Node` entities as children.
+pub fn validate_leaf_nodes(
+    mut commands: Commands,
+    children: Query<&Children>,
+    leaf_nodes: Query<Entity, With<LeafNode>>,
+    nodes: Query<Entity, Added<Node>>,
+) {
+    for leaf_node in &leaf_nodes {
+        for child in children.iter_descendants(leaf_node) {
+            if let Ok(node) = nodes.get(child) {
+                warn!("Entity {leaf_node} is marked as a `LeafNode` but has entity {node} containing `Node` as a descendant. The invalid relationship has been removed.");
+                commands.entity(node).remove::<ChildOf>();
+            }
+        }
+    }
+}
+
 /// Used to control how each individual item is aligned by default within the space they're given.
 /// - For Flexbox containers, sets default cross axis alignment of the child items.
 /// - For CSS Grid containers, controls block (vertical) axis alignment of children of this grid container within their grid areas.

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ComputedNode, ComputedNodeTarget, ContentSize, FixedMeasure, Measure, MeasureArgs, Node,
-    NodeMeasure,
+    ComputedNode, ComputedNodeTarget, ContentSize, FixedMeasure, LeafNode, Measure, MeasureArgs,
+    Node, NodeMeasure,
 };
 use bevy_asset::Assets;
 use bevy_color::Color;
@@ -95,7 +95,15 @@ impl Default for TextNodeFlags {
 /// ```
 #[derive(Component, Debug, Default, Clone, Deref, DerefMut, Reflect, PartialEq)]
 #[reflect(Component, Default, Debug, PartialEq)]
-#[require(Node, TextLayout, TextFont, TextColor, TextNodeFlags, ContentSize)]
+#[require(
+    Node,
+    TextLayout,
+    TextFont,
+    TextColor,
+    TextNodeFlags,
+    ContentSize,
+    LeafNode
+)]
 pub struct Text(pub String);
 
 impl Text {


### PR DESCRIPTION
# Objective

Forbid adding children with `Node` components to certain entities, namely `Text` components.

Closes #18015

Related #17551
Prior conversation #18112

## Solution

Add a new marker component and accompanying system that prevents the addition of children with a `Node` component to any entity with the `LeafNode` component.

I've opted for removal/forbid over a warning as this is the same behavior as self-referencing relationships.

The validation system runs in `PreUpdate` but should be a couple no-op loops most of the time, as it removes the relationship it queries for when run. 

## Testing

<details>
  <summary>Click to view test code</summary>

```rust
use bevy::{input::common_conditions::input_just_pressed, prelude::*};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, (setup, setup_insert))
        .add_systems(
            Update,
            insert_test.run_if(input_just_pressed(MouseButton::Left)),
        )
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2d);
    let text = commands.spawn(Text::new("Hello, bevy!")).id();

    commands
        .spawn(Node::default())
        .insert(ChildOf { parent: text }); // Removal triggers here.

    commands
        .spawn(Text::new("Hello, bevy!"))
        .with_children(|cb| {
            cb.spawn(Node::default()); // Removal triggers here.
        });
}

fn setup_insert(mut commands: Commands) {
    commands
        .spawn(Text::new("Hello, bevy!"))
        .with_children(|cb| {
            cb.spawn_empty().with_children(|cb| {
                cb.spawn(Node::default()); // Removal triggers on grandchild.
            });
        });
}

fn insert_test(mut commands: Commands, q: Query<Entity, With<ChildOf>>) {
    for e in &q {
        commands.entity(e).insert(Node::default()); // Removal triggers here.
    }
}
```

</details>

Local CI + typos

---

## Migration Guide

Relationships where entities with `Node` components have a `LeafNode` / `Text` in their ancestry will be broken with this change. Ensure that any currently used `Text` components do not have `Node` children.
