### PR TITLE
Only include files when packaging `bevy`, rather than excluding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,14 @@ version = "0.16.0-dev"
 edition = "2024"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A refreshingly simple data-driven game engine and app framework"
-exclude = ["assets/", "tools/", ".github/", "crates/", "examples/wasm/assets/"]
+include = [
+  "docs/**",
+  "docs-rs/**",
+  "src/**",
+  "/LICENSE-APACHE",
+  "/LICENSE-MIT",
+  "/README.md",
+]
 homepage = "https://bevyengine.org"
 keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A refreshingly simple data-driven game engine and app framework"
 include = [
-  "docs/**",
-  "docs-rs/**",
-  "src/**",
+  "/docs/**",
+  "/docs-rs/**",
+  "/src/**",
   "/LICENSE-APACHE",
   "/LICENSE-MIT",
   "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ description = "A refreshingly simple data-driven game engine and app framework"
 include = [
   "/docs/**",
   "/docs-rs/**",
+  "/examples/**",
   "/src/**",
+  "/tests/**",
+  "/tests-integration",
   "/LICENSE-APACHE",
   "/LICENSE-MIT",
   "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,15 @@ description = "A refreshingly simple data-driven game engine and app framework"
 include = [
   "/docs/**",
   "/docs-rs/**",
+  # Examples are shown alongside the documentation on docs.rs
   "/examples/**",
+  # However, these files just waste space.
+  "!/examples/no_std/README.md",
+  "!/examples/stress_tests/README.md",
+  "!/examples/wasm/**",
+  "!/examples/README.md",
   "/src/**",
   "/tests/**",
-  "/tests-integration",
   "/LICENSE-APACHE",
   "/LICENSE-MIT",
   "/README.md",


### PR DESCRIPTION
# Objective
Reduce the size of `.crate` files generated by `cargo package` or `cargo publish` for the `bevy` package.

## Solution
Change what files are included in a `.crate` file, by only including necessary folders and files, rather than excluding a few specific folders and keeping the rest.

As a result of this change, several files and folders are no longer included in the generated `.crate` files:

* `.cargo/` - Only contains `config_fast_builds.toml`, which does nothing unless renamed to `config.toml`
* `docs-template/` - Only used for generating documentation
* `examples/wasm/` - Does not contain any examples that would be scraped by rustdoc.
* `examples/no_std/README.md`, `examples/stress_tests/README.md`, `examples/README.md` - These README files aren't used anywhere in the docs, so they just take up space in the `.crate`
* `working-migration-guides/`, `working-release-notes/` - These are only relevant for building up documentation that will be released alongside `0.16` proper.
* `.gitattributes`, `.gitignore` - Only used for the repo, and have no effect on how Cargo handles the package
* `clippy.toml`, `deny.toml`, `rustfmt.toml`, `typos.toml` - Only relevant when developing Bevy
* `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `CREDITS.md` - Only relevant in their latest form as contained on the repo (so there's not much point to packaging these up, since they can quickly become outdated)

## Testing

This change was tested following these steps:

1. Run `cargo package` at the root of the repo
2. Rename the resulting `.crate` file so it isn't overwritten later
3. Insert the changes from this PR into `/Cargo.toml`
4. Run `cargo package` at the root of the repo
5. Compare the resulting `.crate` file sizes

I performed my testing on Windows 10 22H2, with Rust 1.85.1, using commit 0d90da896be1bc2dfaf700fe61f9f41939fe7b69. Only one change was made from this commit that was unrelated to testing: The removal of an instance of `"bevy_internal/bevy_anti_aliasing"` from `/Cargo.toml`. This was done because Cargo would complain about the use of a non-existent feature otherwise - I do not believe it affects the results in any major way.