### PR TITLE
bevy-ui widgets abstraction

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -39,7 +39,7 @@ pub use render::*;
 pub use ui_material::*;
 pub use ui_node::*;
 
-use widget::{ImageNode, ImageNodeSize};
+use widget::{BorderStyle, ColorStyle, EventsPlugin, ImageNode, ImageNodeSize, PickingEvent};
 
 /// The UI prelude.
 ///
@@ -59,7 +59,10 @@ pub mod prelude {
             geometry::*,
             ui_material::*,
             ui_node::*,
-            widget::{Button, ImageNode, Label, NodeImageMode},
+            widget::{
+                BorderGeometry, BorderStyle, Button, ColorStyle, Event, EventsDispatch, ImageNode,
+                Label, NodeImageMode, WidgetBundle,
+            },
             Interaction, MaterialNode, UiMaterialPlugin, UiScale,
         },
         // `bevy_sprite` re-exports for texture slicing
@@ -142,6 +145,7 @@ struct AmbiguousWithUpdateText2DLayout;
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<UiSurface>()
+            .add_plugins(EventsPlugin::<PickingEvent>::default())
             .init_resource::<UiScale>()
             .init_resource::<UiStack>()
             .register_type::<BackgroundColor>()
@@ -169,6 +173,9 @@ impl Plugin for UiPlugin {
             .register_type::<UiAntiAlias>()
             .register_type::<TextShadow>()
             .register_type::<ComputedNodeTarget>()
+            .register_type::<ColorStyle>()
+            .register_type::<BorderStyle>()
+            .register_type::<ShadowStyle>()
             .configure_sets(
                 PostUpdate,
                 (
@@ -183,6 +190,7 @@ impl Plugin for UiPlugin {
             .add_systems(
                 PreUpdate,
                 ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),
+                // widget::handle_button_clicks,
             );
 
         #[cfg(feature = "bevy_ui_picking_backend")]

--- a/crates/bevy_ui/src/widget/builder.rs
+++ b/crates/bevy_ui/src/widget/builder.rs
@@ -1,0 +1,247 @@
+use std::ops::{Deref, DerefMut};
+
+use crate::{
+    AlignContent, AlignItems, AlignSelf, BoxSizing, Display, FlexDirection, FlexWrap, GridAutoFlow,
+    GridPlacement, GridTrack, JustifyContent, JustifyItems, JustifySelf, Node, Overflow,
+    OverflowClipMargin, PositionType, RepeatedGridTrack, UiRect, Val,
+};
+
+/// A shared [`Node`] builder API that can be auto-implemented for types that can deref to `Node`
+pub trait WidgetNodeBuilder {
+    fn display(self, input: Display) -> Self;
+    fn box_sizing(self, input: BoxSizing) -> Self;
+    fn position_type(self, input: PositionType) -> Self;
+    fn left(self, input: Val) -> Self;
+    fn right(self, input: Val) -> Self;
+    fn top(self, input: Val) -> Self;
+    fn bottom(self, input: Val) -> Self;
+    fn flex_direction(self, input: FlexDirection) -> Self;
+    fn flex_wrap(self, input: FlexWrap) -> Self;
+    fn align_items(self, input: AlignItems) -> Self;
+    fn justify_items(self, input: JustifyItems) -> Self;
+    fn align_self(self, input: AlignSelf) -> Self;
+    fn justify_self(self, input: JustifySelf) -> Self;
+    fn align_content(self, input: AlignContent) -> Self;
+    fn justify_content(self, input: JustifyContent) -> Self;
+    fn margin(self, input: UiRect) -> Self;
+    fn padding(self, input: UiRect) -> Self;
+    fn border(self, input: UiRect) -> Self;
+    fn flex_grow(self, input: f32) -> Self;
+    fn flex_shrink(self, input: f32) -> Self;
+    fn flex_basis(self, input: Val) -> Self;
+    fn width(self, input: Val) -> Self;
+    fn height(self, input: Val) -> Self;
+    fn min_width(self, input: Val) -> Self;
+    fn min_height(self, input: Val) -> Self;
+    fn max_width(self, input: Val) -> Self;
+    fn max_height(self, input: Val) -> Self;
+    fn aspect_ratio(self, input: Option<f32>) -> Self;
+    fn overflow(self, input: Overflow) -> Self;
+    fn overflow_clip_margin(self, input: OverflowClipMargin) -> Self;
+    fn row_gap(self, input: Val) -> Self;
+    fn column_gap(self, input: Val) -> Self;
+    fn grid_auto_flow(self, input: GridAutoFlow) -> Self;
+    fn grid_template_rows(self, input: Vec<RepeatedGridTrack>) -> Self;
+    fn grid_template_columns(self, input: Vec<RepeatedGridTrack>) -> Self;
+    fn grid_auto_rows(self, input: Vec<GridTrack>) -> Self;
+    fn grid_auto_columns(self, input: Vec<GridTrack>) -> Self;
+    fn grid_column(self, input: GridPlacement) -> Self;
+    fn grid_row(self, input: GridPlacement) -> Self;
+}
+
+impl<T: Deref<Target = Node> + DerefMut> WidgetNodeBuilder for T {
+    fn display(mut self, input: Display) -> Self {
+        self.deref_mut().display = input;
+        self
+    }
+
+    fn box_sizing(mut self, input: BoxSizing) -> Self {
+        self.deref_mut().box_sizing = input;
+        self
+    }
+
+    fn position_type(mut self, input: PositionType) -> Self {
+        self.deref_mut().position_type = input;
+        self
+    }
+
+    fn left(mut self, input: Val) -> Self {
+        self.deref_mut().left = input;
+        self
+    }
+
+    fn right(mut self, input: Val) -> Self {
+        self.deref_mut().right = input;
+        self
+    }
+
+    fn top(mut self, input: Val) -> Self {
+        self.deref_mut().top = input;
+        self
+    }
+
+    fn bottom(mut self, input: Val) -> Self {
+        self.deref_mut().bottom = input;
+        self
+    }
+
+    fn flex_direction(mut self, input: FlexDirection) -> Self {
+        self.deref_mut().flex_direction = input;
+        self
+    }
+
+    fn flex_wrap(mut self, input: FlexWrap) -> Self {
+        self.deref_mut().flex_wrap = input;
+        self
+    }
+
+    fn align_items(mut self, input: AlignItems) -> Self {
+        self.deref_mut().align_items = input;
+        self
+    }
+
+    fn justify_items(mut self, input: JustifyItems) -> Self {
+        self.deref_mut().justify_items = input;
+        self
+    }
+
+    fn align_self(mut self, input: AlignSelf) -> Self {
+        self.deref_mut().align_self = input;
+        self
+    }
+
+    fn justify_self(mut self, input: JustifySelf) -> Self {
+        self.deref_mut().justify_self = input;
+        self
+    }
+
+    fn align_content(mut self, input: AlignContent) -> Self {
+        self.deref_mut().align_content = input;
+        self
+    }
+
+    fn justify_content(mut self, input: JustifyContent) -> Self {
+        self.deref_mut().justify_content = input;
+        self
+    }
+
+    fn margin(mut self, input: UiRect) -> Self {
+        self.deref_mut().margin = input;
+        self
+    }
+
+    fn padding(mut self, input: UiRect) -> Self {
+        self.deref_mut().padding = input;
+        self
+    }
+
+    fn border(mut self, input: UiRect) -> Self {
+        self.deref_mut().border = input;
+        self
+    }
+
+    fn flex_grow(mut self, input: f32) -> Self {
+        self.deref_mut().flex_grow = input;
+        self
+    }
+
+    fn flex_shrink(mut self, input: f32) -> Self {
+        self.deref_mut().flex_shrink = input;
+        self
+    }
+
+    fn flex_basis(mut self, input: Val) -> Self {
+        self.deref_mut().flex_basis = input;
+        self
+    }
+
+    fn width(mut self, input: Val) -> Self {
+        self.deref_mut().width = input;
+        self
+    }
+
+    fn height(mut self, input: Val) -> Self {
+        self.deref_mut().height = input;
+        self
+    }
+
+    fn min_width(mut self, input: Val) -> Self {
+        self.deref_mut().min_width = input;
+        self
+    }
+
+    fn min_height(mut self, input: Val) -> Self {
+        self.deref_mut().min_height = input;
+        self
+    }
+
+    fn max_width(mut self, input: Val) -> Self {
+        self.deref_mut().max_width = input;
+        self
+    }
+
+    fn max_height(mut self, input: Val) -> Self {
+        self.deref_mut().max_height = input;
+        self
+    }
+
+    fn aspect_ratio(mut self, input: Option<f32>) -> Self {
+        self.deref_mut().aspect_ratio = input;
+        self
+    }
+
+    fn overflow(mut self, input: Overflow) -> Self {
+        self.deref_mut().overflow = input;
+        self
+    }
+
+    fn overflow_clip_margin(mut self, input: OverflowClipMargin) -> Self {
+        self.deref_mut().overflow_clip_margin = input;
+        self
+    }
+
+    fn row_gap(mut self, input: Val) -> Self {
+        self.deref_mut().row_gap = input;
+        self
+    }
+
+    fn column_gap(mut self, input: Val) -> Self {
+        self.deref_mut().column_gap = input;
+        self
+    }
+
+    fn grid_auto_flow(mut self, input: GridAutoFlow) -> Self {
+        self.deref_mut().grid_auto_flow = input;
+        self
+    }
+
+    fn grid_template_rows(mut self, input: Vec<RepeatedGridTrack>) -> Self {
+        self.deref_mut().grid_template_rows = input;
+        self
+    }
+
+    fn grid_template_columns(mut self, input: Vec<RepeatedGridTrack>) -> Self {
+        self.deref_mut().grid_template_columns = input;
+        self
+    }
+
+    fn grid_auto_rows(mut self, input: Vec<GridTrack>) -> Self {
+        self.deref_mut().grid_auto_rows = input;
+        self
+    }
+
+    fn grid_auto_columns(mut self, input: Vec<GridTrack>) -> Self {
+        self.deref_mut().grid_auto_columns = input;
+        self
+    }
+
+    fn grid_column(mut self, input: GridPlacement) -> Self {
+        self.deref_mut().grid_column = input;
+        self
+    }
+
+    fn grid_row(mut self, input: GridPlacement) -> Self {
+        self.deref_mut().grid_row = input;
+        self
+    }
+}

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -1,9 +1,21 @@
 use crate::{FocusPolicy, Interaction, Node};
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{bundle::Bundle, component::Component, reflect::ReflectComponent};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+
+use super::{Event, WidgetBundle};
 
 /// Marker struct for buttons
 #[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[require(Node, FocusPolicy::Block, Interaction)]
 pub struct Button;
+
+#[derive(Bundle)]
+pub struct ButtonBundle {
+    pub base: WidgetBundle,
+}
+
+/// Create a button widget with default styling
+pub fn make_button<T: Event>(base_bundle: WidgetBundle) -> ButtonBundle {
+    ButtonBundle { base: base_bundle }
+}

--- a/crates/bevy_ui/src/widget/events.rs
+++ b/crates/bevy_ui/src/widget/events.rs
@@ -1,0 +1,107 @@
+use bevy_app::{Plugin, PreUpdate};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{
+    component::Component,
+    resource::Resource,
+    system::{Query, ResMut},
+};
+use bevy_picking::events::*;
+use bevy_reflect::Reflect;
+use std::{collections::VecDeque, marker::PhantomData};
+
+/// A widget can subscribe to an event type with this component
+#[derive(Component, Debug, Clone, PartialEq, Eq, Reflect, Deref, DerefMut)]
+#[reflect(Component, Default, Debug, PartialEq, Clone)]
+pub struct EventsReactor<T: Event>(pub(crate) VecDeque<T>);
+
+impl<T: Event + 'static> Default for EventsReactor<T> {
+    fn default() -> Self {
+        Self(VecDeque::new())
+    }
+}
+
+/// A resource acts as a single sender per event type
+#[derive(Resource)]
+pub struct EventsDispatch<T: Event + 'static> {
+    queue: VecDeque<T>,
+}
+
+impl<T: Event + 'static> Default for EventsDispatch<T> {
+    fn default() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+}
+
+impl<T: Event + 'static> EventsDispatch<T> {
+    pub fn send(&mut self, event: T) {
+        self.queue.push_back(event);
+    }
+}
+
+/// Marker trait for a user event type
+pub trait Event: Clone + Send + Sync + 'static {}
+impl<T: Clone + Send + Sync + 'static> Event for T {}
+
+/// A generic events relay plugin
+pub struct EventsPlugin<T: Event> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Event> Default for EventsPlugin<T> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: Event + 'static> Plugin for EventsPlugin<T> {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.init_resource::<EventsDispatch<T>>();
+	app.register_type::<EventsReactor<T>>();
+	app.register_type::<T>();
+        app.add_systems(PreUpdate, relay_events::<T>);
+    }
+}
+
+/// Take queued events from a dispatch and insert it into every reactor for the same type
+fn relay_events<T: Event + 'static>(
+    mut dispatch: ResMut<EventsDispatch<T>>,
+    mut q: Query<&mut EventsReactor<T>>,
+) {
+    for ev in &mut dispatch.queue {
+        for mut reactor in q.iter_mut() {
+.            reactor.0.push_back(ev.clone());
+        }
+    }
+}
+
+/// A simple map of `bevy_picking` input events to `bevy_ui::widget` interaction events
+#[derive(Clone, PartialEq, Debug, Reflect, Component)]
+#[reflect(Debug, Clone)]
+pub enum PickingEvent {
+    Over(Pointer<Over>),
+    Out(Pointer<Out>),
+    Click(Pointer<Click>),
+    Move(Pointer<Move>),
+    DragStart(Pointer<DragStart>),
+    Drag(Pointer<Drag>),
+    DragEnd(Pointer<DragEnd>),
+    DragEnter(Pointer<DragEnter>),
+    DragOver(Pointer<DragOver>),
+    DragLeave(Pointer<DragLeave>),
+    DragDrop(Pointer<DragDrop>),
+    DragEntry(Pointer<DragEntry>),
+    Scroll(Pointer<Scroll>),
+}
+
+// // user code
+// pub enum MyEvent {}
+
+// #[derive(Component)]
+// struct MyMarker;
+
+// // Users write this:
+// fn handle_my_event(mut q: Query<&mut EventsReactor<MyEvent>, With<MyMarker>>) {}

--- a/crates/bevy_ui/src/widget/mod.rs
+++ b/crates/bevy_ui/src/widget/mod.rs
@@ -3,11 +3,112 @@
 mod button;
 mod image;
 mod label;
-
 mod text;
+
+use crate::Node;
+
+use bevy_color::{Color, Srgba};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{bundle::Bundle, component::Component};
+use bevy_math::Vec2;
+use bevy_reflect::Reflect;
 
 pub use button::*;
 pub use image::*;
 pub use label::*;
-
 pub use text::*;
+
+pub enum Style {
+    Color(ColorStyle),
+    Border(BorderStyle),
+}
+
+/// A full color palette in use across
+#[derive(Component)]
+pub struct ColorStyle {
+    pub background: Color,
+    pub text: Color,
+    pub primary: Color,
+    pub secondary: Color,
+    pub success: Color,
+    pub failure: Color,
+    pub note: Color,
+}
+
+impl Default for ColorStyle {
+    fn default() -> Self {
+        // Solarized Light, stolen from iced-rs :p
+        Self {
+            background: Srgba::rgb_u8(0x00, 0x2b, 0x36).into(), // base03
+            text: Srgba::rgb_u8(0x65, 0x7b, 0x83).into(),       // base00
+            primary: Srgba::rgb_u8(0x2a, 0xa1, 0x98).into(),    // cyan
+            secondary: Srgba::rgb_u8(0x2a, 0xa1, 0x98).into(),  // cyan
+            success: Srgba::rgb_u8(0x85, 0x99, 0x00).into(),    // green
+            failure: Srgba::rgb_u8(0xb5, 0x89, 0x00).into(),    // yellow
+            note: Srgba::rgb_u8(0xdc, 0x32, 0x2f).into(),       // red
+        }
+    }
+}
+
+#[derive(Component, Default)]
+pub struct BorderStyle {
+    pub color: Color,
+    pub size: Vec2,
+    pub geom: BorderGeometry,
+}
+
+#[derive(Default)]
+pub enum BorderGeometry {
+    Dotted,
+    Dashed,
+    Solid,
+    Double,
+    Groove,
+    Ridge,
+    Outset,
+    #[default]
+    None,
+    Hidden,
+}
+
+/// A stack of style changes that can be pushed into or "rolled back" to previous ones
+#[derive(Component, Default, Reflect)]
+pub struct Rollback<T>(Vec<T>);
+
+impl<T> Rollback<T> {
+    pub fn push(&mut self, t: T) {
+        self.0.push(t);
+    }
+
+    pub fn roll_back(&mut self) -> Option<T> {
+        self.0.pop()
+    }
+}
+
+#[derive(Bundle, Deref, DerefMut)]
+pub struct WidgetBundle {
+    #[deref]
+    pub node: Node,
+    pub color: ColorStyle,
+    pub border: BorderStyle,
+}
+
+/*
+
+Node styling
+- CSS layout parameters
+- Theme/ palette
+- Local style overrides
+
+Interactions
+- Focus
+- Hover
+- Click
+- Touch (?)
+- Drag
+- DragInternal (?)
+- Keyboard
+
+
+
+*/

--- a/crates/bevy_ui/src/widget/mod.rs
+++ b/crates/bevy_ui/src/widget/mod.rs
@@ -1,19 +1,30 @@
 //! This module contains the basic building blocks of Bevy's UI
 
 mod button;
+mod events;
 mod image;
 mod label;
 mod text;
 
-use crate::Node;
-
+use crate::{
+    AlignContent, AlignItems, AlignSelf, BorderRadius, Display, FlexDirection, FlexWrap,
+    JustifyContent, JustifyItems, JustifySelf, Node, ReflectComponent, ReflectDefault, UiRect, Val,
+};
 use bevy_color::{Color, Srgba};
-use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::{bundle::Bundle, component::Component};
+use bevy_ecs::{
+    bundle::Bundle,
+    component::Component,
+    entity::Entity,
+    observer::Trigger,
+    query::With,
+    system::{Commands, Query},
+};
 use bevy_math::Vec2;
+use bevy_picking::events::{Over, Pointer};
 use bevy_reflect::Reflect;
 
 pub use button::*;
+pub use events::*;
 pub use image::*;
 pub use label::*;
 pub use text::*;
@@ -24,7 +35,8 @@ pub enum Style {
 }
 
 /// A full color palette in use across
-#[derive(Component)]
+#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[reflect(Component, Default, Debug, Clone)]
 pub struct ColorStyle {
     pub background: Color,
     pub text: Color,
@@ -50,14 +62,19 @@ impl Default for ColorStyle {
     }
 }
 
-#[derive(Component, Default)]
+#[derive(Component, Default, Clone, Debug, Reflect)]
+#[reflect(Component, Default, Debug, Clone)]
 pub struct BorderStyle {
     pub color: Color,
     pub size: Vec2,
     pub geom: BorderGeometry,
 }
 
-#[derive(Default)]
+#[derive(Component, Default)]
+pub struct ShadowStyle {}
+
+#[derive(Default, Copy, Clone, Debug, Reflect)]
+#[reflect(Default, Debug, Clone)]
 pub enum BorderGeometry {
     Dotted,
     Dashed,
@@ -85,12 +102,30 @@ impl<T> Rollback<T> {
     }
 }
 
-#[derive(Bundle, Deref, DerefMut)]
+/// All components of a basic widget entity
+///
+/// This type also implements two sets of "builder" APIs:
+///
+/// - Mapping `Node` attributes to specify basic layout information
+///
+/// - "Picking" interface with `.observe(...)`, which can be enabled or disabled dynamically via the
+/// `UiActive` component
+///
+/// - Widget "event reactor" API that lets users specify their own UI event type which can be
+/// emitted and handled by widgets for widget-to-widget communication.  See [Elm] for the underlying
+/// model of constructing UI trees.
+#[derive(Bundle, Default)]
 pub struct WidgetBundle {
-    #[deref]
+    /// Size and layout info
     pub node: Node,
+    /// Color scheme used in this widget tree
     pub color: ColorStyle,
+    /// Border layout and color info
     pub border: BorderStyle,
+    /// Rounded corners
+    pub border_radius: BorderRadius,
+    /// React to basic picking events
+    pub picking: EventsReactor<PickingEvent>,
 }
 
 /*
@@ -108,7 +143,192 @@ Interactions
 - Drag
 - DragInternal (?)
 - Keyboard
-
-
-
 */
+
+impl WidgetBundle {
+    /// Set width and height to 100%
+    #[inline]
+    pub fn fill_parent(self) -> Self {
+        Self {
+            node: Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn width(self, w: impl Into<Val>) -> Self {
+        Self {
+            node: Node {
+                width: w.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn height(self, h: impl Into<Val>) -> Self {
+        Self {
+            node: Node {
+                height: h.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn display(self, d: impl Into<Display>) -> Self {
+        Self {
+            node: Node {
+                display: d.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn flex_direction(self, d: impl Into<FlexDirection>) -> Self {
+        Self {
+            node: Node {
+                flex_direction: d.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn flex_wrap(self, w: impl Into<FlexWrap>) -> Self {
+        Self {
+            node: Node {
+                flex_wrap: w.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn align_items(self, a: impl Into<AlignItems>) -> Self {
+        Self {
+            node: Node {
+                align_items: a.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+    #[inline]
+    pub fn align_content(self, a: impl Into<AlignContent>) -> Self {
+        Self {
+            node: Node {
+                align_content: a.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+    #[inline]
+    pub fn align_self(self, a: impl Into<AlignSelf>) -> Self {
+        Self {
+            node: Node {
+                align_self: a.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn justify_items(self, a: impl Into<JustifyItems>) -> Self {
+        Self {
+            node: Node {
+                justify_items: a.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+    #[inline]
+    pub fn justify_content(self, a: impl Into<JustifyContent>) -> Self {
+        Self {
+            node: Node {
+                justify_content: a.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+    #[inline]
+    pub fn justify_self(self, a: impl Into<JustifySelf>) -> Self {
+        Self {
+            node: Node {
+                justify_self: a.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+    #[inline]
+    pub fn padding(self, p: impl Into<UiRect>) -> Self {
+        Self {
+            node: Node {
+                padding: p.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+    #[inline]
+    pub fn margin(self, m: impl Into<UiRect>) -> Self {
+        Self {
+            node: Node {
+                margin: m.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn border(self, b: impl Into<UiRect>) -> Self {
+        Self {
+            node: Node {
+                border: b.into(),
+                ..self.node
+            },
+            ..self
+        }
+    }
+
+    #[inline]
+    pub fn border_radius(self, b: impl Into<BorderRadius>) -> Self {
+        Self {
+            border_radius: b.into(),
+            ..self
+        }
+    }
+}
+
+pub fn apply_observe(mut commands: Commands, q: Query<Entity, With<EventsReactor<PickingEvent>>>) {
+    // fixme: ideally we don't want to re-apply `observe` on nodes that already do so, or where the
+    // observation strategy hasn't changed.  Considering there's currently no way for a user to
+    // insert their own effects here, this is probably a bad design.  Someone in code review will
+    // complain about it :p
+    for ent in q.iter() {
+        commands.entity(ent).observe(
+            |trig: Trigger<Pointer<Over>>, mut reactor: Query<&mut EventsReactor<PickingEvent>>| {
+                let mut reactor = reactor.get_mut(trig.target()).unwrap();
+                reactor
+                    .0
+                    .push_back(PickingEvent::Over(trig.event().clone()));
+            },
+        );
+    }
+}


### PR DESCRIPTION
(This PR is extremely work in progress and mostly here for me to keep track of changes I've made to bevy in my own project development.  Feel free to ignore until I set it to ready)

# Objective

- Improve the workflow for creating user interfaces with `bevy_ui`
- Provide high-level widget types (label, button, text input, check box, radio box, drop down menus (hamburgers), progress bars, toggle switch, + containers such as "`<div>`", scroll area, panel grid, + ?)
- Create a system for widgets to easily communicate with each other via events (somewhat inspired by Elm, but not really)

## Solution

Most of this is aggressively unimplemented 😅 

- Widget builder APIs should abstract away some of the "plumbing" components and chose some defaults for the user
  - To unify configuration of input event and user event handling the widget builder functions need access to their `EntityCommands` (for `.observe`, unless there is a way to observe som trigger by adding a component 🥲), and so e.g. `button(ecmds, ...)` must take an `EntityCommands` as its first parameter.
  - Builder functions return a specialised builder per widget (i.e. `button(...)` returns a `ButtonWidgetBuilder`)
  - Builder interfaces are defined as traits, then implemented by any builder that can.  Any type that can `DerefMut` to `Node` implements the `WidgetNodeBuilder` trait
  - tbh... I'm still working on it 😅
- Defaults are taken from a `Theme`
  - Not sure yet if this should be a resource or component.
  - If it's a resource the theme can easily be switched at run-time.
  - If it's a component then it's easy to assign a different theme for a specific widget, and potentially tree of widgets
- Allow widgets to be notified via events
  - Technically a single-producer-multi-consumer (`Res<EventsDispatch<T>`), but semantically a multi-producer-multi-consumer channel
  - A widget can be given the `EventsReactor<T>` and query for incoming events each update (`Query<&mut EventsReactor<T>>`)
  - An individual `EventsPlugin<T>` needs to be added per event
  - `bevy_ui` adds the `PickingEvent` which wraps interactions with `bevy_picking`
    - This is used to automatically draw interaction effects with a widget (i.e. button clicks)
    - There should be a way to specify interaction effects in the `Theme` but no idea how yet
  - Widgets can react to different events at the same time
  - Currently this system is extremely simplistic



## Testing

I'll be sure to do some.

---

## Showcase

One day,,,
