### PR TITLE
Update text2d example to use children macro

### DIFF
--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -7,7 +7,6 @@
 
 use bevy::{
     color::palettes::css::*,
-    ecs::spawn::SpawnIter,
     math::ops,
     prelude::*,
     sprite::Anchor,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -12,6 +12,7 @@ use bevy::{
     sprite::Anchor,
     text::{FontSmoothing, LineBreak, TextBounds},
 };
+use bevy_ecs::spawn::SpawnIter;
 
 fn main() {
     App::new()
@@ -72,41 +73,35 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     };
     let box_size = Vec2::new(300.0, 200.0);
     let box_position = Vec2::new(0.0, -250.0);
-    commands
-        .spawn((
-            Sprite::from_color(Color::srgb(0.25, 0.25, 0.55), box_size),
-            Transform::from_translation(box_position.extend(0.0)),
-        ))
-        .with_children(|builder| {
-            builder.spawn((
-                Text2d::new("this text wraps in the box\n(Unicode linebreaks)"),
-                slightly_smaller_text_font.clone(),
-                TextLayout::new(JustifyText::Left, LineBreak::WordBoundary),
-                // Wrap text in the rectangle
-                TextBounds::from(box_size),
-                // Ensure the text is drawn on top of the box
-                Transform::from_translation(Vec3::Z),
-            ));
-        });
+    commands.spawn((
+        Sprite::from_color(Color::srgb(0.25, 0.25, 0.55), box_size),
+        Transform::from_translation(box_position.extend(0.0)),
+        children![(
+            Text2d::new("this text wraps in the box\n(Unicode linebreaks)"),
+            slightly_smaller_text_font.clone(),
+            TextLayout::new(JustifyText::Left, LineBreak::WordBoundary),
+            // Wrap text in the rectangle
+            TextBounds::from(box_size),
+            // Ensure the text is drawn on top of the box
+            Transform::from_translation(Vec3::Z),
+        )],
+    ));
 
     let other_box_size = Vec2::new(300.0, 200.0);
     let other_box_position = Vec2::new(320.0, -250.0);
-    commands
-        .spawn((
-            Sprite::from_color(Color::srgb(0.25, 0.25, 0.55), other_box_size),
-            Transform::from_translation(other_box_position.extend(0.0)),
-        ))
-        .with_children(|builder| {
-            builder.spawn((
-                Text2d::new("this text wraps in the box\n(AnyCharacter linebreaks)"),
-                slightly_smaller_text_font.clone(),
-                TextLayout::new(JustifyText::Left, LineBreak::AnyCharacter),
-                // Wrap text in the rectangle
-                TextBounds::from(other_box_size),
-                // Ensure the text is drawn on top of the box
-                Transform::from_translation(Vec3::Z),
-            ));
-        });
+    commands.spawn((
+        Sprite::from_color(Color::srgb(0.25, 0.25, 0.55), other_box_size),
+        Transform::from_translation(other_box_position.extend(0.0)),
+        children![(
+            Text2d::new("this text wraps in the box\n(AnyCharacter linebreaks)"),
+            slightly_smaller_text_font.clone(),
+            TextLayout::new(JustifyText::Left, LineBreak::AnyCharacter),
+            // Wrap text in the rectangle
+            TextBounds::from(other_box_size),
+            // Ensure the text is drawn on top of the box
+            Transform::from_translation(Vec3::Z),
+        )],
+    ));
 
     // Demonstrate font smoothing off
     commands.spawn((

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -7,12 +7,12 @@
 
 use bevy::{
     color::palettes::css::*,
+    ecs::spawn::SpawnIter,
     math::ops,
     prelude::*,
     sprite::Anchor,
     text::{FontSmoothing, LineBreak, TextBounds},
 };
-use bevy_ecs::spawn::SpawnIter;
 
 fn main() {
     App::new()


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `text2d`, example to use the `children!` macro.

I'm not sure I love the SpawnIter usage here, as I feel the `move` keyword in this case is subtle and error prone for those who lose fights with the borrow checker frequently (like me).  Feedback very much welcome.

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

n/a