### PR TITLE
bevy_reflect: bump petgraph dependency

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -31,7 +31,7 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 ] }
 
 # other
-petgraph = { version = "0.6", features = ["serde-1"] }
+petgraph = { version = "0.7", features = ["serde-1"] }
 ron = "0.8"
 serde = "1"
 blake3 = { version = "1.0" }

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -101,7 +101,7 @@ smallvec = { version = "1.11", default-features = false, optional = true }
 glam = { version = "0.29", default-features = false, features = [
   "serde",
 ], optional = true }
-petgraph = { version = "0.6", features = ["serde-1"], optional = true }
+petgraph = { version = "0.7", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", default-features = false, features = [
   "serde",
 ], optional = true }


### PR DESCRIPTION
# Objective

petgraph 0.7 has been released a while ago, but bevy still pulls in petgraph 0.6

## Solution

- Update the version in bevy_reflect's `Cargo.toml`.

## Testing

- I ran `cargo test --all-features`.