### PR TITLE
enable std when building bevy_dylib

### DIFF
--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["dylib"]
 
 [dependencies]
 bevy_internal = { path = "../bevy_internal", version = "0.16.0-dev", default-features = false, features = [
-    "std",
+  "std",
 ] }
 
 [lints]

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["bevy"]
 crate-type = ["dylib"]
 
 [dependencies]
+# feature std is needed to avoid an issue when linking critical_section
+# bevy_dylib is not expected to work in no_std
 bevy_internal = { path = "../bevy_internal", version = "0.16.0-dev", default-features = false, features = [
   "std",
 ] }

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -12,7 +12,9 @@ keywords = ["bevy"]
 crate-type = ["dylib"]
 
 [dependencies]
-bevy_internal = { path = "../bevy_internal", version = "0.16.0-dev", default-features = false }
+bevy_internal = { path = "../bevy_internal", version = "0.16.0-dev", default-features = false, features = [
+    "std",
+] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- bevy_dylib fails to build:
```
   Compiling bevy_dylib v0.16.0-rc.1 (/bevy/crates/bevy_dylib)
error: linking with `cc` failed: exit status: 1
  |
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: Undefined symbols for architecture arm64:
            "__critical_section_1_0_acquire", referenced from:
                critical_section::with::h00cfbe529dea9dc9 in libbevy_tasks-53c9db6a3865f250.rlib[58](bevy_tasks-53c9db6a3865f250.evom2xwveqp508omiiqb25xig.rcgu.o)
            "__critical_section_1_0_release", referenced from:
                core::ptr::drop_in_place$LT$critical_section..with..Guard$GT$::hfa034e0208e1a49d in libbevy_tasks-53c9db6a3865f250.rlib[48](bevy_tasks-53c9db6a3865f250.d9dwgpd0156zfn2h5z5ff94zn.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Solution

- enable `std` when building bevy_dylib
