### PR TITLE
Fix clippy warning about unnecessary return in `single_threaded_taks_pool.rs`

### DIFF
--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -201,23 +201,23 @@ impl TaskPool {
     {
         cfg_if::cfg_if! {
             if #[cfg(all(target_arch = "wasm32", feature = "web"))] {
-                return Task::wrap_future(future);
+                Task::wrap_future(future)
             } else if #[cfg(feature = "std")] {
-                return LOCAL_EXECUTOR.with(|executor| {
+                LOCAL_EXECUTOR.with(|executor| {
                     let task = executor.spawn(future);
                     // Loop until all tasks are done
                     while executor.try_tick() {}
 
                     Task::new(task)
-                });
+                })
             } else {
-                return {
+                {
                     let task = LOCAL_EXECUTOR.spawn(future);
                     // Loop until all tasks are done
                     while LOCAL_EXECUTOR.try_tick() {}
 
                     Task::new(task)
-                };
+                }
             }
         }
     }


### PR DESCRIPTION
# Objective

Every time I run `cargo clippy -p bevy_ecs` it pops up and it's distracting.

## Solution

Removed unnecessary returns. The blocks themselves are necessary or the `#[cfg(...)]` doesn't apply properly

## Testing

`cargo clippy -p bevy_ecs` + ci build tests
