### PR TITLE
Add MainPassResolutionOverride for DLSS

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -266,7 +266,7 @@ impl ViewNode for BloomNode {
                 &[uniform_index.index()],
             );
             if let Some(viewport) = camera.viewport.as_ref() {
-                upsampling_final_pass.set_camera_viewport(viewport);
+                upsampling_final_pass.set_camera_viewport(viewport, None);
             }
             let blend =
                 compute_blend_factor(bloom_settings, 0.0, (bloom_texture.mip_count - 1) as f32);

--- a/crates/bevy_core_pipeline/src/core_2d/main_opaque_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_opaque_pass_2d_node.rs
@@ -75,7 +75,7 @@ impl ViewNode for MainOpaquePass2dNode {
             let pass_span = diagnostics.pass_span(&mut render_pass, "main_opaque_pass_2d");
 
             if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
+                render_pass.set_camera_viewport(viewport, None);
             }
 
             // Opaque draws

--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -77,7 +77,7 @@ impl ViewNode for MainTransparentPass2dNode {
                 let pass_span = diagnostics.pass_span(&mut render_pass, "main_transparent_pass_2d");
 
                 if let Some(viewport) = camera.viewport.as_ref() {
-                    render_pass.set_camera_viewport(viewport);
+                    render_pass.set_camera_viewport(viewport, None);
                 }
 
                 if !transparent_phase.items.is_empty() {

--- a/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bevy_ecs::{prelude::World, query::QueryItem};
 use bevy_render::{
-    camera::ExtractedCamera,
+    camera::{ExtractedCamera, MainPassResolutionOverride},
     diagnostic::RecordDiagnostics,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::{TrackedRenderPass, ViewBinnedRenderPhases},
@@ -31,6 +31,7 @@ impl ViewNode for MainOpaquePass3dNode {
         Option<&'static SkyboxPipelineId>,
         Option<&'static SkyboxBindGroup>,
         &'static ViewUniformOffset,
+        Option<&'static MainPassResolutionOverride>,
     );
 
     fn run<'w>(
@@ -45,6 +46,7 @@ impl ViewNode for MainOpaquePass3dNode {
             skybox_pipeline,
             skybox_bind_group,
             view_uniform_offset,
+            resolution_override,
         ): QueryItem<'w, Self::ViewQuery>,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
@@ -90,7 +92,7 @@ impl ViewNode for MainOpaquePass3dNode {
             let pass_span = diagnostics.pass_span(&mut render_pass, "main_opaque_pass_3d");
 
             if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
+                render_pass.set_camera_viewport(viewport, resolution_override);
             }
 
             // Opaque draws

--- a/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
@@ -2,7 +2,7 @@ use super::{Camera3d, ViewTransmissionTexture};
 use crate::core_3d::Transmissive3d;
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_render::{
-    camera::ExtractedCamera,
+    camera::{ExtractedCamera, MainPassResolutionOverride},
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::ViewSortedRenderPhases,
     render_resource::{Extent3d, RenderPassDescriptor, StoreOp},
@@ -27,13 +27,16 @@ impl ViewNode for MainTransmissivePass3dNode {
         &'static ViewTarget,
         Option<&'static ViewTransmissionTexture>,
         &'static ViewDepthTexture,
+        Option<&'static MainPassResolutionOverride>,
     );
 
     fn run(
         &self,
         graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
-        (camera, view, camera_3d, target, transmission, depth): QueryItem<Self::ViewQuery>,
+        (camera, view, camera_3d, target, transmission, depth, resolution_override): QueryItem<
+            Self::ViewQuery,
+        >,
         world: &World,
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
@@ -96,7 +99,7 @@ impl ViewNode for MainTransmissivePass3dNode {
                         render_context.begin_tracked_render_pass(render_pass_descriptor.clone());
 
                     if let Some(viewport) = camera.viewport.as_ref() {
-                        render_pass.set_camera_viewport(viewport);
+                        render_pass.set_camera_viewport(viewport, resolution_override);
                     }
 
                     // render items in range
@@ -111,7 +114,7 @@ impl ViewNode for MainTransmissivePass3dNode {
                     render_context.begin_tracked_render_pass(render_pass_descriptor);
 
                 if let Some(viewport) = camera.viewport.as_ref() {
-                    render_pass.set_camera_viewport(viewport);
+                    render_pass.set_camera_viewport(viewport, resolution_override);
                 }
 
                 if let Err(err) = transmissive_phase.render(&mut render_pass, world, view_entity) {

--- a/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
@@ -1,7 +1,7 @@
 use crate::core_3d::Transparent3d;
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_render::{
-    camera::ExtractedCamera,
+    camera::{ExtractedCamera, MainPassResolutionOverride},
     diagnostic::RecordDiagnostics,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::ViewSortedRenderPhases,
@@ -24,12 +24,13 @@ impl ViewNode for MainTransparentPass3dNode {
         &'static ExtractedView,
         &'static ViewTarget,
         &'static ViewDepthTexture,
+        Option<&'static MainPassResolutionOverride>,
     );
     fn run(
         &self,
         graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
-        (camera, view, target, depth): QueryItem<Self::ViewQuery>,
+        (camera, view, target, depth, resolution_override): QueryItem<Self::ViewQuery>,
         world: &World,
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
@@ -69,7 +70,7 @@ impl ViewNode for MainTransparentPass3dNode {
             let pass_span = diagnostics.pass_span(&mut render_pass, "main_transparent_pass_3d");
 
             if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
+                render_pass.set_camera_viewport(viewport, resolution_override);
             }
 
             if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {

--- a/crates/bevy_core_pipeline/src/deferred/node.rs
+++ b/crates/bevy_core_pipeline/src/deferred/node.rs
@@ -1,4 +1,5 @@
 use bevy_ecs::{prelude::*, query::QueryItem};
+use bevy_render::camera::MainPassResolutionOverride;
 use bevy_render::experimental::occlusion_culling::OcclusionCulling;
 use bevy_render::render_graph::ViewNode;
 
@@ -66,6 +67,7 @@ impl ViewNode for LateDeferredGBufferPrepassNode {
         &'static ExtractedView,
         &'static ViewDepthTexture,
         &'static ViewPrepassTextures,
+        Option<&'static MainPassResolutionOverride>,
         Has<OcclusionCulling>,
         Has<NoIndirectDrawing>,
     );
@@ -77,7 +79,7 @@ impl ViewNode for LateDeferredGBufferPrepassNode {
         view_query: QueryItem<'w, Self::ViewQuery>,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
-        let (_, _, _, _, occlusion_culling, no_indirect_drawing) = view_query;
+        let (_, _, _, _, _, occlusion_culling, no_indirect_drawing) = view_query;
         if !occlusion_culling || no_indirect_drawing {
             return Ok(());
         }
@@ -105,7 +107,7 @@ impl ViewNode for LateDeferredGBufferPrepassNode {
 fn run_deferred_prepass<'w>(
     graph: &mut RenderGraphContext,
     render_context: &mut RenderContext<'w>,
-    (camera, extracted_view, view_depth_texture, view_prepass_textures, _, _): QueryItem<
+    (camera, extracted_view, view_depth_texture, view_prepass_textures, resolution_override, _, _): QueryItem<
         'w,
         <LateDeferredGBufferPrepassNode as ViewNode>::ViewQuery,
     >,
@@ -219,7 +221,7 @@ fn run_deferred_prepass<'w>(
         });
         let mut render_pass = TrackedRenderPass::new(&render_device, render_pass);
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, resolution_override);
         }
 
         // Opaque draws

--- a/crates/bevy_core_pipeline/src/oit/resolve/node.rs
+++ b/crates/bevy_core_pipeline/src/oit/resolve/node.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_render::{
-    camera::ExtractedCamera,
+    camera::{ExtractedCamera, MainPassResolutionOverride},
     render_graph::{NodeRunError, RenderGraphContext, RenderLabel, ViewNode},
     render_resource::{BindGroupEntries, PipelineCache, RenderPassDescriptor},
     renderer::RenderContext,
@@ -23,13 +23,14 @@ impl ViewNode for OitResolveNode {
         &'static ViewUniformOffset,
         &'static OitResolvePipelineId,
         &'static ViewDepthTexture,
+        Option<&'static MainPassResolutionOverride>,
     );
 
     fn run(
         &self,
         _graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
-        (camera, view_target, view_uniform, oit_resolve_pipeline_id, depth): QueryItem<
+        (camera, view_target, view_uniform, oit_resolve_pipeline_id, depth, resolution_override): QueryItem<
             Self::ViewQuery,
         >,
         world: &World,
@@ -63,7 +64,7 @@ impl ViewNode for OitResolveNode {
             });
 
             if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
+                render_pass.set_camera_viewport(viewport, resolution_override);
             }
 
             render_pass.set_render_pipeline(pipeline);

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_render::{
-    camera::ExtractedCamera,
+    camera::{ExtractedCamera, MainPassResolutionOverride},
     diagnostic::RecordDiagnostics,
     experimental::occlusion_culling::OcclusionCulling,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
@@ -64,6 +64,7 @@ impl ViewNode for LatePrepassNode {
         Option<&'static RenderSkyboxPrepassPipeline>,
         Option<&'static SkyboxPrepassBindGroup>,
         Option<&'static PreviousViewUniformOffset>,
+        Option<&'static MainPassResolutionOverride>,
         Has<OcclusionCulling>,
         Has<NoIndirectDrawing>,
         Has<DeferredPrepass>,
@@ -78,7 +79,7 @@ impl ViewNode for LatePrepassNode {
     ) -> Result<(), NodeRunError> {
         // We only need a late prepass if we have occlusion culling and indirect
         // drawing.
-        let (_, _, _, _, _, _, _, _, _, occlusion_culling, no_indirect_drawing, _) = query;
+        let (_, _, _, _, _, _, _, _, _, _, occlusion_culling, no_indirect_drawing, _) = query;
         if !occlusion_culling || no_indirect_drawing {
             return Ok(());
         }
@@ -109,6 +110,7 @@ fn run_prepass<'w>(
         skybox_prepass_pipeline,
         skybox_prepass_bind_group,
         view_prev_uniform_offset,
+        resolution_override,
         _,
         _,
         has_deferred,
@@ -183,7 +185,7 @@ fn run_prepass<'w>(
         let pass_span = diagnostics.pass_span(&mut render_pass, label);
 
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, resolution_override);
         }
 
         // Opaque draws

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -229,7 +229,7 @@ impl ViewNode for TemporalAntiAliasNode {
             taa_pass.set_render_pipeline(taa_pipeline);
             taa_pass.set_bind_group(0, &taa_bind_group, &[]);
             if let Some(viewport) = camera.viewport.as_ref() {
-                taa_pass.set_camera_viewport(viewport);
+                taa_pass.set_camera_viewport(viewport, None);
             }
             taa_pass.draw(0..3, 0..1);
         }

--- a/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
+++ b/crates/bevy_pbr/src/meshlet/material_shade_nodes.rs
@@ -18,7 +18,7 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_render::{
-    camera::ExtractedCamera,
+    camera::{ExtractedCamera, MainPassResolutionOverride},
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_resource::{
         LoadOp, Operations, PipelineCache, RenderPassDepthStencilAttachment, RenderPassDescriptor,
@@ -42,6 +42,7 @@ impl ViewNode for MeshletMainOpaquePass3dNode {
         &'static ViewLightProbesUniformOffset,
         &'static ViewScreenSpaceReflectionsUniformOffset,
         &'static ViewEnvironmentMapUniformOffset,
+        Option<&'static MainPassResolutionOverride>,
         &'static MeshletViewMaterialsMainOpaquePass,
         &'static MeshletViewBindGroups,
         &'static MeshletViewResources,
@@ -61,6 +62,7 @@ impl ViewNode for MeshletMainOpaquePass3dNode {
             view_light_probes_offset,
             view_ssr_offset,
             view_environment_map_offset,
+            resolution_override,
             meshlet_view_materials,
             meshlet_view_bind_groups,
             meshlet_view_resources,
@@ -101,7 +103,7 @@ impl ViewNode for MeshletMainOpaquePass3dNode {
             occlusion_query_set: None,
         });
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, resolution_override);
         }
 
         render_pass.set_bind_group(
@@ -147,6 +149,7 @@ impl ViewNode for MeshletPrepassNode {
         &'static ViewPrepassTextures,
         &'static ViewUniformOffset,
         &'static PreviousViewUniformOffset,
+        Option<&'static MainPassResolutionOverride>,
         Has<MotionVectorPrepass>,
         &'static MeshletViewMaterialsPrepass,
         &'static MeshletViewBindGroups,
@@ -162,6 +165,7 @@ impl ViewNode for MeshletPrepassNode {
             view_prepass_textures,
             view_uniform_offset,
             previous_view_uniform_offset,
+            resolution_override,
             view_has_motion_vector_prepass,
             meshlet_view_materials,
             meshlet_view_bind_groups,
@@ -219,7 +223,7 @@ impl ViewNode for MeshletPrepassNode {
             occlusion_query_set: None,
         });
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, resolution_override);
         }
 
         if view_has_motion_vector_prepass {
@@ -270,6 +274,7 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
         &'static ViewPrepassTextures,
         &'static ViewUniformOffset,
         &'static PreviousViewUniformOffset,
+        Option<&'static MainPassResolutionOverride>,
         Has<MotionVectorPrepass>,
         &'static MeshletViewMaterialsDeferredGBufferPrepass,
         &'static MeshletViewBindGroups,
@@ -285,6 +290,7 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
             view_prepass_textures,
             view_uniform_offset,
             previous_view_uniform_offset,
+            resolution_override,
             view_has_motion_vector_prepass,
             meshlet_view_materials,
             meshlet_view_bind_groups,
@@ -347,7 +353,7 @@ impl ViewNode for MeshletDeferredGBufferPrepassNode {
             occlusion_query_set: None,
         });
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, resolution_override);
         }
 
         if view_has_motion_vector_prepass {

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_raster_node.rs
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_raster_node.rs
@@ -494,7 +494,7 @@ fn raster_pass(
         occlusion_query_set: None,
     });
     if let Some(viewport) = camera.and_then(|camera| camera.viewport.as_ref()) {
-        hardware_pass.set_camera_viewport(viewport);
+        hardware_pass.set_camera_viewport(viewport, None);
     }
     hardware_pass.set_render_pipeline(visibility_buffer_hardware_raster_pipeline);
     hardware_pass.set_push_constants(
@@ -525,7 +525,7 @@ fn resolve_depth(
         occlusion_query_set: None,
     });
     if let Some(viewport) = &camera.viewport {
-        resolve_pass.set_camera_viewport(viewport);
+        resolve_pass.set_camera_viewport(viewport, None);
     }
     resolve_pass.set_render_pipeline(resolve_depth_pipeline);
     resolve_pass.set_bind_group(0, &meshlet_view_bind_groups.resolve_depth, &[]);
@@ -558,7 +558,7 @@ fn resolve_material_depth(
             occlusion_query_set: None,
         });
         if let Some(viewport) = &camera.viewport {
-            resolve_pass.set_camera_viewport(viewport);
+            resolve_pass.set_camera_viewport(viewport, None);
         }
         resolve_pass.set_render_pipeline(resolve_material_depth_pipeline);
         resolve_pass.set_bind_group(0, resolve_material_depth_bind_group, &[]);

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1342,3 +1342,16 @@ impl TemporalJitter {
 #[derive(Default, Component, Reflect)]
 #[reflect(Default, Component)]
 pub struct MipBias(pub f32);
+
+/// Override the resolution a 3d camera's main pass is rendered at.
+///
+/// Does not affect post processing.
+///
+/// ## Usage
+///
+/// * Insert this component on a 3d camera entity in the render world.
+/// * The resolution override must be smaller than the camera's viewport size.
+/// * The resolution override is specified in physical pixels.
+#[derive(Component, Reflect)]
+#[reflect(Component)]
+pub struct MainPassResolutionOverride(pub UVec2);

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -29,6 +29,7 @@ impl Plugin for CameraPlugin {
             .register_type::<Exposure>()
             .register_type::<TemporalJitter>()
             .register_type::<MipBias>()
+            .register_type::<MainPassResolutionOverride>()
             .init_resource::<ManualTextureViews>()
             .init_resource::<ClearColor>()
             .add_plugins((

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    camera::Viewport,
+    camera::{MainPassResolutionOverride, Viewport},
     diagnostic::internal::{Pass, PassKind, WritePipelineStatistics, WriteTimestamp},
     render_resource::{
         BindGroup, BindGroupId, Buffer, BufferId, BufferSlice, RenderPipeline, RenderPipelineId,
@@ -587,12 +587,20 @@ impl<'a> TrackedRenderPass<'a> {
     /// Set the rendering viewport to the given camera [`Viewport`].
     ///
     /// Subsequent draw calls will be projected into that viewport.
-    pub fn set_camera_viewport(&mut self, viewport: &Viewport) {
+    pub fn set_camera_viewport(
+        &mut self,
+        viewport: &Viewport,
+        resolution_override: Option<&MainPassResolutionOverride>,
+    ) {
         self.set_viewport(
             viewport.physical_position.x as f32,
             viewport.physical_position.y as f32,
-            viewport.physical_size.x as f32,
-            viewport.physical_size.y as f32,
+            resolution_override
+                .map(|resolution_override| resolution_override.0.x)
+                .unwrap_or(viewport.physical_size.x) as f32,
+            resolution_override
+                .map(|resolution_override| resolution_override.0.y)
+                .unwrap_or(viewport.physical_size.y) as f32,
             viewport.depth.start,
             viewport.depth.end,
         );

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -95,7 +95,7 @@ impl Node for UiPassNode {
             occlusion_query_set: None,
         });
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, None);
         }
         if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
             error!("Error encountered while rendering the ui phase {err:?}");

--- a/examples/shader/custom_render_phase.rs
+++ b/examples/shader/custom_render_phase.rs
@@ -33,7 +33,7 @@ use bevy::{
             },
             GetBatchData, GetFullBatchData,
         },
-        camera::ExtractedCamera,
+        camera::{ExtractedCamera, MainPassResolutionOverride},
         extract_component::{ExtractComponent, ExtractComponentPlugin},
         mesh::{allocator::MeshAllocator, MeshVertexBufferLayoutRef, RenderMesh},
         render_asset::RenderAssets,
@@ -582,13 +582,14 @@ impl ViewNode for CustomDrawNode {
         &'static ExtractedCamera,
         &'static ExtractedView,
         &'static ViewTarget,
+        Option<&'static MainPassResolutionOverride>,
     );
 
     fn run<'w>(
         &self,
         graph: &mut RenderGraphContext,
         render_context: &mut RenderContext<'w>,
-        (camera, view, target): QueryItem<'w, Self::ViewQuery>,
+        (camera, view, target, resolution_override): QueryItem<'w, Self::ViewQuery>,
         world: &'w World,
     ) -> Result<(), NodeRunError> {
         // First, we need to get our phases resource
@@ -618,7 +619,7 @@ impl ViewNode for CustomDrawNode {
         });
 
         if let Some(viewport) = camera.viewport.as_ref() {
-            render_pass.set_camera_viewport(viewport);
+            render_pass.set_camera_viewport(viewport, resolution_override);
         }
 
         // Render the phase


### PR DESCRIPTION
# Objective
- Render the main pass at lower resolution, so that DLSS can later upscale it.

## Solution
- Add an optional MainPassResolutionOverride component to be used on render world camera entities
- When the component exists, passes will render to a smaller section of the view texture via setting a smaller viewport

## Testing
- I've ran some basic examples, but there's probably a bunch of places I've missed, especially when it comes to shader code and the usage of view.viewport.zw or textureDimensions().
- Lots more testing needs to be done by reviewers, but also this is an optional component so we could also merge it and fix the bugs later once DLSS is setup.

---

## Migration Guide
- `TrackerRenderPass::set_camera_viewport()` now takes a `Option<&MainPassResolutionOverride>`. Rendering intended to be part of the "main" opaque/transparent 3d passes should set query the view for `Option<&MainPassResolutionOverride>` and pass it in. Postprocessing or 2d passes should pass in None. 
