### PR TITLE
Small docs PR for `PointLightShadowMap`/`DirectionalLightShadowMap`

### DIFF
--- a/crates/bevy_pbr/src/light/directional_light.rs
+++ b/crates/bevy_pbr/src/light/directional_light.rs
@@ -41,14 +41,7 @@ use super::*;
 /// To modify the cascade setup, such as the number of cascades or the maximum shadow distance,
 /// change the [`CascadeShadowConfig`] component of the entity with the [`DirectionalLight`].
 ///
-/// To control the resolution of the shadow maps, use the [`DirectionalLightShadowMap`] resource:
-///
-/// ```
-/// # use bevy_app::prelude::*;
-/// # use bevy_pbr::DirectionalLightShadowMap;
-/// App::new()
-///     .insert_resource(DirectionalLightShadowMap { size: 2048 });
-/// ```
+/// To control the resolution of the shadow maps, use the [`DirectionalLightShadowMap`] resource.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 #[require(

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -102,7 +102,8 @@ pub mod light_consts {
 #[derive(Resource, Clone, Debug, Reflect)]
 #[reflect(Resource, Debug, Default, Clone)]
 pub struct PointLightShadowMap {
-    /// The shadow map texture's width and height in pixels.
+    /// The width and height of each of the 6 faces of the cubemap.
+
     ///
     /// Defaults to `1024`.
     pub size: usize,
@@ -129,7 +130,7 @@ pub type WithLight = Or<(With<PointLight>, With<SpotLight>, With<DirectionalLigh
 #[derive(Resource, Clone, Debug, Reflect)]
 #[reflect(Resource, Debug, Default, Clone)]
 pub struct DirectionalLightShadowMap {
-    /// The shadow map texture's width and height in pixels.
+    // The width and height of each cascade.
     ///
     /// Defaults to `2048`.
     pub size: usize,

--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -91,9 +91,20 @@ pub mod light_consts {
     }
 }
 
+/// Controls the resolution of [`PointLight`] shadow maps.
+///
+/// ```
+/// # use bevy_app::prelude::*;
+/// # use bevy_pbr::PointLightShadowMap;
+/// App::new()
+///     .insert_resource(PointLightShadowMap { size: 2048 });
+/// ```
 #[derive(Resource, Clone, Debug, Reflect)]
 #[reflect(Resource, Debug, Default, Clone)]
 pub struct PointLightShadowMap {
+    /// The shadow map texture's width and height in pixels.
+    ///
+    /// Defaults to `1024`.
     pub size: usize,
 }
 
@@ -108,9 +119,19 @@ impl Default for PointLightShadowMap {
 pub type WithLight = Or<(With<PointLight>, With<SpotLight>, With<DirectionalLight>)>;
 
 /// Controls the resolution of [`DirectionalLight`] shadow maps.
+///
+/// ```
+/// # use bevy_app::prelude::*;
+/// # use bevy_pbr::DirectionalLightShadowMap;
+/// App::new()
+///     .insert_resource(DirectionalLightShadowMap { size: 4096 });
+/// ```
 #[derive(Resource, Clone, Debug, Reflect)]
 #[reflect(Resource, Debug, Default, Clone)]
 pub struct DirectionalLightShadowMap {
+    /// The shadow map texture's width and height in pixels.
+    ///
+    /// Defaults to `2048`.
     pub size: usize,
 }
 

--- a/crates/bevy_pbr/src/light/point_light.rs
+++ b/crates/bevy_pbr/src/light/point_light.rs
@@ -19,6 +19,12 @@ use super::*;
 /// | 4000 | 300 |    | 75-100 | 40.5  |
 ///
 /// Source: [Wikipedia](https://en.wikipedia.org/wiki/Lumen_(unit)#Lighting)
+///
+/// ## Shadows
+///
+/// To enable shadows, set the `shadows_enabled` property to `true`.
+///
+/// To control the resolution of the shadow maps, use the [`PointLightShadowMap`] resource.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 #[require(


### PR DESCRIPTION
# Objective

- Improve the docs for `PointLightShadowMap` and `DirectionalLightShadowMap`

## Solution

- Add example for how to use `PointLightShadowMap` and move the `DirectionalLightShadowMap` example from `DirectionalLight`.
- Match `PointLight` and `DirectionalLight` docs about shadows.
- Describe what `size` means.
