### PR TITLE
The toml workflow job will now install taplo-cli using cargo-binstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@v1.12.3
       - name: Install taplo
         run: cargo binstall taplo-cli --locked
       - name: Run Taplo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
   NIGHTLY_TOOLCHAIN: nightly
   RUSTFLAGS: "-D warnings"
+  BINSTALL_VERSION: "v1.12.3"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
@@ -273,7 +274,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cargo-bins/cargo-binstall@v1.12.3
       - name: Install taplo
-        run: cargo binstall taplo-cli --locked
+        run: cargo binstall taplo-cli@0.9.3 --locked
       - name: Run Taplo
         id: taplo
         run: taplo fmt --check --diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,9 +271,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: cargo-bins/cargo-binstall@main
       - name: Install taplo
-        run: cargo install taplo-cli --locked
+        run: cargo binstall taplo-cli --locked
       - name: Run Taplo
         id: taplo
         run: taplo fmt --check --diff


### PR DESCRIPTION
# Objective
Avoid needing to compile `taplo-cli` every time we use it in CI.

## Solution
Use [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to install `taplo-cli`.

cargo-binstall is different from `cargo install`, in that it will first attempt download a precompiled `taplo-cli` binary, in an attempt to avoid compilation. However, failing that (for any reason), it will fall back to installing the binary through `cargo install`.

While installing `taplo-cli` from source is relatively fast (around 50-60s), this still provides a small speed boost to the job, by not needing to spend time compiling `taplo-cli` from source at all.

## Note on how this affects workflows
This PR does have one side-effect: Should `taplo-cli` need to be compiled from source at all, it is no longer guaranteed to use the latest `stable` version of `rustc`. This may be considered problematic, as `taplo-cli` doesn't appear to have a MSRV policy.

However, its MSRV (as of writing this PR) is `1.74` - a nearly 1.5 year old version. This seems to imply that, if `taplo-cli`'s MSRV is ever updated, it won't be to the absolute latest stable version of Rust until said version is a few months old.

Combine that with [the Github Actions runner images being frequently (and automatically) updated to use the latest Rust tooling](https://github.com/actions/runner-images/pull/11957), and I don't foresee `taplo-cli`'s MSRV being an issue in 99% of circumstances.

Still, there is the possibility of it being a problem in those 1% of circumstances - if this is a concern, please let me know and I'll try to fix it.

## Testing

This change was tested on my local fork. The specific job run can be found [here](https://github.com/LikeLakers2/bevy/actions/runs/14350945588/job/40229485624).
