### PR TITLE
Improve error message for missing events

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -427,10 +427,12 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 #[inline]
                 unsafe fn validate_param<'w, 's>(
                     state: &'s Self::State,
-                    system_meta: &#path::system::SystemMeta,
-                    world: #path::world::unsafe_world_cell::UnsafeWorldCell<'w>,
+                    _system_meta: &#path::system::SystemMeta,
+                    _world: #path::world::unsafe_world_cell::UnsafeWorldCell<'w>,
                 ) -> Result<(), #path::system::SystemParamValidationError> {
-                    <(#(#tuple_types,)*) as #path::system::SystemParam>::validate_param(&state.state, system_meta, world)
+                    let #state_struct_name { state: (#(#tuple_patterns,)*) } = state;
+                    #(<#field_types as #path::system::SystemParam>::validate_param(#field_locals, _system_meta, _world)?;)*
+                    Ok(())
                 }
 
                 #[inline]

--- a/crates/bevy_ecs/src/event/mutator.rs
+++ b/crates/bevy_ecs/src/event/mutator.rs
@@ -44,6 +44,7 @@ use bevy_ecs::{
 #[derive(SystemParam, Debug)]
 pub struct EventMutator<'w, 's, E: Event> {
     pub(super) reader: Local<'s, EventCursor<E>>,
+    #[system_param(validation_message = "Event not initialized")]
     events: ResMut<'w, Events<E>>,
 }
 

--- a/crates/bevy_ecs/src/event/reader.rs
+++ b/crates/bevy_ecs/src/event/reader.rs
@@ -16,6 +16,7 @@ use bevy_ecs::{
 #[derive(SystemParam, Debug)]
 pub struct EventReader<'w, 's, E: Event> {
     pub(super) reader: Local<'s, EventCursor<E>>,
+    #[system_param(validation_message = "Event not initialized")]
     events: Res<'w, Events<E>>,
 }
 

--- a/crates/bevy_ecs/src/event/writer.rs
+++ b/crates/bevy_ecs/src/event/writer.rs
@@ -60,6 +60,7 @@ use bevy_ecs::{
 /// [`Observer`]: crate::observer::Observer
 #[derive(SystemParam)]
 pub struct EventWriter<'w, E: Event> {
+    #[system_param(validation_message = "Event not initialized")]
     events: ResMut<'w, Events<E>>,
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -131,6 +131,29 @@ use variadics_please::{all_tuples, all_tuples_enumerated};
 /// This will most commonly occur when working with `SystemParam`s generically, as the requirement
 /// has not been proven to the compiler.
 ///
+/// ## Custom Validation Messages
+///
+/// When using the derive macro, any [`SystemParamValidationError`]s will be propagated from the sub-parameters.
+/// If you want to override the error message, add a `#[system_param(validation_message = "New message")]` attribute to the parameter.
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # #[derive(Resource)]
+/// # struct SomeResource;
+/// # use bevy_ecs::system::SystemParam;
+/// #
+/// #[derive(SystemParam)]
+/// struct MyParam<'w> {
+///     #[system_param(validation_message = "Custom Message")]
+///     foo: Res<'w, SomeResource>,
+/// }
+///
+/// let mut world = World::new();
+/// let err = world.run_system_cached(|param: MyParam| {}).unwrap_err();
+/// let expected = "Parameter `MyParam::foo` failed validation: Custom Message";
+/// assert!(err.to_string().ends_with(expected));
+/// ```
+///
 /// ## Builders
 ///
 /// If you want to use a [`SystemParamBuilder`](crate::system::SystemParamBuilder) with a derived [`SystemParam`] implementation,
@@ -2987,7 +3010,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Encountered an error in system `bevy_ecs::system::system_param::tests::missing_event_error::event_system`: Parameter `EventReader<MissingEvent>::events` failed validation: Resource does not exist"]
+    #[should_panic = "Encountered an error in system `bevy_ecs::system::system_param::tests::missing_event_error::event_system`: Parameter `EventReader<MissingEvent>::events` failed validation: Event not initialized"]
     fn missing_event_error() {
         use crate::prelude::{Event, EventReader};
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2971,4 +2971,20 @@ mod tests {
 
         fn res_system(_: Res<MissingResource>) {}
     }
+
+    #[test]
+    #[should_panic = "Encountered an error in system `bevy_ecs::system::system_param::tests::missing_event_error::event_system`: Parameter `Res<Events<MissingEvent>>` failed validation: Resource does not exist"]
+    fn missing_event_error() {
+        use crate::prelude::{Event, EventReader};
+
+        #[derive(Event)]
+        pub struct MissingEvent;
+
+        let mut schedule = crate::schedule::Schedule::default();
+        schedule.add_systems(event_system);
+        let mut world = World::new();
+        schedule.run(&mut world);
+
+        fn event_system(_: EventReader<MissingEvent>) {}
+    }
 }


### PR DESCRIPTION
# Objective

Improve the parameter validation error message for `Event(Reader|Writer|Mutator)`.  

System parameters defined using `#[derive(SystemParam)]`, including the parameters for events, currently propagate the validation errors from their subparameters.  The error includes the type of the failing parameter, so the resulting error includes the type of the failing subparameter instead of the derived parameter.  

In particular, `EventReader<T>` will report an error from a `Res<Events<T>>`, even though the user has no parameter of that type!  

This is a follow-up to #18593.

## Solution

Have `#[derive]`d system parameters map errors during propagation so that they report the outer parameter type.  

To continue to provide context, add a field to `SystemParamValidationError` that identifies the subparameter by name, and is empty for non-`#[derive]`d parameters.  

Allow them to override the failure message for individual parameters.  Use this to convert "Resource does not exist" to "Event not initialized" for `Event(Reader|Writer|Mutator)`.  

## Showcase

The validation error for a `EventReader<SomeEvent>` parameter when `add_event` has not been called changes from:

Before: 
```
Parameter `Res<Events<SomeEvent>>` failed validation: Resource does not exist
```

After
```
Parameter `EventReader<SomeEvent>::events` failed validation: Event not initialized
```
