### PR TITLE
unify cursor lock behaviour

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -614,7 +614,7 @@ impl Window {
 
     /// Retrieves the cursor position as reported by the back end.
     ///
-    /// This can be different to the phyical cursor position on
+    /// This can be different to the physical cursor position on
     /// the windows platform when `CursorGrabMode::Locked` is set.
     pub fn backend_cursor_position(&self) -> Option<Vec2> {
         self.internal

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -325,17 +325,20 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                 let physical_position = DVec2::new(position.x, position.y);
 
                 let last_position = win.physical_cursor_position();
-                let delta = last_position.map(|last_pos| {
-                    (physical_position.as_vec2() - last_pos) / win.resolution.scale_factor()
-                });
 
-                win.set_physical_cursor_position(Some(physical_position));
-                let position = (physical_position / win.resolution.scale_factor() as f64).as_vec2();
-                self.bevy_window_events.send(CursorMoved {
-                    window,
-                    position,
-                    delta,
-                });
+                if win.set_backend_cursor_position(Some(physical_position)) {
+                    let delta = last_position.map(|last_pos| {
+                        (physical_position.as_vec2() - last_pos) / win.resolution.scale_factor()
+                    });
+
+                    let position =
+                        (physical_position / win.resolution.scale_factor() as f64).as_vec2();
+                    self.bevy_window_events.send(CursorMoved {
+                        window,
+                        position,
+                        delta,
+                    });
+                }
             }
             WindowEvent::CursorEntered { .. } => {
                 self.bevy_window_events.send(CursorEntered { window });

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -398,6 +398,10 @@ pub(crate) fn changed_windows(
             window.cursor_options.grab_mode = cache.window.cursor_options.grab_mode;
         }
 
+        if window.cursor_options.visible != cache.window.cursor_options.visible {
+            winit_window.set_cursor_visible(window.cursor_options.visible);
+        }
+
         if window.physical_cursor_position() != cache.window.backend_cursor_position() {
             if let Some(physical_position) = window.physical_cursor_position() {
                 let position = PhysicalPosition::new(physical_position.x, physical_position.y);
@@ -406,10 +410,6 @@ pub(crate) fn changed_windows(
                     error!("could not set cursor position: {}", err);
                 }
             }
-        }
-
-        if window.cursor_options.visible != cache.window.cursor_options.visible {
-            winit_window.set_cursor_visible(window.cursor_options.visible);
         }
 
         if window.cursor_options.hit_test != cache.window.cursor_options.hit_test {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -391,7 +391,14 @@ pub(crate) fn changed_windows(
             }
         }
 
-        if window.physical_cursor_position() != cache.window.physical_cursor_position() {
+        if window.cursor_options.grab_mode != cache.window.cursor_options.grab_mode
+            && crate::winit_windows::attempt_grab(winit_window, window.cursor_options.grab_mode)
+                .is_err()
+        {
+            window.cursor_options.grab_mode = cache.window.cursor_options.grab_mode;
+        }
+
+        if window.physical_cursor_position() != cache.window.backend_cursor_position() {
             if let Some(physical_position) = window.physical_cursor_position() {
                 let position = PhysicalPosition::new(physical_position.x, physical_position.y);
 
@@ -399,13 +406,6 @@ pub(crate) fn changed_windows(
                     error!("could not set cursor position: {}", err);
                 }
             }
-        }
-
-        if window.cursor_options.grab_mode != cache.window.cursor_options.grab_mode
-            && crate::winit_windows::attempt_grab(winit_window, window.cursor_options.grab_mode)
-                .is_err()
-        {
-            window.cursor_options.grab_mode = cache.window.cursor_options.grab_mode;
         }
 
         if window.cursor_options.visible != cache.window.cursor_options.visible {


### PR DESCRIPTION
# Objective

unify the behaviour of `CursorGrabMode::Locked` across windows and macos/linux.

currently when the grab mode is changed to `Locked`, on windows only, the cursor is just constrained.
when the cursor is both locked and invisible, it randomly moves to the middle of the window. this changes the `Interaction` results and `cursor_position()` behaviour.

this pr changes windows behaviour to be inline with macos/linux on a best-effort basis
- reset the hardware cursor position each frame (results in jittery appearance but better than nothing)
- leaves the internal cursor at its original location for `Interaction`s and `cursor_position()`s
- avoids the random jump to the middle when locked and invisible

## Solution

- in `window_event`, when a `CursorMoved` event is received and the cursor is `Locked`, don't update the internal cursor's physical position. instead, update only the backend position. this effectively disregards the move to the middle of the screen that winit sends when `CursorGrabMode::Locked` and `!visible` are set
- in `changed_windows`, 
  - update the grab mode and visibliity before attempting to update position (required for the position update to be accepted by the backend)
  - if the internal physical position doesn't match the backend position, update the backend with the internal physical position

## Testing

left click to lock, right click to hide
```rs
use bevy::{prelude::*, window::CursorGrabMode};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, update)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn((
        Node {
            min_width: Val::Px(40.0),
            min_height: Val::Px(40.0),
            ..Default::default()
        },
        BackgroundColor(Color::linear_rgb(1.0, 0.0, 0.0)),
    ));
    
    commands.spawn((Text2d::new(""), TextColor(Color::WHITE)));

    commands.spawn(Camera2d::default());
}

fn update(
    b: Res<ButtonInput<MouseButton>>,
    mut w: Query<&mut Window>,
    mut n: Query<&mut Node>,
    mut t: Query<&mut Text2d>
) {
    let mut w = w.single_mut().unwrap();
    let mut text = "\n\n\n\n".to_owned();

    if b.pressed(MouseButton::Left) {
        if w.cursor_options.grab_mode == CursorGrabMode::None {
            w.cursor_options.grab_mode = CursorGrabMode::Locked;
        }
        text = format!("{text}L");
    } else {
        if w.cursor_options.grab_mode == CursorGrabMode::Locked {
            w.cursor_options.grab_mode = CursorGrabMode::None;
        }
    }

    if b.pressed(MouseButton::Right) {
        if w.cursor_options.visible {
            w.cursor_options.visible = false;
        }
        text = format!("{text}R");
    } else {
        if !w.cursor_options.visible {
            w.cursor_options.visible = true;
        }
    }

    if let Some(cursor_position) = w.cursor_position() {
        let mut node = n.single_mut().unwrap();
        node.left = Val::Px(cursor_position.x - 10.0);
        node.top = Val::Px(cursor_position.y - 10.0);
    }
    t.single_mut().unwrap().0 = text;
}
```
before:


https://github.com/user-attachments/assets/76822a91-e9cb-4b54-aeb6-57861a0f65dd




after: 

https://github.com/user-attachments/assets/d2d0a13d-d8d6-439c-a601-678950afcba0

