### PR TITLE
Fix LogDiagnosticsPlugin log target typo

### DIFF
--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -92,7 +92,7 @@ impl LogDiagnosticsPlugin {
             };
 
             info!(
-                target: "bevy diagnostic",
+                target: "bevy_diagnostic",
                 // Suffix is only used for 's' or 'ms' currently,
                 // so we reserve two columns for it; however,
                 // Do not reserve columns for the suffix in the average
@@ -103,7 +103,7 @@ impl LogDiagnosticsPlugin {
             );
         } else {
             info!(
-                target: "bevy diagnostic",
+                target: "bevy_diagnostic",
                 "{path:<path_width$}: {value:>.6}{suffix:}",
                 path = diagnostic.path(),
                 suffix = diagnostic.suffix,


### PR DESCRIPTION
# Objective

For the LogDiagnosticsPlugin, the log target is "bevy diagnostic" with a space; I think it may (?) be a typo intended to be "bevy_diagnostic" with an underline. 

I couldn't get filtering INFO level logs with work with this plugin, changing this seems to produce the expected behavior.
