### PR TITLE
Remote entity reservation v7

### DIFF
--- a/crates/bevy_ecs/src/entity/entity_allocation.rs
+++ b/crates/bevy_ecs/src/entity/entity_allocation.rs
@@ -22,11 +22,28 @@ struct Chunk {
     first: AtomicPtr<Slot>,
 }
 
+impl Chunk {
+    const NUM_CHUNKS: usize = 24;
+
+    /// Computes the capacity of the chunk at this index within [`Self::NUM_CHUNKS`].
+    /// The first 2 have length 512 (2^9) and the last has length (2^31)
+    fn capacity_of_chunk(chunk_index: usize) -> usize {
+        // We do this because we're skipping the first 8 powers, so we need to make up for them by doubling the first index.
+        // This is why the first 2 indices both have a capacity of 256.
+        let corrected = chunk_index.max(1);
+        // We add 8 because the total capacity should be as if [`Self::NUM_CHUNKS`] were 32.
+        // This skips the first 8 powers.
+        let corrected = corrected + 8;
+        // This bit shift is just 2^corrected.
+        1 << corrected
+    }
+}
+
 /// This is the shared data for the owned list.
 /// It is the source of truth.
 struct OwnedBuffer {
-    /// Each chunk has a length the power of 2. The first has length 256 (2^8) and the last has length (2^31)
-    chunks: [Chunk; 24],
+    /// Each chunk has a length the power of 2.
+    chunks: [Chunk; Chunk::NUM_CHUNKS],
     /// This is the total length of the buffer; the sum of each of the [`chunks`](Self::chunks)'s length.
     len: AtomicUsize,
     /// This points to the index in this buffer of the first [`Slot`] that is pending reuse.
@@ -38,4 +55,17 @@ struct OwnedBuffer {
 /// This includes empty archetype entities and entities pending reuse.
 pub struct Owned {
     buffer: Arc<OwnedBuffer>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure the total capacity of [`OwnedBuffer`] is `u32::MAX + 1`, since the max *index* of an [`Entity`] is `u32::MAX`.
+    #[test]
+    fn chunk_capacity_sums() {
+        let total: usize = (0..Chunk::NUM_CHUNKS).map(Chunk::capacity_of_chunk).sum();
+        let expected = u32::MAX as usize + 1;
+        assert_eq!(total, expected);
+    }
 }

--- a/crates/bevy_ecs/src/entity/entity_allocation.rs
+++ b/crates/bevy_ecs/src/entity/entity_allocation.rs
@@ -353,6 +353,8 @@ impl Owned {
                 last_empty as usize,
                 Ordering::Relaxed,
             );
+            Some(fill_in)
+        }
     }
 
     /// This makes this [`Entity`] in the buffer's empty archetype, returning it's index in the buffer.

--- a/crates/bevy_ecs/src/entity/entity_allocation.rs
+++ b/crates/bevy_ecs/src/entity/entity_allocation.rs
@@ -225,14 +225,17 @@ impl Owned {
         self.set(entity, index);
         // We change the length only after the item is valid.
         self.len += 1;
-        self.buffer.len.store(self.len, Ordering::Relaxed);
 
-        // TODO: What if an allocation happens now?
+        // Start by setting this to 0 to prevent remote allocations while we min the `free_cursor`
+        self.buffer.len.store(0, Ordering::Relaxed);
 
         // If this changes the free cursor, this must be the only free entity, so it should be set to this index.
         self.buffer
             .free_cursor
             .fetch_min(index as usize, Ordering::Relaxed);
+
+        // Set the len now that everything is valid.
+        self.buffer.len.store(self.len, Ordering::Relaxed);
 
         index
     }

--- a/crates/bevy_ecs/src/entity/entity_allocation.rs
+++ b/crates/bevy_ecs/src/entity/entity_allocation.rs
@@ -1,0 +1,41 @@
+use bevy_platform_support::{
+    prelude::Vec,
+    sync::{
+        atomic::{AtomicPtr, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use core::mem::MaybeUninit;
+
+use bevy_utils::syncunsafecell::SyncUnsafeCell;
+
+use super::Entity;
+
+/// This is the item we store in the owned buffers.
+/// It might not be init (if it's out of bounds).
+/// It's in an unsafe cell (makes things simpler.)
+type Slot = MaybeUninit<SyncUnsafeCell<Entity>>;
+
+/// Each chunk stores a buffer of [`Slot`]s at a fixed capacity.
+struct Chunk {
+    /// Points to the first slot. If this is null, we need to allocate it.
+    first: AtomicPtr<Slot>,
+}
+
+/// This is the shared data for the owned list.
+/// It is the source of truth.
+struct OwnedBuffer {
+    /// Each chunk has a length the power of 2. The first has length 256 (2^8) and the last has length (2^31)
+    chunks: [Chunk; 24],
+    /// This is the total length of the buffer; the sum of each of the [`chunks`](Self::chunks)'s length.
+    len: AtomicUsize,
+    /// This points to the index in this buffer of the first [`Slot`] that is pending reuse.
+    free_cursor: AtomicUsize,
+}
+
+/// This is the owned list.
+/// It contains all entities owned by an allocator.
+/// This includes empty archetype entities and entities pending reuse.
+pub struct Owned {
+    buffer: Arc<OwnedBuffer>,
+}

--- a/crates/bevy_ecs/src/entity/entity_allocation.rs
+++ b/crates/bevy_ecs/src/entity/entity_allocation.rs
@@ -23,11 +23,11 @@ struct Chunk {
 }
 
 impl Chunk {
-    const NUM_CHUNKS: usize = 24;
+    const NUM_CHUNKS: u32 = 24;
 
     /// Computes the capacity of the chunk at this index within [`Self::NUM_CHUNKS`].
     /// The first 2 have length 512 (2^9) and the last has length (2^31)
-    fn capacity_of_chunk(chunk_index: usize) -> usize {
+    fn capacity_of_chunk(chunk_index: u32) -> u32 {
         // We do this because we're skipping the first 8 powers, so we need to make up for them by doubling the first index.
         // This is why the first 2 indices both have a capacity of 256.
         let corrected = chunk_index.max(1);
@@ -37,13 +37,21 @@ impl Chunk {
         // This bit shift is just 2^corrected.
         1 << corrected
     }
+
+    /// For this index in the whole buffer, returns the index of the [`Chunk`] and the index within that chunk.
+    fn get_indices(full_idnex: u32) -> (u32, u32) {
+        let leading = full_idnex.leading_zeros().min(Self::NUM_CHUNKS - 1);
+        let chunk_index = Self::NUM_CHUNKS - 1 - leading;
+        let slice_index = full_idnex & !Self::capacity_of_chunk(chunk_index);
+        (chunk_index, slice_index)
+    }
 }
 
 /// This is the shared data for the owned list.
 /// It is the source of truth.
 struct OwnedBuffer {
     /// Each chunk has a length the power of 2.
-    chunks: [Chunk; Chunk::NUM_CHUNKS],
+    chunks: [Chunk; Chunk::NUM_CHUNKS as usize],
     /// This is the total length of the buffer; the sum of each of the [`chunks`](Self::chunks)'s length.
     len: AtomicUsize,
     /// This points to the index in this buffer of the first [`Slot`] that is pending reuse.
@@ -60,12 +68,39 @@ pub struct Owned {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     /// Ensure the total capacity of [`OwnedBuffer`] is `u32::MAX + 1`, since the max *index* of an [`Entity`] is `u32::MAX`.
     #[test]
     fn chunk_capacity_sums() {
-        let total: usize = (0..Chunk::NUM_CHUNKS).map(Chunk::capacity_of_chunk).sum();
+        let total: usize = (0..Chunk::NUM_CHUNKS)
+            .map(Chunk::capacity_of_chunk)
+            .map(|x| x as usize)
+            .sum();
         let expected = u32::MAX as usize + 1;
         assert_eq!(total, expected);
+    }
+
+    /// Ensure [`OwnedBuffer`] can be properly indexed
+    #[test]
+    fn chunk_indexing() {
+        let to_test = vec![
+            (0, (0, 0)), // index 0 cap = 512
+            (1, (0, 1)),
+            (256, (0, 256)),
+            (511, (0, 511)),
+            (512, (1, 0)), // index 1 cap = 512
+            (1023, (1, 511)),
+            (1024, (2, 0)), // index 2 cap = 1024
+            (1025, (2, 1)),
+            (2047, (2, 1023)),
+            (2048, (3, 0)), // index 3 cap = 2048
+            (4095, (3, 2047)),
+            (4096, (4, 0)), // index 3 cap = 4096
+        ];
+
+        for (input, output) in to_test {
+            assert_eq!(Chunk::get_indices(input), output);
+        }
     }
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -37,8 +37,10 @@
 //! [`EntityWorldMut::remove`]: crate::world::EntityWorldMut::remove
 
 mod clone_entities;
+mod entity_allocation;
 mod entity_set;
 mod map_entities;
+
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 #[cfg(all(feature = "bevy_reflect", feature = "serialize"))]


### PR DESCRIPTION
# Objective

This is v7, so you get the idea. See also v6 (#18525). I'll fill this in more if we proceed here.

## Solution

The full design plan is in #18577. A few things changed (actually for the better) as I wrote this.
Instead of accommodating remote reservation from the free list all the time, it is disable very briefly during some operations.
Namely, when freeing an entity or moving it out of the empty archetype, remote reservation will have to get a new brand new entity index. This is faster than the alternative. The only downside is that remote reservation may (very rarely) increase the total number of entities when one could be reused instead. But that would be rare, and it's better than blocking / waiting IMO.

Costs: 
- spawning an empty reusing freed list = 1 atomic op.
- spawning an empty not reusing freed list = 2 atomic op.
- remotely spawning an empty reusing freed list = 2 atomic op.
- remotely spawning an empty not reusing freed list = 3 atomic op.
- allocating a non-empty entity reusing freed list = 2 atomic op.
- allocating a non-empty entity without reusing freed list = 3  atomic op.
- moving archetype of reused entity from empty archetype = 1 atomic op if there's no pending entity, else 3 atomic ops.
- moving an entity into the empty archetype = 2 atomic ops if there's nothing pending, else 4.
- freeing a non-empty entity = 3 atomic ops

Future:
- freeing an empty entity is currently moving its archetype and then freeing (6 ops average), but we can make a faster impl later.
- Currently freeing, spawning, allocating (etc) can only do one entity at a time. On paper we can batch this. Ex: freeing 100 entities should in the long run be no more atomic ops than freeing 1.

## Draft

This is ver much a draft to facilitate discussion. This does not interact with `EntityMeta` or the rest of the ECS yet.
Only the atomic aspects of the design have been built.