### PR TITLE
Fix lint errors on `bevy_ecs` with disabled features

### DIFF
--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -84,7 +84,7 @@ pub struct ComponentCloneCtx<'a, 'b> {
     #[cfg(feature = "bevy_reflect")]
     type_registry: Option<&'a crate::reflect::AppTypeRegistry>,
     #[cfg(not(feature = "bevy_reflect"))]
-    #[expect(dead_code)]
+    #[expect(dead_code, reason = "type_registry is only used with bevy_reflect")]
     type_registry: Option<&'a ()>,
 }
 

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -67,6 +67,13 @@ impl<const SEND: bool> ResourceData<SEND> {
     #[inline]
     fn validate_access(&self) {
         if SEND {
+            #[cfg_attr(
+                not(feature = "std"),
+                expect(
+                    clippy::needless_return,
+                    reason = "needless until no_std is addressed (see below)",
+                )
+            )]
             return;
         }
 
@@ -84,6 +91,7 @@ impl<const SEND: bool> ResourceData<SEND> {
         // TODO: Handle no_std non-send.
         // Currently, no_std is single-threaded only, so this is safe to ignore.
         // To support no_std multithreading, an alternative will be required.
+        // Remove the #[expect] attribute above when this is addressed.
     }
 
     /// Returns true if the resource is populated.


### PR DESCRIPTION
# Objective

- `bevy_ecs` has lint errors without some features

## Solution

- Fix `clippy::allow-attributes-without-reason` when `bevy_reflect` is disabled by adding a reason
- Fix `clippy::needless_return` when `std` is disabled by adding a gated `expect` attribute and a comment to remove it when the `no_std` stuff is addressed

## Testing

- `cargo clippy -p bevy_ecs --no-default-features --no-deps -- --D warnings`
- CI

