### PR TITLE
remove circular dependency between bevy_ecs and bevy_platform_support

### DIFF
--- a/crates/bevy_platform_support/Cargo.toml
+++ b/crates/bevy_platform_support/Cargo.toml
@@ -58,9 +58,6 @@ hashbrown = { version = "0.15.1", features = [
   "raw-entry",
 ], optional = true, default-features = false }
 
-[dev-dependencies]
-bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = { version = "1.1", default-features = false, optional = true }
 getrandom = { version = "0.2.0", default-features = false, optional = true, features = [

--- a/crates/bevy_platform_support/src/collections.rs
+++ b/crates/bevy_platform_support/src/collections.rs
@@ -1,27 +1,6 @@
-//! Provides [`HashMap`] and [`HashSet`] from [`hashbrown`] with some customized defaults.
+//! Provides [`HashMap`] and [`HashSet`] from [`hashbrown`] with some customized defaults.\
 //!
 //! Also provides the [`HashTable`] type, which is specific to [`hashbrown`].
-//!
-//! Note that due to the implementation details of [`hashbrown`], [`HashMap::new`] is only implemented for `HashMap<K, V, RandomState>`.
-//! Whereas, Bevy exports `HashMap<K, V, FixedHasher>` as its default [`HashMap`] type, meaning [`HashMap::new`] will typically fail.
-//! To bypass this issue, use [`HashMap::default`] instead.
-//!
-//! ```
-//! # use bevy_ecs::component::Component;
-//! # use bevy_ecs::system::Commands;
-//! # use bevy_platform_support::collections::HashMap;
-//!
-//! #[derive(Component)]
-//! struct MyComponent {
-//!     map: HashMap<String, String>
-//! }
-//!
-//! fn my_system(mut commands: Commands) {
-//!     commands.spawn(MyComponent {
-//!         map: HashMap::default(),
-//!     });
-//! }
-//! ```
 
 pub use hash_map::HashMap;
 pub use hash_set::HashSet;


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/18350 introduced a circular dependency between bevy_ecs and bevy_platform_support which block publishing

## Solution

- Revert it
