### PR TITLE
Support skipping Relationship on_replace hooks

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -18,7 +18,7 @@ use crate::{
     observer::Observers,
     prelude::World,
     query::DebugCheckedUnwrap,
-    relationship::RelationshipInsertHookMode,
+    relationship::RelationshipHookMode,
     storage::{SparseSetIndex, SparseSets, Storages, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, EntityWorldMut, ON_ADD, ON_INSERT, ON_REPLACE},
 };
@@ -1104,7 +1104,7 @@ impl<'w> BundleInserter<'w> {
         bundle: T,
         insert_mode: InsertMode,
         caller: MaybeLocation,
-        relationship_insert_hook_mode: RelationshipInsertHookMode,
+        relationship_hook_mode: RelationshipHookMode,
     ) -> (EntityLocation, T::Effect) {
         let bundle_info = self.bundle_info.as_ref();
         let archetype_after_insert = self.archetype_after_insert.as_ref();
@@ -1130,6 +1130,7 @@ impl<'w> BundleInserter<'w> {
                     entity,
                     archetype_after_insert.iter_existing(),
                     caller,
+                    relationship_hook_mode,
                 );
             }
         }
@@ -1317,7 +1318,7 @@ impl<'w> BundleInserter<'w> {
                         entity,
                         archetype_after_insert.iter_inserted(),
                         caller,
-                        relationship_insert_hook_mode,
+                        relationship_hook_mode,
                     );
                     if new_archetype.has_insert_observer() {
                         deferred_world.trigger_observers(
@@ -1336,7 +1337,7 @@ impl<'w> BundleInserter<'w> {
                         entity,
                         archetype_after_insert.iter_added(),
                         caller,
-                        relationship_insert_hook_mode,
+                        relationship_hook_mode,
                     );
                     if new_archetype.has_insert_observer() {
                         deferred_world.trigger_observers(
@@ -1484,7 +1485,7 @@ impl<'w> BundleSpawner<'w> {
                 entity,
                 bundle_info.iter_contributed_components(),
                 caller,
-                RelationshipInsertHookMode::Run,
+                RelationshipHookMode::Run,
             );
             if archetype.has_insert_observer() {
                 deferred_world.trigger_observers(

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -6,7 +6,7 @@ use crate::{
     change_detection::{MaybeLocation, MAX_CHANGE_AGE},
     entity::{ComponentCloneCtx, Entity, SourceComponent},
     query::DebugCheckedUnwrap,
-    relationship::RelationshipInsertHookMode,
+    relationship::RelationshipHookMode,
     resource::Resource,
     storage::{SparseSetIndex, SparseSets, Table, TableRow},
     system::{Commands, Local, SystemParam},
@@ -584,7 +584,7 @@ pub struct HookContext {
     /// The caller location is `Some` if the `track_caller` feature is enabled.
     pub caller: MaybeLocation,
     /// Configures how relationship hooks will run
-    pub relationship_insert_hook_mode: RelationshipInsertHookMode,
+    pub relationship_hook_mode: RelationshipHookMode,
 }
 
 /// [`World`]-mutating functions that run as part of lifecycle events of a [`Component`].

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -331,7 +331,7 @@ mod tests {
     use crate::{
         entity::Entity,
         hierarchy::{ChildOf, Children},
-        relationship::RelationshipTarget,
+        relationship::{RelationshipHookMode, RelationshipTarget},
         spawn::{Spawn, SpawnRelated},
         world::World,
     };
@@ -491,5 +491,22 @@ mod tests {
         let mut world = World::new();
         let id = world.spawn(Children::spawn((Spawn(()), Spawn(())))).id();
         assert_eq!(world.entity(id).get::<Children>().unwrap().len(), 2,);
+    }
+
+    #[test]
+    fn child_replace_hook_skip() {
+        let mut world = World::new();
+        let parent = world.spawn_empty().id();
+        let other = world.spawn_empty().id();
+        let child = world.spawn(ChildOf { parent }).id();
+        world.entity_mut(child).insert_with_relationship_hook_mode(
+            ChildOf { parent: other },
+            RelationshipHookMode::Skip,
+        );
+        assert_eq!(
+            &**world.entity(parent).get::<Children>().unwrap(),
+            &[child],
+            "Children should still have the old value, as on_insert/on_replace didn't run"
+        );
     }
 }

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -90,14 +90,14 @@ pub trait Relationship: Component + Sized {
         HookContext {
             entity,
             caller,
-            relationship_insert_hook_mode,
+            relationship_hook_mode,
             ..
         }: HookContext,
     ) {
-        match relationship_insert_hook_mode {
-            RelationshipInsertHookMode::Run => {}
-            RelationshipInsertHookMode::Skip => return,
-            RelationshipInsertHookMode::RunIfNotLinked => {
+        match relationship_hook_mode {
+            RelationshipHookMode::Run => {}
+            RelationshipHookMode::Skip => return,
+            RelationshipHookMode::RunIfNotLinked => {
                 if <Self::RelationshipTarget as RelationshipTarget>::LINKED_SPAWN {
                     return;
                 }
@@ -137,7 +137,23 @@ pub trait Relationship: Component + Sized {
 
     /// The `on_replace` component hook that maintains the [`Relationship`] / [`RelationshipTarget`] connection.
     // note: think of this as "on_drop"
-    fn on_replace(mut world: DeferredWorld, HookContext { entity, .. }: HookContext) {
+    fn on_replace(
+        mut world: DeferredWorld,
+        HookContext {
+            entity,
+            relationship_hook_mode,
+            ..
+        }: HookContext,
+    ) {
+        match relationship_hook_mode {
+            RelationshipHookMode::Run => {}
+            RelationshipHookMode::Skip => return,
+            RelationshipHookMode::RunIfNotLinked => {
+                if <Self::RelationshipTarget as RelationshipTarget>::LINKED_SPAWN {
+                    return;
+                }
+            }
+        }
         let target_entity = world.entity(entity).get::<Self>().unwrap().get();
         if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity) {
             if let Some(mut relationship_target) =
@@ -305,14 +321,14 @@ pub fn clone_relationship_target<T: RelationshipTarget>(
     }
 }
 
-/// Configures the conditions under which the Relationship insert hook will be run.
+/// Configures the conditions under which the Relationship insert/replace hooks will be run.
 #[derive(Copy, Clone, Debug)]
-pub enum RelationshipInsertHookMode {
-    /// Relationship insert hooks will always run
+pub enum RelationshipHookMode {
+    /// Relationship insert/replace hooks will always run
     Run,
-    /// Relationship insert hooks will run if [`RelationshipTarget::LINKED_SPAWN`] is false
+    /// Relationship insert/replace hooks will run if [`RelationshipTarget::LINKED_SPAWN`] is false
     RunIfNotLinked,
-    /// Relationship insert hooks will always be skipped
+    /// Relationship insert/replace hooks will always be skipped
     Skip,
 }
 

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -15,7 +15,7 @@ use crate::{
     entity::{Entity, EntityClonerBuilder},
     error::Result,
     event::Event,
-    relationship::RelationshipInsertHookMode,
+    relationship::RelationshipHookMode,
     system::{command::HandleError, Command, IntoObserverSystem},
     world::{error::EntityMutableFetchError, EntityWorldMut, FromWorld, World},
 };
@@ -157,7 +157,7 @@ where
 pub fn insert(bundle: impl Bundle, mode: InsertMode) -> impl EntityCommand {
     let caller = MaybeLocation::caller();
     move |mut entity: EntityWorldMut| {
-        entity.insert_with_caller(bundle, mode, caller, RelationshipInsertHookMode::Run);
+        entity.insert_with_caller(bundle, mode, caller, RelationshipHookMode::Run);
     }
 }
 
@@ -184,7 +184,7 @@ pub unsafe fn insert_by_id<T: Send + 'static>(
                 ptr,
                 mode,
                 caller,
-                RelationshipInsertHookMode::Run,
+                RelationshipHookMode::Run,
             );
         });
     }
@@ -197,7 +197,7 @@ pub fn insert_from_world<T: Component + FromWorld>(mode: InsertMode) -> impl Ent
     let caller = MaybeLocation::caller();
     move |mut entity: EntityWorldMut| {
         let value = entity.world_scope(|world| T::from_world(world));
-        entity.insert_with_caller(value, mode, caller, RelationshipInsertHookMode::Run);
+        entity.insert_with_caller(value, mode, caller, RelationshipHookMode::Run);
     }
 }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -9,7 +9,7 @@ use crate::{
     observer::{Observers, TriggerTargets},
     prelude::{Component, QueryState},
     query::{QueryData, QueryFilter},
-    relationship::RelationshipInsertHookMode,
+    relationship::RelationshipHookMode,
     resource::Resource,
     system::{Commands, Query},
     traversal::Traversal,
@@ -121,6 +121,7 @@ impl<'w> DeferredWorld<'w> {
                 entity,
                 [component_id].into_iter(),
                 MaybeLocation::caller(),
+                RelationshipHookMode::Run,
             );
             if archetype.has_replace_observer() {
                 self.trigger_observers(
@@ -160,7 +161,7 @@ impl<'w> DeferredWorld<'w> {
                 entity,
                 [component_id].into_iter(),
                 MaybeLocation::caller(),
-                RelationshipInsertHookMode::Run,
+                RelationshipHookMode::Run,
             );
             if archetype.has_insert_observer() {
                 self.trigger_observers(
@@ -564,7 +565,7 @@ impl<'w> DeferredWorld<'w> {
                             entity,
                             component_id,
                             caller,
-                            relationship_insert_hook_mode: RelationshipInsertHookMode::Run,
+                            relationship_hook_mode: RelationshipHookMode::Run,
                         },
                     );
                 }
@@ -583,7 +584,7 @@ impl<'w> DeferredWorld<'w> {
         entity: Entity,
         targets: impl Iterator<Item = ComponentId>,
         caller: MaybeLocation,
-        relationship_insert_hook_mode: RelationshipInsertHookMode,
+        relationship_hook_mode: RelationshipHookMode,
     ) {
         if archetype.has_insert_hook() {
             for component_id in targets {
@@ -596,7 +597,7 @@ impl<'w> DeferredWorld<'w> {
                             entity,
                             component_id,
                             caller,
-                            relationship_insert_hook_mode,
+                            relationship_hook_mode,
                         },
                     );
                 }
@@ -615,6 +616,7 @@ impl<'w> DeferredWorld<'w> {
         entity: Entity,
         targets: impl Iterator<Item = ComponentId>,
         caller: MaybeLocation,
+        relationship_hook_mode: RelationshipHookMode,
     ) {
         if archetype.has_replace_hook() {
             for component_id in targets {
@@ -627,7 +629,7 @@ impl<'w> DeferredWorld<'w> {
                             entity,
                             component_id,
                             caller,
-                            relationship_insert_hook_mode: RelationshipInsertHookMode::Run,
+                            relationship_hook_mode,
                         },
                     );
                 }
@@ -658,7 +660,7 @@ impl<'w> DeferredWorld<'w> {
                             entity,
                             component_id,
                             caller,
-                            relationship_insert_hook_mode: RelationshipInsertHookMode::Run,
+                            relationship_hook_mode: RelationshipHookMode::Run,
                         },
                     );
                 }
@@ -689,7 +691,7 @@ impl<'w> DeferredWorld<'w> {
                             entity,
                             component_id,
                             caller,
-                            relationship_insert_hook_mode: RelationshipInsertHookMode::Run,
+                            relationship_hook_mode: RelationshipHookMode::Run,
                         },
                     );
                 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -53,7 +53,7 @@ use crate::{
     event::{Event, EventId, Events, SendBatchIds},
     observer::Observers,
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
-    relationship::RelationshipInsertHookMode,
+    relationship::RelationshipHookMode,
     removal_detection::RemovedComponentEvents,
     resource::Resource,
     schedule::{Schedule, ScheduleLabel, Schedules},
@@ -2305,7 +2305,7 @@ impl World {
                                     bundle,
                                     InsertMode::Replace,
                                     caller,
-                                    RelationshipInsertHookMode::Run,
+                                    RelationshipHookMode::Run,
                                 )
                             };
                         }
@@ -2327,7 +2327,7 @@ impl World {
                                     bundle,
                                     InsertMode::Replace,
                                     caller,
-                                    RelationshipInsertHookMode::Run,
+                                    RelationshipHookMode::Run,
                                 )
                             };
                             spawn_or_insert =
@@ -2465,7 +2465,7 @@ impl World {
                         first_bundle,
                         insert_mode,
                         caller,
-                        RelationshipInsertHookMode::Run,
+                        RelationshipHookMode::Run,
                     )
                 };
 
@@ -2493,7 +2493,7 @@ impl World {
                                 bundle,
                                 insert_mode,
                                 caller,
-                                RelationshipInsertHookMode::Run,
+                                RelationshipHookMode::Run,
                             )
                         };
                     } else {
@@ -2615,7 +2615,7 @@ impl World {
                             first_bundle,
                             insert_mode,
                             caller,
-                            RelationshipInsertHookMode::Run,
+                            RelationshipHookMode::Run,
                         )
                     };
                     break Some(cache);
@@ -2652,7 +2652,7 @@ impl World {
                             bundle,
                             insert_mode,
                             caller,
-                            RelationshipInsertHookMode::Run,
+                            RelationshipHookMode::Run,
                         )
                     };
                 } else {

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -12,7 +12,7 @@ use crate::reflect_utils::clone_reflect_value;
 #[cfg(feature = "serialize")]
 use crate::serde::SceneSerializer;
 use bevy_ecs::component::ComponentCloneBehavior;
-use bevy_ecs::relationship::RelationshipInsertHookMode;
+use bevy_ecs::relationship::RelationshipHookMode;
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
@@ -122,7 +122,7 @@ impl DynamicScene {
                         component.as_partial_reflect(),
                         &type_registry,
                         mapper,
-                        RelationshipInsertHookMode::Skip,
+                        RelationshipHookMode::Skip,
                     );
                 });
             }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     entity::{hash_map::EntityHashMap, Entity, SceneEntityMapper},
     entity_disabling::DefaultQueryFilters,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
-    relationship::RelationshipInsertHookMode,
+    relationship::RelationshipHookMode,
     world::World,
 };
 use bevy_reflect::TypePath;
@@ -159,7 +159,7 @@ impl Scene {
                             component.as_partial_reflect(),
                             &type_registry,
                             mapper,
-                            RelationshipInsertHookMode::Skip,
+                            RelationshipHookMode::Skip,
                         );
                     });
                 }


### PR DESCRIPTION
# Objective

Fixes #18357

## Solution

Generalize `RelationshipInsertHookMode` to `RelationshipHookMode`, wire it up to on_replace execution, and use it in the `Relationship::on_replace` hook.