### PR TITLE
Fix UpdateMode::Reactive behavior on Windows

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -454,7 +454,6 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
                     // Have the startup behavior run in about_to_wait, which prevents issues with
                     // invisible window creation. https://github.com/bevyengine/bevy/issues/18027
                     if self.startup_forced_updates == 0 {
-                        self.redraw_requested = true;
                         self.redraw_requested(_event_loop);
                     }
                 }
@@ -508,11 +507,14 @@ impl<T: Event> ApplicationHandler<T> for WinitAppRunnerState<T> {
             let winit_windows = self.world().non_send_resource::<WinitWindows>();
             let headless = winit_windows.windows.is_empty();
             let exiting = self.app_exit.is_some();
+            let reactive = matches!(self.update_mode, UpdateMode::Reactive { .. });
             let all_invisible = winit_windows
                 .windows
                 .iter()
                 .all(|(_, w)| !w.is_visible().unwrap_or(false));
-            if !exiting && (self.startup_forced_updates > 0 || headless || all_invisible) {
+            if !exiting
+                && (self.startup_forced_updates > 0 || headless || all_invisible || reactive)
+            {
                 self.redraw_requested(event_loop);
             }
         }


### PR DESCRIPTION
# Objective

The fix in #17488 forced Windows to always behave as if it were in `UpdateMode::Continuous`.

CC https://github.com/bevyengine/bevy/pull/17991

## Solution

Removed the unconditional `redraw_requested = true` and added a check for `Reactive` in `about_to_wait`.

## Testing

- Verified that the `low_power` example worked as expected with all `UpdateMode` options.
- Verified that animation continued in both `eased_motion ` and `low_power` examples when in `Continuous` update mode while:
  - Resizing the Window
  - Moving the window via clicking and dragging the title bar
- Verified that `window_settings` example still worked as expected.
- Verified that `monitor_info` example still worked as expected.

