### PR TITLE
Use a RandomState HashBuilder for re-exported HashMap and HashSet

### DIFF
--- a/crates/bevy_ecs/src/intern.rs
+++ b/crates/bevy_ecs/src/intern.rs
@@ -123,7 +123,7 @@ impl Internable for str {
 /// The implementation ensures that two equal values return two equal [`Interned<T>`] values.
 ///
 /// To use an [`Interner<T>`], `T` must implement [`Internable`].
-pub struct Interner<T: ?Sized + 'static>(RwLock<HashSet<&'static T>>);
+pub struct Interner<T: ?Sized + 'static>(RwLock<HashSet<&'static T, FixedHasher>>);
 
 impl<T: ?Sized> Interner<T> {
     /// Creates a new empty interner

--- a/crates/bevy_platform_support/src/collections.rs
+++ b/crates/bevy_platform_support/src/collections.rs
@@ -12,9 +12,8 @@ pub use hash_table::HashTable;
 pub use hashbrown::Equivalent;
 
 pub mod hash_map {
-    //! Provides [`HashMap`]
+    //! Provides [`HashMap`], re-exported from `hashbrown` to match `std::collections::hash_map` without an `std` dependency.
 
-    use crate::hash::FixedHasher;
     use hashbrown::hash_map as hb;
 
     // Re-exports to match `std::collections::hash_map`
@@ -28,34 +27,21 @@ pub mod hash_map {
 
     // Additional items from `hashbrown`
     pub use hb::{
-        EntryRef, ExtractIf, OccupiedError, RawEntryBuilder, RawEntryBuilderMut, RawEntryMut,
-        RawOccupiedEntryMut,
+        Entry, EntryRef, ExtractIf, HashMap, OccupiedError, RawEntryBuilder, RawEntryBuilderMut,
+        RawEntryMut, RawOccupiedEntryMut,
     };
-
-    /// Shortcut for [`HashMap`](hb::HashMap) with [`FixedHasher`] as the default hashing provider.
-    pub type HashMap<K, V, S = FixedHasher> = hb::HashMap<K, V, S>;
-
-    /// Shortcut for [`Entry`](hb::Entry) with [`FixedHasher`] as the default hashing provider.
-    pub type Entry<'a, K, V, S = FixedHasher> = hb::Entry<'a, K, V, S>;
 }
 
 pub mod hash_set {
-    //! Provides [`HashSet`]
+    //! Provides [`HashSet`], re-exported from [`hashbrown`] to match `std::collections::hash_set` without an `std` dependency.
 
-    use crate::hash::FixedHasher;
     use hashbrown::hash_set as hb;
 
     // Re-exports to match `std::collections::hash_set`
     pub use hb::{Difference, Drain, Intersection, IntoIter, Iter, SymmetricDifference, Union};
 
     // Additional items from `hashbrown`
-    pub use hb::{ExtractIf, OccupiedEntry, VacantEntry};
-
-    /// Shortcut for [`HashSet`](hb::HashSet) with [`FixedHasher`] as the default hashing provider.
-    pub type HashSet<T, S = FixedHasher> = hb::HashSet<T, S>;
-
-    /// Shortcut for [`Entry`](hb::Entry) with [`FixedHasher`] as the default hashing provider.
-    pub type Entry<'a, T, S = FixedHasher> = hb::Entry<'a, T, S>;
+    pub use hb::{Entry, ExtractIf, HashSet, OccupiedEntry, VacantEntry};
 }
 
 pub mod hash_table {

--- a/crates/bevy_platform_support/src/collections.rs
+++ b/crates/bevy_platform_support/src/collections.rs
@@ -52,3 +52,29 @@ pub mod hash_table {
         IterMut, OccupiedEntry, VacantEntry,
     };
 }
+
+#[cfg(test)]
+mod tests {
+
+    // This is a compilation test for the UX regressions laid out in
+    // https://github.com/bevyengine/bevy/issues/18690.
+    // It ensures that the `HashSet` and `HashMap` types are usable without any confusing end-user problems.
+    // This test should never be removed: any future solution must make this test compiles as written.
+    #[test]
+    fn hash_set_and_map_new_work() {
+        use super::{HashMap, HashSet};
+
+        let new_set = HashSet::<u32>::new();
+        let new_map = HashMap::<u32, u32>::new();
+        let default_set = HashSet::<u32>::default();
+        let default_map = HashMap::<u32, u32>::default();
+
+        // This requires the types of new and default to match,
+        // which only works when HashMap's S generic is RandomState.
+        assert_eq!(new_set, default_set);
+        assert_eq!(new_map, default_map);
+
+        let _new_set_with_capacity = HashSet::<u32>::with_capacity(10);
+        let _new_map_with_capacity = HashMap::<u32, u32>::with_capacity(10);
+    }
+}

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -528,10 +528,12 @@ pub fn process_remote_get_resource_request(
     };
 
     // Get the single value out of the map.
-    let value = serialized_object.into_values().next().ok_or_else(|| {
+    let value = serialized_object.values().next().ok_or_else(|| {
         BrpError::internal(anyhow!("Unexpected format of serialized resource value"))
     })?;
-    let response = BrpGetResourceResponse { value };
+    let response = BrpGetResourceResponse {
+        value: value.clone(),
+    };
     serde_json::to_value(response).map_err(BrpError::internal)
 }
 
@@ -553,7 +555,7 @@ pub fn process_remote_get_watching_request(
 
     let mut changed = Vec::new();
     let mut removed = Vec::new();
-    let mut errors = <HashMap<_, _>>::default();
+    let mut errors = HashMap::new();
 
     'component_loop: for component_path in components {
         let Ok(type_registration) =

--- a/crates/bevy_remote/src/builtin_methods.rs
+++ b/crates/bevy_remote/src/builtin_methods.rs
@@ -528,12 +528,10 @@ pub fn process_remote_get_resource_request(
     };
 
     // Get the single value out of the map.
-    let value = serialized_object.values().next().ok_or_else(|| {
+    let value = serialized_object.into_values().next().ok_or_else(|| {
         BrpError::internal(anyhow!("Unexpected format of serialized resource value"))
     })?;
-    let response = BrpGetResourceResponse {
-        value: value.clone(),
-    };
+    let response = BrpGetResourceResponse { value };
     serde_json::to_value(response).map_err(BrpError::internal)
 }
 

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -11,7 +11,7 @@ use bevy_platform_support::{
         hash_map::{Entry, RawEntryMut, VacantEntry},
         HashMap,
     },
-    hash::FixedHasher,
+    hash::RandomState,
 };
 use bevy_utils::default;
 use core::{fmt::Debug, hash::Hash};
@@ -138,7 +138,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
             entry: VacantEntry<
                 (MeshVertexBufferLayoutRef, S::Key),
                 CachedRenderPipelineId,
-                FixedHasher,
+                RandomState,
             >,
         ) -> Result<CachedRenderPipelineId, SpecializedMeshPipelineError>
         where


### PR DESCRIPTION
# Objective

The changes to the Hash made in #15801 to the [`BuildHasher`](https://doc.rust-lang.org/std/hash/trait.BuildHasher.html) resulted in serious migration problems and downgraded UX for users of Bevy's re-exported hashmaps.

Fixes #18690. Closes https://github.com/bevyengine/bevy-website/pull/2065, and closes https://github.com/bevyengine/bevy-website/issues/2045, as this is no longer a user-facing migration. Once merged, we need to go in and remove the migration guide added as part of #15801.

## Solution

This PR reverts that change while keeping the hashbrown version upgrade (and corresponding new improved hashing strategy).

## Testing

I've added a regression test demonstrating that these methods can be called and produce the expected type. This fails before, as `HashMap::new` etc are only implemented for one particular choice of `S: BuildHasher`.

## Migration Guide

Bevy's default `HashMap` and `HashSet` types no longer have a deterministic initialization strategy. If you were relying on this, use `FixedState` as the `S` generic on these types.