### PR TITLE
`UiRect::AUTO`

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -349,6 +349,13 @@ impl UiRect {
         bottom: Val::ZERO,
     };
 
+    pub const AUTO: Self = Self {
+        left: Val::Auto,
+        right: Val::Auto,
+        top: Val::Auto,
+        bottom: Val::Auto,
+    };
+
     /// Creates a new [`UiRect`] from the values specified.
     ///
     /// # Example


### PR DESCRIPTION
# Objective

Add a `UiRect::AUTO` const which is a `UiRect` with all its edge values set to `Val::Auto`.

IIRC `UiRect`'s default for its fields a few versions ago was `Val::Auto` because positions were represented using a `UiRect` and they required `Val::Auto` as a default. Then when position was split up and the default for `UiRect` edge values were changed to `Val::ZERO` we forgot to add a new `UiRect::AUTO` const.