### PR TITLE
Regression fix: Reintroduce sorting/reordering methods on Children

### DIFF
--- a/crates/bevy_ecs/src/hierarchy.rs
+++ b/crates/bevy_ecs/src/hierarchy.rs
@@ -139,6 +139,96 @@ impl FromWorld for ChildOf {
 #[doc(alias = "IsParent")]
 pub struct Children(Vec<Entity>);
 
+impl Children {
+    /// Swaps the child at `a_index` with the child at `b_index`.
+    #[inline]
+    pub fn swap(&mut self, a_index: usize, b_index: usize) {
+        self.0.swap(a_index, b_index);
+    }
+
+    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided comparator function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_by`].
+    ///
+    /// For the unstable version, see [`sort_unstable_by`](Children::sort_unstable_by).
+    ///
+    /// See also [`sort_by_key`](Children::sort_by_key), [`sort_by_cached_key`](Children::sort_by_cached_key).
+    #[inline]
+    pub fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity, &Entity) -> core::cmp::Ordering,
+    {
+        self.0.sort_by(compare);
+    }
+
+    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided key extraction function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_by_key`].
+    ///
+    /// For the unstable version, see [`sort_unstable_by_key`](Children::sort_unstable_by_key).
+    ///
+    /// See also [`sort_by`](Children::sort_by), [`sort_by_cached_key`](Children::sort_by_cached_key).
+    #[inline]
+    pub fn sort_by_key<K, F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity) -> K,
+        K: Ord,
+    {
+        self.0.sort_by_key(compare);
+    }
+
+    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided key extraction function. Only evaluates each key at most
+    /// once per sort, caching the intermediate results in memory.
+    ///
+    /// For the underlying implementation, see [`slice::sort_by_cached_key`].
+    ///
+    /// See also [`sort_by`](Children::sort_by), [`sort_by_key`](Children::sort_by_key).
+    #[inline]
+    pub fn sort_by_cached_key<K, F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity) -> K,
+        K: Ord,
+    {
+        self.0.sort_by_cached_key(compare);
+    }
+
+    /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided comparator function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_unstable_by`].
+    ///
+    /// For the stable version, see [`sort_by`](Children::sort_by).
+    ///
+    /// See also [`sort_unstable_by_key`](Children::sort_unstable_by_key).
+    #[inline]
+    pub fn sort_unstable_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity, &Entity) -> core::cmp::Ordering,
+    {
+        self.0.sort_unstable_by(compare);
+    }
+
+    /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided key extraction function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_unstable_by_key`].
+    ///
+    /// For the stable version, see [`sort_by_key`](Children::sort_by_key).
+    ///
+    /// See also [`sort_unstable_by`](Children::sort_unstable_by).
+    #[inline]
+    pub fn sort_unstable_by_key<K, F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity) -> K,
+        K: Ord,
+    {
+        self.0.sort_unstable_by_key(compare);
+    }
+}
+
 impl<'a> IntoIterator for &'a Children {
     type Item = <Self::IntoIter as Iterator>::Item;
 


### PR DESCRIPTION
# Objective

Bevy 0.15 used to have methods on `Children` for sorting and reordering them. This is very important, because in certain situations, the order of children matters. For example, in the context of UI nodes.

These methods are missing/omitted/forgotten in the current version, after the Relationships rework.

Without them, it is impossible for me to upgrade `iyes_perf_ui` to Bevy 0.16.

## Solution

Reintroduce the methods. This PR simply copy-pastes them from Bevy 0.15.