### PR TITLE
Fix shadow_biases example

### DIFF
--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -52,14 +52,10 @@ fn setup(
                 intensity: 0.0,
                 range: spawn_plane_depth,
                 color: Color::WHITE,
-                shadow_depth_bias: 0.0,
-                shadow_normal_bias: 0.0,
                 shadows_enabled: true,
                 ..default()
             });
             builder.spawn(DirectionalLight {
-                shadow_depth_bias: 0.0,
-                shadow_normal_bias: 0.0,
                 shadows_enabled: true,
                 ..default()
             });


### PR DESCRIPTION
Fix moire artifacts in https://github.com/bevyengine/bevy/issues/16635.

Default directional light biases are overkill but it's fine.