### PR TITLE
Add `no_std` compatible `ceil` method

### DIFF
--- a/crates/bevy_math/clippy.toml
+++ b/crates/bevy_math/clippy.toml
@@ -34,5 +34,6 @@ disallowed-methods = [
   { path = "f32::copysign", reason = "use ops::copysign instead for no_std compatibility" },
   { path = "f32::round", reason = "use ops::round instead for no_std compatibility" },
   { path = "f32::floor", reason = "use ops::floor instead for no_std compatibility" },
+  { path = "f32::ceil", reason = "use ops::ceil instead for no_std compatibility" },
   { path = "f32::fract", reason = "use ops::fract instead for no_std compatibility" },
 ]

--- a/crates/bevy_math/src/ops.rs
+++ b/crates/bevy_math/src/ops.rs
@@ -510,6 +510,14 @@ mod libm_ops_for_no_std {
         libm::floorf(x)
     }
 
+    /// Returns the smallest integer greater than or equal to `x`.
+    ///
+    /// Precision is specified when the `libm` feature is enabled.
+    #[inline(always)]
+    pub fn ceil(x: f32) -> f32 {
+        libm::ceilf(x)
+    }
+
     /// Returns the fractional part of `x`.
     ///
     /// This function always returns the precise result.
@@ -579,6 +587,14 @@ mod std_ops_for_no_std {
     #[inline(always)]
     pub fn floor(x: f32) -> f32 {
         f32::floor(x)
+    }
+
+    /// Returns the smallest integer greater than or equal to `x`.
+    ///
+    /// This function always returns the precise result.
+    #[inline(always)]
+    pub fn ceil(x: f32) -> f32 {
+        f32::ceil(x)
     }
 
     /// Returns the fractional part of `x`.


### PR DESCRIPTION
# Objective

[`f32::ceil`](https://doc.rust-lang.org/std/primitive.f32.html#method.ceil) is not available in `core`. We have `floor` in `bevy_math::ops`, but no equivalent for `floor`.

## Solution

Add `ops::ceil` for `no_std` compatibility.