### PR TITLE
Add comment to custom vertex attribute example to make it easier to convert to 2D

### DIFF
--- a/assets/shaders/custom_vertex_attribute.wgsl
+++ b/assets/shaders/custom_vertex_attribute.wgsl
@@ -1,3 +1,5 @@
+// For 2d replace `bevy_pbr::mesh_functions` with `bevy_sprite::mesh2d_functions`
+// and `mesh_position_local_to_clip` with `mesh2d_position_local_to_clip`.
 #import bevy_pbr::mesh_functions::{get_world_from_local, mesh_position_local_to_clip}
 
 struct CustomMaterial {


### PR DESCRIPTION
# Objective

- It's not clear what changes are needed to the shader to convert the example to 2D.
- Fixes #14077

## Solution

A separate example probably isn't needed as there is little difference between 3D and 2D, but a note saying what changes are needed to the shader would make it a lot easier.

## Testing

- I just spent a long time working it out the hard way. This would have made it a lot quicker.