### PR TITLE
Fix nested immediate asset loading.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -727,7 +727,7 @@ mod tests {
                     .map_err(|_| Self::Error::CannotLoadDependency {
                         dependency: dep.into(),
                     })?;
-                let cool = loaded.get_asset().get();
+                let cool = loaded.get_asset();
                 embedded.push_str(&cool.text);
             }
             Ok(CoolText {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -719,7 +719,7 @@ mod tests {
             let mut ron: CoolTextRon = ron::de::from_bytes(&bytes)?;
             let mut embedded = String::new();
             for dep in ron.embedded_dependencies {
-                let loaded = load_context
+                let (_, loaded) = load_context
                     .loader()
                     .immediate()
                     .load::<CoolText>(&dep)

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -654,6 +654,17 @@ impl<'a> LoadContext<'a> {
         )
     }
 
+    /// Gets a previously direct-loaded nested asset by its path.
+    ///
+    /// Returns None if the asset either hasn't been loaded yet or hasn't finished loading. See
+    /// [`Self::loader`] for starting nested asset loads.
+    pub fn get_direct_nested_asset<'p>(
+        &self,
+        path: impl Into<AssetPath<'p>>,
+    ) -> Option<NestedErasedAssetRef> {
+        NestedErasedAssetRef::new(self.nested_direct_loaded_assets.read(), &path.into())
+    }
+
     /// Create a builder for loading nested assets in this context.
     #[must_use]
     pub fn loader(&mut self) -> NestedLoader<'a, '_, StaticTyped, Deferred> {

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -633,6 +633,7 @@ impl<'a> LoadContext<'a> {
                 reader,
                 false,
                 self.populate_hashes,
+                self.nested_direct_loaded_assets,
             )
             .await
             .map_err(|error| LoadDirectError::LoadError {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -650,6 +650,7 @@ impl AssetServer {
             (handle.clone().unwrap(), path.clone())
         };
 
+        let nested_direct_loaded_assets = RwLock::new(NestedAssets::default());
         match self
             .load_with_meta_loader_and_reader(
                 &base_path,
@@ -658,6 +659,7 @@ impl AssetServer {
                 &mut *reader,
                 true,
                 false,
+                &nested_direct_loaded_assets,
             )
             .await
         {
@@ -1335,13 +1337,13 @@ impl AssetServer {
         reader: &mut dyn Reader,
         load_dependencies: bool,
         populate_hashes: bool,
+        nested_direct_loaded_assets: &RwLock<NestedAssets>,
     ) -> Result<CompleteErasedLoadedAsset, AssetLoadError> {
         // TODO: experiment with this
         let asset_path = asset_path.clone_owned();
-        let nested_direct_loaded_assets = RwLock::new(NestedAssets::default());
         let load_context = LoadContext::new(
             self,
-            &nested_direct_loaded_assets,
+            nested_direct_loaded_assets,
             asset_path.clone(),
             load_dependencies,
             populate_hashes,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -26,7 +26,7 @@ use alloc::{
 };
 use atomicow::CowArc;
 use bevy_ecs::prelude::*;
-use bevy_platform_support::collections::HashSet;
+use bevy_platform_support::collections::{HashMap, HashSet};
 use bevy_tasks::IoTaskPool;
 use core::{any::TypeId, future::Future, panic::AssertUnwindSafe, task::Poll};
 use crossbeam_channel::{Receiver, Sender};
@@ -1337,8 +1337,14 @@ impl AssetServer {
     ) -> Result<CompleteErasedLoadedAsset, AssetLoadError> {
         // TODO: experiment with this
         let asset_path = asset_path.clone_owned();
-        let load_context =
-            LoadContext::new(self, asset_path.clone(), load_dependencies, populate_hashes);
+        let nested_direct_loaded_assets = RwLock::new(HashMap::default());
+        let load_context = LoadContext::new(
+            self,
+            &nested_direct_loaded_assets,
+            asset_path.clone(),
+            load_dependencies,
+            populate_hashes,
+        );
         AssertUnwindSafe(loader.load(reader, meta, load_context))
             .catch_unwind()
             .await

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -30,6 +30,7 @@ use bevy_platform_support::collections::{HashMap, HashSet};
 use bevy_tasks::IoTaskPool;
 use core::{any::TypeId, future::Future, panic::AssertUnwindSafe, task::Poll};
 use crossbeam_channel::{Receiver, Sender};
+use derive_more::derive::{Deref, DerefMut};
 use either::Either;
 use futures_lite::{FutureExt, StreamExt};
 use info::*;
@@ -1337,7 +1338,7 @@ impl AssetServer {
     ) -> Result<CompleteErasedLoadedAsset, AssetLoadError> {
         // TODO: experiment with this
         let asset_path = asset_path.clone_owned();
-        let nested_direct_loaded_assets = RwLock::new(HashMap::default());
+        let nested_direct_loaded_assets = RwLock::new(NestedAssets::default());
         let load_context = LoadContext::new(
             self,
             &nested_direct_loaded_assets,
@@ -1786,6 +1787,10 @@ impl RecursiveDependencyLoadState {
         matches!(self, Self::Failed(_))
     }
 }
+
+/// A wrapper for storing nested directly-loaded assets.
+#[derive(Deref, DerefMut, Default)]
+pub(crate) struct NestedAssets(HashMap<AssetPath<'static>, CompleteErasedLoadedAsset>);
 
 /// An error that occurs during an [`Asset`] load.
 #[derive(Error, Debug, Clone)]

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -153,8 +153,9 @@ impl AssetLoader for CoolTextLoader {
                 .loader()
                 .immediate()
                 .load::<Text>(&embedded)
-                .await?;
-            base_text.push_str(&complete_loaded.get_asset().get().0);
+                .await?
+                .1;
+            base_text.push_str(&complete_loaded.get_asset().0);
         }
         for (path, settings_override) in ron.dependencies_with_settings {
             let complete_loaded = load_context
@@ -164,8 +165,9 @@ impl AssetLoader for CoolTextLoader {
                 })
                 .immediate()
                 .load::<Text>(&path)
-                .await?;
-            base_text.push_str(&complete_loaded.get_asset().get().0);
+                .await?
+                .1;
+            base_text.push_str(&complete_loaded.get_asset().0);
         }
         Ok(CoolText {
             text: base_text,


### PR DESCRIPTION
# Objective

- Fixes #18010.

## Solution

- When performing a nested immediate asset load, the asset is stored in the `LoadContext`. Users are only given a `NestedAssetRef`/`NestedErasedAssetRef` which is merely an immutable reference to the assets.
- Once the "outer" asset finishes loading, any nested immediate assets it had loaded also get sent to the asset system (along with the outer asset). This will either refresh the asset if it was already loaded, or it will now be loaded (unless the handle gets dropped).
- Users no longer need to (and can't) add nested immediate assets as subassets.

## Testing

- Updated the existing `load_dependencies` test to account for the fact that nested immediate loaded assets now modify the previously loaded assets.

## Risks

- Nested, immediate asset loads **that use a custom reader** will not give you ownership of the value. These must be accessed through a handle (or cloned). The `asset_decompression` example is relevant here: it needed to be refactored to no longer need to store the decompressed asset.

---

## Migration Guide

Nested, immediate asset loads no longer return a `CompleteLoadedAsset`/`CompleteErasedLoadedAsset`. Instead they return a handle to the asset and a `NestedAssetRef`/`NestedErasedAssetRef` to access its data. Previously, nested asset loads could look like:

```rust
let loaded_asset = load_context.loader().immediate().load<Image>("nested_asset.png").await?;
let image = loaded_asset.get_asset();
// Access the image here, or even call `.take()` to take inner asset!

let handle = load_context.add_loaded_labeled_asset("this_is_nested", image);
// Store this handle somewhere.
```

Now these nested assets are "registered" for you.

```rust
let (handle, loaded_asset) = load_context.loader().immediate().load<Image>("nested_asset.png").await?;
let image = loaded_asset.get_asset();
// Access the image here, but we can't `.take()` it anymore...
// Store this handle somewhere.
```