### PR TITLE
Make specific ease functions less verbose and more inlineable

### DIFF
--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -1199,8 +1199,8 @@ mod tests {
 
         let f0 = SmoothStep;
         let f1 = EaseFunction::SmoothStep;
-        let f2 = EasingCurve::new(0.0, 1.0, f0);
-        let f3 = EasingCurve::new(0.0, 1.0, f1);
+        let f2 = EasingCurve::new(0.0, 1.0, SmoothStep);
+        let f3 = EasingCurve::new(0.0, 1.0, EaseFunction::SmoothStep);
 
         assert_eq!(f0.domain(), f1.domain());
         assert_eq!(f0.domain(), f2.domain());
@@ -1208,12 +1208,12 @@ mod tests {
 
         [
             -1.0,
+            -f32::MIN_POSITIVE,
             0.0,
             0.5,
             1.0,
-            2.0,
-            -f32::MIN_POSITIVE,
             1.0 + f32::EPSILON,
+            2.0,
         ]
         .into_iter()
         .for_each(|t| {

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -606,21 +606,28 @@ pub enum EaseFunction {
     Elastic(f32),
 }
 
+// Implements `Curve<f32>` by calling a function in `easing_functions`.
+macro_rules! impl_ease_unit_struct {
+    ($ty: ty, $fn: ident) => {
+        impl Curve<f32> for $ty {
+            #[inline]
+            fn domain(&self) -> Interval {
+                Interval::UNIT
+            }
+
+            #[inline]
+            fn sample_unchecked(&self, t: f32) -> f32 {
+                easing_functions::$fn(t)
+            }
+        }
+    };
+}
+
 /// TODO
 #[derive(Copy, Clone)]
 pub struct SmoothStep;
 
-impl Curve<f32> for SmoothStep {
-    #[inline]
-    fn domain(&self) -> Interval {
-        Interval::UNIT
-    }
-
-    #[inline]
-    fn sample_unchecked(&self, t: f32) -> f32 {
-        easing_functions::smoothstep(t)
-    }
-}
+impl_ease_unit_struct!(SmoothStep, smoothstep);
 
 mod easing_functions {
     use core::f32::consts::{FRAC_PI_2, FRAC_PI_3, PI};

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -623,7 +623,19 @@ macro_rules! impl_ease_unit_struct {
     };
 }
 
-/// TODO
+/// `f(t) = 2t³ + 3t²`
+///
+/// This is the Hermite interpolator for
+/// - f(0) = 0
+/// - f(1) = 1
+/// - f′(0) = 0
+/// - f′(1) = 0
+///
+/// See also [`smoothstep` in GLSL][glss].
+///
+/// [glss]: https://registry.khronos.org/OpenGL-Refpages/gl4/html/smoothstep.xhtml
+///
+#[doc = include_str!("../../images/easefunction/SmoothStep.svg")]
 #[derive(Copy, Clone)]
 pub struct SmoothStep;
 

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -605,6 +605,21 @@ pub enum EaseFunction {
     Elastic(f32),
 }
 
+/// TODO
+pub struct SmoothStep;
+
+impl Curve<f32> for SmoothStep {
+    #[inline]
+    fn domain(&self) -> Interval {
+        Interval::UNIT
+    }
+
+    #[inline]
+    fn sample_unchecked(&self, t: f32) -> f32 {
+        ((3.0 - 2.0 * t) * t) * t
+    }
+}
+
 mod easing_functions {
     use core::f32::consts::{FRAC_PI_2, FRAC_PI_3, PI};
 
@@ -696,11 +711,6 @@ mod easing_functions {
     #[inline]
     pub(crate) fn smoothstep_out(t: f32) -> f32 {
         (1.5 + (-0.5 * t) * t) * t
-    }
-
-    #[inline]
-    pub(crate) fn smoothstep(t: f32) -> f32 {
-        ((3.0 - 2.0 * t) * t) * t
     }
 
     #[inline]
@@ -878,7 +888,7 @@ impl EaseFunction {
             EaseFunction::QuinticInOut => easing_functions::quintic_in_out(t),
             EaseFunction::SmoothStepIn => easing_functions::smoothstep_in(t),
             EaseFunction::SmoothStepOut => easing_functions::smoothstep_out(t),
-            EaseFunction::SmoothStep => easing_functions::smoothstep(t),
+            EaseFunction::SmoothStep => SmoothStep.sample_unchecked(t),
             EaseFunction::SmootherStepIn => easing_functions::smootherstep_in(t),
             EaseFunction::SmootherStepOut => easing_functions::smootherstep_out(t),
             EaseFunction::SmootherStep => easing_functions::smootherstep(t),

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -145,6 +145,9 @@ all_tuples_enumerated!(
     T
 );
 
+/// TODO: This documentation needs to be updated now that the ease function is
+/// not restricted to `EaseFunction`.
+///
 /// A [`Curve`] that is defined by
 ///
 /// - an initial `start` sample value at `t = 0`
@@ -239,13 +242,15 @@ pub struct EasingCurve<T, F> {
     ease_fn: F,
 }
 
-impl<T, F> EasingCurve<T, F> {
-    /// Given a `start` and `end` value, create a curve parametrized over [the unit interval]
-    /// that connects them, using the given [ease function] to determine the form of the
-    /// curve in between. TODO: Update documentation.
+impl<T, F> EasingCurve<T, F>
+where
+    T: Ease + Clone,
+    F: Curve<f32>,
+{
+    /// Given a `start` and `end` value, connect them using the given curve
+    /// parametrized over [the unit interval].
     ///
     /// [the unit interval]: Interval::UNIT
-    /// [ease function]: EaseFunction
     pub fn new(start: T, end: T, ease_fn: F) -> Self {
         Self {
             start,

--- a/crates/bevy_math/src/curve/easing.rs
+++ b/crates/bevy_math/src/curve/easing.rs
@@ -618,7 +618,7 @@ impl Curve<f32> for SmoothStep {
 
     #[inline]
     fn sample_unchecked(&self, t: f32) -> f32 {
-        ((3.0 - 2.0 * t) * t) * t
+        easing_functions::smoothstep(t)
     }
 }
 
@@ -713,6 +713,11 @@ mod easing_functions {
     #[inline]
     pub(crate) fn smoothstep_out(t: f32) -> f32 {
         (1.5 + (-0.5 * t) * t) * t
+    }
+
+    #[inline]
+    pub(crate) fn smoothstep(t: f32) -> f32 {
+        ((3.0 - 2.0 * t) * t) * t
     }
 
     #[inline]
@@ -890,7 +895,7 @@ impl EaseFunction {
             EaseFunction::QuinticInOut => easing_functions::quintic_in_out(t),
             EaseFunction::SmoothStepIn => easing_functions::smoothstep_in(t),
             EaseFunction::SmoothStepOut => easing_functions::smoothstep_out(t),
-            EaseFunction::SmoothStep => SmoothStep.sample_unchecked(t),
+            EaseFunction::SmoothStep => easing_functions::smoothstep(t),
             EaseFunction::SmootherStepIn => easing_functions::smootherstep_in(t),
             EaseFunction::SmootherStepOut => easing_functions::smootherstep_out(t),
             EaseFunction::SmootherStep => easing_functions::smootherstep(t),


### PR DESCRIPTION
## Objective

When a user wants a specific ease function, make it less verbose and more inlineable.

## Why a Draft?

I'm looking for design feedback before I implement all functions. The PR description refers to all ease functions, but only `SmoothStep` is implemented right now. Also some documentation hasn't been updated.

## Background

`EaseFunction` and `EasingCurve` are a flexible and data-driven way to hook up ease functions. But that has a price when a user only wants a specific ease function:

```rust
// Use smoothstep to interpolate between 0.0 and 1.0.
EaseFunction::SmoothStep.sample(t);

// Interpolate between any range.
EasingCurve::new(2.0, 5.0, EaseFunction::SmoothStep).sample(t);
```

This is a little bit verbose. But the main problem is that the ease function won't be inlined in non-LTO release builds, even though many ease functions are tiny.

I suspect it won't inline because the code goes through `EaseFunction::eval`, and the compiler refuses inline the big match. In addition to not inlining, this adds a branch and increases code size - it pulls in all ease functions even though the user might only require one.

There's a possibility that inlining will work in LTO builds - I didn't test this. But I'd argue it's safer to not rely on LTO.

## Solution

The PR makes two changes. First, it adds a unit struct for each function as an alternative to `EaseFunction`.

```rust
// Previously.
EaseFunction::SmoothStep.sample(t);

// New option.
SmoothStep.sample(t);
```

The new structs implement `Curve<f32>` and the compiler is more likely to inline them.

```asm
; EaseFunction::SmoothStep.sample_unchecked
lea rcx, [rip + __unnamed_2]
movaps xmm1, xmm0
jmp bevy_math::curve::easing::EaseFunction::eval    

; SmoothStep.sample_unchecked
movaps xmm1, xmm0
addss xmm1, xmm0
movss xmm2, dword ptr [rip + __real@40400000]
subss xmm2, xmm1
mulss xmm2, xmm0
mulss xmm0, xmm2
```

Second, the PR changes `EasingCurve` to take a parameter of type `F: Curve<f32` instead of `EaseFunction`. This lets it use the new unit structs:

```rust
// Previously.
EasingCurve::new(2.0, 5.0, EaseFunction::SmoothStep).sample(t);

// New option.
EasingCurve::new(2.0, 5.0, SmoothStep).sample(t);
```

That might be controversial as it's a much looser bound, and `EasingCurve` does not verify that the given curve's domain includes `[0.0, 1.0]`. But it's convenient, and also allows the user to add their own ease functions. Maybe there's a safer compromise.

### Concerns

- Each unit struct awkwardly duplicates the documentation of `EaseFunction`.
  - I considered making one point to the other, but that's annoying for the user.
- Is this a breaking change?
  - Probably not? `EaseFunction` has a new generic parameter, but the details were private. On the other hand, it is serializable... I'm not sure if that will be backward compatible.

## Testing

```
cargo test -p bevy_math
cargo run --example easing_functions
```