### PR TITLE
Generalize `DiGraph`/`UnGraph` 📊

### DIFF
--- a/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
+++ b/crates/bevy_ecs/src/schedule/auto_insert_apply_deferred.rs
@@ -75,7 +75,7 @@ impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
         &mut self,
         _world: &mut World,
         graph: &mut ScheduleGraph,
-        dependency_flattened: &mut DiGraph,
+        dependency_flattened: &mut DiGraph<NodeId>,
     ) -> Result<(), ScheduleBuildError> {
         let mut sync_point_graph = dependency_flattened.clone();
         let topo = graph.topsort_graph(dependency_flattened, ReportCycles::Dependency)?;
@@ -217,7 +217,7 @@ impl ScheduleBuildPass for AutoInsertApplyDeferredPass {
         &mut self,
         set: NodeId,
         systems: &[NodeId],
-        dependency_flattened: &DiGraph,
+        dependency_flattened: &DiGraph<NodeId>,
     ) -> impl Iterator<Item = (NodeId, NodeId)> {
         if systems.is_empty() {
             // collapse dependencies for empty sets

--- a/crates/bevy_ecs/src/schedule/graph/mod.rs
+++ b/crates/bevy_ecs/src/schedule/graph/mod.rs
@@ -82,24 +82,24 @@ pub(crate) fn row_col(index: usize, num_cols: usize) -> (usize, usize) {
 }
 
 /// Stores the results of the graph analysis.
-pub(crate) struct CheckGraphResults {
+pub(crate) struct CheckGraphResults<Id: GraphNodeId> {
     /// Boolean reachability matrix for the graph.
     pub(crate) reachable: FixedBitSet,
     /// Pairs of nodes that have a path connecting them.
-    pub(crate) connected: HashSet<(NodeId, NodeId)>,
+    pub(crate) connected: HashSet<(Id, Id)>,
     /// Pairs of nodes that don't have a path connecting them.
-    pub(crate) disconnected: Vec<(NodeId, NodeId)>,
+    pub(crate) disconnected: Vec<(Id, Id)>,
     /// Edges that are redundant because a longer path exists.
-    pub(crate) transitive_edges: Vec<(NodeId, NodeId)>,
+    pub(crate) transitive_edges: Vec<(Id, Id)>,
     /// Variant of the graph with no transitive edges.
-    pub(crate) transitive_reduction: DiGraph<NodeId>,
+    pub(crate) transitive_reduction: DiGraph<Id>,
     /// Variant of the graph with all possible transitive edges.
     // TODO: this will very likely be used by "if-needed" ordering
     #[expect(dead_code, reason = "See the TODO above this attribute.")]
-    pub(crate) transitive_closure: DiGraph<NodeId>,
+    pub(crate) transitive_closure: DiGraph<Id>,
 }
 
-impl Default for CheckGraphResults {
+impl<Id: GraphNodeId> Default for CheckGraphResults<Id> {
     fn default() -> Self {
         Self {
             reachable: FixedBitSet::new(),
@@ -123,10 +123,10 @@ impl Default for CheckGraphResults {
 /// ["On the calculation of transitive reduction-closure of orders"][1] by Habib, Morvan and Rampon.
 ///
 /// [1]: https://doi.org/10.1016/0012-365X(93)90164-O
-pub(crate) fn check_graph(
-    graph: &DiGraph<NodeId>,
-    topological_order: &[NodeId],
-) -> CheckGraphResults {
+pub(crate) fn check_graph<Id: GraphNodeId>(
+    graph: &DiGraph<Id>,
+    topological_order: &[Id],
+) -> CheckGraphResults<Id> {
     if graph.node_count() == 0 {
         return CheckGraphResults::default();
     }
@@ -135,7 +135,7 @@ pub(crate) fn check_graph(
 
     // build a copy of the graph where the nodes and edges appear in topsorted order
     let mut map = <HashMap<_, _>>::with_capacity_and_hasher(n, Default::default());
-    let mut topsorted = DiGraph::<NodeId>::default();
+    let mut topsorted = DiGraph::<Id>::default();
     // iterate nodes in topological order
     for (i, &node) in topological_order.iter().enumerate() {
         map.insert(node, i);
@@ -231,13 +231,16 @@ pub(crate) fn check_graph(
 /// ["Finding all the elementary circuits of a directed graph"][1] by D. B. Johnson.
 ///
 /// [1]: https://doi.org/10.1137/0204007
-pub fn simple_cycles_in_component(graph: &DiGraph<NodeId>, scc: &[NodeId]) -> Vec<Vec<NodeId>> {
+pub fn simple_cycles_in_component<Id: GraphNodeId>(
+    graph: &DiGraph<Id>,
+    scc: &[Id],
+) -> Vec<Vec<Id>> {
     let mut cycles = vec![];
     let mut sccs = vec![SmallVec::from_slice(scc)];
 
     while let Some(mut scc) = sccs.pop() {
         // only look at nodes and edges in this strongly-connected component
-        let mut subgraph = DiGraph::<NodeId>::default();
+        let mut subgraph = DiGraph::<Id>::default();
         for &node in &scc {
             subgraph.add_node(node);
         }
@@ -257,12 +260,12 @@ pub fn simple_cycles_in_component(graph: &DiGraph<NodeId>, scc: &[NodeId]) -> Ve
             HashSet::with_capacity_and_hasher(subgraph.node_count(), Default::default());
         // connects nodes along path segments that can't be part of a cycle (given current root)
         // those nodes can be unblocked at the same time
-        let mut unblock_together: HashMap<NodeId, HashSet<NodeId>> =
+        let mut unblock_together: HashMap<Id, HashSet<Id>> =
             HashMap::with_capacity_and_hasher(subgraph.node_count(), Default::default());
         // stack for unblocking nodes
         let mut unblock_stack = Vec::with_capacity(subgraph.node_count());
         // nodes can be involved in multiple cycles
-        let mut maybe_in_more_cycles: HashSet<NodeId> =
+        let mut maybe_in_more_cycles: HashSet<Id> =
             HashSet::with_capacity_and_hasher(subgraph.node_count(), Default::default());
         // stack for DFS
         let mut stack = Vec::with_capacity(subgraph.node_count());

--- a/crates/bevy_ecs/src/schedule/graph/mod.rs
+++ b/crates/bevy_ecs/src/schedule/graph/mod.rs
@@ -17,7 +17,7 @@ mod node;
 mod tarjan_scc;
 
 pub use graph_map::{DiGraph, Direction, UnGraph};
-pub use node::NodeId;
+pub use node::{DirectedGraphNodeId, GraphNodeId, GraphNodeIdPair, NodeId};
 
 /// Specifies what kind of edge should be added to the dependency graph.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
@@ -92,11 +92,11 @@ pub(crate) struct CheckGraphResults {
     /// Edges that are redundant because a longer path exists.
     pub(crate) transitive_edges: Vec<(NodeId, NodeId)>,
     /// Variant of the graph with no transitive edges.
-    pub(crate) transitive_reduction: DiGraph,
+    pub(crate) transitive_reduction: DiGraph<NodeId>,
     /// Variant of the graph with all possible transitive edges.
     // TODO: this will very likely be used by "if-needed" ordering
     #[expect(dead_code, reason = "See the TODO above this attribute.")]
-    pub(crate) transitive_closure: DiGraph,
+    pub(crate) transitive_closure: DiGraph<NodeId>,
 }
 
 impl Default for CheckGraphResults {
@@ -123,7 +123,10 @@ impl Default for CheckGraphResults {
 /// ["On the calculation of transitive reduction-closure of orders"][1] by Habib, Morvan and Rampon.
 ///
 /// [1]: https://doi.org/10.1016/0012-365X(93)90164-O
-pub(crate) fn check_graph(graph: &DiGraph, topological_order: &[NodeId]) -> CheckGraphResults {
+pub(crate) fn check_graph(
+    graph: &DiGraph<NodeId>,
+    topological_order: &[NodeId],
+) -> CheckGraphResults {
     if graph.node_count() == 0 {
         return CheckGraphResults::default();
     }
@@ -132,7 +135,7 @@ pub(crate) fn check_graph(graph: &DiGraph, topological_order: &[NodeId]) -> Chec
 
     // build a copy of the graph where the nodes and edges appear in topsorted order
     let mut map = <HashMap<_, _>>::with_capacity_and_hasher(n, Default::default());
-    let mut topsorted = <DiGraph>::default();
+    let mut topsorted = DiGraph::<NodeId>::default();
     // iterate nodes in topological order
     for (i, &node) in topological_order.iter().enumerate() {
         map.insert(node, i);
@@ -228,13 +231,13 @@ pub(crate) fn check_graph(graph: &DiGraph, topological_order: &[NodeId]) -> Chec
 /// ["Finding all the elementary circuits of a directed graph"][1] by D. B. Johnson.
 ///
 /// [1]: https://doi.org/10.1137/0204007
-pub fn simple_cycles_in_component(graph: &DiGraph, scc: &[NodeId]) -> Vec<Vec<NodeId>> {
+pub fn simple_cycles_in_component(graph: &DiGraph<NodeId>, scc: &[NodeId]) -> Vec<Vec<NodeId>> {
     let mut cycles = vec![];
     let mut sccs = vec![SmallVec::from_slice(scc)];
 
     while let Some(mut scc) = sccs.pop() {
         // only look at nodes and edges in this strongly-connected component
-        let mut subgraph = <DiGraph>::default();
+        let mut subgraph = DiGraph::<NodeId>::default();
         for &node in &scc {
             subgraph.add_node(node);
         }

--- a/crates/bevy_ecs/src/schedule/graph/mod.rs
+++ b/crates/bevy_ecs/src/schedule/graph/mod.rs
@@ -17,7 +17,7 @@ mod node;
 mod tarjan_scc;
 
 pub use graph_map::{DiGraph, Direction, UnGraph};
-pub use node::{GraphNodeNeighbor, GraphNodeId, GraphNodeEdge, NodeId};
+pub use node::{GraphNodeEdge, GraphNodeId, GraphNodeNeighbor, NodeId};
 
 /// Specifies what kind of edge should be added to the dependency graph.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]

--- a/crates/bevy_ecs/src/schedule/graph/mod.rs
+++ b/crates/bevy_ecs/src/schedule/graph/mod.rs
@@ -17,7 +17,7 @@ mod node;
 mod tarjan_scc;
 
 pub use graph_map::{DiGraph, Direction, UnGraph};
-pub use node::{DirectedGraphNodeId, GraphNodeId, GraphNodeIdPair, NodeId};
+pub use node::{GraphNodeNeighbor, GraphNodeId, GraphNodeEdge, NodeId};
 
 /// Specifies what kind of edge should be added to the dependency graph.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]

--- a/crates/bevy_ecs/src/schedule/graph/node.rs
+++ b/crates/bevy_ecs/src/schedule/graph/node.rs
@@ -1,4 +1,9 @@
-use core::fmt::Debug;
+use core::{
+    fmt::{self, Debug},
+    hash::Hash,
+};
+
+use crate::schedule::graph::Direction;
 
 /// Unique identifier for a system or system set stored in a [`ScheduleGraph`].
 ///
@@ -43,5 +48,133 @@ impl NodeId {
             (System(_), Set(_)) => Less,
             (Set(_), System(_)) => Greater,
         }
+    }
+}
+
+impl GraphNodeId for NodeId {
+    type Pair = CompactNodeIdPair;
+    type Directed = CompactNodeIdAndDirection;
+}
+
+/// Compact storage of a [`NodeId`] pair.
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub struct CompactNodeIdPair {
+    index_a: usize,
+    index_b: usize,
+    is_system_a: bool,
+    is_system_b: bool,
+}
+
+impl Debug for CompactNodeIdPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.unpack().fmt(f)
+    }
+}
+
+impl GraphNodeIdPair<NodeId> for CompactNodeIdPair {
+    fn pack(a: NodeId, b: NodeId) -> Self {
+        Self {
+            index_a: a.index(),
+            index_b: b.index(),
+            is_system_a: a.is_system(),
+            is_system_b: b.is_system(),
+        }
+    }
+
+    fn unpack(self) -> (NodeId, NodeId) {
+        let a = match self.is_system_a {
+            true => NodeId::System(self.index_a),
+            false => NodeId::Set(self.index_a),
+        };
+        let b = match self.is_system_b {
+            true => NodeId::System(self.index_b),
+            false => NodeId::Set(self.index_b),
+        };
+        (a, b)
+    }
+}
+
+/// Compact storage of a [`NodeId`] and a [`Direction`].
+#[derive(Clone, Copy)]
+pub struct CompactNodeIdAndDirection {
+    index: usize,
+    is_system: bool,
+    direction: Direction,
+}
+
+impl Debug for CompactNodeIdAndDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.unpack().fmt(f)
+    }
+}
+
+impl DirectedGraphNodeId<NodeId> for CompactNodeIdAndDirection {
+    fn pack(node: NodeId, dir: Direction) -> Self {
+        Self {
+            index: node.index(),
+            is_system: node.is_system(),
+            direction: dir,
+        }
+    }
+
+    fn unpack(self) -> (NodeId, Direction) {
+        let node = match self.is_system {
+            true => NodeId::System(self.index),
+            false => NodeId::Set(self.index),
+        };
+        (node, self.direction)
+    }
+}
+
+/// A node in a [`DiGraph`] or [`UnGraph`].
+///
+/// [`DiGraph`]: crate::schedule::graph::DiGraph
+/// [`UnGraph`]: crate::schedule::graph::UnGraph
+pub trait GraphNodeId: Copy + Eq + Ord + Debug + Hash {
+    /// A pair of [`GraphNodeId`]s for storing edge information. Typically
+    /// stored in a memory-efficient format.
+    type Pair: GraphNodeIdPair<Self>;
+    /// A pair of [`GraphNodeId`] and [`Direction`] for storing neighbor
+    /// information. Typically stored in a memory-efficient format.
+    type Directed: DirectedGraphNodeId<Self>;
+}
+
+/// A pair of [`GraphNodeId`]s for storing edge information. Typically stored in
+/// a memory-efficient format.
+pub trait GraphNodeIdPair<Id: GraphNodeId>: Copy + Eq + Hash {
+    /// Packs the given identifiers into a pair.
+    fn pack(a: Id, b: Id) -> Self;
+
+    /// Unpacks this pair into two identifiers.
+    fn unpack(self) -> (Id, Id);
+}
+
+impl<Id: GraphNodeId> GraphNodeIdPair<Id> for (Id, Id) {
+    fn pack(a: Id, b: Id) -> Self {
+        (a, b)
+    }
+
+    fn unpack(self) -> (Id, Id) {
+        (self.0, self.1)
+    }
+}
+
+/// A pair of [`GraphNodeId`] and [`Direction`] for storing neighbor
+/// information. Typically stored in a memory-efficient format.
+pub trait DirectedGraphNodeId<Id: GraphNodeId>: Copy + Debug {
+    /// Packs the given identifier and direction into a pair.
+    fn pack(node: Id, dir: Direction) -> Self;
+
+    /// Unpacks this pair into the identifier and direction.
+    fn unpack(self) -> (Id, Direction);
+}
+
+impl<Id: GraphNodeId> DirectedGraphNodeId<Id> for (Id, Direction) {
+    fn pack(node: Id, dir: Direction) -> Self {
+        (node, dir)
+    }
+
+    fn unpack(self) -> (Id, Direction) {
+        (self.0, self.1)
     }
 }

--- a/crates/bevy_ecs/src/schedule/graph/node.rs
+++ b/crates/bevy_ecs/src/schedule/graph/node.rs
@@ -52,8 +52,8 @@ impl NodeId {
 }
 
 impl GraphNodeId for NodeId {
-    type Pair = CompactNodeIdPair;
-    type Directed = CompactNodeIdAndDirection;
+    type Edge = CompactNodeIdPair;
+    type Neighbor = CompactNodeIdAndDirection;
 }
 
 /// Compact storage of a [`NodeId`] pair.
@@ -71,7 +71,7 @@ impl Debug for CompactNodeIdPair {
     }
 }
 
-impl GraphNodeIdPair<NodeId> for CompactNodeIdPair {
+impl GraphNodeEdge<NodeId> for CompactNodeIdPair {
     fn pack(a: NodeId, b: NodeId) -> Self {
         Self {
             index_a: a.index(),
@@ -108,7 +108,7 @@ impl Debug for CompactNodeIdAndDirection {
     }
 }
 
-impl DirectedGraphNodeId<NodeId> for CompactNodeIdAndDirection {
+impl GraphNodeNeighbor<NodeId> for CompactNodeIdAndDirection {
     fn pack(node: NodeId, dir: Direction) -> Self {
         Self {
             index: node.index(),
@@ -133,23 +133,23 @@ impl DirectedGraphNodeId<NodeId> for CompactNodeIdAndDirection {
 pub trait GraphNodeId: Copy + Eq + Ord + Debug + Hash {
     /// A pair of [`GraphNodeId`]s for storing edge information. Typically
     /// stored in a memory-efficient format.
-    type Pair: GraphNodeIdPair<Self>;
+    type Edge: GraphNodeEdge<Self>;
     /// A pair of [`GraphNodeId`] and [`Direction`] for storing neighbor
     /// information. Typically stored in a memory-efficient format.
-    type Directed: DirectedGraphNodeId<Self>;
+    type Neighbor: GraphNodeNeighbor<Self>;
 }
 
 /// A pair of [`GraphNodeId`]s for storing edge information. Typically stored in
 /// a memory-efficient format.
-pub trait GraphNodeIdPair<Id: GraphNodeId>: Copy + Eq + Hash {
-    /// Packs the given identifiers into a pair.
+pub trait GraphNodeEdge<Id: GraphNodeId>: Copy + Eq + Hash {
+    /// Packs the given nodes into an edge.
     fn pack(a: Id, b: Id) -> Self;
 
-    /// Unpacks this pair into two identifiers.
+    /// Unpacks this edge into two nodes.
     fn unpack(self) -> (Id, Id);
 }
 
-impl<Id: GraphNodeId> GraphNodeIdPair<Id> for (Id, Id) {
+impl<Id: GraphNodeId> GraphNodeEdge<Id> for (Id, Id) {
     fn pack(a: Id, b: Id) -> Self {
         (a, b)
     }
@@ -161,15 +161,15 @@ impl<Id: GraphNodeId> GraphNodeIdPair<Id> for (Id, Id) {
 
 /// A pair of [`GraphNodeId`] and [`Direction`] for storing neighbor
 /// information. Typically stored in a memory-efficient format.
-pub trait DirectedGraphNodeId<Id: GraphNodeId>: Copy + Debug {
-    /// Packs the given identifier and direction into a pair.
+pub trait GraphNodeNeighbor<Id: GraphNodeId>: Copy + Debug {
+    /// Packs the given identifier and direction into a neighbor.
     fn pack(node: Id, dir: Direction) -> Self;
 
-    /// Unpacks this pair into the identifier and direction.
+    /// Unpacks this neighbor into the identifier and direction.
     fn unpack(self) -> (Id, Direction);
 }
 
-impl<Id: GraphNodeId> DirectedGraphNodeId<Id> for (Id, Direction) {
+impl<Id: GraphNodeId> GraphNodeNeighbor<Id> for (Id, Direction) {
     fn pack(node: Id, dir: Direction) -> Self {
         (node, dir)
     }

--- a/crates/bevy_ecs/src/schedule/graph/tarjan_scc.rs
+++ b/crates/bevy_ecs/src/schedule/graph/tarjan_scc.rs
@@ -1,8 +1,7 @@
-use super::DiGraph;
-use super::NodeId;
 use alloc::vec::Vec;
-use core::hash::BuildHasher;
-use core::num::NonZeroUsize;
+use core::{hash::BuildHasher, num::NonZeroUsize};
+
+use crate::schedule::graph::{DiGraph, GraphNodeId};
 use smallvec::SmallVec;
 
 /// Create an iterator over *strongly connected components* using Algorithm 3 in
@@ -16,9 +15,9 @@ use smallvec::SmallVec;
 /// Returns each strongly strongly connected component (scc).
 /// The order of node ids within each scc is arbitrary, but the order of
 /// the sccs is their postorder (reverse topological sort).
-pub(crate) fn new_tarjan_scc<S: BuildHasher>(
-    graph: &DiGraph<S>,
-) -> impl Iterator<Item = SmallVec<[NodeId; 4]>> + '_ {
+pub(crate) fn new_tarjan_scc<Id: GraphNodeId, S: BuildHasher>(
+    graph: &DiGraph<Id, S>,
+) -> impl Iterator<Item = SmallVec<[Id; 4]>> + '_ {
     // Create a list of all nodes we need to visit.
     let unchecked_nodes = graph.nodes();
 
@@ -46,7 +45,7 @@ pub(crate) fn new_tarjan_scc<S: BuildHasher>(
     }
 }
 
-struct NodeData<N: Iterator<Item = NodeId>> {
+struct NodeData<Id: GraphNodeId, N: Iterator<Item = Id>> {
     root_index: Option<NonZeroUsize>,
     neighbors: N,
 }
@@ -58,35 +57,40 @@ struct NodeData<N: Iterator<Item = NodeId>> {
 /// [1]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
 /// [`petgraph`]: https://docs.rs/petgraph/0.6.5/petgraph/
 /// [`TarjanScc`]: https://docs.rs/petgraph/0.6.5/petgraph/algo/struct.TarjanScc.html
-struct TarjanScc<'graph, Hasher, AllNodes, Neighbors>
+struct TarjanScc<'graph, Id, Hasher, AllNodes, Neighbors>
 where
+    Id: GraphNodeId,
     Hasher: BuildHasher,
-    AllNodes: Iterator<Item = NodeId>,
-    Neighbors: Iterator<Item = NodeId>,
+    AllNodes: Iterator<Item = Id>,
+    Neighbors: Iterator<Item = Id>,
 {
     /// Source of truth [`DiGraph`]
-    graph: &'graph DiGraph<Hasher>,
-    /// An [`Iterator`] of [`NodeId`]s from the `graph` which may not have been visited yet.
+    graph: &'graph DiGraph<Id, Hasher>,
+    /// An [`Iterator`] of [`GraphNodeId`]s from the `graph` which may not have been visited yet.
     unchecked_nodes: AllNodes,
     /// The index of the next SCC
     index: usize,
     /// A count of potentially remaining SCCs
     component_count: usize,
-    /// Information about each [`NodeId`], including a possible SCC index and an
+    /// Information about each [`GraphNodeId`], including a possible SCC index and an
     /// [`Iterator`] of possibly unvisited neighbors.
-    nodes: Vec<NodeData<Neighbors>>,
-    /// A stack of [`NodeId`]s where a SCC will be found starting at the top of the stack.
-    stack: Vec<NodeId>,
-    /// A stack of [`NodeId`]s which need to be visited to determine which SCC they belong to.
-    visitation_stack: Vec<(NodeId, bool)>,
+    nodes: Vec<NodeData<Id, Neighbors>>,
+    /// A stack of [`GraphNodeId`]s where a SCC will be found starting at the top of the stack.
+    stack: Vec<Id>,
+    /// A stack of [`GraphNodeId`]s which need to be visited to determine which SCC they belong to.
+    visitation_stack: Vec<(Id, bool)>,
     /// An index into the `stack` indicating the starting point of a SCC.
     start: Option<usize>,
     /// An adjustment to the `index` which will be applied once the current SCC is found.
     index_adjustment: Option<usize>,
 }
 
-impl<'graph, S: BuildHasher, A: Iterator<Item = NodeId>, N: Iterator<Item = NodeId>>
-    TarjanScc<'graph, S, A, N>
+impl<'graph, Id, S, A, N> TarjanScc<'graph, Id, S, A, N>
+where
+    Id: GraphNodeId,
+    S: BuildHasher,
+    A: Iterator<Item = Id>,
+    N: Iterator<Item = Id>,
 {
     /// Compute the next *strongly connected component* using Algorithm 3 in
     /// [A Space-Efficient Algorithm for Finding Strongly Connected Components][1] by David J. Pierce,
@@ -99,7 +103,7 @@ impl<'graph, S: BuildHasher, A: Iterator<Item = NodeId>, N: Iterator<Item = Node
     /// Returns `Some` for each strongly strongly connected component (scc).
     /// The order of node ids within each scc is arbitrary, but the order of
     /// the sccs is their postorder (reverse topological sort).
-    fn next_scc(&mut self) -> Option<&[NodeId]> {
+    fn next_scc(&mut self) -> Option<&[Id]> {
         // Cleanup from possible previous iteration
         if let (Some(start), Some(index_adjustment)) =
             (self.start.take(), self.index_adjustment.take())
@@ -139,7 +143,7 @@ impl<'graph, S: BuildHasher, A: Iterator<Item = NodeId>, N: Iterator<Item = Node
     /// If a visitation is required, this will return `None` and mark the required neighbor and the
     /// current node as in need of visitation again.
     /// If no SCC can be found in the current visitation stack, returns `None`.
-    fn visit_once(&mut self, v: NodeId, mut v_is_local_root: bool) -> Option<usize> {
+    fn visit_once(&mut self, v: Id, mut v_is_local_root: bool) -> Option<usize> {
         let node_v = &mut self.nodes[self.graph.to_index(v)];
 
         if node_v.root_index.is_none() {
@@ -203,13 +207,17 @@ impl<'graph, S: BuildHasher, A: Iterator<Item = NodeId>, N: Iterator<Item = Node
     }
 }
 
-impl<'graph, S: BuildHasher, A: Iterator<Item = NodeId>, N: Iterator<Item = NodeId>> Iterator
-    for TarjanScc<'graph, S, A, N>
+impl<'graph, Id, S, A, N> Iterator for TarjanScc<'graph, Id, S, A, N>
+where
+    Id: GraphNodeId,
+    S: BuildHasher,
+    A: Iterator<Item = Id>,
+    N: Iterator<Item = Id>,
 {
     // It is expected that the `DiGraph` is sparse, and as such wont have many large SCCs.
     // Returning a `SmallVec` allows this iterator to skip allocation in cases where that
     // assumption holds.
-    type Item = SmallVec<[NodeId; 4]>;
+    type Item = SmallVec<[Id; 4]>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = SmallVec::from_slice(self.next_scc()?);

--- a/crates/bevy_ecs/src/schedule/pass.rs
+++ b/crates/bevy_ecs/src/schedule/pass.rs
@@ -21,7 +21,7 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
         &mut self,
         set: NodeId,
         systems: &[NodeId],
-        dependency_flattened: &DiGraph,
+        dependency_flattened: &DiGraph<NodeId>,
     ) -> impl Iterator<Item = (NodeId, NodeId)>;
 
     /// The implementation will be able to modify the `ScheduleGraph` here.
@@ -29,7 +29,7 @@ pub trait ScheduleBuildPass: Send + Sync + Debug + 'static {
         &mut self,
         world: &mut World,
         graph: &mut ScheduleGraph,
-        dependency_flattened: &mut DiGraph,
+        dependency_flattened: &mut DiGraph<NodeId>,
     ) -> Result<(), ScheduleBuildError>;
 }
 
@@ -39,14 +39,14 @@ pub(super) trait ScheduleBuildPassObj: Send + Sync + Debug {
         &mut self,
         world: &mut World,
         graph: &mut ScheduleGraph,
-        dependency_flattened: &mut DiGraph,
+        dependency_flattened: &mut DiGraph<NodeId>,
     ) -> Result<(), ScheduleBuildError>;
 
     fn collapse_set(
         &mut self,
         set: NodeId,
         systems: &[NodeId],
-        dependency_flattened: &DiGraph,
+        dependency_flattened: &DiGraph<NodeId>,
         dependencies_to_add: &mut Vec<(NodeId, NodeId)>,
     );
     fn add_dependency(&mut self, from: NodeId, to: NodeId, all_options: &TypeIdMap<Box<dyn Any>>);
@@ -56,7 +56,7 @@ impl<T: ScheduleBuildPass> ScheduleBuildPassObj for T {
         &mut self,
         world: &mut World,
         graph: &mut ScheduleGraph,
-        dependency_flattened: &mut DiGraph,
+        dependency_flattened: &mut DiGraph<NodeId>,
     ) -> Result<(), ScheduleBuildError> {
         self.build(world, graph, dependency_flattened)
     }
@@ -64,7 +64,7 @@ impl<T: ScheduleBuildPass> ScheduleBuildPassObj for T {
         &mut self,
         set: NodeId,
         systems: &[NodeId],
-        dependency_flattened: &DiGraph,
+        dependency_flattened: &DiGraph<NodeId>,
         dependencies_to_add: &mut Vec<(NodeId, NodeId)>,
     ) {
         let iter = self.collapse_set(set, systems, dependency_flattened);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1789,7 +1789,7 @@ impl ScheduleGraph {
 
     fn check_for_cross_dependencies(
         &self,
-        dep_results: &CheckGraphResults,
+        dep_results: &CheckGraphResults<NodeId>,
         hier_results_connected: &HashSet<(NodeId, NodeId)>,
     ) -> Result<(), ScheduleBuildError> {
         for &(a, b) in &dep_results.connected {


### PR DESCRIPTION
# Objective

As the first step towards more modular schedule graph structures, we first need to generalize the foundational pieces: the `Graph` data structure and related algorithms.

One might ask: "what are 'more modular schedule graph structures'?" I've come across quite a few use cases that can *almost* be fulfilled with a `Schedule`, but have different-enough requirements that render `Schedule` incompatible as-is:
- My WIP utility AI library needs a graph of read-only systems while linking system output values as inputs to other systems.
- `bevy_render`'s `RenderGraph` is already somewhat `Schedule`-like, but requires all nodes to be read-only and currently only allows a single query to be performed.
- `bevy_render`'s `Extract` schedule could be statically enforced to be read-only, which would allow its executor to skip access conflict checks.
- Occasionally users in the Discord will show interest in statically-dispatched schedules, where a fork-join sequence can be modeled at compile time.

Therefore, by providing modular and generic building blocks for building `Schedule`-shaped things, we can satisfy each of the above and more. And since most of these are likely to make use of `DiGraph` or `UnGraph`, generalizing them is a good start.

One might ask: "what does this give us over `petgraph`?" A couple things:
- `petgraph` is not currently `no_std`, which is a prerequisite to pull it in now that `bevy_ecs` is `no_std`.
    - https://github.com/petgraph/petgraph/pull/747 has been recently opened to fix this.
- The associated types on `GraphNodeId` allows us to use memory-efficient forms for edge and neighbor information, which currently saves us 8 bytes for each edge pair and each neighbor+direction.

## Solution

Replaces the hardcoded usage of `NodeId` with an implementable `GraphNodeId` trait in `DiGraph`/`UnGraph` and associated algorithms. Algorithms implemented as part of `ScheduleGraph` will be tackled in a future PR in order to keep this one small.

## Testing

Current tests are being reused.

---

## Migration Guide

- Bare `DiGraph` or `UnGraph` usage must be changed to `DiGraph<NodeId>` or `UnGraph<NodeId>`, respectively.