### PR TITLE
bevy_reflect: Add `ReflectClone` type data

### DIFF
--- a/crates/bevy_reflect/src/std_traits.rs
+++ b/crates/bevy_reflect/src/std_traits.rs
@@ -1,4 +1,4 @@
-use crate::{FromType, Reflect};
+use crate::{FromType, PartialReflect, Reflect};
 use alloc::boxed::Box;
 
 /// A struct used to provide the default value of a type.
@@ -19,6 +19,69 @@ impl<T: Reflect + Default> FromType<T> for ReflectDefault {
     fn from_type() -> Self {
         ReflectDefault {
             default: || Box::<T>::default(),
+        }
+    }
+}
+
+/// Type data for the [`Clone`] trait.
+///
+/// This type data can be used to attempt to clone a [`PartialReflect`] value
+/// using the concrete type's [`Clone`] implementation.
+#[derive(Clone)]
+pub struct ReflectClone {
+    try_clone: fn(&dyn PartialReflect) -> Option<Box<dyn Reflect>>,
+}
+
+impl ReflectClone {
+    /// Clones a [`PartialReflect`] value using the concrete type's [`Clone`] implementation.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the provided value is not the same type as the type this [`ReflectClone`] was created for.
+    ///
+    /// For a non-panicking version, see [`ReflectClone::try_clone`].
+    pub fn clone(&self, value: &dyn PartialReflect) -> Box<dyn Reflect> {
+        self.try_clone(value).unwrap()
+    }
+
+    /// Attempts to clone a [`PartialReflect`] value using the concrete type's [`Clone`] implementation.
+    ///
+    /// If the provided value is not the same type as the type this [`ReflectClone`] was created for,
+    /// this function will return `None`.
+    ///
+    /// For a panicking version, see [`ReflectClone::clone`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_reflect::{Reflect, std_traits::ReflectClone, FromType, PartialReflect};
+    /// # #[derive(Clone, Reflect, Debug, PartialEq)]
+    /// # #[reflect(Clone)]
+    /// # struct AnotherStruct(i32);
+    /// #[derive(Clone, Reflect, Debug, PartialEq)]
+    /// #[reflect(Clone)]
+    /// struct MyStruct(i32);
+    ///
+    /// let reflect_clone = <ReflectClone as FromType<MyStruct>>::from_type();
+    /// let value: Box<dyn PartialReflect> = Box::new(MyStruct(123));
+    ///
+    /// let cloned_value = reflect_clone.try_clone(&*value);
+    /// assert!(cloned_value.is_some());
+    /// assert_eq!(MyStruct(123), cloned_value.unwrap().take::<MyStruct>().unwrap());
+    ///
+    /// // Attempting to clone a value of a different type will return None
+    /// let another_value: Box<dyn PartialReflect> = Box::new(AnotherStruct(123));
+    /// assert!(reflect_clone.try_clone(&*another_value).is_none());
+    /// ```
+    pub fn try_clone(&self, value: &dyn PartialReflect) -> Option<Box<dyn Reflect>> {
+        (self.try_clone)(value)
+    }
+}
+
+impl<T: Reflect + Clone> FromType<T> for ReflectClone {
+    fn from_type() -> Self {
+        ReflectClone {
+            try_clone: |value| Some(Box::new(value.try_downcast_ref::<T>()?.clone())),
         }
     }
 }


### PR DESCRIPTION
# Objective

This PR is a partial followup to #13432, but is not based on that branch as it also works as a completely standalone change.

The goal of this PR is to add reflection type data for the `Clone` trait.

For #13432, this is desired because it addresses inconsistencies mentioned in this [comment](https://github.com/bevyengine/bevy/pull/7317#issuecomment-2143075852) (which are further addressed in #13723). Namely, we should try to reduce the split between special trait type data registration and regular trait type data registration.

Apart from that PR, this PR should allow users to create concrete clones within reflection much easier.

For reference, here are some ways cloning is typically handled:

```rust
// If the value is an `Opaque` type (e.g. primitives):
let clone: Box<dyn PartialReflect> = value.clone_value();

// If the value is any other type, we can use `ReflectFromReflect`:
let clone: Box<dyn PartialReflect> = {
  let info = value.get_represented_type_info().unwrap();
  let rfr = registry.get_type_data::<ReflectFromReflect>(info.type_id())).unwrap();
  rfr.from_reflect(&*value).unwrap()
};

// Or `ReflectDefault`:
let clone: Box<dyn PartialReflect> = {
  let info = value.get_represented_type_info().unwrap();
  let rd = registry.get_type_data::<ReflectDefault>(info.type_id())).unwrap();
  let default = rd.default();
  default.apply(&*value);
  default
};
```

Those solutions are also not ideal since some types do extra things when cloned (e.g. increasing a ref-count). It would be better if we could call that `Clone` impl directly via reflection.

## Solution

This PR simply introduces a `ReflectClone` type data struct that can be registered like any other type data (assuming the type implements `Clone`).

This simplifies our above approach:

```rust
let clone: Box<dyn PartialReflect> = {
  let info = value.get_represented_type_info().unwrap();
  let rc = registry.get_type_data::<ReflectClone>(info.type_id()).unwrap();
  rc.clone(&*value)
};
```

Note that with #13432 this is even simpler, but this provides a solid alternative if needing to use type data (or if wanting to specially handle types that implement `Clone`).

## Testing

You can test locally by running:

```
cargo test --doc "std_traits::ReflectClone::try_clone" --package bevy_reflect
```

---

## Showcase

Reflected types that implement `Clone` can now register the `ReflectClone` type data, allowing for reflected values to be directly cloned.

```rust
#[derive(Reflect, Clone)]
#[reflect(Clone)]
struct MyStruct(String);

let mut registry = TypeRegistry::new();
registry.register::<MyStruct>();

let value: Box<dyn Reflect> = Box::new(MyStruct(String::from("Hello!")));

let reflect_clone = registry.get_type_data::<ReflectClone>(TypeId::of::<MyStruct>()).unwrap();

let clone: Box<dyn Reflect> = reflect_clone.clone(&*value);

assert!(value.reflect_partial_eq(&*clone).unwrap());
```
