### PR TITLE
Update render_primitives example for children! macro

### DIFF
--- a/examples/math/render_primitives.rs
+++ b/examples/math/render_primitives.rs
@@ -368,39 +368,31 @@ fn setup_text(mut commands: Commands, cameras: Query<(Entity, &Camera)>) {
         .iter()
         .find_map(|(entity, camera)| camera.is_active.then_some(entity))
         .expect("run condition ensures existence");
-    commands
-        .spawn((
-            HeaderNode,
-            Node {
-                justify_self: JustifySelf::Center,
-                top: Val::Px(5.0),
-                ..Default::default()
-            },
-            UiTargetCamera(active_camera),
-        ))
-        .with_children(|p| {
-            p.spawn((
-                Text::default(),
-                HeaderText,
-                TextLayout::new_with_justify(JustifyText::Center),
-            ))
-            .with_children(|p| {
-                p.spawn(TextSpan::new("Primitive: "));
-                p.spawn(TextSpan(format!(
-                    "{text}",
-                    text = PrimitiveSelected::default()
-                )));
-                p.spawn(TextSpan::new("\n\n"));
-                p.spawn(TextSpan::new(
+    commands.spawn((
+        HeaderNode,
+        Node {
+            justify_self: JustifySelf::Center,
+            top: Val::Px(5.0),
+            ..Default::default()
+        },
+        UiTargetCamera(active_camera),
+        children![(
+            Text::default(),
+            HeaderText,
+            TextLayout::new_with_justify(JustifyText::Center),
+            children![
+                TextSpan::new("Primitive: "),
+                TextSpan(format!("{text}", text = PrimitiveSelected::default())),
+                TextSpan::new("\n\n"),
+                TextSpan::new(
                     "Press 'C' to switch between 2D and 3D mode\n\
                     Press 'Up' or 'Down' to switch to the next/previous primitive",
-                ));
-                p.spawn(TextSpan::new("\n\n"));
-                p.spawn(TextSpan::new(
-                    "(If nothing is displayed, there's no rendering support yet)",
-                ));
-            });
-        });
+                ),
+                TextSpan::new("\n\n"),
+                TextSpan::new("(If nothing is displayed, there's no rendering support yet)",),
+            ]
+        )],
+    ));
 }
 
 fn update_text(


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `render_primitives` example to use the `children!` macro.  

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

n/a