### PR TITLE
bevy_image: derive TypePath when Reflect is not available

### DIFF
--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["bevy"]
 [features]
 default = ["bevy_reflect"]
 
+# bevy_reflect can't optional as it's needed for TypePath
+# this feature only control reflection in bevy_image
 bevy_reflect = ["bevy_math/bevy_reflect"]
 
 # Image formats

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 [features]
 default = ["bevy_reflect"]
 
-bevy_reflect = ["dep:bevy_reflect", "bevy_math/bevy_reflect"]
+bevy_reflect = ["bevy_math/bevy_reflect"]
 
 # Image formats
 basis-universal = ["dep:basis-universal"]
@@ -49,7 +49,7 @@ bevy_color = { path = "../bevy_color", version = "0.16.0-dev", features = [
   "wgpu-types",
 ] }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", optional = true }
+bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev" }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "std",

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -4,6 +4,8 @@ use super::basis::*;
 use super::dds::*;
 #[cfg(feature = "ktx2")]
 use super::ktx2::*;
+#[cfg(not(feature = "bevy_reflect"))]
+use bevy_reflect::TypePath;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
@@ -338,6 +340,7 @@ impl ImageFormat {
     derive(Reflect),
     reflect(opaque, Default, Debug, Clone)
 )]
+#[cfg_attr(not(feature = "bevy_reflect"), derive(TypePath))]
 pub struct Image {
     /// Raw pixel data.
     /// If the image is being used as a storage texture which doesn't need to be initialized by the

--- a/crates/bevy_image/src/texture_atlas.rs
+++ b/crates/bevy_image/src/texture_atlas.rs
@@ -2,6 +2,8 @@ use bevy_app::prelude::*;
 use bevy_asset::{Asset, AssetApp as _, AssetId, Assets, Handle};
 use bevy_math::{Rect, URect, UVec2};
 use bevy_platform_support::collections::HashMap;
+#[cfg(not(feature = "bevy_reflect"))]
+use bevy_reflect::TypePath;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 #[cfg(feature = "serialize")]
@@ -97,6 +99,7 @@ impl TextureAtlasSources {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
+#[cfg_attr(not(feature = "bevy_reflect"), derive(TypePath))]
 pub struct TextureAtlasLayout {
     /// Total size of texture atlas.
     pub size: UVec2,


### PR DESCRIPTION
# Objective

- bevy_image fails to build without default features:
```
error[E0277]: `image::Image` does not implement `TypePath` so cannot provide static type path information
   --> crates/bevy_image/src/image.rs:341:12
    |
341 | pub struct Image {
    |            ^^^^^ the trait `bevy_reflect::type_path::TypePath` is not implemented for `image::Image`
    |
    = note: consider annotating `image::Image` with `#[derive(Reflect)]` or `#[derive(TypePath)]`
    = help: the following other types implement trait `bevy_reflect::type_path::TypePath`:
              &'static Location<'static>
              &'static T
              &'static mut T
              ()
              (P,)
              (P1, P0)
              (P1, P2, P0)
              (P1, P2, P3, P0)
            and 146 others
note: required by a bound in `Asset`
   --> /home/runner/work/bevy-releasability/bevy-releasability/crates/bevy_asset/src/lib.rs:415:43
    |
415 | pub trait Asset: VisitAssetDependencies + TypePath + Send + Sync + 'static {}
    |                                           ^^^^^^^^ required by this bound in `Asset`
    = note: `Asset` is a "sealed trait", because to implement it you also need to implement `bevy_reflect::type_path::TypePath`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
    = help: the following types implement the trait:
              bevy_asset::AssetIndex
              bevy_asset::LoadedUntypedAsset
              bevy_asset::AssetEvent<A>
              bevy_asset::LoadedFolder
              bevy_asset::StrongHandle
              bevy_asset::Handle<A>
              bevy_asset::AssetId<A>
              bevy_asset::AssetPath<'a>
            and 148 others

error[E0277]: `image::Image` does not implement `TypePath` so cannot provide static type path information
   --> crates/bevy_image/src/image_loader.rs:121:18
    |
121 |     type Asset = Image;
    |                  ^^^^^ the trait `bevy_reflect::type_path::TypePath` is not implemented for `image::Image`
    |
    = note: consider annotating `image::Image` with `#[derive(Reflect)]` or `#[derive(TypePath)]`
    = help: the following other types implement trait `bevy_reflect::type_path::TypePath`:
              &'static Location<'static>
              &'static T
              &'static mut T
              ()
              (P,)
              (P1, P0)
              (P1, P2, P0)
              (P1, P2, P3, P0)
            and 146 others
    = note: required for `<ImageLoader as AssetLoader>::Asset` to implement `Asset`
note: required by a bound in `bevy_asset::AssetLoader::Asset`
   --> /home/runner/work/bevy-releasability/bevy-releasability/crates/bevy_asset/src/loader.rs:33:17
    |
33  |     type Asset: Asset;
    |                 ^^^^^ required by this bound in `AssetLoader::Asset`

error[E0277]: `texture_atlas::TextureAtlasLayout` does not implement `TypePath` so cannot provide static type path information
   --> crates/bevy_image/src/texture_atlas.rs:100:12
    |
100 | pub struct TextureAtlasLayout {
    |            ^^^^^^^^^^^^^^^^^^ the trait `bevy_reflect::type_path::TypePath` is not implemented for `texture_atlas::TextureAtlasLayout`
    |
    = note: consider annotating `texture_atlas::TextureAtlasLayout` with `#[derive(Reflect)]` or `#[derive(TypePath)]`
    = help: the following other types implement trait `bevy_reflect::type_path::TypePath`:
              &'static Location<'static>
              &'static T
              &'static mut T
              ()
              (P,)
              (P1, P0)
              (P1, P2, P0)
              (P1, P2, P3, P0)
            and 146 others
note: required by a bound in `Asset`
   --> /home/runner/work/bevy-releasability/bevy-releasability/crates/bevy_asset/src/lib.rs:415:43
    |
415 | pub trait Asset: VisitAssetDependencies + TypePath + Send + Sync + 'static {}
    |                                           ^^^^^^^^ required by this bound in `Asset`
    = note: `Asset` is a "sealed trait", because to implement it you also need to implement `bevy_reflect::type_path::TypePath`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
    = help: the following types implement the trait:
              bevy_asset::AssetIndex
              bevy_asset::LoadedUntypedAsset
              bevy_asset::AssetEvent<A>
              bevy_asset::LoadedFolder
              bevy_asset::StrongHandle
              bevy_asset::Handle<A>
              bevy_asset::AssetId<A>
              bevy_asset::AssetPath<'a>
            and 148 others
```
- `Asset` trait depends on `TypePath` which is in bevy_reflect. it's usually implemented by the `Reflect` derive


## Solution

- make bevy_reflect not an optional dependency
- when feature `bevy_reflect` is not enabled, derive `TypePath` directly
