### PR TITLE
Make TAA non-experimental, fixes

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -56,7 +56,7 @@ pub struct Camera3d {
     ///
     /// Higher qualities are more GPU-intensive.
     ///
-    /// **Note:** You can get better-looking results at any quality level by enabling TAA. See: [`TemporalAntiAliasPlugin`](crate::experimental::taa::TemporalAntiAliasPlugin).
+    /// **Note:** You can get better-looking results at any quality level by enabling TAA. See: [`TemporalAntiAliasing`](crate::taa::TemporalAntiAliasing).
     pub screen_space_specular_transmission_quality: ScreenSpaceTransmissionQuality,
 }
 
@@ -117,7 +117,7 @@ impl From<Camera3dDepthLoadOp> for LoadOp<f32> {
 ///
 /// Higher qualities are more GPU-intensive.
 ///
-/// **Note:** You can get better-looking results at any quality level by enabling TAA. See: [`TemporalAntiAliasPlugin`](crate::experimental::taa::TemporalAntiAliasPlugin).
+/// **Note:** You can get better-looking results at any quality level by enabling TAA. See: [`TemporalAntiAliasing`](crate::taa::TemporalAntiAliasing).
 #[derive(Resource, Default, Clone, Copy, Reflect, PartialEq, PartialOrd, Debug)]
 #[reflect(Resource, Default, Debug, PartialEq)]
 pub enum ScreenSpaceTransmissionQuality {

--- a/crates/bevy_core_pipeline/src/experimental/mod.rs
+++ b/crates/bevy_core_pipeline/src/experimental/mod.rs
@@ -5,7 +5,3 @@
 //! are included nonetheless for testing purposes.
 
 pub mod mip_generation;
-
-pub mod taa {
-    pub use crate::taa::{TemporalAntiAliasNode, TemporalAntiAliasPlugin, TemporalAntiAliasing};
-}

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -24,7 +24,7 @@ pub mod post_process;
 pub mod prepass;
 mod skybox;
 pub mod smaa;
-mod taa;
+pub mod taa;
 pub mod tonemapping;
 pub mod upscaling;
 
@@ -54,6 +54,7 @@ use crate::{
     post_process::PostProcessingPlugin,
     prepass::{DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass},
     smaa::SmaaPlugin,
+    taa::TemporalAntiAliasPlugin,
     tonemapping::TonemappingPlugin,
     upscaling::UpscalingPlugin,
 };
@@ -93,6 +94,7 @@ impl Plugin for CorePipelinePlugin {
                 PostProcessingPlugin,
                 OrderIndependentTransparencyPlugin,
                 MipGenerationPlugin,
+                TemporalAntiAliasPlugin,
             ));
     }
 }

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -115,7 +115,6 @@ impl Plugin for TemporalAntiAliasPlugin {
 ///
 /// # Usage Notes
 ///
-/// The [`TemporalAntiAliasPlugin`] must be added to your app.
 /// Any camera with this component must also disable [`Msaa`] by setting it to [`Msaa::Off`].
 ///
 /// [Currently](https://github.com/bevyengine/bevy/issues/8423), TAA cannot be used with [`bevy_render::camera::OrthographicProjection`].
@@ -153,7 +152,7 @@ impl Default for TemporalAntiAliasing {
 
 /// Render [`bevy_render::render_graph::Node`] used by temporal anti-aliasing.
 #[derive(Default)]
-pub struct TemporalAntiAliasNode;
+struct TemporalAntiAliasNode;
 
 impl ViewNode for TemporalAntiAliasNode {
     type ViewQuery = (
@@ -408,7 +407,7 @@ fn prepare_taa_jitter_and_mip_bias(
 }
 
 #[derive(Component)]
-pub struct TemporalAntiAliasHistoryTextures {
+struct TemporalAntiAliasHistoryTextures {
     write: CachedTexture,
     read: CachedTexture,
 }
@@ -465,7 +464,7 @@ fn prepare_taa_history_textures(
 }
 
 #[derive(Component)]
-pub struct TemporalAntiAliasPipelineId(CachedRenderPipelineId);
+struct TemporalAntiAliasPipelineId(CachedRenderPipelineId);
 
 fn prepare_taa_pipelines(
     mut commands: Commands,

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -383,8 +383,9 @@ fn prepare_taa_jitter_and_mip_bias(
     mut query: Query<(Entity, &mut TemporalJitter, Option<&MipBias>), With<TemporalAntiAliasing>>,
     mut commands: Commands,
 ) {
-    // Halton sequence (2, 3) - 0.5, skipping i = 0
+    // Halton sequence (2, 3) - 0.5
     let halton_sequence = [
+        vec2(0.0, 0.0),
         vec2(0.0, -0.16666666),
         vec2(-0.25, 0.16666669),
         vec2(0.25, -0.3888889),
@@ -392,7 +393,6 @@ fn prepare_taa_jitter_and_mip_bias(
         vec2(0.125, 0.2777778),
         vec2(-0.125, -0.2777778),
         vec2(0.375, 0.055555582),
-        vec2(-0.4375, 0.3888889),
     ];
 
     let offset = halton_sequence[frame_count.0 as usize % halton_sequence.len()];

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -492,7 +492,7 @@ pub enum ShadowFilteringMethod {
     /// A randomized filter that varies over time, good when TAA is in use.
     ///
     /// Good quality when used with
-    /// [`TemporalAntiAliasing`](bevy_core_pipeline::experimental::taa::TemporalAntiAliasing)
+    /// [`TemporalAntiAliasing`](bevy_core_pipeline::taa::TemporalAntiAliasing)
     /// and good performance.
     ///
     /// For directional and spot lights, this uses a [method by Jorge Jimenez for

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -146,7 +146,7 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
 /// Requires that you add [`ScreenSpaceAmbientOcclusionPlugin`] to your app.
 ///
 /// It strongly recommended that you use SSAO in conjunction with
-/// TAA ([`bevy_core_pipeline::experimental::taa::TemporalAntiAliasing`]).
+/// TAA ([`bevy_core_pipeline::taa::TemporalAntiAliasing`]).
 /// Doing so greatly reduces SSAO noise.
 ///
 /// SSAO is not supported on `WebGL2`, and is not currently supported on `WebGPU`.

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1069,6 +1069,7 @@ pub fn extract_cameras(
             Option<&ColorGrading>,
             Option<&Exposure>,
             Option<&TemporalJitter>,
+            Option<&MipBias>,
             Option<&RenderLayers>,
             Option<&Projection>,
             Has<NoIndirectDrawing>,
@@ -1090,6 +1091,7 @@ pub fn extract_cameras(
         color_grading,
         exposure,
         temporal_jitter,
+        mip_bias,
         render_layers,
         projection,
         no_indirect_drawing,
@@ -1101,6 +1103,7 @@ pub fn extract_cameras(
                 ExtractedView,
                 RenderVisibleEntities,
                 TemporalJitter,
+                MipBias,
                 RenderLayers,
                 Projection,
                 NoIndirectDrawing,
@@ -1187,14 +1190,26 @@ pub fn extract_cameras(
 
             if let Some(temporal_jitter) = temporal_jitter {
                 commands.insert(temporal_jitter.clone());
+            } else {
+                commands.remove::<TemporalJitter>();
+            }
+
+            if let Some(mip_bias) = mip_bias {
+                commands.insert(mip_bias.clone());
+            } else {
+                commands.remove::<MipBias>();
             }
 
             if let Some(render_layers) = render_layers {
                 commands.insert(render_layers.clone());
+            } else {
+                commands.remove::<RenderLayers>();
             }
 
             if let Some(perspective) = projection {
                 commands.insert(perspective.clone());
+            } else {
+                commands.remove::<Projection>();
             }
 
             if no_indirect_drawing
@@ -1204,6 +1219,8 @@ pub fn extract_cameras(
                 )
             {
                 commands.insert(NoIndirectDrawing);
+            } else {
+                commands.remove::<NoIndirectDrawing>();
             }
         };
     }
@@ -1304,6 +1321,12 @@ impl TemporalJitter {
 /// Camera component specifying a mip bias to apply when sampling from material textures.
 ///
 /// Often used in conjunction with antialiasing post-process effects to reduce textures blurriness.
-#[derive(Default, Component, Reflect)]
+#[derive(Component, Reflect, Clone)]
 #[reflect(Default, Component)]
 pub struct MipBias(pub f32);
+
+impl Default for MipBias {
+    fn default() -> Self {
+        Self(-1.0)
+    }
+}

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -14,7 +14,7 @@ use bevy::{
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
     render::{
-        camera::TemporalJitter,
+        camera::{MipBias, TemporalJitter},
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat},
     },
@@ -31,6 +31,7 @@ fn main() {
 type TaaComponents = (
     TemporalAntiAliasing,
     TemporalJitter,
+    MipBias,
     DepthPrepass,
     MotionVectorPrepass,
 );

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -5,10 +5,10 @@ use std::{f32::consts::PI, fmt::Write};
 use bevy::{
     core_pipeline::{
         contrast_adaptive_sharpening::ContrastAdaptiveSharpening,
-        experimental::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing},
         fxaa::{Fxaa, Sensitivity},
         prepass::{DepthPrepass, MotionVectorPrepass},
         smaa::{Smaa, SmaaPreset},
+        taa::TemporalAntiAliasing,
     },
     image::{ImageSampler, ImageSamplerDescriptor},
     pbr::CascadeShadowConfigBuilder,
@@ -22,7 +22,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, TemporalAntiAliasPlugin))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, (modify_aa, modify_sharpening, update_ui))
         .run();

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -4,9 +4,8 @@ use std::f32::consts::PI;
 
 use bevy::{
     core_pipeline::{
-        experimental::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing},
         prepass::{DepthPrepass, MotionVectorPrepass},
-        Skybox,
+        Skybox, TemporalAntiAliasing,
     },
     math::vec3,
     pbr::{CubemapVisibleEntities, ShadowFilteringMethod, VisibleMeshEntities},
@@ -120,7 +119,6 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugins(TemporalAntiAliasPlugin)
         .add_event::<WidgetClickEvent<AppSetting>>()
         .add_systems(Startup, setup)
         .add_systems(Update, widgets::handle_ui_interactions::<AppSetting>)

--- a/examples/3d/scrolling_fog.rs
+++ b/examples/3d/scrolling_fog.rs
@@ -11,10 +11,7 @@
 //! interactions change based on the density of the fog.
 
 use bevy::{
-    core_pipeline::{
-        bloom::Bloom,
-        experimental::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing},
-    },
+    core_pipeline::{bloom::Bloom, TemporalAntiAliasing},
     image::{
         ImageAddressMode, ImageFilterMode, ImageLoaderSettings, ImageSampler,
         ImageSamplerDescriptor,
@@ -34,7 +31,6 @@ fn main() {
             ..default()
         }))
         .insert_resource(DirectionalLightShadowMap { size: 4096 })
-        .add_plugins(TemporalAntiAliasPlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, scroll_fog)
         .run();

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -1,7 +1,7 @@
 //! A scene showcasing screen space ambient occlusion.
 
 use bevy::{
-    core_pipeline::experimental::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing},
+    core_pipeline::taa::TemporalAntiAliasing,
     math::ops,
     pbr::{ScreenSpaceAmbientOcclusion, ScreenSpaceAmbientOcclusionQualityLevel},
     prelude::*,
@@ -15,7 +15,7 @@ fn main() {
             brightness: 1000.,
             ..default()
         })
-        .add_plugins((DefaultPlugins, TemporalAntiAliasPlugin))
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, update)
         .run();

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -35,14 +35,16 @@ use bevy::{
     },
 };
 
+// *Note:* TAA is not _required_ for specular transmission, but
+// it _greatly enhances_ the look of the resulting blur effects.
+// Sadly, it's not available under WebGL.
 #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
-use bevy::core_pipeline::experimental::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing};
+use bevy::core_pipeline::taa::TemporalAntiAliasing;
 use rand::random;
 
 fn main() {
-    let mut app = App::new();
-
-    app.add_plugins(DefaultPlugins)
+    App::new()
+        .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(PointLightShadowMap { size: 2048 })
         .insert_resource(AmbientLight {
@@ -50,15 +52,8 @@ fn main() {
             ..default()
         })
         .add_systems(Startup, setup)
-        .add_systems(Update, (example_control_system, flicker_system));
-
-    // *Note:* TAA is not _required_ for specular transmission, but
-    // it _greatly enhances_ the look of the resulting blur effects.
-    // Sadly, it's not available under WebGL.
-    #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
-    app.add_plugins(TemporalAntiAliasPlugin);
-
-    app.run();
+        .add_systems(Update, (example_control_system, flicker_system))
+        .run();
 }
 
 /// set up a simple 3D scene


### PR DESCRIPTION
The first 4 commits are designed to be reviewed independently.

- Mark TAA non-experimental now that motion vectors are written for skinned and morphed meshes, along with skyboxes, and add it to DefaultPlugins
- Adjust halton sequence to match what DLSS is going to use, doesn't really affect anything, but may as well
- Make MipBias a required component on TAA instead of inserting it in the render world
- Remove MipBias, TemporalJitter, RenderLayers, etc from the render world if they're removed from the main world (fixes a retained render world bug)
- Remove TAA components from the render world properly if TemporalAntiAliasing is removed from the main world (fixes a retained render world bug)
  - extract_taa_settings() now has to query over `Option<&mut TemporalAntiAliasing>`, which will match every single camera, in order to cover cameras that had TemporalAntiAliasing removed this frame. This kind of sucks, but I can't think of anything better.
  - We probably have the same bug with every other rendering feature component we have.

## Migration Guide
- TAA is no longer experimental
  - TemporalAntiAliasing no longer needs to be added to your app to use TAA. It is now part of DefaultPlugins/CorePipelinePlugin.
  - TemporalAntiAliasing now uses MipBias as a required component in the main world, instead of overriding it manually in the render world.
