### PR TITLE
Many-to-Many Relationships

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -1068,7 +1068,7 @@ impl EntityDoesNotExistError {
 /// regarding an entity that did not exist.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct EntityDoesNotExistDetails {
-    location: MaybeLocation<Option<&'static Location<'static>>>,
+    pub(crate) location: MaybeLocation<Option<&'static Location<'static>>>,
 }
 
 impl fmt::Display for EntityDoesNotExistDetails {

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -136,7 +136,13 @@ pub trait Relationship: Component + Sized {
                     core::any::type_name::<Self>(),
                     core::any::type_name::<Self>()
                 );
-                commands.entity(source).remove::<Self>();
+                commands
+                    .entity(source)
+                    .queue(move |mut entity: EntityWorldMut| {
+                        entity.modify_component(|relationship: &mut Self| {
+                            relationship.collection_mut().remove(target_entity);
+                        });
+                    });
             } else if let Ok(mut target_entity_mut) = entities.get_mut(target_entity) {
                 if let Some(mut relationship_target) =
                     target_entity_mut.get_mut::<Self::RelationshipTarget>()
@@ -155,7 +161,13 @@ pub trait Relationship: Component + Sized {
                     core::any::type_name::<Self>(),
                     core::any::type_name::<Self>()
                 );
-                commands.entity(source).remove::<Self>();
+                commands
+                    .entity(source)
+                    .queue(move |mut entity: EntityWorldMut| {
+                        entity.modify_component(|relationship: &mut Self| {
+                            relationship.collection_mut().remove(target_entity);
+                        });
+                    });
             }
         }
     }
@@ -195,7 +207,7 @@ pub trait Relationship: Component + Sized {
                     target_entity_mut.get_mut::<Self::RelationshipTarget>()
                 {
                     relationship_target.collection_mut_risky().remove(source);
-                    if relationship_target.len() == 0 {
+                    if relationship_target.is_empty() {
                         if let Ok(mut entity) = commands.get_entity(target_entity) {
                             // this "remove" operation must check emptiness because in the event that an identical
                             // relationship is inserted on top, this despawn would result in the removal of that identical

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -178,9 +178,9 @@ pub trait Relationship: Component + Sized {
 }
 
 /// The iterator type for the source entities in a [`RelationshipTarget`] collection,
-/// as defined in the [`RelationshipSourceCollection`] trait.
-pub type SourceIter<'w, R> =
-    <<R as RelationshipTarget>::Collection as RelationshipSourceCollection>::SourceIter<'w>;
+/// as defined in the [`RelationshipCollection`] trait.
+pub type RelationshipIter<'w, R> =
+    <<R as RelationshipTarget>::Collection as RelationshipCollection>::Iter<'w>;
 
 /// A [`Component`] containing the collection of entities that relate to this [`Entity`] via the associated `Relationship` type.
 /// See the [`Relationship`] documentation for more information.
@@ -197,11 +197,11 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
     type Relationship: Relationship<RelationshipTarget = Self>;
     /// The collection type that stores the "source" entities for this [`RelationshipTarget`] component.
     ///
-    /// Check the list of types which implement [`RelationshipSourceCollection`] for the data structures that can be used inside of your component.
-    /// If you need a new collection type, you can implement the [`RelationshipSourceCollection`] trait
+    /// Check the list of types which implement [`RelationshipCollection`] for the data structures that can be used inside of your component.
+    /// If you need a new collection type, you can implement the [`RelationshipCollection`] trait
     /// for a type you own which wraps the collection you want to use (to avoid the orphan rule),
     /// or open an issue on the Bevy repository to request first-party support for your collection type.
-    type Collection: RelationshipSourceCollection;
+    type Collection: RelationshipCollection;
 
     /// Returns a reference to the stored [`RelationshipTarget::Collection`].
     fn collection(&self) -> &Self::Collection;
@@ -270,14 +270,13 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
 
     /// Creates this [`RelationshipTarget`] with the given pre-allocated entity capacity.
     fn with_capacity(capacity: usize) -> Self {
-        let collection =
-            <Self::Collection as RelationshipSourceCollection>::with_capacity(capacity);
+        let collection = <Self::Collection as RelationshipCollection>::with_capacity(capacity);
         Self::from_collection_risky(collection)
     }
 
     /// Iterates the entities stored in this collection.
     #[inline]
-    fn iter(&self) -> SourceIter<'_, Self> {
+    fn iter(&self) -> RelationshipIter<'_, Self> {
         self.collection().iter()
     }
 

--- a/crates/bevy_ecs/src/relationship/mod.rs
+++ b/crates/bevy_ecs/src/relationship/mod.rs
@@ -1,14 +1,14 @@
 //! This module provides functionality to link entities to each other using specialized components called "relationships". See the [`Relationship`] trait for more info.
 
 mod related_methods;
+mod relationship_collection;
 mod relationship_query;
-mod relationship_source_collection;
 
 use alloc::format;
 
 pub use related_methods::*;
+pub use relationship_collection::*;
 pub use relationship_query::*;
-pub use relationship_source_collection::*;
 
 use crate::{
     component::{Component, HookContext, Mutable},
@@ -71,21 +71,43 @@ use log::warn;
 /// pub struct Children(Vec<Entity>);
 /// ```
 pub trait Relationship: Component + Sized {
-    /// The [`Component`] added to the "target" entities of this [`Relationship`], which contains the list of all "source"
-    /// entities that relate to the "target".
+    /// The [`Component`] added to the "target" entities of this [`Relationship`],
+    /// which contains the list of all "source" entities that relate to the "target".
     type RelationshipTarget: RelationshipTarget<Relationship = Self>;
 
-    /// Gets the [`Entity`] ID of the related entity.
-    fn get(&self) -> Entity;
+    /// The collection type that stores the "target" entities for this
+    /// [`Relationship`] component.
+    ///
+    /// Check the list of types which implement [`RelationshipCollection`] for
+    /// the data structures that can be used inside of your component. If you
+    /// need a new collection type, you can implement the [`RelationshipCollection`]
+    /// trait for a type you own which wraps the collection you want to use (to
+    /// avoid the orphan rule), or open an issue on the Bevy repository to request
+    /// first-party support for your collection type.
+    type Collection: RelationshipCollection;
 
-    /// Creates this [`Relationship`] from the given `entity`.
-    fn from(entity: Entity) -> Self;
+    /// Returns a reference to the stored [`Relationship::Collection`].
+    fn collection(&self) -> &Self::Collection;
 
-    /// The `on_insert` component hook that maintains the [`Relationship`] / [`RelationshipTarget`] connection.
+    /// Returns a mutable reference to the stored [`Relationship::Collection`].
+    fn collection_mut(&mut self) -> &mut Self::Collection;
+
+    /// Creates a new [`Relationship`] from the given [`Relationship::Collection`].
+    fn from_collection(collection: Self::Collection) -> Self;
+
+    /// Creates a new [`Relationship`] from the given [`Entity`].
+    fn from(target: Entity) -> Self {
+        let mut rel = Self::with_capacity(1);
+        rel.collection_mut().add(target);
+        rel
+    }
+
+    /// The `on_insert` component hook that maintains the [`Relationship`] /
+    /// [`RelationshipTarget`] connection.
     fn on_insert(
         mut world: DeferredWorld,
         HookContext {
-            entity,
+            entity: source,
             caller,
             relationship_hook_mode,
             ..
@@ -100,44 +122,53 @@ pub trait Relationship: Component + Sized {
                 }
             }
         }
-        let target_entity = world.entity(entity).get::<Self>().unwrap().get();
-        if target_entity == entity {
-            warn!(
-                "{}The {}({target_entity:?}) relationship on entity {entity:?} points to itself. The invalid {} relationship has been removed.",
-                caller.map(|location|format!("{location}: ")).unwrap_or_default(),
-                core::any::type_name::<Self>(),
-                core::any::type_name::<Self>()
-            );
-            world.commands().entity(entity).remove::<Self>();
+        let (mut entities, mut commands) = world.entities_and_commands();
+        let (source_mut, mut entities) = entities.split_off(source).unwrap();
+        let target_entities = source_mut.get::<Self>().unwrap();
+        if target_entities.is_empty() {
+            // We don't like empty relationships, so we remove them.
+            commands.entity(source).remove::<Self>();
             return;
         }
-        if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity) {
-            if let Some(mut relationship_target) =
-                target_entity_mut.get_mut::<Self::RelationshipTarget>()
-            {
-                relationship_target.collection_mut_risky().add(entity);
+        for target_entity in target_entities.iter() {
+            if target_entity == source {
+                warn!(
+                    "{}The {}({target_entity:?}) relationship on entity {source:?} points to itself. The invalid {} relationship has been removed.",
+                    caller.map(|location|format!("{location}: ")).unwrap_or_default(),
+                    core::any::type_name::<Self>(),
+                    core::any::type_name::<Self>()
+                );
+                commands.entity(source).remove::<Self>();
+            } else if let Ok(mut target_entity_mut) = entities.get_mut(target_entity) {
+                if let Some(mut relationship_target) =
+                    target_entity_mut.get_mut::<Self::RelationshipTarget>()
+                {
+                    relationship_target.collection_mut_risky().add(source);
+                } else {
+                    let mut target =
+                        <Self::RelationshipTarget as RelationshipTarget>::with_capacity(1);
+                    target.collection_mut_risky().add(source);
+                    commands.entity(target_entity).insert(target);
+                }
             } else {
-                let mut target = <Self::RelationshipTarget as RelationshipTarget>::with_capacity(1);
-                target.collection_mut_risky().add(entity);
-                world.commands().entity(target_entity).insert(target);
+                warn!(
+                    "{}The {}({target_entity:?}) relationship on entity {source:?} relates to an entity that does not exist. The invalid {} relationship has been removed.",
+                    caller.map(|location|format!("{location}: ")).unwrap_or_default(),
+                    core::any::type_name::<Self>(),
+                    core::any::type_name::<Self>()
+                );
+                commands.entity(source).remove::<Self>();
             }
-        } else {
-            warn!(
-                "{}The {}({target_entity:?}) relationship on entity {entity:?} relates to an entity that does not exist. The invalid {} relationship has been removed.",
-                caller.map(|location|format!("{location}: ")).unwrap_or_default(),
-                core::any::type_name::<Self>(),
-                core::any::type_name::<Self>()
-            );
-            world.commands().entity(entity).remove::<Self>();
         }
     }
 
-    /// The `on_replace` component hook that maintains the [`Relationship`] / [`RelationshipTarget`] connection.
+    /// The `on_replace` component hook that maintains the [`Relationship`] /
+    /// [`RelationshipTarget`] connection.
     // note: think of this as "on_drop"
     fn on_replace(
         mut world: DeferredWorld,
         HookContext {
-            entity,
+            entity: source,
             relationship_hook_mode,
             ..
         }: HookContext,
@@ -151,56 +182,108 @@ pub trait Relationship: Component + Sized {
                 }
             }
         }
-        let target_entity = world.entity(entity).get::<Self>().unwrap().get();
-        if let Ok(mut target_entity_mut) = world.get_entity_mut(target_entity) {
-            if let Some(mut relationship_target) =
-                target_entity_mut.get_mut::<Self::RelationshipTarget>()
-            {
-                relationship_target.collection_mut_risky().remove(entity);
-                if relationship_target.len() == 0 {
-                    if let Ok(mut entity) = world.commands().get_entity(target_entity) {
-                        // this "remove" operation must check emptiness because in the event that an identical
-                        // relationship is inserted on top, this despawn would result in the removal of that identical
-                        // relationship ... not what we want!
-                        entity.queue(|mut entity: EntityWorldMut| {
-                            if entity
-                                .get::<Self::RelationshipTarget>()
-                                .is_some_and(RelationshipTarget::is_empty)
-                            {
-                                entity.remove::<Self::RelationshipTarget>();
-                            }
-                        });
+
+        let (mut entities, mut commands) = world.entities_and_commands();
+        let (source_mut, mut entities) = entities.split_off(source).unwrap();
+        let target_entities = source_mut.get::<Self>().unwrap();
+        if target_entities.is_empty() {
+            // We don't like empty relationships, so we remove them.
+            commands.entity(source).remove::<Self>();
+            return;
+        }
+        for target_entity in target_entities.iter() {
+            if let Ok(mut target_entity_mut) = entities.get_mut(target_entity) {
+                if let Some(mut relationship_target) =
+                    target_entity_mut.get_mut::<Self::RelationshipTarget>()
+                {
+                    relationship_target.collection_mut_risky().remove(source);
+                    if relationship_target.len() == 0 {
+                        if let Ok(mut entity) = commands.get_entity(target_entity) {
+                            // this "remove" operation must check emptiness because in the event that an identical
+                            // relationship is inserted on top, this despawn would result in the removal of that identical
+                            // relationship ... not what we want!
+                            entity.queue(|mut entity: EntityWorldMut| {
+                                if entity
+                                    .get::<Self::RelationshipTarget>()
+                                    .is_some_and(RelationshipTarget::is_empty)
+                                {
+                                    entity.remove::<Self::RelationshipTarget>();
+                                }
+                            });
+                        }
                     }
                 }
             }
         }
     }
+
+    /// Creates this [`Relationship`] with the given pre-allocated entity capacity.
+    fn with_capacity(capacity: usize) -> Self {
+        let collection = <Self::Collection as RelationshipCollection>::with_capacity(capacity);
+        Self::from_collection(collection)
+    }
+
+    /// Iterates the target entities stored in this collection.
+    #[inline]
+    fn iter(&self) -> TargetIter<'_, Self> {
+        self.collection().iter()
+    }
+
+    /// Returns true if this entity collection contains the given entity.
+    #[inline]
+    fn contains(&self, entity: Entity) -> bool {
+        self.collection().contains(entity)
+    }
+
+    /// Returns the number of entities in this collection.
+    #[inline]
+    fn len(&self) -> usize {
+        self.collection().len()
+    }
+
+    /// Returns true if this entity collection is empty.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.collection().is_empty()
+    }
 }
+
+/// The iterator type for the target entities in a [`Relationship`] collection,
+/// as defined in the [`RelationshipCollection`] trait.
+pub type TargetIter<'w, R> = <<R as Relationship>::Collection as RelationshipCollection>::Iter<'w>;
 
 /// The iterator type for the source entities in a [`RelationshipTarget`] collection,
 /// as defined in the [`RelationshipCollection`] trait.
-pub type RelationshipIter<'w, R> =
+pub type SourceIter<'w, R> =
     <<R as RelationshipTarget>::Collection as RelationshipCollection>::Iter<'w>;
 
 /// A [`Component`] containing the collection of entities that relate to this [`Entity`] via the associated `Relationship` type.
 /// See the [`Relationship`] documentation for more information.
 pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
-    /// If this is true, when despawning or cloning (when [linked cloning is enabled](crate::entity::EntityClonerBuilder::linked_cloning)), the related entities targeting this entity will also be despawned or cloned.
+    /// If this is true, when despawning or cloning (when
+    /// [linked cloning is enabled](crate::entity::EntityClonerBuilder::linked_cloning)),
+    /// the related entities targeting this entity will also be despawned or cloned.
     ///
-    /// For example, this is set to `true` for Bevy's built-in parent-child relation, defined by [`ChildOf`](crate::prelude::ChildOf) and [`Children`](crate::prelude::Children).
-    /// This means that when a parent is despawned, any children targeting that parent are also despawned (and the same applies to cloning).
+    /// For example, this is set to `true` for Bevy's built-in parent-child
+    /// relation, defined by [`ChildOf`](crate::prelude::ChildOf) and
+    /// [`Children`](crate::prelude::Children). This means that when a parent is
+    /// despawned, any children targeting that parent are also despawned (and
+    /// the same applies to cloning).
     ///
-    /// To get around this behavior, you can first break the relationship between entities, and *then* despawn or clone.
-    /// This defaults to false when derived.
+    /// To get around this behavior, you can first break the relationship between
+    /// entities, and *then* despawn or clone. This defaults to false when derived.
     const LINKED_SPAWN: bool;
     /// The [`Relationship`] that populates this [`RelationshipTarget`] collection.
     type Relationship: Relationship<RelationshipTarget = Self>;
-    /// The collection type that stores the "source" entities for this [`RelationshipTarget`] component.
+    /// The collection type that stores the "source" entities for this
+    /// [`RelationshipTarget`] component.
     ///
-    /// Check the list of types which implement [`RelationshipCollection`] for the data structures that can be used inside of your component.
-    /// If you need a new collection type, you can implement the [`RelationshipCollection`] trait
-    /// for a type you own which wraps the collection you want to use (to avoid the orphan rule),
-    /// or open an issue on the Bevy repository to request first-party support for your collection type.
+    /// Check the list of types which implement [`RelationshipCollection`] for
+    /// the data structures that can be used inside of your component. If you need
+    /// a new collection type, you can implement the [`RelationshipCollection`]
+    /// trait for a type you own which wraps the collection you want to use (to
+    /// avoid the orphan rule), or open an issue on the Bevy repository to request
+    /// first-party support for your collection type.
     type Collection: RelationshipCollection;
 
     /// Returns a reference to the stored [`RelationshipTarget::Collection`].
@@ -274,9 +357,9 @@ pub trait RelationshipTarget: Component<Mutability = Mutable> + Sized {
         Self::from_collection_risky(collection)
     }
 
-    /// Iterates the entities stored in this collection.
+    /// Iterates the source entities stored in this collection.
     #[inline]
-    fn iter(&self) -> RelationshipIter<'_, Self> {
+    fn iter(&self) -> SourceIter<'_, Self> {
         self.collection().iter()
     }
 

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -2,7 +2,7 @@ use crate::{
     bundle::Bundle,
     entity::{hash_set::EntityHashSet, Entity},
     relationship::{
-        Relationship, RelationshipHookMode, RelationshipSourceCollection, RelationshipTarget,
+        Relationship, RelationshipCollection, RelationshipHookMode, RelationshipTarget,
     },
     system::{Commands, EntityCommands},
     world::{EntityWorldMut, World},
@@ -10,7 +10,7 @@ use crate::{
 use bevy_platform_support::prelude::{Box, Vec};
 use core::{marker::PhantomData, mem};
 
-use super::OrderedRelationshipSourceCollection;
+use super::OrderedRelationshipCollection;
 
 impl<'w> EntityWorldMut<'w> {
     /// Spawns entities related to this entity (with the `R` relationship) by taking a function that operates on a [`RelatedSpawner`].
@@ -66,8 +66,7 @@ impl<'w> EntityWorldMut<'w> {
     /// ```
     pub fn insert_related<R: Relationship>(&mut self, index: usize, related: &[Entity]) -> &mut Self
     where
-        <R::RelationshipTarget as RelationshipTarget>::Collection:
-            OrderedRelationshipSourceCollection,
+        <R::RelationshipTarget as RelationshipTarget>::Collection: OrderedRelationshipCollection,
     {
         let id = self.id();
         self.world_scope(|world| {

--- a/crates/bevy_ecs/src/relationship/related_methods.rs
+++ b/crates/bevy_ecs/src/relationship/related_methods.rs
@@ -74,7 +74,7 @@ impl<'w> EntityWorldMut<'w> {
                 let index = index + offset;
                 if world
                     .get::<R>(*related)
-                    .is_some_and(|relationship| relationship.get() == id)
+                    .is_some_and(|relationship| relationship.contains(id))
                 {
                     world
                         .get_mut::<R::RelationshipTarget>(id)

--- a/crates/bevy_ecs/src/relationship/relationship_collection.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_collection.rs
@@ -42,6 +42,9 @@ pub trait RelationshipCollection {
     /// the entity.
     fn remove(&mut self, entity: Entity) -> bool;
 
+    /// Returns true if the collection contains the given `entity`.
+    fn contains(&self, entity: Entity) -> bool;
+
     /// Iterates all entities in the collection.
     fn iter(&self) -> Self::Iter<'_>;
 
@@ -156,6 +159,10 @@ impl RelationshipCollection for Vec<Entity> {
         false
     }
 
+    fn contains(&self, entity: Entity) -> bool {
+        <[Entity]>::iter(self).any(|e| *e == entity)
+    }
+
     fn iter(&self) -> Self::Iter<'_> {
         <[Entity]>::iter(self).copied()
     }
@@ -253,6 +260,10 @@ impl RelationshipCollection for EntityHashSet {
         self.0.remove(&entity)
     }
 
+    fn contains(&self, entity: Entity) -> bool {
+        self.0.contains(&entity)
+    }
+
     fn iter(&self) -> Self::Iter<'_> {
         self.iter().copied()
     }
@@ -304,6 +315,10 @@ impl<const N: usize> RelationshipCollection for SmallVec<[Entity; N]> {
         false
     }
 
+    fn contains(&self, entity: Entity) -> bool {
+        <[Entity]>::iter(self).any(|e| *e == entity)
+    }
+
     fn iter(&self) -> Self::Iter<'_> {
         <[Entity]>::iter(self).copied()
     }
@@ -352,6 +367,10 @@ impl RelationshipCollection for Entity {
         }
 
         false
+    }
+
+    fn contains(&self, entity: Entity) -> bool {
+        *self == entity
     }
 
     fn iter(&self) -> Self::Iter<'_> {

--- a/crates/bevy_ecs/src/relationship/relationship_query.rs
+++ b/crates/bevy_ecs/src/relationship/relationship_query.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloc::collections::VecDeque;
 use smallvec::SmallVec;
 
-use super::SourceIter;
+use super::RelationshipIter;
 
 impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// If the given `entity` contains the `R` [`Relationship`] component, returns the
@@ -63,7 +63,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ) -> impl Iterator<Item = Entity> + 'w
     where
         <D as QueryData>::ReadOnly: QueryData<Item<'w> = &'w S>,
-        SourceIter<'w, S>: DoubleEndedIterator,
+        RelationshipIter<'w, S>: DoubleEndedIterator,
     {
         self.iter_descendants_depth_first(entity).filter(|entity| {
             self.get(*entity)
@@ -121,7 +121,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ) -> DescendantDepthFirstIter<'w, 's, D, F, S>
     where
         D::ReadOnly: QueryData<Item<'w> = &'w S>,
-        SourceIter<'w, S>: DoubleEndedIterator,
+        RelationshipIter<'w, S>: DoubleEndedIterator,
     {
         DescendantDepthFirstIter::new(self, entity)
     }
@@ -204,7 +204,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget>
     DescendantDepthFirstIter<'w, 's, D, F, S>
 where
     D::ReadOnly: QueryData<Item<'w> = &'w S>,
-    SourceIter<'w, S>: DoubleEndedIterator,
+    RelationshipIter<'w, S>: DoubleEndedIterator,
 {
     /// Returns a new [`DescendantDepthFirstIter`].
     pub fn new(children_query: &'w Query<'w, 's, D, F>, entity: Entity) -> Self {
@@ -221,7 +221,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, S: RelationshipTarget> Iterator
     for DescendantDepthFirstIter<'w, 's, D, F, S>
 where
     D::ReadOnly: QueryData<Item<'w> = &'w S>,
-    SourceIter<'w, S>: DoubleEndedIterator,
+    RelationshipIter<'w, S>: DoubleEndedIterator,
 {
     type Item = Entity;
 

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -38,8 +38,9 @@ impl<D> Traversal<D> for () {
 /// Traversing in a loop could result in infinite loops for relationship graphs with loops.
 ///
 /// [event propagation]: crate::observer::Trigger::propagate
-impl<R: Relationship, D> Traversal<D> for &R {
+// TODO: support many-to-many relationships
+impl<R: Relationship<Collection = Entity>, D> Traversal<D> for &R {
     fn traverse(item: Self::Item<'_>, _data: &D) -> Option<Entity> {
-        Some(item.get())
+        Some(*item.collection())
     }
 }

--- a/crates/bevy_ecs/src/world/entity_fetch.rs
+++ b/crates/bevy_ecs/src/world/entity_fetch.rs
@@ -116,6 +116,12 @@ impl<'w> EntityFetcher<'w> {
         &mut self,
         entity: Entity,
     ) -> Result<(EntityMut<'_>, EntityFetcher<'_>), EntityDoesNotExistError> {
+        if self.excluded.is_some() {
+            panic!(
+                "Cannot split off an entity from a fetcher that already has an excluded entity."
+            );
+        }
+
         // SAFETY: `&mut self` gives mutable access to all entities,
         // and prevents any other access to entities.
         let entity_mut = unsafe { EntityMut::new(self.cell.get_entity(entity)?) };


### PR DESCRIPTION
# Objective

- Closes #18121

## Solution

- `Relationship`s now have their own `RelationshipCollection` as well (previously named `RelationshipSourceCollection`).

## Testing

Added additional unit tests.

---

## Showcase

Many-to-many relationships are now supported:

```rust
#[derive(Component, PartialEq, Debug)]
#[relationship(relationship_target = LikedBy)]
struct Likes(pub Vec<Entity>);

#[derive(Component)]
#[relationship_target(relationship = Likes)]
struct LikedBy(Vec<Entity>);
```
