### PR TITLE
Update wireframe 2d example to fix material issue

### DIFF
--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -50,7 +50,7 @@ fn main() {
 
 /// set up a simple 2D scene
 /// Note that entities cannot be spawned with both a material and a wireframe, so for objects we want
-/// to show both for, we spawn one with the Material and NoWireframe2d, the other we spawn with a
+/// to show both for, we spawn one with the Material and `NoWireframe2d`, the other we spawn with a
 /// Wireframe (or global Wireframe config), and no Material.
 fn setup(
     mut commands: Commands,

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -48,7 +48,10 @@ fn main() {
         .run();
 }
 
-/// Set up a simple 3D scene
+/// set up a simple 2D scene
+/// Note that entities cannot be spawned with both a material and a wireframe, so for objects we want
+/// to show both for, we spawn one with the Material and NoWireframe2d, the other we spawn with a
+/// Wireframe (or global Wireframe config), and no Material.
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -66,15 +69,24 @@ fn setup(
         NoWireframe2d,
     ));
     // Rectangle: Follows global wireframe setting
+    let rectangle_mesh = meshes.add(Rectangle::new(100.0, 100.0));
     commands.spawn((
-        Mesh2d(meshes.add(Rectangle::new(100.0, 100.0))),
+        Mesh2d(rectangle_mesh.clone()),
         MeshMaterial2d(materials.add(Color::BLACK)),
         Transform::from_xyz(0.0, 0.0, 0.0),
+        NoWireframe2d,
     ));
+    commands.spawn((Mesh2d(rectangle_mesh), Transform::from_xyz(0.0, 0.0, 0.0)));
     // Circle: Always renders a wireframe
+    let circle_mesh = meshes.add(Circle::new(50.0));
     commands.spawn((
-        Mesh2d(meshes.add(Circle::new(50.0))),
+        Mesh2d(circle_mesh.clone()),
         MeshMaterial2d(materials.add(Color::BLACK)),
+        Transform::from_xyz(150.0, 0.0, 0.0),
+        NoWireframe2d,
+    ));
+    commands.spawn((
+        Mesh2d(circle_mesh),
         Transform::from_xyz(150.0, 0.0, 0.0),
         Wireframe2d,
         // This lets you configure the wireframe color of this entity.


### PR DESCRIPTION
# Objective

Addresses the .16 scope of #16896 
Fixes #17737 

## Solution

- Duplicates the spawning of all entities without wireframes when they have a material, and without materials when they have a wireframe.

## Testing

- Ran the example using --features wayland on Ubuntu 24.04.2 LTS

---

## Showcase

![image](https://github.com/user-attachments/assets/9baf1074-711f-4b31-afbf-ce2546de7fea)

## Migration Guide

N/A
