### PR TITLE
Remote entity reservation v9

### DIFF
--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -92,28 +92,28 @@ pub fn insert_commands(criterion: &mut Criterion) {
             command_queue.apply(&mut world);
         });
     });
-    group.bench_function("insert_or_spawn_batch", |bencher| {
-        let mut world = World::default();
-        let mut command_queue = CommandQueue::default();
-        let mut entities = Vec::new();
-        for _ in 0..entity_count {
-            entities.push(world.spawn_empty().id());
-        }
+    // group.bench_function("insert_or_spawn_batch", |bencher| {
+    //     let mut world = World::default();
+    //     let mut command_queue = CommandQueue::default();
+    //     let mut entities = Vec::new();
+    //     for _ in 0..entity_count {
+    //         entities.push(world.spawn_empty().id());
+    //     }
 
-        bencher.iter(|| {
-            let mut commands = Commands::new(&mut command_queue, &world);
-            let mut values = Vec::with_capacity(entity_count);
-            for entity in &entities {
-                values.push((*entity, (Matrix::default(), Vec3::default())));
-            }
-            #[expect(
-                deprecated,
-                reason = "This needs to be supported for now, and therefore still needs the benchmark."
-            )]
-            commands.insert_or_spawn_batch(values);
-            command_queue.apply(&mut world);
-        });
-    });
+    //     bencher.iter(|| {
+    //         let mut commands = Commands::new(&mut command_queue, &world);
+    //         let mut values = Vec::with_capacity(entity_count);
+    //         for entity in &entities {
+    //             values.push((*entity, (Matrix::default(), Vec3::default())));
+    //         }
+    //         #[expect(
+    //             deprecated,
+    //             reason = "This needs to be supported for now, and therefore still needs the benchmark."
+    //         )]
+    //         commands.insert_or_spawn_batch(values);
+    //         command_queue.apply(&mut world);
+    //     });
+    // });
     group.bench_function("insert_batch", |bencher| {
         let mut world = World::default();
         let mut command_queue = CommandQueue::default();

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -142,6 +142,7 @@ impl SubApp {
     /// Runs the default schedule and updates internal component trackers.
     pub fn update(&mut self) {
         self.run_default_schedule();
+        self.world.entities().queue_remote_pending_to_be_flushed();
         self.world.clear_trackers();
     }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -81,6 +81,11 @@ pub struct ArchetypeId(u32);
 impl ArchetypeId {
     /// The ID for the [`Archetype`] without any components.
     pub const EMPTY: ArchetypeId = ArchetypeId(0);
+    /// This represents an archetype that does not actually exist.
+    /// This can be used as a placeholder.
+    ///
+    /// On an entity, this archetype signals that the entity is not yet part of any archetype.
+    ///
     /// # Safety:
     ///
     /// This must always have an all-1s bit pattern to ensure soundness in fast entity id space allocation.

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1420,6 +1420,8 @@ impl<'w> BundleSpawner<'w> {
         table.reserve(additional);
     }
 
+    /// **Note:** This will not cause eny entities to be freed.
+    ///
     /// # Safety
     /// `entity` must be allocated (but non-existent), `T` must match this [`BundleInfo`]'s type
     #[inline]

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -140,6 +140,15 @@ struct PendingBuffer {
 }
 
 impl PendingBuffer {
+    /// Gets the number of pending entities.
+    ///
+    /// # Safety
+    ///
+    /// For this to be accurate, this must not be called during a [`Self::free`].
+    unsafe fn num_pending(&self) -> u64 {
+        self.len.load(Ordering::Relaxed).max(0) as u64
+    }
+
     /// Frees the `entity` allowing it to be reused.
     ///
     /// # Safety
@@ -351,6 +360,12 @@ impl Allocator {
     /// The total number of indices given out.
     pub fn total_entity_indices(&self) -> u64 {
         self.shared.total_entity_indices()
+    }
+
+    /// The number of pending entities.
+    pub fn num_pending(&self) -> u64 {
+        // SAFETY: `free` is not being called since it takes `&mut self`.
+        unsafe { self.shared.pending.num_pending() }
     }
 
     /// Returns whether or not the index is valid in this allocator.

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -1,0 +1,96 @@
+use bevy_platform_support::{
+    prelude::Vec,
+    sync::{
+        atomic::{AtomicPtr, AtomicU32, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use core::mem::{ManuallyDrop, MaybeUninit};
+
+use super::Entity;
+
+/// This is the item we store in the owned buffers.
+/// It might not be init (if it's out of bounds).
+type Slot = MaybeUninit<Entity>;
+
+/// Each chunk stores a buffer of [`Slot`]s at a fixed capacity.
+struct Chunk {
+    /// Points to the first slot. If this is null, we need to allocate it.
+    first: AtomicPtr<Slot>,
+}
+
+impl Chunk {
+    const NUM_CHUNKS: u32 = 24;
+    const NUM_SKIPPED: u32 = u32::BITS - Self::NUM_CHUNKS;
+
+    /// Computes the capacity of the chunk at this index within [`Self::NUM_CHUNKS`].
+    /// The first 2 have length 512 (2^9) and the last has length (2^31)
+    fn capacity_of_chunk(chunk_index: u32) -> u32 {
+        // We do this because we're skipping the first 8 powers, so we need to make up for them by doubling the first index.
+        // This is why the first 2 indices both have a capacity of 256.
+        let corrected = chunk_index.max(1);
+        // We add NUM_SKIPPED because the total capacity should be as if [`Self::NUM_CHUNKS`] were 32.
+        // This skips the first NUM_SKIPPED powers.
+        let corrected = corrected + Self::NUM_SKIPPED;
+        // This bit shift is just 2^corrected.
+        1 << corrected
+    }
+
+    /// For this index in the whole buffer, returns the index of the [`Chunk`] and the index within that chunk.
+    fn get_indices(full_idnex: u32) -> (u32, u32) {
+        // We're countint leading zeros since each chunk has power of 2 capacity.
+        // So the leading zeros will be proportional to the chunk index.
+        let leading = full_idnex
+            .leading_zeros()
+            // We do a min because we skip the first 8 powers.
+            // The -1 is because this is the number of chunks, but we want the index in the end.
+            .min(Self::NUM_CHUNKS - 1);
+        // We store chunks in smallest to biggest order, so we need to reverse it.
+        let chunk_index = Self::NUM_CHUNKS - 1 - leading;
+        // We only need to cut of this particular bit.
+        // The capacity is only one bit, and if other bits needed to be dropped, `leading` would have been greater
+        let slice_index = full_idnex & !Self::capacity_of_chunk(chunk_index);
+
+        (chunk_index, slice_index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    /// Ensure the total capacity of [`OwnedBuffer`] is `u32::MAX + 1`, since the max *index* of an [`Entity`] is `u32::MAX`.
+    #[test]
+    fn chunk_capacity_sums() {
+        let total: usize = (0..Chunk::NUM_CHUNKS)
+            .map(Chunk::capacity_of_chunk)
+            .map(|x| x as usize)
+            .sum();
+        let expected = u32::MAX as usize + 1;
+        assert_eq!(total, expected);
+    }
+
+    /// Ensure [`OwnedBuffer`] can be properly indexed
+    #[test]
+    fn chunk_indexing() {
+        let to_test = vec![
+            (0, (0, 0)), // index 0 cap = 512
+            (1, (0, 1)),
+            (256, (0, 256)),
+            (511, (0, 511)),
+            (512, (1, 0)), // index 1 cap = 512
+            (1023, (1, 511)),
+            (1024, (2, 0)), // index 2 cap = 1024
+            (1025, (2, 1)),
+            (2047, (2, 1023)),
+            (2048, (3, 0)), // index 3 cap = 2048
+            (4095, (3, 2047)),
+            (4096, (4, 0)), // index 3 cap = 4096
+        ];
+
+        for (input, output) in to_test {
+            assert_eq!(Chunk::get_indices(input), output);
+        }
+    }
+}

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -290,7 +290,7 @@ impl SharedAllocator {
                 0
             }
         } else {
-            (next - 1) as u64
+            next as u64
         }
     }
 

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -390,6 +390,15 @@ impl Allocator {
     }
 }
 
+impl core::fmt::Debug for Allocator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct(core::any::type_name::<Self>())
+            .field("total_indices", &self.total_entity_indices())
+            .field("total_pending", &self.num_pending())
+            .finish()
+    }
+}
+
 /// An [`Iterator`] returning a sequence of [`Entity`] values from an [`Allocator`].
 pub struct AllocEntitiesIterator<'a> {
     allocator: &'a Allocator,

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -442,6 +442,8 @@ impl Drop for AllocEntitiesIterator<'_> {
 /// As a result, using this will be slower than [`Allocator`] but this offers additional freedoms.
 #[derive(Clone)]
 pub struct RemoteAllocator {
+    // PERF: We could avoid the extra 2 atomic ops from upgrading and then dropping the `Weak`,
+    // But this provides more safety and allows memory to be freed earlier.
     shared: Weak<SharedAllocator>,
 }
 

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -239,6 +239,13 @@ impl PendingBuffer {
             }
         }
     }
+
+    fn new() -> Self {
+        Self {
+            chunks: core::array::from_fn(|_index| Chunk::new()),
+            len: AtomicIsize::new(0),
+        }
+    }
 }
 
 impl Drop for PendingBuffer {
@@ -292,6 +299,13 @@ impl SharedAllocator {
         let next = self.next_entity_index.load(Ordering::Relaxed);
         index < next
     }
+
+    fn new() -> Self {
+        Self {
+            pending: PendingBuffer::new(),
+            next_entity_index: AtomicU32::new(0),
+        }
+    }
 }
 
 pub struct Allocator {
@@ -299,6 +313,12 @@ pub struct Allocator {
 }
 
 impl Allocator {
+    pub fn new() -> Self {
+        Self {
+            shared: Arc::new(SharedAllocator::new()),
+        }
+    }
+
     /// Allocates a new [`Entity`], reusing a freed index if one exists.
     pub fn alloc(&self) -> Entity {
         // SAFETY: violating safety requires a `&mut self` to exist, but rust does not allow that.

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -518,6 +518,20 @@ impl Allocator {
         // SAFETY: `free` takes `&mut self`, but this lifetime is captured by the iterator.
         unsafe { self.shared.alloc_many(count) }
     }
+
+    /// Allocates `count` entities in an iterator.
+    ///
+    /// # Safety
+    ///
+    /// Caller ensures [`Self::free`] is not called for the duration of the iterator.
+    /// Caller ensures this allocator is not dropped for the lifetime of the iterator.
+    #[inline]
+    pub unsafe fn alloc_many_unsafe(&self, count: u32) -> AllocEntitiesIterator<'static> {
+        // SAFETY: Caller ensures this instance is valid until the returned value is dropped.
+        let this: &'static Self = unsafe { &*core::ptr::from_ref(self) };
+        // SAFETY:  Caller ensures free is not called.
+        unsafe { this.shared.alloc_many(count) }
+    }
 }
 
 impl core::fmt::Debug for Allocator {

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -417,6 +417,7 @@ unsafe impl EntitySetIterator for AllocEntitiesIterator<'_> {}
 
 /// This is a stripped down version of [`Allocator`] that operates on fewer assumptions.
 /// As a result, using this will be slower than [`Allocator`] but this offers additional freedoms.
+#[derive(Clone)]
 pub struct RemoteAllocator {
     shared: Weak<SharedAllocator>,
 }
@@ -430,6 +431,11 @@ impl RemoteAllocator {
         self.shared
             .upgrade()
             .map(|allocator| allocator.remote_alloc())
+    }
+
+    /// Returns whether or not this [`RemoteAllocator`] is still connected to its source [`Allocator`].
+    pub fn is_closed(&self) -> bool {
+        self.shared.strong_count() > 0
     }
 
     /// Creates a new [`RemoteAllocator`] with the provided [`Allocator`] source.

--- a/crates/bevy_ecs/src/entity/allocator.rs
+++ b/crates/bevy_ecs/src/entity/allocator.rs
@@ -214,7 +214,7 @@ impl PendingBuffer {
 
         let mut len = self.len.load(Ordering::Acquire);
         loop {
-            if len == 0 {
+            if len <= 0 {
                 return None;
             }
 

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -48,7 +48,7 @@ use smallvec::SmallVec;
 pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_mapper`.
     ///
-    /// Implementors should look up any and all [`Entity`] values stored within `self` and
+    /// Implementers should look up any and all [`Entity`] values stored within `self` and
     /// update them to the mapped values via `entity_mapper`.
     fn map_entities<E: EntityMapper>(&mut self, entity_mapper: &mut E);
 }
@@ -102,7 +102,7 @@ impl<A: smallvec::Array<Item = Entity>> MapEntities for SmallVec<A> {
 ///
 /// More generally, this can be used to map [`Entity`] references between any two [`Worlds`](World).
 ///
-/// This is used by [`MapEntities`] implementors.
+/// This is used by [`MapEntities`] implementers.
 ///
 /// ## Example
 ///
@@ -120,7 +120,7 @@ impl<A: smallvec::Array<Item = Entity>> MapEntities for SmallVec<A> {
 ///     fn get_mapped(&mut self, entity: Entity) -> Entity {
 ///         self.map.get(&entity).copied().unwrap_or(entity)
 ///     }
-///     
+///
 ///     fn set_mapped(&mut self, source: Entity, target: Entity) {
 ///         self.map.insert(source, target);
 ///     }
@@ -333,17 +333,12 @@ mod tests {
     #[test]
     fn entity_mapper_no_panic() {
         let mut world = World::new();
-        // "Dirty" the `Entities`, requiring a flush afterward.
         world.entities.reserve_entity();
-        assert!(world.entities.needs_flush());
 
         // Create and exercise a SceneEntityMapper - should not panic because it flushes
         // `Entities` first.
         SceneEntityMapper::world_scope(&mut Default::default(), &mut world, |_, m| {
             m.get_mapped(Entity::PLACEHOLDER);
         });
-
-        // The SceneEntityMapper should leave `Entities` in a flushed state.
-        assert!(!world.entities.needs_flush());
     }
 }

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -256,8 +256,9 @@ impl<'m> SceneEntityMapper<'m> {
     pub fn finish(self, world: &mut World) {
         // SAFETY: Entities data is kept in a valid state via `EntityMap::world_scope`
         let entities = unsafe { world.entities_mut() };
-        assert!(entities.free(self.dead_start).is_some());
-        assert!(entities.reserve_generations(self.dead_start.index(), self.generations));
+        assert!(entities
+            .free_current_and_future_generations(self.dead_start, self.generations)
+            .is_some());
     }
 
     /// Creates an [`SceneEntityMapper`] from a provided [`World`] and [`EntityHashMap<Entity>`], then calls the

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -239,9 +239,6 @@ impl<'m> SceneEntityMapper<'m> {
 
     /// Creates a new [`SceneEntityMapper`], spawning a temporary base [`Entity`] in the provided [`World`]
     pub fn new(map: &'m mut EntityHashMap<Entity>, world: &mut World) -> Self {
-        // We're going to be calling methods on `Entities` that require advance
-        // flushing, such as `alloc` and `free`.
-        world.flush_entities();
         Self {
             map,
             // SAFETY: Entities data is kept in a valid state via `EntityMapper::world_scope`

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -595,7 +595,7 @@ impl Entities {
 
     /// Ensure at least `n` allocations can succeed without reallocating.
     pub fn reserve(&mut self, additional: u32) {
-        let shortfall = (additional as u64).saturating_sub(self.allocator.num_pending());
+        let shortfall = (additional as u64).saturating_sub(self.allocator.num_free());
         self.meta.reserve(shortfall as usize);
     }
 
@@ -719,7 +719,7 @@ impl Entities {
     /// The count of currently allocated entities.
     #[inline]
     pub fn len(&self) -> u64 {
-        self.allocator.total_entity_indices() - self.allocator.num_pending()
+        self.allocator.total_entity_indices() - self.allocator.num_free()
     }
 
     /// Checks if any entity is currently active.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -36,9 +36,11 @@
 //! [`EntityWorldMut::insert`]: crate::world::EntityWorldMut::insert
 //! [`EntityWorldMut::remove`]: crate::world::EntityWorldMut::remove
 
+mod allocator;
 mod clone_entities;
 mod entity_set;
 mod map_entities;
+
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 #[cfg(all(feature = "bevy_reflect", feature = "serialize"))]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -557,6 +557,8 @@ impl fmt::Debug for Pending {
 
 /// An [`Iterator`] returning a sequence of [`Entity`] values from [`Entities`].
 /// These will be flushed.
+///
+/// **NOTE:** Dropping will leak the remaining entities!
 pub struct ReserveEntitiesIterator<'a> {
     allocator: allocator::AllocEntitiesIterator<'a>,
     entities: &'a Entities,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -41,6 +41,7 @@ mod clone_entities;
 mod entity_set;
 mod map_entities;
 
+use allocator::Allocator;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 #[cfg(all(feature = "bevy_reflect", feature = "serialize"))]
@@ -91,19 +92,6 @@ use log::warn;
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-
-#[cfg(target_has_atomic = "64")]
-use bevy_platform_support::sync::atomic::AtomicI64 as AtomicIdCursor;
-#[cfg(target_has_atomic = "64")]
-type IdCursor = i64;
-
-/// Most modern platforms support 64-bit atomics, but some less-common platforms
-/// do not. This fallback allows compilation using a 32-bit cursor instead, with
-/// the caveat that some conversions may fail (and panic) at runtime.
-#[cfg(not(target_has_atomic = "64"))]
-use bevy_platform_support::sync::atomic::AtomicIsize as AtomicIdCursor;
-#[cfg(not(target_has_atomic = "64"))]
-type IdCursor = isize;
 
 /// Lightweight identifier of an [entity](crate::entity).
 ///
@@ -492,7 +480,7 @@ impl SparseSetIndex for Entity {
 }
 
 /// An [`Iterator`] returning a sequence of [`Entity`] values from
-pub struct ReserveEntitiesIterator<'a> {
+pub struct AllocEntitiesIterator<'a> {
     // Metas, so we can recover the current generation for anything in the freelist.
     meta: &'a [EntityMeta],
 
@@ -503,7 +491,7 @@ pub struct ReserveEntitiesIterator<'a> {
     new_indices: core::ops::Range<u32>,
 }
 
-impl<'a> Iterator for ReserveEntitiesIterator<'a> {
+impl<'a> Iterator for AllocEntitiesIterator<'a> {
     type Item = Entity;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -521,11 +509,11 @@ impl<'a> Iterator for ReserveEntitiesIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for ReserveEntitiesIterator<'a> {}
-impl<'a> core::iter::FusedIterator for ReserveEntitiesIterator<'a> {}
+impl<'a> ExactSizeIterator for AllocEntitiesIterator<'a> {}
+impl<'a> core::iter::FusedIterator for AllocEntitiesIterator<'a> {}
 
 // SAFETY: Newly reserved entity values are unique.
-unsafe impl EntitySetIterator for ReserveEntitiesIterator<'_> {}
+unsafe impl EntitySetIterator for AllocEntitiesIterator<'_> {}
 
 /// A [`World`]'s internal metadata store on all of its entities.
 ///
@@ -535,160 +523,42 @@ unsafe impl EntitySetIterator for ReserveEntitiesIterator<'_> {}
 ///  - The location of the entity's components in memory (via [`EntityLocation`])
 ///
 /// [`World`]: crate::world::World
-#[derive(Debug)]
+// #[derive(Debug)]
 pub struct Entities {
     meta: Vec<EntityMeta>,
-
-    /// The `pending` and `free_cursor` fields describe three sets of Entity IDs
-    /// that have been freed or are in the process of being allocated:
-    ///
-    /// - The `freelist` IDs, previously freed by `free()`. These IDs are available to any of
-    ///   [`alloc`], [`reserve_entity`] or [`reserve_entities`]. Allocation will always prefer
-    ///   these over brand new IDs.
-    ///
-    /// - The `reserved` list of IDs that were once in the freelist, but got reserved by
-    ///   [`reserve_entities`] or [`reserve_entity`]. They are now waiting for [`flush`] to make them
-    ///   fully allocated.
-    ///
-    /// - The count of new IDs that do not yet exist in `self.meta`, but which we have handed out
-    ///   and reserved. [`flush`] will allocate room for them in `self.meta`.
-    ///
-    /// The contents of `pending` look like this:
-    ///
-    /// ```txt
-    /// ----------------------------
-    /// |  freelist  |  reserved   |
-    /// ----------------------------
-    ///              ^             ^
-    ///          free_cursor   pending.len()
-    /// ```
-    ///
-    /// As IDs are allocated, `free_cursor` is atomically decremented, moving
-    /// items from the freelist into the reserved list by sliding over the boundary.
-    ///
-    /// Once the freelist runs out, `free_cursor` starts going negative.
-    /// The more negative it is, the more IDs have been reserved starting exactly at
-    /// the end of `meta.len()`.
-    ///
-    /// This formulation allows us to reserve any number of IDs first from the freelist
-    /// and then from the new IDs, using only a single atomic subtract.
-    ///
-    /// Once [`flush`] is done, `free_cursor` will equal `pending.len()`.
-    ///
-    /// [`alloc`]: Entities::alloc
-    /// [`reserve_entity`]: Entities::reserve_entity
-    /// [`reserve_entities`]: Entities::reserve_entities
-    /// [`flush`]: Entities::flush
-    pending: Vec<u32>,
-    free_cursor: AtomicIdCursor,
+    allocator: Allocator,
 }
 
 impl Entities {
-    pub(crate) const fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Entities {
             meta: Vec::new(),
-            pending: Vec::new(),
-            free_cursor: AtomicIdCursor::new(0),
+            allocator: Allocator::new(),
         }
     }
 
     /// Reserve entity IDs concurrently.
     ///
     /// Storage for entity generation and location is lazily allocated by calling [`flush`](Entities::flush).
-    #[expect(
-        clippy::allow_attributes,
-        reason = "`clippy::unnecessary_fallible_conversions` may not always lint."
-    )]
-    #[allow(
-        clippy::unnecessary_fallible_conversions,
-        reason = "`IdCursor::try_from` may fail on 32-bit platforms."
-    )]
-    pub fn reserve_entities(&self, count: u32) -> ReserveEntitiesIterator {
-        // Use one atomic subtract to grab a range of new IDs. The range might be
-        // entirely nonnegative, meaning all IDs come from the freelist, or entirely
-        // negative, meaning they are all new IDs to allocate, or a mix of both.
-        let range_end = self.free_cursor.fetch_sub(
-            IdCursor::try_from(count)
-                .expect("64-bit atomic operations are not supported on this platform."),
-            Ordering::Relaxed,
-        );
-        let range_start = range_end
-            - IdCursor::try_from(count)
-                .expect("64-bit atomic operations are not supported on this platform.");
-
-        let freelist_range = range_start.max(0) as usize..range_end.max(0) as usize;
-
-        let (new_id_start, new_id_end) = if range_start >= 0 {
-            // We satisfied all requests from the freelist.
-            (0, 0)
-        } else {
-            // We need to allocate some new Entity IDs outside of the range of self.meta.
-            //
-            // `range_start` covers some negative territory, e.g. `-3..6`.
-            // Since the nonnegative values `0..6` are handled by the freelist, that
-            // means we need to handle the negative range here.
-            //
-            // In this example, we truncate the end to 0, leaving us with `-3..0`.
-            // Then we negate these values to indicate how far beyond the end of `meta.end()`
-            // to go, yielding `meta.len()+0 .. meta.len()+3`.
-            let base = self.meta.len() as IdCursor;
-
-            let new_id_end = u32::try_from(base - range_start).expect("too many entities");
-
-            // `new_id_end` is in range, so no need to check `start`.
-            let new_id_start = (base - range_end.min(0)) as u32;
-
-            (new_id_start, new_id_end)
-        };
-
-        ReserveEntitiesIterator {
-            meta: &self.meta[..],
-            freelist_indices: self.pending[freelist_range].iter(),
-            new_indices: new_id_start..new_id_end,
-        }
+    pub fn reserve_entities(&self, count: u32) -> AllocEntitiesIterator {
+        self.alloc_entities(count)
     }
 
     /// Reserve one entity ID concurrently.
     ///
     /// Equivalent to `self.reserve_entities(1).next().unwrap()`, but more efficient.
     pub fn reserve_entity(&self) -> Entity {
-        let n = self.free_cursor.fetch_sub(1, Ordering::Relaxed);
-        if n > 0 {
-            // Allocate from the freelist.
-            let index = self.pending[(n - 1) as usize];
-            Entity::from_raw_and_generation(index, self.meta[index as usize].generation)
-        } else {
-            // Grab a new ID, outside the range of `meta.len()`. `flush()` must
-            // eventually be called to make it valid.
-            //
-            // As `self.free_cursor` goes more and more negative, we return IDs farther
-            // and farther beyond `meta.len()`.
-            Entity::from_raw(
-                u32::try_from(self.meta.len() as IdCursor - n).expect("too many entities"),
-            )
-        }
-    }
-
-    /// Check that we do not have pending work requiring `flush()` to be called.
-    fn verify_flushed(&mut self) {
-        debug_assert!(
-            !self.needs_flush(),
-            "flush() needs to be called before this operation is legal"
-        );
+        self.alloc()
     }
 
     /// Allocate an entity ID directly.
-    pub fn alloc(&mut self) -> Entity {
-        self.verify_flushed();
-        if let Some(index) = self.pending.pop() {
-            let new_free_cursor = self.pending.len() as IdCursor;
-            *self.free_cursor.get_mut() = new_free_cursor;
-            Entity::from_raw_and_generation(index, self.meta[index as usize].generation)
-        } else {
-            let index = u32::try_from(self.meta.len()).expect("too many entities");
-            self.meta.push(EntityMeta::EMPTY);
-            Entity::from_raw(index)
-        }
+    pub fn alloc(&self) -> Entity {
+        todo!()
+    }
+
+    /// A more efficient way to [`alloc`](Self::alloc) multiple entities.
+    pub fn alloc_entities(&self, count: u32) -> AllocEntitiesIterator {
+        todo!()
     }
 
     /// Allocate a specific entity ID, overwriting its generation.
@@ -699,31 +569,7 @@ impl Entities {
         note = "This can cause extreme performance problems when used after freeing a large number of entities and requesting an arbitrary entity. See #18054 on GitHub."
     )]
     pub fn alloc_at(&mut self, entity: Entity) -> Option<EntityLocation> {
-        self.verify_flushed();
-
-        let loc = if entity.index() as usize >= self.meta.len() {
-            self.pending
-                .extend((self.meta.len() as u32)..entity.index());
-            let new_free_cursor = self.pending.len() as IdCursor;
-            *self.free_cursor.get_mut() = new_free_cursor;
-            self.meta
-                .resize(entity.index() as usize + 1, EntityMeta::EMPTY);
-            None
-        } else if let Some(index) = self.pending.iter().position(|item| *item == entity.index()) {
-            self.pending.swap_remove(index);
-            let new_free_cursor = self.pending.len() as IdCursor;
-            *self.free_cursor.get_mut() = new_free_cursor;
-            None
-        } else {
-            Some(mem::replace(
-                &mut self.meta[entity.index() as usize].location,
-                EntityMeta::EMPTY.location,
-            ))
-        };
-
-        self.meta[entity.index() as usize].generation = entity.generation;
-
-        loc
+        unimplemented!()
     }
 
     /// Allocate a specific entity ID, overwriting its generation.
@@ -740,42 +586,13 @@ impl Entities {
         &mut self,
         entity: Entity,
     ) -> AllocAtWithoutReplacement {
-        self.verify_flushed();
-
-        let result = if entity.index() as usize >= self.meta.len() {
-            self.pending
-                .extend((self.meta.len() as u32)..entity.index());
-            let new_free_cursor = self.pending.len() as IdCursor;
-            *self.free_cursor.get_mut() = new_free_cursor;
-            self.meta
-                .resize(entity.index() as usize + 1, EntityMeta::EMPTY);
-            AllocAtWithoutReplacement::DidNotExist
-        } else if let Some(index) = self.pending.iter().position(|item| *item == entity.index()) {
-            self.pending.swap_remove(index);
-            let new_free_cursor = self.pending.len() as IdCursor;
-            *self.free_cursor.get_mut() = new_free_cursor;
-            AllocAtWithoutReplacement::DidNotExist
-        } else {
-            let current_meta = &self.meta[entity.index() as usize];
-            if current_meta.location.archetype_id == ArchetypeId::INVALID {
-                AllocAtWithoutReplacement::DidNotExist
-            } else if current_meta.generation == entity.generation {
-                AllocAtWithoutReplacement::Exists(current_meta.location)
-            } else {
-                return AllocAtWithoutReplacement::ExistsWithWrongGeneration;
-            }
-        };
-
-        self.meta[entity.index() as usize].generation = entity.generation;
-        result
+        unimplemented!()
     }
 
     /// Destroy an entity, allowing it to be reused.
     ///
     /// Must not be called while reserved entities are awaiting `flush()`.
     pub fn free(&mut self, entity: Entity) -> Option<EntityLocation> {
-        self.verify_flushed();
-
         let meta = &mut self.meta[entity.index() as usize];
         if meta.generation != entity.generation {
             return None;
@@ -790,13 +607,7 @@ impl Entities {
             );
         }
 
-        let loc = mem::replace(&mut meta.location, EntityMeta::EMPTY.location);
-
-        self.pending.push(entity.index());
-
-        let new_free_cursor = self.pending.len() as IdCursor;
-        *self.free_cursor.get_mut() = new_free_cursor;
-        Some(loc)
+        todo!()
     }
 
     /// Ensure at least `n` allocations can succeed without reallocating.
@@ -809,15 +620,7 @@ impl Entities {
         reason = "`IdCursor::try_from` may fail on 32-bit platforms."
     )]
     pub fn reserve(&mut self, additional: u32) {
-        self.verify_flushed();
-
-        let freelist_size = *self.free_cursor.get_mut();
-        let shortfall = IdCursor::try_from(additional)
-            .expect("64-bit atomic operations are not supported on this platform.")
-            - freelist_size;
-        if shortfall > 0 {
-            self.meta.reserve(shortfall as usize);
-        }
+        todo!()
     }
 
     /// Returns true if the [`Entities`] contains [`entity`](Entity).
@@ -831,8 +634,7 @@ impl Entities {
     /// Clears all [`Entity`] from the World.
     pub fn clear(&mut self) {
         self.meta.clear();
-        self.pending.clear();
-        *self.free_cursor.get_mut() = 0;
+        self.allocator = Allocator::new();
     }
 
     /// Returns the location of an [`Entity`].
@@ -904,10 +706,6 @@ impl Entities {
         }
     }
 
-    fn needs_flush(&mut self) -> bool {
-        *self.free_cursor.get_mut() != self.pending.len() as IdCursor
-    }
-
     /// Allocates space for entities previously reserved with [`reserve_entity`](Entities::reserve_entity) or
     /// [`reserve_entities`](Entities::reserve_entities), then initializes each one using the supplied function.
     ///
@@ -918,35 +716,7 @@ impl Entities {
     ///
     /// Note: freshly-allocated entities (ones which don't come from the pending list) are guaranteed
     /// to be initialized with the invalid archetype.
-    pub unsafe fn flush(&mut self, mut init: impl FnMut(Entity, &mut EntityLocation)) {
-        let free_cursor = self.free_cursor.get_mut();
-        let current_free_cursor = *free_cursor;
-
-        let new_free_cursor = if current_free_cursor >= 0 {
-            current_free_cursor as usize
-        } else {
-            let old_meta_len = self.meta.len();
-            let new_meta_len = old_meta_len + -current_free_cursor as usize;
-            self.meta.resize(new_meta_len, EntityMeta::EMPTY);
-            for (index, meta) in self.meta.iter_mut().enumerate().skip(old_meta_len) {
-                init(
-                    Entity::from_raw_and_generation(index as u32, meta.generation),
-                    &mut meta.location,
-                );
-            }
-
-            *free_cursor = 0;
-            0
-        };
-
-        for index in self.pending.drain(new_free_cursor..) {
-            let meta = &mut self.meta[index as usize];
-            init(
-                Entity::from_raw_and_generation(index, meta.generation),
-                &mut meta.location,
-            );
-        }
-    }
+    pub unsafe fn flush(&mut self, mut _init: impl FnMut(Entity, &mut EntityLocation)) {}
 
     /// Flushes all reserved entities to an "invalid" state. Attempting to retrieve them will return `None`
     /// unless they are later populated with a valid archetype.

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -575,16 +575,9 @@ impl Entities {
     }
 
     /// Ensure at least `n` allocations can succeed without reallocating.
-    #[expect(
-        clippy::allow_attributes,
-        reason = "`clippy::unnecessary_fallible_conversions` may not always lint."
-    )]
-    #[allow(
-        clippy::unnecessary_fallible_conversions,
-        reason = "`IdCursor::try_from` may fail on 32-bit platforms."
-    )]
     pub fn reserve(&mut self, additional: u32) {
-        todo!()
+        let shortfall = (additional as u64).saturating_sub(self.allocator.num_pending());
+        self.meta.reserve(shortfall as usize);
     }
 
     /// Returns true if the [`Entities`] contains [`entity`](Entity).

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -733,7 +733,9 @@ impl Entities {
     #[inline]
     pub fn get(&self, entity: Entity) -> Option<EntityLocation> {
         if let Some(meta) = self.meta.get(entity.index() as usize) {
-            if meta.generation != entity.generation {
+            if meta.generation != entity.generation
+                || meta.location.archetype_id == ArchetypeId::INVALID
+            {
                 return None;
             }
             Some(meta.location)

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -826,7 +826,7 @@ impl Entities {
         self.pending.flush_local(|entity| {
             // SAFETY: `meta` has been resized to include all entities.
             let meta = unsafe { self.meta.get_unchecked_mut(entity.index() as usize) };
-            if meta.generation == entity.generation && meta.location != EntityLocation::INVALID {
+            if meta.generation == entity.generation && meta.location == EntityLocation::INVALID {
                 init(entity, &mut meta.location);
             }
         });

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -487,7 +487,7 @@ impl SparseSetIndex for Entity {
 ///  - The location of the entity's components in memory (via [`EntityLocation`])
 ///
 /// [`World`]: crate::world::World
-// #[derive(Debug)]
+#[derive(Debug)]
 pub struct Entities {
     meta: Vec<EntityMeta>,
     allocator: Allocator,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -777,6 +777,17 @@ impl Entities {
         }
     }
 
+    /// Entities reserved via [`RemoteEntities::reserve`] may or may not be flushed naturally.
+    /// Before using an entity reserved remotely, either set its location manually (usually though [`flush_entity`](crate::world::World::flush_entity)),
+    /// or call this method to queue remotely reserved entities to be flushed with the rest.
+    pub fn queue_remote_pending_to_be_flushed(&self) {
+        #[cfg(feature = "std")]
+        {
+            let remote = self.pending.remote.pending.try_iter();
+            self.pending.local.scope(|pending| pending.extend(remote));
+        }
+    }
+
     /// Allocates space for entities previously reserved with [`reserve_entity`](Entities::reserve_entity) or
     /// [`reserve_entities`](Entities::reserve_entities), then initializes each one using the supplied function.
     ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -703,8 +703,6 @@ impl Entities {
     }
 
     /// Destroy an entity, allowing it to be reused.
-    ///
-    /// Must not be called while reserved entities are awaiting `flush()`.
     pub fn free(&mut self, entity: Entity) -> Option<EntityLocation> {
         self.free_current_and_future_generations(entity, 1)
     }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -613,7 +613,7 @@ impl Entities {
     /// but, if desiered, caller may [`set`](Self::set) the [`EntityLocation`] prior to the flush instead.
     pub fn reserve_entities(&self, count: u32) -> ReserveEntitiesIterator {
         ReserveEntitiesIterator {
-            allocator: self.alloc_many(count),
+            allocator: self.alloc_entities(count),
             entities: self,
         }
     }
@@ -635,7 +635,7 @@ impl Entities {
     }
 
     /// A more efficient way to [`alloc`](Self::alloc) multiple entities.
-    pub fn alloc_many(&self, count: u32) -> allocator::AllocEntitiesIterator {
+    pub fn alloc_entities(&self, count: u32) -> allocator::AllocEntitiesIterator {
         self.allocator.alloc_many(count)
     }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -86,10 +86,7 @@ use crate::{
     storage::{SparseSetIndex, TableId, TableRow},
 };
 use alloc::vec::Vec;
-use bevy_platform_support::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use bevy_platform_support::sync::Arc;
 use concurrent_queue::ConcurrentQueue;
 use core::{fmt, hash::Hash, num::NonZero, panic::Location};
 use log::warn;
@@ -507,7 +504,6 @@ struct Pending {
     remote: RemotePending,
     #[cfg(feature = "std")]
     local: bevy_utils::Parallel<Vec<Entity>>,
-    any_local: AtomicBool,
 }
 
 impl Pending {
@@ -517,7 +513,6 @@ impl Pending {
             Self {
                 remote: RemotePending::new(),
                 local: bevy_utils::Parallel::default(),
-                any_local: AtomicBool::new(false),
             }
         }
 
@@ -539,14 +534,9 @@ impl Pending {
         {
             self.remote.queue_flush(entity)
         }
-        self.any_local.store(true, Ordering::Relaxed);
     }
 
     fn flush_local(&mut self, mut flusher: impl FnMut(Entity)) {
-        if !core::mem::replace(self.any_local.get_mut(), false) {
-            return;
-        }
-
         #[cfg(feature = "std")]
         let pending = { self.local.iter_mut().flat_map(|pending| pending.drain(..)) };
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -763,6 +763,7 @@ impl Entities {
     /// # Safetey
     ///
     /// `idnex` must be a valid index
+    #[inline]
     unsafe fn force_get_meta_mut(&mut self, index: usize) -> &mut EntityMeta {
         if index >= self.meta.len() {
             self.resize_meta_for_index_risky(index)
@@ -790,6 +791,7 @@ impl Entities {
     /// Note: This method may return [`Entities`](Entity) which are currently free
     /// Note that [`contains`](Entities::contains) will correctly return false for freed
     /// entities, since it checks the generation
+    #[inline]
     pub fn resolve_from_id(&self, index: u32) -> Option<Entity> {
         let idu = index as usize;
         if let Some(&EntityMeta { generation, .. }) = self.meta.get(idu) {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -151,7 +151,6 @@ mod tests {
     use core::{
         any::TypeId,
         marker::PhantomData,
-        num::NonZero,
         sync::atomic::{AtomicUsize, Ordering},
     };
     use std::sync::Mutex;
@@ -1694,97 +1693,6 @@ mod tests {
         assert_eq!(0, query_min_size![(&A, &B), Changed<A>]);
         assert_eq!(0, query_min_size![&A, (Changed<A>, With<B>)]);
         assert_eq!(0, query_min_size![(&A, &B), Or<(Changed<A>, Changed<B>)>]);
-    }
-
-    #[test]
-    fn insert_or_spawn_batch() {
-        let mut world = World::default();
-        let e0 = world.spawn(A(0)).id();
-        let e1 = Entity::from_raw(1);
-
-        let values = vec![(e0, (B(0), C)), (e1, (B(1), C))];
-
-        #[expect(
-            deprecated,
-            reason = "This needs to be supported for now, and therefore still needs the test."
-        )]
-        world.insert_or_spawn_batch(values).unwrap();
-
-        assert_eq!(
-            world.get::<A>(e0),
-            Some(&A(0)),
-            "existing component was preserved"
-        );
-        assert_eq!(
-            world.get::<B>(e0),
-            Some(&B(0)),
-            "pre-existing entity received correct B component"
-        );
-        assert_eq!(
-            world.get::<B>(e1),
-            Some(&B(1)),
-            "new entity was spawned and received correct B component"
-        );
-        assert_eq!(
-            world.get::<C>(e0),
-            Some(&C),
-            "pre-existing entity received C component"
-        );
-        assert_eq!(
-            world.get::<C>(e1),
-            Some(&C),
-            "new entity was spawned and received C component"
-        );
-    }
-
-    #[test]
-    fn insert_or_spawn_batch_invalid() {
-        let mut world = World::default();
-        let e0 = world.spawn(A(0)).id();
-        let e1 = Entity::from_raw(1);
-        let e2 = world.spawn_empty().id();
-        let invalid_e2 =
-            Entity::from_raw_and_generation(e2.index(), NonZero::<u32>::new(2).unwrap());
-
-        let values = vec![(e0, (B(0), C)), (e1, (B(1), C)), (invalid_e2, (B(2), C))];
-
-        #[expect(
-            deprecated,
-            reason = "This needs to be supported for now, and therefore still needs the test."
-        )]
-        let result = world.insert_or_spawn_batch(values);
-
-        assert_eq!(
-            result,
-            Err(vec![invalid_e2]),
-            "e2 failed to be spawned or inserted into"
-        );
-
-        assert_eq!(
-            world.get::<A>(e0),
-            Some(&A(0)),
-            "existing component was preserved"
-        );
-        assert_eq!(
-            world.get::<B>(e0),
-            Some(&B(0)),
-            "pre-existing entity received correct B component"
-        );
-        assert_eq!(
-            world.get::<B>(e1),
-            Some(&B(1)),
-            "new entity was spawned and received correct B component"
-        );
-        assert_eq!(
-            world.get::<C>(e0),
-            Some(&C),
-            "pre-existing entity received C component"
-        );
-        assert_eq!(
-            world.get::<C>(e1),
-            Some(&C),
-            "new entity was spawned and received C component"
-        );
     }
 
     #[test]

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2884,6 +2884,7 @@ impl<'w> EntityWorldMut<'w> {
         self.assert_not_despawned();
 
         let entity_clone = self.world.entities.reserve_entity();
+        // If there is a command that could change what we are cloning, apply it.
         self.world.flush();
 
         let mut builder = EntityCloner::build(self.world);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2545,10 +2545,6 @@ impl<'w> EntityWorldMut<'w> {
             world.removed_components.send(component_id, self.entity);
         }
 
-        // Observers and on_remove hooks may reserve new entities, which
-        // requires a flush before Entities::free may be called.
-        world.flush_entities();
-
         let location = world
             .entities
             .free(self.entity)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2918,6 +2918,20 @@ impl World {
         }
     }
 
+    /// If this entity is not in any [`Archetype`](crate::archetype::Archetype), this will flush it to the empty archetype.
+    /// Returns `Some` with the new [`EntityLocation`] if the entity is now valid in the empty archetype.
+    pub fn flush_entity(&mut self, entity: Entity) -> Option<EntityLocation> {
+        if self.entities.contains(entity) && self.entities.get(entity).is_none() {
+            let empty_archetype = self.archetypes.empty_mut();
+            let table = &mut self.storages.tables[empty_archetype.table_id()];
+            // SAFETY: It's empty so no values need to be written
+            let new_location = unsafe { empty_archetype.allocate(entity, table.allocate(entity)) };
+            Some(new_location)
+        } else {
+            None
+        }
+    }
+
     /// Applies any commands in the world's internal [`CommandQueue`].
     /// This does not apply commands from any systems, only those stored in the world.
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1088,7 +1088,6 @@ impl World {
     /// ```
     #[track_caller]
     pub fn spawn_empty(&mut self) -> EntityWorldMut {
-        self.flush();
         let entity = self.entities.alloc();
         // SAFETY: entity was just allocated
         unsafe { self.spawn_at_empty_internal(entity, MaybeLocation::caller()) }
@@ -1164,7 +1163,6 @@ impl World {
         bundle: B,
         caller: MaybeLocation,
     ) -> EntityWorldMut {
-        self.flush();
         let change_tick = self.change_tick();
         let entity = self.entities.alloc();
         let mut bundle_spawner = BundleSpawner::new::<B>(self, change_tick);
@@ -1328,6 +1326,7 @@ impl World {
 
         let result = world.modify_component(entity, f)?;
 
+        // Handles queued commands from hooks, etc.
         self.flush();
         Ok(result)
     }
@@ -1357,6 +1356,7 @@ impl World {
 
         let result = world.modify_component_by_id(entity, component_id, f)?;
 
+        // Handles queued commands from hooks, etc.
         self.flush();
         Ok(result)
     }
@@ -1419,6 +1419,7 @@ impl World {
         entity: Entity,
         caller: MaybeLocation,
     ) -> Result<(), EntityDespawnError> {
+        // If any command depended on this entity, run those before we despawn.
         self.flush();
         let entity = self.get_entity_mut(entity)?;
         entity.despawn_with_caller(caller);
@@ -2461,7 +2462,6 @@ impl World {
             archetype_id: ArchetypeId,
         }
 
-        self.flush();
         let change_tick = self.change_tick();
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =
@@ -2606,7 +2606,6 @@ impl World {
             archetype_id: ArchetypeId,
         }
 
-        self.flush();
         let change_tick = self.change_tick();
         // SAFETY: These come from the same world. `Self.components_registrator` can't be used since we borrow other fields too.
         let mut registrator =

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -28,10 +28,6 @@ where
     #[inline]
     #[track_caller]
     pub(crate) fn new(world: &'w mut World, iter: I, caller: MaybeLocation) -> Self {
-        // Ensure all entity allocations are accounted for so `self.entities` can realloc if
-        // necessary
-        world.flush();
-
         let change_tick = world.change_tick();
 
         let (lower, upper) = iter.size_hint();

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -18,6 +18,7 @@ where
     inner: I,
     spawner: BundleSpawner<'w>,
     caller: MaybeLocation,
+    allocator: crate::entity::allocator::AllocEntitiesIterator<'static>,
 }
 
 impl<'w, I> SpawnBatchIter<'w, I>
@@ -32,7 +33,11 @@ where
 
         let (lower, upper) = iter.size_hint();
         let length = upper.unwrap_or(lower);
-        world.entities.reserve(length as u32);
+
+        world.entities.prepare(length as u32);
+        // SAFETY: We take the lifetime of the world, so the instance is valid.
+        // `BundleSpawner::spawn_non_existent` never frees entities, and that is the only thing we call on it while the iterator is not empty.
+        let allocator = unsafe { world.entities.alloc_entities_unsafe(lower as u32) };
 
         let mut spawner = BundleSpawner::new::<I::Item>(world, change_tick);
         spawner.reserve_storage(length);
@@ -41,6 +46,7 @@ where
             inner: iter,
             spawner,
             caller,
+            allocator,
         }
     }
 }
@@ -68,8 +74,19 @@ where
 
     fn next(&mut self) -> Option<Entity> {
         let bundle = self.inner.next()?;
-        // SAFETY: bundle matches spawner type
-        unsafe { Some(self.spawner.spawn(bundle, self.caller).0) }
+        let entity = self.allocator.next();
+
+        let spawned = match entity {
+            // SAFETY: bundle matches spawner type. `entity` is fresh
+            Some(entity) => unsafe {
+                self.spawner.spawn_non_existent(entity, bundle, self.caller);
+                entity
+            },
+            // SAFETY: bundle matches spawner type
+            None => unsafe { self.spawner.spawn(bundle, self.caller).0 },
+        };
+
+        Some(spawned)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
# Objective

It's version 9 of the same objective lol. For assets as entities, we need entities to be able to be reserved from any thread. Ideally, this can be done without depending on an async context, blocking, or waiting. Any of these compromises *could* hurt asset performance or discontinue the completely non-blocking nature of the asset system. 

As a bonus, this PR makes allocating entities only need `&Entities` instead of `&mut`. `Entities::flush` is now completely optional, meaning none of the `Entities` methods depends on the flush at all, and there is protection against flushing an entity twice.

(If you're curious, v9 actually branched from v8. v8 was focused on #18577 (never flush entities), but this still includes flushing.)

## Solution

Organizationally, I split off the underlying `EntityAllocator` from `Entities`. This makes it easier to read, etc, now that it's more involved.

The basic problem is that we need to be able to allocate an entity from any thread at any time. We also need to be able to free an entity. So at the allocator level, that's 3 operations: `free`, `alloc` (I know `free` isn't being called), and `remote_alloc` (can be called any time). None of these can require mutable access.

The biggest challenge is having a list of entities that are `free` and waiting to be re-used. The list needs to be fully functional without mutable access, needs to be resizable, and needs to be pinned in memory. I ended up using a strategy similar to [`SplitVec`](https://docs.rs/orx-split-vec/latest/orx_split_vec/). That dependency requires `std`, and knowing the max capacity ahead of time lets us simplify the implementation.

## Testing

No new tests right now. I may look into using [loom](https://docs.rs/loom/latest/loom/) at some point. 

## Future work

#18577 is still a good end game here IMO. Ultimately, (just like @maniwani said would happen), I decided that doing this all at once would be both too challenging and add too much complexity. However, v9 makes "never flush" much, *much* more approachable for the future. The biggest issues I ran into were that lots of places hold a reference to an entity's `Archetype` (but the entity now might not have an archetype) and that checking archetypes everywhere *might* actually be less performant than flushing. Maybe.

We can also potentially speed up a lot of different processes now that `alloc` can be called without mutable access and `free` (etc.) can be called without needing to `flush` first.

## Costs

<details>
  <summary>Benchmarks</summary>

```txt
group                                          main_baseline                           remote_reservation_v9_baseline
-----                                          -------------                           ------------------------------
add_remove/sparse_set                          1.07   625.2±42.08µs        ? ?/sec     1.00   583.5±20.43µs        ? ?/sec
add_remove/table                               1.11   883.9±66.56µs        ? ?/sec     1.00   794.4±41.67µs        ? ?/sec
add_remove_very_big/table                      1.09     37.7±2.55ms        ? ?/sec     1.00     34.5±0.46ms        ? ?/sec
added_archetypes/archetype_count/1000          1.77  688.8±175.58µs        ? ?/sec     1.00   388.9±37.14µs        ? ?/sec
added_archetypes/archetype_count/10000         1.24      6.1±0.86ms        ? ?/sec     1.00      4.9±0.24ms        ? ?/sec
added_archetypes/archetype_count/200           1.21    72.7±18.97µs        ? ?/sec     1.00     60.3±1.02µs        ? ?/sec
added_archetypes/archetype_count/2000          1.43  1086.7±290.33µs        ? ?/sec    1.00   760.0±60.02µs        ? ?/sec
added_archetypes/archetype_count/500           1.81  338.3±110.19µs        ? ?/sec     1.00   186.5±13.56µs        ? ?/sec
added_archetypes/archetype_count/5000          1.29      2.7±0.29ms        ? ?/sec     1.00      2.1±0.16ms        ? ?/sec
despawn_world/10_entities                      1.00   695.6±13.85ns        ? ?/sec     1.14   794.3±91.92ns        ? ?/sec
despawn_world/1_entities                       1.00   182.0±24.14ns        ? ?/sec     1.11   202.7±17.31ns        ? ?/sec
despawn_world_recursive/10000_entities         1.00  1668.8±95.30µs        ? ?/sec     1.06  1764.1±110.06µs        ? ?/sec
despawn_world_recursive/1_entities             1.00   382.2±36.07ns        ? ?/sec     1.11   423.9±48.44ns        ? ?/sec
empty_archetypes/iter/100                      1.05      8.5±0.38µs        ? ?/sec     1.00      8.1±0.59µs        ? ?/sec
empty_archetypes/iter/10000                    1.07     12.8±1.61µs        ? ?/sec     1.00     11.9±0.63µs        ? ?/sec
empty_archetypes/iter/5000                     1.06     11.5±0.85µs        ? ?/sec     1.00     10.8±0.64µs        ? ?/sec
empty_archetypes/par_for_each/1000             1.12     12.8±0.87µs        ? ?/sec     1.00     11.4±0.26µs        ? ?/sec
empty_archetypes/par_for_each/10000            1.16     25.4±0.98µs        ? ?/sec     1.00     21.9±0.98µs        ? ?/sec
empty_archetypes/par_for_each/2000             1.15     13.6±1.17µs        ? ?/sec     1.00     11.8±0.84µs        ? ?/sec
empty_archetypes/par_for_each/500              1.05     11.1±0.70µs        ? ?/sec     1.00     10.6±0.36µs        ? ?/sec
empty_commands/0_entities                      1.00      3.9±0.06ns        ? ?/sec     1.40      5.4±0.06ns        ? ?/sec
entity_hash/entity_set_build/10000             1.05     44.8±2.51µs 212.9 MElem/sec    1.00     42.5±1.51µs 224.3 MElem/sec
entity_hash/entity_set_lookup_hit/316          1.00    415.7±5.96ns 725.0 MElem/sec    1.06    439.2±8.67ns 686.2 MElem/sec
entity_hash/entity_set_lookup_miss_id/10000    1.13     44.5±5.30µs 214.2 MElem/sec    1.00     39.5±4.77µs 241.6 MElem/sec
event_propagation/four_event_types             1.14   606.5±27.06µs        ? ?/sec     1.00    533.5±8.35µs        ? ?/sec
event_propagation/single_event_type            1.14   870.3±27.20µs        ? ?/sec     1.00   761.7±13.76µs        ? ?/sec
fake_commands/2000_commands                    1.00     12.1±0.08µs        ? ?/sec     1.27     15.4±0.24µs        ? ?/sec
fake_commands/4000_commands                    1.00     24.2±0.26µs        ? ?/sec     1.27     30.7±0.18µs        ? ?/sec
fake_commands/6000_commands                    1.00     36.3±0.50µs        ? ?/sec     1.28     46.7±2.34µs        ? ?/sec
fake_commands/8000_commands                    1.00     48.3±0.15µs        ? ?/sec     1.29     62.1±1.64µs        ? ?/sec
insert_simple/base                             1.00   403.9±79.33µs        ? ?/sec     1.48    596.6±4.11µs        ? ?/sec
insert_simple/unbatched                        2.19  1021.5±234.06µs        ? ?/sec    1.00    466.7±4.37µs        ? ?/sec
iter_fragmented/base                           1.00    346.6±8.58ns        ? ?/sec     1.41    488.3±3.24ns        ? ?/sec
iter_fragmented/foreach                        1.06    141.4±6.76ns        ? ?/sec     1.00    133.6±4.34ns        ? ?/sec
iter_fragmented_sparse/base                    1.20      7.9±0.16ns        ? ?/sec     1.00      6.5±0.09ns        ? ?/sec
iter_simple/foreach_wide                       2.77     46.4±0.46µs        ? ?/sec     1.00     16.7±0.08µs        ? ?/sec
observe/trigger_simple                         1.00    450.3±9.25µs        ? ?/sec     1.09   490.5±11.04µs        ? ?/sec
par_iter_simple/with_10_fragment               1.00     36.4±0.55µs        ? ?/sec     1.07     38.9±3.67µs        ? ?/sec
query_get_many_2/50000_calls_sparse            1.06   242.4±10.51µs        ? ?/sec     1.00    229.0±2.07µs        ? ?/sec
query_get_many_5/50000_calls_sparse            1.06   607.3±14.47µs        ? ?/sec     1.00   571.6±36.08µs        ? ?/sec
sized_commands_0_bytes/2000_commands           1.00     10.6±1.20µs        ? ?/sec     1.25     13.2±0.10µs        ? ?/sec
sized_commands_0_bytes/4000_commands           1.00     20.6±0.33µs        ? ?/sec     1.30     26.7±0.71µs        ? ?/sec
sized_commands_0_bytes/6000_commands           1.00     30.8±0.26µs        ? ?/sec     1.29     39.7±0.33µs        ? ?/sec
sized_commands_0_bytes/8000_commands           1.00     41.4±0.77µs        ? ?/sec     1.28     53.0±0.63µs        ? ?/sec
sized_commands_12_bytes/2000_commands          1.00     11.6±0.29µs        ? ?/sec     1.23     14.2±0.58µs        ? ?/sec
sized_commands_12_bytes/4000_commands          1.00     22.8±3.30µs        ? ?/sec     1.24     28.2±0.59µs        ? ?/sec
sized_commands_12_bytes/6000_commands          1.00     33.6±0.20µs        ? ?/sec     1.26     42.5±0.35µs        ? ?/sec
sized_commands_12_bytes/8000_commands          1.00     48.8±6.10µs        ? ?/sec     1.22     59.6±0.51µs        ? ?/sec
sized_commands_512_bytes/2000_commands         1.00     46.3±1.28µs        ? ?/sec     1.07     49.4±1.49µs        ? ?/sec
sized_commands_512_bytes/4000_commands         1.00     90.5±2.06µs        ? ?/sec     1.09     98.2±5.62µs        ? ?/sec
spawn_commands/2000_entities                   1.00   155.4±11.61µs        ? ?/sec     1.14   176.4±10.47µs        ? ?/sec
spawn_commands/4000_entities                   1.00   303.7±15.69µs        ? ?/sec     1.16   352.5±10.95µs        ? ?/sec
spawn_commands/6000_entities                   1.00   463.3±31.95µs        ? ?/sec     1.20   555.0±75.62µs        ? ?/sec
spawn_commands/8000_entities                   1.00   619.7±44.57µs        ? ?/sec     1.17   725.8±38.32µs        ? ?/sec
spawn_world/100_entities                       1.23      4.8±2.29µs        ? ?/sec     1.00      3.9±0.71µs        ? ?/sec
spawn_world/10_entities                        1.15   461.9±80.36ns        ? ?/sec     1.00   400.4±30.03ns        ? ?/sec
world_get/50000_entities_sparse                1.00    167.1±4.23µs        ? ?/sec     1.09    182.4±4.87µs        ? ?/sec
world_query_iter/50000_entities_sparse         1.00     38.7±0.08µs        ? ?/sec     1.17     45.4±0.54µs        ? ?/sec
```
</details>

**Interpreting benches:**

In most places, v9 is on par with or even faster than main. Some notable exceptions are the "sized_commands" and "fake_commands" sections, but the regression there is purely due to `Entities::flush` being slower, but we make up for that elsewhere. These commands don't actually do anything though, so this is not relevant to actual use cases. The benchmarks just exist to stress test `CommandQueue`.

The only place where v9 causes a significant and real-world applicable regression is "spawn_commands", where v9 is roughly 15% slower than main. This is something that can be changed later now that `alloc` doesn't need mutable access. I expect we can change this 15% regression to a 15% improvement given that "spawn_world" is roughly 20% faster on v9 than on main. For users that need really fast spawn commands though, they are already using some form of batch spawning or direct world access.

Other regressions seem to be either minimal, unrealistic, easily corrected in the future, or wrong. I feel confident saying "wrong" since running them back to back can sometimes yield different results. I'm on a M2 Max, so there might be some things jumping from perf cores to efficiency cores or something. (I look forward to standardized benchmarking hardware.)

**Wins:** I was worried that, without "never flush", this would be an overall regression, but I am relived that that is not the case. Some very common operations, "insert_simple/unbatched" for example, are way faster on this branch than on main. Basically, on main, `alloc` also adds `EntityMeta` for the entity immediately, but on this branch, we only do so in `set`. That seems to improve cache locality and leads to this roughly 220% improvement. "added_arhcetype" sees 20%-80% improvements too, etc. "iter_simple/foreach_wide" also sees a 270% improvement.

I think in practice, v9 will out perform main for real-world schedules. And I think moving towards "never flush" (even for only a few operations, like `Commands::spawn`) will improve performance even more.

## Next steps

First, I'd like some review. These wins are no use if they cause major bugs. (like what happened in #18266, v2).

Then, I'll add some proper testing and improve documentation. (Review will help inform where to spend my time on the docs and which edge cases need extra testing.) Don't worry, the docs are good enough to review; I just mean user-facing docs.

Finally, some functionality like `alloc_at` are not implemented here. So we need to merge #18148 before this.