### PR TITLE
Required components accept const values (#16720)

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -222,6 +222,16 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
                         );
                     });
                 }
+                Some(RequireFunc::Enum(label)) => {
+                    register_required.push(quote! {
+                        components.register_required_components_manual::<Self, #ident>(
+                            required_components,
+                            || #ident::#label,
+                            inheritance_depth,
+                            recursion_check_stack
+                        );
+                    });
+                }
                 None => {
                     register_required.push(quote! {
                         components.register_required_components_manual::<Self, #ident>(
@@ -505,6 +515,7 @@ struct Require {
 enum RequireFunc {
     Path(Path),
     Closure(ExprClosure),
+    Enum(Ident),
 }
 
 struct Relationship {
@@ -611,6 +622,10 @@ impl Parse for Require {
                 let func = content.parse::<Path>()?;
                 Some(RequireFunc::Path(func))
             }
+        } else if input.peek(Token![=]) {
+            let _t: Token![=] = input.parse()?;
+            let label = input.parse::<Ident>()?;
+            Some(RequireFunc::Enum(label))
         } else {
             None
         };

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -189,7 +189,7 @@ use thiserror::Error;
 /// assert_eq!(&C(20), world.entity(id).get::<C>().unwrap());
 /// ```
 ///
-/// for convenience sake, you can abbreviate enum labels or constant values
+/// For convenience sake, you can abbreviate enum labels or constant values, with the type inferred to match that of the component you are requiring:
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -180,10 +180,33 @@ use thiserror::Error;
 /// }
 ///
 /// # let mut world = World::default();
+/// // This will implicitly also insert C with the init_c() constructor
+/// let id = world.spawn(A).id();
+/// assert_eq!(&C(10), world.entity(id).get::<C>().unwrap());
+///
 /// // This will implicitly also insert C with the `|| C(20)` constructor closure
 /// let id = world.spawn(B).id();
 /// assert_eq!(&C(20), world.entity(id).get::<C>().unwrap());
+///
+/// let id = world.
 /// ```
+///
+/// for convenience sake, you can abbreviate enums
+/// ```
+/// #[derive(Component)]
+/// #[require(B = One)]
+/// struct A;
+///
+/// #[derive(Component)]
+/// enum B {
+///    One,
+///    Two
+/// }
+///
+/// # let mut world = World::default();
+/// let id = world.spawn(A).id();
+/// assert_eq!(&B::One, world.entity(id).get::<B>().unwrap());
+/// ````
 ///
 /// Required components are _recursive_. This means, if a Required Component has required components,
 /// those components will _also_ be inserted if they are missing:

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -187,17 +187,17 @@ use thiserror::Error;
 /// // This will implicitly also insert C with the `|| C(20)` constructor closure
 /// let id = world.spawn(B).id();
 /// assert_eq!(&C(20), world.entity(id).get::<C>().unwrap());
-///
-/// let id = world.
 /// ```
 ///
 /// for convenience sake, you can abbreviate enums
+///
 /// ```
+/// # use bevy_ecs::prelude::*;
 /// #[derive(Component)]
 /// #[require(B = One)]
 /// struct A;
 ///
-/// #[derive(Component)]
+/// #[derive(Component, PartialEq, Eq, Debug)]
 /// enum B {
 ///    One,
 ///    Two

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -189,23 +189,32 @@ use thiserror::Error;
 /// assert_eq!(&C(20), world.entity(id).get::<C>().unwrap());
 /// ```
 ///
-/// for convenience sake, you can abbreviate enums
+/// for convenience sake, you can abbreviate enum labels or constant values
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// #[derive(Component)]
-/// #[require(B = One)]
+/// #[require(B = One, C = ONE)]
 /// struct A;
 ///
 /// #[derive(Component, PartialEq, Eq, Debug)]
 /// enum B {
+///    Zero,
 ///    One,
 ///    Two
+/// }
+///
+/// #[derive(Component, PartialEq, Eq, Debug)]
+/// struct C(u8);
+///
+/// impl C {
+///     pub const ONE: Self = Self(1);
 /// }
 ///
 /// # let mut world = World::default();
 /// let id = world.spawn(A).id();
 /// assert_eq!(&B::One, world.entity(id).get::<B>().unwrap());
+/// assert_eq!(&C(1), world.entity(id).get::<C>().unwrap());
 /// ````
 ///
 /// Required components are _recursive_. This means, if a Required Component has required components,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2847,3 +2847,28 @@ mod tests {
     #[derive(Component, VisitEntities, VisitEntitiesMut)]
     struct MyEntitiesTuple(Vec<Entity>, Entity, #[visit_entities(ignore)] usize);
 }
+
+mod temp {
+    use crate::*;
+    use component::Component;
+
+    #[derive(Component)]
+    enum MyEnum {
+        Unit,
+        Tuple(u16),
+        Struct { a: u8, b: u8 },
+    }
+
+    // #[derive(Component)]
+    // #[require(MyEnum::Unit)]
+    // pub struct StructWithUnit;
+
+    // #[derive(Component)]
+    // #[require(MyEnum::Tuple(2))]
+    // pub struct StructWithTuple;
+
+    #[derive(Component)]
+    // #[require(MyEnum::Struct { a: 1, b: 2})]
+    #[require(MyEnum = Unit)]
+    pub struct StructWithStruct;
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2847,28 +2847,3 @@ mod tests {
     #[derive(Component, VisitEntities, VisitEntitiesMut)]
     struct MyEntitiesTuple(Vec<Entity>, Entity, #[visit_entities(ignore)] usize);
 }
-
-mod temp {
-    use crate::*;
-    use component::Component;
-
-    #[derive(Component)]
-    enum MyEnum {
-        Unit,
-        Tuple(u16),
-        Struct { a: u8, b: u8 },
-    }
-
-    // #[derive(Component)]
-    // #[require(MyEnum::Unit)]
-    // pub struct StructWithUnit;
-
-    // #[derive(Component)]
-    // #[require(MyEnum::Tuple(2))]
-    // pub struct StructWithTuple;
-
-    #[derive(Component)]
-    // #[require(MyEnum::Struct { a: 1, b: 2})]
-    #[require(MyEnum = Unit)]
-    pub struct StructWithStruct;
-}


### PR DESCRIPTION
# Objective

Const values should be more ergonomic to insert, since this is too verbose
``` rust
#[derive(Component)]
#[require(
    LockedAxes(||LockedAxes::ROTATION_LOCKED),
)]
pub struct CharacterController;
```
instead, users can now abbreviate that nonsense like this
``` rust
#[derive(Component)]
#[require(
    LockedAxes = ROTATION_LOCKED),
)]
pub struct CharacterController;
```
it also works for enum labels.
I chose to omit the type, since were trying to reduce typing here. The alternative would have been this:
```rust
#[require(
    LockedAxes = LockedAxes::ROTATION_LOCKED),
)]
```
This of course has its disadvantages, since the const has to be associated, but the old closure method is still possible, so I dont think its a problem.
- Fixes #16720

## Testing

I added one new test in the docs, which also explain the new change. I also saw that the docs for the required components on line 165 was missing an assertion, so I added it back in
