### PR TITLE
FilteredResource returns a Result instead of a simple Option

### DIFF
--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -58,7 +58,9 @@ pub struct ReflectResourceFns {
     pub reflect:
         for<'w> fn(FilteredResources<'w, '_>) -> Result<&'w dyn Reflect, ResourceFetchError>,
     /// Function pointer implementing [`ReflectResource::reflect_mut()`].
-    pub reflect_mut: for<'w> fn(FilteredResourcesMut<'w, '_>) -> Option<Mut<'w, dyn Reflect>>,
+    pub reflect_mut: for<'w> fn(
+        FilteredResourcesMut<'w, '_>,
+    ) -> Result<Mut<'w, dyn Reflect>, ResourceFetchError>,
     /// Function pointer implementing [`ReflectResource::reflect_unchecked_mut()`].
     ///
     /// # Safety
@@ -132,7 +134,7 @@ impl ReflectResource {
     pub fn reflect_mut<'w, 's>(
         &self,
         resources: impl Into<FilteredResourcesMut<'w, 's>>,
-    ) -> Option<Mut<'w, dyn Reflect>> {
+    ) -> Result<Mut<'w, dyn Reflect>, ResourceFetchError> {
         (self.0.reflect_mut)(resources.into())
     }
 

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -8,7 +8,10 @@ use crate::{
     change_detection::Mut,
     component::ComponentId,
     resource::Resource,
-    world::{unsafe_world_cell::UnsafeWorldCell, FilteredResources, FilteredResourcesMut, World},
+    world::{
+        error::ResourceFetchError, unsafe_world_cell::UnsafeWorldCell, FilteredResources,
+        FilteredResourcesMut, World,
+    },
 };
 use bevy_reflect::{FromReflect, FromType, PartialReflect, Reflect, TypePath, TypeRegistry};
 
@@ -52,7 +55,8 @@ pub struct ReflectResourceFns {
     /// Function pointer implementing [`ReflectResource::remove()`].
     pub remove: fn(&mut World),
     /// Function pointer implementing [`ReflectResource::reflect()`].
-    pub reflect: for<'w> fn(FilteredResources<'w, '_>) -> Option<&'w dyn Reflect>,
+    pub reflect:
+        for<'w> fn(FilteredResources<'w, '_>) -> Result<&'w dyn Reflect, ResourceFetchError>,
     /// Function pointer implementing [`ReflectResource::reflect_mut()`].
     pub reflect_mut: for<'w> fn(FilteredResourcesMut<'w, '_>) -> Option<Mut<'w, dyn Reflect>>,
     /// Function pointer implementing [`ReflectResource::reflect_unchecked_mut()`].
@@ -118,7 +122,7 @@ impl ReflectResource {
     pub fn reflect<'w, 's>(
         &self,
         resources: impl Into<FilteredResources<'w, 's>>,
-    ) -> Option<&'w dyn Reflect> {
+    ) -> Result<&'w dyn Reflect, ResourceFetchError> {
         (self.0.reflect)(resources.into())
     }
 

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -59,12 +59,12 @@ pub enum EntityMutableFetchError {
 /// An error that occurs when getting a resource of a given type in a world.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResourceFetchError {
-    /// The resource does not exist in the world.
-    #[error("The resource does not exist in the world.")]
-    MissingResource,
-    /// The resource with the given [`ComponentId`] is not initialized in the world.
-    #[error("The resource with ID {0:?} is not initialized in the world.")]
-    NotInitialized(ComponentId),
+    /// The resource has never been initialized or registered with the world.
+    #[error("The resource has never been initialized or registered with the world. Did you forget to add it using `app.insert_resource` / `app.init_resource`?")]
+    NotRegistered,
+    /// The resource with the given [`ComponentId`] does not currently exist in the world.
+    #[error("The resource with ID {0:?} does not currently exist in the world.")]
+    DoesNotExist(ComponentId),
     /// Cannot get access to the resource with the given [`ComponentId`] in the world as it conflicts with an on going operation.
     #[error("Cannot get access to the resource with ID {0:?} in the world as it conflicts with an on going operation.")]
     NoResourceAccess(ComponentId),

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -55,3 +55,14 @@ pub enum EntityMutableFetchError {
     #[error("The entity with ID {0} was requested mutably more than once")]
     AliasedMutability(Entity),
 }
+
+/// An error that occurs when getting a resource of a given type in a world.
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceFetchError {
+    /// The resource does not exist in the world.
+    #[error("The resource does not exist in the world.")]
+    MissingResource,
+    /// No access to the resource with the given [`ComponentId`] in the world.
+    #[error("No access to the resource with ID {0:?} in the world.")]
+    NoResourceAccess(ComponentId),
+}

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -62,6 +62,9 @@ pub enum ResourceFetchError {
     /// The resource does not exist in the world.
     #[error("The resource does not exist in the world.")]
     MissingResource,
+    /// The resource with the given [`ComponentId`] is not initialized in the world.
+    #[error("The resource with ID {0:?} is not initialized in the world.")]
+    NotInitialized(ComponentId),
     /// Cannot get access to the resource with the given [`ComponentId`] in the world as it conflicts with an on going operation.
     #[error("Cannot get access to the resource with ID {0:?} in the world as it conflicts with an on going operation.")]
     NoResourceAccess(ComponentId),

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -62,7 +62,7 @@ pub enum ResourceFetchError {
     /// The resource does not exist in the world.
     #[error("The resource does not exist in the world.")]
     MissingResource,
-    /// No access to the resource with the given [`ComponentId`] in the world.
-    #[error("No access to the resource with ID {0:?} in the world.")]
+    /// Cannot get access to the resource with the given [`ComponentId`] in the world as it conflicts with an on going operation.
+    #[error("Cannot get access to the resource with ID {0:?} in the world as it conflicts with an on going operation.")]
     NoResourceAccess(ComponentId),
 }

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -165,7 +165,7 @@ impl<'w, 's> FilteredResources<'w, 's> {
 
         // SAFETY: We have read access to this resource
         let (value, ticks, caller) = unsafe { self.world.get_resource_with_ticks(component_id) }
-            .ok_or(ResourceFetchError::MissingResource)?;
+            .ok_or(ResourceFetchError::NotInitialized(component_id))?;
 
         Ok(Ref {
             // SAFETY: `component_id` was obtained from the type ID of `R`.
@@ -183,8 +183,8 @@ impl<'w, 's> FilteredResources<'w, 's> {
             return Err(ResourceFetchError::NoResourceAccess(component_id));
         }
         // SAFETY: We have read access to this resource
-        Ok(unsafe { self.world.get_resource_by_id(component_id) }
-            .ok_or(ResourceFetchError::MissingResource)?)
+        unsafe { self.world.get_resource_by_id(component_id) }
+            .ok_or(ResourceFetchError::NotInitialized(component_id))
     }
 }
 
@@ -492,8 +492,10 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
         if !self.access.has_resource_write(component_id) {
             return Err(ResourceFetchError::NoResourceAccess(component_id));
         }
+
+        // SAFETY: We have read access to this resource
         let (value, ticks, caller) = unsafe { self.world.get_resource_with_ticks(component_id) }
-            .ok_or(ResourceFetchError::MissingResource)?;
+            .ok_or(ResourceFetchError::NotInitialized(component_id))?;
 
         Ok(MutUntyped {
             // SAFETY: We have exclusive access to the underlying storage.

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -44,9 +44,9 @@ use super::error::ResourceFetchError;
 ///
 /// fn resource_system(res: FilteredResources) {
 ///     // The resource exists, but we have no access, so we can't read it.
-///     assert!(res.get::<A>().is_none());
+///     assert!(res.get::<A>().is_err());
 ///     // The resource doesn't exist, so we can't read it.
-///     assert!(res.get::<B>().is_none());
+///     assert!(res.get::<B>().is_err());
 ///     // The resource exists and we have access, so we can read it.
 ///     let c = res.get::<C>().unwrap();
 ///     // The type parameter can be left out if it can be determined from use.
@@ -146,7 +146,7 @@ impl<'w, 's> FilteredResources<'w, 's> {
     }
 
     /// Returns `true` if the `FilteredResources` has access to the given resource.
-    /// Note that [`Self::get()`] may still return `None` if the resource does not exist.
+    /// Note that [`Self::get()`] may still return `Err` if the resource does not exist.
     pub fn has_read<R: Resource>(&self) -> bool {
         let component_id = self.world.components().resource_id::<R>();
         component_id.is_some_and(|component_id| self.access.has_resource_read(component_id))
@@ -288,14 +288,14 @@ impl<'w> From<&'w mut World> for FilteredResources<'w, 'static> {
 ///
 /// fn resource_system(mut res: FilteredResourcesMut) {
 ///     // The resource exists, but we have no access, so we can't read it or write it.
-///     assert!(res.get::<A>().is_none());
-///     assert!(res.get_mut::<A>().is_none());
+///     assert!(res.get::<A>().is_err());
+///     assert!(res.get_mut::<A>().is_err());
 ///     // The resource doesn't exist, so we can't read it or write it.
-///     assert!(res.get::<B>().is_none());
-///     assert!(res.get_mut::<B>().is_none());
+///     assert!(res.get::<B>().is_err());
+///     assert!(res.get_mut::<B>().is_err());
 ///     // The resource exists and we have read access, so we can read it but not write it.
 ///     let c = res.get::<C>().unwrap();
-///     assert!(res.get_mut::<C>().is_none());
+///     assert!(res.get_mut::<C>().is_err());
 ///     // The resource exists and we have write access, so we can read it or write it.
 ///     let d = res.get::<D>().unwrap();
 ///     let d = res.get_mut::<D>().unwrap();
@@ -414,14 +414,14 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
     }
 
     /// Returns `true` if the `FilteredResources` has read access to the given resource.
-    /// Note that [`Self::get()`] may still return `None` if the resource does not exist.
+    /// Note that [`Self::get()`] may still return `Err` if the resource does not exist.
     pub fn has_read<R: Resource>(&self) -> bool {
         let component_id = self.world.components().resource_id::<R>();
         component_id.is_some_and(|component_id| self.access.has_resource_read(component_id))
     }
 
     /// Returns `true` if the `FilteredResources` has write access to the given resource.
-    /// Note that [`Self::get_mut()`] may still return `None` if the resource does not exist.
+    /// Note that [`Self::get_mut()`] may still return `Err` if the resource does not exist.
     pub fn has_write<R: Resource>(&self) -> bool {
         let component_id = self.world.components().resource_id::<R>();
         component_id.is_some_and(|component_id| self.access.has_resource_write(component_id))

--- a/crates/bevy_ecs/src/world/filtered_resource.rs
+++ b/crates/bevy_ecs/src/world/filtered_resource.rs
@@ -158,14 +158,14 @@ impl<'w, 's> FilteredResources<'w, 's> {
             .world
             .components()
             .resource_id::<R>()
-            .ok_or(ResourceFetchError::MissingResource)?;
+            .ok_or(ResourceFetchError::NotRegistered)?;
         if !self.access.has_resource_read(component_id) {
             return Err(ResourceFetchError::NoResourceAccess(component_id));
         }
 
         // SAFETY: We have read access to this resource
         let (value, ticks, caller) = unsafe { self.world.get_resource_with_ticks(component_id) }
-            .ok_or(ResourceFetchError::NotInitialized(component_id))?;
+            .ok_or(ResourceFetchError::DoesNotExist(component_id))?;
 
         Ok(Ref {
             // SAFETY: `component_id` was obtained from the type ID of `R`.
@@ -184,7 +184,7 @@ impl<'w, 's> FilteredResources<'w, 's> {
         }
         // SAFETY: We have read access to this resource
         unsafe { self.world.get_resource_by_id(component_id) }
-            .ok_or(ResourceFetchError::NotInitialized(component_id))
+            .ok_or(ResourceFetchError::DoesNotExist(component_id))
     }
 }
 
@@ -475,7 +475,7 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
             .world
             .components()
             .resource_id::<R>()
-            .ok_or(ResourceFetchError::MissingResource)?;
+            .ok_or(ResourceFetchError::NotRegistered)?;
         // SAFETY: THe caller ensures that there are no conflicting borrows.
         unsafe { self.get_mut_by_id_unchecked(component_id) }
             // SAFETY: The underlying type of the resource is `R`.
@@ -495,7 +495,7 @@ impl<'w, 's> FilteredResourcesMut<'w, 's> {
 
         // SAFETY: We have read access to this resource
         let (value, ticks, caller) = unsafe { self.world.get_resource_with_ticks(component_id) }
-            .ok_or(ResourceFetchError::NotInitialized(component_id))?;
+            .ok_or(ResourceFetchError::DoesNotExist(component_id))?;
 
         Ok(MutUntyped {
             // SAFETY: We have exclusive access to the underlying storage.

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -502,7 +502,7 @@ pub fn process_remote_get_resource_request(
     let reflect_resource =
         get_reflect_resource(&type_registry, &resource_path).map_err(BrpError::resource_error)?;
 
-    let Some(reflected) = reflect_resource.reflect(world) else {
+    let Ok(reflected) = reflect_resource.reflect(world) else {
         return Err(BrpError::resource_not_present(&resource_path));
     };
 
@@ -937,7 +937,7 @@ pub fn process_remote_mutate_resource_request(
     // Get the actual resource value from the world as a `dyn Reflect`.
     let mut reflected_resource = reflect_resource
         .reflect_mut(world)
-        .ok_or_else(|| BrpError::resource_not_present(&resource_path))?;
+        .map_err(|_| BrpError::resource_not_present(&resource_path))?;
 
     // Get the type registration for the field with the given path.
     let value_registration = type_registry

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -381,7 +381,8 @@ impl<'w> DynamicSceneBuilder<'w> {
 
                 let resource = type_registration
                     .data::<ReflectResource>()?
-                    .reflect(self.original_world)?;
+                    .reflect(self.original_world)
+                    .ok()?;
 
                 let resource = type_registration
                     .data::<ReflectFromReflect>()


### PR DESCRIPTION
# Objective
FilteredResource::get should return a Result instead of Option

Fixes #17480 

---

## Migration Guide

Users will need to handle the different return type on FilteredResource::get, FilteredResource::get_id, FilteredResource::get_mut as it is now a Result not an Option.
