### PR TITLE
Address `clippy::let_and_return` in `bevy_utils`

### DIFF
--- a/crates/bevy_utils/src/parallel_queue.rs
+++ b/crates/bevy_utils/src/parallel_queue.rs
@@ -29,8 +29,7 @@ impl<T: Default + Send> Parallel<T> {
     /// If there is no thread-local value, it will be initialized to its default.
     pub fn scope<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
         let mut cell = self.locals.get_or_default().borrow_mut();
-        let ret = f(cell.deref_mut());
-        ret
+        f(cell.deref_mut())
     }
 
     /// Mutably borrows the thread-local value.


### PR DESCRIPTION
# Objective

`clippy::let_and_return` fails on Windows.

## Solution

Fixed it!

## Testing

- CI