### PR TITLE
Document required components with a marker trait

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -220,7 +220,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 quote! {
                     /// If not already present, the required component will be inserted using
                     #[doc = #insertion_info]
-                    unsafe impl #impl_generics #bevy_ecs_path::component::document_required_components::Require<#path> for #struct_name #type_generics #where_clause {}
+                    impl #impl_generics #bevy_ecs_path::component::document_required_components::Require<#path> for #struct_name #type_generics #where_clause {}
                 }
             });
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -220,7 +220,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 quote! {
                     /// If not already present, the required component will be inserted using
                     #[doc = #insertion_info]
-                    impl #impl_generics #bevy_ecs_path::component::Require<#path> for #struct_name #type_generics #where_clause {}
+                    unsafe impl #impl_generics #bevy_ecs_path::component::Require<#path> for #struct_name #type_generics #where_clause {}
                 }
             });
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -220,7 +220,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                 quote! {
                     /// If not already present, the required component will be inserted using
                     #[doc = #insertion_info]
-                    unsafe impl #impl_generics #bevy_ecs_path::component::Require<#path> for #struct_name #type_generics #where_clause {}
+                    unsafe impl #impl_generics #bevy_ecs_path::component::document_required_components::Require<#path> for #struct_name #type_generics #where_clause {}
                 }
             });
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -456,7 +456,13 @@ pub trait Component: Send + Sync + 'static {
 }
 
 /// Indicates this [`Component`] requires another [`Component`] `C`.
-pub trait Require<C: Component>: Component {}
+/// This trait is similar to [`Eq`] in the sense that it is up to the implementer to ensure `C` is
+/// appropriately registered as a required component.
+///
+/// # Safety
+///
+/// Implementing this trait must be done in tandem with updating the implementation of [`Component::register_required_components`].
+pub unsafe trait Require<C: Component>: Component {}
 
 mod private {
     pub trait Seal {}

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -455,6 +455,9 @@ pub trait Component: Send + Sync + 'static {
     fn visit_entities_mut(_this: &mut Self, _f: impl FnMut(&mut Entity)) {}
 }
 
+/// Indicates this [`Component`] requires another [`Component`] `C`.
+pub trait Require<C: Component>: Component {}
+
 mod private {
     pub trait Seal {}
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -462,13 +462,14 @@ pub mod document_required_components {
 
     /// Indicates this [`Component`] requires another [`Component`] `C`.
     ///
-    /// **This trait does not register required components on its own**
+    /// **This trait does not register required components on its own.**
     ///
-    /// This trait is similar to [`Eq`] in the sense that it is up to the implementer to ensure `C` is
-    /// appropriately registered as a required component.
+    /// This trait is similar to [`Eq`] in the sense that it is up to the implementer to ensure `C`
+    /// is appropriately registered as a required component.
     ///
-    /// It is the implementor's responsibility to ensure the implementation of [`Component::register_required_components`]
-    /// matches any and all implementations of [`Require`] on this type.
+    /// You should never manually implement this trait, but it is the implementor's responsibility
+    /// to ensure the implementation of [`Component::register_required_components`] matches any and
+    /// all implementations of [`Require`] on this type.
     pub trait Require<C: Component>: Component {}
 }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -455,14 +455,22 @@ pub trait Component: Send + Sync + 'static {
     fn visit_entities_mut(_this: &mut Self, _f: impl FnMut(&mut Entity)) {}
 }
 
-/// Indicates this [`Component`] requires another [`Component`] `C`.
-/// This trait is similar to [`Eq`] in the sense that it is up to the implementer to ensure `C` is
-/// appropriately registered as a required component.
-///
-/// # Safety
-///
-/// Implementing this trait must be done in tandem with updating the implementation of [`Component::register_required_components`].
-pub unsafe trait Require<C: Component>: Component {}
+// doc(hidden) module makes it clear that usage of this trait outside of `bevy_ecs` is unsupported.
+#[doc(hidden)]
+pub mod document_required_components {
+    use super::Component;
+
+    /// Indicates this [`Component`] requires another [`Component`] `C`.
+    ///
+    /// **This trait does not register required components on its own**
+    ///
+    /// This trait is similar to [`Eq`] in the sense that it is up to the implementer to ensure `C` is
+    /// appropriately registered as a required component.
+    ///
+    /// It is the implementor's responsibility to ensure the implementation of [`Component::register_required_components`]
+    /// matches any and all implementations of [`Require`] on this type.
+    pub trait Require<C: Component>: Component {}
+}
 
 mod private {
     pub trait Seal {}


### PR DESCRIPTION
# Objective

- Builds on #18165
- Alternative to #18171

## Solution

- Added a new trait, `Require<C: Component>: Component`, which is automatically implemented in the `Component` derive macro.

## Testing

- CI

---

## Notes

- This trait is purely for documentation purposes and has no impact on the _functionality_ of required components.
- I recommend using `cargo doc --open` with this PR and inspecting the `Button` and `Node` components as examples for the effects of this PR.
- ~~I have based this PR off of #18165 and will rebase once it is merged.~~

## Examples

_`Button` required components are listed logically in *Trait Implementations*_
![image](https://github.com/user-attachments/assets/1356dce8-30c9-47cb-9c8d-23ffda97dc7d)

_The method used to insert a required component can also be documented_
![image](https://github.com/user-attachments/assets/61596b4b-e267-4687-b76e-e7f4325c9c6d)

_`Node` can document components it requires *and* components that require it_
![image](https://github.com/user-attachments/assets/7751175e-65d4-4b46-8e9b-6f4eb6671564)

## Comparison to #18171 (Rustdoc Extension)

### Cons

- Can only place information within the trait implementation section, whereas the extension can place it anywhere, including at the top of the page as-if a user had done so themselves.
- Information is more verbose, as it includes `where` bounds, etc.

### Pros

- This PR works for all ecosystem and user crates automatically, whereas the extension requires opt-in configuration during doc generation.
- List format is better suited for items with many required components.
- Can easily show additional information, such as the method used to insert a required component if it is not present.
- Automatically shows documentation on the required and requiring components (e.g., `Button` and `Node` both get documentation for `Button` requiring `Node`)