### PR TITLE
Update linux_dependencies.md

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -152,7 +152,7 @@ for more information about `devShells`.
 Note that this template does not add Rust to the environment because there are many ways to do it.
 For example, to use stable Rust from nixpkgs, you can add `cargo` and `rustc` to `nativeBuildInputs`.
 
-[Here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ju/jumpy/package.nix)
+[Here]([https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ju/jumpy/package.nix](https://github.com/NixOS/nixpkgs/blob/0da3c44a9460a26d2025ec3ed2ec60a895eb1114/pkgs/games/jumpy/default.nix))
 is an example of packaging a Bevy program in nix.
 
 ## [OpenSUSE](https://www.opensuse.org/)


### PR DESCRIPTION
# Objective

The latest version of nixpkgs doesn't include the file, breaking the old link.

## Solution

Change the nixos packaging example link to a permalink with the latest known version of the 'jumpy' program.

## Testing

- Did you test these changes? If so, how?
  - No testing needed. Just a link change.
- Are there any parts that need more testing?
  - No