### PR TITLE
Move initializing the `ScreenshotToScreenPipeline` to the `ScreenshotPlugin`.

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -21,7 +21,7 @@ use wgpu::{
 
 pub mod screenshot;
 
-use screenshot::{ScreenshotPlugin, ScreenshotToScreenPipeline};
+use screenshot::ScreenshotPlugin;
 
 pub struct WindowRenderPlugin;
 
@@ -41,12 +41,6 @@ impl Plugin for WindowRenderPlugin {
                         .before(prepare_windows),
                 )
                 .add_systems(Render, prepare_windows.in_set(RenderSet::ManageViews));
-        }
-    }
-
-    fn finish(&self, app: &mut App) {
-        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.init_resource::<ScreenshotToScreenPipeline>();
         }
     }
 }

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -425,6 +425,7 @@ impl Plugin for ScreenshotPlugin {
                 .init_resource::<RenderScreenshotTargets>()
                 .init_resource::<RenderScreenshotsPrepared>()
                 .init_resource::<SpecializedRenderPipelines<ScreenshotToScreenPipeline>>()
+                .init_resource::<ScreenshotToScreenPipeline>()
                 .add_systems(ExtractSchedule, extract_screenshots.ambiguous_with_all())
                 .add_systems(
                     Render,


### PR DESCRIPTION
# Objective

- Minor cleanup.
- This seems to have been introduced in #8336. There is no discussion about it I can see, there's no comment explaining why this is here and not in `ScreenshotPlugin`. This seems to have just been misplaced.

## Solution

- Move this to the ScreenshotPlugin!

## Testing

- The screenshot example still works at least on desktop.
