### PR TITLE
Make Timer usable as a component

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -1,4 +1,5 @@
 use crate::Stopwatch;
+use bevy_ecs::{component::Component, event::Event};
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::prelude::*;
 use core::time::Duration;
@@ -12,7 +13,10 @@ use core::time::Duration;
 /// Paused timers will not have elapsed time increased.
 ///
 /// Note that in order to advance the timer [`tick`](Timer::tick) **MUST** be called.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// For timers used as components this will be done automatically by the
+/// [`update_timers_system`](crate::update_timers_system) unless
+/// [`TimerNoAutoTick`] is also present.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Component)]
 #[cfg_attr(feature = "serialize", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(
     feature = "bevy_reflect",
@@ -453,6 +457,16 @@ pub enum TimerMode {
     /// Reset when finished.
     Repeating,
 }
+
+/// Event that is triggered when a [`Timer`] attached as a component finishes.
+#[derive(Event, Debug, Clone, Copy)]
+pub struct TimerFinishedEvent;
+
+/// Marker component to prevent timers used as components from being
+/// automatically ticked by
+/// [`update_timers_system`](crate::update_timers_system).
+#[derive(Component, Debug, Clone, Copy)]
+pub struct TimerNoAutoTick;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Objective

Partially fixes #15129 by implementing the suggestion from that issue by @Vrixyz. 

## Solution

Add support for using `Timer` as a component and add a system that auto-ticks timers added this way unless they are marked with `TimerNoAutoTick`. 

## Questions
- Which schedule should we tick the timers in? I kind of arbitrarily chose `PreUpdate` for now, but it could also make sense in `Update` (where gameplay events usually get triggered).

## Testing

Added a unit test that covers the new functionality.

---

## Showcase

Automatically despawn entities
```rust
        commands
            .spawn(Timer::new(Duration::from_secs(3.0, TimerMode::Once))
            .observe(|trigger: Trigger<TimerFinishedEvent>| {
                    commands.entity(trigger.entity).despawn();
                },
            );
```

Make an entity do something at a regular interval
```rust
        commands
            .spawn(Timer::new(Duration::from_secs(3.0, TimerMode::Repeat))
            .observe(|trigger: Trigger<TimerFinishedEvent>, events: EventWriter<Shoot>| {
                    events.send(Shoot);
                },
            );
```
