### PR TITLE
fix error and lints when building for wasm32

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -52,7 +52,7 @@ fn js_value_to_err(context: &str) -> impl FnOnce(JsValue) -> std::io::Error + '_
 }
 
 impl HttpWasmAssetReader {
-    async fn fetch_bytes<'a>(&self, path: PathBuf) -> Result<impl Reader, AssetReaderError> {
+    async fn fetch_bytes(&self, path: PathBuf) -> Result<impl Reader, AssetReaderError> {
         // The JS global scope includes a self-reference via a specializing name, which can be used to determine the type of global context available.
         let global: Global = js_sys::global().unchecked_into();
         let promise = if !global.window().is_undefined() {

--- a/crates/bevy_gltf/src/loader/gltf_ext/mesh.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/mesh.rs
@@ -14,9 +14,12 @@ pub(crate) fn primitive_name(mesh: &Mesh<'_>, primitive: &Primitive) -> String {
 }
 
 /// Maps the `primitive_topology` from glTF to `wgpu`.
-#[expect(
-    clippy::result_large_err,
-    reason = "`GltfError` is only barely past the threshold for large errors."
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::result_large_err,
+        reason = "`GltfError` is only barely past the threshold for large errors."
+    )
 )]
 pub(crate) fn primitive_topology(mode: Mode) -> Result<PrimitiveTopology, GltfError> {
     match mode {

--- a/crates/bevy_gltf/src/loader/gltf_ext/mod.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/mod.rs
@@ -14,9 +14,12 @@ use super::GltfError;
 
 use self::{material::extension_texture_index, scene::check_is_part_of_cycle};
 
-#[expect(
-    clippy::result_large_err,
-    reason = "need to be signature compatible with `load_gltf`"
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::result_large_err,
+        reason = "need to be signature compatible with `load_gltf`"
+    )
 )]
 /// Checks all glTF nodes for cycles, starting at the scene root.
 pub(crate) fn check_for_cycles(gltf: &Gltf) -> Result<(), GltfError> {

--- a/crates/bevy_gltf/src/loader/gltf_ext/scene.rs
+++ b/crates/bevy_gltf/src/loader/gltf_ext/scene.rs
@@ -43,9 +43,12 @@ pub(crate) fn node_transform(node: &Node) -> Transform {
     }
 }
 
-#[expect(
-    clippy::result_large_err,
-    reason = "need to be signature compatible with `load_gltf`"
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::result_large_err,
+        reason = "need to be signature compatible with `load_gltf`"
+    )
 )]
 /// Check if [`Node`] is part of cycle
 pub(crate) fn check_is_part_of_cycle(

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -1281,9 +1281,12 @@ fn load_material(
 }
 
 /// Loads a glTF node.
-#[expect(
-    clippy::result_large_err,
-    reason = "`GltfError` is only barely past the threshold for large errors."
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(
+        clippy::result_large_err,
+        reason = "`GltfError` is only barely past the threshold for large errors."
+    )
 )]
 fn load_node(
     gltf_node: &Node,

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -28,7 +28,7 @@ use crate::{
     BrpError, BrpResult,
 };
 
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", not(target_family = "wasm")))]
 use {crate::schemas::open_rpc::ServerObject, bevy_utils::default};
 
 /// The method path for a `bevy/get` request.
@@ -821,7 +821,7 @@ pub fn process_remote_list_methods_request(
 ) -> BrpResult {
     let remote_methods = world.resource::<crate::RemoteMethods>();
 
-    #[cfg(feature = "http")]
+    #[cfg(all(feature = "http", not(target_family = "wasm")))]
     let servers = match (
         world.get_resource::<crate::http::HostAddress>(),
         world.get_resource::<crate::http::HostPort>(),
@@ -839,7 +839,7 @@ pub fn process_remote_list_methods_request(
         _ => None,
     };
 
-    #[cfg(not(feature = "http"))]
+    #[cfg(any(not(feature = "http"), target_family = "wasm"))]
     let servers = None;
 
     let doc = OpenRpcDocument {

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -16,7 +16,7 @@ use bevy_input::{
     gestures::*,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
 };
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(not(target_arch = "wasm32"), feature = "custom_cursor"))]
 use bevy_log::error;
 use bevy_log::{trace, warn};
 #[cfg(feature = "custom_cursor")]

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -16,7 +16,9 @@ use bevy_input::{
     gestures::*,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
 };
-use bevy_log::{error, trace, warn};
+#[cfg(not(target_arch = "wasm32"))]
+use bevy_log::error;
+use bevy_log::{trace, warn};
 #[cfg(feature = "custom_cursor")]
 use bevy_math::URect;
 use bevy_math::{ivec2, DVec2, Vec2};


### PR DESCRIPTION
# Objective

- Some crates don't compile or have clippy warnings when building for wasm32

## Solution

- bevy_asset: unused lifetime
- bevy_gltf: the error is not too large in wasm32
- bevy_remote: fails to compile as feature http is also gated on wasm32
- bevy_winit: unused import `error`
