### PR TITLE
Fix animation transitions affecting other entities

### DIFF
--- a/crates/bevy_animation/src/transition.rs
+++ b/crates/bevy_animation/src/transition.rs
@@ -118,8 +118,9 @@ pub fn advance_transitions(
     // is divided between all the other layers, eventually culminating in the
     // currently-playing animation receiving whatever's left. This results in a
     // nicely normalized weight.
-    let mut remaining_weight = 1.0;
     for (mut animation_transitions, mut player) in query.iter_mut() {
+        let mut remaining_weight = 1.0;
+
         for transition in &mut animation_transitions.transitions.iter_mut().rev() {
             // Decrease weight.
             transition.current_weight = (transition.current_weight


### PR DESCRIPTION
## Objective

 Fix #18557.

## Solution

As described in the bug, `remaining_weight` should have been inside the loop.

## Testing

Locally changed the `animated_mesh_control` example to spawn multiple meshes and play different transitions.