### PR TITLE
Switch to `ImDocument` in `BevyManifest`

### DIFF
--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -35,12 +35,12 @@ impl BevyManifest {
             }
         }
 
-        let key = manifest_path.clone();
         let manifest = BevyManifest {
             manifest: Self::read_manifest(&manifest_path),
             modified_time,
         };
-
+        
+        let key = manifest_path.clone();
         let mut manifests = MANIFESTS.write();
         manifests.insert(key, manifest);
 

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -39,7 +39,7 @@ impl BevyManifest {
             manifest: Self::read_manifest(&manifest_path),
             modified_time,
         };
-        
+
         let key = manifest_path.clone();
         let mut manifests = MANIFESTS.write();
         manifests.insert(key, manifest);


### PR DESCRIPTION
# Objective

When reviewing #18263, I noticed that `BevyManifest` internally stores a `DocumentMut`, a mutable TOML document, instead of an `ImDocument`, an immutable one. The process of creating a `DocumentMut` first involves creating a `ImDocument` and then cloning all the referenced spans of text into their own allocations (internally referred to as `despan` in `toml_edit`). As such, using a `DocumentMut` without mutation is strictly additional overhead.

In addition, I noticed that the filesystem operations associated with reading a manifest and parsing it were written to be completed _while_ a write-lock was held on `MANIFESTS`. This likely doesn't translate into a performance or deadlock issue as the manifest files are generally small and can be read quickly, but it is generally considered a bad practice.

## Solution

- Switched to `ImDocument<Box<str>>` instead of `DocumentMut`
- Re-ordered operations in `BevyManifest::shared` to minimise time spent holding open the write-lock on `MANIFESTS`

## Testing

- CI

---

## Notes

I wasn't able to measure a meaningful performance difference with this PR, so this is purely a code quality change and not one for performance.