### PR TITLE
don't wait during publishing

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -11,7 +11,6 @@ do
   pushd "$crate"
   cargo publish
   popd
-  sleep 20
 done
 
 popd


### PR DESCRIPTION
# Objective

- Publishing takes a long time
- There's a 20 second wait between crates to not hit the rate limit on crates.io

## Solution

- Our rate limit has been increased by the crates.io team, don't wait anymore!
