### PR TITLE
Make bindings behind `pbr_specular_textures` flag consistent with other gated fields

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -437,8 +437,8 @@ pub struct StandardMaterial {
     /// the [`StandardMaterial::specular_tint_texture`] has no alpha value, it
     /// may be desirable to pack the values together and supply the same
     /// texture to both fields.
-    #[texture(27)]
-    #[sampler(28)]
+    #[cfg_attr(feature = "pbr_specular_textures", texture(27))]
+    #[cfg_attr(feature = "pbr_specular_textures", sampler(28))]
     #[cfg(feature = "pbr_specular_textures")]
     pub specular_texture: Option<Handle<Image>>,
 
@@ -458,9 +458,9 @@ pub struct StandardMaterial {
     ///
     /// Like the fixed specular tint value, this texture map isn't supported in
     /// the deferred renderer.
+    #[cfg_attr(feature = "pbr_specular_textures", texture(29))]
+    #[cfg_attr(feature = "pbr_specular_textures", sampler(30))]
     #[cfg(feature = "pbr_specular_textures")]
-    #[texture(29)]
-    #[sampler(30)]
     pub specular_tint_texture: Option<Handle<Image>>,
 
     /// An extra thin translucent layer on top of the main PBR layer. This is


### PR DESCRIPTION
# Objective

Make all feature gated bindings consistent with each other

## Solution

Make the bindings of fields gated by `pbr_specular_textures` feature consistent with the other gated bindings
