### PR TITLE
docs:  Fix incorrect cycle_modes function documentation

### DIFF
--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -112,7 +112,7 @@ pub(crate) mod test_setup {
         window::RequestRedraw,
     };
 
-    /// Switch between update modes when the mouse is clicked.
+    /// Switch between update modes when the spacebar is pressed.
     pub(crate) fn cycle_modes(
         mut mode: ResMut<ExampleMode>,
         button_input: Res<ButtonInput<KeyCode>>,


### PR DESCRIPTION
Update the documentation comment to correctly state that the function responds to spacebar presses rather than mouse clicks. This aligns the documentation with the actual implementation, which was already using keyboard input.

# Objective

- Fix incorrect documentation comment for the cycle_modes function that inaccurately described using mouse input when the implementation actually uses spacebar.
- This ensures documentation accuracy and prevents confusion for new learners.

## Solution

- Updated the documentation comment to correctly state that the function responds to spacebar presses rather than mouse clicks.
- The code functionality remains unchanged.