### PR TITLE
Update text_input and virtual_time examples to use Improved Spawning API

### DIFF
--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -34,33 +34,30 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     // sections that will hold text input.
     let font = asset_server.load("fonts/FiraMono-Medium.ttf");
 
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
-                ..default()
-            },
-        ))
-        .with_children(|p| {
-            p.spawn(TextSpan::new(
-                "Click to toggle IME. Press return to start a new line.\n\n",
-            ));
-            p.spawn(TextSpan::new("IME Enabled: "));
-            p.spawn(TextSpan::new("false\n"));
-            p.spawn(TextSpan::new("IME Active:  "));
-            p.spawn(TextSpan::new("false\n"));
-            p.spawn(TextSpan::new("IME Buffer:  "));
-            p.spawn((
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        children![
+            TextSpan::new("Click to toggle IME. Press return to start a new line.\n\n",),
+            TextSpan::new("IME Enabled: "),
+            TextSpan::new("false\n"),
+            TextSpan::new("IME Active:  "),
+            TextSpan::new("false\n"),
+            TextSpan::new("IME Buffer:  "),
+            (
                 TextSpan::new("\n"),
                 TextFont {
                     font: font.clone(),
                     ..default()
                 },
-            ));
-        });
+            ),
+        ],
+    ));
 
     commands.spawn((
         Text2d::new(""),

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -76,8 +76,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
     // info UI
     let font_size = 33.;
 
-    commands
-        .spawn(Node {
+    commands.spawn((
+        Node {
             display: Display::Flex,
             justify_content: JustifyContent::SpaceBetween,
             width: Val::Percent(100.),
@@ -85,20 +85,17 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
             top: Val::Px(0.),
             padding: UiRect::all(Val::Px(20.0)),
             ..default()
-        })
-        .with_children(|builder| {
-            // real time info
-            builder.spawn((
+        },
+        children![
+            (
                 Text::default(),
                 TextFont {
                     font_size,
                     ..default()
                 },
                 RealTime,
-            ));
-
-            // keybindings
-            builder.spawn((
+            ),
+            (
                 Text::new("CONTROLS\nUn/Pause: Space\nSpeed+: Up\nSpeed-: Down"),
                 TextFont {
                     font_size,
@@ -106,10 +103,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                 },
                 TextColor(Color::srgb(0.85, 0.85, 0.85)),
                 TextLayout::new_with_justify(JustifyText::Center),
-            ));
-
-            // virtual time info
-            builder.spawn((
+            ),
+            (
                 Text::default(),
                 TextFont {
                     font_size,
@@ -118,8 +113,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                 TextColor(virtual_color),
                 TextLayout::new_with_justify(JustifyText::Right),
                 VirtualTime,
-            ));
-        });
+            ),
+        ],
+    ));
 }
 
 /// Move sprites using `Real` (unscaled) time


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `text_input` and `virtual_time` examples to use the `children!` macro.  I wanted to keep the PR small but chose to do two examples since they both included only a single `with_children` call.

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

n/a