### PR TITLE
Fix relationship macro for multiple named members fields

### DIFF
--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -14,7 +14,6 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 syn = { version = "2.0.99", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-
 [lints]
 workspace = true
 

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -15,9 +15,6 @@ syn = { version = "2.0.99", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 
-[dev-dependencies]
-bevy_ecs = { path = "../", version = "0.16.0-dev" }
-
 [lints]
 workspace = true
 

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -14,6 +14,10 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.16.0-dev" }
 syn = { version = "2.0.99", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[dev-dependencies]
+bevy_ecs = { path = "../", version = "0.16.0-dev" }
+
 [lints]
 workspace = true
 

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -746,7 +746,7 @@ fn derive_relationship(
             #[inline]
             fn from(entity: #bevy_ecs_path::entity::Entity) -> Self {
                 Self {
-                    #(#members: core::default::Default::default(),),*
+                    #(#members: core::default::Default::default(),)*
                     #relationship_member: entity
                 }
             }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -703,6 +703,64 @@ impl Parse for RelationshipTarget {
     }
 }
 
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source(Entity);
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target(Vec<Entity>);
+/// ```
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source{
+///     #[relationship]
+///     target: Entity,
+/// };
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target(Vec<Entity>);
+/// ```
+/// Testing case with single extra field
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source{
+///     #[relationship]
+///     target: Entity,
+///     foo: String,
+/// };
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target(Vec<Entity>);
+/// ```
+/// Testing case with multiple extra fields
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source{
+///     #[relationship]
+///     target: Entity,
+///     foo: String,
+///     bar: String,
+/// };
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target(Vec<Entity>);
+/// ```
 fn derive_relationship(
     ast: &DeriveInput,
     attrs: &Attrs,
@@ -754,6 +812,63 @@ fn derive_relationship(
     }))
 }
 
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source(Entity);
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target(Vec<Entity>);
+/// ```
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source(Entity);
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target{
+///     related: Vec<Entity>,
+/// }
+/// ```
+/// Testing case with single extra field
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source(Entity);
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target{
+///     #[relationship]
+///     related: Vec<Entity>,
+///     foo: String,
+/// }
+/// ```
+/// Testing case with multiple extra fields
+/// ```
+/// # use bevy_ecs::component::Component;
+/// # use bevy_ecs::entity::Entity;
+/// #[derive(Component)]
+/// #[relationship(relationship_target=Target)]
+/// struct Source(Entity);
+///
+/// #[derive(Component)]
+/// #[relationship_target(relationship=Source)]
+/// struct Target{
+///     #[relationship]
+///     related: Vec<Entity>,
+///     foo: String,
+///     bar: String,
+/// }
+/// ```
 fn derive_relationship_target(
     ast: &DeriveInput,
     attrs: &Attrs,

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -809,7 +809,7 @@ fn derive_relationship_target(
             #[inline]
             fn from_collection_risky(collection: Self::Collection) -> Self {
                 Self {
-                    #(#members: core::default::Default::default(),),*
+                    #(#members: core::default::Default::default(),)*
                     #relationship_member: collection
                 }
             }

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -703,64 +703,6 @@ impl Parse for RelationshipTarget {
     }
 }
 
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source(Entity);
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target(Vec<Entity>);
-/// ```
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source{
-///     #[relationship]
-///     target: Entity,
-/// };
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target(Vec<Entity>);
-/// ```
-/// Testing case with single extra field
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source{
-///     #[relationship]
-///     target: Entity,
-///     foo: String,
-/// };
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target(Vec<Entity>);
-/// ```
-/// Testing case with multiple extra fields
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source{
-///     #[relationship]
-///     target: Entity,
-///     foo: String,
-///     bar: String,
-/// };
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target(Vec<Entity>);
-/// ```
 fn derive_relationship(
     ast: &DeriveInput,
     attrs: &Attrs,
@@ -812,63 +754,6 @@ fn derive_relationship(
     }))
 }
 
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source(Entity);
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target(Vec<Entity>);
-/// ```
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source(Entity);
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target{
-///     related: Vec<Entity>,
-/// }
-/// ```
-/// Testing case with single extra field
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source(Entity);
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target{
-///     #[relationship]
-///     related: Vec<Entity>,
-///     foo: String,
-/// }
-/// ```
-/// Testing case with multiple extra fields
-/// ```
-/// # use bevy_ecs::component::Component;
-/// # use bevy_ecs::entity::Entity;
-/// #[derive(Component)]
-/// #[relationship(relationship_target=Target)]
-/// struct Source(Entity);
-///
-/// #[derive(Component)]
-/// #[relationship_target(relationship=Source)]
-/// struct Target{
-///     #[relationship]
-///     related: Vec<Entity>,
-///     foo: String,
-///     bar: String,
-/// }
-/// ```
 fn derive_relationship_target(
     ast: &DeriveInput,
     attrs: &Attrs,

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -385,4 +385,41 @@ mod tests {
         assert!(!world.entity(b).contains::<Rel>());
         assert!(!world.entity(b).contains::<RelTarget>());
     }
+
+    #[test]
+    fn relationship_with_multiple_non_target_fields_compiles() {
+        #[derive(Component)]
+        #[relationship(relationship_target=Target)]
+        #[expect(dead_code, reason = "test struct")]
+        struct Source {
+            #[relationship]
+            target: Entity,
+            foo: u8,
+            bar: u8,
+        }
+
+        #[derive(Component)]
+        #[relationship_target(relationship=Source)]
+        struct Target(Vec<Entity>);
+
+        // No assert necessary, looking to make sure compilation works with the macros
+    }
+    #[test]
+    fn relationship_target_with_multiple_non_target_fields_compiles() {
+        #[derive(Component)]
+        #[relationship(relationship_target=Target)]
+        struct Source(Entity);
+
+        #[derive(Component)]
+        #[relationship_target(relationship=Source)]
+        #[expect(dead_code, reason = "test struct")]
+        struct Target {
+            #[relationship]
+            target: Vec<Entity>,
+            foo: u8,
+            bar: u8,
+        }
+
+        // No assert necessary, looking to make sure compilation works with the macros
+    }
 }


### PR DESCRIPTION
# Objective

Fixes #18466 

## Solution

Updated the macro generation pattern to place the comma in the correct place in the pattern.

## Testing

- Tried named and unnamed fields in combination, and used rust expand macro tooling to see the generated code and verify its correctness (see screenshots in example below)

---

## Showcase

Screenshot showing expanded macro with multiple named fields
![image](https://github.com/user-attachments/assets/7ecd324c-10ba-4b23-9b53-b94da03567d3)

Screenshot showing expanded macro with single unnamed field
![image](https://github.com/user-attachments/assets/be72f061-5f07-4d19-b5f6-7ff6c35ec679)

## Migration Guide

n/a
