### PR TITLE
Only send unused event when final handle is dropped.

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -465,7 +465,6 @@ impl<A: Asset> Assets<A> {
             None => {}
             Some(0) => {
                 self.duplicate_handles.remove(&id);
-                self.queued_events.push(AssetEvent::Unused { id });
             }
             Some(value) => {
                 *value -= 1;

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -462,7 +462,9 @@ impl<A: Asset> Assets<A> {
     /// Removes the [`Asset`] with the given `id`.
     pub(crate) fn remove_dropped(&mut self, id: AssetId<A>) -> bool {
         match self.duplicate_handles.get_mut(&id) {
-            None | Some(0) => {}
+            None | Some(0) => {
+                self.queued_events.push(AssetEvent::Unused { id });
+            }
             Some(value) => {
                 *value -= 1;
                 return false;
@@ -555,9 +557,7 @@ impl<A: Asset> Assets<A> {
                 }
             }
 
-            if assets.remove_dropped(id) {
-                assets.queued_events.push(AssetEvent::Unused { id });
-            }
+            assets.remove_dropped(id);
         }
     }
 

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -460,12 +460,12 @@ impl<A: Asset> Assets<A> {
     }
 
     /// Removes the [`Asset`] with the given `id`.
-    pub(crate) fn remove_dropped(&mut self, id: AssetId<A>) {
+    pub(crate) fn remove_dropped(&mut self, id: AssetId<A>) -> bool {
         match self.duplicate_handles.get_mut(&id) {
             None | Some(0) => {}
             Some(value) => {
                 *value -= 1;
-                return;
+                return false;
             }
         }
         let existed = match id {
@@ -475,6 +475,8 @@ impl<A: Asset> Assets<A> {
         if existed {
             self.queued_events.push(AssetEvent::Removed { id });
         }
+
+        existed
     }
 
     /// Returns `true` if there are no assets in this collection.
@@ -553,8 +555,9 @@ impl<A: Asset> Assets<A> {
                 }
             }
 
-            assets.queued_events.push(AssetEvent::Unused { id });
-            assets.remove_dropped(id);
+            if assets.remove_dropped(id) {
+                assets.queued_events.push(AssetEvent::Unused { id });
+            }
         }
     }
 

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -462,13 +462,14 @@ impl<A: Asset> Assets<A> {
     /// Removes the [`Asset`] with the given `id`.
     pub(crate) fn remove_dropped(&mut self, id: AssetId<A>) -> bool {
         match self.duplicate_handles.get_mut(&id) {
-            None | Some(0) => {
+            Some(0) => {
                 self.queued_events.push(AssetEvent::Unused { id });
             }
             Some(value) => {
                 *value -= 1;
                 return false;
             }
+            None => {}
         }
         let existed = match id {
             AssetId::Index { index, .. } => self.dense_storage.remove_dropped(index).is_some(),


### PR DESCRIPTION
# Objective

Fixes #18457

## Solution

Move the Unused even after the check for existing strong handles.