### PR TITLE
Use current_exe for default window title

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -25,10 +25,18 @@ use crate::VideoMode;
 ///
 /// It will try to use the name of the current exe if possible, otherwise it defaults to "App"
 static DEFAULT_WINDOW_TITLE: LazyLock<String> = LazyLock::new(|| {
-    std::env::current_exe()
-        .ok()
-        .and_then(|current_exe| Some(format!("{}", current_exe.file_stem()?.to_string_lossy())))
-        .unwrap_or_else(|| "App".to_string())
+    #[cfg(feature = "std")]
+    {
+        std::env::current_exe()
+            .ok()
+            .and_then(|current_exe| Some(format!("{}", current_exe.file_stem()?.to_string_lossy())))
+            .unwrap_or_else(|| "App".to_string())
+    }
+    
+    #[cfg(not(feature = "std"))]
+    {
+        "App".to_string()
+    }
 });
 
 /// Marker [`Component`] for the window considered the primary window.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,7 +1,7 @@
 use alloc::string::ToString;
 use alloc::{format, string::String};
 use core::num::NonZero;
-use std::sync::LazyLock;
+use bevy_platform_support::sync::LazyLock;
 
 use bevy_ecs::{
     entity::{Entity, EntityBorrow},

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,6 +1,5 @@
 use alloc::string::ToString;
 use alloc::{format, string::String};
-use bevy_platform_support::sync::LazyLock;
 use core::num::NonZero;
 
 use bevy_ecs::{
@@ -8,6 +7,7 @@ use bevy_ecs::{
     prelude::Component,
 };
 use bevy_math::{CompassOctant, DVec2, IVec2, UVec2, Vec2};
+use bevy_platform_support::sync::LazyLock;
 use log::warn;
 
 #[cfg(feature = "bevy_reflect")]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,7 +1,7 @@
 use alloc::string::ToString;
 use alloc::{format, string::String};
-use core::num::NonZero;
 use bevy_platform_support::sync::LazyLock;
+use core::num::NonZero;
 
 use bevy_ecs::{
     entity::{Entity, EntityBorrow},
@@ -32,7 +32,7 @@ static DEFAULT_WINDOW_TITLE: LazyLock<String> = LazyLock::new(|| {
             .and_then(|current_exe| Some(format!("{}", current_exe.file_stem()?.to_string_lossy())))
             .unwrap_or_else(|| "App".to_string())
     }
-    
+
     #[cfg(not(feature = "std"))]
     {
         "App".to_string()

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,5 +1,7 @@
-use alloc::{borrow::ToOwned, string::String};
+use alloc::string::ToString;
+use alloc::{format, string::String};
 use core::num::NonZero;
+use std::sync::LazyLock;
 
 use bevy_ecs::{
     entity::{Entity, EntityBorrow},
@@ -18,6 +20,16 @@ use {
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 use crate::VideoMode;
+
+/// Default string used for the window title.
+///
+/// It will try to use the name of the current exe if possible, otherwise it defaults to "App"
+static DEFAULT_WINDOW_TITLE: LazyLock<String> = LazyLock::new(|| {
+    std::env::current_exe()
+        .ok()
+        .and_then(|current_exe| Some(format!("{}", current_exe.file_stem()?.to_string_lossy())))
+        .unwrap_or_else(|| "App".to_string())
+});
 
 /// Marker [`Component`] for the window considered the primary window.
 ///
@@ -429,7 +441,7 @@ pub struct Window {
 impl Default for Window {
     fn default() -> Self {
         Self {
-            title: "App".to_owned(),
+            title: DEFAULT_WINDOW_TITLE.to_string(),
             name: None,
             cursor_options: Default::default(),
             present_mode: Default::default(),

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,5 +1,4 @@
-use alloc::string::ToString;
-use alloc::{format, string::String};
+use alloc::{borrow::ToOwned, format, string::String};
 use core::num::NonZero;
 
 use bevy_ecs::{
@@ -30,12 +29,12 @@ static DEFAULT_WINDOW_TITLE: LazyLock<String> = LazyLock::new(|| {
         std::env::current_exe()
             .ok()
             .and_then(|current_exe| Some(format!("{}", current_exe.file_stem()?.to_string_lossy())))
-            .unwrap_or_else(|| "App".to_string())
+            .unwrap_or_else(|| "App".to_owned())
     }
 
     #[cfg(not(feature = "std"))]
     {
-        "App".to_string()
+        "App".to_owned()
     }
 });
 
@@ -449,7 +448,7 @@ pub struct Window {
 impl Default for Window {
     fn default() -> Self {
         Self {
-            title: DEFAULT_WINDOW_TITLE.to_string(),
+            title: DEFAULT_WINDOW_TITLE.to_owned(),
             name: None,
             cursor_options: Default::default(),
             present_mode: Default::default(),


### PR DESCRIPTION
# Objective

- We currently default to "App" for the window title, it would be nice if examples had more descriptive names

## Solution

- Use `std::env::current_exe` to try to figure out a default title. If it's not present. Use "App".

## Testing

- I tested that examples that set a custom title still use the custom title and that examples without a custom title use the example name

---

### Showcase

Here's the 3d_scene example:

![image](https://github.com/user-attachments/assets/bc67edc7-4211-4479-a027-ee6c52b0bd02)

### Notes

Here's a previous attempt at this from a few years ago https://github.com/bevyengine/bevy/pull/3404

There's some relevant discussion in there, but cart's decision was to default to "App" when no name was found.