### PR TITLE
Derive Macro for MapEntites (#17611)

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate proc_macro;
 
 mod component;
+mod map_entities;
 mod query_data;
 mod query_filter;
 mod states;
@@ -611,6 +612,11 @@ pub fn derive_states(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(SubStates, attributes(source))]
 pub fn derive_substates(input: TokenStream) -> TokenStream {
     states::derive_substates(input)
+}
+
+#[proc_macro_derive(MapEntities)]
+pub fn derive_map_entities(input: TokenStream) -> TokenStream {
+    map_entities::derive_map_entities(input)
 }
 
 #[proc_macro_derive(FromWorld, attributes(from_world))]

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -614,7 +614,7 @@ pub fn derive_substates(input: TokenStream) -> TokenStream {
     states::derive_substates(input)
 }
 
-#[proc_macro_derive(MapEntities)]
+#[proc_macro_derive(MapEntities, attributes(skip_mapping))]
 pub fn derive_map_entities(input: TokenStream) -> TokenStream {
     map_entities::derive_map_entities(input)
 }

--- a/crates/bevy_ecs/macros/src/map_entities.rs
+++ b/crates/bevy_ecs/macros/src/map_entities.rs
@@ -17,28 +17,28 @@ fn map_struct(name: syn::Ident, fields: &Fields) -> proc_macro2::TokenStream {
     let mut map_entities = vec![];
 
     'fields: for (i, field) in fields.iter().enumerate() {
-        // skip that field
+        // check for skipping fields
         for attr in &field.attrs {
             if attr.path().is_ident("skip_mapping") {
                 match &attr.meta {
+                    // skip that fields
                     syn::Meta::Path(_) => continue 'fields,
+                    // the attribute has been used incorrectly
                     _ => panic!("just use the bare `#[skip_mapping]`"),
                 }
             }
         }
 
         let ty = &field.ty;
-        let map_field = if let Some(field_name) = &field.ident {
-            // Named field (struct)
-            quote! {
-                <#ty as bevy_ecs::entity::MapEntities>::map_entities(&mut self.#field_name, entity_mapper);
-            }
-        } else {
+        let member = match &field.ident {
+            // a named field (struct)
+            Some(field_name) => syn::Member::Named(field_name.clone()),
             // Unnamed field (tuple-like struct)
-            let idx = syn::Index::from(i);
-            quote! {
-                <#ty as bevy_ecs::entity::MapEntities>::map_entities(&mut self.#idx, entity_mapper);
-            }
+            None => syn::Member::Unnamed(syn::Index::from(i)),
+        };
+
+        let map_field = quote! {
+            <#ty as bevy_ecs::entity::MapEntities>::map_entities(&mut self.#member, entity_mapper);
         };
 
         map_entities.push(map_field);

--- a/crates/bevy_ecs/macros/src/map_entities.rs
+++ b/crates/bevy_ecs/macros/src/map_entities.rs
@@ -8,7 +8,8 @@ pub(super) fn derive_map_entities(input: TokenStream) -> TokenStream {
 
     match input.data {
         Data::Struct(data_struct) => map_struct(name, &data_struct.fields),
-        _ => unimplemented!(),
+        Data::Enum(data_enum) => map_enum(name, &data_enum.variants),
+        Data::Union(_) => panic!("MapEntities is only valid on structs or enums"),
     }
     .into()
 }
@@ -16,17 +17,9 @@ pub(super) fn derive_map_entities(input: TokenStream) -> TokenStream {
 fn map_struct(name: syn::Ident, fields: &Fields) -> proc_macro2::TokenStream {
     let mut map_entities = vec![];
 
-    'fields: for (i, field) in fields.iter().enumerate() {
-        // check for skipping fields
-        for attr in &field.attrs {
-            if attr.path().is_ident("skip_mapping") {
-                match &attr.meta {
-                    // skip that fields
-                    syn::Meta::Path(_) => continue 'fields,
-                    // the attribute has been used incorrectly
-                    _ => panic!("just use the bare `#[skip_mapping]`"),
-                }
-            }
+    for (i, field) in fields.iter().enumerate() {
+        if skip_mapping(&field.attrs) {
+            continue;
         }
 
         let ty = &field.ty;
@@ -45,10 +38,108 @@ fn map_struct(name: syn::Ident, fields: &Fields) -> proc_macro2::TokenStream {
     }
 
     quote! {
-     impl MapEntities for #name {
+         impl MapEntities for #name {
             fn map_entities<M: bevy_ecs::entity::EntityMapper>(&mut self, entity_mapper: &mut M) {
                 #(#map_entities)*
             }
         }
     }
+}
+
+// fn map_enum(name:syn::Ident, variantes: &[])
+
+fn map_enum(
+    name: syn::Ident,
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
+) -> proc_macro2::TokenStream {
+    let variants = variants.iter().map(|variant| {
+        let variant_name = &variant.ident;
+        let pattern = get_enum_variant_pattern(&variant.fields);
+        let map_entities = map_enum_variant(&variant.fields);
+
+        quote! {
+            #name::#variant_name #pattern => {
+                #map_entities
+            }
+        }
+    });
+
+    quote! {
+        impl MapEntities for #name {
+            fn map_entities<M: bevy_ecs::entity::EntityMapper>(&mut self, entity_mapper:&mut M) {
+                match self {
+                    #(#variants)*
+                }
+            }
+        }
+    }
+}
+
+/// Generates the match pattern for unnamed fields (e.g., `(field_0, field_1)`)
+///
+/// Or named fields (e.g., `(item, quantity)`)
+fn get_enum_variant_pattern(fields: &Fields) -> proc_macro2::TokenStream {
+    match fields {
+        Fields::Named(named_fields) => {
+            let field_vars = named_fields.named.iter().map(|field| {
+                let var_name = field.ident.as_ref().unwrap();
+                quote! { #var_name }
+            });
+            quote! { {#(#field_vars),*} }
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let field_vars = (0..unnamed_fields.unnamed.len()).map(|i| {
+                let var_name =
+                    syn::Ident::new(&format!("field_{}", i), proc_macro2::Span::call_site());
+                quote! { #var_name }
+            });
+            quote! { ( #(#field_vars),* ) }
+        }
+        Fields::Unit => quote! {},
+    }
+}
+
+// Function to generate code to map fields for an enum variant
+fn map_enum_variant(fields: &Fields) -> proc_macro2::TokenStream {
+    let mut map_entities = vec![];
+
+    for (i, field) in fields.iter().enumerate() {
+        if skip_mapping(&field.attrs) {
+            continue;
+        }
+
+        let map_field = match &field.ident {
+            // named field
+            Some(field_name) => field_name.clone(),
+            // Unnamed field
+            None => syn::Ident::new(&format!("field_{}", i), proc_macro2::Span::call_site()),
+        };
+
+        let map_field = quote! {
+            #map_field.map_entities(entity_mapper);
+        };
+
+        map_entities.push(map_field);
+    }
+
+    quote! {
+        #(#map_entities)*
+    }
+}
+
+/// check if any attribute contains `skip_mapping`
+fn skip_mapping(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("skip_mapping") {
+            continue;
+        }
+        match &attr.meta {
+            // skip that fields
+            syn::Meta::Path(_) => return true,
+            // the attribute has been used incorrectly
+            _ => panic!("just use the bare `#[skip_mapping]`"),
+        }
+    }
+
+    false
 }

--- a/crates/bevy_ecs/macros/src/map_entities.rs
+++ b/crates/bevy_ecs/macros/src/map_entities.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Attribute, Data, DeriveInput, Fields};
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
 
 pub(super) fn derive_map_entities(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_ecs/macros/src/map_entities.rs
+++ b/crates/bevy_ecs/macros/src/map_entities.rs
@@ -1,0 +1,43 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Fields, Path, Type};
+
+pub(super) fn derive_map_entities(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident.clone();
+
+    let ty = &input.ident;
+    let component_trait: Path = parse_quote!(::bevy_ecs::component::Component);
+
+    todo!()
+}
+
+// Function to generate code to map fields for a struct
+fn map_struct_fields(fields: &Fields) -> proc_macro2::TokenStream {
+    let mut map_entities = vec![];
+
+    for (i, field) in fields.iter().enumerate() {
+        // let map_field = if is_primitive(&field.ty) {
+        //     quote! {}
+        // } else if let Some(field_name) = &field.ident {
+        //     // Named field (struct)
+        //     quote! {
+        //         self.#field_name.auto_map_entities(entity_mapper);
+        //     }
+        // } else {
+        //     // Unnamed field (tuple-like struct or enum variant)
+        //     let idx = syn::Index::from(i);
+        //     quote! {
+        //         self.#idx.auto_map_entities(entity_mapper);
+        //     }
+        // };
+
+        // map_entities.push(map_field);
+        println!("field: {field:#?}");
+    }
+    todo!()
+
+    // quote! {
+    //     #(#map_entities)*
+    // }
+}

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -343,4 +343,19 @@ mod tests {
         // The SceneEntityMapper should leave `Entities` in a flushed state.
         assert!(!world.entities.needs_flush());
     }
+
+    #[test]
+    #[ignore = "todo"]
+    fn entity_mapper_macro_on_tuple_struct() {
+        todo!()
+    }
+
+    #[test]
+    #[ignore = "todo"]
+    fn entity_mapper_macro_on_enum() {
+        // check named variant
+        // check unnamed variant
+        // include #[skip_mapping]
+        todo!()
+    }
 }

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -63,7 +63,7 @@ pub use bevy_ecs_macros::MapEntities;
 ///
 /// # #[derive(MapEntities)]
 /// # struct TestTuple(A);
-///
+/// #
 /// /* the above derive macro is equivalent to this
 /// impl MapEntities for MyStruct {
 ///     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
@@ -73,8 +73,6 @@ pub use bevy_ecs_macros::MapEntities;
 /// }
 /// */
 /// ```
-///
-///
 pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///
@@ -278,7 +276,7 @@ impl<'m> SceneEntityMapper<'m> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        entity::{hash_map::EntityHashMap, Entity, EntityMapper, SceneEntityMapper},
+        entity::{hash_map::EntityHashMap, Entity, EntityMapper, MapEntities, SceneEntityMapper},
         world::World,
     };
 
@@ -345,17 +343,23 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "todo"]
-    fn entity_mapper_macro_on_tuple_struct() {
-        todo!()
-    }
-
-    #[test]
-    #[ignore = "todo"]
+    #[expect(dead_code, reason = "just test if it compiles")]
     fn entity_mapper_macro_on_enum() {
-        // check named variant
-        // check unnamed variant
-        // include #[skip_mapping]
-        todo!()
+        #[derive(MapEntities)]
+        enum EmptyEnum {}
+
+        #[derive(MapEntities)]
+        struct A;
+        struct B;
+
+        #[derive(MapEntities)]
+        enum TestEnum {
+            Unnamed(A, #[skip_mapping] B),
+            Named {
+                a: A,
+                #[skip_mapping]
+                _b: B,
+            },
+        }
     }
 }

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -3,7 +3,7 @@ use crate::{
     identifier::masks::{IdentifierMask, HIGH_MASK},
     world::World,
 };
-
+pub use bevy_ecs_macros::MapEntities;
 use super::{hash_map::EntityHashMap, VisitEntitiesMut};
 
 /// Operation to map all contained [`Entity`] fields in a type to new values.

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,10 +1,10 @@
+use super::{hash_map::EntityHashMap, VisitEntitiesMut};
 use crate::{
     entity::Entity,
     identifier::masks::{IdentifierMask, HIGH_MASK},
     world::World,
 };
 pub use bevy_ecs_macros::MapEntities;
-use super::{hash_map::EntityHashMap, VisitEntitiesMut};
 
 /// Operation to map all contained [`Entity`] fields in a type to new values.
 ///
@@ -44,16 +44,16 @@ use super::{hash_map::EntityHashMap, VisitEntitiesMut};
 ///     }
 /// }
 /// ```
-/// 
-/// a derive macro is avaliable to reduce boilerplate
+///
+/// a derive macro is available to reduce boilerplate
 /// ```
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::entity::MapEntities;
-/// 
+///
 /// #[derive(MapEntities)]
 /// pub struct A;
 /// pub struct B;
-/// 
+///
 /// #[derive(MapEntities)]
 /// struct MyStruct {
 ///     a: A,
@@ -73,8 +73,8 @@ use super::{hash_map::EntityHashMap, VisitEntitiesMut};
 /// }
 /// */
 /// ```
-/// 
-/// 
+///
+///
 pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -44,6 +44,37 @@ use super::{hash_map::EntityHashMap, VisitEntitiesMut};
 ///     }
 /// }
 /// ```
+/// 
+/// a derive macro is avaliable to reduce boilerplate
+/// ```
+/// use bevy_ecs::prelude::*;
+/// use bevy_ecs::entity::MapEntities;
+/// 
+/// #[derive(MapEntities)]
+/// pub struct A;
+/// pub struct B;
+/// 
+/// #[derive(MapEntities)]
+/// struct MyStruct {
+///     a: A,
+///     #[skip_mapping]
+///     b: B,
+/// }
+///
+/// # #[derive(MapEntities)]
+/// # struct TestTuple(A);
+///
+/// /* the above derive macro is equivalent to this
+/// impl MapEntities for MyStruct {
+///     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+///         self.a.map_entities(entity_mapper);
+///         // self.b is skipped because of the #[skip_mapping] attribute
+///     }
+/// }
+/// */
+/// ```
+/// 
+/// 
 pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2847,3 +2847,12 @@ mod tests {
     #[derive(Component, VisitEntities, VisitEntitiesMut)]
     struct MyEntitiesTuple(Vec<Entity>, Entity, #[visit_entities(ignore)] usize);
 }
+
+mod temp {
+    use crate::prelude::*;
+    use crate::entity::MapEntities;
+
+    #[derive(MapEntities)]
+    // #[derive(Component, MapEntities)]
+    struct MyStruct;
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2849,10 +2849,35 @@ mod tests {
 }
 
 mod temp {
-    use crate::prelude::*;
     use crate::entity::MapEntities;
+    use crate::prelude::*;
+
+    #[derive(Component)]
+    struct A;
+    #[derive(Component)]
+    struct B;
 
     #[derive(MapEntities)]
-    // #[derive(Component, MapEntities)]
-    struct MyStruct;
+    struct MyStruct(A);
+    // #[derive(MapEntities)]
+    // struct MyStruct {
+    //     a: A,
+    //     b: B,
+    // }
+
+    impl MapEntities for A {
+        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+            todo!()
+        }
+    }
+    // impl MapEntities for B {
+    //     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+    //         todo!()
+    //     }
+    // }
+
+    // fn xxx(s:MyStruct, mapper:&mut impl EntityMapper){
+    //     let x = s.a;
+    //     <A as bevy_ecs::entity::MapEntities>::map_entities(&mut s,mapper);
+    // }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2847,39 +2847,3 @@ mod tests {
     #[derive(Component, VisitEntities, VisitEntitiesMut)]
     struct MyEntitiesTuple(Vec<Entity>, Entity, #[visit_entities(ignore)] usize);
 }
-
-mod temp {
-    use crate::entity::MapEntities;
-    use crate::prelude::*;
-
-    #[derive(Component)]
-    struct A;
-    #[derive(Component)]
-    struct B;
-
-    // #[derive(MapEntities)]
-    // struct MyStruct(A);
-
-    #[derive(MapEntities)]
-    struct MyStruct {
-        a: A,
-        #[skip_mapping]
-        b: B,
-    }
-
-    impl MapEntities for A {
-        fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-            todo!()
-        }
-    }
-    // impl MapEntities for B {
-    //     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-    //         todo!()
-    //     }
-    // }
-
-    // fn xxx(s:MyStruct, mapper:&mut impl EntityMapper){
-    //     let x = s.a;
-    //     <A as bevy_ecs::entity::MapEntities>::map_entities(&mut s,mapper);
-    // }
-}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -2857,13 +2857,15 @@ mod temp {
     #[derive(Component)]
     struct B;
 
-    #[derive(MapEntities)]
-    struct MyStruct(A);
     // #[derive(MapEntities)]
-    // struct MyStruct {
-    //     a: A,
-    //     b: B,
-    // }
+    // struct MyStruct(A);
+
+    #[derive(MapEntities)]
+    struct MyStruct {
+        a: A,
+        #[skip_mapping]
+        b: B,
+    }
 
     impl MapEntities for A {
         fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {


### PR DESCRIPTION
# Objective
instead of writing boilerplate like this
```rust
impl MapEntities for Foo {
    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
        self.a.map_entities(entity_mapper);
        self.b.map_entities(entity_mapper);
    }
}
```
users can now use the derive macro `MapEntities`.
If any fields dont implement that trait, they can be skipped with a `#[skip_mapping]` attribute.
```rust
#[derive(MapEntities)]
struct Foo {
    a: A,
    b: B,
    #[skip_mapping]
    c: C, // C doesnt implement MapEntities, so we need to skip it
}
```
Fixes #17611

## Solution

My implementation is a heavily simplified version of @Liam19's version, as I didnt want to add too much complexity at once, and I am not familiar with that trait. So feedback is appreciated.
Since its possible that people want to derive enums as well, I have put the derive function in its own file, so that it has space to grow

## Testing

Theres now an example in the documentation

