### PR TITLE
Add more to the 2d testbed for text

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -143,21 +143,119 @@ mod bloom {
 }
 
 mod text {
+    use bevy::color::palettes;
     use bevy::prelude::*;
+    use bevy::sprite::Anchor;
+    use bevy::text::TextBounds;
 
-    pub fn setup(mut commands: Commands) {
-        let text_font = TextFont {
-            font_size: 50.0,
+    pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+        commands.spawn((Camera2d::default(), StateScoped(super::Scene::Text)));
+
+        for (i, justify) in [
+            JustifyText::Left,
+            JustifyText::Right,
+            JustifyText::Center,
+            JustifyText::Justified,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let y = 230. - 150. * i as f32;
+            spawn_anchored_text(&mut commands, -300. * Vec3::X + y * Vec3::Y, justify, None);
+            spawn_anchored_text(
+                &mut commands,
+                300. * Vec3::X + y * Vec3::Y,
+                justify,
+                Some(TextBounds::new(150., 55.)),
+            );
+        }
+
+        let sans_serif = TextFont {
+            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
             ..default()
         };
-        let text_justification = JustifyText::Center;
-        commands.spawn((Camera2d, StateScoped(super::Scene::Text)));
+
+        const NUM_ITERATIONS: usize = 10;
+        for i in 0..NUM_ITERATIONS {
+            let fraction = i as f32 / (NUM_ITERATIONS - 1) as f32;
+
+            commands.spawn((
+                Text2d::new(format!("Bevy")),
+                sans_serif.clone(),
+                Transform::from_xyz(0.0, fraction * 200.0, i as f32)
+                    .with_scale(1.0 + Vec2::splat(fraction).extend(1.))
+                    .with_rotation(Quat::from_rotation_z(fraction * core::f32::consts::PI)),
+                TextColor(Color::hsla(fraction * 360.0, 0.8, 0.8, 0.8)),
+                StateScoped(super::Scene::Text),
+            ));
+        }
+
+        commands.spawn((Text2d::new("This text is invisible."), Visibility::Hidden));
+    }
+
+    fn spawn_anchored_text(
+        commands: &mut Commands,
+        dest: Vec3,
+        justify: JustifyText,
+        bounds: Option<TextBounds>,
+    ) {
         commands.spawn((
-            Text2d::new("Hello World"),
-            text_font,
-            TextLayout::new_with_justify(text_justification),
+            Sprite {
+                color: palettes::css::YELLOW.into(),
+                custom_size: Some(5. * Vec2::ONE),
+                ..Default::default()
+            },
+            Transform::from_translation(dest),
             StateScoped(super::Scene::Text),
         ));
+
+        for anchor in [
+            Anchor::TopLeft,
+            Anchor::TopRight,
+            Anchor::BottomRight,
+            Anchor::BottomLeft,
+        ] {
+            let mut text = commands.spawn((
+                Text2d::new("L R\n"),
+                TextLayout::new_with_justify(justify.clone()),
+                Transform::from_translation(dest + Vec3::Z),
+                anchor.clone(),
+                StateScoped(super::Scene::Text),
+            ));
+            text.with_children(|parent| {
+                parent.spawn((
+                    TextSpan::new(format!("{anchor:?}\n")),
+                    TextFont {
+                        font_size: 14.0,
+                        ..default()
+                    },
+                    TextColor(palettes::tailwind::BLUE_400.into()),
+                ));
+                parent.spawn((
+                    TextSpan::new(format!("{justify:?}")),
+                    TextFont {
+                        font_size: 14.0,
+                        ..default()
+                    },
+                    TextColor(palettes::tailwind::GREEN_400.into()),
+                ));
+            });
+
+            if let Some(bounds) = bounds {
+                text.insert(bounds);
+
+                commands.spawn((
+                    Sprite {
+                        color: palettes::tailwind::GRAY_900.into(),
+                        custom_size: Some(Vec2::new(bounds.width.unwrap(), bounds.height.unwrap())),
+                        anchor: anchor.clone(),
+                        ..Default::default()
+                    },
+                    Transform::from_translation(dest - Vec3::Z),
+                    StateScoped(super::Scene::Text),
+                ));
+            }
+        }
     }
 }
 

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -190,7 +190,11 @@ mod text {
             ));
         }
 
-        commands.spawn((Text2d::new("This text is invisible."), Visibility::Hidden));
+        commands.spawn((
+            Text2d::new("This text is invisible."),
+            Visibility::Hidden,
+            StateScoped(super::Scene::Text),
+        ));
     }
 
     fn spawn_anchored_text(

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -170,10 +170,7 @@ mod text {
             );
         }
 
-        let sans_serif = TextFont {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-            ..default()
-        };
+        let sans_serif = TextFont::from_font(asset_server.load("fonts/FiraSans-Bold.ttf"));
 
         const NUM_ITERATIONS: usize = 10;
         for i in 0..NUM_ITERATIONS {

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -149,7 +149,7 @@ mod text {
     use bevy::text::TextBounds;
 
     pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn((Camera2d::default(), StateScoped(super::Scene::Text)));
+        commands.spawn((Camera2d, StateScoped(super::Scene::Text)));
 
         for (i, justify) in [
             JustifyText::Left,
@@ -180,7 +180,7 @@ mod text {
             let fraction = i as f32 / (NUM_ITERATIONS - 1) as f32;
 
             commands.spawn((
-                Text2d::new(format!("Bevy")),
+                Text2d::new("Bevy"),
                 sans_serif.clone(),
                 Transform::from_xyz(0.0, fraction * 200.0, i as f32)
                     .with_scale(1.0 + Vec2::splat(fraction).extend(1.))
@@ -217,9 +217,9 @@ mod text {
         ] {
             let mut text = commands.spawn((
                 Text2d::new("L R\n"),
-                TextLayout::new_with_justify(justify.clone()),
+                TextLayout::new_with_justify(justify),
                 Transform::from_translation(dest + Vec3::Z),
-                anchor.clone(),
+                anchor,
                 StateScoped(super::Scene::Text),
             ));
             text.with_children(|parent| {
@@ -248,7 +248,7 @@ mod text {
                     Sprite {
                         color: palettes::tailwind::GRAY_900.into(),
                         custom_size: Some(Vec2::new(bounds.width.unwrap(), bounds.height.unwrap())),
-                        anchor: anchor.clone(),
+                        anchor,
                         ..Default::default()
                     },
                     Transform::from_translation(dest - Vec3::Z),

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -237,10 +237,7 @@ mod text {
                 ));
                 parent.spawn((
                     TextSpan::new(format!("{justify:?}")),
-                    TextFont {
-                        font_size: 14.0,
-                        ..default()
-                    },
+                    TextFont::from_font_size(14.0),
                     TextColor(palettes::tailwind::GREEN_400.into()),
                 ));
             });

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -226,10 +226,7 @@ mod text {
             text.with_children(|parent| {
                 parent.spawn((
                     TextSpan::new(format!("{anchor:?}\n")),
-                    TextFont {
-                        font_size: 14.0,
-                        ..default()
-                    },
+                    TextFont::from_font_size(14.0),
                     TextColor(palettes::tailwind::BLUE_400.into()),
                 ));
                 parent.spawn((


### PR DESCRIPTION
# Objective

`Text2d` testing hasn't been as thorough as text in the UI, and it suffered a bunch of bugs / perf issues in recent cycles.

## Solution

Add some more `Text2d` scenarios to the 2d testbed to catch bugs, testing bounded and unbounded text with various justification.

## Testing

`cargo run --example testbed_2d` (press space a few times)

<img width="1280" alt="Screenshot 2025-03-10 at 1 02 03 PM" src="https://github.com/user-attachments/assets/1e4ee39c-809b-4cc6-81bd-68e67b9625b5" />
