### PR TITLE
Small cleanup for ECS error handling

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1276,7 +1276,7 @@ impl App {
 
     /// Set the global system error handler to use for systems that return a [`Result`].
     ///
-    /// See the [`bevy_ecs::result` module-level documentation](../../bevy_ecs/result/index.html)
+    /// See the [`bevy_ecs::error` module-level documentation](bevy_ecs::error)
     /// for more information.
     pub fn set_system_error_handler(
         &mut self,

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -338,7 +338,7 @@ impl SubApp {
 
     /// Set the global error handler to use for systems that return a [`Result`].
     ///
-    /// See the [`bevy_ecs::result` module-level documentation](../../bevy_ecs/result/index.html)
+    /// See the [`bevy_ecs::error` module-level documentation](bevy_ecs::error)
     /// for more information.
     pub fn set_system_error_handler(
         &mut self,

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -1,14 +1,6 @@
-use crate::{component::Tick, error::BevyError, resource::Resource};
-use alloc::borrow::Cow;
+use crate::{error::BevyError, resource::Resource};
 
-/// Additional context for a failed system run.
-pub struct SystemErrorContext {
-    /// The name of the system that failed.
-    pub name: Cow<'static, str>,
-
-    /// The last tick that the system was run.
-    pub last_run: Tick,
-}
+use super::SystemErrorContext;
 
 /// The default systems error handler stored as a resource in the [`World`](crate::world::World).
 pub struct DefaultSystemErrorHandler(pub fn(BevyError, SystemErrorContext));

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -1,6 +1,14 @@
-use crate::{error::BevyError, resource::Resource};
+use crate::{component::Tick, error::BevyError, resource::Resource};
+use alloc::borrow::Cow;
 
-use super::SystemErrorContext;
+/// Additional context for a failed system run.
+pub struct SystemErrorContext {
+    /// The name of the system that failed.
+    pub name: Cow<'static, str>,
+
+    /// The last tick that the system was run.
+    pub last_run: Tick,
+}
 
 /// The default systems error handler stored as a resource in the [`World`](crate::world::World).
 pub struct DefaultSystemErrorHandler(pub fn(BevyError, SystemErrorContext));

--- a/crates/bevy_ecs/src/error/mod.rs
+++ b/crates/bevy_ecs/src/error/mod.rs
@@ -8,10 +8,10 @@
 //! [`panic`] error handler function is used, resulting in a panic with the error message attached.
 //!
 //! You can change the default behavior by registering a custom error handler, either globally or
-//! per `Schedule`:
+//! per [`Schedule`]:
 //!
-//! - [`App::set_system_error_handler`] sets the global error handler for all systems of the
-//!   current [`World`].
+//! - `App::set_system_error_handler` (via `bevy_app`) sets the global error handler for all systems of the
+//!   current [`World`] by modifying the [`DefaultSystemErrorHandler`].
 //! - [`Schedule::set_error_handler`] sets the error handler for all systems of that schedule.
 //!
 //! Bevy provides a number of pre-built error-handlers for you to use:

--- a/crates/bevy_ecs/src/error/mod.rs
+++ b/crates/bevy_ecs/src/error/mod.rs
@@ -76,5 +76,7 @@ mod handler;
 pub use bevy_error::*;
 pub use handler::*;
 
-/// A result type for use in fallible systems.
+/// A result type for use in fallible systems, commands and observers.
+///
+/// The [`BevyError`] type is a type-erased error type with optional Bevy-specific diagnostics.
 pub type Result<T = (), E = BevyError> = core::result::Result<T, E>;

--- a/crates/bevy_ecs/src/error/mod.rs
+++ b/crates/bevy_ecs/src/error/mod.rs
@@ -76,19 +76,7 @@ mod handler;
 pub use bevy_error::*;
 pub use handler::*;
 
-use crate::component::Tick;
-use alloc::borrow::Cow;
-
 /// A result type for use in fallible systems, commands and observers.
 ///
 /// The [`BevyError`] type is a type-erased error type with optional Bevy-specific diagnostics.
 pub type Result<T = (), E = BevyError> = core::result::Result<T, E>;
-
-/// Additional context for a failed system run.
-pub struct SystemErrorContext {
-    /// The name of the system that failed.
-    pub name: Cow<'static, str>,
-
-    /// The last tick that the system was run.
-    pub last_run: Tick,
-}

--- a/crates/bevy_ecs/src/error/mod.rs
+++ b/crates/bevy_ecs/src/error/mod.rs
@@ -76,7 +76,19 @@ mod handler;
 pub use bevy_error::*;
 pub use handler::*;
 
+use crate::component::Tick;
+use alloc::borrow::Cow;
+
 /// A result type for use in fallible systems, commands and observers.
 ///
 /// The [`BevyError`] type is a type-erased error type with optional Bevy-specific diagnostics.
 pub type Result<T = (), E = BevyError> = core::result::Result<T, E>;
+
+/// Additional context for a failed system run.
+pub struct SystemErrorContext {
+    /// The name of the system that failed.
+    pub name: Cow<'static, str>,
+
+    /// The last tick that the system was run.
+    pub last_run: Tick,
+}


### PR DESCRIPTION
# Objective

While poking at https://github.com/bevyengine/bevy/issues/17272, I noticed a few small things to clean up.

## Solution

- Improve the docs
- ~~move `SystemErrorContext` out of the `handler.rs` module: it's not an error handler~~