### PR TITLE
Make `AccessConflicts::is_empty` public

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -952,7 +952,8 @@ impl AccessConflicts {
         }
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    /// Returns true if there are no conflicts present
+    pub fn is_empty(&self) -> bool {
         match self {
             Self::All => false,
             Self::Individual(set) => set.is_empty(),


### PR DESCRIPTION
# Objective

When implementing `SystemParam` for an object which contains a mutable
reference to World, which cannot be derived due to a required lifetime parameter, it's necessary to check that there aren't any conflicts. 

As far as I know, the is_empty method is the only way provided to check for no conflicts at all  
