### PR TITLE
Fixes #13466, implementing resource_scope_by_id

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2761,6 +2761,7 @@ impl World {
     ///  /// # Example
     /// ```
     /// use bevy_ecs::prelude::*;
+    /// use std::any::TypeId;
     /// #[derive(Resource)]
     /// struct A(u32);
     /// #[derive(Component)]
@@ -2768,7 +2769,10 @@ impl World {
     /// let mut world = World::new();
     /// world.insert_resource(A(1));
     /// let entity = world.spawn(B(1)).id();
-    /// let component_id = A.id();
+    /// let component_id = world
+    /// .components()
+    /// .get_resource_id(TypeId::of::<A>())
+    /// .expect("Failed to get component ID for MyResource");
     /// world.resource_scope_by_id(component_id, |world: &mut World, mut a: Mut<A>| {
     ///     let b = world.get_mut::<B>(entity).unwrap();
     ///     a.0 += b.0;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2758,14 +2758,16 @@ impl World {
     ///
     /// This enables safe simultaneous mutable access to both a resource and the rest of the [`World`].
     /// For more complex access patterns, consider using [`SystemState`](crate::system::SystemState).
-    ///  /// # Example
+    /// # Example
     /// ```
     /// use bevy_ecs::prelude::*;
     /// use std::any::TypeId;
+    /// 
     /// #[derive(Resource)]
     /// struct A(u32);
     /// #[derive(Component)]
     /// struct B(u32);
+    /// 
     /// let mut world = World::new();
     /// world.insert_resource(A(1));
     /// let entity = world.spawn(B(1)).id();
@@ -2776,29 +2778,11 @@ impl World {
     /// world.resource_scope_by_id(component_id, |world: &mut World, mut a: Mut<A>| {
     ///     let b = world.get_mut::<B>(entity).unwrap();
     ///     a.0 += b.0;
+    ///     assert!(world.get_resource::<A>().is_none(), "Should not be able to access A inside this scope.");
     /// });
     /// assert_eq!(world.get_resource::<A>().unwrap().0, 2);
     /// ```
-    ///
-    /// See also [`try_resource_scope_by_id`](Self::try_resource_scope_by_id).
-    #[track_caller]
     pub fn resource_scope_by_id<R: Resource, U>(
-        &mut self,
-        id: ComponentId,
-        f: impl FnOnce(&mut World, Mut<R>) -> U,
-    ) -> U {
-        self.try_resource_scope_by_id(id, f)
-            .unwrap_or_else(|| panic!("resource with ComponentId {} does not exist.", id.index()))
-    }
-
-    /// Temporarily removes the requested resource from this [`World`] if it exists, runs custom user code,
-    /// then re-adds the resource before returning. Returns `None` if the resource does not exist in this [`World`].
-    ///
-    /// This enables safe simultaneous mutable access to both a resource and the rest of the [`World`].
-    /// For more complex access patterns, consider using [`SystemState`](crate::system::SystemState).
-    ///
-    /// See also [`resource_scope_by_id`](Self::resource_scope_by_id).
-    pub fn try_resource_scope_by_id<R: Resource, U>(
         &mut self,
         id: ComponentId,
         f: impl FnOnce(&mut World, Mut<R>) -> U,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2753,6 +2753,81 @@ impl World {
         Some(result)
     }
 
+    /// Temporarily removes the requested resource from this [`World`] if it exists, runs custom user code,
+    /// then re-adds the resource before returning. Returns the result of the closure.
+    ///
+    /// This enables safe simultaneous mutable access to both a resource and the rest of the [`World`].
+    /// For more complex access patterns, consider using [`SystemState`](crate::system::SystemState).
+    ///  /// # Example
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// #[derive(Resource)]
+    /// struct A(u32);
+    /// #[derive(Component)]
+    /// struct B(u32);
+    /// let mut world = World::new();
+    /// world.insert_resource(A(1));
+    /// let entity = world.spawn(B(1)).id();
+    /// let component_id = A.id();
+    /// world.resource_scope_by_id(component_id, |world: &mut World, mut a: Mut<A>| {
+    ///     let b = world.get_mut::<B>(entity).unwrap();
+    ///     a.0 += b.0;
+    /// });
+    /// assert_eq!(world.get_resource::<A>().unwrap().0, 2);
+    /// ```
+    ///
+    /// See also [`try_resource_scopy_by_id`](Self::try_resource_scopy_by_id).
+    #[track_caller]
+    pub fn resource_scope_by_id<R: Resource, U>(&mut self, id: ComponentId, f: impl FnOnce(&mut World, Mut<R>) -> U) -> U {
+        self.try_resource_scope_by_id(id, f)
+            .unwrap_or_else(|| panic!("resource with ComponentId {} does not exist.", id.index()))
+    }
+
+    /// Temporarily removes the requested resource from this [`World`] if it exists, runs custom user code,
+    /// then re-adds the resource before returning. Returns `None` if the resource does not exist in this [`World`].
+    ///
+    /// This enables safe simultaneous mutable access to both a resource and the rest of the [`World`].
+    /// For more complex access patterns, consider using [`SystemState`](crate::system::SystemState).
+    pub fn try_resource_scope_by_id<R: Resource, U>(&mut self, id: ComponentId, f: impl FnOnce(&mut World, Mut<R>) -> U) -> Option<U> {
+        let last_change_tick = self.last_change_tick();
+        let change_tick = self.change_tick();
+    
+        let (ptr, mut ticks, mut caller) = self
+            .storages
+            .resources
+            .get_mut(id)
+            .and_then(ResourceData::remove)?;
+        // Read the value onto the stack to avoid potential mut aliasing.
+        // SAFETY: `ptr` was obtained from the TypeId of `R`.
+        let mut value = unsafe { ptr.read::<R>() };
+        let value_mut = Mut {
+            value: &mut value,
+            ticks: TicksMut {
+                added: &mut ticks.added,
+                changed: &mut ticks.changed,
+                last_run: last_change_tick,
+                this_run: change_tick,
+            },
+            changed_by: caller.as_mut(),
+        };
+        let result = f(self, value_mut);
+        assert!(!self.contains_resource_by_id(id),
+            "Resource; ComponentId  = `{}`, was inserted during a call to World::resource_scope_by_id.\n\
+            This is not allowed as the original resource is reinserted to the world after the closure is invoked.",
+            id.index());
+    
+        OwningPtr::make(value, |ptr| {
+            // SAFETY: pointer is of type R
+            unsafe {
+                self.storages.resources.get_mut(id).map(|info| {
+                    info.insert_with_ticks(ptr, ticks, caller);
+                })
+            }
+        })?;
+    
+        Some(result)
+    }
+
     /// Sends an [`Event`].
     /// This method returns the [ID](`EventId`) of the sent `event`,
     /// or [`None`] if the `event` could not be sent.


### PR DESCRIPTION
# Objective

- Fixes #13466, implementing resource_scope_by_id

## Testing

- Tested in the same way resource_scope was tested. Used the old precedent to test our new function by pulling the component id first and passing it in.

---

## Showcase

Allows mutable retrieval of resources using component id in a way they are then inserted back into the world. Similar to resource_scope.

```rust
let mut world = World::default();

// Insert the resources into the world with initial values
world.insert_resource(MyResource { value: 42 });
world.insert_resource(MyOtherResource { value: 100 });

// Get the component ID for MyResource
let component_id = world
    .components()
    .get_resource_id(TypeId::of::<MyResource>())
    .expect("Failed to get component ID for MyResource");

println!("component_id of MyResource =  {}", component_id.index());

// Use resource_scope_by_id to modify MyResource safely
world.resource_scope_by_id(component_id, |world: &mut World, mut res: Mut<MyResource>| {
    println!("Resource before: {}", res.value);
    res.value += 10;  // Modify the res
    println!("Resource after modification: {}", res.value);

    // Now, let's access another resource inside the closure
    // Get the component ID for MyOtherResource
    let other_component_id = world
           .components()
           .get_resource_id(TypeId::of::<MyOtherResource>())
           .expect("Failed to get component ID for MyOtherResource");

    // Access MyOtherResource using resource_scope_by_id
    world.resource_scope_by_id(other_component_id, |_world: &mut World, mut other_res: Mut<MyResource>| {
        println!("Second Resource before: {}", other_res.value);
        other_res.value += 20;  // Modify the second resource
        println!("Second Resource after modification: {}", other_res.value);
    });
});
```
