### PR TITLE
don't flip sprites twice

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -789,15 +789,6 @@ pub fn prepare_sprite_image_bind_groups(
                         );
                     }
 
-                    if extracted_sprite.flip_x {
-                        uv_offset_scale.x += uv_offset_scale.z;
-                        uv_offset_scale.z *= -1.0;
-                    }
-                    if extracted_sprite.flip_y {
-                        uv_offset_scale.y += uv_offset_scale.w;
-                        uv_offset_scale.w *= -1.0;
-                    }
-
                     let transform = extracted_sprite.transform.affine()
                         * Affine3A::from_scale_rotation_translation(
                             quad_size.extend(1.0),


### PR DESCRIPTION
# Objective

- After #17041, sprite flipping doesn't work

## Solution

- Sprite flipping is applied twice:
https://github.com/bevyengine/bevy/blob/b6ccc2a2a0fac4d1a8d717920166b32f39b40cd9/crates/bevy_sprite/src/render/mod.rs#L766-L773
https://github.com/bevyengine/bevy/blob/b6ccc2a2a0fac4d1a8d717920166b32f39b40cd9/crates/bevy_sprite/src/render/mod.rs#L792-L799
- Keep one
