### PR TITLE
action shouldn't comment on a pr if last comment is from action

### DIFF
--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -48,8 +48,21 @@ jobs:
             return "true"
       - run: unzip missing-examples.zip
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
-      - name: 'Comment on PR'
+      - name: "Check if last comment is already from actions"
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
+        id: check-last-comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=`cat ./NR`
+          if [[ `gh api --jq '.[-1].user.login' /repos/bevyengine/bevy/issues/$PR/comments` == 'github-actions[bot]' ]]
+          then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+      - name: "Comment on PR"
+        if: ${{ steps.find-artifact.outputs.result == 'true' && check-last-comment.outputs.result == 'false' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -106,8 +119,21 @@ jobs:
             return "true"
       - run: unzip missing-features.zip
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
-      - name: 'Comment on PR'
+      - name: "Check if last comment is already from actions"
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
+        id: check-last-comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=`cat ./NR`
+          if [[ `gh api --jq '.[-1].user.login' /repos/bevyengine/bevy/issues/$PR/comments` == 'github-actions[bot]' ]]
+          then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+      - name: "Comment on PR"
+        if: ${{ steps.find-artifact.outputs.result == 'true' && steps.check-last-comment.outputs.result == 'false' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -164,8 +190,21 @@ jobs:
             return "true"
       - run: unzip msrv.zip
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
-      - name: 'Comment on PR'
+      - name: "Check if last comment is already from actions"
         if: ${{ steps.find-artifact.outputs.result == 'true' }}
+        id: check-last-comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=`cat ./NR`
+          if [[ `gh api --jq '.[-1].user.login' /repos/bevyengine/bevy/issues/$PR/comments` == 'github-actions[bot]' ]]
+          then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+      - name: "Comment on PR"
+        if: ${{ steps.find-artifact.outputs.result == 'true' && steps.check-last-comment.outputs.result == 'false' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -96,8 +96,20 @@ jobs:
           else
             echo "result=false" >> $GITHUB_OUTPUT
           fi
+      - name: "Check if last comment is already from actions"
+        id: check-last-comment
+        env:
+          PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ `gh api --jq '.[-1].user.login' /repos/bevyengine/bevy/issues/18139/comments` == 'github-actions[bot' ]]
+          then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
       - name: "Comment on PR"
-        if: ${{ steps.check-label.outputs.result == 'false' }}
+        if: ${{ steps.check-label.outputs.result == 'false' && steps.check-last-comment.outputs.result == 'false' }}
         env:
           PROJECT: B04F67C0-C054-4A6F-92EC-F599FEC2FD1D
           PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number }}

--- a/.github/workflows/example-run-report.yml
+++ b/.github/workflows/example-run-report.yml
@@ -102,7 +102,7 @@ jobs:
           PR: ${{ needs.make-macos-screenshots-available.outputs.pr-number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ `gh api --jq '.[-1].user.login' /repos/bevyengine/bevy/issues/18139/comments` == 'github-actions[bot' ]]
+          if [[ `gh api --jq '.[-1].user.login' /repos/bevyengine/bevy/issues/$PR/comments` == 'github-actions[bot' ]]
           then
             echo "result=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
# Objective

- While a PR is in work, if several commits fail and trigger a comment from the action, this can create a lot of comments from actions with low value
- Noticed on https://github.com/bevyengine/bevy/pull/18139

## Solution

- If last comment on a PR is from an action, don't add a new comment
