### PR TITLE
Fix missed RedrawRequested and WindowCloseRequested events with UpdateMode::Reactive (part 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3639,6 +3639,7 @@ hidden = true
 name = "desktop_request_redraw"
 path = "tests/window/desktop_request_redraw.rs"
 doc-scrape-examples = true
+required-features = ["bevy_dev_tools"]
 
 [package.metadata.example.desktop_request_redraw]
 hidden = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3636,6 +3636,14 @@ doc-scrape-examples = true
 hidden = true
 
 [[example]]
+name = "desktop_request_redraw"
+path = "tests/window/desktop_request_redraw.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.desktop_request_redraw]
+hidden = true
+
+[[example]]
 name = "window_resizing"
 path = "examples/window/window_resizing.rs"
 doc-scrape-examples = true

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -541,12 +541,6 @@ impl<T: Event> WinitAppRunnerState<T> {
         let mut focused_windows_state: SystemState<(Res<WinitSettings>, Query<(Entity, &Window)>)> =
             SystemState::new(self.world_mut());
 
-        if let Some(app_redraw_events) = self.world().get_resource::<Events<RequestRedraw>>() {
-            if redraw_event_reader.read(app_redraw_events).last().is_some() {
-                self.redraw_requested = true;
-            }
-        }
-
         let (config, windows) = focused_windows_state.get(self.world());
         let focused = windows.iter().any(|(_, window)| window.focused);
 

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -646,15 +646,6 @@ impl<T: Event> WinitAppRunnerState<T> {
                 #[cfg(not(feature = "custom_cursor"))]
                 self.update_cursors();
                 self.ran_update_since_last_redraw = true;
-
-                // Read RequestRedraw events that may have been sent during the update
-                if let Some(app_redraw_events) =
-                    self.world().get_resource::<Events<RequestRedraw>>()
-                {
-                    if redraw_event_reader.read(app_redraw_events).last().is_some() {
-                        self.redraw_requested = true;
-                    }
-                }
             } else {
                 self.redraw_requested = true;
             }
@@ -673,6 +664,13 @@ impl<T: Event> WinitAppRunnerState<T> {
                     .last()
                     .is_some()
                 {
+                    self.redraw_requested = true;
+                }
+            }
+
+            // Read RequestRedraw events that may have been sent during the update
+            if let Some(app_redraw_events) = self.world().get_resource::<Events<RequestRedraw>>() {
+                if redraw_event_reader.read(app_redraw_events).last().is_some() {
                     self.redraw_requested = true;
                 }
             }

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -651,6 +651,15 @@ impl<T: Event> WinitAppRunnerState<T> {
                 #[cfg(not(feature = "custom_cursor"))]
                 self.update_cursors();
                 self.ran_update_since_last_redraw = true;
+
+                // Read RequestRedraw events that may have been sent during the update
+                if let Some(app_redraw_events) =
+                    self.world().get_resource::<Events<RequestRedraw>>()
+                {
+                    if redraw_event_reader.read(app_redraw_events).last().is_some() {
+                        self.redraw_requested = true;
+                    }
+                }
             } else {
                 self.redraw_requested = true;
             }

--- a/tests/window/desktop_request_redraw.rs
+++ b/tests/window/desktop_request_redraw.rs
@@ -1,0 +1,87 @@
+//! Desktop request redraw
+use bevy::{prelude::*, window::RequestRedraw, winit::WinitSettings};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(MeshPickingPlugin)
+        .insert_resource(WinitSettings::desktop_app())
+        .add_systems(Startup, setup)
+        .add_systems(Update, (update, redraw.after(update)))
+        .run();
+}
+
+#[derive(Component)]
+struct AnimationActive;
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 5.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+
+    commands.spawn((
+        PointLight {
+            intensity: 1e6,
+            ..Default::default()
+        },
+        Transform::from_xyz(-1.0, 5.0, 1.0),
+    ));
+
+    let node = Node {
+        display: Display::Block,
+        padding: UiRect::all(Val::Px(10.0)),
+        row_gap: Val::Px(10.0),
+        ..Default::default()
+    };
+
+    commands.spawn((
+        node.clone(),
+        children![
+            (
+                node.clone(),
+                children![Text::new("Right click cube to pause animation")]
+            ),
+            (
+                node.clone(),
+                children![Text::new("Left click cube to start animation")]
+            )
+        ],
+    ));
+
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Cuboid::from_length(1.0))),
+            MeshMaterial3d(materials.add(Color::WHITE)),
+            AnimationActive,
+        ))
+        .observe(
+            |trigger: Trigger<Pointer<Click>>, mut commands: Commands| match trigger.button {
+                PointerButton::Primary => {
+                    commands.entity(trigger.target()).insert(AnimationActive);
+                }
+                PointerButton::Secondary => {
+                    commands
+                        .entity(trigger.target())
+                        .remove::<AnimationActive>();
+                }
+                _ => {}
+            },
+        );
+}
+
+fn update(time: Res<Time>, mut query: Query<&mut Transform, With<AnimationActive>>) {
+    if let Ok(mut transform) = query.single_mut() {
+        transform.rotate_x(time.delta_secs().min(1.0 / 60.0));
+    }
+}
+
+fn redraw(mut commands: Commands, query: Query<Entity, With<AnimationActive>>) {
+    if query.iter().next().is_some() {
+        commands.send_event(RequestRedraw);
+    }
+}

--- a/tests/window/desktop_request_redraw.rs
+++ b/tests/window/desktop_request_redraw.rs
@@ -1,10 +1,32 @@
 //! Desktop request redraw
-use bevy::{prelude::*, window::RequestRedraw, winit::WinitSettings};
+use bevy::{
+    dev_tools::fps_overlay::{FpsOverlayConfig, FpsOverlayPlugin},
+    prelude::*,
+    window::RequestRedraw,
+    winit::WinitSettings,
+};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(MeshPickingPlugin)
+        // Enable the FPS overlay with a high resolution refresh interval. This makes it
+        // easier to validate that UpdateMode is behaving correctly when desktop_app is used.
+        // The FPS counter should essentially pause when the cube is not rotating and should
+        // update rapidly when the cube is rotating or there is input (e.g. moving the mouse).
+        //
+        // Left and Right clicking the cube should roggle rotation on/off.
+        .add_plugins(FpsOverlayPlugin {
+            config: FpsOverlayConfig {
+                text_config: TextFont {
+                    font_size: 12.0,
+                    ..default()
+                },
+                text_color: Color::srgb(0.0, 1.0, 0.0),
+                refresh_interval: core::time::Duration::from_millis(16),
+                ..default()
+            },
+        })
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
         .add_systems(Update, (update, redraw.after(update)))


### PR DESCRIPTION
# Objective

This PR continues the work started by @boondocklabs in #17991 in order to fix missed `RedrawRequested` events that are sent during app update. Additionally, this PR now also fixes a similar issue where `WindowCloseRequested` events were also missed during app update. In both cases, the event would not be handled until the **next** app update.

This bug applies when the app is running with **`UpdateMode::Reactive`**. These missed events won't be handled until the next event loop timeout or triggered by a new window or device event (such as moving the mouse).

## Use-Cases

When using `UpdateMode::Reactive`:

1. Sending a `RedrawRequested` event from an `observe` system should trigger a redraw immediately. The app should not stall until the next window event or event loop timeout.
2. Clicking the close button on a window should be handled immediately. The app should not stall until the next window event or event loop timeout.

## Solution

* `RedrawRequested` events are already read and checked in the winit event loop runner. Move this read **after** the app update executes.
* `WindowCloseRequested` were not previously read or checked. Read and check if an event has fired **after** the app update executes.

## Prior Art

The `UpdateMode` itself is (re)read after the app update with a note about re-extracting it since the app update may have changed the value and we should act accordingly. We're essentially applying this same logic (i.e. check after the app update) for `RedrawRequested` and `WindowCloseRequested`.


## Original PR Notes from @boondocklabs 

> ## Solution
> Currently RequestRedraw events can be missed in about_to_wait() as it is can call run_app_update() after reading the event cursor, thus the redraw_requested flag is stale.
>
> This adds a subsequent read after the call to run_app_update to ensure redraw_requested is updated if any events were sent during the update.
>
> ## Testing
> Tested in Reactive mode with animations using a forked bevy_tweening which supports 0.16-dev and sends RequestRedraw events while there are any Animator components active.
>
> Prior to this change, the animation would only run a single update, and would stall for the reactive mode timeout before continuing the animation.
>
> With this patch, the animation runs smooth in Reactive mode. Tested on MacOS and iOS on iPad and iPhone.
