### PR TITLE
Add child! macro for single child

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -324,11 +324,12 @@ macro_rules! children {
     };
 }
 
-/// Returns a [`Spawn`](crate::spawn::Spawn) that will insert the [`Children`] component, spawn an
-/// entity with the given bundle that relates to the [`Children`] entity via the [`ChildOf`] component, and reserve space
-/// in the [`Children`] for the spawned entity
+/// Returns a [`SpawnRelatedBundle`] that will insert the [`Children`] component, spawn a [`SpawnableList`] of
+/// a single entity with the given bundle, which relates to the [`Children`] entity via the [`ChildOf`] component,
+/// and reserve space in the [`Children`] for the singularly spawned entity.
 ///
-/// Also see [`children`] for a version of this that works with many bundles.
+/// Also see [`children`] for a related macro which spawns multiple children with potentially
+/// different bundles.
 ///
 /// ```
 /// # use bevy_ecs::hierarchy::Children;

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -293,6 +293,12 @@ pub fn validate_parent_has_component<C: Component>(
 ///
 /// Any additional arguments will be interpreted as bundles to be spawned.
 ///
+/// Also see [`child`] for a similar macro which spawns a single child.
+/// While the [`children`] macro can also be used to spawn a single child,
+/// `children![Foo, Bar]` spawns two children, one with Foo, and one with Bar, and `children![(Foo,
+/// Bar)]` spawns one child with both Foo and Bar. `child!((Foo,Bar))` is the alternative provided
+/// for authors seeking the ability to differentiate at a glance.
+///
 /// Also see [`related`](crate::related) for a version of this that works with any [`RelationshipTarget`] type.
 ///
 /// ```
@@ -329,7 +335,12 @@ macro_rules! children {
 /// and reserve space in the [`Children`] for the singularly spawned entity.
 ///
 /// Also see [`children`] for a related macro which spawns multiple children with potentially
-/// different bundles.
+/// different bundles. While the [`children`] macro can also be used to spawn a single child,
+/// `children![Foo, Bar]` spawns two children, one with Foo, and one with Bar, and `children![(Foo,
+/// Bar)]` spawns one child with both Foo and Bar. `child!((Foo,Bar))` is the alternative provided
+/// for authors seeking the ability to differentiate at a glance.
+///
+/// Also see [`related`](crate::related) for a macro similar to [`children`] but for use with any [`RelationshipTarget`] type.
 ///
 /// ```
 /// # use bevy_ecs::hierarchy::Children;

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -323,6 +323,7 @@ pub fn validate_parent_has_component<C: Component>(
 /// [`RelationshipTarget`]: crate::relationship::RelationshipTarget
 /// [`SpawnRelatedBundle`]: crate::spawn::SpawnRelatedBundle
 /// [`SpawnableList`]: crate::spawn::SpawnableList
+/// [`child`]: crate::hierarchy::child
 #[macro_export]
 macro_rules! children {
     [$($child:expr),*$(,)?] => {
@@ -358,6 +359,7 @@ macro_rules! children {
 /// [`RelationshipTarget`]: crate::relationship::RelationshipTarget
 /// [`SpawnRelatedBundle`]: crate::spawn::SpawnRelatedBundle
 /// [`SpawnableList`]: crate::spawn::SpawnableList
+/// [`children`]: crate::hierarchy::children
 #[macro_export]
 macro_rules! child {
     ($child:expr) => {

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -324,6 +324,34 @@ macro_rules! children {
     };
 }
 
+/// Returns a [`Spawn`](crate::spawn::Spawn) that will insert the [`Children`] component, spawn an
+/// entity with the given bundle that relates to the [`Children`] entity via the [`ChildOf`] component, and reserve space
+/// in the [`Children`] for the spawned entity
+///
+/// Also see [`children`] for a version of this that works with many bundles.
+///
+/// ```
+/// # use bevy_ecs::hierarchy::Children;
+/// # use bevy_ecs::name::Name;
+/// # use bevy_ecs::world::World;
+/// # use bevy_ecs::children;
+/// # use bevy_ecs::spawn::{Spawn, SpawnRelated};
+/// let mut world = World::new();
+/// world.spawn((
+///     Name::new("Root"),
+///     child!(Name::new("Child"));
+/// ));
+/// ```
+///
+/// [`RelationshipTarget`]: crate::relationship::RelationshipTarget
+/// [`Spawn`]: crate::spawn::Spawn
+#[macro_export]
+macro_rules! child {
+    ($child:expr) => {
+        $crate::hierarchy::Children::spawn($crate::spawn::Spawn($child))
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -335,7 +335,7 @@ macro_rules! children {
 /// # use bevy_ecs::hierarchy::Children;
 /// # use bevy_ecs::name::Name;
 /// # use bevy_ecs::world::World;
-/// # use bevy_ecs::children;
+/// # use bevy_ecs::child;
 /// # use bevy_ecs::spawn::{Spawn, SpawnRelated};
 /// let mut world = World::new();
 /// world.spawn((

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -340,7 +340,7 @@ macro_rules! children {
 /// let mut world = World::new();
 /// world.spawn((
 ///     Name::new("Root"),
-///     child!(Name::new("Child"));
+///     child!(Name::new("Child")),
 /// ));
 /// ```
 ///

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -323,7 +323,8 @@ pub fn validate_parent_has_component<C: Component>(
 /// [`RelationshipTarget`]: crate::relationship::RelationshipTarget
 /// [`SpawnRelatedBundle`]: crate::spawn::SpawnRelatedBundle
 /// [`SpawnableList`]: crate::spawn::SpawnableList
-/// [`child`]: crate::hierarchy::child
+/// [`child`]: crate::child
+/// [`children`]: crate::children
 #[macro_export]
 macro_rules! children {
     [$($child:expr),*$(,)?] => {
@@ -359,7 +360,7 @@ macro_rules! children {
 /// [`RelationshipTarget`]: crate::relationship::RelationshipTarget
 /// [`SpawnRelatedBundle`]: crate::spawn::SpawnRelatedBundle
 /// [`SpawnableList`]: crate::spawn::SpawnableList
-/// [`children`]: crate::hierarchy::children
+/// [`children`]: crate::children
 #[macro_export]
 macro_rules! child {
     ($child:expr) => {

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -345,7 +345,8 @@ macro_rules! children {
 /// ```
 ///
 /// [`RelationshipTarget`]: crate::relationship::RelationshipTarget
-/// [`Spawn`]: crate::spawn::Spawn
+/// [`SpawnRelatedBundle`]: crate::spawn::SpawnRelatedBundle
+/// [`SpawnableList`]: crate::spawn::SpawnableList
 #[macro_export]
 macro_rules! child {
     ($child:expr) => {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -71,7 +71,7 @@ pub mod prelude {
     pub use crate::{
         bundle::Bundle,
         change_detection::{DetectChanges, DetectChangesMut, Mut, Ref},
-        children,
+        child, children,
         component::Component,
         entity::{Entity, EntityBorrow, EntityMapper},
         error::{BevyError, Result},

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -7,6 +7,7 @@ use bevy::{
     prelude::*,
     sprite::Anchor,
 };
+use bevy_ecs::child;
 
 const BUTTON_RADIUS: f32 = 25.;
 const BUTTON_CLUSTER_RADIUS: f32 = 50.;
@@ -132,41 +133,40 @@ fn setup(mut commands: Commands, meshes: Res<ButtonMeshes>, materials: Res<Butto
 
     // Buttons
 
-    commands
-        .spawn((
-            Transform::from_xyz(BUTTONS_X, BUTTONS_Y, 0.),
-            Visibility::default(),
-        ))
-        .with_children(|parent| {
-            parent.spawn(GamepadButtonBundle::new(
+    commands.spawn((
+        Transform::from_xyz(BUTTONS_X, BUTTONS_Y, 0.),
+        Visibility::default(),
+        children![
+            GamepadButtonBundle::new(
                 GamepadButton::North,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 0.,
                 BUTTON_CLUSTER_RADIUS,
-            ));
-            parent.spawn(GamepadButtonBundle::new(
+            ),
+            GamepadButtonBundle::new(
                 GamepadButton::South,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 0.,
                 -BUTTON_CLUSTER_RADIUS,
-            ));
-            parent.spawn(GamepadButtonBundle::new(
+            ),
+            GamepadButtonBundle::new(
                 GamepadButton::West,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 -BUTTON_CLUSTER_RADIUS,
                 0.,
-            ));
-            parent.spawn(GamepadButtonBundle::new(
+            ),
+            GamepadButtonBundle::new(
                 GamepadButton::East,
                 meshes.circle.clone(),
                 materials.normal.clone(),
                 BUTTON_CLUSTER_RADIUS,
                 0.,
-            ));
-        });
+            ),
+        ],
+    ));
 
     // Start and Pause
 
@@ -188,50 +188,43 @@ fn setup(mut commands: Commands, meshes: Res<ButtonMeshes>, materials: Res<Butto
 
     // D-Pad
 
-    commands
-        .spawn((
-            Transform::from_xyz(-BUTTONS_X, BUTTONS_Y, 0.),
-            Visibility::default(),
-        ))
-        .with_children(|parent| {
-            parent.spawn(GamepadButtonBundle::new(
+    commands.spawn((
+        Transform::from_xyz(-BUTTONS_X, BUTTONS_Y, 0.),
+        Visibility::default(),
+        children![
+            GamepadButtonBundle::new(
                 GamepadButton::DPadUp,
                 meshes.triangle.clone(),
                 materials.normal.clone(),
                 0.,
                 BUTTON_CLUSTER_RADIUS,
-            ));
-            parent.spawn(
-                GamepadButtonBundle::new(
-                    GamepadButton::DPadDown,
-                    meshes.triangle.clone(),
-                    materials.normal.clone(),
-                    0.,
-                    -BUTTON_CLUSTER_RADIUS,
-                )
-                .with_rotation(PI),
-            );
-            parent.spawn(
-                GamepadButtonBundle::new(
-                    GamepadButton::DPadLeft,
-                    meshes.triangle.clone(),
-                    materials.normal.clone(),
-                    -BUTTON_CLUSTER_RADIUS,
-                    0.,
-                )
-                .with_rotation(PI / 2.),
-            );
-            parent.spawn(
-                GamepadButtonBundle::new(
-                    GamepadButton::DPadRight,
-                    meshes.triangle.clone(),
-                    materials.normal.clone(),
-                    BUTTON_CLUSTER_RADIUS,
-                    0.,
-                )
-                .with_rotation(-PI / 2.),
-            );
-        });
+            ),
+            GamepadButtonBundle::new(
+                GamepadButton::DPadDown,
+                meshes.triangle.clone(),
+                materials.normal.clone(),
+                0.,
+                -BUTTON_CLUSTER_RADIUS,
+            )
+            .with_rotation(PI),
+            GamepadButtonBundle::new(
+                GamepadButton::DPadLeft,
+                meshes.triangle.clone(),
+                materials.normal.clone(),
+                -BUTTON_CLUSTER_RADIUS,
+                0.,
+            )
+            .with_rotation(PI / 2.),
+            GamepadButtonBundle::new(
+                GamepadButton::DPadRight,
+                meshes.triangle.clone(),
+                materials.normal.clone(),
+                BUTTON_CLUSTER_RADIUS,
+                0.,
+            )
+            .with_rotation(-PI / 2.),
+        ],
+    ));
 
     // Triggers
 
@@ -275,43 +268,35 @@ fn setup_sticks(
     let live_mid = (live_lower + live_upper) / 2.0;
 
     let mut spawn_stick = |x_pos, y_pos, x_axis, y_axis, button| {
-        commands
-            .spawn((Transform::from_xyz(x_pos, y_pos, 0.), Visibility::default()))
-            .with_children(|parent| {
-                // full extent
-                parent.spawn(Sprite::from_color(
-                    DEAD_COLOR,
-                    Vec2::splat(STICK_BOUNDS_SIZE * 2.),
-                ));
-                // live zone
-                parent.spawn((
+        let style = TextFont {
+            font_size: 13.,
+            ..default()
+        };
+        commands.spawn((
+            Transform::from_xyz(x_pos, y_pos, 0.),
+            Visibility::default(),
+            children![
+                Sprite::from_color(DEAD_COLOR, Vec2::splat(STICK_BOUNDS_SIZE * 2.),),
+                (
                     Sprite::from_color(LIVE_COLOR, Vec2::splat(live_size)),
                     Transform::from_xyz(live_mid, live_mid, 2.),
-                ));
-                // dead zone
-                parent.spawn((
+                ),
+                (
                     Sprite::from_color(DEAD_COLOR, Vec2::splat(dead_size)),
                     Transform::from_xyz(dead_mid, dead_mid, 3.),
-                ));
-                // text
-                let style = TextFont {
-                    font_size: 13.,
-                    ..default()
-                };
-                parent
-                    .spawn((
-                        Text2d::default(),
-                        Transform::from_xyz(0., STICK_BOUNDS_SIZE + 2., 4.),
-                        Anchor::BottomCenter,
-                        TextWithAxes { x_axis, y_axis },
-                    ))
-                    .with_children(|p| {
-                        p.spawn((TextSpan(format!("{:.3}", 0.)), style.clone()));
-                        p.spawn((TextSpan::new(", "), style.clone()));
-                        p.spawn((TextSpan(format!("{:.3}", 0.)), style));
-                    });
-                // cursor
-                parent.spawn((
+                ),
+                (
+                    Text2d::default(),
+                    Transform::from_xyz(0., STICK_BOUNDS_SIZE + 2., 4.),
+                    Anchor::BottomCenter,
+                    TextWithAxes { x_axis, y_axis },
+                    children![
+                        (TextSpan(format!("{:.3}", 0.)), style.clone()),
+                        (TextSpan::new(", "), style.clone()),
+                        (TextSpan(format!("{:.3}", 0.)), style),
+                    ]
+                ),
+                (
                     meshes.circle.clone(),
                     materials.normal.clone(),
                     Transform::from_xyz(0., 0., 5.).with_scale(Vec2::splat(0.15).extend(1.)),
@@ -321,8 +306,9 @@ fn setup_sticks(
                         scale: STICK_BOUNDS_SIZE,
                     },
                     ReactTo(button),
-                ));
-            });
+                ),
+            ],
+        ));
     };
 
     spawn_stick(
@@ -347,25 +333,24 @@ fn setup_triggers(
     materials: Res<ButtonMaterials>,
 ) {
     let mut spawn_trigger = |x, y, button_type| {
-        commands
-            .spawn(GamepadButtonBundle::new(
+        commands.spawn((
+            GamepadButtonBundle::new(
                 button_type,
                 meshes.trigger.clone(),
                 materials.normal.clone(),
                 x,
                 y,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Transform::from_xyz(0., 0., 1.),
-                    Text(format!("{:.3}", 0.)),
-                    TextFont {
-                        font_size: 13.,
-                        ..default()
-                    },
-                    TextWithButtonValue(button_type),
-                ));
-            });
+            ),
+            child!((
+                Transform::from_xyz(0., 0., 1.),
+                Text(format!("{:.3}", 0.)),
+                TextFont {
+                    font_size: 13.,
+                    ..default()
+                },
+                TextWithButtonValue(button_type),
+            )),
+        ));
     };
 
     spawn_trigger(-BUTTONS_X, BUTTONS_Y + 145., GamepadButton::LeftTrigger2);
@@ -374,18 +359,17 @@ fn setup_triggers(
 
 fn setup_connected(mut commands: Commands) {
     // This is UI text, unlike other text in this example which is 2d.
-    commands
-        .spawn((
-            Text::new("Connected Gamepads:\n"),
-            Node {
-                position_type: PositionType::Absolute,
-                top: Val::Px(12.),
-                left: Val::Px(12.),
-                ..default()
-            },
-            ConnectedGamepadsText,
-        ))
-        .with_child(TextSpan::new("None"));
+    commands.spawn((
+        Text::new("Connected Gamepads:\n"),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.),
+            left: Val::Px(12.),
+            ..default()
+        },
+        ConnectedGamepadsText,
+        child!(TextSpan::new("None")),
+    ));
 }
 
 fn update_buttons(

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -2,7 +2,6 @@
 
 use std::f32::consts::PI;
 
-use bevy::ecs::child;
 use bevy::{
     input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadConnectionEvent},
     prelude::*,

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -2,12 +2,12 @@
 
 use std::f32::consts::PI;
 
+use bevy::ecs::child;
 use bevy::{
     input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadConnectionEvent},
     prelude::*,
     sprite::Anchor,
 };
-use bevy_ecs::child;
 
 const BUTTON_RADIUS: f32 = 25.;
 const BUTTON_CLUSTER_RADIUS: f32 = 50.;


### PR DESCRIPTION
# Objective

Contributes to #18238 

While updating the `gamepad_viewer` example, I came across a place where I was using the `children!` macro to spawn a single child, but it had a tuple of components, e.g.
```rs
commands.spawn(
    ...,
    children![(
        Transform::from_xyz(0., 0., 1.),
        Text(format!("{:.3}", 0.)),
        TextFont {
            font_size: 13.,
            ..default()
        },
        TextWithButtonValue(button_type),
    )],
);
```
and I thought it was difficult to tell the difference between that and one that didn't wrap the single child in a tuple at a glance, e.g.
```rs
commands.spawn(
    ...,
    children![
        Transform::from_xyz(0., 0., 1.),
        Text(format!("{:.3}", 0.)),
        TextFont {
            font_size: 13.,
            ..default()
        },
        TextWithButtonValue(button_type),
    ],
);
```
Since this latter example spawns 4 children, each with different Components, and the first spawns a single child with all 4 Components, I thought it might be useful to have a `child!` macro in addition to `children!`, as an option for authors to write code that's easier to grok at a glance:
```rs
commands.spawn(
    ...,
    child!((
        Transform::from_xyz(0., 0., 1.),
        Text(format!("{:.3}", 0.)),
        TextFont {
            font_size: 13.,
            ..default()
        },
        TextWithButtonValue(button_type),
    )),
);
```

## Solution

Adds a new `child!` macro that is basically the same as the `children!` macro but without the repetition.  I'm pretty sure it's right because it worked in my testing but my macro-fu is VERY WEAK so extra eyes are very much appreciated here.

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

Optionally use the `child!` macro in places where you spawn a single child.  It can replace `children!` macros that take a single bundle, or instances of `with_child`.