### PR TITLE
Properly gate functionality on `http` in `bevy_remote`

### DIFF
--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -19,18 +19,17 @@ use bevy_reflect::{
     serde::{ReflectSerializer, TypedReflectDeserializer},
     GetPath, PartialReflect, TypeRegistration, TypeRegistry,
 };
-use bevy_utils::default;
 use serde::{de::DeserializeSeed as _, Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::{
     error_codes,
-    schemas::{
-        json_schema::JsonSchemaBevyType,
-        open_rpc::{OpenRpcDocument, ServerObject},
-    },
+    schemas::{json_schema::JsonSchemaBevyType, open_rpc::OpenRpcDocument},
     BrpError, BrpResult,
 };
+
+#[cfg(feature = "http")]
+use {crate::schemas::open_rpc::ServerObject, bevy_utils::default};
 
 /// The method path for a `bevy/get` request.
 pub const BRP_GET_METHOD: &str = "bevy/get";
@@ -821,6 +820,8 @@ pub fn process_remote_list_methods_request(
     world: &mut World,
 ) -> BrpResult {
     let remote_methods = world.resource::<crate::RemoteMethods>();
+
+    #[cfg(feature = "http")]
     let servers = match (
         world.get_resource::<crate::http::HostAddress>(),
         world.get_resource::<crate::http::HostPort>(),
@@ -837,6 +838,10 @@ pub fn process_remote_list_methods_request(
         }]),
         _ => None,
     };
+
+    #[cfg(not(feature = "http"))]
+    let servers = None;
+
     let doc = OpenRpcDocument {
         info: Default::default(),
         methods: remote_methods.into(),


### PR DESCRIPTION
# Objective

Noticed that `bevy_remote` fails to compile without default features.

## Solution

Adjusted offending method to avoid reliance on `http` module when it is disabled.

## Testing

- CI
- `cargo clippy -p bevy_remote --no-default-features`

