### PR TITLE
Fix and improve tracy rendering spans

### DIFF
--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -87,10 +87,10 @@ impl RenderGraphRunner {
         finalizer(render_context.command_encoder());
 
         let (render_device, mut diagnostics_recorder) = {
+            let (commands, render_device, diagnostics_recorder) = render_context.finish();
+
             #[cfg(feature = "trace")]
             let _span = info_span!("submit_graph_commands").entered();
-
-            let (commands, render_device, diagnostics_recorder) = render_context.finish();
             queue.submit(commands);
 
             (render_device, diagnostics_recorder)

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -498,6 +498,10 @@ impl<'w> RenderContext<'w> {
 
         let mut command_buffers = Vec::with_capacity(self.command_buffer_queue.len());
 
+        #[cfg(feature = "trace")]
+        let _command_buffer_generation_tasks_span =
+            info_span!("command_buffer_generation_tasks").entered();
+
         #[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
         {
             let mut task_based_command_buffers = ComputeTaskPool::get().scope(|task_pool| {
@@ -536,6 +540,9 @@ impl<'w> RenderContext<'w> {
                 }
             }
         }
+
+        #[cfg(feature = "trace")]
+        drop(_command_buffer_generation_tasks_span);
 
         command_buffers.sort_unstable_by_key(|(i, _)| *i);
 


### PR DESCRIPTION
* `submit_graph_commands` was incorrectly timing the command buffer generation tasks as well, and not only the queue submission. Moved the span to fix that.
* Added a new `command_buffer_generation_tasks` span as a parent for all the individual command buffer generation tasks that don't run as part of the Core3d span.

![image](https://github.com/user-attachments/assets/5a20c2f5-f1df-4c03-afbb-4865327aea33)
