### PR TITLE
Get names of queued components

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -85,7 +85,6 @@ std = [
   "arrayvec?/std",
   "log/std",
   "bevy_platform_support/std",
-  "atomicow/std",
 ]
 
 ## `critical-section` provides the building blocks for synchronization primitives
@@ -132,7 +131,6 @@ variadics_please = { version = "1.1", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 bumpalo = "3"
-atomicow = { version = "1.1", default-features = false }
 
 concurrent-queue = { version = "2.5.0", default-features = false }
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -34,7 +34,7 @@ bevy_reflect = ["dep:bevy_reflect"]
 reflect_functions = ["bevy_reflect", "bevy_reflect/functions"]
 
 ## Use the configurable global error handler as the default error handler.
-## 
+##
 ## This is typically used to turn panics from the ECS into loggable errors.
 ## This may be useful for production builds,
 ## but can result in a measurable performance impact, especially for commands.
@@ -85,6 +85,7 @@ std = [
   "arrayvec?/std",
   "log/std",
   "bevy_platform_support/std",
+  "atomicow/std",
 ]
 
 ## `critical-section` provides the building blocks for synchronization primitives
@@ -110,7 +111,6 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 ] }
 
 bitflags = { version = "2.3", default-features = false }
-concurrent-queue = { version = "2.5.0", default-features = false }
 disqualified = { version = "1.0", default-features = false }
 fixedbitset = { version = "0.5", default-features = false }
 serde = { version = "1", default-features = false, features = [
@@ -132,7 +132,9 @@ variadics_please = { version = "1.1", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }
 bumpalo = "3"
+atomicow = { version = "1.1", default-features = false }
 
+concurrent-queue = { version = "2.5.0", default-features = false }
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 concurrent-queue = { version = "2.5.0", default-features = false, features = [
   "portable-atomic",

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2005,7 +2005,7 @@ impl Components {
             })
     }
 
-    /// Gets the [`ComponentName`] of the component with this [`ComponentId`] if it is present.
+    /// Gets the name of the component with this [`ComponentId`] if it is present.
     /// This will return `None` only if the id is neither regisered nor queued to be registered.
     ///
     /// This will return an incorrect result if `id` did not come from the same world as `self`. It may return `None` or a garbage value.

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -13,7 +13,6 @@ use crate::{
     world::{DeferredWorld, FromWorld, World},
 };
 use alloc::boxed::Box;
-use alloc::string::ToString;
 use alloc::{borrow::Cow, format, vec::Vec};
 pub use bevy_ecs_macros::Component;
 use bevy_platform_support::sync::Arc;

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2026,7 +2026,7 @@ impl Components {
                     .chain(queued.resources.values())
                     .chain(queued.dynamic_registrations.iter())
                     .find(|queued| queued.id == id)
-                    .map(|queued| Cow::Owned(queued.descriptor.name().to_string()))
+                    .map(|queued| queued.descriptor.name.clone())
             })
     }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -2027,28 +2027,14 @@ impl Components {
             .and_then(|info| info.as_ref().map(|info| CowArc::Borrowed(&info.descriptor)))
             .or_else(|| {
                 let queued = self.queued.read().unwrap_or_else(PoisonError::into_inner);
-                // first check components
+                // first check components, then resources, then dynamic
                 queued
                     .components
                     .values()
+                    .chain(queued.resources.values())
+                    .chain(queued.dynamic_registrations.iter())
                     .find(|queued| queued.id == id)
                     .map(|queued| CowArc::Owned(Arc::new(queued.descriptor.clone())))
-                    .or_else(|| {
-                        // otherwise check resources
-                        queued
-                            .resources
-                            .values()
-                            .find(|queued| queued.id == id)
-                            .map(|queued| CowArc::Owned(Arc::new(queued.descriptor.clone())))
-                    })
-                    .or_else(|| {
-                        // otherwise check dynamic
-                        queued
-                            .dynamic_registrations
-                            .iter()
-                            .find(|queued| queued.id == id)
-                            .map(|queued| CowArc::Owned(Arc::new(queued.descriptor.clone())))
-                    })
             })
     }
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1863,7 +1863,7 @@ impl<'w> ComponentsRegistrator<'w> {
         }
     }
 
-    /// Same as [`Components::register_resource_unchecked_with`] but handles safety.
+    /// Same as [`Components::register_resource_unchecked`] but handles safety.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -985,7 +985,7 @@ impl SparseSetIndex for ComponentId {
 
 /// Represents the name of a component.
 #[derive(Clone)]
-pub struct ComponentName<'a>(Cow<'a, Arc<ComponentDescriptor>>);
+pub struct ComponentName<'a>(pub Cow<'a, Arc<ComponentDescriptor>>);
 
 impl Deref for ComponentName<'_> {
     type Target = str;
@@ -2022,6 +2022,8 @@ impl Components {
 
     /// Gets the [`ComponentDescriptor`] of the component with this [`ComponentId`] if it is present.
     /// This will return `None` only if the id is neither regisered nor queued to be registered.
+    ///
+    /// Currently, the [`Cow`] will be [`Cow::Owned`] if and only if the component is queued. It will be [`Cow::Borrowed`] otherwise.
     ///
     /// This will return an incorrect result if `id` did not come from the same world as `self`. It may return `None` or a garbage value.
     #[inline]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1007,6 +1007,12 @@ impl core::fmt::Display for ComponentName {
     }
 }
 
+impl From<ComponentName> for alloc::string::String {
+    fn from(value: ComponentName) -> Self {
+        value.0.name().into()
+    }
+}
+
 /// A value describing a component or resource, which may or may not correspond to a Rust type.
 #[derive(Clone)]
 pub struct ComponentDescriptor {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1327,6 +1327,7 @@ impl ComponentIds {
 ///
 /// As a rule of thumb, if you have mutable access to [`ComponentsRegistrator`], prefer to use that instead.
 /// Use this only if you need to know the id of a component but do not need to modify the contents of the world based on that id.
+#[derive(Clone, Copy)]
 pub struct ComponentsQueuedRegistrator<'w> {
     components: &'w Components,
     ids: &'w ComponentIds,
@@ -1424,6 +1425,8 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// This will reserve an id and queue the registration.
     /// These registrations will be carried out at the next opportunity.
     ///
+    /// If this has already been registered or queued, this returns the previous [`ComponentId`].
+    ///
     /// # Note
     ///
     /// Technically speaking, the returned [`ComponentId`] is not valid, but it will become valid later.
@@ -1476,6 +1479,8 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// This will reserve an id and queue the registration.
     /// These registrations will be carried out at the next opportunity.
     ///
+    /// If this has already been registered or queued, this returns the previous [`ComponentId`].
+    ///
     /// # Note
     ///
     /// Technically speaking, the returned [`ComponentId`] is not valid, but it will become valid later.
@@ -1505,6 +1510,8 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
     /// This is a queued version of [`ComponentsRegistrator::register_non_send`].
     /// This will reserve an id and queue the registration.
     /// These registrations will be carried out at the next opportunity.
+    ///
+    /// If this has already been registered or queued, this returns the previous [`ComponentId`].
     ///
     /// # Note
     ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1461,8 +1461,7 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
                         // SAFETY: Id uniqueness handled by caller, and the type_id matches descriptor.
                         #[expect(unused_unsafe, reason = "More precise to specify.")]
                         unsafe {
-                            registrator
-                                .register_resource_unchecked_with(type_id, id, || descriptor);
+                            registrator.register_resource_unchecked(type_id, id, descriptor);
                         }
                     },
                 )
@@ -1492,8 +1491,7 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
                         // SAFETY: Id uniqueness handled by caller, and the type_id matches descriptor.
                         #[expect(unused_unsafe, reason = "More precise to specify.")]
                         unsafe {
-                            registrator
-                                .register_resource_unchecked_with(type_id, id, || descriptor);
+                            registrator.register_resource_unchecked(type_id, id, descriptor);
                         }
                     },
                 )
@@ -1849,7 +1847,7 @@ impl<'w> ComponentsRegistrator<'w> {
         let id = self.ids.next_mut();
         // SAFETY: The resource is not currently registered, the id is fresh, and the [`ComponentDescriptor`] matches the [`TypeId`]
         unsafe {
-            self.register_resource_unchecked_with(type_id, id, descriptor);
+            self.register_resource_unchecked(type_id, id, descriptor());
         }
         id
     }
@@ -2404,15 +2402,15 @@ impl Components {
     /// The [`ComponentId`] must be unique.
     /// The [`TypeId`] and [`ComponentId`] must not be registered or queued.
     #[inline]
-    unsafe fn register_resource_unchecked_with(
+    unsafe fn register_resource_unchecked(
         &mut self,
         type_id: TypeId,
         component_id: ComponentId,
-        func: impl FnOnce() -> ComponentDescriptor,
+        descriptor: ComponentDescriptor,
     ) {
         // SAFETY: ensured by caller
         unsafe {
-            self.register_component_inner(component_id, func());
+            self.register_component_inner(component_id, descriptor);
         }
         let prev = self.resource_indices.insert(type_id, component_id);
         debug_assert!(prev.is_none());

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -968,11 +968,10 @@ impl AccessConflicts {
                     format!(
                         "{}",
                         ShortName(
-                            world
+                            &world
                                 .components
-                                .get_info(ComponentId::get_sparse_set_index(index))
+                                .get_name(ComponentId::get_sparse_set_index(index))
                                 .unwrap()
-                                .name()
                         )
                     )
                 })

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -1097,6 +1097,13 @@ mod tests {
             let ambiguities: Vec<_> = schedule
                 .graph()
                 .conflicts_to_string(schedule.graph().conflicting_systems(), world.components())
+                .map(|item| {
+                    (
+                        item.0,
+                        item.1,
+                        item.2.into_iter().map(|name| name.to_string()),
+                    )
+                })
                 .collect();
 
             let expected = &[
@@ -1146,6 +1153,13 @@ mod tests {
             let ambiguities: Vec<_> = schedule
                 .graph()
                 .conflicts_to_string(schedule.graph().conflicting_systems(), world.components())
+                .map(|item| {
+                    (
+                        item.0,
+                        item.1,
+                        item.2.into_iter().map(|name| name.to_string()),
+                    )
+                })
                 .collect();
 
             assert_eq!(

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -1101,7 +1101,10 @@ mod tests {
                     (
                         item.0,
                         item.1,
-                        item.2.into_iter().map(|name| name.to_string()),
+                        item.2
+                            .into_iter()
+                            .map(|name| name.to_string())
+                            .collect::<Vec<_>>(),
                     )
                 })
                 .collect();
@@ -1110,22 +1113,22 @@ mod tests {
                 (
                     "system_d".to_string(),
                     "system_a".to_string(),
-                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R"],
+                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R".into()],
                 ),
                 (
                     "system_d".to_string(),
                     "system_e".to_string(),
-                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R"],
+                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R".into()],
                 ),
                 (
                     "system_b".to_string(),
                     "system_a".to_string(),
-                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R"],
+                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R".into()],
                 ),
                 (
                     "system_b".to_string(),
                     "system_e".to_string(),
-                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R"],
+                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R".into()],
                 ),
             ];
 
@@ -1157,7 +1160,10 @@ mod tests {
                     (
                         item.0,
                         item.1,
-                        item.2.into_iter().map(|name| name.to_string()),
+                        item.2
+                            .into_iter()
+                            .map(|name| name.to_string())
+                            .collect::<Vec<_>>(),
                     )
                 })
                 .collect();
@@ -1167,7 +1173,7 @@ mod tests {
                 (
                     "resmut_system (in set (resmut_system, resmut_system))".to_string(),
                     "resmut_system (in set (resmut_system, resmut_system))".to_string(),
-                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R"],
+                    vec!["bevy_ecs::schedule::tests::system_ambiguity::R".into()],
                 )
             );
         }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -2,6 +2,7 @@
     clippy::module_inception,
     reason = "This instance of module inception is being discussed; see #17344."
 )]
+use alloc::borrow::Cow;
 use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
@@ -25,7 +26,7 @@ use thiserror::Error;
 use tracing::info_span;
 
 use crate::{
-    component::{ComponentId, ComponentName, Components, Tick},
+    component::{ComponentId, Components, Tick},
     error::default_error_handler,
     prelude::Component,
     resource::Resource,
@@ -1902,7 +1903,7 @@ impl ScheduleGraph {
         &'a self,
         ambiguities: &'a [(NodeId, NodeId, Vec<ComponentId>)],
         components: &'a Components,
-    ) -> impl Iterator<Item = (String, String, Vec<ComponentName<'a>>)> + 'a {
+    ) -> impl Iterator<Item = (String, String, Vec<Cow<'a, str>>)> + 'a {
         ambiguities
             .iter()
             .map(move |(system_a, system_b, conflicts)| {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use tracing::info_span;
 
 use crate::{
-    component::{ComponentId, Components, Tick},
+    component::{ComponentId, ComponentName, Components, Tick},
     error::default_error_handler,
     prelude::Component,
     resource::Resource,
@@ -1898,11 +1898,11 @@ impl ScheduleGraph {
     }
 
     /// convert conflicts to human readable format
-    pub fn conflicts_to_string<'a>(
-        &'a self,
-        ambiguities: &'a [(NodeId, NodeId, Vec<ComponentId>)],
-        components: &'a Components,
-    ) -> impl Iterator<Item = (String, String, Vec<&'a str>)> + 'a {
+    pub fn conflicts_to_string(
+        &self,
+        ambiguities: &[(NodeId, NodeId, Vec<ComponentId>)],
+        components: &Components,
+    ) -> impl Iterator<Item = (String, String, Vec<ComponentName>)> {
         ambiguities
             .iter()
             .map(move |(system_a, system_b, conflicts)| {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1898,11 +1898,11 @@ impl ScheduleGraph {
     }
 
     /// convert conflicts to human readable format
-    pub fn conflicts_to_string(
-        &self,
-        ambiguities: &[(NodeId, NodeId, Vec<ComponentId>)],
-        components: &Components,
-    ) -> impl Iterator<Item = (String, String, Vec<ComponentName>)> {
+    pub fn conflicts_to_string<'a>(
+        &'a self,
+        ambiguities: &'a [(NodeId, NodeId, Vec<ComponentId>)],
+        components: &'a Components,
+    ) -> impl Iterator<Item = (String, String, Vec<ComponentName<'a>>)> + 'a {
         ambiguities
             .iter()
             .map(move |(system_a, system_b, conflicts)| {

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -656,7 +656,6 @@ mod tests {
         storage::SparseSet,
     };
     use alloc::{vec, vec::Vec};
-    use bevy_platform_support::sync::Arc;
 
     #[derive(Debug, Eq, PartialEq)]
     struct Foo(usize);
@@ -743,7 +742,7 @@ mod tests {
         fn register_component<T: Component>(sets: &mut SparseSets, id: usize) {
             let descriptor = ComponentDescriptor::new::<T>();
             let id = ComponentId::new(id);
-            let info = ComponentInfo::new(id, Arc::new(descriptor));
+            let info = ComponentInfo::new(id, descriptor);
             sets.get_or_insert(&info);
         }
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -656,6 +656,7 @@ mod tests {
         storage::SparseSet,
     };
     use alloc::{vec, vec::Vec};
+    use bevy_platform_support::sync::Arc;
 
     #[derive(Debug, Eq, PartialEq)]
     struct Foo(usize);
@@ -742,7 +743,7 @@ mod tests {
         fn register_component<T: Component>(sets: &mut SparseSets, id: usize) {
             let descriptor = ComponentDescriptor::new::<T>();
             let id = ComponentId::new(id);
-            let info = ComponentInfo::new(id, descriptor);
+            let info = ComponentInfo::new(id, Arc::new(descriptor));
             sets.get_or_insert(&info);
         }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2847,6 +2847,7 @@ impl World {
         &mut self,
         component_id: ComponentId,
     ) -> &mut ResourceData<true> {
+        self.flush_components();
         let archetypes = &mut self.archetypes;
         self.storages
             .resources
@@ -2862,6 +2863,7 @@ impl World {
         &mut self,
         component_id: ComponentId,
     ) -> &mut ResourceData<false> {
+        self.flush_components();
         let archetypes = &mut self.archetypes;
         self.storages
             .non_send_resources

--- a/crates/bevy_ecs/src/world/reflect.rs
+++ b/crates/bevy_ecs/src/world/reflect.rs
@@ -80,7 +80,7 @@ impl World {
             let component_name = self
                 .components()
                 .get_name(component_id)
-                .map(ToString::to_string);
+                .map(|name| name.to_string());
 
             return Err(GetComponentReflectError::EntityDoesNotHaveComponent {
                 entity,
@@ -169,7 +169,7 @@ impl World {
         let component_name = self
             .components()
             .get_name(component_id)
-            .map(ToString::to_string);
+            .map(|name| name.to_string());
 
         let Some(comp_mut_untyped) = self.get_mut_by_id(entity, component_id) else {
             return Err(GetComponentReflectError::EntityDoesNotHaveComponent {


### PR DESCRIPTION
# Objective

#18173 allows components to be queued without being fully registered. But much of bevy's debug logging contained `components.get_name(id).unwrap()`. However, this panics when the id is queued. This PR fixes this, allowing names to be retrieved for debugging purposes, etc, even while they're still queued.

## Solution

We change `ComponentInfo::descriptor` to be `Arc<ComponentDescriptor>` instead of not arc'd. This lets us pass the descriptor around (as a name or otherwise) as needed. The alternative would require some form of `MappedRwLockReadGuard`, which is unstable, and would be terribly blocking. Putting it in an arc also signifies that it doesn't change, which is a nice signal to users. This does mean there's an extra pointer dereference, but I don't think that's an issue here, as almost all paths that use this are for debugging purposes or one-time set ups.

## Testing

Existing tests.

## Migration Guide

`Components::get_name` now returns `Option<Cow<'_, str>` instead of `Option<&str>`. This is because it now returns results for queued components. If that behavior is not desired, or you know the component is not queued, you can use `components.get_info().map(ComponentInfo::name)` instead.

Similarly, `ScheduleGraph::conflicts_to_string` now returns `impl Iterator<Item = (String, String, Vec<Cow<str>>)>` instead of `impl Iterator<Item = (String, String, Vec<&str>)>`. Because `Cow<str>` derefs to `&str`, most use cases can remain unchanged.
