### PR TITLE
Remove `bevy_input_focus` from `bevy_a11y`

### DIFF
--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -18,14 +18,12 @@ bevy_reflect = [
   "dep:bevy_reflect",
   "bevy_app/bevy_reflect",
   "bevy_ecs/bevy_reflect",
-  "bevy_input_focus/bevy_reflect",
 ]
 
 ## Adds serialization support through `serde`.
 serialize = [
   "dep:serde",
   "bevy_ecs/serialize",
-  "bevy_input_focus/serialize",
   "accesskit/serde",
 ]
 
@@ -38,7 +36,6 @@ std = [
   "bevy_app/std",
   "bevy_ecs/std",
   "bevy_reflect/std",
-  "bevy_input_focus/std",
 ]
 
 ## `critical-section` provides the building blocks for synchronization primitives
@@ -47,11 +44,7 @@ critical-section = [
   "bevy_app/critical-section",
   "bevy_ecs/critical-section",
   "bevy_reflect?/critical-section",
-  "bevy_input_focus/critical-section",
 ]
-
-## Uses the `libm` maths library instead of the one provided in `std` and `core`.
-libm = ["bevy_input_focus/libm"]
 
 [dependencies]
 # bevy
@@ -59,7 +52,6 @@ bevy_app = { path = "../bevy_app", version = "0.16.0-dev", default-features = fa
 bevy_derive = { path = "../bevy_derive", version = "0.16.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-features = false, optional = true }
-bevy_input_focus = { path = "../bevy_input_focus", version = "0.16.0-dev", default-features = false }
 
 # other
 accesskit = { version = "0.17", default-features = false }

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -21,22 +21,14 @@ bevy_reflect = [
 ]
 
 ## Adds serialization support through `serde`.
-serialize = [
-  "dep:serde",
-  "bevy_ecs/serialize",
-  "accesskit/serde",
-]
+serialize = ["dep:serde", "bevy_ecs/serialize", "accesskit/serde"]
 
 # Platform Compatibility
 
 ## Allows access to the `std` crate. Enabling this feature will prevent compilation
 ## on `no_std` targets, but provides access to certain additional features on
 ## supported platforms.
-std = [
-  "bevy_app/std",
-  "bevy_ecs/std",
-  "bevy_reflect/std",
-]
+std = ["bevy_app/std", "bevy_ecs/std", "bevy_reflect/std"]
 
 ## `critical-section` provides the building blocks for synchronization primitives
 ## on all platforms, including `no_std`.

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -329,7 +329,6 @@ critical-section = [
 
 # Uses the `libm` maths library instead of the one provided in `std` and `core`.
 libm = [
-  "bevy_a11y?/libm",
   "bevy_color?/libm",
   "bevy_input/libm",
   "bevy_input_focus?/libm",


### PR DESCRIPTION
# Objective

- Compiling `bevy_a11y` without default features fails because you need to select a floating point backed. But you actually don't need it, this requirement is from an unused linkage to `bevy_input_focus`

## Solution

- Remove link

## Testing

- CI
