### PR TITLE
Create cfg aliases for `bevy_app`

### DIFF
--- a/crates/bevy_app/build.rs
+++ b/crates/bevy_app/build.rs
@@ -1,0 +1,44 @@
+//! Build script containing cfg aliases
+
+fn main() {
+    // Collecting information that will be used to decide which cfg aliases
+    // will be exported.
+    // Using `cfg!(target_arch = "wasm32")` and such does not work because
+    // `build.rs` uses the host archtecture and other information, not the target's.
+    // Cargo then defines environment variables for the information of the target
+    let windows = std::env::var("CARGO_CFG_WINDOWS").is_ok();
+    let unix = std::env::var("CARGO_CFG_UNIX").is_ok();
+
+    let is_wasm32 = target_archtecture("wasm32");
+
+    let feature_bevy_tasks = feature_present("bevy_tasks");
+    let feature_std = feature_present("std");
+
+    // Prevent warnings on uses of `#[cfg]`
+    let cfgs = ["can_run_tasks", "std_windows_or_unix"];
+    println!("cargo::rustc-check-cfg=cfg({})", cfgs.join(","));
+
+    // Defining cfg aliases
+    if !is_wasm32 && feature_bevy_tasks {
+        println!("cargo::rustc-cfg=can_run_tasks");
+    }
+    if (windows || unix) && feature_std {
+        println!("cargo::rustc-cfg=std_windows_or_unix");
+    }
+}
+
+fn feature_present(feature: &str) -> bool {
+    // This is very naive and may fail if there is `=`, `\0`, or unicode characters.
+    let feature_name = format!("CARGO_FEATURE_{}", feature.to_uppercase().replace("-", "_"));
+    std::env::var(feature_name.as_str())
+        .ok()
+        .filter(|feature| feature == "1")
+        .is_some()
+}
+
+fn target_archtecture(target: &str) -> bool {
+    std::env::var("CARGO_CFG_TARGET_ARCH")
+        .ok()
+        .filter(|arch| arch == target)
+        .is_some()
+}

--- a/crates/bevy_app/build.rs
+++ b/crates/bevy_app/build.rs
@@ -4,12 +4,12 @@ fn main() {
     // Collecting information that will be used to decide which cfg aliases
     // will be exported.
     // Using `cfg!(target_arch = "wasm32")` and such does not work because
-    // `build.rs` uses the host archtecture and other information, not the target's.
+    // `build.rs` uses the host architecture and other information, not the target's.
     // Cargo then defines environment variables for the information of the target
     let windows = std::env::var("CARGO_CFG_WINDOWS").is_ok();
     let unix = std::env::var("CARGO_CFG_UNIX").is_ok();
 
-    let is_wasm32 = target_archtecture("wasm32");
+    let is_wasm32 = target_architecture("wasm32");
 
     let feature_bevy_tasks = feature_present("bevy_tasks");
     let feature_std = feature_present("std");
@@ -36,7 +36,7 @@ fn feature_present(feature: &str) -> bool {
         .is_some()
 }
 
-fn target_archtecture(target: &str) -> bool {
+fn target_architecture(target: &str) -> bool {
     std::env::var("CARGO_CFG_TARGET_ARCH")
         .ok()
         .filter(|arch| arch == target)

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1353,7 +1353,7 @@ type RunnerFn = Box<dyn FnOnce(App) -> AppExit>;
 
 fn run_once(mut app: App) -> AppExit {
     while app.plugins_state() == PluginsState::Adding {
-        #[cfg(all(not(target_arch = "wasm32"), feature = "bevy_tasks"))]
+        #[cfg(can_run_tasks)]
         bevy_tasks::tick_global_task_pools_on_main_thread();
     }
     app.finish();

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -32,7 +32,7 @@ mod schedule_runner;
 mod sub_app;
 #[cfg(feature = "bevy_tasks")]
 mod task_pool_plugin;
-#[cfg(all(any(unix, windows), feature = "std"))]
+#[cfg(std_windows_or_unix)]
 mod terminal_ctrl_c_handler;
 
 pub use app::*;
@@ -44,7 +44,7 @@ pub use schedule_runner::*;
 pub use sub_app::*;
 #[cfg(feature = "bevy_tasks")]
 pub use task_pool_plugin::*;
-#[cfg(all(any(unix, windows), feature = "std"))]
+#[cfg(std_windows_or_unix)]
 pub use terminal_ctrl_c_handler::*;
 
 /// The app prelude.

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -77,7 +77,7 @@ impl Plugin for ScheduleRunnerPlugin {
             let plugins_state = app.plugins_state();
             if plugins_state != PluginsState::Cleaned {
                 while app.plugins_state() == PluginsState::Adding {
-                    #[cfg(all(not(target_arch = "wasm32"), feature = "bevy_tasks"))]
+                    #[cfg(can_run_tasks)]
                     bevy_tasks::tick_global_task_pools_on_main_thread();
                 }
                 app.finish();


### PR DESCRIPTION
# Objective

Implements partially feature requested in #1615 

## Solution

Create cfg aliases for some of the cfg used in `bevy_app`

## Testing

Ran `cargo run -p ci` but needs more testing

## Showcase

Before
```rust
#[cfg(all(any(unix, windows), feature = "std"))]
pub use terminal_ctrl_c_handler;
// ...
#[cfg(all(not(target_arch = "wasm32"), feature = "bevy_tasks"))]
bevy_tasks::tick_global_task_pools_on_main_thread();
```

After
```rust
#[cfg(std_windows_or_unix)]
pub use terminal_ctrl_c_handler::*;
// ...
#[cfg(can_run_tasks)]
bevy_tasks::tick_global_task_pools_on_main_thread();
```