### PR TITLE
Fix `mesh_picking` not working due to mixing vertex and triangle indices.

### DIFF
--- a/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
+++ b/crates/bevy_picking/src/mesh_picking/ray_cast/intersections.rs
@@ -83,9 +83,10 @@ pub fn ray_mesh_intersection<I: TryInto<usize> + Clone + Copy>(
 
         indices
             .chunks_exact(3)
+            .enumerate()
             .fold(
                 (f32::MAX, None),
-                |(closest_distance, closest_hit), triangle| {
+                |(closest_distance, closest_hit), (tri_idx, triangle)| {
                     let [Ok(a), Ok(b), Ok(c)] = [
                         triangle[0].try_into(),
                         triangle[1].try_into(),
@@ -104,7 +105,7 @@ pub fn ray_mesh_intersection<I: TryInto<usize> + Clone + Copy>(
 
                     match ray_triangle_intersection(&ray, &tri_vertices, backface_culling) {
                         Some(hit) if hit.distance >= 0. && hit.distance < closest_distance => {
-                            (hit.distance, Some((a, hit)))
+                            (hit.distance, Some((tri_idx, hit)))
                         }
                         _ => (closest_distance, closest_hit),
                     }


### PR DESCRIPTION
# Objective

- #18495 

## Solution

- The code in the PR #18232 accidentally used a vertex index as a triangle index, causing the wrong triangle to be used for normal computation and if the triangle went out of bounds, it would skip the ray-hit.
- Don't do that.

## Testing

- Run `cargo run --example mesh_picking`