### PR TITLE
Added `io` Module to `bevy_platform_support`

### DIFF
--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -17,14 +17,14 @@ impl AsyncSeekForward for File {
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
         offset: u64,
-    ) -> Poll<futures_io::Result<u64>> {
+    ) -> Poll<bevy_platform_support::io::Result<u64>> {
         let offset: Result<i64, _> = offset.try_into();
 
         if let Ok(offset) = offset {
             Pin::new(&mut self).poll_seek(cx, futures_io::SeekFrom::Current(offset))
         } else {
-            Poll::Ready(Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
+            Poll::Ready(Err(bevy_platform_support::io::Error::new(
+                bevy_platform_support::io::ErrorKind::InvalidInput,
                 "seek position is out of range",
             )))
         }
@@ -37,7 +37,7 @@ impl AssetReader for FileAssetReader {
     async fn read<'a>(&'a self, path: &'a Path) -> Result<impl Reader + 'a, AssetReaderError> {
         let full_path = self.root_path.join(path);
         File::open(&full_path).await.map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
+            if e.kind() == bevy_platform_support::io::ErrorKind::NotFound {
                 AssetReaderError::NotFound(full_path)
             } else {
                 e.into()
@@ -49,7 +49,7 @@ impl AssetReader for FileAssetReader {
         let meta_path = get_meta_path(path);
         let full_path = self.root_path.join(meta_path);
         File::open(&full_path).await.map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
+            if e.kind() == bevy_platform_support::io::ErrorKind::NotFound {
                 AssetReaderError::NotFound(full_path)
             } else {
                 e.into()
@@ -82,7 +82,7 @@ impl AssetReader for FileAssetReader {
                 Ok(read_dir)
             }
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
+                if e.kind() == bevy_platform_support::io::ErrorKind::NotFound {
                     Err(AssetReaderError::NotFound(full_path))
                 } else {
                     Err(e.into())

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -23,7 +23,7 @@ impl AsyncRead for FileReader {
         self: Pin<&mut Self>,
         _cx: &mut core::task::Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
+    ) -> Poll<bevy_platform_support::io::Result<usize>> {
         let this = self.get_mut();
         let read = this.0.read(buf);
         Poll::Ready(read)
@@ -35,7 +35,7 @@ impl AsyncSeekForward for FileReader {
         self: Pin<&mut Self>,
         _cx: &mut core::task::Context<'_>,
         offset: u64,
-    ) -> Poll<std::io::Result<u64>> {
+    ) -> Poll<bevy_platform_support::io::Result<u64>> {
         let this = self.get_mut();
         let current = this.0.stream_position()?;
         let seek = this.0.seek(std::io::SeekFrom::Start(current + offset));
@@ -48,8 +48,11 @@ impl Reader for FileReader {
     fn read_to_end<'a>(
         &'a mut self,
         buf: &'a mut Vec<u8>,
-    ) -> stackfuture::StackFuture<'a, std::io::Result<usize>, { crate::io::STACK_FUTURE_SIZE }>
-    {
+    ) -> stackfuture::StackFuture<
+        'a,
+        bevy_platform_support::io::Result<usize>,
+        { crate::io::STACK_FUTURE_SIZE },
+    > {
         stackfuture::StackFuture::from(async { self.0.read_to_end(buf) })
     }
 }
@@ -61,7 +64,7 @@ impl AsyncWrite for FileWriter {
         self: Pin<&mut Self>,
         _cx: &mut core::task::Context<'_>,
         buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
+    ) -> Poll<bevy_platform_support::io::Result<usize>> {
         let this = self.get_mut();
         let wrote = this.0.write(buf);
         Poll::Ready(wrote)
@@ -70,7 +73,7 @@ impl AsyncWrite for FileWriter {
     fn poll_flush(
         self: Pin<&mut Self>,
         _cx: &mut core::task::Context<'_>,
-    ) -> Poll<std::io::Result<()>> {
+    ) -> Poll<bevy_platform_support::io::Result<()>> {
         let this = self.get_mut();
         let flushed = this.0.flush();
         Poll::Ready(flushed)
@@ -79,7 +82,7 @@ impl AsyncWrite for FileWriter {
     fn poll_close(
         self: Pin<&mut Self>,
         _cx: &mut core::task::Context<'_>,
-    ) -> Poll<std::io::Result<()>> {
+    ) -> Poll<bevy_platform_support::io::Result<()>> {
         Poll::Ready(Ok(()))
     }
 }
@@ -104,7 +107,7 @@ impl AssetReader for FileAssetReader {
         match File::open(&full_path) {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
+                if e.kind() == bevy_platform_support::io::ErrorKind::NotFound {
                     Err(AssetReaderError::NotFound(full_path))
                 } else {
                     Err(e.into())
@@ -119,7 +122,7 @@ impl AssetReader for FileAssetReader {
         match File::open(&full_path) {
             Ok(file) => Ok(FileReader(file)),
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
+                if e.kind() == bevy_platform_support::io::ErrorKind::NotFound {
                     Err(AssetReaderError::NotFound(full_path))
                 } else {
                     Err(e.into())
@@ -153,7 +156,7 @@ impl AssetReader for FileAssetReader {
                 Ok(read_dir)
             }
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
+                if e.kind() == bevy_platform_support::io::ErrorKind::NotFound {
                     Err(AssetReaderError::NotFound(full_path))
                 } else {
                     Err(e.into())

--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -234,7 +234,7 @@ impl AsyncRead for DataReader {
         mut self: Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<futures_io::Result<usize>> {
+    ) -> Poll<bevy_platform_support::io::Result<usize>> {
         if self.bytes_read >= self.data.value().len() {
             Poll::Ready(Ok(0))
         } else {
@@ -251,7 +251,7 @@ impl AsyncSeekForward for DataReader {
         mut self: Pin<&mut Self>,
         _cx: &mut core::task::Context<'_>,
         offset: u64,
-    ) -> Poll<std::io::Result<u64>> {
+    ) -> Poll<bevy_platform_support::io::Result<u64>> {
         let result = self
             .bytes_read
             .try_into()
@@ -261,8 +261,8 @@ impl AsyncSeekForward for DataReader {
             self.bytes_read = new_pos as _;
             Poll::Ready(Ok(new_pos as _))
         } else {
-            Poll::Ready(Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
+            Poll::Ready(Err(bevy_platform_support::io::Error::new(
+                bevy_platform_support::io::ErrorKind::InvalidInput,
                 "seek position is out of range",
             )))
         }
@@ -273,7 +273,11 @@ impl Reader for DataReader {
     fn read_to_end<'a>(
         &'a mut self,
         buf: &'a mut Vec<u8>,
-    ) -> stackfuture::StackFuture<'a, std::io::Result<usize>, { super::STACK_FUTURE_SIZE }> {
+    ) -> stackfuture::StackFuture<
+        'a,
+        bevy_platform_support::io::Result<usize>,
+        { super::STACK_FUTURE_SIZE },
+    > {
         stackfuture::StackFuture::from(async {
             if self.bytes_read >= self.data.value().len() {
                 Ok(0)

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -137,7 +137,7 @@ impl AsyncRead for TransactionLockedReader<'_> {
         mut self: Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<futures_io::Result<usize>> {
+    ) -> Poll<bevy_platform_support::io::Result<usize>> {
         Pin::new(&mut self.reader).poll_read(cx, buf)
     }
 }
@@ -147,7 +147,7 @@ impl AsyncSeekForward for TransactionLockedReader<'_> {
         mut self: Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
         offset: u64,
-    ) -> Poll<std::io::Result<u64>> {
+    ) -> Poll<bevy_platform_support::io::Result<u64>> {
         Pin::new(&mut self.reader).poll_seek_forward(cx, offset)
     }
 }
@@ -156,7 +156,11 @@ impl Reader for TransactionLockedReader<'_> {
     fn read_to_end<'a>(
         &'a mut self,
         buf: &'a mut Vec<u8>,
-    ) -> stackfuture::StackFuture<'a, std::io::Result<usize>, { super::STACK_FUTURE_SIZE }> {
+    ) -> stackfuture::StackFuture<
+        'a,
+        bevy_platform_support::io::Result<usize>,
+        { super::STACK_FUTURE_SIZE },
+    > {
         self.reader.read_to_end(buf)
     }
 }

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -38,7 +38,7 @@ impl HttpWasmAssetReader {
     }
 }
 
-fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> std::io::Error + '_ {
+fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> bevy_platform_support::io::Error + '_ {
     move |value| {
         let message = match JSON::stringify(&value) {
             Ok(js_str) => format!("Failed to {context}: {js_str}"),
@@ -47,7 +47,7 @@ fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> std::io::Error + '_
             }
         };
 
-        std::io::Error::new(std::io::ErrorKind::Other, message)
+        bevy_platform_support::io::Error::new(bevy_platform_support::io::ErrorKind::Other, message)
     }
 }
 
@@ -62,8 +62,8 @@ impl HttpWasmAssetReader {
             let worker: web_sys::WorkerGlobalScope = global.unchecked_into();
             worker.fetch_with_str(path.to_str().unwrap())
         } else {
-            let error = std::io::Error::new(
-                std::io::ErrorKind::Other,
+            let error = bevy_platform_support::io::Error::new(
+                bevy_platform_support::io::ErrorKind::Other,
                 "Unsupported JavaScript global context",
             );
             return Err(AssetReaderError::Io(error.into()));

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -698,7 +698,7 @@ mod tests {
         #[error(transparent)]
         DuplicateLabelAssetError(#[from] DuplicateLabelAssetError),
         #[error("An IO error occurred during loading")]
-        Io(#[from] std::io::Error),
+        Io(#[from] bevy_platform_support::io::Error),
     }
 
     impl AssetLoader for CoolTextLoader {
@@ -754,7 +754,7 @@ mod tests {
     /// A dummy [`CoolText`] asset reader that only succeeds after `failure_count` times it's read from for each asset.
     #[derive(Default, Clone)]
     pub struct UnstableMemoryAssetReader {
-        pub attempt_counters: Arc<std::sync::Mutex<HashMap<Box<Path>, usize>>>,
+        pub attempt_counters: Arc<bevy_platform_support::sync::Mutex<HashMap<Box<Path>, usize>>>,
         pub load_delay: Duration,
         memory_reader: MemoryAssetReader,
         failure_count: usize,
@@ -800,8 +800,8 @@ mod tests {
             };
 
             if attempt_number <= self.failure_count {
-                let io_error = std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
+                let io_error = bevy_platform_support::io::Error::new(
+                    bevy_platform_support::io::ErrorKind::ConnectionRefused,
                     format!(
                         "Simulated failure {attempt_number} of {}",
                         self.failure_count

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -33,7 +33,7 @@ pub trait AssetLoader: Send + Sync + 'static {
     type Asset: Asset;
     /// The settings type used by this [`AssetLoader`].
     type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
-    /// The type of [error](`std::error::Error`) which could be encountered by this loader.
+    /// The type of [error](`core::error::Error`) which could be encountered by this loader.
     type Error: Into<Box<dyn core::error::Error + Send + Sync + 'static>>;
     /// Asynchronously loads [`AssetLoader::Asset`] (and any other labeled assets) from the bytes provided by [`Reader`].
     fn load(
@@ -669,7 +669,7 @@ pub enum ReadAssetBytesError {
     #[error("Encountered an io error while loading asset at `{}`: {source}", path.display())]
     Io {
         path: PathBuf,
-        source: std::io::Error,
+        source: bevy_platform_support::io::Error,
     },
     #[error("The LoadContext for this read_asset_bytes call requires hash metadata, but it was not provided. This is likely an internal implementation error.")]
     MissingAssetHash,

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -201,7 +201,7 @@ impl VisitAssetDependencies for () {
 impl AssetLoader for () {
     type Asset = ();
     type Settings = ();
-    type Error = std::io::Error;
+    type Error = bevy_platform_support::io::Error;
     async fn load(
         &self,
         _reader: &mut dyn crate::io::Reader,

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -59,8 +59,8 @@ use crate::{
 use alloc::{borrow::ToOwned, boxed::Box, collections::VecDeque, sync::Arc, vec, vec::Vec};
 use bevy_ecs::prelude::*;
 use bevy_platform_support::collections::{HashMap, HashSet};
+use bevy_platform_support::io::ErrorKind;
 use bevy_tasks::IoTaskPool;
-use futures_io::ErrorKind;
 use futures_lite::{AsyncReadExt, AsyncWriteExt, StreamExt};
 use parking_lot::RwLock;
 use std::path::{Path, PathBuf};
@@ -216,7 +216,7 @@ impl AssetProcessor {
     ///   (if the latest version of the asset has not been processed).
     #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
     pub fn process_assets(&self) {
-        let start_time = std::time::Instant::now();
+        let start_time = bevy_platform_support::time::Instant::now();
         debug!("Processing Assets");
         IoTaskPool::get().scope(|scope| {
             scope.spawn(async move {
@@ -231,7 +231,7 @@ impl AssetProcessor {
         // This must happen _after_ the scope resolves or it will happen "too early"
         // Don't move this into the async scope above! process_assets is a blocking/sync function this is fine
         bevy_tasks::block_on(self.finish_processing_assets());
-        let end_time = std::time::Instant::now();
+        let end_time = bevy_platform_support::time::Instant::now();
         debug!("Processing finished in {:?}", end_time - start_time);
     }
 

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -22,7 +22,7 @@ pub trait AssetSaver: Send + Sync + 'static {
     type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
     /// The type of [`AssetLoader`] used to load this [`Asset`]
     type OutputLoader: AssetLoader;
-    /// The type of [error](`std::error::Error`) which could be encountered by this saver.
+    /// The type of [error](`core::error::Error`) which could be encountered by this saver.
     type Error: Into<Box<dyn core::error::Error + Send + Sync + 'static>>;
 
     /// Saves the given runtime [`Asset`] by writing it to a byte format using `writer`. The passed in `settings` can influence how the

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1945,7 +1945,7 @@ pub enum WriteDefaultMetaError {
     #[error("asset meta file already exists, so avoiding overwrite")]
     MetaAlreadyExists,
     #[error("encountered an I/O error while reading the existing meta file: {0}")]
-    IoErrorFromExistingMetaCheck(Arc<std::io::Error>),
+    IoErrorFromExistingMetaCheck(Arc<bevy_platform_support::io::Error>),
     #[error("encountered HTTP status {0} when reading the existing meta file")]
     HttpErrorFromExistingMetaCheck(u16),
 }

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -25,7 +25,7 @@ pub trait AssetTransformer: Send + Sync + 'static {
     type AssetOutput: Asset;
     /// The settings type used by this [`AssetTransformer`].
     type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
-    /// The type of [error](`std::error::Error`) which could be encountered by this transformer.
+    /// The type of [error](`core::error::Error`) which could be encountered by this transformer.
     type Error: Into<Box<dyn core::error::Error + Send + Sync + 'static>>;
 
     /// Transforms the given [`TransformedAsset`] to [`AssetTransformer::AssetOutput`].

--- a/crates/bevy_platform_support/src/io/fallback.rs
+++ b/crates/bevy_platform_support/src/io/fallback.rs
@@ -1,0 +1,306 @@
+use core::fmt::{Debug, Display};
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+
+/// An error associated with an IO operation.
+pub struct Error {
+    kind: ErrorKind,
+    inner: InnerError,
+}
+
+enum InnerError {
+    Simple,
+    Code(RawOsError),
+    #[cfg(feature = "alloc")]
+    Complex(Box<dyn core::error::Error + Send + Sync>),
+}
+
+impl core::error::Error for Error {}
+
+impl Debug for Error {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <ErrorKind as Debug>::fmt(&self.kind, fmt)?;
+        match &self.inner {
+            InnerError::Simple => Ok(()),
+            InnerError::Code(code) => {
+                fmt.write_str(": ")?;
+                <RawOsError as Debug>::fmt(code, fmt)
+            }
+            #[cfg(feature = "alloc")]
+            InnerError::Complex(error) => {
+                fmt.write_str(": ")?;
+                <Box<dyn core::error::Error + Send + Sync> as Debug>::fmt(error, fmt)
+            }
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <ErrorKind as Display>::fmt(&self.kind, fmt)?;
+        match &self.inner {
+            InnerError::Simple => Ok(()),
+            InnerError::Code(code) => {
+                fmt.write_str(": ")?;
+                <RawOsError as Display>::fmt(code, fmt)
+            }
+            #[cfg(feature = "alloc")]
+            InnerError::Complex(error) => {
+                fmt.write_str(": ")?;
+                <Box<dyn core::error::Error + Send + Sync> as Display>::fmt(error, fmt)
+            }
+        }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            kind,
+            inner: InnerError::Simple,
+        }
+    }
+}
+
+impl Error {
+    /// Gets the [kind](ErrorKind) of this error.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Gets the last reported [`Error`] from the underlying OS.
+    pub fn last_os_error() -> Error {
+        ErrorKind::Other.into()
+    }
+
+    /// Creates an [`Error`] from the provided [code](RawOsError).
+    pub fn from_raw_os_error(code: RawOsError) -> Error {
+        Error {
+            kind: ErrorKind::Other,
+            inner: InnerError::Code(code),
+        }
+    }
+
+    /// Gets the underlying error [code](RawOsError), if applicable.
+    pub fn raw_os_error(&self) -> Option<RawOsError> {
+        match &self.inner {
+            InnerError::Code(code) => Some(*code),
+            _ => None,
+        }
+    }
+
+    /// Downcasts the underlying [error](core::error::Error) into the type `E`, if applicable.
+    pub fn downcast<E>(self) -> core::result::Result<E, Self>
+    where
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        match self.inner {
+            #[cfg(feature = "alloc")]
+            InnerError::Complex(error) if error.as_ref().is::<E>() => {
+                let res = error.downcast::<E>();
+                Ok(*res.unwrap())
+            }
+            inner => Err(Self {
+                kind: self.kind,
+                inner,
+            }),
+        }
+    }
+
+    /// Gets a reference to the underlying [error](core::error::Error), if applicable.
+    pub fn get_ref(&self) -> Option<&(dyn core::error::Error + Send + Sync)> {
+        match &self.inner {
+            #[cfg(feature = "alloc")]
+            InnerError::Complex(error) => Some(error.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Gets a mutable reference to the underlying [error](core::error::Error), if applicable.
+    pub fn get_mut(&mut self) -> Option<&mut (dyn core::error::Error + Send + Sync)> {
+        match &mut self.inner {
+            #[cfg(feature = "alloc")]
+            InnerError::Complex(error) => Some(error.as_mut()),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Error {
+    /// Creates a new [`Error`] based on the provided [kind](ErrorKind) and inner [error](core::error::Error).
+    pub fn new<E>(kind: ErrorKind, error: E) -> Error
+    where
+        E: Into<Box<dyn core::error::Error + Send + Sync>>,
+    {
+        Error {
+            kind,
+            inner: InnerError::Complex(error.into()),
+        }
+    }
+
+    /// Creates a new [`Error`] from the inner [error](core::error::Error).
+    pub fn other<E>(error: E) -> Error
+    where
+        E: Into<Box<dyn core::error::Error + Send + Sync>>,
+    {
+        Error::new(ErrorKind::Other, error)
+    }
+
+    /// Gets the underlying [error](core::error::Error), if applicable.
+    pub fn into_inner(self) -> Option<Box<dyn core::error::Error + Send + Sync>> {
+        match self.inner {
+            InnerError::Complex(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// A classification of IO [`Error`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub enum ErrorKind {
+    /// An entity was not found, often a file.
+    NotFound,
+    /// The operation lacked the necessary privileges to complete.
+    PermissionDenied,
+    /// The connection was refused by the remote server.
+    ConnectionRefused,
+    /// The connection was reset by the remote server.
+    ConnectionReset,
+    /// The remote host is not reachable.
+    HostUnreachable,
+    /// The network containing the remote host is not reachable.
+    NetworkUnreachable,
+    /// The connection was aborted (terminated) by the remote server.
+    ConnectionAborted,
+    /// The network operation failed because it was not connected yet.
+    NotConnected,
+    /// A socket address could not be bound because the address is already in
+    /// use elsewhere.
+    AddrInUse,
+    /// A nonexistent interface was requested or the requested address was not
+    /// local.
+    AddrNotAvailable,
+    /// The system's networking is down.
+    NetworkDown,
+    /// The operation failed because a pipe was closed.
+    BrokenPipe,
+    /// An entity already exists, often a file.
+    AlreadyExists,
+    /// The operation needs to block to complete, but the blocking operation was
+    /// requested to not occur.
+    WouldBlock,
+    /// A filesystem object is, unexpectedly, not a directory.
+    NotADirectory,
+    /// The filesystem object is, unexpectedly, a directory.
+    IsADirectory,
+    /// A non-empty directory was specified where an empty directory was expected.
+    DirectoryNotEmpty,
+    /// The filesystem or storage medium is read-only, but a write operation was attempted.
+    ReadOnlyFilesystem,
+    /// Stale network file handle.
+    StaleNetworkFileHandle,
+    /// A parameter was incorrect.
+    InvalidInput,
+    /// Data not valid for the operation were encountered.
+    InvalidData,
+    /// The I/O operation's timeout expired, causing it to be canceled.
+    TimedOut,
+    /// An error returned when an operation could not be completed because a
+    /// call to [`write`] returned [`Ok(0)`].
+    WriteZero,
+    /// The underlying storage (typically, a filesystem) is full.
+    StorageFull,
+    /// Seek on unseekable file.
+    NotSeekable,
+    /// Filesystem quota or some other kind of quota was exceeded.
+    QuotaExceeded,
+    /// File larger than allowed or supported.
+    FileTooLarge,
+    /// Resource is busy.
+    ResourceBusy,
+    /// Executable file is busy.
+    ExecutableFileBusy,
+    /// Deadlock (avoided).
+    Deadlock,
+    /// Cross-device or cross-filesystem (hard) link or rename.
+    CrossesDevices,
+    /// Too many (hard) links to the same filesystem object.
+    TooManyLinks,
+    /// A filename was invalid.
+    InvalidFilename,
+    /// Program argument list too long.
+    ArgumentListTooLong,
+    /// This operation was interrupted.
+    Interrupted,
+    /// This operation is unsupported on this platform.
+    Unsupported,
+    /// An error returned when an operation could not be completed because an
+    /// "end of file" was reached prematurely.
+    UnexpectedEof,
+    /// An operation could not be completed, because it failed
+    /// to allocate enough memory.
+    OutOfMemory,
+    /// A custom error that does not fall under any other I/O error kind.
+    Other,
+}
+
+impl ErrorKind {
+    fn as_str(&self) -> &'static str {
+        use ErrorKind::*;
+        match *self {
+            AddrInUse => "address in use",
+            AddrNotAvailable => "address not available",
+            AlreadyExists => "entity already exists",
+            ArgumentListTooLong => "argument list too long",
+            BrokenPipe => "broken pipe",
+            ConnectionAborted => "connection aborted",
+            ConnectionRefused => "connection refused",
+            ConnectionReset => "connection reset",
+            CrossesDevices => "cross-device link or rename",
+            Deadlock => "deadlock",
+            DirectoryNotEmpty => "directory not empty",
+            ExecutableFileBusy => "executable file busy",
+            FileTooLarge => "file too large",
+            HostUnreachable => "host unreachable",
+            Interrupted => "operation interrupted",
+            InvalidData => "invalid data",
+            InvalidFilename => "invalid filename",
+            InvalidInput => "invalid input parameter",
+            IsADirectory => "is a directory",
+            NetworkDown => "network down",
+            NetworkUnreachable => "network unreachable",
+            NotADirectory => "not a directory",
+            NotConnected => "not connected",
+            NotFound => "entity not found",
+            NotSeekable => "seek on unseekable file",
+            Other => "other error",
+            OutOfMemory => "out of memory",
+            PermissionDenied => "permission denied",
+            QuotaExceeded => "quota exceeded",
+            ReadOnlyFilesystem => "read-only filesystem or storage medium",
+            ResourceBusy => "resource busy",
+            StaleNetworkFileHandle => "stale network file handle",
+            StorageFull => "no storage space",
+            TimedOut => "timed out",
+            TooManyLinks => "too many links",
+            UnexpectedEof => "unexpected end of file",
+            Unsupported => "unsupported",
+            WouldBlock => "operation would block",
+            WriteZero => "write zero",
+        }
+    }
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.write_str(self.as_str())
+    }
+}
+
+/// A result returned from IO operations.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// A raw error code.
+pub type RawOsError = i32;

--- a/crates/bevy_platform_support/src/io/mod.rs
+++ b/crates/bevy_platform_support/src/io/mod.rs
@@ -1,0 +1,13 @@
+//! Provides standard types for IO systems.
+
+pub use io::{Error, ErrorKind, Result};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        use std::io as io;
+    } else {
+        mod fallback;
+
+        use fallback as io;
+    }
+}

--- a/crates/bevy_platform_support/src/lib.rs
+++ b/crates/bevy_platform_support/src/lib.rs
@@ -16,6 +16,7 @@ extern crate std;
 extern crate alloc;
 
 pub mod hash;
+pub mod io;
 pub mod sync;
 pub mod time;
 


### PR DESCRIPTION
# Objective

Continuing `no_std` proliferation in Bevy is currently blocked on `bevy_asset` which makes extensive use of the standard library in two main areas:
- `std::io`
- `std::path`
This is entirely sensible, since `bevy_asset`'s primary job is to load assets from a _path_ using filesystem _IO_.

However, assets can be used outside of strict IO operations. For example, users can manually add assets to an appropriate `Assets<T>` resource. Further, while Bevy _supports_ `std::path::Path`, we have strong rules around what's considered canonical for an `AssetPath`; namely that platform specific behaviour (backslashes and drive letters on Windows for example) is _not_ supported.

Since `no_std` support is likely to be highly disruptive in `bevy_asset`, this PR attempts to tackle a subset of the problem: independence from `std::io::Result`.

## Solution

- Created a new `io` module in `bevy_platform_support` which provides `Error`, `Result`, and `ErrorKind`.
- When the standard library is not available, `bevy_platform_support::io` will fallback to an API compatible alternative.
- Switch `bevy_asset` to use `bevy_platform_support::io::Result`. Since it _is_ `std::io::Result` with the `std` feature enabled this is purely a path change and has no impact on API or functionality.

## Testing

- CI

---

## Notes

- It may be desirable to actually make a more breaking change to `bevy_asset` and instead roll its own `AssetIoError` type. However, this is likely more controversial so I have opted for this as a more gradual step.
