### PR TITLE
Force serial command encoding on Linux/amdvlk

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -391,12 +391,13 @@ impl<'w> RenderContext<'w> {
         adapter_info: AdapterInfo,
         diagnostics_recorder: Option<DiagnosticsRecorder>,
     ) -> Self {
-        // HACK: Parallel command encoding is currently bugged on AMD + Windows + Vulkan with wgpu 0.19.1
-        #[cfg(target_os = "windows")]
+        // HACK: Parallel command encoding is currently bugged on AMD + Windows/Linux + Vulkan
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
         let force_serial =
             adapter_info.driver.contains("AMD") && adapter_info.backend == wgpu::Backend::Vulkan;
         #[cfg(not(any(
             target_os = "windows",
+            target_os = "linux",
             all(target_arch = "wasm32", target_feature = "atomics")
         )))]
         let force_serial = {


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/18366 which seems to have a similar underlying cause than the already closed (but not fixed) https://github.com/bevyengine/bevy/issues/16185.

## Solution

For Windows with the AMD vulkan driver, there was already a hack to force serial command encoding, which prevented these issues. The Linux version of the AMD vulkan driver seems to have similar issues than its Windows counterpart, so I extended the hack to also cover AMD on Linux.

I also removed the mention of `wgpu` since it was already outdated, and doesn't seem to be relevant to the core issue (the AMD driver being buggy).

## Testing

- Did you test these changes? If so, how?
  - I ran the `3d_scene` example, which on `main` produced the flickering shadows on Linux with the amdvlk driver, while it no longer does with the workaround applied.
- Are there any parts that need more testing?
  - Not sure.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Requires a Linux system with an AMD card and the AMDVLK driver.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - My change should only affect Linux, where I did test it.
