### PR TITLE
Prefer `core::time::Duration` over `std::time::Duration`

### DIFF
--- a/benches/benches/bevy_picking/ray_mesh_intersection.rs
+++ b/benches/benches/bevy_picking/ray_mesh_intersection.rs
@@ -1,5 +1,5 @@
 use core::hint::black_box;
-use std::time::Duration;
+use core::time::Duration;
 
 use benches::bench;
 use bevy_math::{Dir3, Mat4, Ray3d, Vec3};

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -372,7 +372,7 @@ use thiserror::Error;
 /// use bevy_ecs::component::Component;
 ///
 /// // `Duration` is defined in the `std` crate.
-/// use std::time::Duration;
+/// use core::time::Duration;
 ///
 /// // It is not possible to implement `Component` for `Duration` from this position, as they are
 /// // both foreign items, defined in an external crate. However, nothing prevents to define a new

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -135,7 +135,7 @@ plugin_group! {
     /// or remove the loop using [`run_once`](crate::app::ScheduleRunnerPlugin::run_once).
     /// # Example:
     /// ```rust, no_run
-    /// # use std::time::Duration;
+    /// # use core::time::Duration;
     /// # use bevy_app::{App, PluginGroup, ScheduleRunnerPlugin};
     /// # use bevy_internal::MinimalPlugins;
     /// App::new().add_plugins(MinimalPlugins.set(ScheduleRunnerPlugin::run_loop(

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -9,7 +9,7 @@ use core::time::Duration;
 ///
 /// ```
 /// # use bevy_time::*;
-/// use std::time::Duration;
+/// use core::time::Duration;
 /// let mut stopwatch = Stopwatch::new();
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 ///
@@ -52,7 +52,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(1));
@@ -73,7 +73,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
@@ -105,7 +105,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.set_elapsed(Duration::from_secs_f32(1.0));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
@@ -122,7 +122,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
@@ -140,7 +140,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
@@ -157,7 +157,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.0));
@@ -193,7 +193,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut stopwatch = Stopwatch::new();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// stopwatch.reset();

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -57,7 +57,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     ///
     /// let mut timer_once = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer_once.tick(Duration::from_secs_f32(1.5));
@@ -83,7 +83,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// assert!(timer.just_finished());
@@ -103,7 +103,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.elapsed(), Duration::from_secs_f32(0.5));
@@ -134,7 +134,7 @@ impl Timer {
     /// #
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.set_elapsed(Duration::from_secs(2));
     /// assert_eq!(timer.elapsed(), Duration::from_secs(2));
@@ -151,7 +151,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let timer = Timer::new(Duration::from_secs(1), TimerMode::Once);
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
     /// ```
@@ -165,7 +165,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.5, TimerMode::Once);
     /// timer.set_duration(Duration::from_secs(1));
     /// assert_eq!(timer.duration(), Duration::from_secs(1));
@@ -217,7 +217,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// let mut repeating = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.tick(Duration::from_secs_f32(1.5));
@@ -273,7 +273,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.pause();
     /// timer.tick(Duration::from_secs_f32(0.5));
@@ -291,7 +291,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.pause();
     /// timer.tick(Duration::from_secs_f32(0.5));
@@ -330,7 +330,7 @@ impl Timer {
     /// Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(1.5));
     /// timer.reset();
@@ -349,7 +349,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.fraction(), 0.25);
@@ -368,7 +368,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.fraction_remaining(), 0.75);
@@ -384,7 +384,7 @@ impl Timer {
     /// ```
     /// # use bevy_time::*;
     /// use std::cmp::Ordering;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// let result = timer.remaining_secs().total_cmp(&1.5);
@@ -400,7 +400,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
     /// assert_eq!(timer.remaining(), Duration::from_secs_f32(1.5));
@@ -419,7 +419,7 @@ impl Timer {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// let mut timer = Timer::from_seconds(1.0, TimerMode::Repeating);
     /// timer.tick(Duration::from_secs_f32(6.0));
     /// assert_eq!(timer.times_finished_this_tick(), 6);

--- a/examples/2d/sprite_animation.rs
+++ b/examples/2d/sprite_animation.rs
@@ -2,7 +2,7 @@
 //!
 //! See `sprite_sheet.rs` for an example where the sprite animation loops indefinitely.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -6,8 +6,8 @@ use bevy::{
     prelude::*,
     tasks::{block_on, futures_lite::future, AsyncComputeTaskPool, Task},
 };
+use core::time::Duration;
 use rand::Rng;
-use std::time::Duration;
 
 fn main() {
     App::new()

--- a/examples/audio/pitch.rs
+++ b/examples/audio/pitch.rs
@@ -1,7 +1,7 @@
 //! This example illustrates how to play a single-frequency sound (aka a pitch)
 
 use bevy::prelude::*;
-use std::time::Duration;
+use core::time::Duration;
 
 fn main() {
     App::new()

--- a/examples/diagnostics/enabling_disabling_diagnostic.rs
+++ b/examples/diagnostics/enabling_disabling_diagnostic.rs
@@ -1,6 +1,6 @@
 //! Shows how to disable/re-enable a Diagnostic during runtime
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},

--- a/examples/ecs/observer_propagation.rs
+++ b/examples/ecs/observer_propagation.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to propagate events through the hierarchy with observers.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{log::LogPlugin, prelude::*, time::common_conditions::on_timer};
 use rand::{seq::IteratorRandom, thread_rng, Rng};

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -3,7 +3,7 @@
 //! This example sets up many animated sprites in different sizes, rotations, and scales in the world.
 //! It also moves the camera over them to see how well frustum culling works.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -1,7 +1,7 @@
 //! Shows how `Time<Virtual>` can be used to pause, resume, slow down
 //! and speed up a game.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{
     color::palettes::css::*, input::common_conditions::input_just_pressed, prelude::*,

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -5,7 +5,7 @@
 //!
 //! In this example, we will set up a simple UI with a grid of buttons that can be navigated using the arrow keys or gamepad input.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{
     input_focus::{

--- a/examples/window/custom_cursor_image.rs
+++ b/examples/window/custom_cursor_image.rs
@@ -1,7 +1,7 @@
 //! Illustrates how to use a custom cursor image with a texture atlas and
 //! animation.
 
-use std::time::Duration;
+use core::time::Duration;
 
 use bevy::{
     prelude::*,

--- a/tests/window/change_window_mode.rs
+++ b/tests/window/change_window_mode.rs
@@ -48,14 +48,14 @@ fn toggle_window_mode(mut qry_window: Query<&mut Window>) {
     window.mode = match window.mode {
         WindowMode::Windowed => {
             // it takes a while for the window to change from `Windowed` to `Fullscreen` and back
-            std::thread::sleep(std::time::Duration::from_secs(4));
+            std::thread::sleep(core::time::Duration::from_secs(4));
             WindowMode::Fullscreen(
                 MonitorSelection::Entity(entity),
                 VideoModeSelection::Current,
             )
         }
         _ => {
-            std::thread::sleep(std::time::Duration::from_secs(4));
+            std::thread::sleep(core::time::Duration::from_secs(4));
             WindowMode::Windowed
         }
     };


### PR DESCRIPTION
# Objective

- While working on a bevy 0.15 project and then checking the current state of the `main` bevy branch to see why my autocomplete wasn't picking up the `bevy::utils::Duration` export I noticed that I couldn't find it anymore. As far as I can see https://github.com/bevyengine/bevy/pull/17158 removed this re-export, yet some parts of the code still use `std::time::Duration`. To standardize this I'm replacing all instances of `std::time::Duration` in favor of `core::time::Duration`. These are mostly example code and comments for what is worth.

## Solution

- Replaced all instances of `std::time::Duration` in favor of `core::time::Duration`.

## Testing

- I haven't tested this changeset thoroughly as I think its impact should be negligible. Might be good to perform an example run on CI though.