### PR TITLE
Fix missed error_handling example rename and update description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2228,8 +2228,8 @@ doc-scrape-examples = true
 required-features = ["bevy_mesh_picking_backend", "configurable_error_handler"]
 
 [package.metadata.example.error_handling]
-name = "Fallible Systems"
-description = "Systems that return results to handle errors"
+name = "Error handling"
+description = "How to return and handle errors across the ECS"
 category = "ECS (Entity Component System)"
 wasm = false
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -311,9 +311,9 @@ Example | Description
 [Dynamic ECS](../examples/ecs/dynamic.rs) | Dynamically create components, spawn entities with those components and query those components
 [ECS Guide](../examples/ecs/ecs_guide.rs) | Full guide to Bevy's ECS
 [Entity disabling](../examples/ecs/entity_disabling.rs) | Demonstrates how to hide entities from the ECS without deleting them
+[Error handling](../examples/ecs/error_handling.rs) | How to return and handle errors across the ECS
 [Event](../examples/ecs/event.rs) | Illustrates event creation, activation, and reception
 [Fallible System Parameters](../examples/ecs/fallible_params.rs) | Systems are skipped if their parameters cannot be acquired
-[Fallible Systems](../examples/ecs/error_handling.rs) | Systems that return results to handle errors
 [Fixed Timestep](../examples/ecs/fixed_timestep.rs) | Shows how to create systems that run every fixed timestep, rather than every tick
 [Generic System](../examples/ecs/generic_system.rs) | Shows how to create systems that can be reused with different types
 [Hierarchy](../examples/ecs/hierarchy.rs) | Creates a hierarchy of parents and children entities


### PR DESCRIPTION
# Objective

I didn't rename the example properly in the meta data, and the description is unclear and limited.

## Solution

Fix both of those.