### PR TITLE
Update wireframe example to spawn materials without wireframes

### DIFF
--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -50,34 +50,35 @@ fn main() {
 
 /// set up a simple 3D scene
 /// Note that entities cannot be spawned with both a material and a wireframe, so for cubes we want
-/// to show both for, we spawn one with the Material and NoWireframe, the other we spawn with a
+/// to show both for, we spawn one with the Material and `NoWireframe`, the other we spawn with a
 /// Wireframe (or global Wireframe config), and no Material.
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    let cube_mesh = meshes.add(Cuboid::default());
     // Red cube: Never renders a wireframe
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::default())),
+        Mesh3d(cube_mesh.clone()),
         MeshMaterial3d(materials.add(Color::from(RED))),
         Transform::from_xyz(-1.0, 0.5, -1.0),
         NoWireframe,
     ));
     // Orange cube: Follows global wireframe setting
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::default())),
+        Mesh3d(cube_mesh.clone()),
         MeshMaterial3d(materials.add(Color::from(ORANGE))),
         Transform::from_xyz(0.0, 0.5, 0.0),
         NoWireframe,
     ));
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::default())),
+        Mesh3d(cube_mesh.clone()),
         Transform::from_xyz(0.0, 0.5, 0.0),
     ));
     // Green cube: Always renders a wireframe
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::default())),
+        Mesh3d(cube_mesh.clone()),
         Transform::from_xyz(1.0, 0.5, 1.0),
         Wireframe,
         // This lets you configure the wireframe color of this entity.
@@ -85,20 +86,21 @@ fn setup(
         WireframeColor { color: LIME.into() },
     ));
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::default())),
+        Mesh3d(cube_mesh),
         MeshMaterial3d(materials.add(Color::from(LIME))),
         Transform::from_xyz(1.0, 0.5, 1.0),
         NoWireframe,
     ));
 
     // plane
+    let plane_mesh = meshes.add(Plane3d::default().mesh().size(5.0, 5.0));
     commands.spawn((
-        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        Mesh3d(plane_mesh.clone()),
         MeshMaterial3d(materials.add(Color::from(BLUE))),
         NoWireframe,
     ));
     commands.spawn((
-        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        Mesh3d(plane_mesh),
         // You can insert this component without the `Wireframe` component
         // to override the color of the global wireframe for this mesh
         WireframeColor {

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -49,6 +49,9 @@ fn main() {
 }
 
 /// set up a simple 3D scene
+/// Note that entities cannot be spawned with both a material and a wireframe, so for cubes we want
+/// to show both for, we spawn one with the Material and NoWireframe, the other we spawn with a
+/// Wireframe (or global Wireframe config), and no Material.
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -66,22 +69,36 @@ fn setup(
         Mesh3d(meshes.add(Cuboid::default())),
         MeshMaterial3d(materials.add(Color::from(ORANGE))),
         Transform::from_xyz(0.0, 0.5, 0.0),
+        NoWireframe,
+    ));
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        Transform::from_xyz(0.0, 0.5, 0.0),
     ));
     // Green cube: Always renders a wireframe
     commands.spawn((
         Mesh3d(meshes.add(Cuboid::default())),
-        MeshMaterial3d(materials.add(Color::from(LIME))),
         Transform::from_xyz(1.0, 0.5, 1.0),
         Wireframe,
         // This lets you configure the wireframe color of this entity.
         // If not set, this will use the color in `WireframeConfig`
         WireframeColor { color: LIME.into() },
     ));
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::from(LIME))),
+        Transform::from_xyz(1.0, 0.5, 1.0),
+        NoWireframe,
+    ));
 
     // plane
     commands.spawn((
         Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
         MeshMaterial3d(materials.add(Color::from(BLUE))),
+        NoWireframe,
+    ));
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
         // You can insert this component without the `Wireframe` component
         // to override the color of the global wireframe for this mesh
         WireframeColor {


### PR DESCRIPTION
# Objective

Addresses the .16 scope of #16896 

## Solution

- Duplicates the spawning of all entities without wireframes when they have a material, and without materials when they have a wireframe.

## Testing

- Ran the example using --features wayland on Ubuntu 24.04.2 LTS

---

## Showcase

![image](https://github.com/user-attachments/assets/22f45e9c-f575-43a5-899e-c5c27ef0c7ac)


## Migration Guide

N/A
