### PR TITLE
Fix system param validation for piped systems

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -315,7 +315,7 @@ mod __rust_begin_short_backtrace {
 #[cfg(test)]
 mod tests {
     use crate::{
-        prelude::{Component, Resource, Schedule},
+        prelude::{Commands, Component, In, IntoSystem, Resource, Schedule},
         schedule::ExecutorKind,
         system::{Populated, Res, ResMut, Single},
         world::World,
@@ -406,6 +406,63 @@ mod tests {
 
         schedule.set_executor_kind(ExecutorKind::MultiThreaded);
         schedule.add_systems(look_for_missing_resource);
+        schedule.run(&mut world);
+    }
+
+    #[test]
+    fn piped_systems_first_system_skipped() {
+        // This system should be skipped when run due to no matching entity
+        fn pipe_out(_single: Single<&TestComponent>) -> u8 {
+            42
+        }
+        fn pipe_in(_input: In<u8>, mut commands: Commands) {
+            commands.remove_resource::<TestState>();
+        }
+
+        let mut world = World::new();
+        world.init_resource::<TestState>();
+        let mut schedule = Schedule::default();
+
+        schedule.add_systems(pipe_out.pipe(pipe_in));
+        schedule.run(&mut world);
+
+        assert!(world.contains_resource::<TestState>());
+    }
+
+    #[test]
+    fn piped_system_second_system_skipped() {
+        fn pipe_out(mut commands: Commands) -> u8 {
+            commands.remove_resource::<TestState>();
+            42
+        }
+
+        // This system should be skipped when run due to no matching entity
+        fn pipe_in(_input: In<u8>, _single: Single<&TestComponent>) {}
+
+        let mut world = World::new();
+        world.init_resource::<TestState>();
+        let mut schedule = Schedule::default();
+
+        schedule.add_systems(pipe_out.pipe(pipe_in));
+        schedule.run(&mut world);
+
+        assert!(world.contains_resource::<TestState>());
+    }
+
+    #[test]
+    #[should_panic]
+    fn piped_system_second_system_panics() {
+        fn pipe_out() -> u8 {
+            42
+        }
+
+        // This system should panic when run because the resource is missing
+        fn pipe_in(_input: In<u8>, _res: Res<TestState>) {}
+
+        let mut world = World::new();
+        let mut schedule = Schedule::default();
+
+        schedule.add_systems(pipe_out.pipe(pipe_in));
         schedule.run(&mut world);
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -488,8 +488,9 @@ mod tests {
         schedule.run(&mut world);
     }
 
+    // This test runs without panicking because we've
+    // decided to use early-out behavior for piped systems
     #[test]
-    #[should_panic]
     fn piped_system_skip_and_panic() {
         // This system should be skipped when run due to no matching entity
         fn pipe_out(_single: Single<&TestComponent>) -> u8 {

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -428,6 +428,9 @@ where
     /// Because the system validation is performed upfront, this can lead to situations
     /// where later systems pass validation, but fail at runtime due to changes made earlier
     /// in the piped systems.
+    // TODO: ensure that systems are only validated just before they are run.
+    // Fixing this will require fundamentally rethinking how piped systems work:
+    // they're currently treated as a single system from the perspective of the scheduler.
     unsafe fn validate_param_unsafe(
         &mut self,
         world: UnsafeWorldCell,

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -204,8 +204,13 @@ where
         &mut self,
         world: UnsafeWorldCell,
     ) -> Result<(), SystemParamValidationError> {
-        // SAFETY: Delegate to other `System` implementations.
-        unsafe { self.a.validate_param_unsafe(world) }
+        // SAFETY: Delegate to the `System` implementation for `a`.
+        unsafe { self.a.validate_param_unsafe(world) }?;
+
+        // SAFETY: Delegate to the `System` implementation for `b`.
+        unsafe { self.b.validate_param_unsafe(world) }?;
+
+        Ok(())
     }
 
     fn initialize(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -426,6 +426,7 @@ where
     // TODO: ensure that systems are only validated just before they are run.
     // Fixing this will require fundamentally rethinking how piped systems work:
     // they're currently treated as a single system from the perspective of the scheduler.
+    // See https://github.com/bevyengine/bevy/issues/18796
     unsafe fn validate_param_unsafe(
         &mut self,
         world: UnsafeWorldCell,

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -436,18 +436,6 @@ where
         Ok(())
     }
 
-    /// This method uses "early out" logic: if the first system fails validation,
-    /// the second system is not validated.
-    ///
-    /// Because the system validation is performed upfront, this can lead to situations
-    /// where later systems pass validation, but fail at runtime due to changes made earlier
-    /// in the piped systems.
-    fn validate_param(&mut self, world: &World) -> Result<(), SystemParamValidationError> {
-        self.a.validate_param(world)?;
-        self.b.validate_param(world)?;
-        Ok(())
-    }
-
     fn initialize(&mut self, world: &mut World) {
         self.a.initialize(world);
         self.b.initialize(world);

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -419,6 +419,10 @@ where
 
     /// This method uses "early out" logic: if the first system fails validation,
     /// the second system is not validated.
+    ///
+    /// Because the system validation is performed upfront, this can lead to situations
+    /// where later systems pass validation, but fail at runtime due to changes made earlier
+    /// in the piped systems.
     unsafe fn validate_param_unsafe(
         &mut self,
         world: UnsafeWorldCell,
@@ -432,6 +436,12 @@ where
         Ok(())
     }
 
+    /// This method uses "early out" logic: if the first system fails validation,
+    /// the second system is not validated.
+    ///
+    /// Because the system validation is performed upfront, this can lead to situations
+    /// where later systems pass validation, but fail at runtime due to changes made earlier
+    /// in the piped systems.
     fn validate_param(&mut self, world: &World) -> Result<(), SystemParamValidationError> {
         self.a.validate_param(world)?;
         self.b.validate_param(world)?;

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -487,3 +487,27 @@ where
     for<'a> B::In: SystemInput<Inner<'a> = A::Out>,
 {
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn exclusive_system_piping_is_possible() {
+        use crate::prelude::*;
+
+        fn my_exclusive_system(_world: &mut World) -> u32 {
+            1
+        }
+
+        fn out_pipe(input: In<u32>) {
+            assert!(input.0 == 1);
+        }
+
+        let mut world = World::new();
+
+        let mut schedule = Schedule::default();
+        schedule.add_systems(my_exclusive_system.pipe(out_pipe));
+
+        schedule.run(&mut world);
+    }
+}

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -433,8 +433,12 @@ where
             (Err(err_a), Ok(_)) => Err(err_a),
             (Err(err_a), Err(err_b)) => {
                 // Combine the errors from both systems, using the most severe outcome.
+                // TODO: consider combining the error strings in a more intelligible way
+                // but be mindful of the possibility of multiple piped systems!
                 Err(SystemParamValidationError {
-                    skipped: err_a.skipped || err_b.skipped,
+                    // Only skip if both systems should be skipped.
+                    // Panicking systems should not be skipped!
+                    skipped: err_a.skipped && err_b.skipped,
                     message: err_a.message + err_b.message,
                     param: err_a.param + err_b.param,
                     field: err_a.field + err_b.field,

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -204,13 +204,8 @@ where
         &mut self,
         world: UnsafeWorldCell,
     ) -> Result<(), SystemParamValidationError> {
-        // SAFETY: Delegate to the `System` implementation for `a`.
-        unsafe { self.a.validate_param_unsafe(world) }?;
-
-        // SAFETY: Delegate to the `System` implementation for `b`.
-        unsafe { self.b.validate_param_unsafe(world) }?;
-
-        Ok(())
+        // SAFETY: Delegate to other `System` implementations.
+        unsafe { self.a.validate_param_unsafe(world) }
     }
 
     fn initialize(&mut self, world: &mut World) {


### PR DESCRIPTION
# Objective

- Piped systems are an edge case that we missed when reworking system parameter validation.
- Fixes #18755.

## Solution

- Validate the parameters for both systems, ~~combining the errors if both failed validation~~ by simply using an early out.
- ~~Also fix the same bug for combinator systems while we're here.~~

## Testing

I've added a large number of tests checking the behavior under various permutations. These are separate tests, rather than one mega test because a) it's easier to track down bugs that way and b) many of these are `should_panic` tests, which will halt the evaluation of the rest of the test!

I've also added a test for exclusive systems being pipeable because we don't have one and I was very surprised that that works!