### PR TITLE
bevy: Replace unnecessary tuple type registrations

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/mod.rs
@@ -67,7 +67,9 @@ pub struct MeshPickingPlugin;
 impl Plugin for MeshPickingPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MeshPickingSettings>()
-            .register_type::<(RayCastPickable, MeshPickingSettings, SimplifiedMesh)>()
+            .register_type::<RayCastPickable>()
+            .register_type::<MeshPickingSettings>()
+            .register_type::<SimplifiedMesh>()
             .add_systems(PreUpdate, update_hits.in_set(PickSet::Backend));
     }
 }

--- a/crates/bevy_sprite/src/picking_backend.rs
+++ b/crates/bevy_sprite/src/picking_backend.rs
@@ -68,11 +68,9 @@ pub struct SpritePickingPlugin;
 impl Plugin for SpritePickingPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SpritePickingSettings>()
-            .register_type::<(
-                SpritePickingCamera,
-                SpritePickingMode,
-                SpritePickingSettings,
-            )>()
+            .register_type::<SpritePickingCamera>()
+            .register_type::<SpritePickingMode>()
+            .register_type::<SpritePickingSettings>()
             .add_systems(PreUpdate, sprite_picking.in_set(PickSet::Backend));
     }
 }


### PR DESCRIPTION
# Objective

As pointed out by @cart on [Discord](https://discord.com/channels/691052431525675048/1002362493634629796/1351279139872571462), we should be careful when using tuple shorthand to register types. Doing so incurs some unnecessary penalties such as memory/compile/performance cost to generate registrations for a tuple type that will never be used.

A better solution would be to create a custom lint for this, but for now we can at least remove the existing usages of this pattern.

> [!note]
> This pattern of using tuples to register multiple types at once isn't inherently bad. Users should feel free to use this pattern, knowing the side effects it may have. What this problem really is about is using this in _library_ code, where users of Bevy have no choice in whether a tuple is unnecessarily registered in an internal plugin or not.

## Solution

Replace tuple registrations with single-type registrations.

Note that I left the tuple registrations in test code since I feel like brevity is more important in those cases. But let me know if I should change them or leave a comment above them!

## Testing

You can test locally by running:

```
cargo check --workspace --all-features
```
