### PR TITLE
Use tokio `Bytes` as backing storage for `Image`.

### DIFF
--- a/crates/bevy_core_pipeline/src/post_process/mod.rs
+++ b/crates/bevy_core_pipeline/src/post_process/mod.rs
@@ -15,7 +15,7 @@ use bevy_ecs::{
     system::{lifetimeless::Read, Commands, Query, Res, ResMut},
     world::{FromWorld, World},
 };
-use bevy_image::{BevyDefault, Image};
+use bevy_image::{bytes::Bytes, BevyDefault, Image};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::Camera,
@@ -212,7 +212,7 @@ impl Plugin for PostProcessingPlugin {
                     depth_or_array_layers: 1,
                 },
                 TextureDimension::D2,
-                DEFAULT_CHROMATIC_ABERRATION_LUT_DATA.to_vec(),
+                Bytes::from_static(&DEFAULT_CHROMATIC_ABERRATION_LUT_DATA),
                 TextureFormat::Rgba8UnormSrgb,
                 RenderAssetUsages::RENDER_WORLD,
             ),

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -2,7 +2,7 @@ use crate::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, weak_handle, Assets, Handle};
 use bevy_ecs::prelude::*;
-use bevy_image::{CompressedImageFormats, Image, ImageSampler, ImageType};
+use bevy_image::{bytes::Bytes, CompressedImageFormats, Image, ImageSampler, ImageType};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::Camera,
@@ -461,9 +461,8 @@ fn setup_tonemapping_lut_image(bytes: &[u8], image_type: ImageType) -> Image {
 
 pub fn lut_placeholder() -> Image {
     let format = TextureFormat::Rgba8Unorm;
-    let data = vec![255, 0, 255, 255];
     Image {
-        data: Some(data),
+        data: Bytes::from_static(&[255, 0, 255, 255]),
         texture_descriptor: TextureDescriptor {
             size: Extent3d {
                 width: 1,

--- a/crates/bevy_image/Cargo.toml
+++ b/crates/bevy_image/Cargo.toml
@@ -61,6 +61,7 @@ bevy_platform_support = { path = "../bevy_platform_support", version = "0.16.0-d
 image = { version = "0.25.2", default-features = false }
 
 # misc
+bytes = "1.10.1"
 bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5" }
 wgpu-types = { version = "24", default-features = false }

--- a/crates/bevy_image/src/basis.rs
+++ b/crates/bevy_image/src/basis.rs
@@ -116,7 +116,7 @@ pub fn basis_buffer_to_image(
             )))
         }
     };
-    image.data = Some(transcoded);
+    image.data = transcoded.into();
     Ok(image)
 }
 

--- a/crates/bevy_image/src/compressed_image_saver.rs
+++ b/crates/bevy_image/src/compressed_image_saver.rs
@@ -44,9 +44,10 @@ impl AssetSaver for CompressedImageSaver {
 
             let mut source_image = compressor_params.source_image_mut(0);
             let size = image.size();
-            let Some(ref data) = image.data else {
+            if !image.is_initialized() {
                 return Err(CompressedImageSaverError::UninitializedImage);
-            };
+            }
+            let data = image.data.as_ref();
             source_image.init(data, size.x, size.y, 4);
 
             let mut compressor = basis_universal::Compressor::new(4);

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -99,7 +99,7 @@ pub fn dds_buffer_to_image(
     image.data = if let Some(transcode_format) = transcode_format {
         match transcode_format {
             TranscodeFormat::Rgb8 => {
-                let data = dds
+                let data: Vec<_> = dds
                     .data
                     .chunks_exact(3)
                     .flat_map(|pixel| [pixel[0], pixel[1], pixel[2], u8::MAX])

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -104,7 +104,7 @@ pub fn dds_buffer_to_image(
                     .chunks_exact(3)
                     .flat_map(|pixel| [pixel[0], pixel[1], pixel[2], u8::MAX])
                     .collect();
-                Some(data)
+                data.into()
             }
             _ => {
                 return Err(TextureError::TranscodeError(format!(
@@ -113,7 +113,7 @@ pub fn dds_buffer_to_image(
             }
         }
     } else {
-        Some(dds.data)
+        dds.data.into()
     };
 
     Ok(image)

--- a/crates/bevy_image/src/exr_texture_loader.rs
+++ b/crates/bevy_image/src/exr_texture_loader.rs
@@ -65,7 +65,7 @@ impl AssetLoader for ExrTextureLoader {
                 depth_or_array_layers: 1,
             },
             TextureDimension::D2,
-            buf,
+            buf.into(),
             format,
             settings.asset_usage,
         ))

--- a/crates/bevy_image/src/hdr_texture_loader.rs
+++ b/crates/bevy_image/src/hdr_texture_loader.rs
@@ -67,7 +67,7 @@ impl AssetLoader for HdrTextureLoader {
                 depth_or_array_layers: 1,
             },
             TextureDimension::D2,
-            rgba_data,
+            rgba_data.into(),
             format,
             settings.asset_usage,
         ))

--- a/crates/bevy_image/src/image_mut.rs
+++ b/crates/bevy_image/src/image_mut.rs
@@ -1,0 +1,528 @@
+use crate::{Image, TextureAccessError, TextureFormatPixelInfo};
+use bevy_color::{Color, ColorToComponents, Gray, LinearRgba, Srgba, Xyza};
+use bevy_math::UVec3;
+use bytes::BytesMut;
+use core::mem;
+use wgpu_types::{TextureDimension, TextureFormat};
+
+impl Image {
+    /// If not readonly, returns a mutable version of the underlying data.
+    pub fn as_mut(&mut self) -> Option<ImageMut> {
+        if self.is_readonly() {
+            None
+        } else {
+            let data = mem::take(&mut self.data).into();
+            Some(ImageMut { image: self, data })
+        }
+    }
+
+    /// Returns a mutable version of the underlying data,
+    /// duplicates the underlying data if readonly.
+    pub fn to_mut(&mut self) -> ImageMut {
+        let data = mem::take(&mut self.data).into();
+        ImageMut { image: self, data }
+    }
+}
+
+/// An [`Image`] with mutable underlying data.
+///
+/// [`ImageMut::data`] will be copied back to [`ImageMut::image`] on drop.
+pub struct ImageMut<'t> {
+    pub image: &'t mut Image,
+    pub data: BytesMut,
+}
+
+impl Drop for ImageMut<'_> {
+    fn drop(&mut self) {
+        self.image.data = mem::take(&mut self.data).into();
+    }
+}
+
+impl ImageMut<'_> {
+    /// Get a reference to the data bytes where a specific pixel's value is stored
+    #[inline(always)]
+    pub fn pixel_bytes(&self, coords: UVec3) -> Option<&[u8]> {
+        let len = self.image.texture_descriptor.format.pixel_size();
+        let offset = self.image.pixel_data_offset(coords);
+        offset.map(|start| &self.data[start..(start + len)])
+    }
+
+    /// Get a mutable reference to the data bytes where a specific pixel's value is stored
+    #[inline(always)]
+    pub fn pixel_bytes_mut(&mut self, coords: UVec3) -> Option<&mut [u8]> {
+        let len = self.image.texture_descriptor.format.pixel_size();
+        let offset = self.image.pixel_data_offset(coords);
+        offset.map(|start| &mut self.data[start..(start + len)])
+    }
+
+    /// Read the color of a specific pixel (1D texture).
+    ///
+    /// See [`get_color_at`](Self::get_color_at) for more details.
+    #[inline(always)]
+    pub fn get_color_at_1d(&self, x: u32) -> Result<Color, TextureAccessError> {
+        if self.image.texture_descriptor.dimension != TextureDimension::D1 {
+            return Err(TextureAccessError::WrongDimension);
+        }
+        self.get_color_at_internal(UVec3::new(x, 0, 0))
+    }
+
+    /// Read the color of a specific pixel (2D texture).
+    ///
+    /// This function will find the raw byte data of a specific pixel and
+    /// decode it into a user-friendly [`Color`] struct for you.
+    ///
+    /// Supports many of the common [`TextureFormat`]s:
+    ///  - RGBA/BGRA 8-bit unsigned integer, both sRGB and Linear
+    ///  - 16-bit and 32-bit unsigned integer
+    ///  - 16-bit and 32-bit float
+    ///
+    /// Be careful: as the data is converted to [`Color`] (which uses `f32` internally),
+    /// there may be issues with precision when using non-f32 [`TextureFormat`]s.
+    /// If you read a value you previously wrote using `set_color_at`, it will not match.
+    /// If you are working with a 32-bit integer [`TextureFormat`], the value will be
+    /// inaccurate (as `f32` does not have enough bits to represent it exactly).
+    ///
+    /// Single channel (R) formats are assumed to represent grayscale, so the value
+    /// will be copied to all three RGB channels in the resulting [`Color`].
+    ///
+    /// Other [`TextureFormat`]s are unsupported, such as:
+    ///  - block-compressed formats
+    ///  - non-byte-aligned formats like 10-bit
+    ///  - signed integer formats
+    #[inline(always)]
+    pub fn get_color_at(&self, x: u32, y: u32) -> Result<Color, TextureAccessError> {
+        if self.image.texture_descriptor.dimension != TextureDimension::D2 {
+            return Err(TextureAccessError::WrongDimension);
+        }
+        self.get_color_at_internal(UVec3::new(x, y, 0))
+    }
+
+    /// Read the color of a specific pixel (2D texture with layers or 3D texture).
+    ///
+    /// See [`get_color_at`](Self::get_color_at) for more details.
+    #[inline(always)]
+    pub fn get_color_at_3d(&self, x: u32, y: u32, z: u32) -> Result<Color, TextureAccessError> {
+        match (
+            self.image.texture_descriptor.dimension,
+            self.image.texture_descriptor.size.depth_or_array_layers,
+        ) {
+            (TextureDimension::D3, _) | (TextureDimension::D2, 2..) => {
+                self.get_color_at_internal(UVec3::new(x, y, z))
+            }
+            _ => Err(TextureAccessError::WrongDimension),
+        }
+    }
+
+    /// Change the color of a specific pixel (1D texture).
+    ///
+    /// See [`set_color_at`](Self::set_color_at) for more details.
+    #[inline(always)]
+    pub fn set_color_at_1d(&mut self, x: u32, color: Color) -> Result<(), TextureAccessError> {
+        if self.image.texture_descriptor.dimension != TextureDimension::D1 {
+            return Err(TextureAccessError::WrongDimension);
+        }
+        self.set_color_at_internal(UVec3::new(x, 0, 0), color)
+    }
+
+    /// Change the color of a specific pixel (2D texture).
+    ///
+    /// This function will find the raw byte data of a specific pixel and
+    /// change it according to a [`Color`] you provide. The [`Color`] struct
+    /// will be encoded into the [`Image`]'s [`TextureFormat`].
+    ///
+    /// Supports many of the common [`TextureFormat`]s:
+    ///  - RGBA/BGRA 8-bit unsigned integer, both sRGB and Linear
+    ///  - 16-bit and 32-bit unsigned integer (with possibly-limited precision, as [`Color`] uses `f32`)
+    ///  - 16-bit and 32-bit float
+    ///
+    /// Be careful: writing to non-f32 [`TextureFormat`]s is lossy! The data has to be converted,
+    /// so if you read it back using `get_color_at`, the `Color` you get will not equal the value
+    /// you used when writing it using this function.
+    ///
+    /// For R and RG formats, only the respective values from the linear RGB [`Color`] will be used.
+    ///
+    /// Other [`TextureFormat`]s are unsupported, such as:
+    ///  - block-compressed formats
+    ///  - non-byte-aligned formats like 10-bit
+    ///  - signed integer formats
+    #[inline(always)]
+    pub fn set_color_at(&mut self, x: u32, y: u32, color: Color) -> Result<(), TextureAccessError> {
+        if self.image.texture_descriptor.dimension != TextureDimension::D2 {
+            return Err(TextureAccessError::WrongDimension);
+        }
+        self.set_color_at_internal(UVec3::new(x, y, 0), color)
+    }
+
+    /// Change the color of a specific pixel (2D texture with layers or 3D texture).
+    ///
+    /// See [`set_color_at`](Self::set_color_at) for more details.
+    #[inline(always)]
+    pub fn set_color_at_3d(
+        &mut self,
+        x: u32,
+        y: u32,
+        z: u32,
+        color: Color,
+    ) -> Result<(), TextureAccessError> {
+        match (
+            self.image.texture_descriptor.dimension,
+            self.image.texture_descriptor.size.depth_or_array_layers,
+        ) {
+            (TextureDimension::D3, _) | (TextureDimension::D2, 2..) => {
+                self.set_color_at_internal(UVec3::new(x, y, z), color)
+            }
+            _ => Err(TextureAccessError::WrongDimension),
+        }
+    }
+
+    #[inline(always)]
+    fn get_color_at_internal(&self, coords: UVec3) -> Result<Color, TextureAccessError> {
+        let Some(bytes) = self.pixel_bytes(coords) else {
+            return Err(TextureAccessError::OutOfBounds {
+                x: coords.x,
+                y: coords.y,
+                z: coords.z,
+            });
+        };
+
+        // NOTE: GPUs are always Little Endian.
+        // Make sure to respect that when we create color values from bytes.
+        match self.image.texture_descriptor.format {
+            TextureFormat::Rgba8UnormSrgb => Ok(Color::srgba(
+                bytes[0] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8Uint => Ok(Color::linear_rgba(
+                bytes[0] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Bgra8UnormSrgb => Ok(Color::srgba(
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[0] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Bgra8Unorm => Ok(Color::linear_rgba(
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[0] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Rgba32Float => Ok(Color::linear_rgba(
+                f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                f32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                f32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+            )),
+            TextureFormat::Rgba16Float => Ok(Color::linear_rgba(
+                half::f16::from_le_bytes([bytes[0], bytes[1]]).to_f32(),
+                half::f16::from_le_bytes([bytes[2], bytes[3]]).to_f32(),
+                half::f16::from_le_bytes([bytes[4], bytes[5]]).to_f32(),
+                half::f16::from_le_bytes([bytes[6], bytes[7]]).to_f32(),
+            )),
+            TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
+                let (r, g, b, a) = (
+                    u16::from_le_bytes([bytes[0], bytes[1]]),
+                    u16::from_le_bytes([bytes[2], bytes[3]]),
+                    u16::from_le_bytes([bytes[4], bytes[5]]),
+                    u16::from_le_bytes([bytes[6], bytes[7]]),
+                );
+                Ok(Color::linear_rgba(
+                    // going via f64 to avoid rounding errors with large numbers and division
+                    (r as f64 / u16::MAX as f64) as f32,
+                    (g as f64 / u16::MAX as f64) as f32,
+                    (b as f64 / u16::MAX as f64) as f32,
+                    (a as f64 / u16::MAX as f64) as f32,
+                ))
+            }
+            TextureFormat::Rgba32Uint => {
+                let (r, g, b, a) = (
+                    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                    u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                    u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                    u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+                );
+                Ok(Color::linear_rgba(
+                    // going via f64 to avoid rounding errors with large numbers and division
+                    (r as f64 / u32::MAX as f64) as f32,
+                    (g as f64 / u32::MAX as f64) as f32,
+                    (b as f64 / u32::MAX as f64) as f32,
+                    (a as f64 / u32::MAX as f64) as f32,
+                ))
+            }
+            // assume R-only texture format means grayscale (linear)
+            // copy value to all of RGB in Color
+            TextureFormat::R8Unorm | TextureFormat::R8Uint => {
+                let x = bytes[0] as f32 / u8::MAX as f32;
+                Ok(Color::linear_rgb(x, x, x))
+            }
+            TextureFormat::R16Unorm | TextureFormat::R16Uint => {
+                let x = u16::from_le_bytes([bytes[0], bytes[1]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let x = (x as f64 / u16::MAX as f64) as f32;
+                Ok(Color::linear_rgb(x, x, x))
+            }
+            TextureFormat::R32Uint => {
+                let x = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let x = (x as f64 / u32::MAX as f64) as f32;
+                Ok(Color::linear_rgb(x, x, x))
+            }
+            TextureFormat::R16Float => {
+                let x = half::f16::from_le_bytes([bytes[0], bytes[1]]).to_f32();
+                Ok(Color::linear_rgb(x, x, x))
+            }
+            TextureFormat::R32Float => {
+                let x = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                Ok(Color::linear_rgb(x, x, x))
+            }
+            TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
+                let r = bytes[0] as f32 / u8::MAX as f32;
+                let g = bytes[1] as f32 / u8::MAX as f32;
+                Ok(Color::linear_rgb(r, g, 0.0))
+            }
+            TextureFormat::Rg16Unorm | TextureFormat::Rg16Uint => {
+                let r = u16::from_le_bytes([bytes[0], bytes[1]]);
+                let g = u16::from_le_bytes([bytes[2], bytes[3]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let r = (r as f64 / u16::MAX as f64) as f32;
+                let g = (g as f64 / u16::MAX as f64) as f32;
+                Ok(Color::linear_rgb(r, g, 0.0))
+            }
+            TextureFormat::Rg32Uint => {
+                let r = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let r = (r as f64 / u32::MAX as f64) as f32;
+                let g = (g as f64 / u32::MAX as f64) as f32;
+                Ok(Color::linear_rgb(r, g, 0.0))
+            }
+            TextureFormat::Rg16Float => {
+                let r = half::f16::from_le_bytes([bytes[0], bytes[1]]).to_f32();
+                let g = half::f16::from_le_bytes([bytes[2], bytes[3]]).to_f32();
+                Ok(Color::linear_rgb(r, g, 0.0))
+            }
+            TextureFormat::Rg32Float => {
+                let r = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                Ok(Color::linear_rgb(r, g, 0.0))
+            }
+            _ => Err(TextureAccessError::UnsupportedTextureFormat(
+                self.image.texture_descriptor.format,
+            )),
+        }
+    }
+
+    #[inline(always)]
+    fn set_color_at_internal(
+        &mut self,
+        coords: UVec3,
+        color: Color,
+    ) -> Result<(), TextureAccessError> {
+        let format = self.image.texture_descriptor.format;
+
+        let Some(bytes) = self.pixel_bytes_mut(coords) else {
+            return Err(TextureAccessError::OutOfBounds {
+                x: coords.x,
+                y: coords.y,
+                z: coords.z,
+            });
+        };
+
+        // NOTE: GPUs are always Little Endian.
+        // Make sure to respect that when we convert color values to bytes.
+        match format {
+            TextureFormat::Rgba8UnormSrgb => {
+                let [r, g, b, a] = Srgba::from(color).to_f32_array();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (b * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8Uint => {
+                let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (b * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Bgra8UnormSrgb => {
+                let [r, g, b, a] = Srgba::from(color).to_f32_array();
+                bytes[0] = (b * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (r * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Bgra8Unorm => {
+                let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
+                bytes[0] = (b * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (r * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Rgba16Float => {
+                let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
+                bytes[0..2].copy_from_slice(&half::f16::to_le_bytes(half::f16::from_f32(r)));
+                bytes[2..4].copy_from_slice(&half::f16::to_le_bytes(half::f16::from_f32(g)));
+                bytes[4..6].copy_from_slice(&half::f16::to_le_bytes(half::f16::from_f32(b)));
+                bytes[6..8].copy_from_slice(&half::f16::to_le_bytes(half::f16::from_f32(a)));
+            }
+            TextureFormat::Rgba32Float => {
+                let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
+                bytes[8..12].copy_from_slice(&f32::to_le_bytes(b));
+                bytes[12..16].copy_from_slice(&f32::to_le_bytes(a));
+            }
+            TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
+                let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
+                let [r, g, b, a] = [
+                    (r * u16::MAX as f32) as u16,
+                    (g * u16::MAX as f32) as u16,
+                    (b * u16::MAX as f32) as u16,
+                    (a * u16::MAX as f32) as u16,
+                ];
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
+                bytes[4..6].copy_from_slice(&u16::to_le_bytes(b));
+                bytes[6..8].copy_from_slice(&u16::to_le_bytes(a));
+            }
+            TextureFormat::Rgba32Uint => {
+                let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
+                let [r, g, b, a] = [
+                    (r * u32::MAX as f32) as u32,
+                    (g * u32::MAX as f32) as u32,
+                    (b * u32::MAX as f32) as u32,
+                    (a * u32::MAX as f32) as u32,
+                ];
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
+                bytes[8..12].copy_from_slice(&u32::to_le_bytes(b));
+                bytes[12..16].copy_from_slice(&u32::to_le_bytes(a));
+            }
+            TextureFormat::R8Unorm | TextureFormat::R8Uint => {
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+            }
+            TextureFormat::R16Unorm | TextureFormat::R16Uint => {
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
+                let r = (r * u16::MAX as f32) as u16;
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+            }
+            TextureFormat::R32Uint => {
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
+                // go via f64 to avoid imprecision
+                let r = (r as f64 * u32::MAX as f64) as u32;
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+            }
+            TextureFormat::R16Float => {
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
+                let x = half::f16::from_f32(r);
+                bytes[0..2].copy_from_slice(&half::f16::to_le_bytes(x));
+            }
+            TextureFormat::R32Float => {
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+            }
+            TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
+                let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Rg16Unorm | TextureFormat::Rg16Uint => {
+                let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
+                let r = (r * u16::MAX as f32) as u16;
+                let g = (g * u16::MAX as f32) as u16;
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
+            }
+            TextureFormat::Rg32Uint => {
+                let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
+                // go via f64 to avoid imprecision
+                let r = (r as f64 * u32::MAX as f64) as u32;
+                let g = (g as f64 * u32::MAX as f64) as u32;
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
+            }
+            TextureFormat::Rg16Float => {
+                let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
+                bytes[0..2].copy_from_slice(&half::f16::to_le_bytes(half::f16::from_f32(r)));
+                bytes[2..4].copy_from_slice(&half::f16::to_le_bytes(half::f16::from_f32(g)));
+            }
+            TextureFormat::Rg32Float => {
+                let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
+            }
+            _ => {
+                return Err(TextureAccessError::UnsupportedTextureFormat(
+                    self.image.texture_descriptor.format,
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bevy_asset::RenderAssetUsages;
+    use bevy_color::Color;
+    use wgpu_types::{Extent3d, TextureDimension, TextureFormat};
+
+    use crate::Image;
+
+    #[test]
+    fn get_set_pixel_2d_with_layers() {
+        let mut image = Image::new_fill(
+            Extent3d {
+                width: 5,
+                height: 10,
+                depth_or_array_layers: 3,
+            },
+            TextureDimension::D2,
+            &[0, 0, 0, 255],
+            TextureFormat::Rgba8Unorm,
+            RenderAssetUsages::MAIN_WORLD,
+        );
+        let mut image_mut = image.as_mut().unwrap();
+        image_mut.set_color_at_3d(0, 0, 0, Color::WHITE).unwrap();
+        assert!(matches!(
+            image_mut.get_color_at_3d(0, 0, 0),
+            Ok(Color::WHITE)
+        ));
+        image_mut.set_color_at_3d(2, 3, 1, Color::WHITE).unwrap();
+        assert!(matches!(
+            image_mut.get_color_at_3d(2, 3, 1),
+            Ok(Color::WHITE)
+        ));
+        image_mut.set_color_at_3d(4, 9, 2, Color::WHITE).unwrap();
+        assert!(matches!(
+            image_mut.get_color_at_3d(4, 9, 2),
+            Ok(Color::WHITE)
+        ));
+        drop(image_mut);
+        assert!(matches!(image.get_color_at_3d(0, 0, 0), Ok(Color::WHITE)));
+        assert!(matches!(image.get_color_at_3d(2, 3, 1), Ok(Color::WHITE)));
+        assert!(matches!(image.get_color_at_3d(4, 9, 2), Ok(Color::WHITE)));
+    }
+}

--- a/crates/bevy_image/src/ktx2.rs
+++ b/crates/bevy_image/src/ktx2.rs
@@ -266,7 +266,7 @@ pub fn ktx2_buffer_to_image(
     // error cases have been handled
     let mut image = Image::default();
     image.texture_descriptor.format = texture_format;
-    image.data = Some(wgpu_data.into_iter().flatten().collect::<Vec<_>>());
+    image.data = wgpu_data.into_iter().flatten().collect::<Vec<_>>().into();
     image.texture_descriptor.size = Extent3d {
         width,
         height,

--- a/crates/bevy_image/src/lib.rs
+++ b/crates/bevy_image/src/lib.rs
@@ -11,6 +11,7 @@ pub mod prelude {
 }
 
 mod image;
+mod image_mut;
 pub use self::image::*;
 #[cfg(feature = "basis-universal")]
 mod basis;
@@ -29,6 +30,7 @@ mod ktx2;
 mod texture_atlas;
 mod texture_atlas_builder;
 
+pub use bytes;
 #[cfg(feature = "basis-universal")]
 pub use compressed_image_saver::*;
 #[cfg(feature = "dds")]

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1837,9 +1837,14 @@ impl FromWorld for MeshPipeline {
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();
+
+            if !image.is_initialized() {
+                panic!("Image was created without data");
+            }
+
             render_queue.write_texture(
                 texture.as_image_copy(),
-                image.data.as_ref().expect("Image was created without data"),
+                &image.data,
                 TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(image.width() * format_size as u32),

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -114,7 +114,7 @@ fn fallback_image_new(
             render_queue,
             &image.texture_descriptor,
             TextureDataOrder::default(),
-            &image.data.expect("Image has no data"),
+            &image.data,
         )
     } else {
         render_device.create_texture(&image.texture_descriptor)

--- a/crates/bevy_render/src/texture/gpu_image.rs
+++ b/crates/bevy_render/src/texture/gpu_image.rs
@@ -36,7 +36,7 @@ impl RenderAsset for GpuImage {
 
     #[inline]
     fn byte_len(image: &Self::SourceAsset) -> Option<usize> {
-        image.data.as_ref().map(Vec::len)
+        image.is_initialized().then_some(image.data.len())
     }
 
     /// Converts the extracted image into a [`GpuImage`].
@@ -45,13 +45,13 @@ impl RenderAsset for GpuImage {
         _: AssetId<Self::SourceAsset>,
         (render_device, render_queue, default_sampler): &mut SystemParamItem<Self::Param>,
     ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
-        let texture = if let Some(ref data) = image.data {
+        let texture = if image.is_initialized() {
             render_device.create_texture_with_data(
                 render_queue,
                 &image.texture_descriptor,
                 // TODO: Is this correct? Do we need to use `MipMajor` if it's a ktx2 file?
                 wgpu::util::TextureDataOrder::default(),
-                data,
+                &image.data,
             )
         } else {
             render_device.create_texture(&image.texture_descriptor)

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -681,7 +681,7 @@ pub(crate) fn collect_screenshots(world: &mut World) {
                         depth_or_array_layers: 1,
                     },
                     wgpu::TextureDimension::D2,
-                    result,
+                    result.into(),
                     texture_format,
                     RenderAssetUsages::RENDER_WORLD,
                 ),

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -369,9 +369,12 @@ impl FromWorld for Mesh2dPipeline {
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();
+            if !image.is_initialized() {
+                panic!("Image has no data");
+            }
             render_queue.write_texture(
                 texture.as_image_copy(),
-                image.data.as_ref().expect("Image has no data"),
+                image.data.as_ref(),
                 TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(image.width() * format_size as u32),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -99,9 +99,12 @@ impl FromWorld for SpritePipeline {
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();
+            if !image.is_initialized() {
+                panic!("Image has no data");
+            }
             render_queue.write_texture(
                 texture.as_image_copy(),
-                image.data.as_ref().expect("Image has no data"),
+                &image.data,
                 TexelCopyBufferLayout {
                     offset: 0,
                     bytes_per_row: Some(image.width() * format_size as u32),

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -255,7 +255,7 @@ impl FontAtlasSet {
                     depth_or_array_layers: 1,
                 },
                 TextureDimension::D2,
-                data,
+                data.into(),
                 TextureFormat::Rgba8UnormSrgb,
                 RenderAssetUsages::MAIN_WORLD,
             ),

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -56,6 +56,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
         RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD,
     );
 
+    let mut image_mut = image.to_mut();
     // To make it extra fancy, we can set the Alpha of each pixel,
     // so that it fades out in a circular fashion.
     for y in 0..IMAGE_HEIGHT {
@@ -69,12 +70,12 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
             // (it is the 4th byte of each pixel, as per our `TextureFormat`)
 
             // Find our pixel by its coordinates
-            let pixel_bytes = image.pixel_bytes_mut(UVec3::new(x, y, 0)).unwrap();
+            let pixel_bytes = image_mut.pixel_bytes_mut(UVec3::new(x, y, 0)).unwrap();
             // Convert our f32 to u8
             pixel_bytes[3] = (a * u8::MAX as f32) as u8;
         }
     }
-
+    drop(image_mut);
     // Add it to Bevy's assets, so it can be used for rendering
     // this will give us a handle we can use
     // (to display it in a sprite, or as part of UI, etc.)
@@ -136,9 +137,11 @@ fn draw(
     }
 
     // Set the new color, but keep old alpha value from image.
-    image
-        .set_color_at(x, y, draw_color.with_alpha(old_color.alpha()))
-        .unwrap();
+    if let Some(mut image) = image.as_mut() {
+        image
+            .set_color_at(x, y, draw_color.with_alpha(old_color.alpha()))
+            .unwrap();
+    }
 
     *i += 1;
 }

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -499,17 +499,15 @@ fn update(
                         * img_bytes.texture_descriptor.format.pixel_size();
                     let aligned_row_bytes = RenderDevice::align_copy_bytes_per_row(row_bytes);
                     if row_bytes == aligned_row_bytes {
-                        img_bytes.data.as_mut().unwrap().clone_from(&image_data);
+                        img_bytes.data = core::mem::take(&mut image_data).into();
                     } else {
                         // shrink data to original image size
-                        img_bytes.data = Some(
-                            image_data
-                                .chunks(aligned_row_bytes)
-                                .take(img_bytes.height() as usize)
-                                .flat_map(|row| &row[..row_bytes.min(row.len())])
-                                .cloned()
-                                .collect(),
-                        );
+                        img_bytes.data = image_data
+                            .chunks(aligned_row_bytes)
+                            .take(img_bytes.height() as usize)
+                            .flat_map(|row| &row[..row_bytes.min(row.len())])
+                            .cloned()
+                            .collect();
                     }
 
                     // Create RGBA Image Buffer

--- a/examples/asset/alter_sprite.rs
+++ b/examples/asset/alter_sprite.rs
@@ -127,7 +127,7 @@ fn alter_asset(mut images: ResMut<Assets<Image>>, left_bird: Single<&Sprite, Wit
         return;
     };
 
-    for pixel in image.data.as_mut().unwrap() {
+    for pixel in image.to_mut().data.as_mut() {
         // Directly modify the asset data, which will affect all users of this asset. By
         // contrast, mutating the handle (as we did above) affects only one copy. In this case,
         // we'll just invert the colors, by way of demonstration. Notice that both uses of the


### PR DESCRIPTION
# Objective

`Vec<u8>` is inflexible as backing storage for `Image`.

## Solution

Use `Bytes` from `tokio` as its backing storage, this supports static bytes and subslices, and can potentially avoid some cloning.

## Testing

Changed some tests.
