### PR TITLE
Update scene_viewer example to use Children::spawn

### DIFF
--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -9,8 +9,8 @@
 //! Also illustrates how to read morph target names in [`detect_morphs`].
 
 use crate::scene_viewer_plugin::SceneHandle;
+use bevy::ecs::spawn::SpawnIter;
 use bevy::prelude::*;
-use bevy_ecs::spawn::SpawnIter;
 use std::fmt;
 
 const FONT_SIZE: f32 = 13.0;

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -10,6 +10,7 @@
 
 use crate::scene_viewer_plugin::SceneHandle;
 use bevy::prelude::*;
+use bevy_ecs::spawn::SpawnIter;
 use std::fmt;
 
 const FONT_SIZE: f32 = 13.0;
@@ -273,21 +274,16 @@ fn detect_morphs(
         |(i, target): (usize, &Target)| target.text_span(AVAILABLE_KEYS[i].name, style.clone());
     spans.extend(detected.iter().enumerate().map(target_to_text));
     commands.insert_resource(WeightsControl { weights: detected });
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
-                ..default()
-            },
-        ))
-        .with_children(|p| {
-            for span in spans {
-                p.spawn(span);
-            }
-        });
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        Children::spawn(SpawnIter(spans.into_iter())),
+    ));
 }
 
 pub struct MorphViewerPlugin;


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `scene_viewer` example to use the `Children::spawn` method.

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

## Showcase

n/a

## Migration Guide

n/a