### PR TITLE
Finish #17558, re-adding `insert_children`

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -204,7 +204,7 @@ impl<'w> EntityWorldMut<'w> {
             }
             children_component.0.reserve(children.len());
             let mut v = children_component.0.split_off(index);
-            children_component.0.extend_from_slice(&children);
+            children_component.0.extend_from_slice(children);
             children_component.0.append(&mut v);
         } else {
             self.insert(Children(children.to_vec()));

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -192,7 +192,11 @@ impl<'w> EntityWorldMut<'w> {
             panic!("Cannot insert entity as a child of itself.");
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
+
             children_component.0.retain(|value| !children.contains(value));
+            if index >= children_component.len() {
+                panic!("Index {} out of bounds! There are only {} children!", index, children.len());
+            }
             children_component.0.reserve(children.len());
             let mut v = children_component.0.split_off(index);
             children_component.0.extend_from_slice(&children);

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -192,16 +192,20 @@ impl<'w> EntityWorldMut<'w> {
             panic!("Cannot insert entity as a child of itself.");
         }
         if let Some(mut children_component) = self.get_mut::<Children>() {
-
-            children_component.0.retain(|value| !children.contains(value));
+            children_component
+                .0
+                .retain(|value| !children.contains(value));
             if index >= children_component.len() {
-                panic!("Index {} out of bounds! There are only {} children!", index, children.len());
+                panic!(
+                    "Index {} out of bounds! There are only {} children!",
+                    index,
+                    children.len()
+                );
             }
             children_component.0.reserve(children.len());
             let mut v = children_component.0.split_off(index);
             children_component.0.extend_from_slice(&children);
             children_component.0.append(&mut v);
-
         } else {
             self.insert(Children(children.to_vec()));
         }
@@ -378,7 +382,6 @@ mod tests {
             )
         );
 
-
         // Removal
         world.entity_mut(child1).remove::<ChildOf>();
         let hierarchy = get_hierarchy(&world, root);
@@ -397,7 +400,6 @@ mod tests {
                 ]
             )
         );
-
 
         // Recursive Despawn
         world.entity_mut(root).despawn();
@@ -458,7 +460,15 @@ mod tests {
         let hierarchy = get_hierarchy(&world, root);
         assert_eq!(
             hierarchy,
-            Node::new_with(root, vec![Node::new(child1), Node::new(child3), Node::new(child4), Node::new(child2)])
+            Node::new_with(
+                root,
+                vec![
+                    Node::new(child1),
+                    Node::new(child3),
+                    Node::new(child4),
+                    Node::new(child2)
+                ]
+            )
         );
     }
 

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -175,22 +175,26 @@ pub type ChildSpawnerCommands<'w> = RelatedSpawnerCommands<'w, ChildOf>;
 
 impl<'w> EntityWorldMut<'w> {
     /// Spawns children of this entity (with a [`ChildOf`] relationship) by taking a function that operates on a [`ChildSpawner`].
+    /// See also [`with_related`](Self::with_related).
     pub fn with_children(&mut self, func: impl FnOnce(&mut ChildSpawner)) -> &mut Self {
         self.with_related(func);
         self
     }
 
     /// Adds the given children to this entity
+    /// See also [`add_related`](Self::add_related).
     pub fn add_children(&mut self, children: &[Entity]) -> &mut Self {
         self.add_related::<ChildOf>(children)
     }
 
-    /// Insert children at specific index
+    /// Insert children at specific index.
+    /// See also [`insert_related`](Self::insert_related).
     pub fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         self.insert_related::<ChildOf>(index, children)
     }
 
     /// Adds the given child to this entity
+    /// See also [`add_related`](Self::add_related).
     pub fn add_child(&mut self, child: Entity) -> &mut Self {
         self.add_related::<ChildOf>(&[child])
     }

--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -187,29 +187,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Insert children at specific index
     pub fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
-        let parent = self.id();
-        if children.contains(&parent) {
-            panic!("Cannot insert entity as a child of itself.");
-        }
-        if let Some(mut children_component) = self.get_mut::<Children>() {
-            children_component
-                .0
-                .retain(|value| !children.contains(value));
-            if index >= children_component.len() {
-                panic!(
-                    "Index {} out of bounds! There are only {} children!",
-                    index,
-                    children.len()
-                );
-            }
-            children_component.0.reserve(children.len());
-            let mut v = children_component.0.split_off(index);
-            children_component.0.extend_from_slice(children);
-            children_component.0.append(&mut v);
-        } else {
-            self.insert(Children(children.to_vec()));
-        }
-        self
+        self.insert_related::<ChildOf>(index, children)
     }
 
     /// Adds the given child to this entity

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -158,12 +158,14 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
     ///
     /// # Warning
     /// This should generally not be called by user code, as modifying the internal collection could invalidate the relationship.
+    /// The collection should not ever contain duplicates.
     fn collection_mut_risky(&mut self) -> &mut Self::Collection;
 
     /// Creates a new [`RelationshipTarget`] from the given [`RelationshipTarget::Collection`].
     ///
     /// # Warning
     /// This should generally not be called by user code, as constructing the internal collection could invalidate the relationship.
+    /// The collection should not ever contain duplicates.
     fn from_collection_risky(collection: Self::Collection) -> Self;
 
     /// The `on_replace` component hook that maintains the [`Relationship`] / [`RelationshipTarget`] connection.

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -36,6 +36,7 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Relates the given entities to this entity with the relation `R`, starting at this particular index.
+    /// Note that this first adds the relation and then rearanges it.
     /// See [`OrderedRelationshipSourceCollection::place`] for details on behavior.
     pub fn insert_related<R: Relationship>(&mut self, index: usize, related: &[Entity]) -> &mut Self
     where


### PR DESCRIPTION
# Objective

- Complete #17558.
- the `insert_children` method was previously removed, and as #17478 points out, needs to be added back.

## Solution

- Add a `OrderedRelationshipSourceCollection`, which allows sorting, ordering, rearranging, etc of a `RelationshipSourceCollection`.
- Implement `insert_related`
- Implement `insert_children`
- Tidy up some docs while I'm here.

## Testing

@bjoernp116 set up a unit test, and I added a doc test to `OrderedRelationshipSourceCollection`.

