### PR TITLE
Fix compilation of compile_fail_utils when not using rustup

### DIFF
--- a/tools/compile_fail_utils/src/lib.rs
+++ b/tools/compile_fail_utils/src/lib.rs
@@ -59,7 +59,9 @@ fn basic_config(root_dir: impl Into<PathBuf>, args: &Args) -> ui_test::Result<Co
 
     // Don't leak contributor filesystem paths
     config.path_stderr_filter(Path::new(bevy_root), b"$BEVY_ROOT");
-    config.path_stderr_filter(Path::new(env!("RUSTUP_HOME")), b"$RUSTUP_HOME");
+    if let Some(path) = option_env!("RUSTUP_HOME") {
+        config.path_stderr_filter(Path::new(path), b"$RUSTUP_HOME");
+    }
 
     // ui_test doesn't compile regex with perl character classes.
     // \pL = unicode class for letters, \pN = unicode class for numbers


### PR DESCRIPTION
# Objective

Currently the `compile_fail_utils` crate fails to compile (ironic) when the `RUSTUP_HOME` env var isn't set. This has been the case for a long time, but I only noticed it recently due to rust-analyzer starting to show the error.

## Solution

Only filter the logs for the `RUSTUP_HOME` variable if it's set.