### PR TITLE
Avoid performance pitfalls in update_previous_global_transform system

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -270,7 +270,7 @@ pub fn any_camera_active(views: Query<&Camera, Or<(With<Camera3d>, With<ShadowVi
     views.iter().any(|camera| camera.is_active)
 }
 
-/// Updates the [`PreviousGlobalTransform`] of all meshes that have a [`PreviousMeshFilter`] component,
+/// Updates the [`PreviousGlobalTransform`] of all meshes that match the [`PreviousMeshFilter`],
 /// inserting it if needed.
 pub fn update_mesh_previous_global_transforms(
     mut commands: Commands,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -191,7 +191,6 @@ where
                 // This can't be an attribute on the mesh types due to the shape of our dependency graph
                 .register_required_components::<Mesh3d, PreviousGlobalTransform>();
 
-            //
             #[cfg(feature = "meshlet")]
             app.register_required_components::<MeshletMesh3d, PreviousGlobalTransform>();
         }


### PR DESCRIPTION
# Objective

@aevyrie saw this system showing up in his `big_space` traces.

![image](https://github.com/user-attachments/assets/157e13f0-c5d3-4b8a-baac-76a9b9c8cf65)

Upon investigation, this system is using commands to unconditionally mutate a component. That's slow!

Apparently this fixes https://github.com/bevyengine/bevy/issues/14681.

## Solution

1. Don't use commands.
2. Move the should_run guard statement into an actual run condition.
3. Throw together some simple docs.
4. Make it parallel.
5. Use required components to reduce archetype moves (and bugs).

~~I'm going to avoid parallelizing for now; let's take the free wins here first.~~

>  but good news, it is down to 3ms from 115ms on main

Casual 38x perf improvement.

## Requests for reviewers

1. I am not sure where this is used: what should I be testing?
~~2. @aevyrie I'd be interested in a fresh bench on this, but this is so clearly better that I don't care if we skip it.~~
~~3. Should I swap to using required components here and avoid ever inserting?~~
