### PR TITLE
Bevy update min vers

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -126,8 +126,8 @@ derive_more = { version = "1", default-features = false, features = [
 ] }
 nonmax = { version = "0.5", default-features = false }
 arrayvec = { version = "0.7.4", default-features = false, optional = true }
-smallvec = { version = "1", features = ["union", "const_generics"] }
-indexmap = { version = "2.5.0", default-features = false }
+smallvec = { version = "1.3", features = ["union", "const_generics"] }
+indexmap = { version = "2.6.0", default-features = false }
 variadics_please = { version = "1.1", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 log = { version = "0.4", default-features = false }

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 rust-version = "1.85.0"
 
 [dependencies]
-glam = { version = "0.29", default-features = false, features = ["bytemuck"] }
+glam = { version = "0.29.1", default-features = false, features = ["bytemuck"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = [
   "from",

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -69,7 +69,7 @@ bitvec = { version = "1", optional = true }
 bytemuck = { version = "1", features = ["derive", "must_cast"] }
 radsort = "0.1"
 smallvec = "1.6"
-nonmax = "0.5"
+nonmax = "0.5.1"
 static_assertions = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 offset-allocator = "0.2"

--- a/crates/bevy_remote/Cargo.toml
+++ b/crates/bevy_remote/Cargo.toml
@@ -31,14 +31,14 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 anyhow = "1"
 hyper = { version = "1", features = ["server", "http1"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1" }
+serde_json = { version = "1.0.135" }
 http-body-util = "0.1"
 async-channel = "2"
 
 # dependencies that will not compile on wasm
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 async-io = { version = "2", optional = true }
-smol-hyper = { version = "0.1", optional = true }
+smol-hyper = { version = "0.1.1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -104,7 +104,7 @@ profiling = { version = "1", features = [
   "profile-with-tracing",
 ], optional = true }
 async-channel = "2.3.0"
-nonmax = "0.5"
+nonmax = "0.5.1"
 smallvec = { version = "1.11", features = ["const_new"] }
 offset-allocator = "0.2"
 variadics_please = "1.1"


### PR DESCRIPTION
# Objective

Once while trying to `cargo check` Bevy I ran into a compilation problem where `bevy_remote` referenced a nonexistent function on `serde_json::Map`. Cargo update fixed it but I've been annoyed by the idea of it happening again ever since.

## Solution

Use [`cargo-minimal-versions`](https://github.com/taiki-e/cargo-minimal-versions) to find the minimal dependency version for most our crates. Justification for each version bump has been included in the commit body.

This isn't everything since:
- Compiling `wgpu` ends up with errors. A bunch of their crates end up with incompatible `windows` versions.
- lock_api ends up incorrectly assuming we're compiling with [rustc older than 1.61](https://github.com/Amanieu/parking_lot/blob/ca920b31312839013b4455aba1d53a4aede21b2f/lock_api/build.rs#L6-L8) and doesn't make [`Mutex::new` and `RwLock::new` const functions](https://github.com/Amanieu/parking_lot/blob/ca920b31312839013b4455aba1d53a4aede21b2f/lock_api/src/mutex.rs#L148-L165).
- Somewhere deep in the `cosmic-text` dep graph `font-types` doesn't compile correctly and rust complains that `struct Point<T> {...}` should look like `struct Point<T><T>{...}`

## Testing

`cargo minimal-versions check --workspace`
