### PR TITLE
add Entity default to the entity set wrappers

### DIFF
--- a/crates/bevy_ecs/src/entity/unique_array.rs
+++ b/crates/bevy_ecs/src/entity/unique_array.rs
@@ -21,8 +21,7 @@ use alloc::{
 use bevy_platform_support::sync::Arc;
 
 use super::{
-    unique_slice::{self, UniqueEntitySlice},
-    TrustedEntityBorrow, UniqueEntityIter,
+    unique_slice::{self, UniqueEntitySlice}, Entity, TrustedEntityBorrow, UniqueEntityIter
 };
 
 /// An array that contains only unique entities.
@@ -30,9 +29,9 @@ use super::{
 /// It can be obtained through certain methods on [`UniqueEntitySlice`],
 /// and some [`TryFrom`] implementations.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct UniqueEntityArray<T: TrustedEntityBorrow, const N: usize>([T; N]);
+pub struct UniqueEntityArray<const N: usize, T: TrustedEntityBorrow = Entity>([T; N]);
 
-impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityArray<N, T> {
     /// Constructs a `UniqueEntityArray` from a [`[T; N]`] unsafely.
     ///
     /// # Safety
@@ -127,12 +126,12 @@ impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityArray<T, N> {
     /// size as `self`.
     ///
     /// Equivalent to [`[T; N]::as_ref`](array::each_ref).
-    pub fn each_ref(&self) -> UniqueEntityArray<&T, N> {
+    pub fn each_ref(&self) -> UniqueEntityArray<N, &T> {
         UniqueEntityArray(self.0.each_ref())
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> Deref for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> Deref for UniqueEntityArray<N, T> {
     type Target = UniqueEntitySlice<T>;
 
     fn deref(&self) -> &Self::Target {
@@ -141,19 +140,19 @@ impl<T: TrustedEntityBorrow, const N: usize> Deref for UniqueEntityArray<T, N> {
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> DerefMut for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> DerefMut for UniqueEntityArray<N, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // SAFETY: All elements in the original array are unique.
         unsafe { UniqueEntitySlice::from_slice_unchecked_mut(&mut self.0) }
     }
 }
-impl<T: TrustedEntityBorrow> Default for UniqueEntityArray<T, 0> {
+impl<T: TrustedEntityBorrow> Default for UniqueEntityArray<0, T> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<'a, T: TrustedEntityBorrow, const N: usize> IntoIterator for &'a UniqueEntityArray<T, N> {
+impl<'a, T: TrustedEntityBorrow, const N: usize> IntoIterator for &'a UniqueEntityArray<N, T> {
     type Item = &'a T;
 
     type IntoIter = unique_slice::Iter<'a, T>;
@@ -164,10 +163,10 @@ impl<'a, T: TrustedEntityBorrow, const N: usize> IntoIterator for &'a UniqueEnti
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> IntoIterator for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> IntoIterator for UniqueEntityArray<N, T> {
     type Item = T;
 
-    type IntoIter = IntoIter<T, N>;
+    type IntoIter = IntoIter<N, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         // SAFETY: All elements in the original array are unique.
@@ -176,7 +175,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IntoIterator for UniqueEntityArray<
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> AsRef<UniqueEntitySlice<T>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn as_ref(&self) -> &UniqueEntitySlice<T> {
         self
@@ -184,7 +183,7 @@ impl<T: TrustedEntityBorrow, const N: usize> AsRef<UniqueEntitySlice<T>>
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> AsMut<UniqueEntitySlice<T>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn as_mut(&mut self) -> &mut UniqueEntitySlice<T> {
         self
@@ -192,7 +191,7 @@ impl<T: TrustedEntityBorrow, const N: usize> AsMut<UniqueEntitySlice<T>>
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> Borrow<UniqueEntitySlice<T>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn borrow(&self) -> &UniqueEntitySlice<T> {
         self
@@ -200,7 +199,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Borrow<UniqueEntitySlice<T>>
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> BorrowMut<UniqueEntitySlice<T>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn borrow_mut(&mut self) -> &mut UniqueEntitySlice<T> {
         self
@@ -208,7 +207,7 @@ impl<T: TrustedEntityBorrow, const N: usize> BorrowMut<UniqueEntitySlice<T>>
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> Index<(Bound<usize>, Bound<usize>)>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: (Bound<usize>, Bound<usize>)) -> &Self::Output {
@@ -217,7 +216,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<(Bound<usize>, Bound<usize>)>
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> Index<Range<usize>> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> Index<Range<usize>> for UniqueEntityArray<N, T> {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: Range<usize>) -> &Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -225,7 +224,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<Range<usize>> for UniqueEntit
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFrom<usize>> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFrom<usize>> for UniqueEntityArray<N, T> {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: RangeFrom<usize>) -> &Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -233,7 +232,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFrom<usize>> for UniqueE
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFull> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFull> for UniqueEntityArray<N, T> {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: RangeFull) -> &Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -242,7 +241,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<RangeFull> for UniqueEntityAr
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> Index<RangeInclusive<usize>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: RangeInclusive<usize>) -> &Self::Output {
@@ -251,7 +250,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<RangeInclusive<usize>>
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> Index<RangeTo<usize>> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> Index<RangeTo<usize>> for UniqueEntityArray<N, T> {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: RangeTo<usize>) -> &Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -260,7 +259,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<RangeTo<usize>> for UniqueEnt
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> Index<RangeToInclusive<usize>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     type Output = UniqueEntitySlice<T>;
     fn index(&self, key: RangeToInclusive<usize>) -> &Self::Output {
@@ -269,7 +268,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<RangeToInclusive<usize>>
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> Index<usize> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> Index<usize> for UniqueEntityArray<N, T> {
     type Output = T;
     fn index(&self, key: usize) -> &T {
         self.0.index(key)
@@ -277,7 +276,7 @@ impl<T: TrustedEntityBorrow, const N: usize> Index<usize> for UniqueEntityArray<
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> IndexMut<(Bound<usize>, Bound<usize>)>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn index_mut(&mut self, key: (Bound<usize>, Bound<usize>)) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -285,7 +284,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<(Bound<usize>, Bound<usize
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> IndexMut<Range<usize>> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<Range<usize>> for UniqueEntityArray<N, T> {
     fn index_mut(&mut self, key: Range<usize>) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
         unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
@@ -293,7 +292,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<Range<usize>> for UniqueEn
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFrom<usize>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn index_mut(&mut self, key: RangeFrom<usize>) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -301,7 +300,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFrom<usize>>
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFull> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFull> for UniqueEntityArray<N, T> {
     fn index_mut(&mut self, key: RangeFull) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
         unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
@@ -309,7 +308,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeFull> for UniqueEntit
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeInclusive<usize>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn index_mut(&mut self, key: RangeInclusive<usize>) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -317,7 +316,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeInclusive<usize>>
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeTo<usize>> for UniqueEntityArray<T, N> {
+impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeTo<usize>> for UniqueEntityArray<N, T> {
     fn index_mut(&mut self, key: RangeTo<usize>) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
         unsafe { UniqueEntitySlice::from_slice_unchecked_mut(self.0.index_mut(key)) }
@@ -325,7 +324,7 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeTo<usize>> for Unique
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeToInclusive<usize>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     fn index_mut(&mut self, key: RangeToInclusive<usize>) -> &mut Self::Output {
         // SAFETY: All elements in the original slice are unique.
@@ -333,148 +332,148 @@ impl<T: TrustedEntityBorrow, const N: usize> IndexMut<RangeToInclusive<usize>>
     }
 }
 
-impl<T: TrustedEntityBorrow + Clone> From<&[T; 1]> for UniqueEntityArray<T, 1> {
+impl<T: TrustedEntityBorrow + Clone> From<&[T; 1]> for UniqueEntityArray<1, T> {
     fn from(value: &[T; 1]) -> Self {
         Self(value.clone())
     }
 }
 
-impl<T: TrustedEntityBorrow + Clone> From<&[T; 0]> for UniqueEntityArray<T, 0> {
+impl<T: TrustedEntityBorrow + Clone> From<&[T; 0]> for UniqueEntityArray<0, T> {
     fn from(value: &[T; 0]) -> Self {
         Self(value.clone())
     }
 }
 
-impl<T: TrustedEntityBorrow + Clone> From<&mut [T; 1]> for UniqueEntityArray<T, 1> {
+impl<T: TrustedEntityBorrow + Clone> From<&mut [T; 1]> for UniqueEntityArray<1, T> {
     fn from(value: &mut [T; 1]) -> Self {
         Self(value.clone())
     }
 }
 
-impl<T: TrustedEntityBorrow + Clone> From<&mut [T; 0]> for UniqueEntityArray<T, 0> {
+impl<T: TrustedEntityBorrow + Clone> From<&mut [T; 0]> for UniqueEntityArray<0, T> {
     fn from(value: &mut [T; 0]) -> Self {
         Self(value.clone())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<[T; 1]> for UniqueEntityArray<T, 1> {
+impl<T: TrustedEntityBorrow> From<[T; 1]> for UniqueEntityArray<1, T> {
     fn from(value: [T; 1]) -> Self {
         Self(value)
     }
 }
 
-impl<T: TrustedEntityBorrow> From<[T; 0]> for UniqueEntityArray<T, 0> {
+impl<T: TrustedEntityBorrow> From<[T; 0]> for UniqueEntityArray<0, T> {
     fn from(value: [T; 0]) -> Self {
         Self(value)
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 1>> for (T,) {
-    fn from(array: UniqueEntityArray<T, 1>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<1, T>> for (T,) {
+    fn from(array: UniqueEntityArray<1, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 2>> for (T, T) {
-    fn from(array: UniqueEntityArray<T, 2>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<2, T>> for (T, T) {
+    fn from(array: UniqueEntityArray<2, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 3>> for (T, T, T) {
-    fn from(array: UniqueEntityArray<T, 3>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<3, T>> for (T, T, T) {
+    fn from(array: UniqueEntityArray<3, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 4>> for (T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 4>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<4, T>> for (T, T, T, T) {
+    fn from(array: UniqueEntityArray<4, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 5>> for (T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 5>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<5, T>> for (T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<5, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 6>> for (T, T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 6>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<6, T>> for (T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<6, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 7>> for (T, T, T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 7>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<7, T>> for (T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<7, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 8>> for (T, T, T, T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 8>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<8, T>> for (T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<8, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 9>> for (T, T, T, T, T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 9>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<9, T>> for (T, T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<9, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 10>> for (T, T, T, T, T, T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 10>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<10, T>> for (T, T, T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<10, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 11>> for (T, T, T, T, T, T, T, T, T, T, T) {
-    fn from(array: UniqueEntityArray<T, 11>) -> Self {
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<11, T>> for (T, T, T, T, T, T, T, T, T, T, T) {
+    fn from(array: UniqueEntityArray<11, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow> From<UniqueEntityArray<T, 12>>
+impl<T: TrustedEntityBorrow> From<UniqueEntityArray<12, T>>
     for (T, T, T, T, T, T, T, T, T, T, T, T)
 {
-    fn from(array: UniqueEntityArray<T, 12>) -> Self {
+    fn from(array: UniqueEntityArray<12, T>) -> Self {
         Self::from(array.into_inner())
     }
 }
 
-impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<T, N>> for BTreeSet<T> {
-    fn from(value: UniqueEntityArray<T, N>) -> Self {
+impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<N, T>> for BTreeSet<T> {
+    fn from(value: UniqueEntityArray<N, T>) -> Self {
         BTreeSet::from(value.0)
     }
 }
 
-impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<T, N>> for BinaryHeap<T> {
-    fn from(value: UniqueEntityArray<T, N>) -> Self {
+impl<T: TrustedEntityBorrow + Ord, const N: usize> From<UniqueEntityArray<N, T>> for BinaryHeap<T> {
+    fn from(value: UniqueEntityArray<N, T>) -> Self {
         BinaryHeap::from(value.0)
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for LinkedList<T> {
-    fn from(value: UniqueEntityArray<T, N>) -> Self {
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<N, T>> for LinkedList<T> {
+    fn from(value: UniqueEntityArray<N, T>) -> Self {
         LinkedList::from(value.0)
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for Vec<T> {
-    fn from(value: UniqueEntityArray<T, N>) -> Self {
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<N, T>> for Vec<T> {
+    fn from(value: UniqueEntityArray<N, T>) -> Self {
         Vec::from(value.0)
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for VecDeque<T> {
-    fn from(value: UniqueEntityArray<T, N>) -> Self {
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<N, T>> for VecDeque<T> {
+    fn from(value: UniqueEntityArray<N, T>) -> Self {
         VecDeque::from(value.0)
     }
 }
 
 impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
-    PartialEq<&UniqueEntitySlice<U>> for UniqueEntityArray<T, N>
+    PartialEq<&UniqueEntitySlice<U>> for UniqueEntityArray<N, T>
 {
     fn eq(&self, other: &&UniqueEntitySlice<U>) -> bool {
         self.0.eq(&other.as_inner())
@@ -482,47 +481,47 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usi
 }
 
 impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
-    PartialEq<UniqueEntitySlice<U>> for UniqueEntityArray<T, N>
+    PartialEq<UniqueEntitySlice<U>> for UniqueEntityArray<N, T>
 {
     fn eq(&self, other: &UniqueEntitySlice<U>) -> bool {
         self.0.eq(other.as_inner())
     }
 }
 
-impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntityArray<U, N>>
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntityArray<N, U>>
     for Vec<T>
 {
-    fn eq(&self, other: &&UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &&UniqueEntityArray<N, U>) -> bool {
         self.eq(&other.0)
     }
 }
-impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntityArray<U, N>>
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<&UniqueEntityArray<N, U>>
     for VecDeque<T>
 {
-    fn eq(&self, other: &&UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &&UniqueEntityArray<N, U>) -> bool {
         self.eq(&other.0)
     }
 }
 
 impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
-    PartialEq<&mut UniqueEntityArray<U, N>> for VecDeque<T>
+    PartialEq<&mut UniqueEntityArray<N, U>> for VecDeque<T>
 {
-    fn eq(&self, other: &&mut UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &&mut UniqueEntityArray<N, U>) -> bool {
         self.eq(&other.0)
     }
 }
 
-impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntityArray<U, N>>
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntityArray<N, U>>
     for Vec<T>
 {
-    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &UniqueEntityArray<N, U>) -> bool {
         self.eq(&other.0)
     }
 }
-impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntityArray<U, N>>
+impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEntityArray<N, U>>
     for VecDeque<T>
 {
-    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &UniqueEntityArray<N, U>) -> bool {
         self.eq(&other.0)
     }
 }
@@ -530,7 +529,7 @@ impl<T: PartialEq<U>, U: TrustedEntityBorrow, const N: usize> PartialEq<UniqueEn
 /// A by-value array iterator.
 ///
 /// Equivalent to [`array::IntoIter`].
-pub type IntoIter<T, const N: usize> = UniqueEntityIter<array::IntoIter<T, N>>;
+pub type IntoIter<const N: usize, T = Entity> = UniqueEntityIter<array::IntoIter<T, N>>;
 
 impl<T: TrustedEntityBorrow, const N: usize> UniqueEntityIter<array::IntoIter<T, N>> {
     /// Returns an immutable slice of all elements that have not been yielded

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -412,7 +412,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::chunk_by`].
     ///
     /// [`[T]::chunk_by`]: `slice::chunk_by`
-    pub fn chunk_by<F>(&self, pred: F) -> ChunkBy<'_, T, F>
+    pub fn chunk_by<F>(&self, pred: F) -> ChunkBy<'_, F, T>
     where
         F: FnMut(&T, &T) -> bool,
     {
@@ -426,7 +426,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::chunk_by_mut`].
     ///
     /// [`[T]::chunk_by_mut`]: `slice::chunk_by_mut`
-    pub fn chunk_by_mut<F>(&mut self, pred: F) -> ChunkByMut<'_, T, F>
+    pub fn chunk_by_mut<F>(&mut self, pred: F) -> ChunkByMut<'_, F, T>
     where
         F: FnMut(&T, &T) -> bool,
     {
@@ -546,7 +546,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::split`].
     ///
     /// [`[T]::split`]: `slice::split`
-    pub fn split<F>(&self, pred: F) -> Split<'_, T, F>
+    pub fn split<F>(&self, pred: F) -> Split<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -560,7 +560,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::split_mut`].
     ///
     /// [`[T]::split_mut`]: `slice::split_mut`
-    pub fn split_mut<F>(&mut self, pred: F) -> SplitMut<'_, T, F>
+    pub fn split_mut<F>(&mut self, pred: F) -> SplitMut<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -576,7 +576,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::split_inclusive`].
     ///
     /// [`[T]::split_inclusive`]: `slice::split_inclusive`
-    pub fn split_inclusive<F>(&self, pred: F) -> SplitInclusive<'_, T, F>
+    pub fn split_inclusive<F>(&self, pred: F) -> SplitInclusive<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -592,7 +592,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::split_inclusive_mut`].
     ///
     /// [`[T]::split_inclusive_mut`]: `slice::split_inclusive_mut`
-    pub fn split_inclusive_mut<F>(&mut self, pred: F) -> SplitInclusiveMut<'_, T, F>
+    pub fn split_inclusive_mut<F>(&mut self, pred: F) -> SplitInclusiveMut<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -610,7 +610,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::rsplit`].
     ///
     /// [`[T]::rsplit`]: `slice::rsplit`
-    pub fn rsplit<F>(&self, pred: F) -> RSplit<'_, T, F>
+    pub fn rsplit<F>(&self, pred: F) -> RSplit<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -625,7 +625,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::rsplit_mut`].
     ///
     /// [`[T]::rsplit_mut`]: `slice::rsplit_mut`
-    pub fn rsplit_mut<F>(&mut self, pred: F) -> RSplitMut<'_, T, F>
+    pub fn rsplit_mut<F>(&mut self, pred: F) -> RSplitMut<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -641,7 +641,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::splitn`].
     ///
     /// [`[T]::splitn`]: `slice::splitn`
-    pub fn splitn<F>(&self, n: usize, pred: F) -> SplitN<'_, T, F>
+    pub fn splitn<F>(&self, n: usize, pred: F) -> SplitN<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -655,7 +655,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::splitn_mut`].
     ///
     /// [`[T]::splitn_mut`]: `slice::splitn_mut`
-    pub fn splitn_mut<F>(&mut self, n: usize, pred: F) -> SplitNMut<'_, T, F>
+    pub fn splitn_mut<F>(&mut self, n: usize, pred: F) -> SplitNMut<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -671,7 +671,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::rsplitn`].
     ///
     /// [`[T]::rsplitn`]: `slice::rsplitn`
-    pub fn rsplitn<F>(&self, n: usize, pred: F) -> RSplitN<'_, T, F>
+    pub fn rsplitn<F>(&self, n: usize, pred: F) -> RSplitN<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -685,7 +685,7 @@ impl<T: TrustedEntityBorrow> UniqueEntitySlice<T> {
     /// Equivalent to [`[T]::rsplitn_mut`].
     ///
     /// [`[T]::rsplitn_mut`]: `slice::rsplitn_mut`
-    pub fn rsplitn_mut<F>(&mut self, n: usize, pred: F) -> RSplitNMut<'_, T, F>
+    pub fn rsplitn_mut<F>(&mut self, n: usize, pred: F) -> RSplitNMut<'_, F, T>
     where
         F: FnMut(&T) -> bool,
     {
@@ -1525,19 +1525,19 @@ impl<'a, T: TrustedEntityBorrow + 'a, I: Iterator<Item = &'a [T]> + AsRef<[&'a [
 /// An iterator over overlapping subslices of length `size`.
 ///
 /// This struct is created by [`UniqueEntitySlice::windows`].
-pub type Windows<'a, T> = UniqueEntitySliceIter<'a, T, slice::Windows<'a, T>>;
+pub type Windows<'a, T = Entity> = UniqueEntitySliceIter<'a, T, slice::Windows<'a, T>>;
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
 /// time), starting at the beginning of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::chunks`].
-pub type Chunks<'a, T> = UniqueEntitySliceIter<'a, T, slice::Chunks<'a, T>>;
+pub type Chunks<'a, T = Entity> = UniqueEntitySliceIter<'a, T, slice::Chunks<'a, T>>;
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
 /// time), starting at the beginning of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::chunks_exact`].
-pub type ChunksExact<'a, T> = UniqueEntitySliceIter<'a, T, slice::ChunksExact<'a, T>>;
+pub type ChunksExact<'a, T = Entity> = UniqueEntitySliceIter<'a, T, slice::ChunksExact<'a, T>>;
 
 impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIter<'a, T, slice::ChunksExact<'a, T>> {
     /// Returns the remainder of the original slice that is not going to be
@@ -1554,13 +1554,13 @@ impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIter<'a, T, slice::ChunksExact
 /// time), starting at the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rchunks`].
-pub type RChunks<'a, T> = UniqueEntitySliceIter<'a, T, slice::RChunks<'a, T>>;
+pub type RChunks<'a, T = Entity> = UniqueEntitySliceIter<'a, T, slice::RChunks<'a, T>>;
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
 /// time), starting at the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rchunks_exact`].
-pub type RChunksExact<'a, T> = UniqueEntitySliceIter<'a, T, slice::RChunksExact<'a, T>>;
+pub type RChunksExact<'a, T = Entity> = UniqueEntitySliceIter<'a, T, slice::RChunksExact<'a, T>>;
 
 impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIter<'a, T, slice::RChunksExact<'a, T>> {
     /// Returns the remainder of the original slice that is not going to be
@@ -1576,38 +1576,38 @@ impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIter<'a, T, slice::RChunksExac
 /// An iterator over slice in (non-overlapping) chunks separated by a predicate.
 ///
 /// This struct is created by [`UniqueEntitySlice::chunk_by`].
-pub type ChunkBy<'a, T, P> = UniqueEntitySliceIter<'a, T, slice::ChunkBy<'a, T, P>>;
+pub type ChunkBy<'a, P, T = Entity> = UniqueEntitySliceIter<'a, T, slice::ChunkBy<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a predicate
 /// function.
 ///
 /// This struct is created by [`UniqueEntitySlice::split`].
-pub type Split<'a, T, P> = UniqueEntitySliceIter<'a, T, slice::Split<'a, T, P>>;
+pub type Split<'a, P, T = Entity> = UniqueEntitySliceIter<'a, T, slice::Split<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a predicate
 /// function.
 ///
 /// This struct is created by [`UniqueEntitySlice::split_inclusive`].
-pub type SplitInclusive<'a, T, P> = UniqueEntitySliceIter<'a, T, slice::SplitInclusive<'a, T, P>>;
+pub type SplitInclusive<'a, P, T = Entity> = UniqueEntitySliceIter<'a, T, slice::SplitInclusive<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a predicate
 /// function, starting from the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rsplit`].
-pub type RSplit<'a, T, P> = UniqueEntitySliceIter<'a, T, slice::RSplit<'a, T, P>>;
+pub type RSplit<'a, P, T = Entity> = UniqueEntitySliceIter<'a, T, slice::RSplit<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a predicate
 /// function, limited to a given number of splits.
 ///
 /// This struct is created by [`UniqueEntitySlice::splitn`].
-pub type SplitN<'a, T, P> = UniqueEntitySliceIter<'a, T, slice::SplitN<'a, T, P>>;
+pub type SplitN<'a, P, T = Entity> = UniqueEntitySliceIter<'a, T, slice::SplitN<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a
 /// predicate function, limited to a given number of splits, starting
 /// from the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rsplitn`].
-pub type RSplitN<'a, T, P> = UniqueEntitySliceIter<'a, T, slice::RSplitN<'a, T, P>>;
+pub type RSplitN<'a, P, T = Entity> = UniqueEntitySliceIter<'a, T, slice::RSplitN<'a, T, P>>;
 
 /// An iterator that yields `&mut UniqueEntitySlice`. Note that an entity may appear
 /// in multiple slices, depending on the wrapped iterator.
@@ -1711,13 +1711,13 @@ impl<'a, T: TrustedEntityBorrow + 'a, I: Iterator<Item = &'a mut [T]> + AsMut<[&
 /// elements at a time), starting at the beginning of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::chunks_mut`].
-pub type ChunksMut<'a, T> = UniqueEntitySliceIterMut<'a, T, slice::ChunksMut<'a, T>>;
+pub type ChunksMut<'a, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::ChunksMut<'a, T>>;
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`chunk_size`
 /// elements at a time), starting at the beginning of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::chunks_exact_mut`].
-pub type ChunksExactMut<'a, T> = UniqueEntitySliceIterMut<'a, T, slice::ChunksExactMut<'a, T>>;
+pub type ChunksExactMut<'a, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::ChunksExactMut<'a, T>>;
 
 impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIterMut<'a, T, slice::ChunksExactMut<'a, T>> {
     /// Returns the remainder of the original slice that is not going to be
@@ -1734,13 +1734,13 @@ impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIterMut<'a, T, slice::ChunksEx
 /// elements at a time), starting at the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rchunks_mut`].
-pub type RChunksMut<'a, T> = UniqueEntitySliceIterMut<'a, T, slice::RChunksMut<'a, T>>;
+pub type RChunksMut<'a, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::RChunksMut<'a, T>>;
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`chunk_size`
 /// elements at a time), starting at the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rchunks_exact_mut`].
-pub type RChunksExactMut<'a, T> = UniqueEntitySliceIterMut<'a, T, slice::RChunksExactMut<'a, T>>;
+pub type RChunksExactMut<'a, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::RChunksExactMut<'a, T>>;
 
 impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIterMut<'a, T, slice::RChunksExactMut<'a, T>> {
     /// Returns the remainder of the original slice that is not going to be
@@ -1757,37 +1757,37 @@ impl<'a, T: TrustedEntityBorrow> UniqueEntitySliceIterMut<'a, T, slice::RChunksE
 /// by a predicate.
 ///
 /// This struct is created by [`UniqueEntitySlice::chunk_by_mut`].
-pub type ChunkByMut<'a, T, P> = UniqueEntitySliceIterMut<'a, T, slice::ChunkByMut<'a, T, P>>;
+pub type ChunkByMut<'a, P, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::ChunkByMut<'a, T, P>>;
 
 /// An iterator over the mutable subslices of the vector which are separated
 /// by elements that match `pred`.
 ///
 /// This struct is created by [`UniqueEntitySlice::split_mut`].
-pub type SplitMut<'a, T, P> = UniqueEntitySliceIterMut<'a, T, slice::SplitMut<'a, T, P>>;
+pub type SplitMut<'a, P, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::SplitMut<'a, T, P>>;
 
 /// An iterator over the mutable subslices of the vector which are separated
 /// by elements that match `pred`. Unlike `SplitMut`, it contains the matched
 /// parts in the ends of the subslices.
 ///
 /// This struct is created by [`UniqueEntitySlice::split_inclusive_mut`].
-pub type SplitInclusiveMut<'a, T, P> =
+pub type SplitInclusiveMut<'a, P, T = Entity> =
     UniqueEntitySliceIterMut<'a, T, slice::SplitInclusiveMut<'a, T, P>>;
 
 /// An iterator over the subslices of the vector which are separated
 /// by elements that match `pred`, starting from the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rsplit_mut`].
-pub type RSplitMut<'a, T, P> = UniqueEntitySliceIterMut<'a, T, slice::RSplitMut<'a, T, P>>;
+pub type RSplitMut<'a, P, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::RSplitMut<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a predicate
 /// function, limited to a given number of splits.
 ///
 /// This struct is created by [`UniqueEntitySlice::splitn_mut`].
-pub type SplitNMut<'a, T, P> = UniqueEntitySliceIterMut<'a, T, slice::SplitNMut<'a, T, P>>;
+pub type SplitNMut<'a, P, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::SplitNMut<'a, T, P>>;
 
 /// An iterator over subslices separated by elements that match a
 /// predicate function, limited to a given number of splits, starting
 /// from the end of the slice.
 ///
 /// This struct is created by [`UniqueEntitySlice::rsplitn_mut`].
-pub type RSplitNMut<'a, T, P> = UniqueEntitySliceIterMut<'a, T, slice::RSplitNMut<'a, T, P>>;
+pub type RSplitNMut<'a, P, T = Entity> = UniqueEntitySliceIterMut<'a, T, slice::RSplitNMut<'a, T, P>>;

--- a/crates/bevy_ecs/src/entity/unique_vec.rs
+++ b/crates/bevy_ecs/src/entity/unique_vec.rs
@@ -1041,7 +1041,7 @@ impl<T: TrustedEntityBorrow> IndexMut<RangeToInclusive<usize>> for UniqueEntityV
 ///
 /// This `struct` is created by the [`IntoIterator::into_iter`] trait
 /// method on [`UniqueEntityVec`].
-pub type IntoIter<T> = UniqueEntityIter<vec::IntoIter<T>>;
+pub type IntoIter<T = Entity> = UniqueEntityIter<vec::IntoIter<T>>;
 
 impl<T: TrustedEntityBorrow> UniqueEntityIter<vec::IntoIter<T>> {
     /// Returns the remaining items of this iterator as a slice.
@@ -1065,7 +1065,7 @@ impl<T: TrustedEntityBorrow> UniqueEntityIter<vec::IntoIter<T>> {
 ///
 /// This struct is created by [`UniqueEntityVec::drain`].
 /// See its documentation for more.
-pub type Drain<'a, T> = UniqueEntityIter<vec::Drain<'a, T>>;
+pub type Drain<'a, T = Entity> = UniqueEntityIter<vec::Drain<'a, T>>;
 
 impl<'a, T: TrustedEntityBorrow> UniqueEntityIter<vec::Drain<'a, T>> {
     /// Returns the remaining items of this iterator as a slice.

--- a/crates/bevy_ecs/src/entity/unique_vec.rs
+++ b/crates/bevy_ecs/src/entity/unique_vec.rs
@@ -20,9 +20,7 @@ use alloc::{
 use bevy_platform_support::sync::Arc;
 
 use super::{
-    unique_array::UniqueEntityArray,
-    unique_slice::{self, UniqueEntitySlice},
-    EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter,
+    unique_array::UniqueEntityArray, unique_slice::{self, UniqueEntitySlice}, Entity, EntitySet, FromEntitySetIterator, TrustedEntityBorrow, UniqueEntityIter
 };
 
 /// A `Vec` that contains only unique entities.
@@ -36,7 +34,7 @@ use super::{
 /// While this type can be constructed via `Iterator::collect`, doing so is inefficient,
 /// and not recommended.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct UniqueEntityVec<T: TrustedEntityBorrow>(Vec<T>);
+pub struct UniqueEntityVec<T: TrustedEntityBorrow = Entity>(Vec<T>);
 
 impl<T: TrustedEntityBorrow> UniqueEntityVec<T> {
     /// Constructs a new, empty `UniqueEntityVec<T>`.
@@ -555,9 +553,9 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<&[U; N]
 }
 
 impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
-    PartialEq<&UniqueEntityArray<U, N>> for UniqueEntityVec<T>
+    PartialEq<&UniqueEntityArray<N, U>> for UniqueEntityVec<T>
 {
-    fn eq(&self, other: &&UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &&UniqueEntityArray<N, U>) -> bool {
         self.0.eq(&other.as_inner())
     }
 }
@@ -571,9 +569,9 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<&mut [U
 }
 
 impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
-    PartialEq<&mut UniqueEntityArray<U, N>> for UniqueEntityVec<T>
+    PartialEq<&mut UniqueEntityArray<N, U>> for UniqueEntityVec<T>
 {
-    fn eq(&self, other: &&mut UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &&mut UniqueEntityArray<N, U>) -> bool {
         self.0.eq(other.as_inner())
     }
 }
@@ -601,9 +599,9 @@ impl<T: TrustedEntityBorrow + PartialEq<U>, U, const N: usize> PartialEq<[U; N]>
 }
 
 impl<T: TrustedEntityBorrow + PartialEq<U>, U: TrustedEntityBorrow, const N: usize>
-    PartialEq<UniqueEntityArray<U, N>> for UniqueEntityVec<T>
+    PartialEq<UniqueEntityArray<N, U>> for UniqueEntityVec<T>
 {
-    fn eq(&self, other: &UniqueEntityArray<U, N>) -> bool {
+    fn eq(&self, other: &UniqueEntityArray<N, U>) -> bool {
         self.0.eq(other.as_inner())
     }
 }
@@ -711,24 +709,24 @@ impl<T: TrustedEntityBorrow> From<[T; 0]> for UniqueEntityVec<T> {
     }
 }
 
-impl<T: TrustedEntityBorrow + Clone, const N: usize> From<&UniqueEntityArray<T, N>>
+impl<T: TrustedEntityBorrow + Clone, const N: usize> From<&UniqueEntityArray<N, T>>
     for UniqueEntityVec<T>
 {
-    fn from(value: &UniqueEntityArray<T, N>) -> Self {
+    fn from(value: &UniqueEntityArray<N, T>) -> Self {
         Self(Vec::from(value.as_inner().clone()))
     }
 }
 
-impl<T: TrustedEntityBorrow + Clone, const N: usize> From<&mut UniqueEntityArray<T, N>>
+impl<T: TrustedEntityBorrow + Clone, const N: usize> From<&mut UniqueEntityArray<N, T>>
     for UniqueEntityVec<T>
 {
-    fn from(value: &mut UniqueEntityArray<T, N>) -> Self {
+    fn from(value: &mut UniqueEntityArray<N, T>) -> Self {
         Self(Vec::from(value.as_inner().clone()))
     }
 }
 
-impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<T, N>> for UniqueEntityVec<T> {
-    fn from(value: UniqueEntityArray<T, N>) -> Self {
+impl<T: TrustedEntityBorrow, const N: usize> From<UniqueEntityArray<N, T>> for UniqueEntityVec<T> {
+    fn from(value: UniqueEntityArray<N, T>) -> Self {
         Self(Vec::from(value.into_inner()))
     }
 }
@@ -806,7 +804,7 @@ impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>> for Box
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>>
-    for Box<UniqueEntityArray<T, N>>
+    for Box<UniqueEntityArray<N, T>>
 {
     type Error = UniqueEntityVec<T>;
 
@@ -828,7 +826,7 @@ impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>> for [T;
 }
 
 impl<T: TrustedEntityBorrow, const N: usize> TryFrom<UniqueEntityVec<T>>
-    for UniqueEntityArray<T, N>
+    for UniqueEntityArray<N, T>
 {
     type Error = UniqueEntityVec<T>;
 


### PR DESCRIPTION
# Objective

Installment of the #16547 series.

The vast majority of uses for these types will be the `Entity` case, so it makes sense for it to be the default.

## Solution

`UniqueEntityVec`, `UniqueEntitySlice`, `UniqueEntityArray` and their helper iterator aliases now have `Entity` as a default.

Unfortunately, this means the the `T` parameter for `UniqueEntityArray` now has to be ordered after the `N` constant, which breaks the consistency to `[T; N]`. 
Same with about a dozen iterator aliases that take some `P`/`F` predicate/function parameter.
This should however be an ergonomic improvement in most cases, so we'll just have to live with this inconsistency.

## Migration Guide

Switch type parameter order for the relevant wrapper types/aliases.