### PR TITLE
Remove Image::from_buffer `name` argument (only present in debug "dds" builds)

### DIFF
--- a/crates/bevy_anti_aliasing/Cargo.toml
+++ b/crates/bevy_anti_aliasing/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["bevy"]
 trace = []
 webgl = []
 webgpu = []
-dds = ["bevy_render/dds", "bevy_image/dds", "bevy_core_pipeline/dds"]
 smaa_luts = ["bevy_render/ktx2", "bevy_image/ktx2", "bevy_image/zstd"]
 
 [dependencies]

--- a/crates/bevy_anti_aliasing/src/smaa/mod.rs
+++ b/crates/bevy_anti_aliasing/src/smaa/mod.rs
@@ -297,8 +297,6 @@ impl Plugin for SmaaPlugin {
             SMAA_AREA_LUT_TEXTURE_HANDLE,
             "SMAAAreaLUT.ktx2",
             |bytes, _: String| Image::from_buffer(
-                #[cfg(all(debug_assertions, feature = "dds"))]
-                "SMAAAreaLUT".to_owned(),
                 bytes,
                 bevy_image::ImageType::Format(bevy_image::ImageFormat::Ktx2),
                 bevy_image::CompressedImageFormats::NONE,
@@ -315,8 +313,6 @@ impl Plugin for SmaaPlugin {
             SMAA_SEARCH_LUT_TEXTURE_HANDLE,
             "SMAASearchLUT.ktx2",
             |bytes, _: String| Image::from_buffer(
-                #[cfg(all(debug_assertions, feature = "dds"))]
-                "SMAASearchLUT".to_owned(),
                 bytes,
                 bevy_image::ImageType::Format(bevy_image::ImageFormat::Ktx2),
                 bevy_image::CompressedImageFormats::NONE,

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -13,7 +13,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-dds = ["bevy_render/dds", "bevy_image/dds"]
 trace = []
 webgl = []
 webgpu = []

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -449,8 +449,6 @@ fn setup_tonemapping_lut_image(bytes: &[u8], image_type: ImageType) -> Image {
         ..default()
     });
     Image::from_buffer(
-        #[cfg(all(debug_assertions, feature = "dds"))]
-        "Tonemapping LUT sampler".to_string(),
         bytes,
         image_type,
         CompressedImageFormats::NONE,

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-dds = ["bevy_render/dds", "bevy_image/dds", "bevy_core_pipeline/dds"]
 pbr_transmission_textures = ["bevy_pbr/pbr_transmission_textures"]
 pbr_multi_layer_material_textures = [
   "bevy_pbr/pbr_multi_layer_material_textures",

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -986,8 +986,6 @@ async fn load_image<'a, 'b>(
             let end = view.offset() + view.length();
             let buffer = &buffer_data[view.buffer().index()][start..end];
             let image = Image::from_buffer(
-                #[cfg(all(debug_assertions, feature = "dds"))]
-                name,
                 buffer,
                 ImageType::MimeType(mime_type),
                 supported_compressed_formats,
@@ -1010,8 +1008,6 @@ async fn load_image<'a, 'b>(
                 let image_type = ImageType::MimeType(data_uri.mime_type);
                 Ok(ImageOrPath::Image {
                     image: Image::from_buffer(
-                        #[cfg(all(debug_assertions, feature = "dds"))]
-                        name,
                         &bytes,
                         mime_type.map(ImageType::MimeType).unwrap_or(image_type),
                         supported_compressed_formats,

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -976,10 +976,7 @@ async fn load_image<'a, 'b>(
 ) -> Result<ImageOrPath, GltfError> {
     let is_srgb = !linear_textures.contains(&gltf_texture.index());
     let sampler_descriptor = texture_sampler(&gltf_texture);
-    #[cfg(all(debug_assertions, feature = "dds"))]
-    let name = gltf_texture
-        .name()
-        .map_or("Unknown GLTF Texture".to_string(), ToString::to_string);
+
     match gltf_texture.source().source() {
         Source::View { view, mime_type } => {
             let start = view.offset();

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -12,7 +12,6 @@ use super::{CompressedImageFormats, Image, TextureError, TranscodeFormat};
 
 #[cfg(feature = "dds")]
 pub fn dds_buffer_to_image(
-    #[cfg(debug_assertions)] name: String,
     buffer: &[u8],
     supported_compressed_formats: CompressedImageFormats,
     is_srgb: bool,
@@ -65,10 +64,7 @@ pub fn dds_buffer_to_image(
     let mip_map_level = match dds.get_num_mipmap_levels() {
         0 => {
             #[cfg(debug_assertions)]
-            once!(warn!(
-                "Mipmap levels for texture {} are 0, bumping them to 1",
-                name
-            ));
+            once!(warn!("Mipmap levels for texture are 0, bumping them to 1",));
             1
         }
         t => t,
@@ -409,7 +405,7 @@ mod test {
             0x49, 0x92, 0x24, 0x16, 0x95, 0xae, 0x42, 0xfc, 0, 0xaa, 0x55, 0xff, 0xff, 0x49, 0x92,
             0x24, 0x49, 0x92, 0x24, 0xd8, 0xad, 0xae, 0x42, 0xaf, 0x0a, 0xaa, 0x55,
         ];
-        let r = dds_buffer_to_image("".into(), &buffer, CompressedImageFormats::BC, true);
+        let r = dds_buffer_to_image(&buffer, CompressedImageFormats::BC, true);
         assert!(r.is_ok());
         if let Ok(r) = r {
             fake_wgpu_create_texture_with_data(&r.texture_descriptor, r.data.as_ref().unwrap());

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -928,7 +928,6 @@ impl Image {
     /// Load a bytes buffer in a [`Image`], according to type `image_type`, using the `image`
     /// crate
     pub fn from_buffer(
-        #[cfg(all(debug_assertions, feature = "dds"))] name: String,
         buffer: &[u8],
         image_type: ImageType,
         #[cfg_attr(
@@ -954,13 +953,7 @@ impl Image {
                 basis_buffer_to_image(buffer, supported_compressed_formats, is_srgb)?
             }
             #[cfg(feature = "dds")]
-            ImageFormat::Dds => dds_buffer_to_image(
-                #[cfg(debug_assertions)]
-                name,
-                buffer,
-                supported_compressed_formats,
-                is_srgb,
-            )?,
+            ImageFormat::Dds => dds_buffer_to_image(buffer, supported_compressed_formats, is_srgb)?,
             #[cfg(feature = "ktx2")]
             ImageFormat::Ktx2 => {
                 ktx2_buffer_to_image(buffer, supported_compressed_formats, is_srgb)?

--- a/crates/bevy_image/src/image_loader.rs
+++ b/crates/bevy_image/src/image_loader.rs
@@ -150,8 +150,6 @@ impl AssetLoader for ImageLoader {
             }
         };
         Ok(Image::from_buffer(
-            #[cfg(all(debug_assertions, feature = "dds"))]
-            load_context.path().display().to_string(),
             &bytes,
             image_type,
             self.supported_compressed_formats,

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -30,13 +30,6 @@ sysinfo_plugin = ["bevy_diagnostic/sysinfo_plugin"]
 
 # Texture formats that have specific rendering support (HDR enabled by default)
 basis-universal = ["bevy_image/basis-universal", "bevy_render/basis-universal"]
-dds = [
-  "bevy_image/dds",
-  "bevy_render/dds",
-  "bevy_core_pipeline/dds",
-  "bevy_anti_aliasing/dds",
-  "bevy_gltf?/dds",
-]
 exr = ["bevy_image/exr", "bevy_render/exr"]
 hdr = ["bevy_image/hdr", "bevy_render/hdr"]
 ktx2 = ["bevy_image/ktx2", "bevy_render/ktx2"]
@@ -57,6 +50,7 @@ qoi = ["bevy_image/qoi"]
 tga = ["bevy_image/tga"]
 tiff = ["bevy_image/tiff"]
 webp = ["bevy_image/webp"]
+dds = ["bevy_image/dds"]
 
 # Enable SPIR-V passthrough
 spirv_shader_passthrough = ["bevy_render/spirv_shader_passthrough"]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -23,7 +23,6 @@ decoupled_naga = []
 
 # Texture formats (require more than just image support)
 basis-universal = ["bevy_image/basis-universal"]
-dds = ["bevy_image/dds"]
 exr = ["bevy_image/exr"]
 hdr = ["bevy_image/hdr"]
 ktx2 = ["dep:ktx2", "bevy_image/ktx2"]


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/17891
- Cherry-picked from https://github.com/bevyengine/bevy/pull/18411

## Solution

The `name` argument could either be made permanent (by removing the `#[cfg(...)]` condition) or eliminated entirely. I opted to remove it, as debugging a specific DDS texture edge case in GLTF files doesn't seem necessary, and there isn't any other foreseeable need to have it.

## Migration Guide

- `Image::from_buffer()` no longer has a `name` argument that's only present in debug builds when the `"dds"` feature is enabled. If you happen to pass a name, remove it.
