### PR TITLE
Fix lints and re-organize gated imports for `bevy_gizmos`

### DIFF
--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -250,9 +250,10 @@ impl Default for GizmoLineConfig {
 ))]
 #[derive(Component)]
 pub(crate) struct GizmoMeshConfig {
-    pub line_perspective: bool,
     pub line_style: GizmoLineStyle,
     pub line_joints: GizmoLineJoint,
     pub render_layers: bevy_render::view::RenderLayers,
     pub handle: Handle<GizmoAsset>,
+    #[cfg(feature = "bevy_pbr")]
+    pub _line_perspective: bool,
 }

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -365,7 +365,7 @@ fn queue_line_gizmos_3d(
                     LineGizmoPipelineKey {
                         view_key,
                         strip: false,
-                        perspective: config.line_perspective,
+                        perspective: config._line_perspective,
                         line_style: config.line_style,
                     },
                 );
@@ -387,7 +387,7 @@ fn queue_line_gizmos_3d(
                     LineGizmoPipelineKey {
                         view_key,
                         strip: true,
-                        perspective: config.line_perspective,
+                        perspective: config._line_perspective,
                         line_style: config.line_style,
                     },
                 );
@@ -481,7 +481,7 @@ fn queue_line_joint_gizmos_3d(
                 &pipeline,
                 LineJointGizmoPipelineKey {
                     view_key,
-                    perspective: config.line_perspective,
+                    perspective: config._line_perspective,
                     joints: config.line_joints,
                 },
             );

--- a/crates/bevy_gizmos/src/retained.rs
+++ b/crates/bevy_gizmos/src/retained.rs
@@ -109,7 +109,7 @@ pub(crate) fn extract_linegizmos(
     use crate::config::GizmoLineStyle;
 
     let mut values = Vec::with_capacity(*previous_len);
-    for (entity, gizmo, transform, render_layers) in &query {
+    for (entity, gizmo, transform, _render_layers) in &query {
         let joints_resolution = if let GizmoLineJoint::Round(resolution) = gizmo.line_config.joints
         {
             resolution
@@ -145,11 +145,12 @@ pub(crate) fn extract_linegizmos(
             },
             #[cfg(any(feature = "bevy_pbr", feature = "bevy_sprite"))]
             crate::config::GizmoMeshConfig {
-                line_perspective: gizmo.line_config.perspective,
                 line_style: gizmo.line_config.style,
                 line_joints: gizmo.line_config.joints,
-                render_layers: render_layers.cloned().unwrap_or_default(),
+                render_layers: _render_layers.cloned().unwrap_or_default(),
                 handle: gizmo.handle.clone_weak(),
+                #[cfg(feature = "bevy_pbr")]
+                _line_perspective: gizmo.line_config.perspective,
             },
             MainEntity::from(entity),
             TemporaryRenderEntity,


### PR DESCRIPTION
# Objective

- `bevy_gizmos` has lint errors on some feature combinations. 
- The `use`-declarations are a bit of a mess

## Solution

- Fixed the lint errors by ensuring correct gated imports for the different features
- Hardened gating for some internal structs/fields only used with `bevy_pbr`/`bevy_sprite` features.
- Re-organized `use`-declarations in `lib.rs` into more reasonable blocks (still a bit of a mess, but now _less_ of a mess)

## Testing
- Local
```sh
# Ran lints for the following feature combos - all passing
$ cargo clippy -p bevy_gizmos --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --no-default-features --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=webgl --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=webgpu --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=bevy_render,webgl --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=bevy_render,webgpu --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=bevy_render,bevy_pbr --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=bevy_render,bevy_pbr,bevy_sprite --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --features=bevy_render,bevy_sprite --no-deps -- --D warnings
$ cargo clippy -p bevy_gizmos --all-features --no-deps -- --D warnings

# Ran (doc) tests - all passing
$ cargo test -p bevy_gizmos

# Ran the gizmo examples - all of them work (MacOS)
$ cargo run --example=2d_gizmos
$ cargo run --example=3d_gizmos
$ cargo run --example=axes
$ cargo run --example=light_gizmos
```
- CI