### PR TITLE
Upgrade to Glam 0.29.3 and Simplify Feature Gating

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -91,11 +91,11 @@ serialize = [
   "bevy_color?/serialize",
   "bevy_ecs/serialize",
   "bevy_image?/serialize",
-  "bevy_input?/serialize",
-  "bevy_math?/serialize",
+  "bevy_input/serialize",
+  "bevy_math/serialize",
   "bevy_scene?/serialize",
   "bevy_time/serialize",
-  "bevy_transform?/serialize",
+  "bevy_transform/serialize",
   "bevy_ui?/serialize",
   "bevy_window?/serialize",
   "bevy_winit?/serialize",
@@ -311,7 +311,7 @@ critical-section = [
   "bevy_app/critical-section",
   "bevy_diagnostic/critical-section",
   "bevy_ecs/critical-section",
-  "bevy_input?/critical-section",
+  "bevy_input/critical-section",
   "bevy_input_focus?/critical-section",
   "bevy_platform_support/critical-section",
   "bevy_reflect/critical-section",
@@ -337,7 +337,7 @@ async_executor = [
   "std",
   "bevy_tasks/async_executor",
   "bevy_ecs/async_executor",
-  "bevy_transform?/async_executor",
+  "bevy_transform/async_executor",
 ]
 
 # Enables use of browser APIs.
@@ -361,10 +361,11 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.16.0-dev", default-features = fa
 ] }
 bevy_input = { path = "../bevy_input", version = "0.16.0-dev", default-features = false, features = [
   "bevy_reflect",
-], optional = true }
+] }
 bevy_math = { path = "../bevy_math", version = "0.16.0-dev", default-features = false, features = [
   "bevy_reflect",
-], optional = true }
+  "nostd-libm",
+] }
 bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-dev", default-features = false, features = [
   "alloc",
 ] }
@@ -378,7 +379,7 @@ bevy_time = { path = "../bevy_time", version = "0.16.0-dev", default-features = 
 bevy_transform = { path = "../bevy_transform", version = "0.16.0-dev", default-features = false, features = [
   "bevy-support",
   "bevy_reflect",
-], optional = true }
+] }
 bevy_utils = { path = "../bevy_utils", version = "0.16.0-dev", default-features = false, features = [
   "alloc",
 ] }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -9,10 +9,8 @@ plugin_group! {
         bevy_app:::TaskPoolPlugin,
         bevy_diagnostic:::FrameCountPlugin,
         bevy_time:::TimePlugin,
-        #[custom(cfg(any(feature = "libm", feature = "std")))]
         bevy_transform:::TransformPlugin,
         bevy_diagnostic:::DiagnosticsPlugin,
-        #[custom(cfg(any(feature = "libm", feature = "std")))]
         bevy_input:::InputPlugin,
         #[custom(cfg(not(feature = "bevy_window")))]
         bevy_app:::ScheduleRunnerPlugin,

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -41,13 +41,11 @@ pub use bevy_gizmos as gizmos;
 pub use bevy_gltf as gltf;
 #[cfg(feature = "bevy_image")]
 pub use bevy_image as image;
-#[cfg(any(feature = "libm", feature = "std"))]
 pub use bevy_input as input;
 #[cfg(feature = "bevy_input_focus")]
 pub use bevy_input_focus as input_focus;
 #[cfg(feature = "bevy_log")]
 pub use bevy_log as log;
-#[cfg(any(feature = "libm", feature = "std"))]
 pub use bevy_math as math;
 #[cfg(feature = "bevy_pbr")]
 pub use bevy_pbr as pbr;
@@ -70,7 +68,6 @@ pub use bevy_tasks as tasks;
 #[cfg(feature = "bevy_text")]
 pub use bevy_text as text;
 pub use bevy_time as time;
-#[cfg(any(feature = "libm", feature = "std"))]
 pub use bevy_transform as transform;
 #[cfg(feature = "bevy_ui")]
 pub use bevy_ui as ui;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,12 +1,9 @@
 #[doc(hidden)]
 pub use crate::{
-    app::prelude::*, ecs::prelude::*, platform_support::prelude::*, reflect::prelude::*,
-    time::prelude::*, utils::prelude::*, DefaultPlugins, MinimalPlugins,
+    app::prelude::*, ecs::prelude::*, input::prelude::*, math::prelude::*,
+    platform_support::prelude::*, reflect::prelude::*, time::prelude::*, transform::prelude::*,
+    utils::prelude::*, DefaultPlugins, MinimalPlugins,
 };
-
-#[doc(hidden)]
-#[cfg(any(feature = "libm", feature = "std"))]
-pub use crate::{input::prelude::*, math::prelude::*, transform::prelude::*};
 
 #[doc(hidden)]
 #[cfg(feature = "bevy_log")]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 rust-version = "1.85.0"
 
 [dependencies]
-glam = { version = "0.29", default-features = false, features = ["bytemuck"] }
+glam = { version = "0.29.3", default-features = false, features = ["bytemuck"] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "1", default-features = false, features = [
   "from",
@@ -37,7 +37,7 @@ rand = "0.8"
 rand_chacha = "0.3"
 # Enable the approx feature when testing.
 bevy_math = { path = ".", default-features = false, features = ["approx"] }
-glam = { version = "0.29", default-features = false, features = ["approx"] }
+glam = { version = "0.29.3", default-features = false, features = ["approx"] }
 
 [features]
 default = ["std", "rand", "curve"]
@@ -77,6 +77,9 @@ rand = ["dep:rand", "dep:rand_distr", "glam/rand"]
 curve = []
 # Enable bevy_reflect (requires alloc)
 bevy_reflect = ["dep:bevy_reflect", "alloc"]
+# Enable libm mathematical functions as a fallback for no_std environments.
+# Can be overridden with std feature.
+nostd-libm = ["dep:libm", "glam/nostd-libm"]
 
 [lints]
 workspace = true

--- a/crates/bevy_math/src/ops.rs
+++ b/crates/bevy_math/src/ops.rs
@@ -19,7 +19,7 @@
 // - `f32::gamma`
 // - `f32::ln_gamma`
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 #[expect(
     clippy::disallowed_methods,
     reason = "Many of the disallowed methods are disallowed to force code to use the feature-conditional re-exports from this module, but this module itself is exempt from that rule."
@@ -233,7 +233,7 @@ mod std_ops {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 mod libm_ops {
 
     /// Raises a number to a floating point power.
@@ -448,7 +448,7 @@ mod libm_ops {
     }
 }
 
-#[cfg(all(feature = "libm", not(feature = "std")))]
+#[cfg(all(any(feature = "libm", feature = "nostd-libm"), not(feature = "std")))]
 mod libm_ops_for_no_std {
     //! Provides standardized names for [`f32`] operations which may not be
     //! supported on `no_std` platforms.
@@ -606,20 +606,24 @@ mod std_ops_for_no_std {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 pub use libm_ops::*;
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 pub use std_ops::*;
 
 #[cfg(feature = "std")]
 pub use std_ops_for_no_std::*;
 
-#[cfg(all(feature = "libm", not(feature = "std")))]
+#[cfg(all(any(feature = "libm", feature = "nostd-libm"), not(feature = "std")))]
 pub use libm_ops_for_no_std::*;
 
-#[cfg(all(not(feature = "libm"), not(feature = "std")))]
-compile_error!("Either the `libm` feature or the `std` feature must be enabled.");
+#[cfg(all(
+    not(feature = "libm"),
+    not(feature = "std"),
+    not(feature = "nostd-libm")
+))]
+compile_error!("Either the `libm`, `std`, or `nostd-libm` feature must be enabled.");
 
 /// This extension trait covers shortfall in determinacy from the lack of a `libm` counterpart
 /// to `f32::powi`. Use this for the common small exponents.

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -22,7 +22,7 @@ std = ["glam/std"]
 libm = ["glam/libm", "dep:libm"]
 
 [dependencies]
-glam = { version = "0.29.0", default-features = false }
+glam = { version = "0.29.3", default-features = false }
 libm = { version = "0.2", default-features = false, optional = true }
 
 [[example]]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -99,7 +99,7 @@ derive_more = { version = "1", default-features = false, features = ["from"] }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 assert_type_match = "0.1.1"
 smallvec = { version = "1.11", default-features = false, optional = true }
-glam = { version = "0.29.2", default-features = false, features = [
+glam = { version = "0.29.3", default-features = false, features = [
   "serde",
 ], optional = true }
 petgraph = { version = "0.7", features = ["serde-1"], optional = true }


### PR DESCRIPTION
# Objective

- Fixes #18397
- Supersedes #18474
- Simplifies 0.16 migration

## Solution

- Upgrade to Glam 0.29.3, which has backported the `nostd-libm` feature.
- Expose a similar feature in `bevy_math` and enable it in `bevy_internal`, allowing `bevy_math`, `bevy_input`, and `bevy_transform` to be unconditional dependencies again.

## Testing

- CI

---

## Notes

- This includes `libm` as a dependency, but this was already the case in the common scenario where `rand` or many other features were enabled. Considering `libm` is an official Rust crate, it's a very low-risk dependency to unconditionally include.
- For users who do not want `libm` included, simply import Bevy's subcrates directly, since `bevy_math/nostd-libm` will not be enabled.
- I know we are _very_ late in the RC cycle for 0.16, but this has a substantial impact on the usability of `bevy` that I consider worth including.
