### PR TITLE
Remove system set indirection on `TransformPlugin`

### DIFF
--- a/crates/bevy_transform/src/plugins.rs
+++ b/crates/bevy_transform/src/plugins.rs
@@ -15,45 +15,34 @@ pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
     fn build(&self, app: &mut App) {
-        // A set for `propagate_transforms` to mark it as ambiguous with `sync_simple_transforms`.
-        // Used instead of the `SystemTypeSet` as that would not allow multiple instances of the system.
-        #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-        struct PropagateTransformsSet;
-
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<crate::components::Transform>()
             .register_type::<crate::components::TransformTreeChanged>()
             .register_type::<crate::components::GlobalTransform>();
 
-        app.configure_sets(
-            PostStartup,
-            PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
-        )
-        // add transform systems to startup so the first update is "correct"
-        .add_systems(
-            PostStartup,
-            (
-                mark_dirty_trees,
-                propagate_parent_transforms,
-                sync_simple_transforms,
+        app.configure_sets(PostStartup, TransformSystem::TransformPropagate)
+            // add transform systems to startup so the first update is "correct"
+            .add_systems(
+                PostStartup,
+                (
+                    mark_dirty_trees,
+                    propagate_parent_transforms,
+                    sync_simple_transforms,
+                )
+                    .chain()
+                    .in_set(TransformSystem::TransformPropagate),
             )
-                .chain()
-                .in_set(PropagateTransformsSet),
-        )
-        .configure_sets(
-            PostUpdate,
-            PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
-        )
-        .add_systems(
-            PostUpdate,
-            (
-                mark_dirty_trees,
-                propagate_parent_transforms,
-                // TODO: Adjust the internal parallel queries to make this system more efficiently share and fill CPU time.
-                sync_simple_transforms,
-            )
-                .chain()
-                .in_set(PropagateTransformsSet),
-        );
+            .configure_sets(PostUpdate, TransformSystem::TransformPropagate)
+            .add_systems(
+                PostUpdate,
+                (
+                    mark_dirty_trees,
+                    propagate_parent_transforms,
+                    // TODO: Adjust the internal parallel queries to make this system more efficiently share and fill CPU time.
+                    sync_simple_transforms,
+                )
+                    .chain()
+                    .in_set(TransformSystem::TransformPropagate),
+            );
     }
 }


### PR DESCRIPTION
# Objective

Remove system set indirection from `TransformPlugin`

## Solution

Change uses of `PropagateTransformSet` with `TransformSystem::TransformPropagate`.

## Reasoning

This indirection does not seem to be needed anymore, on an older commit there were systems that were added to `PropagateTransformSet` and others to `TransformSystem::TransformPropagete`, and using `ambiguoes_with` to prevent the 2 sets from running in parallel, but now all systems are chained, removing the need to mark the systems as ambiguous with each other. 

## Testing

`cargo run -p ci` and `many_foxes` example