### PR TITLE
Address Lints in `bevy_reflect`

### DIFF
--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -401,9 +401,11 @@ impl ContainerAttributes {
             // Override `lit` if this is a `FromReflect` derive.
             // This typically means a user is opting out of the default implementation
             // from the `Reflect` derive and using the `FromReflect` derive directly instead.
-            (trait_ == ReflectTraitToImpl::FromReflect)
-                .then(|| LitBool::new(true, Span::call_site()))
-                .unwrap_or_else(|| lit.clone())
+            if trait_ == ReflectTraitToImpl::FromReflect {
+                LitBool::new(true, Span::call_site())
+            } else {
+                lit.clone()
+            }
         })?;
 
         if let Some(existing) = &self.from_reflect_attrs.auto_derive {
@@ -434,9 +436,11 @@ impl ContainerAttributes {
             // Override `lit` if this is a `FromReflect` derive.
             // This typically means a user is opting out of the default implementation
             // from the `Reflect` derive and using the `FromReflect` derive directly instead.
-            (trait_ == ReflectTraitToImpl::TypePath)
-                .then(|| LitBool::new(true, Span::call_site()))
-                .unwrap_or_else(|| lit.clone())
+            if trait_ == ReflectTraitToImpl::TypePath {
+                LitBool::new(true, Span::call_site())
+            } else {
+                lit.clone()
+            }
         })?;
 
         if let Some(existing) = &self.type_path_attrs.auto_derive {

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -1100,7 +1100,7 @@ pub(crate) enum ReflectTypePath<'a> {
         reason = "Not currently used but may be useful in the future due to its generality."
     )]
     Anonymous {
-        qualified_type: Type,
+        qualified_type: Box<Type>,
         long_type_path: StringExpr,
         short_type_path: StringExpr,
     },


### PR DESCRIPTION
# Objective

On Windows there are several unaddressed lints raised by clippy.

## Solution

Addressed them!

## Testing

- CI on Windows & Ubuntu