### PR TITLE
Reduce dependencies on `bevy_render` by preferring `bevy_mesh` imports

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -16,6 +16,7 @@ bevy_color = { path = "../bevy_color", version = "0.16.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
+bevy_mesh = { path = "../bevy_mesh", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", features = [
   "petgraph",
 ] }

--- a/crates/bevy_animation/src/animation_curves.rs
+++ b/crates/bevy_animation/src/animation_curves.rs
@@ -100,9 +100,9 @@ use bevy_math::curve::{
     iterable::IterableCurve,
     Curve, Interval,
 };
+use bevy_mesh::morph::MorphWeights;
 use bevy_platform_support::hash::Hashed;
 use bevy_reflect::{FromReflect, Reflect, Reflectable, TypeInfo, Typed};
-use bevy_render::mesh::morph::MorphWeights;
 use downcast_rs::{impl_downcast, Downcast};
 
 /// A value on a component that Bevy can animate.

--- a/crates/bevy_animation/src/gltf_curves.rs
+++ b/crates/bevy_animation/src/gltf_curves.rs
@@ -373,7 +373,7 @@ impl<T> WideCubicKeyframeCurve<T> {
 /// recommended to use its implementation of the [`IterableCurve`] trait, which allows iterating
 /// directly over information derived from the curve without allocating.
 ///
-/// [`MorphWeights`]: bevy_render::prelude::MorphWeights
+/// [`MorphWeights`]: bevy_mesh::morph::MorphWeights
 #[derive(Debug, Clone, Reflect)]
 #[reflect(Clone)]
 pub enum WeightsCurve {

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -27,6 +27,7 @@ bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.16.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.16.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
+bevy_mesh = { path = "../bevy_mesh", version = "0.16.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.16.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.16.0-dev" }

--- a/crates/bevy_gltf/src/assets.rs
+++ b/crates/bevy_gltf/src/assets.rs
@@ -4,10 +4,10 @@
 use bevy_animation::AnimationClip;
 use bevy_asset::{Asset, Handle};
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_mesh::{skinning::SkinnedMeshInverseBindposes, Mesh};
 use bevy_pbr::StandardMaterial;
 use bevy_platform_support::collections::HashMap;
 use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
-use bevy_render::mesh::{skinning::SkinnedMeshInverseBindposes, Mesh};
 use bevy_scene::Scene;
 
 use crate::GltfAssetLabel;
@@ -214,7 +214,7 @@ impl GltfPrimitive {
     }
 }
 
-/// A glTF skin with all of its joint nodes, [`SkinnedMeshInversiveBindposes`](bevy_render::mesh::skinning::SkinnedMeshInverseBindposes)
+/// A glTF skin with all of its joint nodes, [`SkinnedMeshInversiveBindposes`](bevy_mesh::skinning::SkinnedMeshInverseBindposes)
 /// and an optional [`GltfExtras`].
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-skin).

--- a/crates/bevy_gltf/src/label.rs
+++ b/crates/bevy_gltf/src/label.rs
@@ -37,7 +37,7 @@ pub enum GltfAssetLabel {
     Node(usize),
     /// `Mesh{}`: glTF Mesh as a [`GltfMesh`](crate::GltfMesh)
     Mesh(usize),
-    /// `Mesh{}/Primitive{}`: glTF Primitive as a Bevy [`Mesh`](bevy_render::mesh::Mesh)
+    /// `Mesh{}/Primitive{}`: glTF Primitive as a Bevy [`Mesh`](bevy_mesh::Mesh)
     Primitive {
         /// Index of the mesh for this primitive
         mesh: usize,
@@ -70,7 +70,7 @@ pub enum GltfAssetLabel {
     /// `Skin{}`: glTF mesh skin as [`GltfSkin`](crate::GltfSkin)
     Skin(usize),
     /// `Skin{}/InverseBindMatrices`: glTF mesh skin matrices as Bevy
-    /// [`SkinnedMeshInverseBindposes`](bevy_render::mesh::skinning::SkinnedMeshInverseBindposes)
+    /// [`SkinnedMeshInverseBindposes`](bevy_mesh::skinning::SkinnedMeshInverseBindposes)
     InverseBindMatrices(usize),
 }
 

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -102,7 +102,8 @@ use bevy_platform_support::collections::HashMap;
 use bevy_app::prelude::*;
 use bevy_asset::AssetApp;
 use bevy_image::CompressedImageFormats;
-use bevy_render::{mesh::MeshVertexAttribute, renderer::RenderDevice};
+use bevy_mesh::MeshVertexAttribute;
+use bevy_render::renderer::RenderDevice;
 
 /// The glTF prelude.
 ///

--- a/crates/bevy_gltf/src/loader/gltf_ext/mesh.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/mesh.rs
@@ -1,4 +1,4 @@
-use bevy_render::mesh::PrimitiveTopology;
+use bevy_mesh::PrimitiveTopology;
 
 use gltf::mesh::{Mesh, Mode, Primitive};
 

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -10,6 +10,7 @@ use std::{
 use bevy_animation::{prelude::*, AnimationTarget, AnimationTargetId};
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, Handle, LoadContext, ReadAssetBytesError,
+    RenderAssetUsages,
 };
 use bevy_color::{Color, LinearRgba};
 use bevy_core_pipeline::prelude::Camera3d;
@@ -24,6 +25,11 @@ use bevy_image::{
     ImageType, TextureError,
 };
 use bevy_math::{Mat4, Vec3};
+use bevy_mesh::{
+    morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
+    skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
+    Indices, Mesh, MeshVertexAttribute, PrimitiveTopology, VertexAttributeValues,
+};
 #[cfg(feature = "pbr_transmission_textures")]
 use bevy_pbr::UvChannel;
 use bevy_pbr::{
@@ -32,14 +38,9 @@ use bevy_pbr::{
 use bevy_platform_support::collections::{HashMap, HashSet};
 use bevy_render::{
     camera::{Camera, OrthographicProjection, PerspectiveProjection, Projection, ScalingMode},
-    mesh::{
-        morph::{MeshMorphWeights, MorphAttributes, MorphTargetImage, MorphWeights},
-        skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-        Indices, Mesh, Mesh3d, MeshVertexAttribute, VertexAttributeValues,
-    },
+    mesh::Mesh3d,
     primitives::Aabb,
-    render_asset::RenderAssetUsages,
-    render_resource::{Face, PrimitiveTopology},
+    render_resource::Face,
     view::Visibility,
 };
 use bevy_scene::Scene;
@@ -122,10 +123,10 @@ pub enum GltfError {
     MissingAnimationSampler(usize),
     /// Failed to generate tangents.
     #[error("failed to generate tangents: {0}")]
-    GenerateTangentsError(#[from] bevy_render::mesh::GenerateTangentsError),
+    GenerateTangentsError(#[from] bevy_mesh::GenerateTangentsError),
     /// Failed to generate morph targets.
     #[error("failed to generate morph targets: {0}")]
-    MorphTarget(#[from] bevy_render::mesh::morph::MorphBuildError),
+    MorphTarget(#[from] bevy_mesh::morph::MorphBuildError),
     /// Circular children in Nodes
     #[error("GLTF model must be a tree, found cycle instead at node indices: {0:?}")]
     #[from(ignore)]
@@ -1771,7 +1772,8 @@ mod test {
     };
     use bevy_ecs::{resource::Resource, world::World};
     use bevy_log::LogPlugin;
-    use bevy_render::mesh::{skinning::SkinnedMeshInverseBindposes, MeshPlugin};
+    use bevy_mesh::skinning::SkinnedMeshInverseBindposes;
+    use bevy_render::mesh::MeshPlugin;
     use bevy_scene::ScenePlugin;
 
     fn test_app(dir: Dir) -> App {

--- a/crates/bevy_gltf/src/vertex_attributes.rs
+++ b/crates/bevy_gltf/src/vertex_attributes.rs
@@ -1,9 +1,5 @@
+use bevy_mesh::{Mesh, MeshVertexAttribute, VertexAttributeValues as Values, VertexFormat};
 use bevy_platform_support::collections::HashMap;
-use bevy_render::{
-    mesh::{MeshVertexAttribute, VertexAttributeValues as Values},
-    prelude::Mesh,
-    render_resource::VertexFormat,
-};
 use gltf::{
     accessor::{DataType, Dimensions},
     mesh::util::{ReadColors, ReadJoints, ReadTexCoords, ReadWeights},

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -17,6 +17,7 @@ pub use mesh::*;
 pub use mikktspace::*;
 pub use primitives::*;
 pub use vertex::*;
+pub use wgpu_types::VertexFormat;
 
 bitflags! {
     /// Our base mesh pipeline key bits start from the highest bit and go

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
@@ -1,6 +1,6 @@
 use bevy_math::{bounding::Aabb3d, Dir3, Mat4, Ray3d, Vec3, Vec3A};
+use bevy_mesh::{Indices, Mesh, PrimitiveTopology};
 use bevy_reflect::Reflect;
-use bevy_render::mesh::{Indices, Mesh, PrimitiveTopology};
 
 use super::Backfaces;
 

--- a/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/mod.rs
@@ -7,8 +7,8 @@ mod intersections;
 use bevy_derive::{Deref, DerefMut};
 
 use bevy_math::{bounding::Aabb3d, Ray3d};
+use bevy_mesh::Mesh;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::mesh::Mesh;
 
 use intersections::*;
 pub use intersections::{ray_aabb_intersection_3d, ray_mesh_intersection, RayMeshHit};


### PR DESCRIPTION
## Objective

Reduce dependencies on `bevy_render` by preferring `bevy_mesh` imports over `bevy_render` re-exports. 

```diff
- use bevy_render::mesh::Mesh;
+ use bevy_mesh::Mesh;
```

This is intended to help with #18423 (render crate restructure). Affects `bevy_gltf`, `bevy_animation` and `bevy_picking`.

## But Why?

As part of #18423, I'm assuming there'll be a push to make crates less dependent on the big render crates. This PR seemed like a small and safe step along that path - it only changes imports and makes the `bevy_mesh` crate dependency explicit in `Cargo.toml`. Any remaining dependencies on `bevy_render` are true dependencies.

## Testing

```
cargo run --example testbed_3d
cargo run --example mesh_picking
```