### PR TITLE
Use Display instead of Debug in the default error handler

### DIFF
--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -35,9 +35,10 @@ impl BevyError {
         self.inner.error.downcast_ref::<E>()
     }
 
-    fn format_backtrace(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn format_backtrace(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         #[cfg(feature = "backtrace")]
         {
+            let f = _f;
             let backtrace = &self.inner.backtrace;
             if let std::backtrace::BacktraceStatus::Captured = backtrace.status() {
                 let full_backtrace = std::env::var("BEVY_BACKTRACE").is_ok_and(|val| val == "full");

--- a/crates/bevy_ecs/src/error/handler.rs
+++ b/crates/bevy_ecs/src/error/handler.rs
@@ -127,7 +127,7 @@ pub fn default_error_handler() -> fn(BevyError, ErrorContext) {
 macro_rules! inner {
     ($call:path, $e:ident, $c:ident) => {
         $call!(
-            "Encountered an error in {} `{}`: {:?}",
+            "Encountered an error in {} `{}`: {}",
             $c.kind(),
             $c.name(),
             $e

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2959,7 +2959,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Encountered an error in system `bevy_ecs::system::system_param::tests::missing_resource_error::res_system`: SystemParamValidationError { skipped: false, message: \"Resource does not exist\", param: \"bevy_ecs::change_detection::Res<bevy_ecs::system::system_param::tests::missing_resource_error::MissingResource>\" }"]
+    #[should_panic = "Encountered an error in system `bevy_ecs::system::system_param::tests::missing_resource_error::res_system`: Parameter `Res<MissingResource>` failed validation: Resource does not exist"]
     fn missing_resource_error() {
         #[derive(Resource)]
         pub struct MissingResource;

--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -55,7 +55,7 @@ fn main() {
 
     // If we run the app, we'll see the following output at startup:
     //
-    //  WARN Encountered an error in system `fallible_systems::failing_system`: "Resource not initialized"
+    //  WARN Encountered an error in system `fallible_systems::failing_system`: Resource not initialized
     // ERROR fallible_systems::failing_system failed: Resource not initialized
     //  INFO captured error: Resource not initialized
     app.run();


### PR DESCRIPTION
# Objective

Improve error messages for missing resources.  

The default error handler currently prints the `Debug` representation of the error type instead of `Display`.  Most error types use `#[derive(Debug)]`, resulting in a dump of the structure, but will have a user-friendly message for `Display`.  

Follow-up to #18593

## Solution

Change the default error handler to use `Display` instead of `Debug`.  

Change `BevyError` to include the backtrace in the `Display` format in addition to `Debug` so that it is still included.  

## Showcase

Before: 

```
Encountered an error in system `system_name`: SystemParamValidationError { skipped: false, message: "Resource does not exist", param: "bevy_ecs::change_detection::Res<app_name::ResourceType>" }

Encountered an error in system `other_system_name`: "String message with\nmultiple lines."
```

After

```
Encountered an error in system `system_name`: Parameter `Res<ResourceType>` failed validation: Resource does not exist

Encountered an error in system `other_system_name`: String message with
multiple lines.
```
