### PR TITLE
Remote entity reservation

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -982,6 +982,14 @@ impl Entities {
         (self.meta.len() as isize - self.free_cursor.load(Ordering::Relaxed) as isize) as usize
     }
 
+    /// The count of all entities in the [`World`] that have ever been allocated or reserved, including those that are freed.
+    ///
+    /// [`World`]: crate::world::World
+    #[inline]
+    pub fn total_prospective_count(&self) -> usize {
+        self.total_count() + (-self.free_cursor.load(Ordering::Relaxed)).min(0) as usize
+    }
+
     /// The count of currently allocated entities.
     #[inline]
     pub fn len(&self) -> u32 {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -116,7 +116,7 @@ type RemoteInner = u64;
 /// do not. This fallback allows compilation using a 32-bit cursor instead, with
 /// the caveat that some conversions may fail (and panic) at runtime.
 #[cfg(not(target_has_atomic = "64"))]
-use bevy_platform_support::sync::atomic::AtomicUsize as AtomicUdCursor;
+use bevy_platform_support::sync::atomic::AtomicUsize as RemoteIdCursor;
 #[cfg(not(target_has_atomic = "64"))]
 type RemoteInner = usize;
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -508,7 +508,7 @@ impl SparseSetIndex for Entity {
 
 /// An [`Iterator`] returning a sequence of [`Entity`] values from [`Entities`].
 ///
-/// # Droping
+/// # Dropping
 ///
 /// If this is dropped, the remaining entities will remain reserved and unused. This is effectively a memory leak.
 pub struct ReserveEntitiesIterator<'a> {
@@ -548,7 +548,7 @@ unsafe impl EntitySetIterator for ReserveEntitiesIterator<'_> {}
 
 /// An [`Iterator`] returning a sequence of [`Entity`] values from a [`RemoteEntityReserver`].
 ///
-/// # Droping
+/// # Dropping
 ///
 /// If this is dropped, the remaining entities will remain reserved and unused. This is effectively a memory leak.
 pub struct RemoteReserveEntitiesIterator {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -582,8 +582,6 @@ pub struct Entities {
     /// [`flush`]: Entities::flush
     pending: Vec<u32>,
     free_cursor: AtomicIdCursor,
-    /// Stores the number of free entities for [`len`](Entities::len)
-    len: u32,
 }
 
 impl Entities {
@@ -592,7 +590,6 @@ impl Entities {
             meta: Vec::new(),
             pending: Vec::new(),
             free_cursor: AtomicIdCursor::new(0),
-            len: 0,
         }
     }
 
@@ -684,7 +681,6 @@ impl Entities {
     /// Allocate an entity ID directly.
     pub fn alloc(&mut self) -> Entity {
         self.verify_flushed();
-        self.len += 1;
         if let Some(index) = self.pending.pop() {
             let new_free_cursor = self.pending.len() as IdCursor;
             *self.free_cursor.get_mut() = new_free_cursor;
@@ -713,13 +709,11 @@ impl Entities {
             *self.free_cursor.get_mut() = new_free_cursor;
             self.meta
                 .resize(entity.index() as usize + 1, EntityMeta::EMPTY);
-            self.len += 1;
             None
         } else if let Some(index) = self.pending.iter().position(|item| *item == entity.index()) {
             self.pending.swap_remove(index);
             let new_free_cursor = self.pending.len() as IdCursor;
             *self.free_cursor.get_mut() = new_free_cursor;
-            self.len += 1;
             None
         } else {
             Some(mem::replace(
@@ -756,13 +750,11 @@ impl Entities {
             *self.free_cursor.get_mut() = new_free_cursor;
             self.meta
                 .resize(entity.index() as usize + 1, EntityMeta::EMPTY);
-            self.len += 1;
             AllocAtWithoutReplacement::DidNotExist
         } else if let Some(index) = self.pending.iter().position(|item| *item == entity.index()) {
             self.pending.swap_remove(index);
             let new_free_cursor = self.pending.len() as IdCursor;
             *self.free_cursor.get_mut() = new_free_cursor;
-            self.len += 1;
             AllocAtWithoutReplacement::DidNotExist
         } else {
             let current_meta = &self.meta[entity.index() as usize];
@@ -805,7 +797,6 @@ impl Entities {
 
         let new_free_cursor = self.pending.len() as IdCursor;
         *self.free_cursor.get_mut() = new_free_cursor;
-        self.len -= 1;
         Some(loc)
     }
 
@@ -843,7 +834,6 @@ impl Entities {
         self.meta.clear();
         self.pending.clear();
         *self.free_cursor.get_mut() = 0;
-        self.len = 0;
     }
 
     /// Returns the location of an [`Entity`].
@@ -939,7 +929,6 @@ impl Entities {
             let old_meta_len = self.meta.len();
             let new_meta_len = old_meta_len + -current_free_cursor as usize;
             self.meta.resize(new_meta_len, EntityMeta::EMPTY);
-            self.len += -current_free_cursor as u32;
             for (index, meta) in self.meta.iter_mut().enumerate().skip(old_meta_len) {
                 init(
                     Entity::from_raw_and_generation(index as u32, meta.generation),
@@ -951,7 +940,6 @@ impl Entities {
             0
         };
 
-        self.len += (self.pending.len() - new_free_cursor) as u32;
         for index in self.pending.drain(new_free_cursor..) {
             let meta = &mut self.meta[index as usize];
             init(
@@ -985,16 +973,26 @@ impl Entities {
         self.meta.len()
     }
 
+    /// The count of all entities in the [`World`] that are used,
+    /// indluding both those allocated and those reserved, but not those freed.
+    ///
+    /// [`World`]: crate::world::World
+    #[inline]
+    pub fn used_count(&self) -> usize {
+        (self.meta.len() as isize - self.free_cursor.load(Ordering::Relaxed) as isize) as usize
+    }
+
     /// The count of currently allocated entities.
     #[inline]
     pub fn len(&self) -> u32 {
-        self.len
+        // `pending`, by definition, can't be bigger than `meta`.
+        (self.meta.len() - self.pending.len()) as u32
     }
 
     /// Checks if any entity is currently active.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.len() == 0
     }
 
     /// Sets the source code location from which this entity has last been spawned

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -987,7 +987,7 @@ impl Entities {
     /// [`World`]: crate::world::World
     #[inline]
     pub fn total_prospective_count(&self) -> usize {
-        self.total_count() + (-self.free_cursor.load(Ordering::Relaxed)).min(0) as usize
+        self.meta.len() + (-self.free_cursor.load(Ordering::Relaxed)).min(0) as usize
     }
 
     /// The count of currently allocated entities.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1079,6 +1079,7 @@ impl Entities {
         let free_cursor = self.free_cursor.get_mut();
         let current_free_cursor = *free_cursor;
         let new_free_cursor = current_free_cursor.max(0);
+        *free_cursor = new_free_cursor;
 
         // pending
         for index in self.pending.drain((new_free_cursor as usize)..) {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -974,7 +974,7 @@ impl Entities {
     }
 
     /// The count of all entities in the [`World`] that are used,
-    /// indluding both those allocated and those reserved, but not those freed.
+    /// including both those allocated and those reserved, but not those freed.
     ///
     /// [`World`]: crate::world::World
     #[inline]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -983,6 +983,7 @@ impl Entities {
     }
 
     /// The count of all entities in the [`World`] that have ever been allocated or reserved, including those that are freed.
+    /// This is the value that [`Self::total_count()`] would return if [`Self::flush()`] were called right now.
     ///
     /// [`World`]: crate::world::World
     #[inline]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -778,7 +778,7 @@ impl Entities {
             //
             // As `self.free_cursor` goes more and more negative, we return IDs farther
             // and farther beyond `meta.len()`.
-            self.verify_room_for(1 - n as usize);
+            self.verify_room_for((1 - n) as usize);
             Entity::from_raw((self.meta.len() as IdCursor - n) as u32)
         }
     }


### PR DESCRIPTION
# Objective

fixes #18003

For assets as entities and components as entities, it is convinient to reserve an entity from an `Arc`, fully outside of the ECS. See [here](https://discord.com/channels/691052431525675048/1347575124068405288/1347602981100589218) on discord for why.

It is probably possible to do both assets and components as entities without this, but we would have to eat extra complexity for that, and so would users making their own custom assets.

## Solution

This design comes from [here](https://discord.com/channels/691052431525675048/749335865876021248/1347624804668276787) on discord.

Before this PR, `EntityMeta` is stored in a single `Vec` called `meta`. A `pending` list stores free entities, and an atomic cursor manages which `pending` entities are reserved and what new entities need to be created on `meta`.

All of that remains the same, but after this PR, an additional `Vec<EntityMeta>` called `remote_entities` exists. These indices are reversed from `meta`, so the index in `remote_entities` = `u32::MAX - entity.index` and visa versa. We only extend `remote_entities` based on an `Arc<AtomicInt>`. That counter represents `remote_entities`'s length after the next flush. When we free one of these entities, we just add it to the pending list like normal, and the existing atomic cursor manages it.

## Problems

I kinda had to tiptoe around `Entity::PLACEHOLDER`. The docs for that say it *may* exist, but with this, it *will* exist the first time the remote allocator is used. For now, I just start the generations at 2 instead of 1 to avoid accidental conflicts. This is easily changed if there are other ideas.

## Alternatives

It is possible to create a paging/chunking system for Entities that would additionally allow entity partitioning. This design will simplify that if bevy chooses to add it in the future. In the meantime, this PR is much simpler than that.

## Testing

We are not using the feature anywhere, so if current tests pass, we shouldn't have an issue.

However, it makes sense to add tests for this. If anyone has specific ideas for situations to test, I'd be more than happy to write them.
