### PR TITLE
Update bincode to 2.0

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -118,7 +118,7 @@ wgpu-types = { version = "24", features = [
 [dev-dependencies]
 ron = "0.8.0"
 rmp-serde = "1.1"
-bincode = "1.3"
+bincode = { version = "2.0", features = ["serde"] }
 serde_json = "1.0"
 serde = { version = "1", features = ["derive"] }
 static_assertions = "1.1.0"

--- a/crates/bevy_reflect/src/serde/de/mod.rs
+++ b/crates/bevy_reflect/src/serde/de/mod.rs
@@ -30,7 +30,6 @@ mod tests {
         vec,
         vec::Vec,
     };
-    use bincode::Options;
     use core::{any::TypeId, f32::consts::PI, ops::RangeInclusive};
     use serde::{de::DeserializeSeed, Deserialize};
     use serde::{de::IgnoredAny, Deserializer};
@@ -470,10 +469,9 @@ mod tests {
 
         let deserializer = ReflectDeserializer::new(&registry);
 
-        let dynamic_output = bincode::DefaultOptions::new()
-            .with_fixint_encoding()
-            .deserialize_seed(deserializer, &input)
-            .unwrap();
+        let config = bincode::config::standard().with_fixed_int_encoding();
+        let (dynamic_output, _read_bytes) =
+            bincode::serde::seed_decode_from_slice(deserializer, &input, config).unwrap();
 
         let output = <MyStruct as FromReflect>::from_reflect(dynamic_output.as_ref()).unwrap();
         assert_eq!(expected, output);

--- a/crates/bevy_reflect/src/serde/ser/mod.rs
+++ b/crates/bevy_reflect/src/serde/ser/mod.rs
@@ -24,8 +24,9 @@ mod tests {
         serde::{ReflectSerializer, ReflectSerializerProcessor},
         PartialReflect, Reflect, ReflectSerialize, Struct, TypeRegistry,
     };
+    #[cfg(feature = "functions")]
+    use alloc::boxed::Box;
     use alloc::{
-        boxed::Box,
         string::{String, ToString},
         vec,
         vec::Vec,
@@ -348,7 +349,8 @@ mod tests {
         let registry = get_registry();
 
         let serializer = ReflectSerializer::new(&input, &registry);
-        let bytes = bincode::serialize(&serializer).unwrap();
+        let config = bincode::config::standard().with_fixed_int_encoding();
+        let bytes = bincode::serde::encode_to_vec(&serializer, config).unwrap();
 
         let expected: Vec<u8> = vec![
             1, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 0, 98, 101, 118, 121, 95, 114, 101, 102,

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -43,7 +43,7 @@ uuid = { version = "1.13.1", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 postcard = { version = "1.0", features = ["alloc"] }
-bincode = "1.3"
+bincode = { version = "2.0", features = ["serde"] }
 rmp-serde = "1.1"
 
 [lints]

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -913,7 +913,7 @@ mod tests {
             type_registry: registry,
         };
 
-        let (deserialized_scene, _bytes_read) =
+        let (deserialized_scene, _read_bytes) =
             bincode::serde::seed_decode_from_slice(scene_deserializer, &serialized_scene, config)
                 .unwrap();
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -522,7 +522,6 @@ mod tests {
         world::FromWorld,
     };
     use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
-    use bincode::Options;
     use serde::{de::DeserializeSeed, Deserialize, Serialize};
     use std::io::BufReader;
 
@@ -894,8 +893,9 @@ mod tests {
 
         let scene = DynamicScene::from_world(&world);
 
+        let config = bincode::config::standard().with_fixed_int_encoding();
         let scene_serializer = SceneSerializer::new(&scene, registry);
-        let serialized_scene = bincode::serialize(&scene_serializer).unwrap();
+        let serialized_scene = bincode::serde::encode_to_vec(&scene_serializer, config).unwrap();
 
         assert_eq!(
             vec![
@@ -913,10 +913,9 @@ mod tests {
             type_registry: registry,
         };
 
-        let deserialized_scene = bincode::DefaultOptions::new()
-            .with_fixint_encoding()
-            .deserialize_seed(scene_deserializer, &serialized_scene)
-            .unwrap();
+        let (deserialized_scene, _bytes_read) =
+            bincode::serde::seed_decode_from_slice(scene_deserializer, &serialized_scene, config)
+                .unwrap();
 
         assert_eq!(1, deserialized_scene.entities.len());
         assert_scene_eq(&scene, &deserialized_scene);


### PR DESCRIPTION
# Objective

Update bincode

## Solution

Fix compilation for #18352 by reading the [migration guide](https://github.com/bincode-org/bincode/blob/trunk/docs/migration_guide.md)

Also fixes an unused import warning I got when running the tests for bevy_reflect.
