### PR TITLE
Fix warning spam on `mesh2d_manual` example

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -25,7 +25,8 @@ use bevy::{
             SpecializedRenderPipeline, SpecializedRenderPipelines, StencilFaceState, StencilState,
             TextureFormat, VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
         },
-        sync_world::MainEntityHashMap,
+        sync_component::SyncComponentPlugin,
+        sync_world::{MainEntityHashMap, RenderEntity},
         view::{ExtractedView, RenderVisibleEntities, ViewTarget},
         Extract, Render, RenderApp, RenderSet,
     },
@@ -35,7 +36,6 @@ use bevy::{
         SetMesh2dViewBindGroup,
     },
 };
-use bevy_render::{sync_component::SyncComponentPlugin, sync_world::RenderEntity};
 use std::f32::consts::PI;
 
 fn main() {

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -35,6 +35,7 @@ use bevy::{
         SetMesh2dViewBindGroup,
     },
 };
+use bevy_render::{sync_component::SyncComponentPlugin, sync_world::RenderEntity};
 use std::f32::consts::PI;
 
 fn main() {
@@ -300,6 +301,7 @@ impl Plugin for ColoredMesh2dPlugin {
             &COLORED_MESH2D_SHADER_HANDLE,
             Shader::from_wgsl(COLORED_MESH2D_SHADER, file!()),
         );
+        app.add_plugins(SyncComponentPlugin::<ColoredMesh2d>::default());
 
         // Register our custom draw function, and add our render systems
         app.get_sub_app_mut(RenderApp)
@@ -329,12 +331,21 @@ pub fn extract_colored_mesh2d(
     // When extracting, you must use `Extract` to mark the `SystemParam`s
     // which should be taken from the main world.
     query: Extract<
-        Query<(Entity, &ViewVisibility, &GlobalTransform, &Mesh2d), With<ColoredMesh2d>>,
+        Query<
+            (
+                Entity,
+                RenderEntity,
+                &ViewVisibility,
+                &GlobalTransform,
+                &Mesh2d,
+            ),
+            With<ColoredMesh2d>,
+        >,
     >,
     mut render_mesh_instances: ResMut<RenderColoredMesh2dInstances>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
-    for (entity, view_visibility, transform, handle) in &query {
+    for (entity, render_entity, view_visibility, transform, handle) in &query {
         if !view_visibility.get() {
             continue;
         }
@@ -344,7 +355,7 @@ pub fn extract_colored_mesh2d(
             flags: MeshFlags::empty().bits(),
         };
 
-        values.push((entity, ColoredMesh2d));
+        values.push((render_entity, ColoredMesh2d));
         render_mesh_instances.insert(
             entity.into(),
             RenderMesh2dInstance {


### PR DESCRIPTION
# Objective

Fixes #18429 

## Solution

Add syncing to the render world for the `ColoredMesh2d` component

## Testing

Ran the example and it works as intended without the warning spam
