### PR TITLE
Expose the added tick for change detection, both getting and setting.

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -123,6 +123,10 @@ pub trait DetectChangesMut: DetectChanges {
 
     /// Flags this value as having been added.
     ///
+    /// It is not normally necessary to call this method.
+    /// The 'added' tick is set when the value is first added,
+    /// and is not normally changed afterwards.
+    ///
     /// **Note**: This operation cannot be undone.
     fn set_added(&mut self);
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -141,8 +141,7 @@ pub trait DetectChangesMut: DetectChanges {
     /// Manually sets the added tick recording the time when this data was last added.
     ///
     /// # Warning
-    /// The caveats of [`set_last_changed`](DetectChangesMut::set_last_changed) apply, with the additional caveat
-    /// that unexpected behavior may occur should added be ahead of changed. This does not modify the changed tick in any way.
+    /// The caveats of [`set_last_changed`](DetectChangesMut::set_last_changed) apply. This modifies both the added and changed ticks together.
     fn set_last_added(&mut self, last_added: Tick);
 
     /// Manually bypasses change detection, allowing you to mutate the underlying value without updating the change tick.
@@ -419,6 +418,7 @@ macro_rules! change_detection_mut_impl {
             #[track_caller]
             fn set_last_added(&mut self, last_added: Tick) {
                 *self.ticks.added = last_added;
+                *self.ticks.changed = last_added;
                 self.changed_by.assign(MaybeLocation::caller());
             }
 
@@ -1214,6 +1214,7 @@ impl<'w> DetectChangesMut for MutUntyped<'w> {
     #[track_caller]
     fn set_last_added(&mut self, last_added: Tick) {
         *self.ticks.added = last_added;
+        *self.ticks.changed = last_added;
         self.changed_by.assign(MaybeLocation::caller());
     }
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -122,7 +122,6 @@ pub trait DetectChangesMut: DetectChanges {
     fn set_changed(&mut self);
 
     /// Flags this value as having been added.
-    /// This is equivalent to removing and reinserting the value.
     ///
     /// **Note**: This operation cannot be undone.
     fn set_added(&mut self);

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -138,8 +138,8 @@ pub trait DetectChangesMut: DetectChanges {
     /// Manually sets the added tick recording the time when this data was last added.
     ///
     /// # Warning
-    /// The caveats of [set_last_changed](DetectChangesMut::set_last_changed) apply, with the additional caveat
-    /// that unexpected behavior may occur should added be ahead of changed.
+    /// The caveats of [`set_last_changed`](DetectChangesMut::set_last_changed) apply, with the additional caveat
+    /// that unexpected behavior may occur should added be ahead of changed. This does not modify the changed tick in any way.
     fn set_last_added(&mut self, last_added: Tick);
 
     /// Manually bypasses change detection, allowing you to mutate the underlying value without updating the change tick.


### PR DESCRIPTION
# Objective

- Allow viewing and setting the added tick for change detection aware data, to allow operations like checking if the value has been modified since first being added, and spoofing that state (i.e. returning the value to default in place without a remove/insert dance)

## Solution

- Added corresponding functions matching the existing `changed` API:
  - `fn added(&self) -> Tick`
  - `fn set_added(&mut self)`
  - `fn set_last_added(&mut self, last_added: Tick)`

Discussed on discord @ https://canary.discord.com/channels/691052431525675048/749335865876021248/1358718892465193060

## Testing

- Running the bevy test suite by.. making a PR, heck.
- No new tests were introduced due to triviality (i.e. I don't know what to test about this API, and the corresponding API for `changed` is similarly lacking tests.)

