### PR TITLE
don't include file not available on docs.rs

### DIFF
--- a/examples/shader/shader_material_wesl.rs
+++ b/examples/shader/shader_material_wesl.rs
@@ -1,7 +1,7 @@
 //! A shader that uses the WESL shading language.
 
 use bevy::{
-    asset::{load_internal_asset, weak_handle},
+    asset::weak_handle,
     pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::TypePath,
@@ -16,8 +16,6 @@ use bevy::{
 
 /// This example uses shader source files from the assets subdirectory
 const FRAGMENT_SHADER_ASSET_PATH: &str = "shaders/custom_material.wesl";
-/// An example utility shader that is used by the custom material
-pub const UTIL_SHADER_HANDLE: Handle<Shader> = weak_handle!("748706a1-969e-43d4-be36-74559bd31d23");
 
 fn main() {
     App::new()
@@ -34,14 +32,21 @@ fn main() {
 /// A plugin that loads the custom material shader
 pub struct CustomMaterialPlugin;
 
+/// An example utility shader that is used by the custom material
+#[expect(
+    dead_code,
+    reason = "used to kept a strong handle, shader is referenced by the material"
+)]
+#[derive(Resource)]
+struct UtilityShader(Handle<Shader>);
+
 impl Plugin for CustomMaterialPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            UTIL_SHADER_HANDLE,
-            "../../assets/shaders/util.wesl",
-            Shader::from_wesl
-        );
+        let handle = app
+            .world_mut()
+            .resource_mut::<AssetServer>()
+            .load::<Shader>("shaders/util.wesl");
+        app.insert_resource(UtilityShader(handle));
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #18539 
- Doc failed to build as an example `include_str!` an asset, but assets are not available in the packaged crate

## Solution

- Don't `include_str!` the shader but read it at runtime
