### PR TITLE
Canonicalize the root path to match the canonicalized asset path.

### DIFF
--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -35,7 +35,7 @@ impl FileWatcher {
         sender: Sender<AssetSourceEvent>,
         debounce_wait_time: Duration,
     ) -> Result<Self, notify::Error> {
-        let root = normalize_path(&path);
+        let root = normalize_path(&path).canonicalize().unwrap();
         let watcher = new_asset_event_debouncer(
             path.clone(),
             debounce_wait_time,


### PR DESCRIPTION
# Objective

- Fixes #18342.

## Solution

- Canonicalize the root path so that when we try to strip the prefix, it matches the canonicalized asset path.
- This is basically just a followup to #18023.

## Testing

- Ran the hot_asset_reloading example and it no longer panics.