### PR TITLE
Tracy GPU support

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -2238,18 +2238,12 @@ impl ShadowPassNode {
         world: &'w World,
         is_late: bool,
     ) -> Result<(), NodeRunError> {
-        let diagnostics = render_context.diagnostic_recorder();
-
-        let view_entity = graph.view_entity();
-
         let Some(shadow_render_phases) = world.get_resource::<ViewBinnedRenderPhases<Shadow>>()
         else {
             return Ok(());
         };
 
-        let time_span = diagnostics.time_span(render_context.command_encoder(), "shadows");
-
-        if let Ok(view_lights) = self.main_view_query.get_manual(world, view_entity) {
+        if let Ok(view_lights) = self.main_view_query.get_manual(world, graph.view_entity()) {
             for view_light_entity in view_lights.lights.iter().copied() {
                 let Ok((view_light, extracted_light_view, occlusion_culling)) =
                     self.view_light_query.get_manual(world, view_light_entity)
@@ -2305,8 +2299,6 @@ impl ShadowPassNode {
                 });
             }
         }
-
-        time_span.end(render_context.command_encoder());
 
         Ok(())
     }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -42,7 +42,7 @@ spirv_shader_passthrough = ["wgpu/spirv"]
 statically-linked-dxc = ["wgpu/static-dxc"]
 
 trace = ["profiling"]
-tracing-tracy = []
+tracing-tracy = ["dep:tracy-client"]
 ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
@@ -110,6 +110,7 @@ smallvec = { version = "1.11", features = ["const_new"] }
 offset-allocator = "0.2"
 variadics_please = "1.1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracy-client = { version = "0.18.0", optional = true }
 indexmap = { version = "2" }
 fixedbitset = { version = "0.5" }
 bitflags = "2"

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -53,7 +53,7 @@ impl DiagnosticsRecorder {
         #[cfg(feature = "tracing-tracy")]
         let tracy_gpu_context =
             super::tracy_gpu::new_tracy_gpu_context(adapter_info, device, queue);
-        let _ = adapter_info;
+        let _ = adapter_info; // Prevent unused variable warnings when tracing-tracy is not enabled
 
         DiagnosticsRecorder(WgpuWrapper::new(DiagnosticsRecorderInternal {
             timestamp_period_ns: queue.get_timestamp_period(),

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -57,7 +57,12 @@ impl DiagnosticsRecorder {
         DiagnosticsRecorder(WgpuWrapper::new(DiagnosticsRecorderInternal {
             timestamp_period_ns: queue.get_timestamp_period(),
             features,
-            current_frame: Mutex::new(FrameData::new(device, features, tracy_gpu_context.clone())),
+            current_frame: Mutex::new(FrameData::new(
+                device,
+                features,
+                #[cfg(feature = "tracing-tracy")]
+                tracy_gpu_context.clone(),
+            )),
             submitted_frames: Vec::new(),
             finished_frames: Vec::new(),
             #[cfg(feature = "tracing-tracy")]
@@ -356,6 +361,7 @@ impl FrameData {
             begin_instant: None,
             end_instant: None,
             pipeline_statistics_index: None,
+            #[cfg(feature = "tracing-tracy")]
             tracy_gpu_span,
         });
 
@@ -372,6 +378,7 @@ impl FrameData {
             .next_back()
             .unwrap();
 
+        #[allow(unused_mut)]
         let mut span = self.open_spans.swap_remove(index);
 
         #[cfg(feature = "tracing-tracy")]

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -341,7 +341,7 @@ impl FrameData {
             None => self.path_components.len()..self.path_components.len() + 1,
         };
 
-        self.path_components.push(name.clone());
+        self.path_components.push(name);
 
         self.open_spans.push(SpanRecord {
             thread_id,

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -346,7 +346,7 @@ impl FrameData {
 
         #[cfg(feature = "tracing-tracy")]
         let tracy_gpu_span = {
-            let location = std::panic::Location::caller();
+            let location = core::panic::Location::caller();
             self.tracy_gpu_context
                 .span_alloc(&name, "", location.file(), location.line())
                 .unwrap()

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -22,8 +22,8 @@ use super::{RenderDevice, RenderQueue};
 /// Enables collecting render diagnostics, such as CPU/GPU elapsed time per render pass,
 /// as well as pipeline statistics (number of primitives, number of shader invocations, etc).
 ///
-/// To access the diagnostics, you can use [`DiagnosticsStore`](bevy_diagnostic::DiagnosticsStore) resource,
-/// or add [`LogDiagnosticsPlugin`](bevy_diagnostic::LogDiagnosticsPlugin).
+/// To access the diagnostics, you can use the [`DiagnosticsStore`](bevy_diagnostic::DiagnosticsStore) resource,
+/// add [`LogDiagnosticsPlugin`](bevy_diagnostic::LogDiagnosticsPlugin), or use [Tracy](https://github.com/bevyengine/bevy/blob/main/docs/profiling.md#tracy-renderqueue).
 ///
 /// To record diagnostics in your own passes:
 ///  1. First, obtain the diagnostic recorder using [`RenderContext::diagnostic_recorder`](crate::renderer::RenderContext::diagnostic_recorder).

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -3,13 +3,15 @@
 //! For more info, see [`RenderDiagnosticsPlugin`].
 
 pub(crate) mod internal;
+#[cfg(feature = "tracing-tracy")]
+mod tracy_gpu;
 
 use alloc::{borrow::Cow, sync::Arc};
 use core::marker::PhantomData;
 
 use bevy_app::{App, Plugin, PreUpdate};
 
-use crate::RenderApp;
+use crate::{renderer::RenderAdapterInfo, RenderApp};
 
 use self::internal::{
     sync_diagnostics, DiagnosticsRecorder, Pass, RenderDiagnosticsMutex, WriteTimestamp,
@@ -62,9 +64,10 @@ impl Plugin for RenderDiagnosticsPlugin {
             return;
         };
 
+        let adapter_info = render_app.world().resource::<RenderAdapterInfo>();
         let device = render_app.world().resource::<RenderDevice>();
         let queue = render_app.world().resource::<RenderQueue>();
-        render_app.insert_resource(DiagnosticsRecorder::new(device, queue));
+        render_app.insert_resource(DiagnosticsRecorder::new(adapter_info, device, queue));
     }
 }
 

--- a/crates/bevy_render/src/diagnostic/tracy_gpu.rs
+++ b/crates/bevy_render/src/diagnostic/tracy_gpu.rs
@@ -28,6 +28,7 @@ pub fn new_tracy_gpu_context(
         .unwrap()
 }
 
+// Code copied from https://github.com/Wumpf/wgpu-profiler/blob/f9de342a62cb75f50904a98d11dd2bbeb40ceab8/src/tracy.rs
 fn initial_timestamp(device: &RenderDevice, queue: &RenderQueue) -> i64 {
     let query_set = device.wgpu_device().create_query_set(&QuerySetDescriptor {
         label: None,

--- a/crates/bevy_render/src/diagnostic/tracy_gpu.rs
+++ b/crates/bevy_render/src/diagnostic/tracy_gpu.rs
@@ -1,0 +1,66 @@
+use crate::renderer::{RenderAdapterInfo, RenderDevice, RenderQueue};
+use tracy_client::{Client, GpuContext, GpuContextType};
+use wgpu::{
+    Backend, BufferDescriptor, BufferUsages, CommandEncoderDescriptor, Maintain, MapMode,
+    QuerySetDescriptor, QueryType, QUERY_SIZE,
+};
+
+pub fn new_tracy_gpu_context(
+    adapter_info: &RenderAdapterInfo,
+    device: &RenderDevice,
+    queue: &RenderQueue,
+) -> GpuContext {
+    let tracy_gpu_backend = match adapter_info.backend {
+        Backend::Vulkan => GpuContextType::Vulkan,
+        Backend::Dx12 => GpuContextType::Direct3D12,
+        Backend::Gl => GpuContextType::OpenGL,
+        Backend::Metal | Backend::BrowserWebGpu | Backend::Empty => GpuContextType::Invalid,
+    };
+
+    let tracy_client = Client::running().unwrap();
+    tracy_client
+        .new_gpu_context(
+            Some("RenderQueue"),
+            tracy_gpu_backend,
+            initial_timestamp(device, queue),
+            queue.get_timestamp_period(),
+        )
+        .unwrap()
+}
+
+fn initial_timestamp(device: &RenderDevice, queue: &RenderQueue) -> i64 {
+    let query_set = device.wgpu_device().create_query_set(&QuerySetDescriptor {
+        label: None,
+        ty: QueryType::Timestamp,
+        count: 1,
+    });
+
+    let resolve_buffer = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: QUERY_SIZE as _,
+        usage: BufferUsages::QUERY_RESOLVE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let map_buffer = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: QUERY_SIZE as _,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let mut timestamp_encoder = device.create_command_encoder(&CommandEncoderDescriptor::default());
+    timestamp_encoder.write_timestamp(&query_set, 0);
+    timestamp_encoder.resolve_query_set(&query_set, 0..1, &resolve_buffer, 0);
+    // Workaround for https://github.com/gfx-rs/wgpu/issues/6406
+    // TODO when that bug is fixed, merge these encoders together again
+    let mut copy_encoder = device.create_command_encoder(&CommandEncoderDescriptor::default());
+    copy_encoder.copy_buffer_to_buffer(&resolve_buffer, 0, &map_buffer, 0, QUERY_SIZE as _);
+    queue.submit([timestamp_encoder.finish(), copy_encoder.finish()]);
+
+    map_buffer.slice(..).map_async(MapMode::Read, |_| ());
+    device.poll(Maintain::Wait);
+
+    let view = map_buffer.slice(..).get_mapped_range();
+    i64::from_le_bytes((*view).try_into().unwrap())
+}

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -408,6 +408,8 @@ impl Plugin for RenderPlugin {
             StoragePlugin,
             GpuReadbackPlugin::default(),
             OcclusionCullingPlugin,
+            #[cfg(feature = "tracing-tracy")]
+            diagnostic::RenderDiagnosticsPlugin,
         ));
 
         app.init_resource::<RenderAssetBytesPerFrame>();

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -155,7 +155,7 @@ Add the `RenderDiagnosticsPlugin` to your app, and then compile with Bevy's `tra
 
 > [!NOTE]
 > Due to dynamic clock speeds, GPU timings will have large frame-to-frame variance, unless you use an external tool to lock your GPU clocks to base speeds. When measuring GPU performance via Tracy, only look at the MTPC column of Tracy's statistics panel, and not individual frame data.
-
+<!-- markdownlint-disable MD028 -->
 
 > [!NOTE]
 > Unlike ECS systems, Bevy will not automatically add GPU profiling spans. You will need to add GPU timing spans yourself for any custom rendering work. See the [`RenderDiagnosticsPlugin`](https://docs.rs/bevy/latest/bevy/render/diagnostic/struct.RenderDiagnosticsPlugin.html) docs for more details.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -151,10 +151,10 @@ Note that while RenderDoc is a great debugging tool, it is _not_ a profiler, and
 
 While it doesn't provide as much detail as vendor-specific tooling, Tracy can also be used to coarsely measure GPU performance.
 
-Add the `RenderDiagnosticsPlugin` to your app, and then compile with Bevy's `trace_tracy` feature. GPU spans will show up in a separate row at the top of Tracy, labeled as `RenderQueue`.
+When you compile with Bevy's `trace_tracy` feature, GPU spans will show up in a separate row at the top of Tracy, labeled as `RenderQueue`.
 
 > [!NOTE]
-> Due to dynamic clock speeds, GPU timings will have large frame-to-frame variance, unless you use an external tool to lock your GPU clocks to base speeds. When measuring GPU performance via Tracy, only look at the MTPC column of Tracy's statistics panel, and not individual frame data.
+> Due to dynamic clock speeds, GPU timings will have large frame-to-frame variance, unless you use an external tool to lock your GPU clocks to base speeds. When measuring GPU performance via Tracy, only look at the MTPC column of Tracy's statistics panel, or the span distribution/median, and not at any individual frame data.
 <!-- markdownlint-disable MD028 -->
 
 > [!NOTE]

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -156,6 +156,7 @@ Add the `RenderDiagnosticsPlugin` to your app, and then compile with Bevy's `tra
 > [!NOTE]
 > Due to dynamic clock speeds, GPU timings will have large frame-to-frame variance, unless you use an external tool to lock your GPU clocks to base speeds. When measuring GPU performance via Tracy, only look at the MTPC column of Tracy's statistics panel, and not individual frame data.
 
+
 > [!NOTE]
 > Unlike ECS systems, Bevy will not automatically add GPU profiling spans. You will need to add GPU timing spans yourself for any custom rendering work. See the [`RenderDiagnosticsPlugin`](https://docs.rs/bevy/latest/bevy/render/diagnostic/struct.RenderDiagnosticsPlugin.html) docs for more details.
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -9,6 +9,8 @@
   - [Chrome tracing format](#chrome-tracing-format)
   - [Perf flame graph](#perf-flame-graph)
 - [GPU runtime](#gpu-runtime)
+  - [Vendor tools](#vendor-tools)
+  - [Tracy RenderQueue](#tracy-renderqueue)
 - [Compile time](#compile-time)
 
 ## CPU runtime
@@ -124,8 +126,15 @@ After closing your app, an interactive `svg` file will be produced:
 
 ## GPU runtime
 
-TODO: Talk about tracy RenderQueue
+First, a quick note on how GPU programming works. GPUs are essentially separate computers with their own compiler, scheduler, memory (for discrete GPUs), etc. You do not simply call functions to have the GPU perform work - instead, you communicate with them by sending data back and forth over the PCIe bus, via the GPU driver.
 
+Specifically, you record a list of tasks (commands) for the GPU to perform into a CommandBuffer, and then submit that on a Queue to the GPU. At some point in the future, the GPU will receive the commands and execute them.
+
+In terms of where your app is spending time doing graphics work, it might manifest as a CPU bottleneck (extracting to the render world, wgpu resource tracking, recording commands to a CommandBuffer, or GPU driver code), as a GPU bottleneck (the GPU actually running your commands), or even as a data transfer bottleneck (uploading new assets or other data to the GPU over the PCIe bus).
+
+Graphics related work is not all CPU work or all GPU work, but a mix of both, and you should find the bottleneck and profile using the appropriate tool for each case.
+
+### Vendor tools
 If CPU profiling has shown that GPU work is the bottleneck, it's time to profile the GPU.
 
 For profiling GPU work, you should use the tool corresponding to your GPU's vendor:
@@ -137,15 +146,17 @@ For profiling GPU work, you should use the tool corresponding to your GPU's vend
 
 Note that while RenderDoc is a great debugging tool, it is _not_ a profiler, and should not be used for this purpose.
 
-### Graphics work
+### Tracy RenderQueue
 
-Finally, a quick note on how GPU programming works. GPUs are essentially separate computers with their own compiler, scheduler, memory (for discrete GPUs), etc. You do not simply call functions to have the GPU perform work - instead, you communicate with them by sending data back and forth over the PCIe bus, via the GPU driver.
+While it dosen't provide as much detail as vendor-specific tooling, Tracy can also be used to coarsely measure GPU performance.
 
-Specifically, you record a list of tasks (commands) for the GPU to perform into a CommandBuffer, and then submit that on a Queue to the GPU. At some point in the future, the GPU will receive the commands and execute them.
+Add the `RenderDiagnosticsPlugin` to your app, and then compile with Bevy's `trace_tracy` feature. GPU spans will show up in a separate row at the top of Tracy, labeled as `RenderQueue`.
 
-In terms of where your app is spending time doing graphics work, it might manifest as a CPU bottleneck (extracting to the render world, wgpu resource tracking, recording commands to a CommandBuffer, or GPU driver code), or it might manifest as a GPU bottleneck (the GPU actually running your commands).
+> [!NOTE]
+> Due to dynamic clock speeds, GPU timings will have large frame-to-frame variance, unless you use an external tool to lock your GPU clocks to base speeds. When measuring GPU performance via Tracy, only look at the MTPC column of Tracy's statistics panel, and not individual frame data.
 
-Graphics related work is not all CPU work or all GPU work, but a mix of both, and you should find the bottleneck and profile using the appropriate tool for each case.
+> [!NOTE]
+> Unlike ECS systems, Bevy will not automatically add GPU profiling spans. You will need to add GPU timing spans yourself for any custom rendering work. See the [`RenderDiagnosticsPlugin`](https://docs.rs/bevy/latest/bevy/render/diagnostic/struct.RenderDiagnosticsPlugin.html) docs for more details.
 
 ## Compile time
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -148,7 +148,7 @@ Note that while RenderDoc is a great debugging tool, it is _not_ a profiler, and
 
 ### Tracy RenderQueue
 
-While it dosen't provide as much detail as vendor-specific tooling, Tracy can also be used to coarsely measure GPU performance.
+While it doesn't provide as much detail as vendor-specific tooling, Tracy can also be used to coarsely measure GPU performance.
 
 Add the `RenderDiagnosticsPlugin` to your app, and then compile with Bevy's `trace_tracy` feature. GPU spans will show up in a separate row at the top of Tracy, labeled as `RenderQueue`.
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -135,6 +135,7 @@ In terms of where your app is spending time doing graphics work, it might manife
 Graphics related work is not all CPU work or all GPU work, but a mix of both, and you should find the bottleneck and profile using the appropriate tool for each case.
 
 ### Vendor tools
+
 If CPU profiling has shown that GPU work is the bottleneck, it's time to profile the GPU.
 
 For profiling GPU work, you should use the tool corresponding to your GPU's vendor:

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -124,6 +124,8 @@ After closing your app, an interactive `svg` file will be produced:
 
 ## GPU runtime
 
+TODO: Talk about tracy RenderQueue
+
 If CPU profiling has shown that GPU work is the bottleneck, it's time to profile the GPU.
 
 For profiling GPU work, you should use the tool corresponding to your GPU's vendor:


### PR DESCRIPTION
# Objective

- Add tracy GPU support

## Solution

- Build on top of the existing render diagnostics recording to also upload gpu timestamps to tracy
- Copy code from https://github.com/Wumpf/wgpu-profiler

## Showcase
![image](https://github.com/user-attachments/assets/4dd7a7cd-bc0b-43c3-8390-6783dfda6473)

