### PR TITLE
Update the version of glam required by bevy_reflect to 0.29.2

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -99,7 +99,7 @@ derive_more = { version = "1", default-features = false, features = ["from"] }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 assert_type_match = "0.1.1"
 smallvec = { version = "1.11", default-features = false, optional = true }
-glam = { version = "0.29", default-features = false, features = [
+glam = { version = "0.29.2", default-features = false, features = [
   "serde",
 ], optional = true }
 petgraph = { version = "0.7", features = ["serde-1"], optional = true }


### PR DESCRIPTION
# Objective

- Avoid breaking builds for projects that have glam `0.29.0` in their `Cargo.lock` files.

## Solution

Reflection support for additional `glam` types were added in #17493, which were only introduced to `glam` in [`0.29.1`][glam-changelog]. If you have a `Cargo.lock` file that refers to `0.29.0`, then `bevy_derive` will fail to compile.

The workaround is easy enough once you figure out what's going on, but specifying the required minimum will avoid the paper cut for others.

`0.29.2` is used here as the required version to include the fix for a regression that was introduced `0.29.1`.

[glam-changelog]: <https://github.com/bitshifter/glam-rs/blob/main/CHANGELOG.md#0291---2024-10-30>
