### PR TITLE
Replace `try_query`

### DIFF
--- a/benches/benches/bevy_ecs/world/world_get.rs
+++ b/benches/benches/bevy_ecs/world/world_get.rs
@@ -101,7 +101,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
-            let mut world = setup::<Table>(entity_count);
+            let world = setup::<Table>(entity_count);
             let mut query = world.query::<&Table>();
 
             bencher.iter(|| {
@@ -112,7 +112,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
             });
         });
         group.bench_function(format!("{}_entities_table_wide", entity_count), |bencher| {
-            let mut world = setup_wide::<(
+            let world = setup_wide::<(
                 WideTable<0>,
                 WideTable<1>,
                 WideTable<2>,
@@ -137,7 +137,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
             });
         });
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
-            let mut world = setup::<Sparse>(entity_count);
+            let world = setup::<Sparse>(entity_count);
             let mut query = world.query::<&Sparse>();
 
             bencher.iter(|| {
@@ -150,7 +150,7 @@ pub fn world_query_get(criterion: &mut Criterion) {
         group.bench_function(
             format!("{}_entities_sparse_wide", entity_count),
             |bencher| {
-                let mut world = setup_wide::<(
+                let world = setup_wide::<(
                     WideSparse<0>,
                     WideSparse<1>,
                     WideSparse<2>,
@@ -187,7 +187,7 @@ pub fn world_query_iter(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
-            let mut world = setup::<Table>(entity_count);
+            let world = setup::<Table>(entity_count);
             let mut query = world.query::<&Table>();
 
             bencher.iter(|| {
@@ -201,7 +201,7 @@ pub fn world_query_iter(criterion: &mut Criterion) {
             });
         });
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
-            let mut world = setup::<Sparse>(entity_count);
+            let world = setup::<Sparse>(entity_count);
             let mut query = world.query::<&Sparse>();
 
             bencher.iter(|| {
@@ -226,7 +226,7 @@ pub fn world_query_for_each(criterion: &mut Criterion) {
 
     for entity_count in RANGE.map(|i| i * 10_000) {
         group.bench_function(format!("{}_entities_table", entity_count), |bencher| {
-            let mut world = setup::<Table>(entity_count);
+            let world = setup::<Table>(entity_count);
             let mut query = world.query::<&Table>();
 
             bencher.iter(|| {
@@ -240,7 +240,7 @@ pub fn world_query_for_each(criterion: &mut Criterion) {
             });
         });
         group.bench_function(format!("{}_entities_sparse", entity_count), |bencher| {
-            let mut world = setup::<Sparse>(entity_count);
+            let world = setup::<Sparse>(entity_count);
             let mut query = world.query::<&Sparse>();
 
             bencher.iter(|| {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -141,8 +141,8 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             }
 
             fn get_component_ids(
-                components: &#ecs_path::component::Components,
-                ids: &mut impl FnMut(Option<#ecs_path::component::ComponentId>)
+                components: #ecs_path::component::ComponentsQueuedRegistrator,
+                ids: &mut impl FnMut(#ecs_path::component::ComponentId)
             ){
                 #(#field_get_component_ids)*
             }

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -162,12 +162,6 @@ pub(crate) fn world_query_impl(
                 }
             }
 
-            fn get_state(components: &#path::component::Components) -> Option<#state_struct_name #user_ty_generics> {
-                Some(#state_struct_name {
-                    #(#named_field_idents: <#field_types>::get_state(components)?,)*
-                })
-            }
-
             fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(#path::component::ComponentId) -> bool) -> bool {
                 true #(&& <#field_types>::matches_component_set(&state.#named_field_idents, _set_contains_id))*
             }

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -156,7 +156,7 @@ pub(crate) fn world_query_impl(
                 #( <#field_types>::update_component_access(&state.#named_field_idents, _access); )*
             }
 
-            fn init_state(world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {
+            fn init_state(world: &#path::world::World) -> #state_struct_name #user_ty_generics {
                 #state_struct_name {
                     #(#named_field_idents: <#field_types>::init_state(world),)*
                 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1294,6 +1294,7 @@ impl ComponentIds {
 ///
 /// As a rule of thumb, if you have mutable access to [`ComponentsRegistrator`], prefer to use that instead.
 /// Use this only if you need to know the id of a component but do not need to modify the contents of the world based on that id.
+#[derive(Clone, Copy)]
 pub struct ComponentsQueuedRegistrator<'w> {
     components: &'w Components,
     ids: &'w ComponentIds,
@@ -1388,6 +1389,8 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// This will reserve an id and queue the registration.
     /// These registrations will be carried out at the next opportunity.
     ///
+    /// If this is already registered or queued to be registered, this will return its existing id.
+    ///
     /// # Note
     ///
     /// Technically speaking, the returned [`ComponentId`] is not valid, but it will become valid later.
@@ -1433,6 +1436,8 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// This will reserve an id and queue the registration.
     /// These registrations will be carried out at the next opportunity.
     ///
+    /// If this is already registered or queued to be registered, this will return its existing id.
+    ///
     /// # Note
     ///
     /// Technically speaking, the returned [`ComponentId`] is not valid, but it will become valid later.
@@ -1460,6 +1465,8 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// This is a queued version of [`ComponentsRegistrator::register_non_send`].
     /// This will reserve an id and queue the registration.
     /// These registrations will be carried out at the next opportunity.
+    ///
+    /// If this is already registered or queued to be registered, this will return its existing id.
     ///
     /// # Note
     ///

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -484,7 +484,7 @@ mod tests {
     fn preserving_uniqueness() {
         let mut world = World::new();
 
-        let mut query = QueryState::<&mut Thing>::new(&mut world);
+        let mut query = QueryState::<&mut Thing>::new(&world);
 
         let spawn_batch: Vec<Entity> = world.spawn_batch(vec![Thing; 1000]).collect();
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1451,62 +1451,62 @@ mod tests {
     #[test]
     #[should_panic]
     fn ref_and_mut_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(&A, &mut A)>();
     }
 
     #[test]
     #[should_panic]
     fn entity_ref_and_mut_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(EntityRef, &mut A)>();
     }
 
     #[test]
     #[should_panic]
     fn mut_and_ref_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(&mut A, &A)>();
     }
 
     #[test]
     #[should_panic]
     fn mut_and_entity_ref_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(&mut A, EntityRef)>();
     }
 
     #[test]
     #[should_panic]
     fn entity_ref_and_entity_mut_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(EntityRef, EntityMut)>();
     }
 
     #[test]
     #[should_panic]
     fn entity_mut_and_entity_mut_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(EntityMut, EntityMut)>();
     }
 
     #[test]
     fn entity_ref_and_entity_ref_query_no_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(EntityRef, EntityRef)>();
     }
 
     #[test]
     #[should_panic]
     fn mut_and_mut_query_panic() {
-        let mut world = World::new();
+        let world = World::new();
         world.query::<(&mut A, &mut A)>();
     }
 
     #[test]
     #[should_panic]
     fn multiple_worlds_same_query_iter() {
-        let mut world_a = World::new();
+        let world_a = World::new();
         let world_b = World::new();
         let mut query = world_a.query::<&A>();
         query.iter(&world_a);
@@ -1515,7 +1515,7 @@ mod tests {
 
     #[test]
     fn query_filters_dont_collide_with_fetches() {
-        let mut world = World::new();
+        let world = World::new();
         world.query_filtered::<&mut A, Changed<A>>();
     }
 
@@ -1540,7 +1540,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn multiple_worlds_same_query_get() {
-        let mut world_a = World::new();
+        let world_a = World::new();
         let world_b = World::new();
         let mut query = world_a.query::<&A>();
         let _ = query.get(&world_a, Entity::from_raw(0));
@@ -1550,7 +1550,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn multiple_worlds_same_query_for_each() {
-        let mut world_a = World::new();
+        let world_a = World::new();
         let world_b = World::new();
         let mut query = world_a.query::<&A>();
         query.iter(&world_a).for_each(|_| {});

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1,4 +1,4 @@
-use crate::component::ComponentId;
+use crate::component::{ComponentId, ComponentInfo};
 use crate::storage::SparseSetIndex;
 use crate::world::World;
 use alloc::{format, string::String, vec, vec::Vec};
@@ -971,8 +971,8 @@ impl AccessConflicts {
                             world
                                 .components
                                 .get_info(ComponentId::get_sparse_set_index(index))
-                                .unwrap()
-                                .name()
+                                .map(ComponentInfo::name)
+                                .unwrap_or("unknown component")
                         )
                     )
                 })

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2,7 +2,7 @@ use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundle,
     change_detection::{MaybeLocation, Ticks, TicksMut},
-    component::{Component, ComponentId, Components, Mutable, StorageType, Tick},
+    component::{Component, ComponentId, Mutable, StorageType, Tick},
     entity::{Entities, Entity, EntityLocation},
     query::{Access, DebugCheckedUnwrap, FilteredAccess, WorldQuery},
     storage::{ComponentSparseSet, Table, TableRow},
@@ -357,10 +357,6 @@ unsafe impl WorldQuery for Entity {
 
     fn init_state(_world: &World) {}
 
-    fn get_state(_components: &Components) -> Option<()> {
-        Some(())
-    }
-
     fn matches_component_set(
         _state: &Self::State,
         _set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -433,10 +429,6 @@ unsafe impl WorldQuery for EntityLocation {
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &World) {}
-
-    fn get_state(_components: &Components) -> Option<()> {
-        Some(())
-    }
 
     fn matches_component_set(
         _state: &Self::State,
@@ -516,10 +508,6 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
 
     fn init_state(_world: &World) {}
 
-    fn get_state(_components: &Components) -> Option<()> {
-        Some(())
-    }
-
     fn matches_component_set(
         _state: &Self::State,
         _set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -596,10 +584,6 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     }
 
     fn init_state(_world: &World) {}
-
-    fn get_state(_components: &Components) -> Option<()> {
-        Some(())
-    }
 
     fn matches_component_set(
         _state: &Self::State,
@@ -688,10 +672,6 @@ unsafe impl<'a> WorldQuery for FilteredEntityRef<'a> {
 
     fn init_state(_world: &World) -> Self::State {
         FilteredAccess::default()
-    }
-
-    fn get_state(_components: &Components) -> Option<Self::State> {
-        Some(FilteredAccess::default())
     }
 
     fn matches_component_set(
@@ -785,10 +765,6 @@ unsafe impl<'a> WorldQuery for FilteredEntityMut<'a> {
         FilteredAccess::default()
     }
 
-    fn get_state(_components: &Components) -> Option<Self::State> {
-        Some(FilteredAccess::default())
-    }
-
     fn matches_component_set(
         _state: &Self::State,
         _set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -880,10 +856,6 @@ where
             ids.push(id);
         });
         ids
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        todo!()
     }
 
     fn matches_component_set(_: &Self::State, _: &impl Fn(ComponentId) -> bool) -> bool {
@@ -980,10 +952,6 @@ where
         ids
     }
 
-    fn get_state(components: &Components) -> Option<Self::State> {
-        todo!()
-    }
-
     fn matches_component_set(_: &Self::State, _: &impl Fn(ComponentId) -> bool) -> bool {
         true
     }
@@ -1053,10 +1021,6 @@ unsafe impl WorldQuery for &Archetype {
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &World) {}
-
-    fn get_state(_components: &Components) -> Option<()> {
-        Some(())
-    }
 
     fn matches_component_set(
         _state: &Self::State,
@@ -1197,10 +1161,6 @@ unsafe impl<T: Component> WorldQuery for &T {
 
     fn init_state(world: &World) -> ComponentId {
         world.components_queue().queue_register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
     }
 
     fn matches_component_set(
@@ -1369,10 +1329,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
 
     fn init_state(world: &World) -> ComponentId {
         world.components_queue().queue_register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
     }
 
     fn matches_component_set(
@@ -1566,10 +1522,6 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         world.components_queue().queue_register_component::<T>()
     }
 
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
-    }
-
     fn matches_component_set(
         &state: &ComponentId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -1708,11 +1660,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
     }
 
     // Forwarded to `&mut T`
-    fn get_state(components: &Components) -> Option<ComponentId> {
-        <&mut T as WorldQuery>::get_state(components)
-    }
-
-    // Forwarded to `&mut T`
     fn matches_component_set(
         state: &ComponentId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -1835,10 +1782,6 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
 
     fn init_state(world: &World) -> T::State {
         T::init_state(world)
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        T::get_state(components)
     }
 
     fn matches_component_set(
@@ -1998,10 +1941,6 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
 
     fn init_state(world: &World) -> ComponentId {
         world.components_queue().queue_register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
     }
 
     fn matches_component_set(
@@ -2198,9 +2137,6 @@ macro_rules! impl_anytuple_fetch {
             fn init_state(world: &World) -> Self::State {
                 ($($name::init_state(world),)*)
             }
-            fn get_state(components: &Components) -> Option<Self::State> {
-                Some(($($name::get_state(components)?,)*))
-            }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
                 let ($($name,)*) = _state;
@@ -2318,10 +2254,6 @@ unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
         D::init_state(world)
     }
 
-    fn get_state(components: &Components) -> Option<Self::State> {
-        D::get_state(components)
-    }
-
     fn matches_component_set(
         state: &Self::State,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -2387,10 +2319,6 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
 
     fn init_state(_world: &World) -> Self::State {}
-
-    fn get_state(_components: &Components) -> Option<Self::State> {
-        Some(())
-    }
 
     fn matches_component_set(
         _state: &Self::State,

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -93,7 +93,7 @@ pub unsafe trait QueryFilter: WorldQuery {
     /// Note that this is called after already restricting the matched [`Table`]s and [`Archetype`]s to the
     /// ones that are compatible with the Filter's access.
     ///
-    /// Implementors of this method will generally either have a trivial `true` body (required for archetypal filters),
+    /// Implementers of this method will generally either have a trivial `true` body (required for archetypal filters),
     /// or access the necessary data within this function to make the final decision on filter inclusion.
     ///
     /// # Safety
@@ -180,8 +180,8 @@ unsafe impl<T: Component> WorldQuery for With<T> {
         access.and_with(id);
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        world.register_component::<T>()
+    fn init_state(world: &World) -> ComponentId {
+        world.components_queue().queue_register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -280,8 +280,8 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
         access.and_without(id);
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        world.register_component::<T>()
+    fn init_state(world: &World) -> ComponentId {
+        world.components_queue().queue_register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<Self::State> {
@@ -460,7 +460,7 @@ macro_rules! impl_or_query_filter {
                 *access = new_access;
             }
 
-            fn init_state(world: &mut World) -> Self::State {
+            fn init_state(world: &World) -> Self::State {
                 ($($filter::init_state(world),)*)
             }
 
@@ -727,8 +727,8 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         access.add_component_read(id);
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        world.register_component::<T>()
+    fn init_state(world: &World) -> ComponentId {
+        world.components_queue().queue_register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<ComponentId> {
@@ -954,8 +954,8 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         access.add_component_read(id);
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
-        world.register_component::<T>()
+    fn init_state(world: &World) -> ComponentId {
+        world.components_queue().queue_register_component::<T>()
     }
 
     fn get_state(components: &Components) -> Option<ComponentId> {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::Archetype,
-    component::{Component, ComponentId, Components, StorageType, Tick},
+    component::{Component, ComponentId, StorageType, Tick},
     entity::Entity,
     query::{DebugCheckedUnwrap, FilteredAccess, StorageSwitch, WorldQuery},
     storage::{ComponentSparseSet, Table, TableRow},
@@ -184,10 +184,6 @@ unsafe impl<T: Component> WorldQuery for With<T> {
         world.components_queue().queue_register_component::<T>()
     }
 
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
-    }
-
     fn matches_component_set(
         &id: &ComponentId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -282,10 +278,6 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
 
     fn init_state(world: &World) -> ComponentId {
         world.components_queue().queue_register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<Self::State> {
-        components.component_id::<T>()
     }
 
     fn matches_component_set(
@@ -462,10 +454,6 @@ macro_rules! impl_or_query_filter {
 
             fn init_state(world: &World) -> Self::State {
                 ($($filter::init_state(world),)*)
-            }
-
-            fn get_state(components: &Components) -> Option<Self::State> {
-                Some(($($filter::get_state(components)?,)*))
             }
 
             fn matches_component_set(state: &Self::State, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -731,10 +719,6 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         world.components_queue().queue_register_component::<T>()
     }
 
-    fn get_state(components: &Components) -> Option<ComponentId> {
-        components.component_id::<T>()
-    }
-
     fn matches_component_set(
         &id: &ComponentId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -956,10 +940,6 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
 
     fn init_state(world: &World) -> ComponentId {
         world.components_queue().queue_register_component::<T>()
-    }
-
-    fn get_state(components: &Components) -> Option<ComponentId> {
-        components.component_id::<T>()
     }
 
     fn matches_component_set(

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2736,7 +2736,7 @@ mod tests {
 
     #[test]
     fn empty_query_iter_sort_after_next_does_not_panic() {
-        let mut world = World::new();
+        let world = World::new();
         {
             let mut query = world.query::<(&A, &Sparse)>();
             let mut iter = query.iter(&world);

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -106,7 +106,7 @@ impl<T> DebugCheckedUnwrap for Option<T> {
 mod tests {
     use crate::{
         archetype::Archetype,
-        component::{Component, ComponentId, Components, Tick},
+        component::{Component, ComponentId, Tick},
         prelude::{AnyOf, Changed, Entity, Or, QueryState, Res, ResMut, Resource, With, Without},
         query::{
             ArchetypeFilter, FilteredAccess, Has, QueryCombinationIter, QueryData,
@@ -516,7 +516,7 @@ mod tests {
             b: &'static mut A,
         }
 
-        let mut world = World::new();
+        let world = World::new();
         world.query::<SelfConflicting>();
     }
 
@@ -865,10 +865,6 @@ mod tests {
 
         fn init_state(world: &World) -> Self::State {
             world.components_queue().queue_register_resource::<R>()
-        }
-
-        fn get_state(components: &Components) -> Option<Self::State> {
-            components.resource_id::<R>()
         }
 
         fn matches_component_set(

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -863,8 +863,8 @@ mod tests {
             access.add_resource_read(component_id);
         }
 
-        fn init_state(world: &mut World) -> Self::State {
-            world.components_registrator().register_resource::<R>()
+        fn init_state(world: &World) -> Self::State {
+            world.components_queue().queue_register_resource::<R>()
         }
 
         fn get_state(components: &Components) -> Option<Self::State> {

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -27,6 +27,7 @@ use variadics_please::all_tuples;
 ///     - Each filter in that disjunction must be a conjunction of the corresponding element's filter with the previous `access`
 /// - For each resource readonly accessed by [`init_fetch`], [`update_component_access`] should add read access.
 /// - Mutable resource access is not allowed.
+/// - [`init_state`] must only access world metadata (like components). It must not access specific entities or resources.
 ///
 /// When implementing [`update_component_access`], note that `add_read` and `add_write` both also add a `With` filter, whereas `extend_access` does not change the filters.
 ///

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::Archetype,
-    component::{ComponentId, Components, Tick},
+    component::{ComponentId, Tick},
     query::FilteredAccess,
     storage::Table,
     world::{unsafe_world_cell::UnsafeWorldCell, World},
@@ -117,10 +117,6 @@ pub unsafe trait WorldQuery {
     /// Creates and initializes a [`State`](WorldQuery::State) for this [`WorldQuery`] type.
     fn init_state(world: &World) -> Self::State;
 
-    /// Attempts to initialize a [`State`](WorldQuery::State) for this [`WorldQuery`] type using read-only
-    /// access to [`Components`].
-    fn get_state(components: &Components) -> Option<Self::State>;
-
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
     ///
     /// Used to check which [`Archetype`]s can be skipped by the query
@@ -204,11 +200,9 @@ macro_rules! impl_tuple_world_query {
                 let ($($name,)*) = state;
                 $($name::update_component_access($name, access);)*
             }
+
             fn init_state(world: &World) -> Self::State {
                 ($($name::init_state(world),)*)
-            }
-            fn get_state(components: &Components) -> Option<Self::State> {
-                Some(($($name::get_state(components)?,)*))
             }
 
             fn matches_component_set(state: &Self::State, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -101,7 +101,7 @@ pub unsafe trait WorldQuery {
     /// - `state` must be the [`State`](Self::State) that `fetch` was initialized with.
     unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table);
 
-    /// Sets available accesses for implementors with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
+    /// Sets available accesses for implementers with dynamic access such as [`FilteredEntityRef`](crate::world::FilteredEntityRef)
     /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).
     ///
     /// Called when constructing a [`QueryLens`](crate::system::QueryLens) or calling [`QueryState::from_builder`](super::QueryState::from_builder)
@@ -115,7 +115,7 @@ pub unsafe trait WorldQuery {
     fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>);
 
     /// Creates and initializes a [`State`](WorldQuery::State) for this [`WorldQuery`] type.
-    fn init_state(world: &mut World) -> Self::State;
+    fn init_state(world: &World) -> Self::State;
 
     /// Attempts to initialize a [`State`](WorldQuery::State) for this [`WorldQuery`] type using read-only
     /// access to [`Components`].
@@ -204,7 +204,7 @@ macro_rules! impl_tuple_world_query {
                 let ($($name,)*) = state;
                 $($name::update_component_access($name, access);)*
             }
-            fn init_state(world: &mut World) -> Self::State {
+            fn init_state(world: &World) -> Self::State {
                 ($($name::init_state(world),)*)
             }
             fn get_state(components: &Components) -> Option<Self::State> {

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -194,8 +194,8 @@ unsafe impl<R: Relationship, L: SpawnableList<R> + Send + Sync + 'static> Bundle
     }
 
     fn get_component_ids(
-        components: &crate::component::Components,
-        ids: &mut impl FnMut(Option<crate::component::ComponentId>),
+        components: crate::component::ComponentsQueuedRegistrator,
+        ids: &mut impl FnMut(crate::component::ComponentId),
     ) {
         <R::RelationshipTarget as Bundle>::get_component_ids(components, ids);
     }
@@ -263,8 +263,8 @@ unsafe impl<R: Relationship, B: Bundle> Bundle for SpawnOneRelated<R, B> {
     }
 
     fn get_component_ids(
-        components: &crate::component::Components,
-        ids: &mut impl FnMut(Option<crate::component::ComponentId>),
+        components: crate::component::ComponentsQueuedRegistrator,
+        ids: &mut impl FnMut(crate::component::ComponentId),
     ) {
         <R::RelationshipTarget as Bundle>::get_component_ids(components, ids);
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1503,7 +1503,7 @@ impl World {
     /// ]);
     /// ```
     #[inline]
-    pub fn query<D: QueryData>(&mut self) -> QueryState<D, ()> {
+    pub fn query<D: QueryData>(&self) -> QueryState<D, ()> {
         self.query_filtered::<D, ()>()
     }
 
@@ -1527,86 +1527,8 @@ impl World {
     /// assert_eq!(matching_entities, vec![e2]);
     /// ```
     #[inline]
-    pub fn query_filtered<D: QueryData, F: QueryFilter>(&mut self) -> QueryState<D, F> {
+    pub fn query_filtered<D: QueryData, F: QueryFilter>(&self) -> QueryState<D, F> {
         QueryState::new(self)
-    }
-
-    /// Returns [`QueryState`] for the given [`QueryData`], which is used to efficiently
-    /// run queries on the [`World`] by storing and reusing the [`QueryState`].
-    /// ```
-    /// use bevy_ecs::{component::Component, entity::Entity, world::World};
-    ///
-    /// #[derive(Component, Debug, PartialEq)]
-    /// struct Position {
-    ///   x: f32,
-    ///   y: f32,
-    /// }
-    ///
-    /// let mut world = World::new();
-    /// world.spawn_batch(vec![
-    ///     Position { x: 0.0, y: 0.0 },
-    ///     Position { x: 1.0, y: 1.0 },
-    /// ]);
-    ///
-    /// fn get_positions(world: &World) -> Vec<(Entity, &Position)> {
-    ///     let mut query = world.try_query::<(Entity, &Position)>().unwrap();
-    ///     query.iter(world).collect()
-    /// }
-    ///
-    /// let positions = get_positions(&world);
-    ///
-    /// assert_eq!(world.get::<Position>(positions[0].0).unwrap(), positions[0].1);
-    /// assert_eq!(world.get::<Position>(positions[1].0).unwrap(), positions[1].1);
-    /// ```
-    ///
-    /// Requires only an immutable world reference, but may fail if, for example,
-    /// the components that make up this query have not been registered into the world.
-    /// ```
-    /// use bevy_ecs::{component::Component, entity::Entity, world::World};
-    ///
-    /// #[derive(Component)]
-    /// struct A;
-    ///
-    /// let mut world = World::new();
-    ///
-    /// let none_query = world.try_query::<&A>();
-    /// assert!(none_query.is_none());
-    ///
-    /// world.register_component::<A>();
-    ///
-    /// let some_query = world.try_query::<&A>();
-    /// assert!(some_query.is_some());
-    /// ```
-    #[inline]
-    pub fn try_query<D: QueryData>(&self) -> Option<QueryState<D, ()>> {
-        self.try_query_filtered::<D, ()>()
-    }
-
-    /// Returns [`QueryState`] for the given filtered [`QueryData`], which is used to efficiently
-    /// run queries on the [`World`] by storing and reusing the [`QueryState`].
-    /// ```
-    /// use bevy_ecs::{component::Component, entity::Entity, world::World, query::With};
-    ///
-    /// #[derive(Component)]
-    /// struct A;
-    /// #[derive(Component)]
-    /// struct B;
-    ///
-    /// let mut world = World::new();
-    /// let e1 = world.spawn(A).id();
-    /// let e2 = world.spawn((A, B)).id();
-    ///
-    /// let mut query = world.try_query_filtered::<Entity, With<B>>().unwrap();
-    /// let matching_entities = query.iter(&world).collect::<Vec<Entity>>();
-    ///
-    /// assert_eq!(matching_entities, vec![e2]);
-    /// ```
-    ///
-    /// Requires only an immutable world reference, but may fail if, for example,
-    /// the components that make up this query have not been registered into the world.
-    #[inline]
-    pub fn try_query_filtered<D: QueryData, F: QueryFilter>(&self) -> Option<QueryState<D, F>> {
-        QueryState::try_new(self)
     }
 
     /// Returns an iterator of entities that had components of type `T` removed

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2769,6 +2769,7 @@ impl World {
         &mut self,
         component_id: ComponentId,
     ) -> &mut ResourceData<true> {
+        self.flush_components();
         let archetypes = &mut self.archetypes;
         self.storages
             .resources
@@ -2784,6 +2785,7 @@ impl World {
         &mut self,
         component_id: ComponentId,
     ) -> &mut ResourceData<false> {
+        self.flush_components();
         let archetypes = &mut self.archetypes;
         self.storages
             .non_send_resources

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -975,7 +975,7 @@ impl<'w> UnsafeEntityCell<'w> {
         // SAFETY: World is only used to access query data and initialize query state
         let state = unsafe {
             let world = self.world().world();
-            Q::get_state(world.components())?
+            Q::init_state(world)
         };
         let location = self.location();
         // SAFETY: Location is guaranteed to exist

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -5,7 +5,10 @@ use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
     change_detection::{MaybeLocation, MutUntyped, Ticks, TicksMut},
-    component::{ComponentId, ComponentTicks, Components, Mutable, StorageType, Tick, TickCells},
+    component::{
+        ComponentId, ComponentTicks, Components, ComponentsQueuedRegistrator, Mutable, StorageType,
+        Tick, TickCells,
+    },
     entity::{Entities, Entity, EntityBorrow, EntityDoesNotExistError, EntityLocation},
     observer::Observers,
     prelude::Component,
@@ -272,6 +275,14 @@ impl<'w> UnsafeWorldCell<'w> {
         // SAFETY:
         // - we only access world metadata
         &unsafe { self.world_metadata() }.components
+    }
+
+    /// Retrieves this world's [`ComponentsQueuedRegistrator`].
+    #[inline]
+    pub fn components_queue(self) -> ComponentsQueuedRegistrator<'w> {
+        // SAFETY:
+        // - we only access world metadata
+        unsafe { self.world_metadata() }.components_queue()
     }
 
     /// Retrieves this world's collection of [removed components](RemovedComponentEvents).

--- a/crates/bevy_render/src/sync_world.rs
+++ b/crates/bevy_render/src/sync_world.rs
@@ -275,7 +275,7 @@ mod render_entities_world_query_impls {
 
     use bevy_ecs::{
         archetype::Archetype,
-        component::{ComponentId, Components, Tick},
+        component::{ComponentId, Tick},
         entity::Entity,
         query::{FilteredAccess, QueryData, ReadOnlyQueryData, WorldQuery},
         storage::{Table, TableRow},
@@ -339,12 +339,8 @@ mod render_entities_world_query_impls {
             <&RenderEntity as WorldQuery>::update_component_access(&component_id, access);
         }
 
-        fn init_state(world: &mut World) -> ComponentId {
+        fn init_state(world: &World) -> ComponentId {
             <&RenderEntity as WorldQuery>::init_state(world)
-        }
-
-        fn get_state(components: &Components) -> Option<Self::State> {
-            <&RenderEntity as WorldQuery>::get_state(components)
         }
 
         fn matches_component_set(
@@ -439,12 +435,8 @@ mod render_entities_world_query_impls {
             <&MainEntity as WorldQuery>::update_component_access(&component_id, access);
         }
 
-        fn init_state(world: &mut World) -> ComponentId {
+        fn init_state(world: &World) -> ComponentId {
             <&MainEntity as WorldQuery>::init_state(world)
-        }
-
-        fn get_state(components: &Components) -> Option<Self::State> {
-            <&MainEntity as WorldQuery>::get_state(components)
         }
 
         fn matches_component_set(

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -309,9 +309,7 @@ impl RenderGraphNode for RunUiSubgraphOnUiViewNode {
         world: &'w World,
     ) -> Result<(), NodeRunError> {
         // Fetch the UI view.
-        let Some(mut render_views) = world.try_query::<&UiCameraView>() else {
-            return Ok(());
-        };
+        let mut render_views = world.query::<&UiCameraView>();
         let Ok(default_camera_view) = render_views.get(world, graph.view_entity()) else {
             return Ok(());
         };


### PR DESCRIPTION
# Objective

Readonly queries should not need to mutate a world, not even to initialize it. Currently the `try_query` api exists to remedy this, but it requires all component ids, etc to be created ahead of time. This is not idea.

## Solution

Make all `WorldQuery` just take `&World` to initialize. Now instead of needing `try_query`, users can just call `query`.

## Testing

No new tests were added, though the existing ones did catch some bugs.

## Migration Guide

`WorldQuery::init_state` now takes `&World` instead of `&mut World`. Additionally, it is now explicitly unsafe to rely on "magic" values in `WorldQuery::init_state`. For example, queries can no longer access resources or entities during initialization. This was possible before but was an anti-pattern since it tied the query results to when the query was *created* instead of when it is *queried*.

Additionally, `Bundle::get_component_ids` now takes `ComponentsQueuedRegistrator` instead of `&Components` and outputs `ComponentId`s instead of `Option<ComponentId>`. 
