### PR TITLE
Fix indentation of `bevy/query` `strict` parameter in docs

### DIFF
--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -143,8 +143,8 @@
 //!     on entities in order for them to be included in results.
 //!   - `without` (optional): An array of fully-qualified type names of components that must *not* be
 //!     present on entities in order for them to be included in results.
-//!   - `strict` (optional): A flag to enable strict mode which will fail if any one of the
-//!     components is not present or can not be reflected. Defaults to false.
+//! - `strict` (optional): A flag to enable strict mode which will fail if any one of the components
+//!   is not present or can not be reflected. Defaults to false.
 //!
 //! `result`: An array, each of which is an object containing:
 //! - `entity`: The ID of a query-matching entity.


### PR DESCRIPTION
# Objective

- The `strict` field of [`BrpQueryParams`](https://dev-docs.bevyengine.org/bevy/remote/builtin_methods/struct.BrpQueryParams.html) was newly added as part of 0.16.
- Its documentation in `lib.rs` improperly indents `strict`, making look like its part of [`BrpQueryFilter`](https://dev-docs.bevyengine.org/bevy/remote/builtin_methods/struct.BrpQueryFilter.html):

![image](https://github.com/user-attachments/assets/f49521da-36d3-4d5d-a7ea-f7a44ddaf195)

## Solution

- Fix `strict`'s indentation so its clear that it is a field of `BrpQueryParams`, not `BrpQueryFilter`.

I would like this to be included in 0.16, since it's a trivial documentation change that fixes an error, but if it needs to be removed from the milestone that's fine.

## Testing

Run `cargo doc -p bevy_remote --no-deps` and verify the indentation is fixed. :)

