### PR TITLE
make various entity wrapper type modules public

### DIFF
--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -13,7 +13,7 @@ use core::{
     option, result,
 };
 
-use super::{Entity, UniqueEntitySlice};
+use super::{unique_slice::UniqueEntitySlice, Entity};
 
 use bevy_platform_support::sync::Arc;
 

--- a/crates/bevy_ecs/src/entity/index_map.rs
+++ b/crates/bevy_ecs/src/entity/index_map.rs
@@ -1,3 +1,7 @@
+//! Contains the [`EntityIndexMap`] type, an [`IndexMap`] pre-configured to use [`EntityHash`] hashing.
+//!
+//! This module is a lightweight wrapper around `indexmap`'s [`IndexMap`] that is more performant for [`Entity`] keys.
+
 use core::{
     fmt::{self, Debug, Formatter},
     hash::BuildHasher,

--- a/crates/bevy_ecs/src/entity/index_set.rs
+++ b/crates/bevy_ecs/src/entity/index_set.rs
@@ -1,3 +1,7 @@
+//! Contains the [`EntityIndexSet`] type, a [`IndexSet`] pre-configured to use [`EntityHash`] hashing.
+//!
+//! This module is a lightweight wrapper around `indexmap`'ss [`IndexSet`] that is more performant for [`Entity`] keys.
+
 use core::{
     fmt::{self, Debug, Formatter},
     hash::BuildHasher,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -50,29 +50,18 @@ pub use entity_set::*;
 pub use map_entities::*;
 pub use visit_entities::*;
 
-mod unique_vec;
-
-pub use unique_vec::*;
-
 mod hash;
 pub use hash::*;
 
 pub mod hash_map;
 pub mod hash_set;
 
-mod index_map;
-mod index_set;
+pub mod index_map;
+pub mod index_set;
 
-pub use index_map::EntityIndexMap;
-pub use index_set::EntityIndexSet;
-
-mod unique_slice;
-
-pub use unique_slice::*;
-
-mod unique_array;
-
-pub use unique_array::UniqueEntityArray;
+pub mod unique_array;
+pub mod unique_slice;
+pub mod unique_vec;
 
 use crate::{
     archetype::{ArchetypeId, ArchetypeRow},

--- a/crates/bevy_ecs/src/entity/unique_array.rs
+++ b/crates/bevy_ecs/src/entity/unique_array.rs
@@ -1,3 +1,5 @@
+//! A wrapper around entity arrays with a uniqueness invariant.
+
 use core::{
     array,
     borrow::{Borrow, BorrowMut},
@@ -18,7 +20,10 @@ use alloc::{
 
 use bevy_platform_support::sync::Arc;
 
-use super::{unique_slice, TrustedEntityBorrow, UniqueEntityIter, UniqueEntitySlice};
+use super::{
+    unique_slice::{self, UniqueEntitySlice},
+    TrustedEntityBorrow, UniqueEntityIter,
+};
 
 /// An array that contains only unique entities.
 ///
@@ -522,6 +527,9 @@ impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEn
     }
 }
 
+/// A by-value array iterator.
+///
+/// Equivalent to [`array::IntoIter`].
 pub type IntoIter<T, const N: usize> = UniqueEntityIter<array::IntoIter<T, N>>;
 
 impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityIter<array::IntoIter<T, N>> {

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -1,3 +1,5 @@
+//! A wrapper around entity slices with a uniqueness invariant.
+
 use core::{
     array::TryFromSliceError,
     borrow::Borrow,
@@ -23,8 +25,9 @@ use alloc::{
 use bevy_platform_support::sync::Arc;
 
 use super::{
-    unique_vec, EntitySet, EntitySetIterator, FromEntitySetIterator, TrustedEntityBorrow,
-    UniqueEntityArray, UniqueEntityIter, UniqueEntityVec,
+    unique_array::UniqueEntityArray,
+    unique_vec::{self, UniqueEntityVec},
+    EntitySet, EntitySetIterator, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
 };
 
 /// A slice that contains only unique entities.

--- a/crates/bevy_ecs/src/entity/unique_vec.rs
+++ b/crates/bevy_ecs/src/entity/unique_vec.rs
@@ -1,3 +1,5 @@
+//! A wrapper around entity [`Vec`]s with a uniqueness invariant.
+
 use core::{
     borrow::{Borrow, BorrowMut},
     mem::MaybeUninit,
@@ -18,8 +20,9 @@ use alloc::{
 use bevy_platform_support::sync::Arc;
 
 use super::{
-    unique_slice, EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityArray,
-    UniqueEntityIter, UniqueEntitySlice,
+    unique_array::UniqueEntityArray,
+    unique_slice::{self, UniqueEntitySlice},
+    EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
 };
 
 /// A `Vec` that contains only unique entities.

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -363,7 +363,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, E: TrustedEntityBorrow + Sync>
     ///
     /// ```
     /// use bevy_utils::Parallel;
-    /// use crate::{bevy_ecs::{prelude::{Component, Res, Resource, Entity}, entity::UniqueEntityVec, system::Query}};
+    /// use crate::{bevy_ecs::{prelude::{Component, Res, Resource, Entity}, entity::unique_vec::UniqueEntityVec, system::Query}};
     /// # use core::slice;
     /// # use crate::bevy_ecs::entity::UniqueEntityIter;
     /// # fn some_expensive_operation(_item: &T) -> usize {

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -1,7 +1,7 @@
 use crate::{
     batching::BatchingStrategy,
     component::Tick,
-    entity::{EntityBorrow, TrustedEntityBorrow, UniqueEntityVec},
+    entity::{unique_vec::UniqueEntityVec, EntityBorrow, TrustedEntityBorrow},
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
-use crate::entity::{TrustedEntityBorrow, UniqueEntitySlice};
+use crate::entity::{unique_slice::UniqueEntitySlice, TrustedEntityBorrow};
 
 use alloc::vec::Vec;
 use core::{fmt, ptr};
@@ -1535,7 +1535,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
-        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
+        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manuals
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
             let chunks = entity_list.chunks_exact(batch_size);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1535,7 +1535,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     {
         // NOTE: If you are changing query iteration code, remember to update the following places, where relevant:
         // QueryIter, QueryIterationCursor, QueryManyIter, QueryCombinationIter,QueryState::par_fold_init_unchecked_manual
-        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manuals
+        // QueryState::par_many_fold_init_unchecked_manual, QueryState::par_many_unique_fold_init_unchecked_manual
 
         bevy_tasks::ComputeTaskPool::get().scope(|scope| {
             let chunks = entity_list.chunks_exact(batch_size);


### PR DESCRIPTION
# Objective

Part of the #16547 series.

The entity wrapper types often have some associated types an aliases with them that cannot be re-exported into an outer module together.
Some helper types are best used with part of their path: `bevy::ecs::entity::index_set::Slice` as `index_set::Slice`.
This has already been done for `entity::hash_set` and `entity::hash_map`.

## Solution

Publicize the `index_set`, `index_map`, `unique_vec`, `unique_slice`, and `unique_array` modules.

## Migration Guide

Any mention or import of types in the affected modules have to add the respective module name to the import path.
F.e.:
`bevy::ecs::entity::EntityIndexSet` -> `bevy::ecs::entity::index_set::EntityIndexSet`