### PR TITLE
Fix double-despawning in `despawn_world` and `despawn_world_recursive` benchmarks

### DIFF
--- a/benches/benches/bevy_ecs/world/despawn.rs
+++ b/benches/benches/bevy_ecs/world/despawn.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
 use glam::*;
 
 #[derive(Component)]
@@ -13,18 +13,23 @@ pub fn world_despawn(criterion: &mut Criterion) {
     group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in (0..5).map(|i| 10_u32.pow(i)) {
-        let mut world = World::default();
-        for _ in 0..entity_count {
-            world.spawn((A(Mat4::default()), B(Vec4::default())));
-        }
-
-        let ents = world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
         group.bench_function(format!("{}_entities", entity_count), |bencher| {
-            bencher.iter(|| {
-                ents.iter().for_each(|e| {
-                    world.despawn(*e);
-                });
-            });
+            bencher.iter_batched_ref(
+                || {
+                    let mut world = World::default();
+                    for _ in 0..entity_count {
+                        world.spawn((A(Mat4::default()), B(Vec4::default())));
+                    }
+                    let ents = world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
+                    (world, ents)
+                },
+                |(world, ents)| {
+                    ents.iter().for_each(|e| {
+                        world.despawn(*e);
+                    });
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
 

--- a/benches/benches/bevy_ecs/world/despawn_recursive.rs
+++ b/benches/benches/bevy_ecs/world/despawn_recursive.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
 use glam::*;
 
 #[derive(Component)]
@@ -13,22 +13,30 @@ pub fn world_despawn_recursive(criterion: &mut Criterion) {
     group.measurement_time(core::time::Duration::from_secs(4));
 
     for entity_count in (0..5).map(|i| 10_u32.pow(i)) {
-        let mut world = World::default();
-        for _ in 0..entity_count {
-            world
-                .spawn((A(Mat4::default()), B(Vec4::default())))
-                .with_children(|parent| {
-                    parent.spawn((A(Mat4::default()), B(Vec4::default())));
-                });
-        }
-
-        let ents = world.iter_entities().map(|e| e.id()).collect::<Vec<_>>();
         group.bench_function(format!("{}_entities", entity_count), |bencher| {
-            bencher.iter(|| {
-                ents.iter().for_each(|e| {
-                    world.entity_mut(*e).despawn();
-                });
-            });
+            bencher.iter_batched_ref(
+                || {
+                    let mut world = World::default();
+                    let parent_ents = (0..entity_count)
+                        .map(|_| {
+                            world
+                                .spawn((A(Mat4::default()), B(Vec4::default())))
+                                .with_children(|parent| {
+                                    parent.spawn((A(Mat4::default()), B(Vec4::default())));
+                                })
+                                .id()
+                        })
+                        .collect::<Vec<_>>();
+
+                    (world, parent_ents)
+                },
+                |(world, parent_ents)| {
+                    parent_ents.iter().for_each(|e| {
+                        world.despawn(*e);
+                    });
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
 


### PR DESCRIPTION
# Objective

- Fixes #18430


## Solution

- Moves world creation into per-iteration setup for both `despawn_world` and `despawn_world_recursive`, meaning the world's entities don't aren't despawned multiple times
- Doesn't affect despawn APIs

## Testing

- Tested manually by running `cargo bench -p benches --bench ecs -- despawn_world`
