### PR TITLE
Fix dynamic scene resources not being entity mapped

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -149,16 +149,22 @@ impl DynamicScene {
 
             // If this component references entities in the scene, update
             // them to the entities in the world.
-            if let Some(map_entities) = registration.data::<ReflectMapEntities>() {
-                let mut resource = clone_reflect_value(resource.as_partial_reflect(), registration);
+            let mut cloned_resource;
+            let partial_reflect_resource = if let Some(map_entities) =
+                registration.data::<ReflectMapEntities>()
+            {
+                cloned_resource = clone_reflect_value(resource.as_partial_reflect(), registration);
                 SceneEntityMapper::world_scope(entity_map, world, |_, mapper| {
-                    map_entities.map_entities(resource.as_partial_reflect_mut(), mapper);
+                    map_entities.map_entities(cloned_resource.as_partial_reflect_mut(), mapper);
                 });
-            }
+                cloned_resource.as_partial_reflect()
+            } else {
+                resource.as_partial_reflect()
+            };
 
             // If the world already contains an instance of the given resource
             // just apply the (possibly) new value, otherwise insert the resource
-            reflect_resource.apply_or_insert(world, resource.as_partial_reflect(), &type_registry);
+            reflect_resource.apply_or_insert(world, partial_reflect_resource, &type_registry);
         }
 
         Ok(())


### PR DESCRIPTION
# Objective

The resources were converted via `clone_reflect_value` and the cloned value was mapped. But the value that is inserted is the source of the clone, which was not mapped.

I ran into this issue while working on #18380. Having non consecutive entity allocations has caught a lot of bugs.

## Solution

Use the cloned value for insertion if it exists.
