### PR TITLE
Shrink from_reflect_with_fallback

### DIFF
--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -94,6 +94,7 @@ pub fn from_reflect_with_fallback<T: Reflect + TypePath>(
     world: &mut World,
     registry: &TypeRegistry,
 ) -> T {
+    #[inline(never)]
     fn type_erased(
         reflected: &dyn PartialReflect,
         world: &mut World,


### PR DESCRIPTION
# Objective

Reduce duplicate code generated by `from_reflect_with_fallback`.

## Solution

Polymorphize part of the function.

In a binary with `#[reflect(Component)]` for 100 types (and nothing else), this reduces the size of the release binary by 3.8% in my testing.

The impact on a normal Bevy app will be almost nothing, but I'm hoping to make more PRs like this.