### PR TITLE
Address lints in `bevy_asset`

### DIFF
--- a/crates/bevy_asset/src/io/memory.rs
+++ b/crates/bevy_asset/src/io/memory.rs
@@ -60,8 +60,7 @@ impl Dir {
             dir = self.get_or_insert_dir(parent);
         }
         let key: Box<str> = path.file_name().unwrap().to_string_lossy().into();
-        let data = dir.0.write().assets.remove(&key);
-        data
+        dir.0.write().assets.remove(&key)
     }
 
     pub fn insert_meta(&self, path: &Path, value: impl Into<Value>) {

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -347,14 +347,9 @@ impl AssetInfos {
 
     /// Returns `true` if the asset this path points to is still alive
     pub(crate) fn is_path_alive<'a>(&self, path: impl Into<AssetPath<'a>>) -> bool {
-        let path = path.into();
-
-        let result = self
-            .get_path_ids(&path)
+        self.get_path_ids(&path.into())
             .filter_map(|id| self.infos.get(&id))
-            .any(|info| info.weak_handle.strong_count() > 0);
-
-        result
+            .any(|info| info.weak_handle.strong_count() > 0)
     }
 
     /// Returns `true` if the asset at this path should be reloaded


### PR DESCRIPTION
# Objective

`cargo clippy -p bevy_asset` warns on a pair of lints on my Windows 10 development machine (return from let binding).

## Solution

Addressed them!

## Testing

- CI
