### PR TITLE
Add process cpu/memory usage to SystemInformationDiagnosticsPlugin

### DIFF
--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -102,7 +102,8 @@ pub mod internal {
             Diagnostic::new(SystemInformationDiagnosticsPlugin::PROCESS_CPU_USAGE).with_suffix("%"),
         );
         diagnostics.add(
-            Diagnostic::new(SystemInformationDiagnosticsPlugin::PROCESS_MEM_USAGE).with_suffix("%"),
+            Diagnostic::new(SystemInformationDiagnosticsPlugin::PROCESS_MEM_USAGE)
+                .with_suffix("MB"),
         );
     }
 
@@ -165,7 +166,7 @@ pub mod internal {
 
                 let process_cpu_usage = sys
                     .process(pid)
-                    .map(|p| p.cpu_usage() as f64)
+                    .map(|p| p.cpu_usage() as f64 / sys.cpus().len() as f64)
                     .unwrap_or(0.0);
 
                 SysinfoRefreshData {

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -105,7 +105,7 @@ pub mod internal {
         );
         diagnostics.add(
             Diagnostic::new(SystemInformationDiagnosticsPlugin::PROCESS_MEM_USAGE)
-                .with_suffix("MB"),
+                .with_suffix("GiB"),
         );
     }
 
@@ -156,14 +156,13 @@ pub mod internal {
                 sys.refresh_cpu_specifics(CpuRefreshKind::nothing().with_cpu_usage());
                 sys.refresh_memory();
                 let system_cpu_usage = sys.global_cpu_usage().into();
-                // `memory()` fns return a value in bytes
-                let total_mem = sys.total_memory() as f64 / BYTES_TO_GIB;
-                let used_mem = sys.used_memory() as f64 / BYTES_TO_GIB;
+                let total_mem = sys.total_memory() as f64;
+                let used_mem = sys.used_memory() as f64;
                 let system_mem_usage = used_mem / total_mem * 100.0;
 
                 let process_mem_usage = sys
                     .process(pid)
-                    .map(|p| p.memory() as f64 / 1024.0 / 1024.0) // Convert to MB
+                    .map(|p| p.memory() as f64 * BYTES_TO_GIB)
                     .unwrap_or(0.0);
 
                 let process_cpu_usage = sys


### PR DESCRIPTION
# Objective

- Adding process specific cpu/mem usages to SystemInformationDiagnosticsPlugin
- Fixes #18135

## Solution

- Adding two new stats by using code provided in #18135

## Testing

- Tested by adding SystemInformationDiagnosticsPlugin into enabling_disabling_diagnostics example
- Tested only on Linux (Ubuntu 24.04.2 LTS)

---

## Showcase

Example output:
> 2025-03-12T18:20:45.355206Z  INFO bevy diagnostic: fps              :  144.139984   (avg 143.968838)    
> 2025-03-12T18:20:45.355229Z  INFO bevy diagnostic: system/cpu_usage :   17.299578%  (avg 16.410863%)    
> 2025-03-12T18:20:45.355235Z  INFO bevy diagnostic: frame_time       :    6.939720ms (avg 6.953508ms)    
> 2025-03-12T18:20:45.355239Z  INFO bevy diagnostic: frame_count      : 1271.000000    
> 2025-03-12T18:20:45.355243Z  INFO bevy diagnostic: process/cpu_usage:  172.151901%  (avg 165.337555%)    
> 2025-03-12T18:20:45.355247Z  INFO bevy diagnostic: process/mem_usage:  400.472656%  (avg 400.478516%)    
> 2025-03-12T18:20:45.355250Z  INFO bevy diagnostic: system/mem_usage :   34.244571%  (avg 34.356289%) 
