### PR TITLE
Restructure morph target pipeline to reduce crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2999,6 +2999,17 @@ category = "Stress Tests"
 wasm = true
 
 [[example]]
+name = "many_morph_targets"
+path = "examples/stress_tests/many_morph_targets.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.many_morph_targets]
+name = "Many Morph Targets"
+description = "Simple benchmark to test rendering many meshes with animated morph targets."
+category = "Stress Tests"
+wasm = true
+
+[[example]]
 name = "many_glyphs"
 path = "examples/stress_tests/many_glyphs.rs"
 doc-scrape-examples = true

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1256,9 +1256,7 @@ impl Plugin for AnimationPlugin {
                     // it to its own system set after `Update` but before
                     // `PostUpdate`. For now, we just disable ambiguity testing
                     // for this system.
-                    animate_targets
-                        .before(bevy_render::mesh::inherit_weights)
-                        .ambiguous_with_all(),
+                    animate_targets.ambiguous_with_all(),
                     trigger_untargeted_animation_events,
                     expire_completed_transitions,
                 )

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -155,32 +155,9 @@ impl MorphWeights {
 /// to control individual weights of each morph target.
 ///
 /// [morph targets]: https://en.wikipedia.org/wiki/Morph_target_animation
-#[derive(Reflect, Default, Debug, Clone, Component)]
-#[reflect(Debug, Component, Default, Clone)]
-pub struct MeshMorphWeights {
-    weights: Vec<f32>,
-}
-impl MeshMorphWeights {
-    pub fn new(weights: Vec<f32>) -> Result<Self, MorphBuildError> {
-        if weights.len() > MAX_MORPH_WEIGHTS {
-            let target_count = weights.len();
-            return Err(MorphBuildError::TooManyTargets { target_count });
-        }
-        Ok(MeshMorphWeights { weights })
-    }
-    pub fn weights(&self) -> &[f32] {
-        &self.weights
-    }
-    pub fn weights_mut(&mut self) -> &mut [f32] {
-        &mut self.weights
-    }
-    pub fn clear_weights(&mut self) {
-        self.weights.clear();
-    }
-    pub fn extend_weights(&mut self, weights: &[f32]) {
-        self.weights.extend(weights);
-    }
-}
+#[derive(Reflect, Debug, Clone, Component)]
+#[reflect(Debug, Component, Clone)]
+pub struct MeshMorphWeights(#[entities] pub Entity);
 
 /// Attributes **differences** used for morph targets.
 ///

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -142,6 +142,12 @@ impl MorphWeights {
     pub fn weights_mut(&mut self) -> &mut [f32] {
         &mut self.weights
     }
+    pub fn clear_weights(&mut self) {
+        self.weights.clear();
+    }
+    pub fn extend_weights(&mut self, weights: &[f32]) {
+        self.weights.extend(weights);
+    }
 }
 
 /// Control a specific [`Mesh`] instance's [morph targets]. These control the weights of

--- a/crates/bevy_mesh/src/morph.rs
+++ b/crates/bevy_mesh/src/morph.rs
@@ -97,6 +97,8 @@ impl MorphTargetImage {
     }
 }
 
+/// TODO: Update this documentation.
+///
 /// Controls the [morph targets] for all child `Mesh3d` entities. In most cases, [`MorphWeights`] should be considered
 /// the "source of truth" when writing morph targets for meshes. However you can choose to write child [`MeshMorphWeights`]
 /// if your situation requires more granularity. Just note that if you set [`MorphWeights`], it will overwrite child
@@ -150,6 +152,8 @@ impl MorphWeights {
     }
 }
 
+/// TODO: Update this documentation.
+///
 /// Control a specific [`Mesh`] instance's [morph targets]. These control the weights of
 /// specific "mesh primitives" in scene formats like GLTF. They can be set manually, but
 /// in most cases they should "automatically" synced by setting the [`MorphWeights`] component

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -4,7 +4,7 @@ use bevy_ecs::prelude::*;
 use bevy_render::sync_world::MainEntityHashMap;
 use bevy_render::{
     batching::NoAutomaticBatching,
-    mesh::morph::{MeshMorphWeights, MAX_MORPH_WEIGHTS},
+    mesh::morph::{MeshMorphWeights, MorphWeights, MAX_MORPH_WEIGHTS},
     render_resource::{BufferUsages, RawBufferVec},
     renderer::{RenderDevice, RenderQueue},
     view::ViewVisibility,
@@ -110,6 +110,7 @@ pub fn extract_morphs(
     morph_indices: ResMut<MorphIndices>,
     uniform: ResMut<MorphUniforms>,
     query: Extract<Query<(Entity, &ViewVisibility, &MeshMorphWeights)>>,
+    weights_query: Extract<Query<&MorphWeights>>,
 ) {
     // Borrow check workaround.
     let (morph_indices, uniform) = (morph_indices.into_inner(), uniform.into_inner());
@@ -125,9 +126,11 @@ pub fn extract_morphs(
         if !view_visibility.get() {
             continue;
         }
+        let Ok(weights) = weights_query.get(morph_weights.0) else {
+            continue;
+        };
         let start = uniform.current_buffer.len();
-        let weights = morph_weights.weights();
-        let legal_weights = weights.iter().take(MAX_MORPH_WEIGHTS).copied();
+        let legal_weights = weights.weights().iter().take(MAX_MORPH_WEIGHTS).copied();
         uniform.current_buffer.extend(legal_weights);
         add_to_alignment::<f32>(&mut uniform.current_buffer);
 

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -84,31 +84,12 @@ impl Plugin for MeshPlugin {
     }
 }
 
-/// [Inherit weights](inherit_weights) from glTF mesh parent entity to direct
-/// bevy mesh child entities (ie: glTF primitive).
+/// Adds morph target types.
 pub struct MorphPlugin;
 impl Plugin for MorphPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<MorphWeights>()
-            .register_type::<MeshMorphWeights>()
-            .add_systems(PostUpdate, inherit_weights);
-    }
-}
-
-/// Bevy meshes are gltf primitives, [`MorphWeights`] on the bevy node entity
-/// should be inherited by children meshes.
-///
-/// Only direct children are updated, to fulfill the expectations of glTF spec.
-pub fn inherit_weights(
-    morph_nodes: Query<(&Children, &MorphWeights), (Without<Mesh3d>, Changed<MorphWeights>)>,
-    mut morph_primitives: Query<&mut MeshMorphWeights, With<Mesh3d>>,
-) {
-    for (children, parent_weights) in &morph_nodes {
-        let mut iter = morph_primitives.iter_many_mut(children);
-        while let Some(mut child_weight) = iter.fetch_next() {
-            child_weight.clear_weights();
-            child_weight.extend_weights(parent_weights.weights());
-        }
+            .register_type::<MeshMorphWeights>();
     }
 }
 

--- a/examples/stress_tests/many_morph_targets.rs
+++ b/examples/stress_tests/many_morph_targets.rs
@@ -1,0 +1,124 @@
+//! TODO
+
+use argh::FromArgs;
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::*,
+    scene::SceneInstanceReady,
+    window::{PresentMode, WindowResolution},
+    winit::{UpdateMode, WinitSettings},
+};
+use std::f32::consts::PI;
+
+/// TODO
+#[derive(FromArgs, Resource)]
+struct Args {
+    /// TODO
+    #[argh(option, default = "1024")]
+    count: usize,
+}
+
+fn main() {
+    // `from_env` panics on the web
+    #[cfg(not(target_arch = "wasm32"))]
+    let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
+    App::new()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "Many Morph Targets".to_string(),
+                    present_mode: PresentMode::AutoNoVsync,
+                    resolution: WindowResolution::new(1920.0, 1080.0)
+                        .with_scale_factor_override(1.0),
+                    ..default()
+                }),
+                ..Default::default()
+            }),
+            FrameTimeDiagnosticsPlugin::default(),
+            LogDiagnosticsPlugin::default(),
+        ))
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
+        .insert_resource(AmbientLight {
+            brightness: 1000.0,
+            ..Default::default()
+        })
+        .insert_resource(args)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+#[derive(Component)]
+struct AnimationToPlay(Handle<AnimationClip>);
+
+fn setup(asset_server: Res<AssetServer>, args: Res<Args>, mut commands: Commands) {
+    let scene_handle = asset_server
+        .load(GltfAssetLabel::Scene(0).from_asset("models/animated/MorphStressTest.gltf"));
+
+    let animation_handles = (0..3)
+        .map(|index| {
+            asset_server.load(
+                GltfAssetLabel::Animation(index).from_asset("models/animated/MorphStressTest.gltf"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let count = args.count.max(1);
+    let x_dim = ((count as f32).sqrt().ceil() as usize).max(1);
+    let y_dim = count.div_ceil(x_dim);
+
+    for mesh_index in 0..count {
+        let animation_index = mesh_index.rem_euclid(animation_handles.len());
+        let animation_handle = animation_handles[animation_index].clone();
+
+        let x = 2.5 + (5.0 * ((mesh_index.rem_euclid(x_dim) as f32) - ((x_dim as f32) * 0.5)));
+        let y = -2.2 - (3.0 * ((mesh_index.div_euclid(x_dim) as f32) - ((y_dim as f32) * 0.5)));
+
+        commands
+            .spawn((
+                AnimationToPlay(animation_handle),
+                SceneRoot(scene_handle.clone()),
+                Transform::from_xyz(x, y, 0.0),
+            ))
+            .observe(play_animation);
+    }
+
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform::from_rotation(Quat::from_rotation_z(PI / 2.0)),
+    ));
+
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 0.0, (x_dim as f32) * 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+fn play_animation(
+    trigger: Trigger<SceneInstanceReady>,
+    mut commands: Commands,
+    children: Query<&Children>,
+    animations_to_play: Query<&AnimationToPlay>,
+    mut players: Query<&mut AnimationPlayer>,
+    mut graphs: ResMut<Assets<AnimationGraph>>,
+) {
+    if let Ok(animation_to_play) = animations_to_play.get(trigger.target()) {
+        for child in children.iter_descendants(trigger.target()) {
+            if let Ok(mut player) = players.get_mut(child) {
+                let (graph, animation_index) =
+                    AnimationGraph::from_clip(animation_to_play.0.clone());
+
+                commands
+                    .entity(child)
+                    .insert(AnimationGraphHandle(graphs.add(graph)));
+
+                player.play(animation_index).repeat();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Objective

- Restructure the morph target runtime pipeline to avoid copying weights between entities.
- The main goal is to make `bevy_animation` less dependent on `bevy_render`.
- It's also a small memory and CPU optimisation, and makes the pipeline more flexible.
- Will require migration guide.

## Why a Draft?

The PR is incomplete. The code works but I haven't updated documentation comments or done a final test and polish. I'm hoping to surface any design disagreements before I finish up. But I can also finish it now if preferred.

## Summary

I've been looking at making `bevy_animation` independent of `bevy_render`. I'm assuming this is good for compile times and alternative renderers.

If #18437 lands then there's only one remaining dependency - a system ordering that makes sure morph target weights are written by `bevy_animation` before the renderer reads them.

```rust
animate_targets.before(bevy_render::mesh::inherit_weights)
```

This PR removes the dependency in a slightly drastic way, by restructuring the morph target pipeline to eliminate `inherit_weights`. As well as removing the `bevy_render` dependency, it's a small optimisation and makes the pipeline more flexible.

The downside is that some users might need to update their code if they were manipulating the morph target pipeline directly. Users who were just importing glTF scenes are unaffected.

The PR also adds a `many_morph_targets` stress test - I can make it a separate PR if preferred.

If this PR and #18437 land then I'll make another PR to fully remove the `bevy_animation` dependency on `bevy_render`.

## Changes

The current pipeline as it's typically used is:

- Some entity has a `MorphWeights` component, which is mostly a `Vec<f32>` of weights.
- `bevy_animation` or user code sets weights on the `MorphWeights` component.
- One or more child entities have `Mesh3d` and `MeshMorphWeights` components. `MeshMorphWeights` is a `Vec<f32>` of weights.
- `bevy_render::inherit_weights` iterates over all `MorphWeights` and copies the weights to any `MeshMorphWeights` in child entities.
- `bevy_render::extract_morphs` iterates over all `Mesh3d` with `MeshMorphWeights` and copies the weights to internal buffers.

The changes are:

- `MeshMorphWeights` is no longer a `Vec<f32>`. It's now a reference to the entity that contains `MorphWeights`.
- `inherit_weights` disappears as there's nothing to copy.
- `extract_morphs` now iterates over `MeshMorphWeights`, uses it to find `MorphWeights`, then copies the weights.

The new pipeline is more flexible, as a mesh can reference `MorphWeights` on any entity. The current pipeline requires `MorphWeights` to be on a parent of the mesh entity.

## Breakage

**Unaffected**: Users who import a glTF scene and drive the `MorphWeights` component themselves or via `bevy_animation`.

**Possibly Affected**: Users who set up their own pipeline or modify the glTF pipeline. In particular, if they're manipulating `MeshMorphWeights` directly then they'll have to restructure to use `MorphWeights`.

I did a github code search and found only [one case that would break](https://github.com/ricky26/bevy-idol/blob/7ca60767a7415b6c59de2d0949429ac4f669d91d/crates/bevy_idol/src/main.rs#L514). Their fix should be fairly simple - just rearranging the components.

There are a couple of options to soften the blow, but they all involve some complexity/performance trade-offs. I can write these options up if desired.

# Performance

Tested on `many_morph_targets`. Win10, AMD Zen4.

- `extract_morphs` goes from 42.51us to 48.86us (+6.35us), probably due to the extra entity lookup.
- `inherit_weights` goes from 30.28us to zero.
- Throughput of the two systems goes from 14 to 21 meshes per us (+50%).

I expect a small memory saving due to one less copy of the weights per mesh.

There's room for further optimisation. The render buffers have a copy of the weights for each mesh, but multiple meshes could be sharing weights (which corresponds to multiple `MeshMorphWeights` referencing a single `MorphWeights`).

# Testing

```
cargo run --example morph_targets
cargo run --example many_morph_targets
cargo run --example scene_viewer -- assets/models/animated/MorphStressTest.gltf
```

Also tested a few other glTFs, and hacked the glTF importer to simulate some valid and invalid combinations (missing weights, mismatched arrays).

# Migration Guide

TODO