### PR TITLE
0.16 Regression fix: re-expose the display handle via a wrapper resource

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -179,10 +179,10 @@ pub struct EventLoopProxyWrapper<T: 'static>(EventLoopProxy<T>);
 
 /// A wrapper around [`winit::event_loop::OwnedDisplayHandle`]
 ///
-/// The DisplayHandleWrapper can be used to build integrations that rely on direct
+/// The `DisplayHandleWrapper` can be used to build integrations that rely on direct
 /// access to the display handle
 ///
-/// Use Res<DisplayHandleWrapper> to receive this resource.
+/// Use `Res<DisplayHandleWrapper>` to receive this resource.
 #[derive(Resource, Deref)]
 pub struct DisplayHandleWrapper(pub winit::event_loop::OwnedDisplayHandle);
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -127,6 +127,7 @@ impl<T: Event> Plugin for WinitPlugin<T> {
         app.init_non_send_resource::<WinitWindows>()
             .init_resource::<WinitMonitors>()
             .init_resource::<WinitSettings>()
+            .insert_resource(DisplayHandleWrapper(event_loop.owned_display_handle()))
             .add_event::<RawWinitWindowEvent>()
             .set_runner(|app| winit_runner(app, event_loop))
             .add_systems(
@@ -175,6 +176,15 @@ pub struct RawWinitWindowEvent {
 /// Use `Res<EventLoopProxy>` to receive this resource.
 #[derive(Resource, Deref)]
 pub struct EventLoopProxyWrapper<T: 'static>(EventLoopProxy<T>);
+
+/// A wrapper around [`winit::event_loop::OwnedDisplayHandle`]
+///
+/// The DisplayHandleWrapper can be used to build integrations that rely on direct
+/// access to the display handle
+///
+/// Use Res<DisplayHandleWrapper> to receive this resource.
+#[derive(Resource, Deref)]
+pub struct DisplayHandleWrapper(pub winit::event_loop::OwnedDisplayHandle);
 
 trait AppSendEvent {
     fn send(&mut self, event: impl Into<WindowEvent>);


### PR DESCRIPTION
# Objective

- In the latest released version (15.3) I am able to obtain this information by getting the actual `EventLoop` via `non_send_resource`. Now that this object has (probably rightfully so) been replaced by the `EventLoopProxy`, I can no longer maintain my custom render backend: https://github.com/HugoPeters1024/bevy_vulkan. I also need the display handle for a custom winit integration, for which I've made patches to bevy before: XREF: https://github.com/bevyengine/bevy/pull/15884


## Solution

- Luckily, all that is required is exposing the `OwnedDisplayHandle` in its own wrapper resource.

## Testing

- Aforementioned custom rendering backend works on this commit.
