### PR TITLE
Provide a safe abstraction for split access to entities and commands

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -341,7 +341,7 @@ impl<'w> DeferredWorld<'w> {
         self.get_entity_mut(entities).unwrap()
     }
 
-    /// Provides split access to fetching entities and to queuing commands.
+    /// Simultaneously provides access to entity data and a command queue, which will be applied when the [`World`] is next flushed.
     pub fn entities_and_commands(&mut self) -> (EntityFetcher, Commands) {
         let cell = self.as_unsafe_world_cell();
         // SAFETY: `&mut self` gives mutable access to the entire world, and prevents simultaneous access.

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -15,9 +15,11 @@ use crate::{
 /// This cannot add or remove components, or spawn or despawn entities,
 /// making it relatively safe to access in concert with other ECS data.
 /// This type can be constructed via [`World::entities_and_commands`],
-/// or the equivalent method on [`DeferredWorld`].
+/// or [`DeferredWorld::entities_and_commands`].
 ///
 /// [`World`]: crate::world::World
+/// [`World::entities_and_commands`]: crate::world::World::entities_and_commands
+/// [`DeferredWorld::entities_and_commands`]: crate::world::DeferredWorld::entities_and_commands
 pub struct EntityFetcher<'w> {
     cell: UnsafeWorldCell<'w>,
 }

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 
-/// Provides a safe interface for acccessing *just* the entities in a [`World`].
+/// Provides a safe interface for accessing *just* the entities in a [`World`].
 ///
 /// [`World`]: crate::world::World
 pub struct EntityFetcher<'w> {

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -3,11 +3,90 @@ use core::mem::MaybeUninit;
 
 use crate::{
     entity::{hash_map::EntityHashMap, hash_set::EntityHashSet, Entity, EntityDoesNotExistError},
+    error::Result,
     world::{
         error::EntityMutableFetchError, unsafe_world_cell::UnsafeWorldCell, EntityMut, EntityRef,
         EntityWorldMut,
     },
 };
+
+/// Provides a safe interface for acccessing *just* the entities in a [`World`].
+///
+/// [`World`]: crate::world::World
+pub struct EntityFetcher<'w> {
+    cell: UnsafeWorldCell<'w>,
+}
+
+impl<'w> EntityFetcher<'w> {
+    // SAFETY:
+    // - The given `cell` has mutable access to all entities.
+    // - No other references to entities exist at the same time.
+    pub(crate) unsafe fn new(cell: UnsafeWorldCell<'w>) -> Self {
+        Self { cell }
+    }
+
+    /// Returns [`EntityRef`]s that expose read-only operations for the given
+    /// `entities`, returning [`Err`] if any of the given entities do not exist.
+    ///
+    /// This function supports fetching a single entity or multiple entities:
+    /// - Pass an [`Entity`] to receive a single [`EntityRef`].
+    /// - Pass a slice of [`Entity`]s to receive a [`Vec<EntityRef>`].
+    /// - Pass an array of [`Entity`]s to receive an equally-sized array of [`EntityRef`]s.
+    /// - Pass a reference to a [`EntityHashSet`](crate::entity::hash_map::EntityHashMap) to receive an
+    ///   [`EntityHashMap<EntityRef>`](crate::entity::hash_map::EntityHashMap).
+    ///
+    /// # Errors
+    ///
+    /// If any of the given `entities` do not exist in the world, the first
+    /// [`Entity`] found to be missing will return an [`EntityDoesNotExistError`].
+    ///
+    /// # Examples
+    ///
+    /// For examples, see [`World::entity`].
+    ///
+    /// [`World::entity`]: crate::world::World::entity
+    #[inline]
+    pub fn get<F: WorldEntityFetch>(
+        &self,
+        entities: F,
+    ) -> Result<F::Ref<'_>, EntityDoesNotExistError> {
+        // SAFETY: `&self` gives read access to all entities, and prevents mutable access.
+        unsafe { entities.fetch_ref(self.cell) }
+    }
+
+    /// Returns [`EntityMut`]s that expose read and write operations for the
+    /// given `entities`, returning [`Err`] if any of the given entities do not
+    /// exist.
+    ///
+    /// This function supports fetching a single entity or multiple entities:
+    /// - Pass an [`Entity`] to receive a single [`EntityMut`].
+    ///    - This reference type allows for structural changes to the entity,
+    ///      such as adding or removing components, or despawning the entity.
+    /// - Pass a slice of [`Entity`]s to receive a [`Vec<EntityMut>`].
+    /// - Pass an array of [`Entity`]s to receive an equally-sized array of [`EntityMut`]s.
+    /// - Pass a reference to a [`EntityHashSet`](crate::entity::hash_map::EntityHashMap) to receive an
+    ///   [`EntityHashMap<EntityMut>`](crate::entity::hash_map::EntityHashMap).
+    /// # Errors
+    ///
+    /// - Returns [`EntityMutableFetchError::EntityDoesNotExist`] if any of the given `entities` do not exist in the world.
+    ///     - Only the first entity found to be missing will be returned.
+    /// - Returns [`EntityMutableFetchError::AliasedMutability`] if the same entity is requested multiple times.
+    ///
+    /// # Examples
+    ///
+    /// For examples, see [`DeferredWorld::entity_mut`].
+    ///
+    /// [`DeferredWorld::entity_mut`]: crate::world::DeferredWorld::entity_mut
+    #[inline]
+    pub fn get_mut<F: WorldEntityFetch>(
+        &mut self,
+        entities: F,
+    ) -> Result<F::DeferredMut<'_>, EntityMutableFetchError> {
+        // SAFETY: `&mut self` gives mutable access to all entities,
+        // and prevents any other access to entities.
+        unsafe { entities.fetch_deferred_mut(self.cell) }
+    }
+}
 
 /// Types that can be used to fetch [`Entity`] references from a [`World`].
 ///

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -10,7 +10,12 @@ use crate::{
     },
 };
 
-/// Provides a safe interface for accessing *just* the entities in a [`World`].
+/// Provides a safe interface for non-structural access to the entities in a [`World`].
+///
+/// This cannot add or remove components, or spawn or despawn entities,
+/// making it relatively safe to access in concert with other ECS data.
+/// This type can be constructed via [`World::entities_and_commands`],
+/// or the equivalent method on [`DeferredWorld`].
 ///
 /// [`World`]: crate::world::World
 pub struct EntityFetcher<'w> {


### PR DESCRIPTION
# Objective

Currently experimenting with manually implementing `Relationship`/`RelationshipTarget` to support associated edge data, which means I need to replace the default hook implementations provided by those traits. However, copying them over for editing revealed that `UnsafeWorldCell::get_raw_command_queue` is `pub(crate)`, and I would like to not have to clone the source collection, like the default impl. So instead, I've taken to providing a safe abstraction for being able to access entities and queue commands simultaneously.

## Solution

Added `World::entities_and_commands` and `DeferredWorld::entities_and_commands`, which can be used like so:

```rust
let eid: Entity = /* ... */;
let (mut fetcher, mut commands) = world.entities_and_commands();
let emut = fetcher.get_mut(eid).unwrap();
commands.entity(eid).despawn();
```

## Testing

- Added a new test for each of the added functions.