### PR TITLE
Move the construction of `LightingInput` in `apply_pbr_lighting` into its own function.

### DIFF
--- a/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
+++ b/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
@@ -4,6 +4,7 @@
     pbr_types::{PbrInput, pbr_input_new, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
     pbr_deferred_types as deferred_types,
     pbr_functions,
+    lighting,
     rgb9e5,
     mesh_view_bindings::view,
     utils::{octahedral_encode, octahedral_decode},
@@ -64,7 +65,7 @@ fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {
     let metallic = in.material.metallic;
     let specular_transmission = in.material.specular_transmission;
     let diffuse_transmission = in.material.diffuse_transmission;
-    let diffuse_color = pbr_functions::calculate_diffuse_color(
+    let diffuse_color = lighting::calculate_diffuse_color(
         base_color,
         metallic,
         specular_transmission,

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -288,10 +288,8 @@ fn apply_pbr_lighting(
     // calculate non-linear roughness from linear perceptualRoughness
     let metallic = in.material.metallic;
     let perceptual_roughness = in.material.perceptual_roughness;
-    let roughness = lighting::perceptualRoughnessToRoughness(perceptual_roughness);
     let ior = in.material.ior;
     let thickness = in.material.thickness;
-    let reflectance = in.material.reflectance;
     let diffuse_transmission = in.material.diffuse_transmission;
     let specular_transmission = in.material.specular_transmission;
 
@@ -300,67 +298,25 @@ fn apply_pbr_lighting(
     let diffuse_occlusion = in.diffuse_occlusion;
     let specular_occlusion = in.specular_occlusion;
 
-    // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
-    let NdotV = max(dot(in.N, in.V), 0.0001);
-    let R = reflect(-in.V, in.N);
-
-#ifdef STANDARD_MATERIAL_CLEARCOAT
-    // Do the above calculations again for the clearcoat layer. Remember that
-    // the clearcoat can have its own roughness and its own normal.
-    let clearcoat = in.material.clearcoat;
-    let clearcoat_perceptual_roughness = in.material.clearcoat_perceptual_roughness;
-    let clearcoat_roughness = lighting::perceptualRoughnessToRoughness(clearcoat_perceptual_roughness);
-    let clearcoat_N = in.clearcoat_N;
-    let clearcoat_NdotV = max(dot(clearcoat_N, in.V), 0.0001);
-    let clearcoat_R = reflect(-in.V, clearcoat_N);
-#endif  // STANDARD_MATERIAL_CLEARCOAT
-
-    let diffuse_color = calculate_diffuse_color(
-        output_color.rgb,
-        metallic,
-        specular_transmission,
-        diffuse_transmission
-    );
-
     // Diffuse transmissive strength is inversely related to metallicity and specular transmission, but directly related to diffuse transmission
     let diffuse_transmissive_color = output_color.rgb * (1.0 - metallic) * (1.0 - specular_transmission) * diffuse_transmission;
 
     // Calculate the world position of the second Lambertian lobe used for diffuse transmission, by subtracting material thickness
     let diffuse_transmissive_lobe_world_position = in.world_position - vec4<f32>(in.world_normal, 0.0) * thickness;
 
-    let F0 = calculate_F0(output_color.rgb, metallic, reflectance);
-    let F_ab = lighting::F_AB(perceptual_roughness, NdotV);
-
     var direct_light: vec3<f32> = vec3<f32>(0.0);
 
     // Transmitted Light (Specular and Diffuse)
     var transmitted_light: vec3<f32> = vec3<f32>(0.0);
 
-    // Pack all the values into a structure.
-    var lighting_input: lighting::LightingInput;
-    lighting_input.layers[LAYER_BASE].NdotV = NdotV;
-    lighting_input.layers[LAYER_BASE].N = in.N;
-    lighting_input.layers[LAYER_BASE].R = R;
-    lighting_input.layers[LAYER_BASE].perceptual_roughness = perceptual_roughness;
-    lighting_input.layers[LAYER_BASE].roughness = roughness;
-    lighting_input.P = in.world_position.xyz;
-    lighting_input.V = in.V;
-    lighting_input.diffuse_color = diffuse_color;
-    lighting_input.F0_ = F0;
-    lighting_input.F_ab = F_ab;
+    var lighting_input = lighting::pbr_input_to_lighting_input(in);
+    let diffuse_color = lighting_input.diffuse_color;
+    let F0 = lighting_input.F0_;
+
+    let NdotV = lighting_input.layers[LAYER_BASE].NdotV;
 #ifdef STANDARD_MATERIAL_CLEARCOAT
-    lighting_input.layers[LAYER_CLEARCOAT].NdotV = clearcoat_NdotV;
-    lighting_input.layers[LAYER_CLEARCOAT].N = clearcoat_N;
-    lighting_input.layers[LAYER_CLEARCOAT].R = clearcoat_R;
-    lighting_input.layers[LAYER_CLEARCOAT].perceptual_roughness = clearcoat_perceptual_roughness;
-    lighting_input.layers[LAYER_CLEARCOAT].roughness = clearcoat_roughness;
-    lighting_input.clearcoat_strength = clearcoat;
-#endif  // STANDARD_MATERIAL_CLEARCOAT
-#ifdef STANDARD_MATERIAL_ANISOTROPY
-    lighting_input.anisotropy = in.anisotropy_strength;
-    lighting_input.Ta = in.anisotropy_T;
-    lighting_input.Ba = in.anisotropy_B;
-#endif  // STANDARD_MATERIAL_ANISOTROPY
+    let clearcoat_NdotV = lighting_input.layers[LAYER_CLEARCOAT].NdotV;
+#endif // STANDARD_MATERIAL_CLEARCOAT
 
     // And do the same for transmissive if we need to.
 #ifdef STANDARD_MATERIAL_DIFFUSE_TRANSMISSION

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -260,23 +260,6 @@ fn calculate_view(
     return V;
 }
 
-// Diffuse strength is inversely related to metallicity, specular and diffuse transmission
-fn calculate_diffuse_color(
-    base_color: vec3<f32>,
-    metallic: f32,
-    specular_transmission: f32,
-    diffuse_transmission: f32
-) -> vec3<f32> {
-    return base_color * (1.0 - metallic) * (1.0 - specular_transmission) *
-        (1.0 - diffuse_transmission);
-}
-
-// Remapping [0,1] reflectance to F0
-// See https://google.github.io/filament/Filament.html#materialsystem/parameterization/remapping
-fn calculate_F0(base_color: vec3<f32>, metallic: f32, reflectance: vec3<f32>) -> vec3<f32> {
-    return 0.16 * reflectance * reflectance * (1.0 - metallic) + base_color * metallic;
-}
-
 #ifndef PREPASS_FRAGMENT
 fn apply_pbr_lighting(
     in: pbr_types::PbrInput,

--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -3,6 +3,7 @@
 #import bevy_pbr::{
     mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     mesh_view_bindings as view_bindings,
+    pbr_types::PbrInput,
 }
 #import bevy_render::maths::PI
 
@@ -248,6 +249,82 @@ fn specular_multiscatter(
     var Fr = (specular_intensity * D * V) * F;
     Fr *= 1.0 + F0 * (1.0 / F_ab.x - 1.0);
     return Fr;
+}
+
+/// Constructs the `LightingInput` from a given `PbrInput`.
+fn pbr_input_to_lighting_input(pbr_input: PbrInput) -> LightingInput {
+    let N = pbr_input.N;
+    let V = pbr_input.V;
+    let material = pbr_input.material;
+
+    var lighting_input: LightingInput;
+
+    lighting_input.layers[LAYER_BASE].N = N;
+
+    // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
+    lighting_input.layers[LAYER_BASE].R = reflect(-V, N);
+    let NdotV = max(dot(N, V), 0.0001);
+    lighting_input.layers[LAYER_BASE].NdotV = NdotV;
+
+    lighting_input.layers[LAYER_BASE].perceptual_roughness = material.perceptual_roughness;
+    // calculate non-linear roughness from linear perceptualRoughness
+    lighting_input.layers[LAYER_BASE].roughness =
+        perceptualRoughnessToRoughness(material.perceptual_roughness);
+
+    lighting_input.P = pbr_input.world_position.xyz;
+    lighting_input.V = V;
+
+    lighting_input.diffuse_color = calculate_diffuse_color(
+        material.base_color.rgb,
+        material.metallic,
+        material.specular_transmission,
+        material.diffuse_transmission
+    );
+
+    lighting_input.F0_ = calculate_F0(material.base_color.rgb, material.metallic, material.reflectance);
+    lighting_input.F_ab = F_AB(material.perceptual_roughness, NdotV);
+
+#ifdef STANDARD_MATERIAL_CLEARCOAT
+    // Do the above calculations again for the clearcoat layer. Remember that
+    // the clearcoat can have its own roughness and its own normal.
+    let clearcoat_N = pbr_input.clearcoat_N;
+
+    lighting_input.layers[LAYER_CLEARCOAT].N = clearcoat_N;
+
+    lighting_input.layers[LAYER_CLEARCOAT].R = reflect(-V, clearcoat_N);
+    lighting_input.layers[LAYER_CLEARCOAT].NdotV = max(dot(clearcoat_N, V), 0.0001);
+
+    lighting_input.layers[LAYER_CLEARCOAT].perceptual_roughness = material.clearcoat_perceptual_roughness;
+    lighting_input.layers[LAYER_CLEARCOAT].roughness =
+        perceptualRoughnessToRoughness(material.clearcoat_perceptual_roughness);
+
+    lighting_input.clearcoat_strength = material.clearcoat;
+#endif // STANDARD_MATERIAL_CLEARCOAT
+
+#ifdef STANDARD_MATERIAL_ANISOTROPY
+    lighting_input.anisotropy = pbr_input.anisotropy_strength;
+    lighting_input.Ta = pbr_input.anisotropy_T;
+    lighting_input.Ba = pbr_input.anisotropy_B;
+#endif // STANDARD_MATERIAL_ANISOTROPY
+
+    return lighting_input;
+}
+
+// Diffuse strength is inversely related to metallicity, specular and diffuse transmission
+fn calculate_diffuse_color(
+    base_color: vec3<f32>,
+    metallic: f32,
+    specular_transmission: f32,
+    diffuse_transmission: f32
+) -> vec3<f32> {
+    return base_color * (1.0 - metallic) * (1.0 - specular_transmission) *
+        (1.0 - diffuse_transmission);
+}
+
+// Remapping [0,1] reflectance to F0
+// See https://google.github.io/filament/Filament.html#materialsystem/parameterization/remapping
+fn calculate_F0(base_color: vec3<f32>, metallic: f32, reflectance: vec3<f32>) -> vec3<f32> {
+    return 0.16 * reflectance * reflectance * (1.0 - metallic) + base_color * metallic;
 }
 
 // Specular BRDF


### PR DESCRIPTION
# Objective
Reduce duplication in the `bevy_pbr` shaders by using a function to create `LightingInput` from `PbrInput` which can then be shared between `apply_pbr_lighting` and `ssr::fragment`.

## Solution
I created a function `pbr_input_to_lighting_input` in `pbr_lighting` to do this (lighting seemed the most logical place for it as that is where `LightingInput` lives and in a higher level language this would be a constructor). This also required moving `calculate_F0` and `calculate_diffuse_color` into `pbr_lighting` to prevent a circular dependency (infinite load during shader compilation), this makes sense for `calculate_F0` as this is now the only thing that uses it but `calculate_diffuse_color` does still have another user file.

## Questions for reviewers

- Should `pbr_input_to_lighting_input` instead accept a `ptr` to `PbrInput`, I don't feel like I have a sufficient grasp of shader optimisers to know whether this is better (or if we can trust this should always be inlined)?
- Should it instead live in `pbr_functions` which has the advantage of making this a non-breaking change (because no functions would have to move) but separates a constructor from its struct definition?

## Testing

I ran `ssr` and `anisotropy` and checked them for visual issues/crashes and ran as much CI as I could before running out of disk space. I tried to test `clearcoat` but that example is broken for me (#18104)

## Migration Guide

Shader function changes:
  - `calculate_diffuse_color` and `calculate_F0` have been moved from `bevy_pbr::pbr_functions` to `bevy_pbr::lighting`.
