### PR TITLE
Bump crate-ci/typos from 1.30.2 to 1.31.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check for typos
-        uses: crate-ci/typos@v1.30.2
+        uses: crate-ci/typos@v1.31.0
       - name: Typos info
         if: failure()
         run: |

--- a/crates/bevy_ecs/src/event/base.rs
+++ b/crates/bevy_ecs/src/event/base.rs
@@ -93,7 +93,7 @@ pub trait Event: Send + Sync + 'static {
 ///
 /// This exists so we can easily get access to a unique [`ComponentId`] for each [`Event`] type,
 /// without requiring that [`Event`] types implement [`Component`] directly.
-/// [`ComponentId`] is used internally as a unique identitifier for events because they are:
+/// [`ComponentId`] is used internally as a unique identifier for events because they are:
 ///
 /// - Unique to each event type.
 /// - Can be quickly generated and looked up.

--- a/crates/bevy_pbr/src/atmosphere/functions.wgsl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wgsl
@@ -49,7 +49,7 @@ const ROOT_2: f32 = 1.41421356; // √2
 // the exponential falloff of atmospheric density.
 const MIDPOINT_RATIO: f32 = 0.3;
 
-// LUT UV PARAMATERIZATIONS
+// LUT UV PARAMETERIZATIONS
 
 fn unit_to_sub_uvs(val: vec2<f32>, resolution: vec2<f32>) -> vec2<f32> {
     return (val + 0.5f / resolution) * (resolution / (resolution + 1.0f));


### PR DESCRIPTION
# Objective

- Fixes #18642

## Solution

- Bumped crate-ci/typos from 1.30.2 to 1.31.0.
- Fixed typos.

## Testing

- Typos were fixed.