### PR TITLE
Update breakout example's stepping plugin to use children

### DIFF
--- a/examples/games/stepping.rs
+++ b/examples/games/stepping.rs
@@ -161,25 +161,20 @@ fn build_ui(
         stepping.always_run_node(label, node);
     }
 
-    commands
-        .spawn((
-            Text::default(),
-            SteppingUi,
-            Node {
-                position_type: PositionType::Absolute,
-                top: state.ui_top,
-                left: state.ui_left,
-                padding: UiRect::all(Val::Px(10.0)),
-                ..default()
-            },
-            BackgroundColor(Color::srgba(1.0, 1.0, 1.0, 0.33)),
-            Visibility::Hidden,
-        ))
-        .with_children(|p| {
-            for span in text_spans {
-                p.spawn(span);
-            }
-        });
+    commands.spawn((
+        Text::default(),
+        SteppingUi,
+        Node {
+            position_type: PositionType::Absolute,
+            top: state.ui_top,
+            left: state.ui_left,
+            padding: UiRect::all(Val::Px(10.0)),
+            ..default()
+        },
+        BackgroundColor(Color::srgba(1.0, 1.0, 1.0, 0.33)),
+        Visibility::Hidden,
+        Children::spawn(text_spans),
+    ));
 }
 
 fn build_stepping_hint(mut commands: Commands) {


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `SteppingPlugin` of the `breakout` example to use the `children!` macro.  Note that in order to test this usage you must use `--features bevy_debug_stepping` and hit the back-tick key to enable stepping mode to see the proper text spans rendered.

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

n/a