### PR TITLE
Ensure `dds` enables `bevy_core_pipeline/dds` in `bevy_anti_aliasing`

### DIFF
--- a/crates/bevy_anti_aliasing/Cargo.toml
+++ b/crates/bevy_anti_aliasing/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 trace = []
 webgl = []
 webgpu = []
-dds = ["bevy_render/dds", "bevy_image/dds"]
+dds = ["bevy_render/dds", "bevy_image/dds", "bevy_core_pipeline/dds"]
 smaa_luts = ["bevy_render/ktx2", "bevy_image/ktx2", "bevy_image/zstd"]
 
 [dependencies]

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -931,13 +931,9 @@ impl Image {
         #[cfg(all(debug_assertions, feature = "dds"))] name: String,
         buffer: &[u8],
         image_type: ImageType,
-        #[expect(
-            clippy::allow_attributes,
-            reason = "`unused_variables` may not always lint"
-        )]
-        #[allow(
-            unused_variables,
-            reason = "`supported_compressed_formats` is needed where the image format is `Basis`, `Dds`, or `Ktx2`; if these are disabled, then `supported_compressed_formats` is unused."
+        #[cfg_attr(
+            not(any(feature = "basis-universal", feature = "dds", feature = "ktx2")),
+            expect(unused_variables, reason = "only used with certain features")
         )]
         supported_compressed_formats: CompressedImageFormats,
         is_srgb: bool,


### PR DESCRIPTION
# Objective

- Compile failure with `bevy_anti_aliasing` due to `dds` feature not enabling `bevy_core_pipeline/dds`, causing a public API desync.

## Solution

- Ensured feature is enabled

## Testing

- CI
