### PR TITLE
Expose symbols needed to replicate SetMeshBindGroup in ecosystem crates.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -938,7 +938,7 @@ impl RenderMeshInstances {
     }
 
     /// Returns the ID of the mesh asset attached to the given entity, if any.
-    pub(crate) fn mesh_asset_id(&self, entity: MainEntity) -> Option<AssetId<Mesh>> {
+    pub fn mesh_asset_id(&self, entity: MainEntity) -> Option<AssetId<Mesh>> {
         match *self {
             RenderMeshInstances::CpuBuilding(ref instances) => instances.mesh_asset_id(entity),
             RenderMeshInstances::GpuBuilding(ref instances) => instances.mesh_asset_id(entity),

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -13,4 +13,5 @@ pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
+pub use morph::MorphIndices;
 pub use skin::{extract_skins, prepare_skins, SkinUniforms, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -13,5 +13,5 @@ pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
-pub use morph::{MorphIndices, MorphUniforms};
+pub use morph::*;
 pub use skin::{extract_skins, prepare_skins, skins_use_uniform_buffers, SkinUniforms, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -13,5 +13,5 @@ pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
-pub use morph::MorphIndices;
+pub use morph::{MorphIndices, MorphUniforms};
 pub use skin::{extract_skins, prepare_skins, skins_use_uniform_buffers, SkinUniforms, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -14,7 +14,7 @@ use bytemuck::NoUninit;
 
 #[derive(Component)]
 pub struct MorphIndex {
-    pub(super) index: u32,
+    pub index: u32,
 }
 
 /// Maps each mesh affected by morph targets to the applicable offset within the


### PR DESCRIPTION
# Objective

My ecosystem crate, bevy_mod_outline, currently uses `SetMeshBindGroup` as part of its custom rendering pipeline. I would like to allow for possibility that, due to changes in 0.16, I need to customise the behaviour of `SetMeshBindGroup` in order to make it work. However, not all of the symbol needed to implement this render command are public outside of Bevy.

## Solution

- Include `MorphIndices` in re-export list. I feel this is morally equivalent to `SkinUniforms` already being exported.
- Change `MorphIndex::index` field to be public. I feel this is morally equivalent to the `SkinByteOffset::byte_offset` field already being public.
- Change `RenderMeshIntances::mesh_asset_id()` to be public (although since all the fields of `RenderMeshInstances` are public it's possible to work around this one by reimplementing).

These changes exclude:
- Making any change to the `RenderLightmaps` type as I don't need to bind the light-maps for my use-case and I wanted to keep these changes minimal. It has a private field which would need to be public or have access methods.
- The changes already included in #18612.

## Testing

Confirmed that a copy of `SetMeshBindGroup` can be compiled outside of Bevy with these changes, provided that the light-map code is removed.