### PR TITLE
Update shader_prepass, testbed_2d, and first_person_view_model examples to use children! macro

### DIFF
--- a/examples/camera/first_person_view_model.rs
+++ b/examples/camera/first_person_view_model.rs
@@ -104,25 +104,22 @@ fn spawn_view_model(
     let arm = meshes.add(Cuboid::new(0.1, 0.1, 0.5));
     let arm_material = materials.add(Color::from(tailwind::TEAL_200));
 
-    commands
-        .spawn((
-            Player,
-            CameraSensitivity::default(),
-            Transform::from_xyz(0.0, 1.0, 0.0),
-            Visibility::default(),
-        ))
-        .with_children(|parent| {
-            parent.spawn((
+    commands.spawn((
+        Player,
+        CameraSensitivity::default(),
+        Transform::from_xyz(0.0, 1.0, 0.0),
+        Visibility::default(),
+        children![
+            (
                 WorldModelCamera,
                 Camera3d::default(),
                 Projection::from(PerspectiveProjection {
                     fov: 90.0_f32.to_radians(),
                     ..default()
                 }),
-            ));
-
+            ),
             // Spawn view model camera.
-            parent.spawn((
+            (
                 Camera3d::default(),
                 Camera {
                     // Bump the order to render on top of the world model.
@@ -135,10 +132,9 @@ fn spawn_view_model(
                 }),
                 // Only render objects belonging to the view model.
                 RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
-            ));
-
+            ),
             // Spawn the player's right arm.
-            parent.spawn((
+            (
                 Mesh3d(arm),
                 MeshMaterial3d(arm_material),
                 Transform::from_xyz(0.2, -0.1, -0.25),
@@ -146,8 +142,9 @@ fn spawn_view_model(
                 RenderLayers::layer(VIEW_MODEL_RENDER_LAYER),
                 // The arm is free-floating, so shadows would look weird.
                 NotShadowCaster,
-            ));
-        });
+            ),
+        ],
+    ));
 }
 
 fn spawn_world_model(

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -123,23 +123,22 @@ fn setup(
         Transform::from_xyz(4.0, 8.0, 4.0),
     ));
 
-    commands
-        .spawn((
-            Text::default(),
-            Node {
-                position_type: PositionType::Absolute,
-                top: Val::Px(12.0),
-                left: Val::Px(12.0),
-                ..default()
-            },
-        ))
-        .with_children(|p| {
-            p.spawn(TextSpan::new("Prepass Output: transparent\n"));
-            p.spawn(TextSpan::new("\n\n"));
-            p.spawn(TextSpan::new("Controls\n"));
-            p.spawn(TextSpan::new("---------------\n"));
-            p.spawn(TextSpan::new("Space - Change output\n"));
-        });
+    commands.spawn((
+        Text::default(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        },
+        children![
+            TextSpan::new("Prepass Output: transparent\n"),
+            TextSpan::new("\n\n"),
+            TextSpan::new("Controls\n"),
+            TextSpan::new("---------------\n"),
+            TextSpan::new("Space - Change output\n"),
+        ],
+    ));
 }
 
 // This is the struct that will be passed to your shader

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -226,20 +226,19 @@ mod text {
                 Transform::from_translation(dest + Vec3::Z),
                 anchor,
                 StateScoped(super::Scene::Text),
+                children![
+                    (
+                        TextSpan::new(format!("{}, {}\n", anchor.x, anchor.y)),
+                        TextFont::from_font_size(14.0),
+                        TextColor(palettes::tailwind::BLUE_400.into()),
+                    ),
+                    (
+                        TextSpan::new(format!("{justify:?}")),
+                        TextFont::from_font_size(14.0),
+                        TextColor(palettes::tailwind::GREEN_400.into()),
+                    ),
+                ],
             ));
-            text.with_children(|parent| {
-                parent.spawn((
-                    TextSpan::new(format!("{}, {}\n", anchor.x, anchor.y)),
-                    TextFont::from_font_size(14.0),
-                    TextColor(palettes::tailwind::BLUE_400.into()),
-                ));
-                parent.spawn((
-                    TextSpan::new(format!("{justify:?}")),
-                    TextFont::from_font_size(14.0),
-                    TextColor(palettes::tailwind::GREEN_400.into()),
-                ));
-            });
-
             if let Some(bounds) = bounds {
                 text.insert(bounds);
 


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `shader_prepass`, `testbed_2d` and `first_person_view_model` examples to use the `children!` macro.  I wanted to keep the PR small but chose to do 3 examples since they were all limited in scope

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

n/a