### PR TITLE
Expose skins_use_uniform_buffers() necessary to use pre-existing setup_morph_and_skinning_defs() API.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -49,7 +49,6 @@ use bevy_utils::{default, Parallel, TypeIdMap};
 use core::any::TypeId;
 use core::mem::size_of;
 use material_bind_groups::MaterialBindingId;
-use render::skin;
 use tracing::{error, warn};
 
 use self::irradiance_volume::IRRADIANCE_VOLUMES_ARE_USABLE;
@@ -1865,7 +1864,7 @@ impl FromWorld for MeshPipeline {
                 &render_device,
                 &render_adapter,
             ),
-            skins_use_uniform_buffers: skin::skins_use_uniform_buffers(&render_device),
+            skins_use_uniform_buffers: skins_use_uniform_buffers(&render_device),
         }
     }
 }
@@ -3004,7 +3003,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
             offset_count += 1;
         }
         if let Some(current_skin_index) = current_skin_byte_offset {
-            if skin::skins_use_uniform_buffers(&render_device) {
+            if skins_use_uniform_buffers(&render_device) {
                 dynamic_offsets[offset_count] = current_skin_index.byte_offset;
                 offset_count += 1;
             }
@@ -3017,7 +3016,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
         // Attach motion vectors if needed.
         if has_motion_vector_prepass {
             // Attach the previous skin index for motion vector computation.
-            if skin::skins_use_uniform_buffers(&render_device) {
+            if skins_use_uniform_buffers(&render_device) {
                 if let Some(current_skin_byte_offset) = current_skin_byte_offset {
                     dynamic_offsets[offset_count] = current_skin_byte_offset.byte_offset;
                     offset_count += 1;

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -13,4 +13,4 @@ pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
-pub use skin::{extract_skins, prepare_skins, SkinUniforms, MAX_JOINTS};
+pub use skin::{extract_skins, prepare_skins, skins_use_uniform_buffers, SkinUniforms, MAX_JOINTS};


### PR DESCRIPTION
# Objective

As of bevy 0.16-dev, the pre-existing public function `bevy::pbr::setup_morph_and_skinning_defs()` is now passed a boolean flag called `skins_use_uniform_buffers`. The value of this boolean is computed by the function `bevy_pbr::render::skin::skins_use_uniform_buffers()`, but it is not exported publicly.

Found while porting [bevy_mod_outline](https://github.com/komadori/bevy_mod_outline) to 0.16.

## Solution

Add `skin::skins_use_uniform_buffers` to the re-export list of `bevy_pbr::render`.

## Testing

Confirmed test program can access public API.