### PR TITLE
Fix shader pre-pass compile failure when using AlphaMode::Blend and a Mesh without UVs (`0.16.0-rc.2`)

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -25,8 +25,10 @@ fn prepass_alpha_discard(in: VertexOutput) {
 #ifdef BINDLESS
     let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
     var output_color: vec4<f32> = pbr_bindings::material_array[material_indices[slot].material].base_color;
+    let flags = pbr_bindings::material_array[material_indices[slot].material].flags;
 #else   // BINDLESS
     var output_color: vec4<f32> = pbr_bindings::material.base_color;
+    let flags = pbr_bindings::material.flags;
 #endif  // BINDLESS
 
 #ifdef VERTEX_UVS
@@ -38,10 +40,8 @@ fn prepass_alpha_discard(in: VertexOutput) {
 
 #ifdef BINDLESS
     let uv_transform = pbr_bindings::material_array[material_indices[slot].material].uv_transform;
-    let flags = pbr_bindings::material_array[material_indices[slot].material].flags;
 #else   // BINDLESS
     let uv_transform = pbr_bindings::material.uv_transform;
-    let flags = pbr_bindings::material.flags;
 #endif  // BINDLESS
 
     uv = (uv_transform * vec3(uv, 1.0)).xy;


### PR DESCRIPTION
# Objective

The flags are referenced later outside of the VERTEX_UVS ifdef/endif block. The current behavior causes the pre-pass shader to fail to compile when UVs are not present in the mesh, such as when using a `LineStrip` to render a grid. 

Fixes #18600

## Solution

Move the definition of the `flags` outside of the ifdef/endif block.

## Testing

Ran a modified `3d_example` that used a mesh and material with alpha_mode blend, `LineStrip` topology, and no UVs.
