### PR TITLE
Improved Require Syntax

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -18,9 +18,9 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 #[require(
     Camera,
     DebandDither,
-    CameraRenderGraph(|| CameraRenderGraph::new(Core2d)),
-    Projection(|| Projection::Orthographic(OrthographicProjection::default_2d())),
-    Frustum(|| OrthographicProjection::default_2d().compute_frustum(&GlobalTransform::from(Transform::default()))),
-    Tonemapping(|| Tonemapping::None),
+    CameraRenderGraph::new(Core2d),
+    Projection::Orthographic(OrthographicProjection::default_2d()),
+    Frustum = OrthographicProjection::default_2d().compute_frustum(&GlobalTransform::from(Transform::default())),
+    Tonemapping::None,
 )]
 pub struct Camera2d;

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -21,8 +21,8 @@ use serde::{Deserialize, Serialize};
 #[reflect(Component, Default, Clone)]
 #[require(
     Camera,
-    DebandDither(|| DebandDither::Enabled),
-    CameraRenderGraph(|| CameraRenderGraph::new(Core3d)),
+    DebandDither::Enabled,
+    CameraRenderGraph::new(Core3d),
     Projection,
     Tonemapping,
     ColorGrading,

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -568,6 +568,9 @@ impl Parse for Require {
         let mut path = input.parse::<Path>()?;
         let mut last_segment_is_lower = false;
         let mut is_constructor_call = false;
+        // Use the case of the type name to check if it's an enum
+        // This doesn't match everything that can be an enum according to the rust spec
+        // but it matches what clippy is OK with
         let is_enum = {
             let mut first_chars = path
                 .segments

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -160,16 +160,69 @@ use thiserror::Error;
 /// assert_eq!(&C(0), world.entity(id).get::<C>().unwrap());
 /// ```
 ///
-/// You can also define a custom constructor function or closure:
+/// You can define inline component values that take the following forms:
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// #[derive(Component)]
+/// #[require(
+///     B(1), // tuple structs
+///     C { value: 1 }, // named-field structs
+///     D::One, // enum variants
+///     E::ONE, // associated consts
+///     F::new(1) // constructors
+/// )]
+/// struct A;
+///
+/// #[derive(Component, PartialEq, Eq, Debug)]
+/// struct B(u8);
+///
+/// #[derive(Component, PartialEq, Eq, Debug)]
+/// struct C {
+///     value: u8
+/// }
+///
+/// #[derive(Component, PartialEq, Eq, Debug)]
+/// enum D {
+///    Zero,
+///    One,
+/// }
+///
+/// #[derive(Component, PartialEq, Eq, Debug)]
+/// struct E(u8);
+///
+/// impl E {
+///     pub const ONE: Self = Self(1);
+/// }
+///
+/// #[derive(Component, PartialEq, Eq, Debug)]
+/// struct F(u8);
+///
+/// impl F {
+///     fn new(value: u8) -> Self {
+///         Self(value)
+///     }
+/// }
+///
+/// # let mut world = World::default();
+/// let id = world.spawn(A).id();
+/// assert_eq!(&B(1), world.entity(id).get::<B>().unwrap());
+/// assert_eq!(&C { value: 1 }, world.entity(id).get::<C>().unwrap());
+/// assert_eq!(&D::One, world.entity(id).get::<D>().unwrap());
+/// assert_eq!(&E(1), world.entity(id).get::<E>().unwrap());
+/// assert_eq!(&F(1), world.entity(id).get::<F>().unwrap());
+/// ````
+///
+///
+/// You can also define arbitrary expressions by using `=`
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// #[derive(Component)]
-/// #[require(C(init_c))]
+/// #[require(C = init_c())]
 /// struct A;
 ///
 /// #[derive(Component, PartialEq, Eq, Debug)]
-/// #[require(C(|| C(20)))]
+/// #[require(C = C(20))]
 /// struct B;
 ///
 /// #[derive(Component, PartialEq, Eq, Debug)]
@@ -188,34 +241,6 @@ use thiserror::Error;
 /// let id = world.spawn(B).id();
 /// assert_eq!(&C(20), world.entity(id).get::<C>().unwrap());
 /// ```
-///
-/// For convenience sake, you can abbreviate enum labels or constant values, with the type inferred to match that of the component you are requiring:
-///
-/// ```
-/// # use bevy_ecs::prelude::*;
-/// #[derive(Component)]
-/// #[require(B = One, C = ONE)]
-/// struct A;
-///
-/// #[derive(Component, PartialEq, Eq, Debug)]
-/// enum B {
-///    Zero,
-///    One,
-///    Two
-/// }
-///
-/// #[derive(Component, PartialEq, Eq, Debug)]
-/// struct C(u8);
-///
-/// impl C {
-///     pub const ONE: Self = Self(1);
-/// }
-///
-/// # let mut world = World::default();
-/// let id = world.spawn(A).id();
-/// assert_eq!(&B::One, world.entity(id).get::<B>().unwrap());
-/// assert_eq!(&C(1), world.entity(id).get::<C>().unwrap());
-/// ````
 ///
 /// Required components are _recursive_. This means, if a Required Component has required components,
 /// those components will _also_ be inserted if they are missing:
@@ -252,13 +277,13 @@ use thiserror::Error;
 /// struct X(usize);
 ///
 /// #[derive(Component, Default)]
-/// #[require(X(|| X(1)))]
+/// #[require(X(1))]
 /// struct Y;
 ///
 /// #[derive(Component)]
 /// #[require(
 ///     Y,
-///     X(|| X(2)),
+///     X(2),
 /// )]
 /// struct Z;
 ///

--- a/crates/bevy_ecs/src/entity/clone_entities.rs
+++ b/crates/bevy_ecs/src/entity/clone_entities.rs
@@ -1229,7 +1229,7 @@ mod tests {
         struct A;
 
         #[derive(Component, Clone, PartialEq, Debug, Default)]
-        #[require(C(|| C(5)))]
+        #[require(C(5))]
         struct B;
 
         #[derive(Component, Clone, PartialEq, Debug)]
@@ -1257,7 +1257,7 @@ mod tests {
         struct A;
 
         #[derive(Component, Clone, PartialEq, Debug, Default)]
-        #[require(C(|| C(5)))]
+        #[require(C(5))]
         struct B;
 
         #[derive(Component, Clone, PartialEq, Debug)]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1926,7 +1926,7 @@ mod tests {
         struct X;
 
         #[derive(Component)]
-        #[require(Z(new_z))]
+        #[require(Z = new_z())]
         struct Y {
             value: String,
         }
@@ -2651,7 +2651,7 @@ mod tests {
         struct MyRequired(bool);
 
         #[derive(Component, Default)]
-        #[require(MyRequired(|| MyRequired(false)))]
+        #[require(MyRequired(false))]
         struct MiddleMan;
 
         #[derive(Component, Default)]
@@ -2659,7 +2659,7 @@ mod tests {
         struct ConflictingRequire;
 
         #[derive(Component, Default)]
-        #[require(MyRequired(|| MyRequired(true)))]
+        #[require(MyRequired(true))]
         struct MyComponent;
 
         let mut world = World::new();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -5836,7 +5836,7 @@ mod tests {
         struct A;
 
         #[derive(Component, Clone, PartialEq, Debug, Default)]
-        #[require(C(|| C(3)))]
+        #[require(C(3))]
         struct B;
 
         #[derive(Component, Clone, PartialEq, Debug, Default)]

--- a/crates/bevy_pbr/src/decal/forward.rs
+++ b/crates/bevy_pbr/src/decal/forward.rs
@@ -67,7 +67,7 @@ impl Plugin for ForwardDecalPlugin {
 /// * Looking at forward decals at a steep angle can cause distortion. This can be mitigated by padding your decal's
 ///   texture with extra transparent pixels on the edges.
 #[derive(Component, Reflect)]
-#[require(Mesh3d(|| Mesh3d(FORWARD_DECAL_MESH_HANDLE)))]
+#[require(Mesh3d(FORWARD_DECAL_MESH_HANDLE))]
 pub struct ForwardDecal;
 
 /// Type alias for an extended material with a [`ForwardDecalMaterialExt`] extension.

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -5,5 +5,5 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// Marker struct for buttons
 #[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
-#[require(Node, FocusPolicy(|| FocusPolicy::Block), Interaction)]
+#[require(Node, FocusPolicy::Block, Interaction)]
 pub struct Button;


### PR DESCRIPTION
# Objective

Requires are currently more verbose than they need to be. People would like to define inline component values. Additionally, the current `#[require(Foo(custom_constructor))]` and `#[require(Foo(|| Foo(10))]` syntax doesn't really make sense within the context of the Rust type system. #18309 was an attempt to improve ergonomics for some cases, but it came at the cost of even more weirdness / unintuitive behavior. Our approach as a whole needs a rethink.

## Solution

Rework the `#[require()]` syntax to make more sense. This is a breaking change, but I think it will make the system easier to learn, while also improving ergonomics substantially:

```rust
#[derive(Component)]
#[require(
    A, // this will use A::default()
    B(1), // inline tuple-struct value
    C { value: 1 }, // inline named-struct value
    D::Variant, // inline enum variant
    E::SOME_CONST, // inline associated const
    F::new(1), // inline constructor
    G = returns_g(), // an expression that returns G
    H = SomethingElse::new(), // expression returns SomethingElse, where SomethingElse: Into<H> 
)]
struct Foo;
```

## Migration Guide

Custom-constructor requires should use the new expression-style syntax:

```rust
// before
#[derive(Component)]
#[require(A(returns_a))]
struct Foo;

// after
#[derive(Component)]
#[require(A = returns_a())]
struct Foo;
```

Inline-closure-constructor requires should use the inline value syntax where possible:

```rust
// before
#[derive(Component)]
#[require(A(|| A(10))]
struct Foo;

// after
#[derive(Component)]
#[require(A(10)]
struct Foo;
```

In cases where that is not possible, use the expression-style syntax:

```rust
// before
#[derive(Component)]
#[require(A(|| A(10))]
struct Foo;

// after
#[derive(Component)]
#[require(A = A(10)]
struct Foo;
```
