### PR TITLE
Named observer

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -3,6 +3,7 @@ use crate::{
     SubApps,
 };
 use alloc::{
+    borrow::Cow,
     boxed::Box,
     string::{String, ToString},
     vec::Vec,
@@ -769,7 +770,7 @@ impl App {
     #[cfg(feature = "reflect_functions")]
     pub fn register_function_with_name<F, Marker>(
         &mut self,
-        name: impl Into<alloc::borrow::Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
         function: F,
     ) -> &mut Self
     where
@@ -1332,6 +1333,46 @@ impl App {
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
         self.world_mut().add_observer(observer);
+        self
+    }
+
+    /// Spawns a named [`Observer`] entity, which will watch for and respond to the given event.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_utils::default;
+    /// #
+    /// # let mut app = App::new();
+    /// #
+    /// # #[derive(Event)]
+    /// # struct Party {
+    /// #   friends_allowed: bool,
+    /// # };
+    /// #
+    /// # #[derive(Event)]
+    /// # struct Invite;
+    /// #
+    /// # #[derive(Component)]
+    /// # struct Friend;
+    /// #
+    /// // An observer system can be any system where the first parameter is a trigger
+    /// app.add_named_observer(|trigger: Trigger<Party>, friends: Query<Entity, With<Friend>>, mut commands: Commands| {
+    ///     if trigger.event().friends_allowed {
+    ///         for friend in friends.iter() {
+    ///             commands.trigger_targets(Invite, friend);
+    ///         }
+    ///     }
+    /// }, "PartyObserver");
+    /// ```
+    pub fn add_named_observer<E: Event, B: Bundle, M>(
+        &mut self,
+        observer: impl IntoObserverSystem<E, B, M>,
+        name: impl Into<Cow<'static, str>>,
+    ) -> &mut Self {
+        self.world_mut().add_named_observer(observer, name);
         self
     }
 }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     system::IntoObserverSystem,
     world::{DeferredWorld, *},
 };
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 use bevy_platform_support::collections::HashMap;
 use bevy_ptr::Ptr;
 use core::{
@@ -567,6 +567,36 @@ impl World {
         system: impl IntoObserverSystem<E, B, M>,
     ) -> EntityWorldMut {
         self.spawn(Observer::new(system))
+    }
+
+    /// Spawns a "global" named [`Observer`] which will watch for the given event.
+    /// Returns its [`Entity`] as a [`EntityWorldMut`].
+    ///
+    /// **Calling [`observe`](EntityWorldMut::observe) on the returned
+    /// [`EntityWorldMut`] will observe the observer itself, which you very
+    /// likely do not want.**
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component)]
+    /// struct A;
+    ///
+    /// # let mut world = World::new();
+    /// world.add_named_observer(|_: Trigger<OnAdd, A>| {
+    ///     // ...
+    /// }, "OnAddA");
+    /// world.add_named_observer(|_: Trigger<OnRemove, A>| {
+    ///     // ...
+    /// }, "OnRemoveA");
+    /// ```
+    pub fn add_named_observer<E: Event, B: Bundle, M>(
+        &mut self,
+        system: impl IntoObserverSystem<E, B, M>,
+        name: impl Into<Cow<'static, str>>,
+    ) -> EntityWorldMut {
+        self.spawn((Observer::new(system), Name::new(name)))
     }
 
     /// Triggers the given [`Event`], which will run any [`Observer`]s watching for it.

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -4,7 +4,7 @@
 //! It also contains functions that return closures for use with
 //! [`EntityCommands`](crate::system::EntityCommands).
 
-use alloc::vec::Vec;
+use alloc::{borrow::Cow, vec::Vec};
 use log::info;
 
 use crate::{
@@ -218,12 +218,24 @@ pub fn despawn() -> impl EntityCommand {
 /// An [`EntityCommand`] that creates an [`Observer`](crate::observer::Observer)
 /// listening for events of type `E` targeting an entity
 #[track_caller]
-pub fn observe<E: Event, B: Bundle, M>(
+pub fn observe_command<E: Event, B: Bundle, M>(
     observer: impl IntoObserverSystem<E, B, M>,
 ) -> impl EntityCommand {
     let caller = MaybeLocation::caller();
     move |mut entity: EntityWorldMut| {
         entity.observe_with_caller(observer, caller);
+    }
+}
+/// An [`EntityCommand`] that creates an [`Observer`](crate::observer::Observer) with a [`Name`](crate::name::Name)
+/// listening for events of type `E` targeting an entity
+#[track_caller]
+pub fn observe_named_command<E: Event, B: Bundle, M>(
+    observer: impl IntoObserverSystem<E, B, M>,
+    name: impl Into<Cow<'static, str>> + Send + 'static,
+) -> impl EntityCommand {
+    let caller = MaybeLocation::caller();
+    move |mut entity: EntityWorldMut| {
+        entity.observe_named_with_caller(observer, name, caller);
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -10,7 +10,7 @@ pub use entity_command::EntityCommand;
 #[cfg(feature = "std")]
 pub use parallel_scope::*;
 
-use alloc::boxed::Box;
+use alloc::{borrow::Cow, boxed::Box};
 use core::marker::PhantomData;
 use log::error;
 
@@ -1915,7 +1915,16 @@ impl<'a> EntityCommands<'a> {
         &mut self,
         observer: impl IntoObserverSystem<E, B, M>,
     ) -> &mut Self {
-        self.queue(entity_command::observe(observer))
+        self.queue(entity_command::observe_command(observer))
+    }
+
+    /// Creates a named [`Observer`] listening for events of type `E` targeting this entity.
+    pub fn observe_named<E: Event, B: Bundle, M>(
+        &mut self,
+        observer: impl IntoObserverSystem<E, B, M>,
+        name: impl Into<Cow<'static, str>> + Send + 'static,
+    ) -> &mut Self {
+        self.queue(entity_command::observe_named_command(observer, name))
     }
 
     /// Clones parts of an entity (components, observers, etc.) onto another entity,

--- a/examples/ecs/observers.rs
+++ b/examples/ecs/observers.rs
@@ -15,7 +15,8 @@ fn main() {
         .add_systems(Update, (draw_shapes, handle_click))
         // Observers are systems that run when an event is "triggered". This observer runs whenever
         // `ExplodeMines` is triggered.
-        .add_observer(
+        // Observers an can be optionally named
+        .add_named_observer(
             |trigger: Trigger<ExplodeMines>,
              mines: Query<&Mine>,
              index: Res<SpatialIndex>,
@@ -33,6 +34,7 @@ fn main() {
                     }
                 }
             },
+            "ChainExplosionObserver",
         )
         // This observer runs whenever the `Mine` component is added to an entity, and places it in a simple spatial index.
         .add_observer(on_add_mine)
@@ -92,6 +94,11 @@ fn setup(mut commands: Commands) {
         // This will create a new observer that runs whenever the Explode event
         // is triggered for this spawned entity.
         .observe(explode_mine);
+    commands
+        .spawn(Mine::random(&mut rng))
+        // You can also give the observer a name for easier distinction between them
+        // when using Bevy Remote Protocol or inspectors
+        .observe_named(explode_mine, "ExplodeMine");
 
     // We want to spawn a bunch of mines. We could just call the code above for each of them.
     // That would create a new observer instance for every Mine entity. Having duplicate observers
@@ -110,6 +117,9 @@ fn setup(mut commands: Commands) {
 
     // By spawning the Observer component, it becomes active!
     commands.spawn(observer);
+    // This observer could also be optionally named by adding `Name` component
+    // to the bundle.
+    // e.g. commands.spawn((observer, Name::new("ExplodeMine")));
 }
 
 fn on_add_mine(


### PR DESCRIPTION
# Objective

Closes #18726 

## Solution

- Add `add_named_observer` to `App` and `World`
- Add `observe_named` to `EntityCommands` and `EntityWorldMut`

## Showcase

```rust
commands.spawn_empty().observe_named(my_observer, "MyObserver");
world.entity(entity).observe_named(my_observer, "MyObserver");
world.add_named_observer(my_observer, "MyObserver");
app.add_named_observer(my_observer, "MyObserver");
```

## TODO

- [ ] Maybe rename `add_named_observer`
- [ ] Maybe rename `observe_named`
- [ ] Maybe add names to some of built-in observers
