### PR TITLE
Delete migration guide section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,11 +36,3 @@ println!("My super cool code.");
 ```
 
 </details>
-
-## Migration Guide
-
-> This section is optional. If there are no breaking changes, you can delete this section.
-
-- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
-- Simply adding new functionality is not a breaking change.
-- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.


### PR DESCRIPTION
# Objective

Due to the work outlined in #18441, we're no longer storing the migration guides on the PR description.

## Solution

Delete the section of the PR template that suggests you do this.