### PR TITLE
Remove entities from specialization caches when despawned.

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -708,7 +708,7 @@ fn extract_mesh_materials<M: Material>(
 pub fn extract_entities_needs_specialization<M>(
     entities_needing_specialization: Extract<Res<EntitiesNeedingSpecialization<M>>>,
     mut entity_specialization_ticks: ResMut<EntitySpecializationTicks<M>>,
-    mut removed_view_visibility_components: Extract<RemovedComponents<ViewVisibility>>,
+    mut removed_mesh_material_components: Extract<RemovedComponents<MeshMaterial3d<M>>>,
     mut specialized_material_pipeline_cache: ResMut<SpecializedMaterialPipelineCache<M>>,
     mut specialized_prepass_material_pipeline_cache: Option<
         ResMut<SpecializedPrepassMaterialPipelineCache<M>>,
@@ -726,7 +726,7 @@ pub fn extract_entities_needs_specialization<M>(
         entity_specialization_ticks.insert((*entity).into(), ticks.this_run());
     }
     // Clean up any despawned entities
-    for entity in removed_view_visibility_components.read() {
+    for entity in removed_mesh_material_components.read() {
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
             if let Some(cache) =

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -726,22 +726,22 @@ pub fn extract_entities_needs_specialization<M>(
     }
     // Clean up any despawned entities
     for entity in removed_view_visibility_components.read() {
-        entity_specialization_ticks.remove(entity.into());
+        entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
             specialized_material_pipeline_cache
                 .get_mut(&view.retained_view_entity)
                 .map(|cache| {
-                    cache.remove(entity.into());
+                    cache.remove(&MainEntity::from(entity));
                 });
             specialized_prepass_material_pipeline_cache
                 .get_mut(&view.retained_view_entity)
                 .map(|cache| {
-                    cache.remove(entity.into());
+                    cache.remove(&MainEntity::from(entity));
                 });
             specialized_shadow_material_pipeline_cache
                 .get_mut(&view.retained_view_entity)
                 .map(|cache| {
-                    cache.remove(entity.into());
+                    cache.remove(&MainEntity::from(entity));
                 });
         }
     }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -728,21 +728,21 @@ pub fn extract_entities_needs_specialization<M>(
     for entity in removed_view_visibility_components.read() {
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
-            specialized_material_pipeline_cache
-                .get_mut(&view.retained_view_entity)
-                .map(|cache| {
-                    cache.remove(&MainEntity::from(entity));
-                });
-            specialized_prepass_material_pipeline_cache
-                .get_mut(&view.retained_view_entity)
-                .map(|cache| {
-                    cache.remove(&MainEntity::from(entity));
-                });
-            specialized_shadow_material_pipeline_cache
-                .get_mut(&view.retained_view_entity)
-                .map(|cache| {
-                    cache.remove(&MainEntity::from(entity));
-                });
+            if let Some(cache) =
+                specialized_material_pipeline_cache.get_mut(&view.retained_view_entity)
+            {
+                cache.remove(&MainEntity::from(entity));
+            }
+            if let Some(cache) =
+                specialized_prepass_material_pipeline_cache.get_mut(&view.retained_view_entity)
+            {
+                cache.remove(&MainEntity::from(entity));
+            }
+            if let Some(cache) =
+                specialized_shadow_material_pipeline_cache.get_mut(&view.retained_view_entity)
+            {
+                cache.remove(&MainEntity::from(entity));
+            }
         }
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -822,12 +822,15 @@ impl<M> Default for SpecializedMaterialViewPipelineCache<M> {
 pub fn check_entities_needing_specialization<M>(
     needs_specialization: Query<
         Entity,
-        Or<(
-            Changed<Mesh3d>,
-            AssetChanged<Mesh3d>,
-            Changed<MeshMaterial3d<M>>,
-            AssetChanged<MeshMaterial3d<M>>,
-        )>,
+        (
+            Or<(
+                Changed<Mesh3d>,
+                AssetChanged<Mesh3d>,
+                Changed<MeshMaterial3d<M>>,
+                AssetChanged<MeshMaterial3d<M>>,
+            )>,
+            With<MeshMaterial3d<M>>,
+        ),
     >,
     mut entities_needing_specialization: ResMut<EntitiesNeedingSpecialization<M>>,
 ) where

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -47,6 +47,7 @@ use bevy_render::{
 use core::{hash::Hash, marker::PhantomData};
 use derive_more::derive::From;
 use tracing::error;
+use bevy_render::camera::extract_cameras;
 
 /// Materials are used alongside [`Material2dPlugin`], [`Mesh2d`], and [`MeshMaterial2d`]
 /// to spawn entities that are rendered with a specific [`Material2d`] type. They serve as an easy to use high level
@@ -286,7 +287,7 @@ where
                 .add_systems(
                     ExtractSchedule,
                     (
-                        extract_entities_needs_specialization::<M>,
+                        extract_entities_needs_specialization::<M>.after(extract_cameras),
                         extract_mesh_materials_2d::<M>,
                     ),
                 )

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -570,11 +570,9 @@ pub fn extract_entities_needs_specialization<M>(
     for entity in removed_view_visibility_components.read() {
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
-            specialized_material2d_pipeline_cache
-                .get_mut(view)
-                .map(|cache| {
-                    cache.remove(&MainEntity::from(entity));
-                });
+            if let Some(cache) = specialized_material2d_pipeline_cache.get_mut(view) {
+                cache.remove(&MainEntity::from(entity));
+            }
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -650,12 +650,15 @@ impl<M> Default for SpecializedMaterial2dViewPipelineCache<M> {
 pub fn check_entities_needing_specialization<M>(
     needs_specialization: Query<
         Entity,
-        Or<(
-            Changed<Mesh2d>,
-            AssetChanged<Mesh2d>,
-            Changed<MeshMaterial2d<M>>,
-            AssetChanged<MeshMaterial2d<M>>,
-        )>,
+        (
+            Or<(
+                Changed<Mesh2d>,
+                AssetChanged<Mesh2d>,
+                Changed<MeshMaterial2d<M>>,
+                AssetChanged<MeshMaterial2d<M>>,
+            )>,
+            With<MeshMaterial2d<M>>,
+        ),
     >,
     mut entities_needing_specialization: ResMut<EntitiesNeedingSpecialization<M>>,
 ) where

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -21,6 +21,7 @@ use bevy_ecs::{
 use bevy_math::FloatOrd;
 use bevy_platform_support::collections::HashMap;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
+use bevy_render::camera::extract_cameras;
 use bevy_render::render_phase::{DrawFunctionId, InputUniformIndex};
 use bevy_render::render_resource::CachedRenderPipelineId;
 use bevy_render::view::RenderVisibleEntities;
@@ -47,7 +48,6 @@ use bevy_render::{
 use core::{hash::Hash, marker::PhantomData};
 use derive_more::derive::From;
 use tracing::error;
-use bevy_render::camera::extract_cameras;
 
 /// Materials are used alongside [`Material2dPlugin`], [`Mesh2d`], and [`MeshMaterial2d`]
 /// to spawn entities that are rendered with a specific [`Material2d`] type. They serve as an easy to use high level

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -556,7 +556,7 @@ pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> Mesh2dPipelin
 pub fn extract_entities_needs_specialization<M>(
     entities_needing_specialization: Extract<Res<EntitiesNeedingSpecialization<M>>>,
     mut entity_specialization_ticks: ResMut<EntitySpecializationTicks<M>>,
-    mut removed_view_visibility_components: Extract<RemovedComponents<ViewVisibility>>,
+    mut removed_mesh_material_components: Extract<RemovedComponents<MeshMaterial2d<M>>>,
     mut specialized_material2d_pipeline_cache: ResMut<SpecializedMaterial2dPipelineCache<M>>,
     views: Query<&MainEntity, With<ExtractedView>>,
     ticks: SystemChangeTick,
@@ -568,7 +568,7 @@ pub fn extract_entities_needs_specialization<M>(
         entity_specialization_ticks.insert((*entity).into(), ticks.this_run());
     }
     // Clean up any despawned entities
-    for entity in removed_view_visibility_components.read() {
+    for entity in removed_mesh_material_components.read() {
         entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
             if let Some(cache) = specialized_material2d_pipeline_cache.get_mut(view) {

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -568,12 +568,12 @@ pub fn extract_entities_needs_specialization<M>(
     }
     // Clean up any despawned entities
     for entity in removed_view_visibility_components.read() {
-        entity_specialization_ticks.remove(entity.into());
+        entity_specialization_ticks.remove(&MainEntity::from(entity));
         for view in views {
             specialized_material2d_pipeline_cache
                 .get_mut(view)
                 .map(|cache| {
-                    cache.remove(entity.into());
+                    cache.remove(&MainEntity::from(entity));
                 });
         }
     }


### PR DESCRIPTION
# Objective

Fixes #17872 

## Solution

This should have basically no impact on static scenes. We can optimize more later if anything comes up. Needing to iterate the two level bin is a bit unfortunate but shouldn't matter for apps that use a single camera.
