### PR TITLE
remove bevy_log as a dev-dependency from bevy_asset

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -79,9 +79,6 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.16.0-dev", default-featu
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 notify-debouncer-full = { version = "0.5.0", optional = true }
 
-[dev-dependencies]
-bevy_log = { path = "../bevy_log", version = "0.16.0-dev" }
-
 [lints]
 workspace = true
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -686,7 +686,6 @@ mod tests {
         prelude::*,
         schedule::{LogLevel, ScheduleBuildSettings},
     };
-    use bevy_log::LogPlugin;
     use bevy_platform_support::collections::HashMap;
     use bevy_reflect::TypePath;
     use core::time::Duration;
@@ -855,11 +854,7 @@ mod tests {
             AssetSourceId::Default,
             AssetSource::build().with_reader(move || Box::new(gated_memory_reader.clone())),
         )
-        .add_plugins((
-            TaskPoolPlugin::default(),
-            LogPlugin::default(),
-            AssetPlugin::default(),
-        ));
+        .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()));
         (app, gate_opener)
     }
 
@@ -1757,11 +1752,7 @@ mod tests {
             "unstable",
             AssetSource::build().with_reader(move || Box::new(unstable_reader.clone())),
         )
-        .add_plugins((
-            TaskPoolPlugin::default(),
-            LogPlugin::default(),
-            AssetPlugin::default(),
-        ))
+        .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()))
         .init_asset::<CoolText>()
         .register_asset_loader(CoolTextLoader)
         .init_resource::<ErrorTracker>()
@@ -1832,11 +1823,7 @@ mod tests {
             AssetSource::build()
                 .with_reader(move || Box::new(MemoryAssetReader { root: dir.clone() })),
         )
-        .add_plugins((
-            TaskPoolPlugin::default(),
-            LogPlugin::default(),
-            AssetPlugin::default(),
-        ));
+        .add_plugins((TaskPoolPlugin::default(), AssetPlugin::default()));
 
         app.init_asset::<CoolText>()
             .init_asset::<SubText>()
@@ -1941,7 +1928,6 @@ mod tests {
         )
         .add_plugins((
             TaskPoolPlugin::default(),
-            LogPlugin::default(),
             AssetPlugin {
                 unapproved_path_mode: mode,
                 ..Default::default()


### PR DESCRIPTION
# Objective

- the bevy workspace fails to publish
```
   Packaging bevy_asset v0.16.0-dev (/home/runner/work/bevy-releasability/bevy-releasability/crates/bevy_asset)
    Updating crates.io index
    Updating `kellnr` index
error: failed to prepare local package for uploading

Caused by:
  no matching package named `bevy_log` found
  location searched: `kellnr` index
  required by package `bevy_asset v0.16.0-dev (/home/runner/work/bevy-releasability/bevy-releasability/crates/bevy_asset)`
```
- https://github.com/TheBevyFlock/bevy-releasability/actions/runs/14153238476/job/39649160443

## Solution

- Remove bevy_log dev-dependency from bevy_asset
- Not sure of why this is a problem, but the dev-dependency is not really needed so... 🤷 
