### PR TITLE
Add Allows filter to bypass DefaultQueryFilters

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -79,7 +79,7 @@ pub mod prelude {
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
         name::{Name, NameOrEntity},
         observer::{Observer, Trigger},
-        query::{Added, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
+        query::{Added, Allows, AnyOf, Changed, Has, Or, QueryBuilder, QueryState, With, Without},
         related,
         relationship::RelationshipTarget,
         removal_detection::RemovedComponents,

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -257,9 +257,10 @@ impl<T: SparseSetIndex> Access<T> {
     /// This is for components whose values are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     ///
-    /// Currently, this is only used for [`Has<T>`].
+    /// Currently, this is only used for [`Has<T>`] and [`Allows<T>`].
     ///
     /// [`Has<T>`]: crate::query::Has
+    /// [`Allows<T>`]: crate::query::filter::Allows
     pub fn add_archetypal(&mut self, index: T) {
         self.archetypal.grow_and_insert(index.sparse_set_index());
     }
@@ -499,6 +500,7 @@ impl<T: SparseSetIndex> Access<T> {
         self.resource_read_and_writes
             .union_with(&other.resource_read_and_writes);
         self.resource_writes.union_with(&other.resource_writes);
+        self.archetypal.union_with(&other.archetypal);
     }
 
     /// Returns `true` if the access and `other` can be active at the same time,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -2232,6 +2232,10 @@ mod tests {
         let mut query = QueryState::<Has<C>>::new(&mut world);
         assert_eq!(3, query.iter(&world).count());
 
+        // Allows should bypass the filter entirely
+        let mut query = QueryState::<(), Allows<C>>::new(&mut world);
+        assert_eq!(3, query.iter(&world).count());
+
         // Other filters should still be respected
         let mut query = QueryState::<Has<C>, Without<B>>::new(&mut world);
         assert_eq!(1, query.iter(&world).count());


### PR DESCRIPTION
# Objective

Fixes #17803 

## Solution

- Add an `Allows<T>` `QueryFilter` that adds archetypal access for `T`
- Fix access merging to include archetypal from both sides

## Testing

- Added a case to the unit test for the application of `DefaultQueryFilters`