### PR TITLE
Fix newline in `PointLightShadowMap` comment

### DIFF
--- a/crates/bevy_pbr/src/light/mod.rs
+++ b/crates/bevy_pbr/src/light/mod.rs
@@ -103,7 +103,6 @@ pub mod light_consts {
 #[reflect(Resource, Debug, Default, Clone)]
 pub struct PointLightShadowMap {
     /// The width and height of each of the 6 faces of the cubemap.
-
     ///
     /// Defaults to `1024`.
     pub size: usize,


### PR DESCRIPTION
A clippy failure slipped into #18768, although I'm not sure why CI didn't catch it.

```sh
> cargo clippy --version
clippy 0.1.85 (4eb161250e 2025-03-15)

> cargo run -p ci
...
error: empty line after doc comment
   --> crates\bevy_pbr\src\light\mod.rs:105:5
    |
105 | /     /// The width and height of each of the 6 faces of the cubemap.
106 | |
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
    = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
    = help: if the empty line is unintentional remove it
help: if the documentation should include the empty line include it in the comment
    |
106 |     ///
    |
```

