### PR TITLE
`bevy_ecs` Debloating for `Res`, `ResMut`, and `BundleInserter`

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -817,25 +817,40 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
     type Item<'w, 's> = Res<'w, T>;
 
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        fn init_state(
+            world: &mut World,
+            system_meta: &mut SystemMeta,
+            component_id: ComponentId,
+            name: &str,
+        ) -> ComponentId {
+            let archetype_component_id = world.initialize_resource_internal(component_id).id();
+
+            let combined_access = system_meta.component_access_set.combined_access();
+            assert!(
+                !combined_access.has_resource_write(component_id),
+                "error[B0002]: Res<{}> in system {} conflicts with a previous ResMut<{0}> access. Consider removing the duplicate access. See: https://bevyengine.org/learn/errors/b0002",
+                name,
+                system_meta.name,
+            );
+            system_meta
+                .component_access_set
+                .add_unfiltered_resource_read(component_id);
+
+            system_meta
+                .archetype_component_access
+                .add_resource_read(archetype_component_id);
+
+            component_id
+        }
+
         let component_id = world.components_registrator().register_resource::<T>();
-        let archetype_component_id = world.initialize_resource_internal(component_id).id();
 
-        let combined_access = system_meta.component_access_set.combined_access();
-        assert!(
-            !combined_access.has_resource_write(component_id),
-            "error[B0002]: Res<{}> in system {} conflicts with a previous ResMut<{0}> access. Consider removing the duplicate access. See: https://bevyengine.org/learn/errors/b0002",
+        init_state(
+            world,
+            system_meta,
+            component_id,
             core::any::type_name::<T>(),
-            system_meta.name,
-        );
-        system_meta
-            .component_access_set
-            .add_unfiltered_resource_read(component_id);
-
-        system_meta
-            .archetype_component_access
-            .add_resource_read(archetype_component_id);
-
-        component_id
+        )
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -877,7 +877,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        unsafe fn get_param<'w, 's>(
+        unsafe fn get_param<'w>(
             component_id: ComponentId,
             system_meta: &SystemMeta,
             world: UnsafeWorldCell<'w>,


### PR DESCRIPTION
# Objective

Compile times in Bevy have consistently degraded over the last several versions. Part of this is due to the extensive use of generic code, which typically leads to duplicated code during monomorphisation. Using [`cargo-llvm-lines`](https://github.com/dtolnay/cargo-llvm-lines) on the crate `bevy_pbr`, I identified several low-hanging-fruit items for refactoring:

* `bevy_ecs::bundle::BundleInserter::insert`: 41214 / 2.2%
* `<bevy_ecs::change_detection::ResMut<T> as bevy_ecs::system::system_param::SystemParam>::init_state` : 19470 / 1.0%
* `<bevy_ecs::change_detection::Res<T> as bevy_ecs::system::system_param::SystemParam>::init_state`: 9999 / 0.5%
* `<bevy_ecs::change_detection::Res<T> as bevy_ecs::system::system_param::SystemParam>::get_param`: 5049 / 0.3%

## Solution

Refactored the above functions to isolate type parameters from the common logic as much as possible. This negatively affects the legibility of the code. But for such fundamental code it may be a necessary evil for improved compile times.

~~Before this change, a clean build of `bevy` took 242 seconds on my laptop. After it took 231 seconds, a reduction of 3.5%.~~

Upon further benchmarking I was unable to reproduce the original results I opened this PR with consistently. I had hoped 11 seconds would be enough of a delta to indicate a definitive improvement, however that appears to be the upper range on the noise I can observe on my machine.

## Testing

- CI

---

## Notes

- Diff looks worse than it is because the indentation level increased.
- Refer to individual commits for function-by-function changes.
