### PR TITLE
remove circular dependency between bevy_image and bevy_core_pipeline

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -16,7 +16,7 @@ bevy_reflect = ["dep:bevy_reflect", "bevy_math/bevy_reflect"]
 # Image formats
 basis-universal = ["dep:basis-universal"]
 bmp = ["image/bmp"]
-dds = ["ddsfile", "bevy_core_pipeline/dds"]
+dds = ["ddsfile"]
 exr = ["image/exr"]
 ff = ["image/ff"]
 gif = ["image/gif"]
@@ -80,7 +80,6 @@ half = { version = "2.4.1" }
 [dev-dependencies]
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.16.0-dev" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.16.0-dev" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/17887 introduced a circular dependency between bevy_image and bevy_core_pipeline
- This makes it impossible to publish Bevy

## Solution

- Remove the circular dependency, reintroduce the compilation failure
- This failure shouldn't be an issue for users of Bevy, only for users of subcrates, and can be workaround
- Proper fix should be done with https://github.com/bevyengine/bevy/issues/17891
- Limited compilation failure is better than publish failure