### PR TITLE
Clean up unused dependencies

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -16,7 +16,6 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
-bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
 
 # other
 rodio = { version = "0.20", default-features = false }

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -47,7 +47,6 @@ nonmax = "0.5"
 smallvec = "1"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-bytemuck = { version = "1" }
 
 [lints]
 workspace = true

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -18,14 +18,12 @@ bevy_asset = { path = "../bevy_asset", version = "0.16.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.16.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.16.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
-bevy_input = { path = "../bevy_input", version = "0.16.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.16.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.16.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.16.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.16.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.16.0-dev" }
 

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -18,7 +18,6 @@ serialize = [
   "dep:serde",
   "bevy_ecs/serialize",
   "bevy_time/serialize",
-  "bevy_utils/serde",
   "bevy_platform_support/serialize",
 ]
 
@@ -39,7 +38,6 @@ std = [
   "bevy_app/std",
   "bevy_platform_support/std",
   "bevy_time/std",
-  "bevy_utils/std",
   "bevy_tasks/std",
 ]
 
@@ -50,7 +48,6 @@ critical-section = [
   "bevy_app/critical-section",
   "bevy_platform_support/critical-section",
   "bevy_time/critical-section",
-  "bevy_utils/critical-section",
   "bevy_tasks/critical-section",
 ]
 
@@ -59,9 +56,6 @@ critical-section = [
 bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = false }
 bevy_time = { path = "../bevy_time", version = "0.16.0-dev", default-features = false }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false, features = [
-  "alloc",
-] }
 bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", default-features = false }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "alloc",

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 
 syn = "2.0"
-proc-macro2 = "1.0"
 quote = "1.0"
 
 [lints]

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -35,7 +35,6 @@ bevy_scene = { path = "../bevy_scene", version = "0.16.0-dev", features = [
 ] }
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "std",
   "serialize",

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -42,7 +42,6 @@ std = [
   "bevy_app/std",
   "bevy_ecs/std",
   "bevy_math/std",
-  "bevy_utils/std",
   "bevy_reflect/std",
   "bevy_platform_support/std",
 ]
@@ -64,7 +63,6 @@ libm = ["bevy_math/libm"]
 bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = false }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = false }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev", default-features = false }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "glam",
 ], default-features = false, optional = true }

--- a/crates/bevy_mesh/Cargo.toml
+++ b/crates/bevy_mesh/Cargo.toml
@@ -18,17 +18,15 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
 bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.16.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "std",
   "serialize",
 ] }
 
 # other
-bitflags = { version = "2.3", features = ["serde"] }
+bitflags = { version = "2.3" }
 bytemuck = { version = "1.5" }
 wgpu-types = { version = "24", default-features = false }
-serde = { version = "1", features = ["derive"] }
 hexasphere = "15.0"
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -45,7 +45,6 @@ bevy_render = { path = "../bevy_render", version = "0.16.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
-bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "std",
 ] }
@@ -67,7 +66,6 @@ itertools = { version = "0.14", optional = true }
 bitvec = { version = "1", optional = true }
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive", "must_cast"] }
-radsort = "0.1"
 smallvec = "1.6"
 nonmax = "0.5"
 static_assertions = "1"

--- a/crates/bevy_picking/Cargo.toml
+++ b/crates/bevy_picking/Cargo.toml
@@ -24,7 +24,6 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.16.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.16.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "std",

--- a/crates/bevy_reflect/derive/Cargo.toml
+++ b/crates/bevy_reflect/derive/Cargo.toml
@@ -23,7 +23,6 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-uuid = { version = "1.13.1", features = ["v4"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -26,7 +26,7 @@ basis-universal = ["bevy_image/basis-universal"]
 dds = ["bevy_image/dds"]
 exr = ["bevy_image/exr"]
 hdr = ["bevy_image/hdr"]
-ktx2 = ["dep:ktx2", "bevy_image/ktx2"]
+ktx2 = ["bevy_image/ktx2"]
 
 multi_threaded = ["bevy_tasks/multi_threaded"]
 
@@ -79,7 +79,6 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 image = { version = "0.25.2", default-features = false }
 
 # misc
-codespan-reporting = "0.11.0"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use Wasm threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm.
 # When the 'atomics' feature is enabled `fragile-send-sync-non-atomic` does nothing
@@ -98,7 +97,6 @@ downcast-rs = { version = "2", default-features = false, features = ["std"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
 futures-lite = "2.0.1"
-ktx2 = { version = "0.3.0", optional = true }
 encase = { version = "0.10", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = [

--- a/crates/bevy_state/macros/Cargo.toml
+++ b/crates/bevy_state/macros/Cargo.toml
@@ -13,7 +13,6 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
-proc-macro2 = "1.0"
 
 [lints]
 workspace = true

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -37,7 +37,6 @@ cosmic-text = { version = "0.13", features = ["shape-run-cache"] }
 thiserror = { version = "2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 smallvec = "1.13"
-unicode-bidi = "0.3.13"
 sys-locale = "0.3.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -38,7 +38,6 @@ serde = { version = "1", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", features = ["derive"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = ["from"] }
-nonmax = "0.5"
 smallvec = "1.11"
 accesskit = "0.17"
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -22,12 +22,7 @@ bevy_reflect = [
 ]
 
 ## Adds serialization support through `serde`.
-serialize = [
-  "serde",
-  "smol_str/serde",
-  "bevy_ecs/serialize",
-  "bevy_input/serialize",
-]
+serialize = ["serde", "bevy_ecs/serialize", "bevy_input/serialize"]
 
 # Platform Compatibility
 
@@ -56,9 +51,7 @@ bevy_input = { path = "../bevy_input", version = "0.16.0-dev", default-features 
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, features = [
   "glam",
-  "smol_str",
 ], optional = true }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false }
 
 # other
@@ -69,7 +62,6 @@ serde = { version = "1.0", features = [
 raw-window-handle = { version = "0.6", features = [
   "alloc",
 ], default-features = false }
-smol_str = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -37,7 +37,6 @@ bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.16.0-dev" }
-bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.16.0-dev" }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "std",
@@ -55,7 +54,6 @@ accesskit_winit = { version = "0.23", default-features = false, features = [
 ] }
 approx = { version = "0.5", default-features = false }
 cfg-if = "1.0"
-raw-window-handle = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", optional = true }
 wgpu-types = { version = "24", optional = true }


### PR DESCRIPTION
# Objective

- A lot of crates define dependencies that aren't used. These dependencies are generally already in the tree so that's why CI isn't complaining and it will likely not result in better compile times but I think it's worth it to keep this in check

## Solution

- Run cargo machete and only remove dependencies I'm sure can be removed

## Testing

- Ran a few examples locally on windows and ran the ci tool locally

## Notes

In a local test, I did end up with 1 less dependencies being compiled. It went from 455 to 454 according to cargo's output. It won't make an impact when compiling the entirety of bevy but it might help users depending on sub crates.
