### PR TITLE
Remote entity reservation v5

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -632,6 +632,10 @@ impl Drop for PortableEntities<'_> {
             if downgraded.strong_count() == 0 {
                 break;
             }
+
+            // We should be able to break *really* soon, so we don't yield.
+            // But this should be more friendly to the cpu.
+            core::hint::spin_loop();
         }
     }
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1557,12 +1557,13 @@ mod tests {
             if threads.is_empty() {
                 break;
             }
-            if timeout.elapsed().as_secs() > 10 {
+            if timeout.elapsed().as_secs() > 60 {
                 panic!("remote entities timmed out.")
             }
         }
 
-        assert_eq!(entities.len(), 300);
+        // It might be a little over since we may have reserved extra entities for remote reservation.
+        assert!(entities.len() >= 300);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1512,6 +1512,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "This test starts multiple threads. In batch testing, this may time out because other tests are running concurrently."]
     #[cfg(feature = "std")]
     fn remote_reservation() {
         let mut entities = Entities::new();

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -551,7 +551,7 @@ impl<'a> PortableEntities<'a> {
     ///
     /// let world = World::new();
     /// let entities = world.entities().portable();
-    /// let remote = unsafe { entities.get_remote() };
+    /// let mut remote = unsafe { entities.get_remote() };
     ///
     /// // drop(entities); // This would violate safety and cause a deadlock.
     ///
@@ -580,7 +580,7 @@ impl<'a> PortableEntities<'a> {
     /// let world = World::new();
     /// let entities = world.entities().portable();
     ///
-    /// let result = unsafe { entities.remote_scope(|remote| {
+    /// let result = unsafe { entities.remote_scope(|mut remote| {
     ///     remote.reserve_entity()
     ///     // remote // Returning `remote` would break safety since it escapes the scope.
     /// }) };

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -698,7 +698,12 @@ struct RemoteEntitiesSource {
     reserved: ConcurrentQueue<Vec<Entity>>,
 }
 
+/// An error that occurs when an [`Entity`] can not be reserved remotely.
+/// See also [`RemoteEntitiesReserver`].
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteReservationError {
+    /// This happens when [`Entities`] are closed, dropped, etc while a [`RemoteEntitiesReserver`] is trying to reserve from it.
+    #[error("A remote entity reserver tried to reserve an entity from a closed `Entities`.")]
     Closed,
 }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -662,8 +662,7 @@ impl Future for RemoteReservedEntities {
                 Poll::Ready(Err(RemoteReservationError::Closed))
             }
             Err(concurrent_queue::PopError::Empty) => {
-                // Someone must have stonlen what we requested. We'll just ask again.
-                self.request_made = false;
+                // We must still be waiting on a flush
                 Poll::Pending
             }
         }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -76,9 +76,12 @@ use crate::{
     storage::{SparseSetIndex, TableId, TableRow},
 };
 use alloc::vec::Vec;
-use bevy_platform_support::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc, Weak,
+use bevy_platform_support::{
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Weak,
+    },
+    task::Waker,
 };
 use concurrent_queue::ConcurrentQueue;
 use core::{fmt, hash::Hash, mem, num::NonZero, panic::Location};
@@ -529,7 +532,7 @@ unsafe impl EntitySetIterator for ReserveEntitiesIterator<'_> {}
 /// This is a portable version of [`Entities`], allowing use in [`RemoteEntitiesReserver`].
 /// This can be attained via [`Entities::portable`].
 ///
-/// See [`get_remote`](Self::get_remote) and [`remote_scope`](Self::get_remote) for examples.
+/// See [`RemoteEntitiesReserver::new`] and [`RemoteEntitiesReserver::scope`] for examples.
 pub struct PortableEntities<'a> {
     entities: &'a Entities,
     security: Arc<EntitiesPtr>,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -570,7 +570,7 @@ impl<'a> PortableEntities<'a> {
     ///
     /// # Safety
     ///
-    /// The passed [`RemoteEntitiesReserver`] must be used outside of `scope`.
+    /// The passed [`RemoteEntitiesReserver`] must never be used outside of `scope` on the calling thread.
     ///
     /// # Example
     ///
@@ -1522,7 +1522,7 @@ mod tests {
         let mut entities = Entities::new();
 
         let portable = entities.portable();
-        // SAFETY: `remote` does not escape scope.
+        // SAFETY: `remote` does not escape scope on this thread.
         let thread_1 = unsafe {
             portable.remote_scope(|mut remote| {
                 std::thread::spawn(move || {
@@ -1532,7 +1532,7 @@ mod tests {
                 })
             })
         };
-        // SAFETY: `remote` does not escape scope.
+        // SAFETY: `remote` does not escape scope on this thread.
         let thread_2 = unsafe {
             portable.remote_scope(|mut remote| {
                 std::thread::spawn(move || {
@@ -1542,7 +1542,7 @@ mod tests {
                 })
             })
         };
-        // SAFETY: `remote` does not escape scope.
+        // SAFETY: `remote` does not escape scope on this thread.
         let thread_3 = unsafe {
             portable.remote_scope(|mut remote| {
                 std::thread::spawn(move || {

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -534,7 +534,7 @@ impl<'a> core::iter::FusedIterator for ReserveEntitiesIterator<'a> {}
 unsafe impl EntitySetIterator for ReserveEntitiesIterator<'_> {}
 
 /// This handles reserving entities remotely.
-/// See also [`PortableEntities`].
+/// See also [`RemoteEntities`].
 pub struct RemoteEntitiesReserver {
     source: Arc<RemoteEntitiesSource>,
     current: Vec<Entity>,
@@ -1469,7 +1469,6 @@ mod tests {
     }
 
     #[test]
-    // #[ignore = "This test starts multiple threads. In batch testing, this may time out because other tests are running concurrently."]
     #[cfg(feature = "std")]
     fn remote_reservation() {
         use std::thread;

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1304,6 +1304,13 @@ impl Entities {
     }
 }
 
+impl Drop for Entities {
+    fn drop(&mut self) {
+        // Make sure remote entities are informed.
+        self.remote.close();
+    }
+}
+
 /// An error that occurs when a specified [`Entity`] does not exist.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 #[error("The entity with ID {entity} {details}")]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -617,7 +617,7 @@ impl RemoteEntitiesReserver {
     ///
     /// let world = World::new();
     /// let entities = world.entities().portable();
-    /// let mut remote = unsafe { RemoteEntitiesReserver.new(&entities) };
+    /// let mut remote = unsafe { RemoteEntitiesReserver::new(&entities) };
     ///
     /// // drop(entities); // This would violate safety and cause a deadlock.
     ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -76,12 +76,9 @@ use crate::{
     storage::{SparseSetIndex, TableId, TableRow},
 };
 use alloc::vec::Vec;
-use bevy_platform_support::{
-    sync::{
-        atomic::{AtomicU32, Ordering},
-        Arc, Weak,
-    },
-    task::Waker,
+use bevy_platform_support::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc, Weak,
 };
 use concurrent_queue::ConcurrentQueue;
 use core::{fmt, hash::Hash, mem, num::NonZero, panic::Location};

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -541,7 +541,7 @@ impl<'a> PortableEntities<'a> {
     /// # Safety
     ///
     /// The caller must ensure that the returned value is only used when either `self` is in scope,
-    /// or the returned [`RemoteEntitiesReserver`] is on a thread which has no active reference to the source [`&Entities`].
+    /// or the returned [`RemoteEntitiesReserver`] is on a thread which has no active reference to the source &[`Entities`].
     /// If this safety is broken, a deadlock may occor.
     ///
     /// # Example


### PR DESCRIPTION
fixes #18003

# Objective

Another implementation of remote entity reservation. This is take 5. In my previous attempts, I had discarded the idea of blocking on remote reservations until the next flush, but with some careful use of `unsafe` we can actually do this without deadlocking.

Thanks a ton to @andriyDev and @maniwani on discord for the inspiration for the design.

Compared to v4 (#18380), this design is more isolated from the rest of the ecs (which I like) and has hopefully better performance. v4 would allows us to skip some `flush` calls, so in the long run that might be more performant as an end-game. Despite that, I think this PR, baring unforeseen performance or ergonomics issues, should be better.

## Solution

We keep two concurrent queues, one requesting batches of reserved entities to distribute remotely, and one fulfilling those requests. We check for those requests and fulfill them immediately before flushing.

Finally, if `Entities` is cleared, dropped, etc, we close the concurrent queues. If that happens, reservation returns an error. This can be bubbled up for asset loading. Before using remotely reserved entities, we need to check if the remote reserver is not closed (or some other validation method). This shouldn't be too bad for the asset system to do.

## Benchmarks

I ran some relevant benchmarks and here's the results where they differ by more than 5%.

```txt
group                               main_baseline                          remote_entities_v5_baseline
-----                               -------------                          ---------------------------
despawn_world/10000_entities        1.22     66.7±9.62µs        ? ?/sec    1.00    54.5±10.52µs        ? ?/sec
despawn_world/1000_entities         1.22      6.5±0.10µs        ? ?/sec    1.00      5.3±0.07µs        ? ?/sec
despawn_world/100_entities          1.23   661.6±52.50ns        ? ?/sec    1.00    536.5±5.59ns        ? ?/sec
despawn_world/10_entities           1.21     69.4±1.24ns        ? ?/sec    1.00     57.5±0.97ns        ? ?/sec
despawn_world/1_entities            1.23      7.3±0.48ns        ? ?/sec    1.00      5.9±0.05ns        ? ?/sec
empty_archetypes/for_each/10000     1.00     11.9±0.69µs        ? ?/sec    1.11     13.2±0.36µs        ? ?/sec
empty_archetypes/par_for_each/10    1.00      8.5±0.98µs        ? ?/sec    1.06      9.0±2.28µs        ? ?/sec
empty_commands/0_entities           1.10      4.2±0.04ns        ? ?/sec    1.00      3.9±0.04ns        ? ?/sec
iter_fragmented/foreach             1.00    132.0±2.42ns        ? ?/sec    1.06    140.4±5.65ns        ? ?/sec
iter_simple/wide_sparse_set         1.00     91.8±8.49µs        ? ?/sec    1.07    98.4±26.74µs        ? ?/sec
par_iter_simple/with_10_fragment    1.06     39.7±6.51µs        ? ?/sec    1.00     37.4±2.34µs        ? ?/sec
spawn_world/10000_entities          1.07   440.6±33.57µs        ? ?/sec    1.00   410.5±29.63µs        ? ?/sec
spawn_world/1000_entities           1.00     42.9±6.98µs        ? ?/sec    1.12    48.2±28.00µs        ? ?/sec
spawn_world/100_entities            1.06      4.4±0.52µs        ? ?/sec    1.00      4.1±0.26µs        ? ?/sec
world_get/50000_entities_sparse     1.05   171.3±18.73µs        ? ?/sec    1.00    162.5±3.88µs        ? ?/sec
world_get/50000_entities_table      1.12  184.5±100.46µs        ? ?/sec    1.00    165.0±5.14µs        ? ?/sec
```

The only real way (that I know of) to improve this is to fulfill remote requests less often. Ex: once per frame instead of once per flush. If that's worth it, let me know and I'll add it, but given that this branch beats main in some places even though it has *only* added work, I'm a little skeptical that these gains are organic. Maybe something's happening at the assembly level that I don't understand.

## Testing

I added two examples and one test. Since it uses threads to test it, it is not in batch testing or ci. That's because it always seems to time out, seemingly because the scheduler gets crowded with all those other test threads. When running the test alone, it works fine.

## Example

```rust
use bevy_ecs::prelude::*;

let mut world = World::new();
let remote = world.entities().get_remote();
let mut reserver = remote.make_reserver();

// The reserve is async so we need it to be on a separate thread.
let thread = std::thread::spawn(move || {
   let future = async {
       for _ in 0..100 {
          reserver.reserve_entity().await.unwrap();
       }
   };
   bevy_tasks::block_on(future);
});

// We need to flush the entities as needed or the remote entities will get stuck.
while !thread.is_finished() {
    world.flush();
}
```
