### PR TITLE
Update ui_test requirement from 0.23.0 to 0.29.1

### DIFF
--- a/tools/compile_fail_utils/Cargo.toml
+++ b/tools/compile_fail_utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-ui_test = "0.23.0"
+ui_test = "0.29.1"
 
 [[test]]
 name = "example"

--- a/tools/compile_fail_utils/src/lib.rs
+++ b/tools/compile_fail_utils/src/lib.rs
@@ -7,13 +7,14 @@ use std::{
 pub use ui_test;
 
 use ui_test::{
+    bless_output_files,
     color_eyre::eyre::eyre,
     default_file_filter, default_per_file_config,
     dependencies::DependencyBuilder,
-    run_tests_generic,
+    ignore_output_conflict, run_tests_generic,
     spanned::Spanned,
     status_emitter::{Gha, StatusEmitter, Text},
-    Args, Config, OutputConflictHandling,
+    Args, Config,
 };
 
 /// Use this instead of hand rolling configs.
@@ -44,10 +45,10 @@ fn basic_config(root_dir: impl Into<PathBuf>, args: &Args) -> ui_test::Result<Co
                 .to_string(),
         ),
         output_conflict_handling: if env::var_os("BLESS").is_some() {
-            OutputConflictHandling::Bless
+            bless_output_files
         } else {
             // stderr output changes between rust versions so we just rely on annotations
-            OutputConflictHandling::Ignore
+            ignore_output_conflict
         },
         ..Config::rustc(root_dir)
     };


### PR DESCRIPTION
# Objective

- Fixes #18223.

## Solution

- Updated ui_test requirement from 0.23.0 to 0.29.1.
- Updated code to use the new APIs.

## Testing

- Ran CI locally.