### PR TITLE
Fix `clippy::unnecessary-literal-unwrap` in `bevy_time`

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -160,12 +160,13 @@ pub fn time_system(
         None => None,
     };
 
-    #[cfg(not(feature = "std"))]
-    let sent_time = None;
-
     match update_strategy.as_ref() {
         TimeUpdateStrategy::Automatic => {
+            #[cfg(feature = "std")]
             real_time.update_with_instant(sent_time.unwrap_or_else(Instant::now));
+
+            #[cfg(not(feature = "std"))]
+            real_time.update_with_instant(Instant::now());
         }
         TimeUpdateStrategy::ManualInstant(instant) => real_time.update_with_instant(*instant),
         TimeUpdateStrategy::ManualDuration(duration) => real_time.update_with_duration(*duration),


### PR DESCRIPTION
# Objective

- Compiling `bevy_time` without the `std`-feature results in a `clippy::unnecessary-literal-unwrap`.

## Solution

- Fix lint error

## Testing

- CI
---
