### PR TITLE
Add `many_morph_targets` stress test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3012,6 +3012,17 @@ category = "Stress Tests"
 wasm = true
 
 [[example]]
+name = "many_morph_targets"
+path = "examples/stress_tests/many_morph_targets.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.many_morph_targets]
+name = "Many Morph Targets"
+description = "Simple benchmark to test rendering many meshes with animated morph targets."
+category = "Stress Tests"
+wasm = true
+
+[[example]]
 name = "many_glyphs"
 path = "examples/stress_tests/many_glyphs.rs"
 doc-scrape-examples = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -502,6 +502,7 @@ Example | Description
 [Many Gizmos](../examples/stress_tests/many_gizmos.rs) | Test rendering of many gizmos
 [Many Glyphs](../examples/stress_tests/many_glyphs.rs) | Simple benchmark to test text rendering.
 [Many Lights](../examples/stress_tests/many_lights.rs) | Simple benchmark to test rendering many point lights. Run with `WGPU_SETTINGS_PRIO=webgl2` to restrict to uniform buffers and max 256 lights
+[Many Morph Targets](../examples/stress_tests/many_morph_targets.rs) | Simple benchmark to test rendering many meshes with animated morph targets.
 [Many Sprites](../examples/stress_tests/many_sprites.rs) | Displays many sprites in a grid arrangement! Used for performance testing. Use `--colored` to enable color tinted sprites.
 [Many Text2d](../examples/stress_tests/many_text2d.rs) | Displays many Text2d! Used for performance testing.
 [Text Pipeline](../examples/stress_tests/text_pipeline.rs) | Text Pipeline benchmark

--- a/examples/stress_tests/many_morph_targets.rs
+++ b/examples/stress_tests/many_morph_targets.rs
@@ -1,0 +1,124 @@
+//! TODO
+
+use argh::FromArgs;
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::*,
+    scene::SceneInstanceReady,
+    window::{PresentMode, WindowResolution},
+    winit::{UpdateMode, WinitSettings},
+};
+use std::f32::consts::PI;
+
+/// TODO
+#[derive(FromArgs, Resource)]
+struct Args {
+    /// TODO
+    #[argh(option, default = "1024")]
+    count: usize,
+}
+
+fn main() {
+    // `from_env` panics on the web
+    #[cfg(not(target_arch = "wasm32"))]
+    let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
+    App::new()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "Many Morph Targets".to_string(),
+                    present_mode: PresentMode::AutoNoVsync,
+                    resolution: WindowResolution::new(1920.0, 1080.0)
+                        .with_scale_factor_override(1.0),
+                    ..default()
+                }),
+                ..Default::default()
+            }),
+            FrameTimeDiagnosticsPlugin::default(),
+            LogDiagnosticsPlugin::default(),
+        ))
+        .insert_resource(WinitSettings {
+            focused_mode: UpdateMode::Continuous,
+            unfocused_mode: UpdateMode::Continuous,
+        })
+        .insert_resource(AmbientLight {
+            brightness: 1000.0,
+            ..Default::default()
+        })
+        .insert_resource(args)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+#[derive(Component)]
+struct AnimationToPlay(Handle<AnimationClip>);
+
+fn setup(asset_server: Res<AssetServer>, args: Res<Args>, mut commands: Commands) {
+    let scene_handle = asset_server
+        .load(GltfAssetLabel::Scene(0).from_asset("models/animated/MorphStressTest.gltf"));
+
+    let animation_handles = (0..3)
+        .map(|index| {
+            asset_server.load(
+                GltfAssetLabel::Animation(index).from_asset("models/animated/MorphStressTest.gltf"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let count = args.count.max(1);
+    let x_dim = ((count as f32).sqrt().ceil() as usize).max(1);
+    let y_dim = count.div_ceil(x_dim);
+
+    for mesh_index in 0..count {
+        let animation_index = mesh_index.rem_euclid(animation_handles.len());
+        let animation_handle = animation_handles[animation_index].clone();
+
+        let x = 2.5 + (5.0 * ((mesh_index.rem_euclid(x_dim) as f32) - ((x_dim as f32) * 0.5)));
+        let y = -2.2 - (3.0 * ((mesh_index.div_euclid(x_dim) as f32) - ((y_dim as f32) * 0.5)));
+
+        commands
+            .spawn((
+                AnimationToPlay(animation_handle),
+                SceneRoot(scene_handle.clone()),
+                Transform::from_xyz(x, y, 0.0),
+            ))
+            .observe(play_animation);
+    }
+
+    commands.spawn((
+        DirectionalLight::default(),
+        Transform::from_rotation(Quat::from_rotation_z(PI / 2.0)),
+    ));
+
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 0.0, (x_dim as f32) * 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+fn play_animation(
+    trigger: Trigger<SceneInstanceReady>,
+    mut commands: Commands,
+    children: Query<&Children>,
+    animations_to_play: Query<&AnimationToPlay>,
+    mut players: Query<&mut AnimationPlayer>,
+    mut graphs: ResMut<Assets<AnimationGraph>>,
+) {
+    if let Ok(animation_to_play) = animations_to_play.get(trigger.target()) {
+        for child in children.iter_descendants(trigger.target()) {
+            if let Ok(mut player) = players.get_mut(child) {
+                let (graph, animation_index) =
+                    AnimationGraph::from_clip(animation_to_play.0.clone());
+
+                commands
+                    .entity(child)
+                    .insert(AnimationGraphHandle(graphs.add(graph)));
+
+                player.play(animation_index).repeat();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Objective

Add a stress test for morph targets, similar to `many_cubes` and `many_foxes`. This is also a useful smoke test as no other example has morph targets on multiple meshes.

## Solution

![425571366-b043c16c-6e6a-491e-a0bd-5ece630d7bf8](https://github.com/user-attachments/assets/86ef26a4-ad00-46fa-9e5a-0aa4238023e3)

Note that #18465 adds the same stress test. I'll remove it from that PR if this one lands.

## Testing

```sh
cargo run --example many_morph_targets

# Test different mesh counts. Default is 1024.
cargo run --example many_morph_targets -- --count 42
```

Tested on Win10/Vulkan/Nvidia, Wasm/WebGl/Chrome/Win10/Nvidia.