### PR TITLE
Sync up the Derive of DragEntry to match the other events

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -278,7 +278,7 @@ pub struct DragDrop {
 }
 
 /// Dragging state.
-#[derive(Debug, Clone)]
+#[derive(Clone, PartialEq, Debug, Reflect)]
 pub struct DragEntry {
     /// The position of the pointer at drag start.
     pub start_pos: Vec2,


### PR DESCRIPTION
# Objective
Add `#[derive(Clone, PartialEq, Debug, Reflect)]` to DragEntry so it matches the other picking events.

## Solution
Copy/paste (RIP Larry Tesler)

## Testing
Just ran cargo check. I don't believe this should break anything because I did not remove any derives it had before.

---

