### PR TITLE
Ignore unmaintained security advisory about paste for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,11 @@ all-features = true
 
 [advisories]
 version = 2
-ignore = []
+ignore = [
+  "RUSTSEC-2024-0436",
+] # paste was announced as unmaintained with no explanation or replacement
+# See: https://rustsec.org/advisories/RUSTSEC-2024-0436
+# Bevy relies on this in multiple indirect ways, so ignoring it is the only feasible current solution
 
 [licenses]
 version = 2

--- a/deny.toml
+++ b/deny.toml
@@ -4,10 +4,11 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
+  # paste was announced as unmaintained with no explanation or replacement
+  # See: https://rustsec.org/advisories/RUSTSEC-2024-0436
+  # Bevy relies on this in multiple indirect ways, so ignoring it is the only feasible current solution
   "RUSTSEC-2024-0436",
-] # paste was announced as unmaintained with no explanation or replacement
-# See: https://rustsec.org/advisories/RUSTSEC-2024-0436
-# Bevy relies on this in multiple indirect ways, so ignoring it is the only feasible current solution
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
# Objective

The `paste` crate is giving us [warnings in CI](https://github.com/bevyengine/bevy/actions/runs/13751490200/job/38452998990?pr=18099) via `cargo-deny` about being unmaintained.

This warning is quite noisy: making unrelated PRs seem like they have a problem due to a job failing.

## Solution

Ignore the warning for now. There are multiple crates (accesskit, metal, macro_rules_attribute, rmp) which are using this, and there's no clear migration advice, even if we want to poke upstream to swap off.

Strategy for ignoring was taken from https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml

## Testing

Let's see if CI works!