### PR TITLE
Add the ability for SubApps to have a custom update function

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -141,7 +141,7 @@ impl App {
         Self {
             sub_apps: SubApps {
                 main: SubApp::new(),
-                sub_apps: HashMap::default(),
+                ..Default::default()
             },
             runner: Box::new(run_once),
         }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
     schedule::{ScheduleBuildSettings, ScheduleLabel},
     system::{IntoObserverSystem, SystemId, SystemInput},
 };
-use bevy_platform_support::collections::HashMap;
+
 use core::{fmt::Debug, num::NonZero, panic::AssertUnwindSafe};
 use log::debug;
 
@@ -147,13 +147,19 @@ impl App {
         }
     }
 
-    /// Runs the default schedules of all sub-apps (starting with the "main" app) once.
+    /// Runs the app update function, by default this runs the default schedules of all sub-apps (starting with the "main" app) once.
+    /// See [`SubApps::update`].
     pub fn update(&mut self) {
         if self.is_building_plugins() {
             panic!("App::update() was called while a plugin was building.");
         }
 
         self.sub_apps.update();
+    }
+
+    /// Sets the update function to use for [`update`](Self::update) on the [SubApps] collection to the provided function.
+    pub fn set_update_fn(&mut self, func: impl Fn(&mut SubApps) + 'static) {
+        self.sub_apps.update_fn = Some(Box::new(func));
     }
 
     /// Runs the [`App`] by calling its [runner](Self::set_runner).

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1441,8 +1441,9 @@ impl Termination for AppExit {
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
     use core::{marker::PhantomData, sync::atomic::AtomicBool};
-    use std::{boxed::Box, sync::Mutex};
+    use std::sync::Mutex;
 
     use bevy_ecs::{
         change_detection::{DetectChanges, ResMut},
@@ -1861,9 +1862,8 @@ mod tests {
 
         app.update();
 
-        assert_eq!(
+        assert!(
             invocation_check.load(core::sync::atomic::Ordering::SeqCst),
-            true,
             "Failed to run the app's custom update function."
         );
     }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -496,6 +496,7 @@ pub struct SubApps {
     /// Other, labeled sub-apps.
     pub sub_apps: HashMap<InternedAppLabel, SubApp>,
     /// The function called by [`update`](SubApps::update) to update all subapps in the collection.
+    /// Replacing the update function can be used to customize how and when [SubApp::update] and [SubApp::extract] are called.
     pub update_fn: Option<UpdateFn>,
 }
 

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -496,7 +496,7 @@ pub struct SubApps {
     /// Other, labeled sub-apps.
     pub sub_apps: HashMap<InternedAppLabel, SubApp>,
     /// The function called by [`update`](SubApps::update) to update all subapps in the collection.
-    /// Replacing the update function can be used to customize how and when [SubApp::update] and [SubApp::extract] are called.
+    /// Replacing the update function can be used to customize how and when [`SubApp::update`] and [`SubApp::extract`] are called.
     pub update_fn: Option<UpdateFn>,
 }
 
@@ -543,7 +543,7 @@ impl Default for SubApps {
 /// Calls [`update`](SubApp::update) for the main sub-app, and then calls
 /// [`extract`](SubApp::extract) and [`update`](SubApp::update) for the rest.
 ///
-/// This serves as the default for [SubApps::update] if none is provided.
+/// This serves as the default for [`SubApps::update`] if none is provided.
 pub fn update_subapps(sub_apps: &mut SubApps) {
     #[cfg(feature = "trace")]
     let _bevy_update_span = info_span!("update").entered();

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -14,6 +14,7 @@ use core::fmt::Debug;
 use tracing::info_span;
 
 type ExtractFn = Box<dyn Fn(&mut World, &mut World) + Send>;
+type UpdateFn = Box<dyn Fn(&mut SubApps)>;
 
 /// A secondary application with its own [`World`]. These can run independently of each other.
 ///
@@ -489,33 +490,24 @@ impl SubApp {
 }
 
 /// The collection of sub-apps that belong to an [`App`].
-#[derive(Default)]
 pub struct SubApps {
     /// The primary sub-app that contains the "main" world.
     pub main: SubApp,
     /// Other, labeled sub-apps.
     pub sub_apps: HashMap<InternedAppLabel, SubApp>,
+    /// The function called by [`update`](SubApps::update) to update all subapps in the collection.
+    pub update_fn: Option<UpdateFn>,
 }
 
 impl SubApps {
-    /// Calls [`update`](SubApp::update) for the main sub-app, and then calls
-    /// [`extract`](SubApp::extract) and [`update`](SubApp::update) for the rest.
+    /// Updates this subapp collection. See [`update_subapps`] for the default behavior.
     pub fn update(&mut self) {
-        #[cfg(feature = "trace")]
-        let _bevy_update_span = info_span!("update").entered();
-        {
-            #[cfg(feature = "trace")]
-            let _bevy_frame_update_span = info_span!("main app").entered();
-            self.main.run_default_schedule();
-        }
-        for (_label, sub_app) in self.sub_apps.iter_mut() {
-            #[cfg(feature = "trace")]
-            let _sub_app_span = info_span!("sub app", name = ?_label).entered();
-            sub_app.extract(&mut self.main.world);
-            sub_app.update();
-        }
+        let update = core::mem::take(&mut self.update_fn)
+            .expect("App update function shouldn't be None when update() is called.");
 
-        self.main.world.clear_trackers();
+        update(self);
+
+        self.update_fn = Some(update);
     }
 
     /// Returns an iterator over the sub-apps (starting with the main one).
@@ -535,4 +527,36 @@ impl SubApps {
             sub_app.update();
         }
     }
+}
+
+impl Default for SubApps {
+    fn default() -> Self {
+        Self {
+            main: Default::default(),
+            sub_apps: Default::default(),
+            update_fn: Some(Box::new(update_subapps)),
+        }
+    }
+}
+
+/// Calls [`update`](SubApp::update) for the main sub-app, and then calls
+/// [`extract`](SubApp::extract) and [`update`](SubApp::update) for the rest.
+///
+/// This serves as the default for [SubApps::update] if none is provided.
+pub fn update_subapps(sub_apps: &mut SubApps) {
+    #[cfg(feature = "trace")]
+    let _bevy_update_span = info_span!("update").entered();
+    {
+        #[cfg(feature = "trace")]
+        let _bevy_frame_update_span = info_span!("main app").entered();
+        sub_apps.main.run_default_schedule();
+    }
+    for (_label, sub_app) in sub_apps.sub_apps.iter_mut() {
+        #[cfg(feature = "trace")]
+        let _sub_app_span = info_span!("sub app", name = ?_label).entered();
+        sub_app.extract(&mut sub_apps.main.world);
+        sub_app.update();
+    }
+
+    sub_apps.main.world.clear_trackers();
 }


### PR DESCRIPTION
# Objective

Implement the solution proposed for #18185

## Solution

Added a new field to SubApps, `update_fn`, which contains the function to invoke for running `SubApps::update()`. `SubApps::update()` was preserved to allow invariant update behavior to be introduced in the future if necessary, and for ease of use. Broke out the Default implementation for `SubApps` so that the update function is set by default.

```rs
  let app = ...;
  // App update is unsuitable, let's do something else.
  app.set_update_fn(|sub_apps| {
    println!("Hello! I did a thing! Probably!");
    ...
  });
  
  // Now invokes our update function internally, so custom runners like the Winit runner will now run our update code!
  app.update();
```

## Testing

PR opened to run bevy test suite (my poor laptop would get mad), API fits the constraints I described in https://canary.discord.com/channels/691052431525675048/742569353878437978/1347321570603044999, full convo transcribed:

<details>
[15:34]moony (Kaylie!): Is there some recommended way to customize the subapp update order? I'm doing my own shenanigans with extract and runtime addition of subapps and would rather not have the defaults.<br> 
[15:35]moony (Kaylie!): atm the blocker seems to be making whatever i do work with the existing winit code <br> 
[15:37]moony (Kaylie!): (I'm already targetting latest instead of stable due to needing .sub_apps() so if it's specific to latest that's still good to know)<br> 
[16:26]moony (Kaylie!): i have worked out a scrungly solution for the meantime:
App in my App.<br> 
[16:43]Alice 🌹: Not really, this is kinda half-baked still<br> 
[16:43]moony (Kaylie!): just being able to replace update() with my own func would be sufficient tbh and likely covers most uses<br> 
[16:44]moony (Kaylie!): filing an issue about that approach atm<br> 
[16:45]Alice 🌹: Okay sweet; that's appreciated. We haven't done a ton of digging into the exact ways that users might want to extend / modify this design, so experienced-based opinions are really useful<br> 
[16:45]Alice 🌹: Mostly my reaction to subapps and windowing is :pain2: due to the difficulty testing and all of the platforms, so changes there are really slow currently<br> 
[16:46]moony (Kaylie!): my exact constraint is I'm adding some arbitrary N set of scene subapps for worlds the player could be in, and allowing the user to swap between them<br> 
this is very easy to do if i can just control which subapp render is running extract on (and otherwise control the extract flow myself)<br> 
[16:46]moony (Kaylie!): in other words a single "main" subapp isn't the right approach for my experiment<br> 
[16:47]Alice 🌹: Interesting. What's the ultimate motivation for that? For the most part my opinion is "don't use subapps if at all possible", and I'd generally use something like states and scenes or something for that design<br> 
[16:47]moony (Kaylie!): isolating those scenes, because UGC<br> 
[16:48]moony (Kaylie!): if one scene gets completely mucked up for whatever reason the user should be able to just close or leave it and be fine<br> 
[16:48]Alice 🌹: Aha, interesting! Okay, that makes more sense to me<br> 
</details>

