### PR TITLE
Use GpuPreprocessingMode::None if features not supported.

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1107,7 +1107,8 @@ impl FromWorld for GpuPreprocessingSupport {
             DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW
         );
 
-        let max_supported_mode = if device.limits().max_compute_workgroup_size_x == 0
+        let max_supported_mode = if !feature_support
+            || device.limits().max_compute_workgroup_size_x == 0
             || is_non_supported_android_device(adapter)
         {
             GpuPreprocessingMode::None


### PR DESCRIPTION
# Objective

Fixes #18463 

## Solution

The features didn't seem to be getting checked for selecting `GpuPreprocessingMode::None`.