### PR TITLE
Fix issues in log_diagnostics example

### DIFF
--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -22,9 +22,8 @@ use super::{RenderDevice, RenderQueue};
 /// Enables collecting render diagnostics, such as CPU/GPU elapsed time per render pass,
 /// as well as pipeline statistics (number of primitives, number of shader invocations, etc).
 ///
-/// To access the diagnostics, you can use the
-/// [`DiagnosticsStore`](bevy_diagnostic::DiagnosticsStore) resource or use
-/// [Tracy](https://github.com/bevyengine/bevy/blob/main/docs/profiling.md#tracy-renderqueue).
+/// To access the diagnostics, you can use the [`DiagnosticsStore`](bevy_diagnostic::DiagnosticsStore) resource,
+/// add [`LogDiagnosticsPlugin`](bevy_diagnostic::LogDiagnosticsPlugin), or use [Tracy](https://github.com/bevyengine/bevy/blob/main/docs/profiling.md#tracy-renderqueue).
 ///
 /// To record diagnostics in your own passes:
 ///  1. First, obtain the diagnostic recorder using [`RenderContext::diagnostic_recorder`](crate::renderer::RenderContext::diagnostic_recorder).

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -22,8 +22,9 @@ use super::{RenderDevice, RenderQueue};
 /// Enables collecting render diagnostics, such as CPU/GPU elapsed time per render pass,
 /// as well as pipeline statistics (number of primitives, number of shader invocations, etc).
 ///
-/// To access the diagnostics, you can use the [`DiagnosticsStore`](bevy_diagnostic::DiagnosticsStore) resource,
-/// add [`LogDiagnosticsPlugin`](bevy_diagnostic::LogDiagnosticsPlugin), or use [Tracy](https://github.com/bevyengine/bevy/blob/main/docs/profiling.md#tracy-renderqueue).
+/// To access the diagnostics, you can use the
+/// [`DiagnosticsStore`](bevy_diagnostic::DiagnosticsStore) resource or use
+/// [Tracy](https://github.com/bevyengine/bevy/blob/main/docs/profiling.md#tracy-renderqueue).
 ///
 /// To record diagnostics in your own passes:
 ///  1. First, obtain the diagnostic recorder using [`RenderContext::diagnostic_recorder`](crate::renderer::RenderContext::diagnostic_recorder).

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -8,22 +8,17 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins((
+            // The diagnostics plugins need to be added after DefaultPlugins as they use e.g. the time plugin for timestamps.
             DefaultPlugins,
-            // Adds frame time diagnostics
-            FrameTimeDiagnosticsPlugin::default(),
-            // Adds a system that prints diagnostics to the console
+            // Adds a system that prints diagnostics to the console.
+            // The other diagnostics plugins can still be used without this if you want to use them in an ingame overlay for example.
             LogDiagnosticsPlugin::default(),
-            // Any plugin can register diagnostics. Uncomment this to add an entity count diagnostics:
-            // bevy::diagnostic::EntityCountDiagnosticsPlugin::default(),
-
-            // Uncomment this to add an asset count diagnostics:
-            // bevy::asset::diagnostic::AssetCountDiagnosticsPlugin::<Texture>::default(),
-
-            // Uncomment this to add system info diagnostics:
-            // bevy::diagnostic::SystemInformationDiagnosticsPlugin::default()
-
-            // Uncomment this to add rendering diagnostics:
-            // bevy::render::diagnostic::RenderDiagnosticsPlugin::default(),
+            // Adds frame time, FPS and frame count diagnostics.
+            FrameTimeDiagnosticsPlugin::default(),
+            // Adds an entity count diagnostic.
+            bevy::diagnostic::EntityCountDiagnosticsPlugin::default(),
+            // Adds cpu and memory usage diagnostics for systems and the entire game process.
+            bevy::diagnostic::SystemInformationDiagnosticsPlugin::default(),
         ))
         .run();
 }

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -19,6 +19,45 @@ fn main() {
             bevy::diagnostic::EntityCountDiagnosticsPlugin,
             // Adds cpu and memory usage diagnostics for systems and the entire game process.
             bevy::diagnostic::SystemInformationDiagnosticsPlugin,
+            // Forwards various diagnostics from the render app to the main app.
+            // These are pretty verbose but can be useful to pinpoint performance issues.
+            bevy_render::diagnostic::RenderDiagnosticsPlugin,
         ))
+        // No rendering diagnostics are emitted unless something is drawn to the screen,
+        // so we spawn a small scene.
+        .add_systems(Startup, setup)
         .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // circular base
+    commands.spawn((
+        Mesh3d(meshes.add(Circle::new(4.0))),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+    ));
+    // cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+    // light
+    commands.spawn((
+        PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -16,9 +16,9 @@ fn main() {
             // Adds frame time, FPS and frame count diagnostics.
             FrameTimeDiagnosticsPlugin::default(),
             // Adds an entity count diagnostic.
-            bevy::diagnostic::EntityCountDiagnosticsPlugin::default(),
+            bevy::diagnostic::EntityCountDiagnosticsPlugin,
             // Adds cpu and memory usage diagnostics for systems and the entire game process.
-            bevy::diagnostic::SystemInformationDiagnosticsPlugin::default(),
+            bevy::diagnostic::SystemInformationDiagnosticsPlugin,
         ))
         .run();
 }


### PR DESCRIPTION
# Objective

Adopts / builds on top of #18435.

The `log_diagnostics` example has bit-rotted and accumulated multiple issues:
-  It didn't explain the ordering constraint on DefaultPlugins, as noted by the original PR
- Apparently `AssetCountDiagnosticsPlugin` no longer exists (?!). I couldn't figure out when or why it was removed, maybe it got missed in Assets v2?
- The comments didn't explain what kind of info you get by the various plugins, making you do work to figure it out
- ~As far as I can tell `RenderDiagnosticsPlugin` currently doesn't register any diagnostics in the traditional sense, but is only focused on rendering spans? At least it doesn't print anything extra when added for me, so having it here is misleading.~ It didn't print anything because there was nothing to render in this example

## Solution

- Make all plugins be commented in to prevent further bit-rot
- Remove reference to the missing plugin
- Add extra comments describing the diagnostics in more detail
- Add something to render so we get render diagnostics

## Testing

Run the example, see relevant diagnostics printed out