### PR TITLE
Implemented `Alpha` for `f32`.

### DIFF
--- a/crates/bevy_color/src/color_ops.rs
+++ b/crates/bevy_color/src/color_ops.rs
@@ -77,6 +77,20 @@ pub trait Alpha: Sized {
     }
 }
 
+impl Alpha for f32 {
+    fn with_alpha(&self, alpha: f32) -> Self {
+        alpha
+    }
+
+    fn alpha(&self) -> f32 {
+        *self
+    }
+
+    fn set_alpha(&mut self, alpha: f32) {
+        *self = alpha;
+    }
+}
+
 /// Trait for manipulating the hue of a color.
 pub trait Hue: Sized {
     /// Return a new version of this color with the hue channel set to the given value.


### PR DESCRIPTION
# Objective

`f32` can be used to represent alpha, this streamlines generic code related to colors.

## Solution

- Implemented `Alpha` for `f32`.
