### PR TITLE
Unified picking cleanup

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -35,7 +35,6 @@ pub use focus::*;
 pub use geometry::*;
 pub use layout::*;
 pub use measurement::*;
-use prelude::UiPickingPlugin;
 pub use render::*;
 pub use ui_material::*;
 pub use ui_node::*;
@@ -180,11 +179,13 @@ impl Plugin for UiPlugin {
                 )
                     .chain(),
             )
-            .add_plugins(UiPickingPlugin)
             .add_systems(
                 PreUpdate,
                 ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),
             );
+
+        #[cfg(feature = "bevy_ui_picking_backend")]
+        app.add_plugins(picking_backend::UiPickingPlugin);
 
         let ui_layout_system_config = ui_layout_system
             .in_set(UiSystem::Layout)

--- a/examples/picking/debug_picking.rs
+++ b/examples/picking/debug_picking.rs
@@ -10,7 +10,7 @@ fn main() {
             filter: "bevy_dev_tools=trace".into(), // Show picking logs trace level and up
             ..default()
         }))
-        .add_plugins((MeshPickingPlugin, DebugPickingPlugin, UiPickingPlugin))
+        .add_plugins((MeshPickingPlugin, DebugPickingPlugin))
         .add_systems(Startup, setup_scene)
         .insert_resource(DebugPickingMode::Normal)
         // A system that cycles the debugging state when you press F3:

--- a/examples/picking/simple_picking.rs
+++ b/examples/picking/simple_picking.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, MeshPickingPlugin, UiPickingPlugin))
+        .add_plugins((DefaultPlugins, MeshPickingPlugin))
         .add_systems(Startup, setup_scene)
         .run();
 }

--- a/examples/picking/sprite_picking.rs
+++ b/examples/picking/sprite_picking.rs
@@ -6,10 +6,7 @@ use std::fmt::Debug;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritePickingPlugin,
-        ))
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_systems(Startup, (setup, setup_atlas))
         .add_systems(Update, (move_sprite, animate_sprite))
         .run();

--- a/examples/ui/directional_navigation.rs
+++ b/examples/ui/directional_navigation.rs
@@ -31,7 +31,6 @@ fn main() {
             DefaultPlugins,
             InputDispatchPlugin,
             DirectionalNavigationPlugin,
-            UiPickingPlugin,
         ))
         // This resource is canonically used to track whether or not to render a focus indicator
         // It starts as false, but we set it to true here as we would like to see the focus indicator

--- a/examples/ui/scroll.rs
+++ b/examples/ui/scroll.rs
@@ -11,7 +11,7 @@ use bevy::{
 
 fn main() {
     let mut app = App::new();
-    app.add_plugins((DefaultPlugins, UiPickingPlugin))
+    app.add_plugins(DefaultPlugins)
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
         .add_systems(Update, update_scroll_position);

--- a/examples/ui/tab_navigation.rs
+++ b/examples/ui/tab_navigation.rs
@@ -12,12 +12,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            InputDispatchPlugin,
-            TabNavigationPlugin,
-            UiPickingPlugin,
-        ))
+        .add_plugins((DefaultPlugins, InputDispatchPlugin, TabNavigationPlugin))
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)


### PR DESCRIPTION
# Objective

@cart noticed some issues with my work in https://github.com/bevyengine/bevy/pull/17348#discussion_r2001815637, which I somehow missed before merging the PR.

## Solution

- feature gate the UiPickingPlugin correctly
- don't manually add the picking plugins

## Testing

Ran the debug_picking and sprite_picking examples (for UI and sprites respectively): both seem to work fine.