### PR TITLE
Fix `bevy_ecs` doc tests with `--all-features`

### DIFF
--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -85,7 +85,7 @@ impl ErrorContext {
 /// To use this error handler in your app for custom error handling logic:
 ///
 /// ```rust
-/// use bevy_ecs::error::{GLOBAL_ERROR_HANDLER, BevyError, ErrorContext, panic};
+/// use bevy_ecs::error::{default_error_handler, GLOBAL_ERROR_HANDLER, BevyError, ErrorContext, panic};
 ///
 /// fn handle_errors(error: BevyError, ctx: ErrorContext) {
 ///    let error_handler = default_error_handler();


### PR DESCRIPTION
## Objective

Fix `bevy_ecs` doc tests failing when used with `--all-features`.

```
---- crates\bevy_ecs\src\error\handler.rs - error::handler::GLOBAL_ERROR_HANDLER (line 87) stdout ----
error[E0425]: cannot find function `default_error_handler` in this scope
 --> crates\bevy_ecs\src\error\handler.rs:92:24
  |
8 |    let error_handler = default_error_handler();
  |                        ^^^^^^^^^^^^^^^^^^^^^ not found in this scope
```

I happened to come across this while testing #12207. I'm not sure it actually needs fixing but seemed worth a go

## Testing

```
cargo test --doc -p bevy_ecs --all-features
```

## Side Notes

The CI misses this error as it doesn't use `--all-features`. Perhaps it should?

I tried adding `--all-features` to `ci/src/commands/doc_tests.rs` but this triggered a linker error:

```
Compiling bevy_dylib v0.16.0-dev (C:\Projects\bevy\crates\bevy_dylib)
error: linking with `link.exe` failed: exit code: 1189
= note: LINK : fatal error LNK1189: library limit of 65535 objects exceeded␍
```