### PR TITLE
Update sprite_slice, spatial_audio_3d, spatial_audio_2d examples to use children macro

### DIFF
--- a/examples/2d/sprite_slice.rs
+++ b/examples/2d/sprite_slice.rs
@@ -83,7 +83,7 @@ fn spawn_sprites(
 
     for (label, text_style, size, scale_mode) in cases {
         position.x += 0.5 * size.x;
-        let mut cmd = commands.spawn((
+        commands.spawn((
             Sprite {
                 image: texture_handle.clone(),
                 custom_size: Some(size),
@@ -91,16 +91,14 @@ fn spawn_sprites(
                 ..default()
             },
             Transform::from_translation(position),
-        ));
-        cmd.with_children(|builder| {
-            builder.spawn((
+            children![(
                 Text2d::new(label),
                 text_style,
                 TextLayout::new_with_justify(JustifyText::Center),
                 Transform::from_xyz(0., -0.5 * size.y - 10., 0.0),
                 bevy::sprite::Anchor::TopCenter,
-            ));
-        });
+            )],
+        ));
         position.x += 0.5 * size.x + gap;
     }
 }

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -43,25 +43,23 @@ fn setup(
     ));
 
     let listener = SpatialListener::new(gap);
-    commands
-        .spawn((
-            Transform::default(),
-            Visibility::default(),
-            listener.clone(),
-        ))
-        .with_children(|parent| {
+    commands.spawn((
+        Transform::default(),
+        Visibility::default(),
+        listener.clone(),
+        children![
             // left ear
-            parent.spawn((
+            (
                 Sprite::from_color(RED, Vec2::splat(20.0)),
                 Transform::from_xyz(-gap / 2.0, 0.0, 0.0),
-            ));
-
+            ),
             // right ear
-            parent.spawn((
+            (
                 Sprite::from_color(LIME, Vec2::splat(20.0)),
                 Transform::from_xyz(gap / 2.0, 0.0, 0.0),
-            ));
-        });
+            )
+        ],
+    ));
 
     // example instructions
     commands.spawn((

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -35,27 +35,25 @@ fn setup(
     ));
 
     let listener = SpatialListener::new(gap);
-    commands
-        .spawn((
-            Transform::default(),
-            Visibility::default(),
-            listener.clone(),
-        ))
-        .with_children(|parent| {
+    commands.spawn((
+        Transform::default(),
+        Visibility::default(),
+        listener.clone(),
+        children![
             // left ear indicator
-            parent.spawn((
+            (
                 Mesh3d(meshes.add(Cuboid::new(0.2, 0.2, 0.2))),
                 MeshMaterial3d(materials.add(Color::from(RED))),
                 Transform::from_translation(listener.left_ear_offset),
-            ));
-
+            ),
             // right ear indicator
-            parent.spawn((
+            (
                 Mesh3d(meshes.add(Cuboid::new(0.2, 0.2, 0.2))),
                 MeshMaterial3d(materials.add(Color::from(LIME))),
                 Transform::from_translation(listener.right_ear_offset),
-            ));
-        });
+            )
+        ],
+    ));
 
     // light
     commands.spawn((


### PR DESCRIPTION
# Objective

Contributes to #18238 
Updates the `sprite_slice`, `spatial_audio_3d` and `spatial_audio_2d` examples to use the `children!` macro.

## Solution

Updates examples to use the Improved Spawning API merged in https://github.com/bevyengine/bevy/pull/17521

## Testing

- Did you test these changes? If so, how?
  - Opened the examples before and after and verified the same behavior was observed.  I did this on Ubuntu 24.04.2 LTS using `--features wayland`.
- Are there any parts that need more testing?
  - Other OS's and features can't hurt, but this is such a small change it shouldn't be a problem.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Run the examples yourself with and without these changes.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - see above

---

## Showcase

n/a

## Migration Guide

n/a