### PR TITLE
Initialize pre-processing pipelines only when culling is enabled.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -3057,6 +3057,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         SRes<PipelineCache>,
         SRes<MeshAllocator>,
         Option<SRes<PreprocessPipelines>>,
+        SRes<GpuPreprocessingSupport>,
     );
     type ViewQuery = Has<PreprocessBindGroups>;
     type ItemQuery = ();
@@ -3072,6 +3073,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
             pipeline_cache,
             mesh_allocator,
             preprocess_pipelines,
+            preprocessing_support,
         ): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -3080,7 +3082,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         // it's compiled. Otherwise, our mesh instance data won't be present.
         if let Some(preprocess_pipelines) = preprocess_pipelines {
             if !has_preprocess_bind_group
-                || !preprocess_pipelines.pipelines_are_loaded(&pipeline_cache)
+                || !preprocess_pipelines.pipelines_are_loaded(&pipeline_cache, &preprocessing_support)
             {
                 return RenderCommandResult::Skip;
             }

--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -111,6 +111,11 @@ impl GpuPreprocessingSupport {
             }
         }
     }
+
+    /// Returns true if GPU culling is supported on this platform.
+    pub fn is_culling_supported(&self) -> bool {
+        self.max_supported_mode == GpuPreprocessingMode::Culling
+    }
 }
 
 /// The amount of GPU preprocessing (compute and indirect draw) that we do.
@@ -1096,7 +1101,7 @@ impl FromWorld for GpuPreprocessingSupport {
             crate::get_adreno_model(adapter).is_some_and(|model| model != 720 && model <= 730)
         }
 
-        let feature_support = device.features().contains(
+        let culling_feature_support = device.features().contains(
             Features::INDIRECT_FIRST_INSTANCE
                 | Features::MULTI_DRAW_INDIRECT
                 | Features::PUSH_CONSTANTS,
@@ -1107,12 +1112,11 @@ impl FromWorld for GpuPreprocessingSupport {
             DownlevelFlags::VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW
         );
 
-        let max_supported_mode = if !feature_support
-            || device.limits().max_compute_workgroup_size_x == 0
+        let max_supported_mode = if device.limits().max_compute_workgroup_size_x == 0
             || is_non_supported_android_device(adapter)
         {
             GpuPreprocessingMode::None
-        } else if !(feature_support && limit_support && downlevel_support) {
+        } else if !(culling_feature_support && limit_support && downlevel_support) {
             GpuPreprocessingMode::PreprocessingOnly
         } else {
             GpuPreprocessingMode::Culling


### PR DESCRIPTION
Better fix for #18463 that still allows enabling mesh preprocessing on webgpu.