### PR TITLE
Split PBR shader light computations into smaller functions

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -358,7 +358,6 @@ fn compute_pbr_lighting(
         in,
         clusterable_object_index_ranges,
         view_z,
-        diffuse_color,
         diffuse_transmissive_color,
         F0, F_ab
     );
@@ -384,30 +383,6 @@ fn compute_pbr_lighting(
 
     return computed_light;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 fn compute_direct_light(
     in: pbr_types::PbrInput,
@@ -556,37 +531,17 @@ fn compute_direct_light(
     return direct_light;
 }
 
-
-
 fn compute_transmitted_direct_light(
     in: pbr_types::PbrInput,
     clusterable_object_index_ranges: clustering::ClusterableObjectIndexRanges,
     view_z: f32,
-    diffuse_color: vec3<f32>,
     diffuse_transmissive_color: vec3<f32>,
     F0: vec3<f32>,
     F_ab: vec2<f32>,
 ) -> vec3<f32> {
     var transmitted_light: vec3<f32> = vec3(0.);
 
-    // calculate non-linear roughness from linear perceptualRoughness
-    let metallic = in.material.metallic;
-    let perceptual_roughness = in.material.perceptual_roughness;
-    let roughness = lighting::perceptualRoughnessToRoughness(perceptual_roughness);
-    let ior = in.material.ior;
     let thickness = in.material.thickness;
-    let reflectance = in.material.reflectance;
-    let diffuse_transmission = in.material.diffuse_transmission;
-    let specular_transmission = in.material.specular_transmission;
-
-    let specular_transmissive_color = specular_transmission * in.material.base_color.rgb;
-
-    let diffuse_occlusion = in.diffuse_occlusion;
-    let specular_occlusion = in.specular_occlusion;
-
-    // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
-    let NdotV = max(dot(in.N, in.V), 0.0001);
-    let R = reflect(-in.V, in.N);
 
     // Calculate the world position of the second Lambertian lobe used for diffuse transmission, by subtracting material thickness
     let diffuse_transmissive_lobe_world_position = in.world_position - vec4<f32>(in.world_normal, 0.0) * thickness;
@@ -954,24 +909,6 @@ fn compute_emissive_light(
 
     return emissive_light;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 fn apply_pbr_lighting(
     in: pbr_types::PbrInput,

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -318,6 +318,17 @@ fn compute_direct_light(
     let NdotV = max(dot(in.N, in.V), 0.0001);
     let R = reflect(-in.V, in.N);
 
+#ifdef STANDARD_MATERIAL_CLEARCOAT
+    // Do the above calculations again for the clearcoat layer. Remember that
+    // the clearcoat can have its own roughness and its own normal.
+    let clearcoat = in.material.clearcoat;
+    let clearcoat_perceptual_roughness = in.material.clearcoat_perceptual_roughness;
+    let clearcoat_roughness = lighting::perceptualRoughnessToRoughness(clearcoat_perceptual_roughness);
+    let clearcoat_N = in.clearcoat_N;
+    let clearcoat_NdotV = max(dot(clearcoat_N, in.V), 0.0001);
+    let clearcoat_R = reflect(-in.V, clearcoat_N);
+#endif  // STANDARD_MATERIAL_CLEARCOAT
+
     // Pack all the values into a structure.
     var lighting_input: lighting::LightingInput;
     lighting_input.layers[LAYER_BASE].NdotV = NdotV;

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -440,7 +440,7 @@ fn compute_direct_light(
     return direct_light;
 }
 
-fn compute_transmitted_light(
+fn compute_transmitted_direct_light(
     in: pbr_types::PbrInput,
     clusterable_object_index_ranges: clustering::ClusterableObjectIndexRanges,
     view_z: f32,
@@ -789,9 +789,8 @@ fn apply_pbr_lighting(
         diffuse_transmissive_color,
         F0, F_ab);
 
-    // Point lights (direct)
 #ifdef STANDARD_MATERIAL_DIFFUSE_TRANSMISSION
-    transmitted_light = compute_transmitted_light(
+    transmitted_light = compute_transmitted_direct_light(
     in,
     clusterable_object_index_ranges,
     view_z,

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -296,6 +296,32 @@ fn compute_direct_light(
 ) -> vec3<f32> {
     var direct_light: vec3<f32> = vec3(0.);
 
+    // Pack all the values into a structure.
+    var lighting_input: lighting::LightingInput;
+    lighting_input.layers[LAYER_BASE].NdotV = NdotV;
+    lighting_input.layers[LAYER_BASE].N = in.N;
+    lighting_input.layers[LAYER_BASE].R = R;
+    lighting_input.layers[LAYER_BASE].perceptual_roughness = perceptual_roughness;
+    lighting_input.layers[LAYER_BASE].roughness = roughness;
+    lighting_input.P = in.world_position.xyz;
+    lighting_input.V = in.V;
+    lighting_input.diffuse_color = diffuse_color;
+    lighting_input.F0_ = F0;
+    lighting_input.F_ab = F_ab;
+#ifdef STANDARD_MATERIAL_CLEARCOAT
+    lighting_input.layers[LAYER_CLEARCOAT].NdotV = clearcoat_NdotV;
+    lighting_input.layers[LAYER_CLEARCOAT].N = clearcoat_N;
+    lighting_input.layers[LAYER_CLEARCOAT].R = clearcoat_R;
+    lighting_input.layers[LAYER_CLEARCOAT].perceptual_roughness = clearcoat_perceptual_roughness;
+    lighting_input.layers[LAYER_CLEARCOAT].roughness = clearcoat_roughness;
+    lighting_input.clearcoat_strength = clearcoat;
+#endif  // STANDARD_MATERIAL_CLEARCOAT
+#ifdef STANDARD_MATERIAL_ANISOTROPY
+    lighting_input.anisotropy = in.anisotropy_strength;
+    lighting_input.Ta = in.anisotropy_T;
+    lighting_input.Ba = in.anisotropy_B;
+#endif  // STANDARD_MATERIAL_ANISOTROPY
+
     // Point lights (direct)
     for (var i: u32 = clusterable_object_index_ranges.first_point_light_index_offset;
             i < clusterable_object_index_ranges.first_spot_light_index_offset;
@@ -512,7 +538,7 @@ fn apply_pbr_lighting(
     var clusterable_object_index_ranges =
         clustering::unpack_clusterable_object_index_ranges(cluster_index);
 
-    let direct_light: vec3<f32> = compute_direct_light(in, clusterable_object_index_ranges, &lighting_input, view_z);
+    let direct_light: vec3<f32> = compute_direct_light(in, clusterable_object_index_ranges, view_z);
 
     // Point lights (direct)
     for (var i: u32 = clusterable_object_index_ranges.first_point_light_index_offset;

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -151,3 +151,14 @@ fn pbr_input_new() -> PbrInput {
 
     return pbr_input;
 }
+
+struct ComputedPbrLight {
+    emissive_light: vec4<f32>,
+    direct_light: vec4<f32>,
+    indirect_light: vec4<f32>,
+    transmitted_light: vec4<f32>,
+}
+
+fn computed_pbr_light_new() -> ComputedPbrLight {
+    return ComputedPbrLight(vec4(0.), vec4(0.), vec4(0.), vec4(0.));
+}

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -153,12 +153,12 @@ fn pbr_input_new() -> PbrInput {
 }
 
 struct ComputedPbrLight {
-    emissive_light: vec4<f32>,
-    direct_light: vec4<f32>,
-    indirect_light: vec4<f32>,
-    transmitted_light: vec4<f32>,
+    emissive: vec3<f32>,
+    direct: vec3<f32>,
+    indirect: vec3<f32>,
+    transmitted: vec3<f32>,
 }
 
 fn computed_pbr_light_new() -> ComputedPbrLight {
-    return ComputedPbrLight(vec4(0.), vec4(0.), vec4(0.), vec4(0.));
+    return ComputedPbrLight(vec3(0.), vec3(0.), vec3(0.), vec3(0.));
 }


### PR DESCRIPTION
# Objective

- Splits the `apply_pbr_lighting` shader function into smaller components, allowing custom and extended materials to reuse lighting calculations while modifying the final result.
- Fixes #17541

## Solution

- Split lighting calculations into separate functions for direct, indirect, transmitted, and emissive light.
- Added a new `compute_pbr_lighting` function which computes the direct, indirect, transmitted, and emissive light components and returns them separately, allowing users to further modify them before outputting the final fragment color.

## Testing

### Did you test these changes? If so, how?

I tested performance by checking register count and general performance metrics reported by Nvidia Nsight Graphics 2024.2.1 for the Vulkan and DX12 backends.
 - for Vulkan there was no difference in register count and a small (0.97x - 1.03x) difference in some performance metrics.
 - for DX12 there was a small (5) increase in register count and a small (0.97 - 1.03x) difference in some performance metrics.

### Are there any parts that need more testing?

I only have one system for testing, with a Ryzen 5950X and an RTX 3060 Ti on Windows., so I am unable to profile performance on AMD and Intel graphics cards, or on Linux and Mac.

I am hoping that others will be able to profile the changes and post their results in this PR so we can get a better idea of the performance impacts.

### How can other people (reviewers) test your changes? Is there anything specific they need to know?

To get the register count in Nsight, I had to run Nsight with administrator privileges and enable `Real-time Shader Profiler` option:

![image](https://github.com/user-attachments/assets/4adb6f4a-c883-4395-8792-212a65fe4fab)

Register count is then shown in the `Shader Pipelines` panel:

![image](https://github.com/user-attachments/assets/9a7e7d25-e626-483f-a5df-b28c8ab64c6f)

### If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

As stated above, I am unable to test on Linux and Mac, and on Intel and AMD cards.

My system specs:

![image](https://github.com/user-attachments/assets/1625d6a4-9800-470f-bfb8-30198b65cc5c)

 - Windows 11 (24H1) Build 26100
 - AMD Ryzen 9 5950X
 - 32 GB RAM
 - Nvidia GeForce RTX 3060 Ti 8 GB LHR
 - Nvidia Driver version 566.36

---

## Showcase

`apply_pbr_lighting` function now looks like this:

```
fn apply_pbr_lighting(
    in: pbr_types::PbrInput,
) -> vec4<f32> {
    var output_color: vec4<f32> = in.material.base_color;

    let computed_light = compute_pbr_lighting(in);

    // Total light
    output_color = vec4<f32>(
        (
            view_bindings::view.exposure *
            (computed_light.transmitted + computed_light.direct + computed_light.indirect)
        ) + computed_light.emissive,
        output_color.a
    );


    output_color = clustering::cluster_debug_visualization(
        /* ... */
    );


    return output_color;
}
```

And `compute_pbr_lighting(in)` can easily be called from extended materials:

```
@fragment
fn fragment(
    in: VertexOutput,
    @builtin(front_facing) is_front: bool,
) -> FragmentOutput {
    // generate a PbrInput struct from the StandardMaterial bindings
    var pbr_input = pbr_input_from_standard_material(in, is_front);

    // we can optionally modify the input before lighting and alpha_discard is applied
    pbr_input.material.base_color.b = pbr_input.material.base_color.r;

    // alpha discard
    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);

    var out: FragmentOutput;

    // apply lighting
    var computed_lighting = compute_pbr_lighting(pbr_input);

    // apply our own effects to the light components:
    computed_lighting.direct = my_special_effect(computed_light.direct);

    out.color = vec4<f32>(
        (
            view_bindings::view.exposure *
            (computed_light.transmitted + computed_light.direct + computed_light.indirect)
        ) + computed_light.emissive,
        output_color.a
    );

    // apply in-shader post processing (fog, alpha-premultiply, and also tonemapping, debanding if the camera is non-hdr)
    // note this does not include fullscreen postprocessing effects like bloom.
    out.color = main_pass_post_lighting_processing(pbr_input, out.color);

    return out;
}
```
