### PR TITLE
Update getrandom requirement from 0.2.0 to 0.3.1 

### DIFF
--- a/crates/bevy_platform_support/Cargo.toml
+++ b/crates/bevy_platform_support/Cargo.toml
@@ -60,7 +60,7 @@ hashbrown = { version = "0.15.1", features = [
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.1", default-features = false, optional = true }
-getrandom = { version = "0.2.0", default-features = false, optional = true, features = [
+getrandom = { version = "0.3.1", default-features = false, optional = true, features = [
   "js",
 ] }
 

--- a/crates/bevy_platform_support/Cargo.toml
+++ b/crates/bevy_platform_support/Cargo.toml
@@ -60,7 +60,9 @@ hashbrown = { version = "0.15.1", features = [
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.1", default-features = false, optional = true }
-getrandom = { version = "0.3.1", default-features = false, optional = true }
+getrandom = { version = "0.3.1", default-features = false, features = [
+  "wasm_js",
+], optional = true }
 
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 portable-atomic = { version = "1", default-features = false, features = [

--- a/crates/bevy_platform_support/Cargo.toml
+++ b/crates/bevy_platform_support/Cargo.toml
@@ -60,9 +60,7 @@ hashbrown = { version = "0.15.1", features = [
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.1", default-features = false, optional = true }
-getrandom = { version = "0.3.1", default-features = false, optional = true, features = [
-  "js",
-] }
+getrandom = { version = "0.3.1", default-features = false, optional = true }
 
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 portable-atomic = { version = "1", default-features = false, features = [


### PR DESCRIPTION
# Objective

- Fixes #18222

## Solution

- Updated `getrandom` version requirement from 0.2.0 to 0.3.1.
- Replaced the deprecated "js" feature with "wasm_js".

## Testing

- Ran CI locally.