### PR TITLE
Fix incorrect command given by the benchmarking README

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -25,10 +25,10 @@ cargo bench -p benches -- name_fragment
 cargo bench -p benches -- --list
 
 # Save a baseline to be compared against later.
-cargo bench -p benches --save-baseline before
+cargo bench -p benches -- --save-baseline before
 
 # Compare the current benchmarks against a baseline to find performance gains and regressions.
-cargo bench -p benches --baseline before
+cargo bench -p benches -- --baseline before
 ```
 
 ## Criterion


### PR DESCRIPTION
Note: Fixing this caused me to open #18430. On the whole, this fix and that bug don't really depend on each other, so I'm opening this PR anyways

# Objective

- Fixes #18387 

## Solution

- Very small update to benchmarking documentation
- Checked through to ensure consistency with other documentation. The only other mention of benchmarking commands I could find is a comment in the `Cargo.toml` associated with the benchmarking; the correct command is already listed there.

## Testing

- Manual testing on command line using updated commands
- Caused me to see #18430
