### PR TITLE
Fixed Reflect derive macro on empty enums (#18277)

### DIFF
--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -937,7 +937,10 @@ impl<'a> ReflectEnum<'a> {
             }
         };
 
-        let body = if self.meta.is_remote_wrapper() {
+        let body = if variant_patterns.is_empty() {
+            // enum variant is empty, so &self will never exist
+            quote!(unreachable!())
+        } else if self.meta.is_remote_wrapper() {
             quote! {
                 let #this = <Self as #bevy_reflect_path::ReflectRemote>::as_remote(self);
                 #FQResult::Ok(#bevy_reflect_path::__macro_exports::alloc_utils::Box::new(<Self as #bevy_reflect_path::ReflectRemote>::into_wrapper(#inner)))

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2644,6 +2644,14 @@ bevy_reflect::tests::Test {
     }
 
     #[test]
+    fn should_allow_empty_enums() {
+        #[derive(Reflect)]
+        enum Empty {}
+
+        assert_impl_all!(Empty: Reflect);
+    }
+
+    #[test]
     fn recursive_typed_storage_does_not_hang() {
         #[derive(Reflect)]
         struct Recurse<T>(T);


### PR DESCRIPTION
obtaining a reference to an empty enum is not possible in Rust, so I just replaced any match on self with an `unreachable!()`
I checked if an enum is empty by checking if the `variant_patterns` vec of the `EnumVariantOutputData` struct is empty
Fixes #18277

## Testing

I added one new unit test.
``` rust
#[test]
fn should_allow_empty_enums() {
    #[derive(Reflect)]
    enum Empty {}

    assert_impl_all!(Empty: Reflect);
}
```