### PR TITLE
Fix compile errors on headless example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1592,6 +1592,7 @@ wasm = true
 name = "headless"
 path = "examples/app/headless.rs"
 doc-scrape-examples = true
+required-features = ["bevy_log"]
 
 [package.metadata.example.headless]
 name = "Headless"

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -19,7 +19,7 @@ fn main() {
         println!("Disable the default features and rerun the example to run headless.");
         println!("To do so, run:");
         println!();
-        println!("    cargo run --example headless --no-default-features");
+        println!("    cargo run --example headless --no-default-features --features bevy_log");
         return;
     }
 


### PR DESCRIPTION
# Objective

- Fixes compile errors on headless example when running `cargo run --example headless --no-default-features`

```
error[E0432]: unresolved import `bevy::log`
  --> examples/app/headless.rs:13:39
   |
13 | use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*};
   |                                       ^^^ could not find `log` in `bevy`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `bevy` (example "headless") due to 1 previous error
```

## Solution

- Since commit cc69fdd bevy_log has been identified as a separate feature, thus requiring additional parameters to build headless example.
- Changed the command to run to: `cargo run --example headless --no-default-features --features bevy_log`

## Testing

- The new command successfully builds the example