### PR TITLE
Added `StableInterpolate` implementations for linear colors.

### DIFF
--- a/crates/bevy_color/src/interpolate.rs
+++ b/crates/bevy_color/src/interpolate.rs
@@ -1,24 +1,20 @@
-use bevy_math::StableInterpolate;
+use bevy_math::{StableInterpolate, VectorSpace};
 
 use crate::{Laba, LinearRgba, Oklaba, Srgba, Xyza};
 
 macro_rules! impl_stable_interpolate_linear {
-    ($name: ident $(, $field: ident)*) => {
-        impl StableInterpolate for $name {
+    ($($name: ident),*) => {
+        $(impl StableInterpolate for $name {
             fn interpolate_stable(&self, other: &Self, t: f32) -> Self {
-                $name {
-                    $($field: self.$field.interpolate_stable(&other.$field, t),)*
-                }
+                $name::lerp(*self, *other, t)
             }
-        }
+        })*
     };
 }
 
-impl_stable_interpolate_linear!(LinearRgba, red, green, blue, alpha);
-impl_stable_interpolate_linear!(Srgba, red, green, blue, alpha);
-impl_stable_interpolate_linear!(Xyza, x, y, z, alpha);
-impl_stable_interpolate_linear!(Laba, lightness, a, b, alpha);
-impl_stable_interpolate_linear!(Oklaba, lightness, a, b, alpha);
+impl_stable_interpolate_linear! {
+    LinearRgba, Srgba, Xyza, Laba, Oklaba
+}
 
 #[cfg(test)]
 mod test {

--- a/crates/bevy_color/src/interpolate.rs
+++ b/crates/bevy_color/src/interpolate.rs
@@ -1,0 +1,38 @@
+use bevy_math::StableInterpolate;
+
+use crate::{Laba, LinearRgba, Oklaba, Srgba, Xyza};
+
+macro_rules! impl_stable_interpolate_linear {
+    ($name: ident $(, $field: ident)*) => {
+        impl StableInterpolate for $name {
+            fn interpolate_stable(&self, other: &Self, t: f32) -> Self {
+                $name {
+                    $($field: self.$field.interpolate_stable(&other.$field, t),)*
+                }
+            }
+        }
+    };
+}
+
+impl_stable_interpolate_linear!(LinearRgba, red, green, blue, alpha);
+impl_stable_interpolate_linear!(Srgba, red, green, blue, alpha);
+impl_stable_interpolate_linear!(Xyza, x, y, z, alpha);
+impl_stable_interpolate_linear!(Laba, lightness, a, b, alpha);
+impl_stable_interpolate_linear!(Oklaba, lightness, a, b, alpha);
+
+#[cfg(test)]
+mod test {
+    use bevy_math::StableInterpolate;
+
+    use crate::Srgba;
+
+    #[test]
+    pub fn test_color_stable_interpolate() {
+        let b = Srgba::BLACK;
+        let w = Srgba::WHITE;
+        assert_eq!(
+            b.interpolate_stable(&w, 0.5),
+            Srgba::new(0.5, 0.5, 0.5, 1.0),
+        );
+    }
+}

--- a/crates/bevy_color/src/interpolate.rs
+++ b/crates/bevy_color/src/interpolate.rs
@@ -1,20 +1,4 @@
-use bevy_math::{StableInterpolate, VectorSpace};
-
-use crate::{Laba, LinearRgba, Oklaba, Srgba, Xyza};
-
-macro_rules! impl_stable_interpolate_linear {
-    ($($name: ident),*) => {
-        $(impl StableInterpolate for $name {
-            fn interpolate_stable(&self, other: &Self, t: f32) -> Self {
-                $name::lerp(*self, *other, t)
-            }
-        })*
-    };
-}
-
-impl_stable_interpolate_linear! {
-    LinearRgba, Srgba, Xyza, Laba, Oklaba
-}
+//! TODO: Implement for non-linear colors.
 
 #[cfg(test)]
 mod test {

--- a/crates/bevy_color/src/interpolate.rs
+++ b/crates/bevy_color/src/interpolate.rs
@@ -20,7 +20,7 @@ impl_stable_interpolate_linear! {
 mod test {
     use bevy_math::StableInterpolate;
 
-    use crate::Srgba;
+    use crate::{Gray, Laba, LinearRgba, Oklaba, Srgba, Xyza};
 
     #[test]
     pub fn test_color_stable_interpolate() {
@@ -30,5 +30,24 @@ mod test {
             b.interpolate_stable(&w, 0.5),
             Srgba::new(0.5, 0.5, 0.5, 1.0),
         );
+
+        let b = LinearRgba::BLACK;
+        let w = LinearRgba::WHITE;
+        assert_eq!(
+            b.interpolate_stable(&w, 0.5),
+            LinearRgba::new(0.5, 0.5, 0.5, 1.0),
+        );
+
+        let b = Xyza::BLACK;
+        let w = Xyza::WHITE;
+        assert_eq!(b.interpolate_stable(&w, 0.5), Xyza::gray(0.5),);
+
+        let b = Laba::BLACK;
+        let w = Laba::WHITE;
+        assert_eq!(b.interpolate_stable(&w, 0.5), Laba::new(0.5, 0.0, 0.0, 1.0),);
+
+        let b = Oklaba::BLACK;
+        let w = Oklaba::WHITE;
+        assert_eq!(b.interpolate_stable(&w, 0.5), Oklaba::gray(0.5),);
     }
 }

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -105,6 +105,7 @@ mod color_range;
 mod hsla;
 mod hsva;
 mod hwba;
+mod interpolate;
 mod laba;
 mod lcha;
 mod linear_rgba;

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -266,6 +266,12 @@ macro_rules! impl_componentwise_vector_space {
                 $($element: 0.0,)+
             };
         }
+
+        impl bevy_math::StableInterpolate for $ty {
+            fn interpolate_stable(&self, other: &Self, t: f32) -> Self {
+                bevy_math::VectorSpace::lerp(*self, *other, t)
+            }
+        }
     };
 }
 


### PR DESCRIPTION
# Objective

Colors currently do not implement `StableInterpolate`, which makes them ineligible for functions like `smooth_nudge` and make some generic APIs awkward.

## Solution

Implemented `StableInterpolate` for linear color types that should be uncontroversial. Non-linear types like `Hsl` are not implemented in this PR.

## Testing

Added a test that checks implementations are correct.
