### PR TITLE
add AlignedRawBufferVec

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -1,4 +1,5 @@
 use core::{iter, marker::PhantomData};
+use std::num::NonZero;
 
 use crate::{
     render_resource::Buffer,
@@ -9,7 +10,7 @@ use encase::{
     internal::{WriteInto, Writer},
     ShaderType,
 };
-use wgpu::{BindingResource, BufferAddress, BufferUsages};
+use wgpu::{BindingResource, BufferAddress, BufferBinding, BufferUsages};
 
 use super::GpuArrayBufferable;
 
@@ -509,5 +510,168 @@ where
         if !self.is_empty() {
             self.reserve(self.len, device);
         }
+    }
+}
+
+/// A structure for storing raw bytes that have already been properly formatted
+/// for use by the GPU.
+///
+/// "Properly formatted" means that item data already meets the alignment and padding
+/// requirements for how it will be used on the GPU. The item type must implement [`NoUninit`]
+/// for its data representation to be directly copyable.
+///
+/// The contained data is stored in system RAM. Calling [`reserve`](RawBufferVec::reserve)
+/// allocates VRAM from the [`RenderDevice`].
+/// [`write_buffer`](RawBufferVec::write_buffer) queues copying of the data
+/// from system RAM to VRAM.
+///
+/// Unlike [`RawBufferVec`] this will add padding to respect aligment rules if necessary when
+/// adding data to it. This is useful when working with buffers that have alignment rules
+/// like uniform buffers.
+pub struct AlignedRawBufferVec<T: NoUninit> {
+    values: Vec<u8>,
+    buffer: Option<Buffer>,
+    capacity: usize,
+    buffer_usage: BufferUsages,
+    label: Option<String>,
+    changed: bool,
+    aligned_size: u64,
+    required_padding: u64,
+    _marker: PhantomData<T>,
+}
+
+impl<T: NoUninit> AlignedRawBufferVec<T> {
+    /// Creates a new [`AlignedRawBufferVec`] with the given [`BufferUsages`].
+    ///
+    /// It will automatically determine the alignment based on the [`RenderDevice`] limits and the
+    /// size of `T`
+    pub fn new(buffer_usage: BufferUsages, render_device: &RenderDevice) -> Self {
+        let item_size = size_of::<T>();
+        let alignment =
+            AlignmentValue::new(render_device.limits().min_uniform_buffer_offset_alignment as u64);
+        let aligned_size = alignment.round_up(item_size as u64);
+        let required_padding = aligned_size - item_size as u64;
+        Self {
+            values: Vec::new(),
+            buffer: None,
+            capacity: 0,
+            buffer_usage,
+            label: None,
+            changed: false,
+            aligned_size,
+            required_padding,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns a handle to the buffer, if the data has been uploaded.
+    #[inline]
+    pub fn buffer(&self) -> Option<&Buffer> {
+        self.buffer.as_ref()
+    }
+
+    /// Returns the binding for the buffer if the data has been uploaded.
+    #[inline]
+    pub fn binding(&self) -> Option<BindingResource> {
+        Some(BindingResource::Buffer(BufferBinding {
+            buffer: self.buffer.as_ref()?,
+            offset: 0,
+            size: Some(NonZero::new(self.aligned_size)?),
+        }))
+    }
+
+    /// Returns the amount of space that the GPU will use before reallocating.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the number of items that have been pushed to this buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.len() / self.aligned_size as usize
+    }
+
+    /// Returns true if the buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Adds a new value and returns its offset in bytes.
+    ///
+    /// This will convert the value to bytes and add any padding it needs to respect alignment
+    pub fn push(&mut self, value: T) -> usize {
+        let index = self.values.len();
+        let bytes: &[u8] = bytemuck::bytes_of(&value);
+        self.values.extend(bytes);
+        if self.required_padding > 0 {
+            for _ in 0..self.required_padding {
+                self.values.push(0);
+            }
+        }
+        index
+    }
+
+    /// Changes the debugging label of the buffer.
+    ///
+    /// The next time the buffer is updated (via [`reserve`](Self::reserve)), Bevy will inform
+    /// the driver of the new label.
+    pub fn set_label(&mut self, label: Option<&str>) {
+        let label = label.map(str::to_string);
+        if label != self.label {
+            self.changed = true;
+        }
+        self.label = label;
+    }
+
+    /// Returns the label
+    pub fn get_label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Creates a [`Buffer`] on the [`RenderDevice`] with size
+    /// at least `alignment * capacity`, unless such a buffer already exists.
+    ///
+    /// If a [`Buffer`] exists, but is too small, references to it will be discarded,
+    /// and a new [`Buffer`] will be created. Any previously created [`Buffer`]s
+    /// that are no longer referenced will be deleted by the [`RenderDevice`]
+    /// once it is done using them (typically 1-2 frames).
+    ///
+    /// In addition to any [`BufferUsages`] provided when
+    /// the `RawBufferVec` was created, the buffer on the [`RenderDevice`]
+    /// is marked as [`BufferUsages::COPY_DST`](BufferUsages).
+    pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
+        let size = self.aligned_size as usize * capacity;
+        if capacity > self.capacity || (self.changed && size > 0) {
+            self.capacity = capacity;
+            self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
+                label: self.label.as_deref(),
+                size: size as BufferAddress,
+                usage: BufferUsages::COPY_DST | self.buffer_usage,
+                mapped_at_creation: false,
+            }));
+            self.changed = false;
+        }
+    }
+
+    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`]
+    /// and the provided [`RenderQueue`].
+    ///
+    /// Before queuing the write, a [`reserve`](RawBufferVec::reserve) operation
+    /// is executed.
+    pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
+        if self.values.is_empty() {
+            return;
+        }
+        self.reserve(self.len(), device);
+        if let Some(buffer) = &self.buffer {
+            queue.write_buffer(buffer, 0, &self.values);
+        }
+    }
+
+    /// Removes all elements from the buffer.
+    pub fn clear(&mut self) {
+        self.values.clear();
     }
 }


### PR DESCRIPTION
# Objective

- The ShaderType derive is pretty expansive so we need alternatives. Using RawBufferVec works well in many cases, but not when buffers have alignment rules like uniform buffers.

## Solution

- Add `AlignedRawBufferVec` which is almost identical to `RawBufferVec` but attempts to respect alignment rules.
- Uses encase `AlignmentValue` to handle alignment. This isn't super necessary and could be trivially upstreamed but as long as encase is in tree it doesn't matter that much.

## Testing

- Tested in a fork of the volumetric fog that uses this new buffer
