### PR TITLE
Fix documentation: incorrect references to the `Update` schedule in `ExitCondition`

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -177,11 +177,11 @@ impl Plugin for WindowPlugin {
 pub enum ExitCondition {
     /// Close application when the primary window is closed
     ///
-    /// The plugin will add [`exit_on_primary_closed`] to [`Update`].
+    /// The plugin will add [`exit_on_primary_closed`] to [`PostUpdate`].
     OnPrimaryClosed,
     /// Close application when all windows are closed
     ///
-    /// The plugin will add [`exit_on_all_closed`] to [`Update`].
+    /// The plugin will add [`exit_on_all_closed`] to [`PostUpdate`].
     OnAllClosed,
     /// Keep application running headless even after closing all windows
     ///


### PR DESCRIPTION
# Objective

- The referenced `ScheduleLabel` for `OnPrimaryClosed` and `OnAllClosed` in `ExitCondition` was incorrect

## Solution

- Changed `Update` to `PostUpdate`