### PR TITLE
bevy_winit: Create the window initially invisible as required by AccessKit

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -110,6 +110,9 @@ impl WinitWindows {
             }
         };
 
+        // It's crucial to avoid setting the window's final visibility here;
+        // as explained above, the window must be invisible until the AccessKit
+        // adapter is created.
         winit_window_attributes = winit_window_attributes
             .with_window_level(convert_window_level(window.window_level))
             .with_theme(window.window_theme.map(convert_window_theme))
@@ -283,6 +286,8 @@ impl WinitWindows {
             handlers,
         );
 
+        // Now that the AccessKit adapter is created, it's safe to show
+        // the window.
         winit_window.set_visible(window.visible);
 
         // Do not set the grab mode on window creation if it's none. It can fail on mobile.

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -116,8 +116,7 @@ impl WinitWindows {
             .with_resizable(window.resizable)
             .with_enabled_buttons(convert_enabled_buttons(window.enabled_buttons))
             .with_decorations(window.decorations)
-            .with_transparent(window.transparent)
-            .with_visible(window.visible);
+            .with_transparent(window.transparent);
 
         #[cfg(target_os = "windows")]
         {
@@ -283,6 +282,8 @@ impl WinitWindows {
             adapters,
             handlers,
         );
+
+        winit_window.set_visible(window.visible);
 
         // Do not set the grab mode on window creation if it's none. It can fail on mobile.
         if window.cursor_options.grab_mode != CursorGrabMode::None {


### PR DESCRIPTION
The initial `with_visible` call was intended to do this, but that was undone by a later `with_visible` call.