### PR TITLE
enable x11 by default in bevy_winit

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -430,7 +430,7 @@ bevy_ui = { path = "../bevy_ui", optional = true, version = "0.16.0-dev" }
 bevy_window = { path = "../bevy_window", optional = true, version = "0.16.0-dev", default-features = false, features = [
   "bevy_reflect",
 ] }
-bevy_winit = { path = "../bevy_winit", optional = true, version = "0.16.0-dev" }
+bevy_winit = { path = "../bevy_winit", optional = true, version = "0.16.0-dev", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
+default = ["x11"]
 trace = []
 wayland = ["winit/wayland", "winit/wayland-csd-adwaita"]
 x11 = ["winit/x11"]


### PR DESCRIPTION
# Objective

- building bevy_winit on linux fails with
```
error: The platform you're compiling for is not supported by winit
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/winit-0.30.9/src/platform_impl/mod.rs:78:1
   |
78 | compile_error!("The platform you're compiling for is not supported by winit");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
- this blocks publishing Bevy from linux during the verification step

## Solution

- Enable `x11` by default when building bevy_winit, and disable default features of bevy_winit in bevy_internal
- This doesn't change anything when depending on Bevy
