### PR TITLE
register ComputedNodeTarget

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -168,6 +168,7 @@ impl Plugin for UiPlugin {
             .register_type::<BoxShadowSamples>()
             .register_type::<UiAntiAlias>()
             .register_type::<TextShadow>()
+            .register_type::<ComputedNodeTarget>()
             .configure_sets(
                 PostUpdate,
                 (


### PR DESCRIPTION
I had no reference to `ComputedNodeTarget` in my project. After updating to bevy 0.16.0-rc1 i got a compile error complaining about this.
