### PR TITLE
Revert "Transform Propagation Optimization: Static Subtree Marking (#18094)"

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -63,11 +63,7 @@ fn assert_is_normalized(message: &str, length_squared: f32) {
 /// [transform_example]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "bevy-support",
-    derive(Component),
-    require(GlobalTransform, TransformTreeChanged)
-)]
+#[cfg_attr(feature = "bevy-support", derive(Component), require(GlobalTransform))]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -648,20 +644,3 @@ impl Mul<Vec3> for Transform {
         self.transform_point(value)
     }
 }
-
-/// An optimization for transform propagation. This ZST marker component uses change detection to
-/// mark all entities of the hierarchy as "dirty" if any of their descendants have a changed
-/// `Transform`. If this component is *not* marked `is_changed()`, propagation will halt.
-#[derive(Clone, Copy, Default, PartialEq, Debug)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "bevy-support", derive(Component))]
-#[cfg_attr(
-    feature = "bevy_reflect",
-    derive(Reflect),
-    reflect(Component, Default, PartialEq, Debug)
-)]
-#[cfg_attr(
-    all(feature = "bevy_reflect", feature = "serialize"),
-    reflect(Serialize, Deserialize)
-)]
-pub struct TransformTreeChanged;

--- a/crates/bevy_transform/src/plugins.rs
+++ b/crates/bevy_transform/src/plugins.rs
@@ -1,4 +1,6 @@
-use crate::systems::{mark_dirty_trees, propagate_parent_transforms, sync_simple_transforms};
+use crate::systems::{
+    compute_transform_leaves, propagate_parent_transforms, sync_simple_transforms,
+};
 use bevy_app::{App, Plugin, PostStartup, PostUpdate};
 use bevy_ecs::schedule::{IntoScheduleConfigs, SystemSet};
 
@@ -22,7 +24,6 @@ impl Plugin for TransformPlugin {
 
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<crate::components::Transform>()
-            .register_type::<crate::components::TransformTreeChanged>()
             .register_type::<crate::components::GlobalTransform>();
 
         app.configure_sets(
@@ -33,9 +34,9 @@ impl Plugin for TransformPlugin {
         .add_systems(
             PostStartup,
             (
-                mark_dirty_trees,
                 propagate_parent_transforms,
-                sync_simple_transforms,
+                (compute_transform_leaves, sync_simple_transforms)
+                    .ambiguous_with(TransformSystem::TransformPropagate),
             )
                 .chain()
                 .in_set(PropagateTransformsSet),
@@ -47,10 +48,9 @@ impl Plugin for TransformPlugin {
         .add_systems(
             PostUpdate,
             (
-                mark_dirty_trees,
                 propagate_parent_transforms,
-                // TODO: Adjust the internal parallel queries to make this system more efficiently share and fill CPU time.
-                sync_simple_transforms,
+                (compute_transform_leaves, sync_simple_transforms) // TODO: Adjust the internal parallel queries to make these parallel systems more efficiently share and fill CPU time.
+                    .ambiguous_with(TransformSystem::TransformPropagate),
             )
                 .chain()
                 .in_set(PropagateTransformsSet),

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -353,10 +353,9 @@ mod tests {
     use bevy_math::{Rect, UVec2, Vec2};
     use bevy_platform_support::collections::HashMap;
     use bevy_render::{camera::ManualTextureViews, prelude::Camera};
-    use bevy_transform::systems::mark_dirty_trees;
     use bevy_transform::{
         prelude::GlobalTransform,
-        systems::{propagate_parent_transforms, sync_simple_transforms},
+        systems::{compute_transform_leaves, propagate_parent_transforms, sync_simple_transforms},
     };
     use bevy_utils::prelude::default;
     use bevy_window::{
@@ -409,9 +408,9 @@ mod tests {
                 update_ui_context_system,
                 ApplyDeferred,
                 ui_layout_system,
-                mark_dirty_trees,
                 sync_simple_transforms,
                 propagate_parent_transforms,
+                compute_transform_leaves,
             )
                 .chain(),
         );


### PR DESCRIPTION

# Objective

- Fixes #18255
- Transform propagation is broken in some cases

## Solution

- Revert #18093 
