### PR TITLE
Add NonNilUuid support to bevy_reflect

### DIFF
--- a/crates/bevy_reflect/src/impls/uuid.rs
+++ b/crates/bevy_reflect/src/impls/uuid.rs
@@ -10,3 +10,12 @@ impl_reflect_opaque!(::uuid::Uuid(
     PartialEq,
     Hash
 ));
+
+impl_reflect_opaque!(::uuid::NonNilUuid(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    Hash
+));


### PR DESCRIPTION
# Objective

- If using a `NonNilUuid` in Bevy, it's difficult to reflect it.

## Solution

- Adds `NonNilUuid` using `impl_reflect_opaque!`.

## Testing

- Built with no issues found locally.
- Essentially the same as the `Uuid` support except without `Default`.
